### PR TITLE
[Automation] - Reduce execution time of pagination tests

### DIFF
--- a/cypress/e2e/blueprints/explorer/workloads/pods/pods-get.ts
+++ b/cypress/e2e/blueprints/explorer/workloads/pods/pods-get.ts
@@ -1,221 +1,608 @@
 // GET /v1/pods - small set of pods data
 const podsGetResponseSmallSet = {
   type:         'collection',
-  links:        { self: 'https://yonasb29.qa.rancher.space/v1/pods' },
-  createTypes:  { pod: 'https://yonasb29.qa.rancher.space/v1/pods' },
+  links:        { self: 'https://izh.qa.rancher.space/v1/pods' },
+  createTypes:  { pod: 'https://izh.qa.rancher.space/v1/pods' },
   actions:      {},
   resourceType: 'pod',
-  revision:     '123',
   count:        3,
-  data:         [
-    {
-      id:    'cattle-fleet-local-system/fleet-agent-0',
-      type:  'pod',
-      links: {
-        remove: 'https://yonasb29.qa.rancher.space/v1/pods/cattle-fleet-local-system/fleet-agent-0',
-        self:   'https://yonasb29.qa.rancher.space/v1/pods/cattle-fleet-local-system/fleet-agent-0',
-        update: 'https://yonasb29.qa.rancher.space/v1/pods/cattle-fleet-local-system/fleet-agent-0',
-        view:   'https://yonasb29.qa.rancher.space/api/v1/namespaces/cattle-fleet-local-system/pods/fleet-agent-0'
-      },
-      apiVersion: 'v1',
-      kind:       'Pod',
-      metadata:   {
-        annotations:       {},
-        creationTimestamp: '2024-06-14T15:50:07Z',
-        fields:            [
-          'fleet-agent-0',
-          '2/2',
-          'Running',
-          '0',
-          '7h29m',
-          '10.42.2.15',
-          'ip-172-31-12-33.us-east-2.compute.internal',
-          '<none>',
-          '<none>'
-        ],
-        generateName:    'fleet-agent-',
-        labels:          {},
-        name:            'aaa-e2e-vai-test-pod-name',
-        namespace:       'cattle-fleet-local-system',
-        ownerReferences: [],
-        relationships:   [],
-        resourceVersion: '7553',
-        state:           {
-          error:         false,
-          message:       '',
-          name:          'running',
-          transitioning: false
+  data:         [{
+    id:    'default/test1',
+    type:  'pod',
+    links: {
+      remove: 'https://izh.qa.rancher.space/v1/pods/default/test1',
+      self:   'https://izh.qa.rancher.space/v1/pods/default/test1',
+      update: 'https://izh.qa.rancher.space/v1/pods/default/test1',
+      view:   'https://izh.qa.rancher.space/api/v1/namespaces/default/pods/test1'
+    },
+    apiVersion: 'v1',
+    kind:       'Pod',
+    metadata:   {
+      creationTimestamp: '2024-08-07T23:58:10Z',
+      fields:            [
+        'test1',
+        '1/1',
+        'Running',
+        '0',
+        '1s',
+        '10.42.2.202',
+        'ip-172-31-14-159',
+        '\u003cnone\u003e',
+        '\u003cnone\u003e'
+      ],
+      labels:        { 'workload.user.cattle.io/workloadselector': 'pod-default-test1' },
+      name:          'test1',
+      namespace:     'default',
+      relationships: [
+        {
+          toId:    'default/default',
+          toType:  'serviceaccount',
+          rel:     'uses',
+          state:   'active',
+          message: 'Resource is current'
         },
-        uid: '76de6052-8eda-42bc-98d5-dd19c335e977'
+        {
+          toId:    'default/kube-root-ca.crt',
+          toType:  'configmap',
+          rel:     'uses',
+          state:   'active',
+          message: 'Resource is always ready'
+        }
+      ],
+      resourceVersion: '541786',
+      state:           {
+        error:         false,
+        message:       '',
+        name:          'running',
+        transitioning: false
       },
-      spec: {
-        affinity: {
-          nodeAffinity: {
-            preferredDuringSchedulingIgnoredDuringExecution: [
+      uid: '549cb335-5b90-40d3-96cf-9d96277069bd'
+    },
+    spec: {
+      affinity:   {},
+      containers: [
+        {
+          image:                    'nginx:latest',
+          imagePullPolicy:          'Always',
+          name:                     'container-0',
+          resources:                {},
+          terminationMessagePath:   '/dev/termination-log',
+          terminationMessagePolicy: 'File',
+          volumeMounts:             [
+            {
+              mountPath: '/var/run/secrets/kubernetes.io/serviceaccount',
+              name:      'kube-api-access-wd2wx',
+              readOnly:  true
+            }
+          ]
+        }
+      ],
+      dnsPolicy:                     'ClusterFirst',
+      enableServiceLinks:            true,
+      nodeName:                      'ip-172-31-14-159',
+      preemptionPolicy:              'PreemptLowerPriority',
+      priority:                      0,
+      restartPolicy:                 'Always',
+      schedulerName:                 'default-scheduler',
+      securityContext:               {},
+      serviceAccount:                'default',
+      serviceAccountName:            'default',
+      terminationGracePeriodSeconds: 30,
+      tolerations:                   [
+        {
+          effect:            'NoExecute',
+          key:               'node.kubernetes.io/not-ready',
+          operator:          'Exists',
+          tolerationSeconds: 300
+        },
+        {
+          effect:            'NoExecute',
+          key:               'node.kubernetes.io/unreachable',
+          operator:          'Exists',
+          tolerationSeconds: 300
+        }
+      ],
+      volumes: [
+        {
+          name:      'kube-api-access-wd2wx',
+          projected: {
+            defaultMode: 420,
+            sources:     [
               {
-                preference: {
-                  matchExpressions: [
+                serviceAccountToken: {
+                  expirationSeconds: 3607,
+                  path:              'token'
+                }
+              },
+              {
+                configMap: {
+                  items: [
                     {
-                      key:      'fleet.cattle.io/agent',
-                      operator: 'In',
-                      values:   [
-                        'true'
-                      ]
+                      key:  'ca.crt',
+                      path: 'ca.crt'
+                    }
+                  ],
+                  name: 'kube-root-ca.crt'
+                }
+              },
+              {
+                downwardAPI: {
+                  items: [
+                    {
+                      fieldRef: {
+                        apiVersion: 'v1',
+                        fieldPath:  'metadata.namespace'
+                      },
+                      path: 'namespace'
                     }
                   ]
-                },
-                weight: 1
+                }
               }
             ]
           }
-        },
-        containers:         [],
-        dnsPolicy:          'ClusterFirst',
-        enableServiceLinks: true,
-        hostname:           'fleet-agent-0',
-        initContainers:     [],
-        nodeName:           'ip-172-31-12-33.us-east-2.compute.internal',
-        nodeSelector:       { 'kubernetes.io/os': 'linux' },
-        preemptionPolicy:   'PreemptLowerPriority',
-        priority:           0,
-        restartPolicy:      'Always',
-        schedulerName:      'default-scheduler',
-        securityContext:    {
-          runAsGroup:   1000,
-          runAsNonRoot: true,
-          runAsUser:    1000
-        },
-        serviceAccount:                'fleet-agent',
-        serviceAccountName:            'fleet-agent',
-        subdomain:                     'fleet-agent',
-        terminationGracePeriodSeconds: 30,
-        tolerations:                   [],
-        volumes:                       []
-      },
-      status: {}
+        }
+      ]
     },
-    {
-      id:    'kube-system/rke2-snapshot-controller-59cc9cd8f4-dr2nv',
-      type:  'pod',
-      links: {
-        remove: 'https://yonasb29.qa.rancher.space/v1/pods/kube-system/rke2-snapshot-controller-59cc9cd8f4-dr2nv',
-        self:   'https://yonasb29.qa.rancher.space/v1/pods/kube-system/rke2-snapshot-controller-59cc9cd8f4-dr2nv',
-        update: 'https://yonasb29.qa.rancher.space/v1/pods/kube-system/rke2-snapshot-controller-59cc9cd8f4-dr2nv',
-        view:   'https://yonasb29.qa.rancher.space/api/v1/namespaces/kube-system/pods/rke2-snapshot-controller-59cc9cd8f4-dr2nv'
-      },
-      apiVersion: 'v1',
-      kind:       'Pod',
-      metadata:   {
-        annotations: {
-          'cni.projectcalico.org/containerID': '212cd9f120c58c007d065f7702a2f3f6c7f2f8e8850af7ed14f56ef577c61615',
-          'cni.projectcalico.org/podIP':       '10.42.0.11/32',
-          'cni.projectcalico.org/podIPs':      '10.42.0.11/32'
+    status: {
+      conditions: [
+        {
+          error:              false,
+          lastProbeTime:      null,
+          lastTransitionTime: '2024-08-07T23:58:10Z',
+          lastUpdateTime:     '2024-08-07T23:58:10Z',
+          status:             'True',
+          transitioning:      false,
+          type:               'Initialized'
         },
-        creationTimestamp: '2024-06-14T15:39:59Z',
-        fields:            [
-          'rke2-snapshot-controller-59cc9cd8f4-dr2nv',
-          '1/1',
-          'Running',
-          '0',
-          '7h39m',
-          '10.42.0.11',
-          'ip-172-31-14-130.us-east-2.compute.internal',
-          '<none>',
-          '<none>'
-        ],
-        generateName:    'rke2-snapshot-controller-59cc9cd8f4-',
-        labels:          {},
-        name:            'rke2-snapshot-controller-59cc9cd8f4-dr2nv',
-        namespace:       'kube-system',
-        ownerReferences: [],
-        relationships:   [],
-        resourceVersion: '1176',
-        state:           {
-          error:         false,
-          message:       '',
-          name:          'running',
-          transitioning: false
+        {
+          error:              false,
+          lastProbeTime:      null,
+          lastTransitionTime: '2024-08-07T23:58:11Z',
+          lastUpdateTime:     '2024-08-07T23:58:11Z',
+          status:             'True',
+          transitioning:      false,
+          type:               'Ready'
         },
-        uid: 'a2157217-0b62-4d95-adcd-686f79925d4d'
-      },
-      spec: {
-        containers:                    [],
-        dnsPolicy:                     'ClusterFirst',
-        enableServiceLinks:            true,
-        nodeName:                      'ip-172-31-14-130.us-east-2.compute.internal',
-        nodeSelector:                  { 'kubernetes.io/os': 'linux' },
-        preemptionPolicy:              'PreemptLowerPriority',
-        priority:                      0,
-        restartPolicy:                 'Always',
-        schedulerName:                 'default-scheduler',
-        securityContext:               {},
-        serviceAccount:                'rke2-snapshot-controller',
-        serviceAccountName:            'rke2-snapshot-controller',
-        terminationGracePeriodSeconds: 30,
-        tolerations:                   [],
-        volumes:                       []
-      },
-      status: {}
-    },
-    {
-      id:    'kube-system/rke2-snapshot-validation-webhook-54c5989b65-87xqh',
-      type:  'pod',
-      links: {
-        remove: 'https://yonasb29.qa.rancher.space/v1/pods/kube-system/rke2-snapshot-validation-webhook-54c5989b65-87xqh',
-        self:   'https://yonasb29.qa.rancher.space/v1/pods/kube-system/rke2-snapshot-validation-webhook-54c5989b65-87xqh',
-        update: 'https://yonasb29.qa.rancher.space/v1/pods/kube-system/rke2-snapshot-validation-webhook-54c5989b65-87xqh',
-        view:   'https://yonasb29.qa.rancher.space/api/v1/namespaces/kube-system/pods/rke2-snapshot-validation-webhook-54c5989b65-87xqh'
-      },
-      apiVersion: 'v1',
-      kind:       'Pod',
-      metadata:   {
-        annotations:       {},
-        creationTimestamp: '2024-06-14T15:39:52Z',
-        fields:            [
-          'rke2-snapshot-validation-webhook-54c5989b65-87xqh',
-          '1/1',
-          'Running',
-          '0',
-          '7h39m',
-          '10.42.0.9',
-          'ip-172-31-14-130.us-east-2.compute.internal',
-          '<none>',
-          '<none>'
-        ],
-        generateName:    'rke2-snapshot-validation-webhook-54c5989b65-',
-        labels:          {},
-        name:            'rke2-snapshot-validation-webhook-54c5989b65-87xqh',
-        namespace:       'kube-system',
-        ownerReferences: [],
-        relationships:   [],
-        resourceVersion: '1138',
-        state:           {
-          error:         false,
-          message:       '',
-          name:          'running',
-          transitioning: false
+        {
+          error:              false,
+          lastProbeTime:      null,
+          lastTransitionTime: '2024-08-07T23:58:11Z',
+          lastUpdateTime:     '2024-08-07T23:58:11Z',
+          status:             'True',
+          transitioning:      false,
+          type:               'ContainersReady'
         },
-        uid: '929106df-13d9-43fc-9c76-09ad0292aab1'
-      },
-      spec: {
-        containers:                    [],
-        dnsPolicy:                     'ClusterFirst',
-        enableServiceLinks:            true,
-        nodeName:                      'ip-172-31-14-130.us-east-2.compute.internal',
-        nodeSelector:                  { 'kubernetes.io/os': 'linux' },
-        preemptionPolicy:              'PreemptLowerPriority',
-        priority:                      0,
-        restartPolicy:                 'Always',
-        schedulerName:                 'default-scheduler',
-        securityContext:               {},
-        serviceAccount:                'rke2-snapshot-validation-webhook',
-        serviceAccountName:            'rke2-snapshot-validation-webhook',
-        terminationGracePeriodSeconds: 30,
-        tolerations:                   [],
-        volumes:                       []
-      },
-      status: {}
+        {
+          error:              false,
+          lastProbeTime:      null,
+          lastTransitionTime: '2024-08-07T23:58:10Z',
+          lastUpdateTime:     '2024-08-07T23:58:10Z',
+          status:             'True',
+          transitioning:      false,
+          type:               'PodScheduled'
+        }
+      ],
+      containerStatuses: [
+        {
+          containerID:  'containerd://ce99568174ad36120fa39b6434fa95ebfe5bf70e417a4d84d2589d2d252bd5ec',
+          image:        'docker.io/library/nginx:latest',
+          imageID:      'docker.io/library/nginx@sha256:6af79ae5de407283dcea8b00d5c37ace95441fd58a8b1d2aa1ed93f5511bb18c',
+          lastState:    {},
+          name:         'container-0',
+          ready:        true,
+          restartCount: 0,
+          started:      true,
+          state:        { running: { startedAt: '2024-08-07T23:58:11Z' } }
+        }
+      ],
+      hostIP: '172.31.14.159',
+      phase:  'Running',
+      podIP:  '10.42.2.202',
+      podIPs: [
+        { ip: '10.42.2.202' }
+      ],
+      qosClass:  'BestEffort',
+      startTime: '2024-08-07T23:58:10Z'
     }
+  },
+  {
+    id:    'default/test2',
+    type:  'pod',
+    links: {
+      remove: 'https://izh.qa.rancher.space/v1/pods/default/test2',
+      self:   'https://izh.qa.rancher.space/v1/pods/default/test2',
+      update: 'https://izh.qa.rancher.space/v1/pods/default/test2',
+      view:   'https://izh.qa.rancher.space/api/v1/namespaces/default/pods/test2'
+    },
+    apiVersion: 'v1',
+    kind:       'Pod',
+    metadata:   {
+      creationTimestamp: '2024-08-07T23:58:28Z',
+      fields:            [
+        'test2',
+        '1/1',
+        'Running',
+        '0',
+        '1s',
+        '10.42.2.203',
+        'ip-172-31-14-159',
+        '\u003cnone\u003e',
+        '\u003cnone\u003e'
+      ],
+      labels:        { 'workload.user.cattle.io/workloadselector': 'pod-default-test2' },
+      name:          'test2',
+      namespace:     'default',
+      relationships: [
+        {
+          toId:    'default/default',
+          toType:  'serviceaccount',
+          rel:     'uses',
+          state:   'active',
+          message: 'Resource is current'
+        },
+        {
+          toId:    'default/kube-root-ca.crt',
+          toType:  'configmap',
+          rel:     'uses',
+          state:   'active',
+          message: 'Resource is always ready'
+        }
+      ],
+      resourceVersion: '541885',
+      state:           {
+        error:         false,
+        message:       '',
+        name:          'running',
+        transitioning: false
+      },
+      uid: 'ea2a929c-85ed-4f70-b2ef-a1c6cdb3a675'
+    },
+    spec: {
+      affinity:   {},
+      containers: [
+        {
+          image:                    'nginx:latest',
+          imagePullPolicy:          'Always',
+          name:                     'container-0',
+          resources:                {},
+          terminationMessagePath:   '/dev/termination-log',
+          terminationMessagePolicy: 'File',
+          volumeMounts:             [
+            {
+              mountPath: '/var/run/secrets/kubernetes.io/serviceaccount',
+              name:      'kube-api-access-sm24m',
+              readOnly:  true
+            }
+          ]
+        }
+      ],
+      dnsPolicy:                     'ClusterFirst',
+      enableServiceLinks:            true,
+      nodeName:                      'ip-172-31-14-159',
+      preemptionPolicy:              'PreemptLowerPriority',
+      priority:                      0,
+      restartPolicy:                 'Always',
+      schedulerName:                 'default-scheduler',
+      securityContext:               {},
+      serviceAccount:                'default',
+      serviceAccountName:            'default',
+      terminationGracePeriodSeconds: 30,
+      tolerations:                   [
+        {
+          effect:            'NoExecute',
+          key:               'node.kubernetes.io/not-ready',
+          operator:          'Exists',
+          tolerationSeconds: 300
+        },
+        {
+          effect:            'NoExecute',
+          key:               'node.kubernetes.io/unreachable',
+          operator:          'Exists',
+          tolerationSeconds: 300
+        }
+      ],
+      volumes: [
+        {
+          name:      'kube-api-access-sm24m',
+          projected: {
+            defaultMode: 420,
+            sources:     [
+              {
+                serviceAccountToken: {
+                  expirationSeconds: 3607,
+                  path:              'token'
+                }
+              },
+              {
+                configMap: {
+                  items: [
+                    {
+                      key:  'ca.crt',
+                      path: 'ca.crt'
+                    }
+                  ],
+                  name: 'kube-root-ca.crt'
+                }
+              },
+              {
+                downwardAPI: {
+                  items: [
+                    {
+                      fieldRef: {
+                        apiVersion: 'v1',
+                        fieldPath:  'metadata.namespace'
+                      },
+                      path: 'namespace'
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    status: {
+      conditions: [
+        {
+          error:              false,
+          lastProbeTime:      null,
+          lastTransitionTime: '2024-08-07T23:58:28Z',
+          lastUpdateTime:     '2024-08-07T23:58:28Z',
+          status:             'True',
+          transitioning:      false,
+          type:               'Initialized'
+        },
+        {
+          error:              false,
+          lastProbeTime:      null,
+          lastTransitionTime: '2024-08-07T23:58:29Z',
+          lastUpdateTime:     '2024-08-07T23:58:29Z',
+          status:             'True',
+          transitioning:      false,
+          type:               'Ready'
+        },
+        {
+          error:              false,
+          lastProbeTime:      null,
+          lastTransitionTime: '2024-08-07T23:58:29Z',
+          lastUpdateTime:     '2024-08-07T23:58:29Z',
+          status:             'True',
+          transitioning:      false,
+          type:               'ContainersReady'
+        },
+        {
+          error:              false,
+          lastProbeTime:      null,
+          lastTransitionTime: '2024-08-07T23:58:28Z',
+          lastUpdateTime:     '2024-08-07T23:58:28Z',
+          status:             'True',
+          transitioning:      false,
+          type:               'PodScheduled'
+        }
+      ],
+      containerStatuses: [
+        {
+          containerID:  'containerd://b3e678e901f55a4bd15cf0b4d272dad5f1793701a638a642cc51bf16bffbcc33',
+          image:        'docker.io/library/nginx:latest',
+          imageID:      'docker.io/library/nginx@sha256:6af79ae5de407283dcea8b00d5c37ace95441fd58a8b1d2aa1ed93f5511bb18c',
+          lastState:    {},
+          name:         'container-0',
+          ready:        true,
+          restartCount: 0,
+          started:      true,
+          state:        { running: { startedAt: '2024-08-07T23:58:29Z' } }
+        }
+      ],
+      hostIP: '172.31.14.159',
+      phase:  'Running',
+      podIP:  '10.42.2.203',
+      podIPs: [
+        { ip: '10.42.2.203' }
+      ],
+      qosClass:  'BestEffort',
+      startTime: '2024-08-07T23:58:28Z'
+    }
+  },
+  {
+    id:    'default/test3',
+    type:  'pod',
+    links: {
+      remove: 'https://izh.qa.rancher.space/v1/pods/default/test3',
+      self:   'https://izh.qa.rancher.space/v1/pods/default/test3',
+      update: 'https://izh.qa.rancher.space/v1/pods/default/test3',
+      view:   'https://izh.qa.rancher.space/api/v1/namespaces/default/pods/test3'
+    },
+    apiVersion: 'v1',
+    kind:       'Pod',
+    metadata:   {
+      creationTimestamp: '2024-08-07T23:58:43Z',
+      fields:            [
+        'test3',
+        '1/1',
+        'Running',
+        '0',
+        '1s',
+        '10.42.2.204',
+        'ip-172-31-14-159',
+        '\u003cnone\u003e',
+        '\u003cnone\u003e'
+      ],
+      labels:        { 'workload.user.cattle.io/workloadselector': 'pod-default-test3' },
+      name:          'test3',
+      namespace:     'default',
+      relationships: [
+        {
+          toId:    'default/default',
+          toType:  'serviceaccount',
+          rel:     'uses',
+          state:   'active',
+          message: 'Resource is current'
+        },
+        {
+          toId:    'default/kube-root-ca.crt',
+          toType:  'configmap',
+          rel:     'uses',
+          state:   'active',
+          message: 'Resource is always ready'
+        }
+      ],
+      resourceVersion: '541968',
+      state:           {
+        error:         false,
+        message:       '',
+        name:          'running',
+        transitioning: false
+      },
+      uid: 'b6d7ab60-507f-44dc-b8be-7037fa2c1163'
+    },
+    spec: {
+      affinity:   {},
+      containers: [
+        {
+          image:                    'nginx:latest',
+          imagePullPolicy:          'Always',
+          name:                     'container-0',
+          resources:                {},
+          terminationMessagePath:   '/dev/termination-log',
+          terminationMessagePolicy: 'File',
+          volumeMounts:             [
+            {
+              mountPath: '/var/run/secrets/kubernetes.io/serviceaccount',
+              name:      'kube-api-access-kvh75',
+              readOnly:  true
+            }
+          ]
+        }
+      ],
+      dnsPolicy:                     'ClusterFirst',
+      enableServiceLinks:            true,
+      nodeName:                      'ip-172-31-14-159',
+      preemptionPolicy:              'PreemptLowerPriority',
+      priority:                      0,
+      restartPolicy:                 'Always',
+      schedulerName:                 'default-scheduler',
+      securityContext:               {},
+      serviceAccount:                'default',
+      serviceAccountName:            'default',
+      terminationGracePeriodSeconds: 30,
+      tolerations:                   [
+        {
+          effect:            'NoExecute',
+          key:               'node.kubernetes.io/not-ready',
+          operator:          'Exists',
+          tolerationSeconds: 300
+        },
+        {
+          effect:            'NoExecute',
+          key:               'node.kubernetes.io/unreachable',
+          operator:          'Exists',
+          tolerationSeconds: 300
+        }
+      ],
+      volumes: [
+        {
+          name:      'kube-api-access-kvh75',
+          projected: {
+            defaultMode: 420,
+            sources:     [
+              {
+                serviceAccountToken: {
+                  expirationSeconds: 3607,
+                  path:              'token'
+                }
+              },
+              {
+                configMap: {
+                  items: [
+                    {
+                      key:  'ca.crt',
+                      path: 'ca.crt'
+                    }
+                  ],
+                  name: 'kube-root-ca.crt'
+                }
+              },
+              {
+                downwardAPI: {
+                  items: [
+                    {
+                      fieldRef: {
+                        apiVersion: 'v1',
+                        fieldPath:  'metadata.namespace'
+                      },
+                      path: 'namespace'
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    status: {
+      conditions: [
+        {
+          error:              false,
+          lastProbeTime:      null,
+          lastTransitionTime: '2024-08-07T23:58:43Z',
+          lastUpdateTime:     '2024-08-07T23:58:43Z',
+          status:             'True',
+          transitioning:      false,
+          type:               'Initialized'
+        },
+        {
+          error:              false,
+          lastProbeTime:      null,
+          lastTransitionTime: '2024-08-07T23:58:44Z',
+          lastUpdateTime:     '2024-08-07T23:58:44Z',
+          status:             'True',
+          transitioning:      false,
+          type:               'Ready'
+        },
+        {
+          error:              false,
+          lastProbeTime:      null,
+          lastTransitionTime: '2024-08-07T23:58:44Z',
+          lastUpdateTime:     '2024-08-07T23:58:44Z',
+          status:             'True',
+          transitioning:      false,
+          type:               'ContainersReady'
+        },
+        {
+          error:              false,
+          lastProbeTime:      null,
+          lastTransitionTime: '2024-08-07T23:58:43Z',
+          lastUpdateTime:     '2024-08-07T23:58:43Z',
+          status:             'True',
+          transitioning:      false,
+          type:               'PodScheduled'
+        }
+      ],
+      containerStatuses: [
+        {
+          containerID:  'containerd://62675e963f91ea73955fa82f67f7082a88e067922d5272aac996eee44b284fe7',
+          image:        'docker.io/library/nginx:latest',
+          imageID:      'docker.io/library/nginx@sha256:6af79ae5de407283dcea8b00d5c37ace95441fd58a8b1d2aa1ed93f5511bb18c',
+          lastState:    {},
+          name:         'container-0',
+          ready:        true,
+          restartCount: 0,
+          started:      true,
+          state:        { running: { startedAt: '2024-08-07T23:58:44Z' } }
+        }
+      ],
+      hostIP: '172.31.14.159',
+      phase:  'Running',
+      podIP:  '10.42.2.204',
+      podIPs: [
+        { ip: '10.42.2.204' }
+      ],
+      qosClass:  'BestEffort',
+      startTime: '2024-08-07T23:58:43Z'
+    }
+  }
   ]
 };
 

--- a/cypress/e2e/po/pages/users-and-auth/roles.po.ts
+++ b/cypress/e2e/po/pages/users-and-auth/roles.po.ts
@@ -7,6 +7,7 @@ import RoleListPo from '@/cypress/e2e/po/lists/role-list.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import ClusterPage from '@/cypress/e2e/po/pages/cluster-page.po';
+import PaginationPo from '~/cypress/e2e/po/components/pagination.po';
 
 export default class RolesPo extends ClusterPage {
   static goTo(path: string): Cypress.Chainable<Cypress.AUTWindow> {
@@ -62,5 +63,9 @@ export default class RolesPo extends ClusterPage {
    */
   list(tabIdSelector: 'GLOBAL' | 'CLUSTER' | 'NAMESPACE') {
     return new RoleListPo(`#${ tabIdSelector } [data-testid="sortable-table-list-container"]`);
+  }
+
+  paginatedTab(tabIdSelector: 'GLOBAL' | 'CLUSTER' | 'NAMESPACE') {
+    return new PaginationPo(`#${ tabIdSelector } div.paging`);
   }
 }

--- a/cypress/e2e/tests/pages/fleet/advanced/workspaces.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/advanced/workspaces.spec.ts
@@ -1,6 +1,7 @@
 import { FleetWorkspaceListPagePo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.fleetworkspace.po';
 import FleetWorkspaceDetailsPo from '@/cypress/e2e/po/detail/fleet/fleet.cattle.io.fleetworkspace.po';
 import { generateFleetWorkspacesDataSmall } from '@/cypress/e2e/blueprints/fleet/workspaces-get';
+import HomePagePo from '~/cypress/e2e/po/pages/home.po';
 
 const defaultWorkspace = 'fleet-default';
 const workspaceNameList = [];
@@ -13,6 +14,8 @@ describe('Workspaces', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] },
   });
 
   describe('List', { tags: ['@vai', '@adminUser'] }, () => {
+    let initialCount: number;
+
     it('check table headers are available in list and details view', () => {
       FleetWorkspaceListPagePo.navTo();
       fleetWorkspacesPage.waitForPage();
@@ -70,10 +73,13 @@ describe('Workspaces', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] },
     const uniqueWorkspaceName = 'aaa-e2e-test-name';
 
     before('set up', () => {
+      cy.getRancherResource('v1', 'management.cattle.io.fleetworkspaces').then((resp: Cypress.Response<any>) => {
+        initialCount = resp.body.count;
+      });
       // create workspaces
       let i = 0;
 
-      while (i < 100) {
+      while (i < 25) {
         const workspaceName = `e2e-${ Cypress._.uniqueId(Date.now().toString()) }`;
         const workspaceDesc = `e2e-desc-${ Cypress._.uniqueId(Date.now().toString()) }`;
 
@@ -92,11 +98,16 @@ describe('Workspaces', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] },
 
         workspaceNameList.push(wsId);
       });
+      cy.tableRowsPerPageAndNamespaceFilter(10, 'local', 'none', '{\"local\":[]}');
+      cy.reload();
     });
 
     it('pagination is visible and user is able to navigate through workspace data', () => {
-      // get fleet workspace count
-      cy.getRancherResource('v1', 'management.cattle.io.fleetworkspaces').then((resp: Cypress.Response<any>) => {
+      HomePagePo.goTo();
+      const count = initialCount + 26;
+
+      // check fleet workspace count
+      cy.waitForRancherResources('v1', 'management.cattle.io.fleetworkspaces', count).then((resp: Cypress.Response<any>) => {
         const count = resp.body.count;
 
         FleetWorkspaceListPagePo.navTo();
@@ -113,7 +124,7 @@ describe('Workspaces', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] },
 
         // check text before navigation
         fleetWorkspacesPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`1 - 100 of ${ count } Workspaces`);
+          expect(el.trim()).to.eq(`1 - 10 of ${ count } Workspaces`);
         });
 
         // navigate to next page - right button
@@ -121,7 +132,7 @@ describe('Workspaces', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] },
 
         // check text and buttons after navigation
         fleetWorkspacesPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`101 - ${ count } of ${ count } Workspaces`);
+          expect(el.trim()).to.eq(`11 - 20 of ${ count } Workspaces`);
         });
         fleetWorkspacesPage.sortableTable().pagination().beginningButton().isEnabled();
         fleetWorkspacesPage.sortableTable().pagination().leftButton().isEnabled();
@@ -131,7 +142,7 @@ describe('Workspaces', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] },
 
         // check text and buttons after navigation
         fleetWorkspacesPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`1 - 100 of ${ count } Workspaces`);
+          expect(el.trim()).to.eq(`1 - 10 of ${ count } Workspaces`);
         });
         fleetWorkspacesPage.sortableTable().pagination().beginningButton().isDisabled();
         fleetWorkspacesPage.sortableTable().pagination().leftButton().isDisabled();
@@ -140,11 +151,11 @@ describe('Workspaces', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] },
         fleetWorkspacesPage.sortableTable().pagination().endButton().click();
 
         // check row count on last page
-        fleetWorkspacesPage.sortableTable().checkRowCount(false, count - 100);
+        fleetWorkspacesPage.sortableTable().checkRowCount(false, count - 20);
 
         // check text after navigation
         fleetWorkspacesPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`101 - ${ count } of ${ count } Workspaces`);
+          expect(el.trim()).to.eq(`21 - ${ count } of ${ count } Workspaces`);
         });
 
         // navigate to first page - beginning button
@@ -152,7 +163,7 @@ describe('Workspaces', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] },
 
         // check text and buttons after navigation
         fleetWorkspacesPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`1 - 100 of ${ count } Workspaces`);
+          expect(el.trim()).to.eq(`1 - 10 of ${ count } Workspaces`);
         });
         fleetWorkspacesPage.sortableTable().pagination().beginningButton().isDisabled();
         fleetWorkspacesPage.sortableTable().pagination().leftButton().isDisabled();
@@ -165,7 +176,7 @@ describe('Workspaces', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] },
 
       fleetWorkspacesPage.sortableTable().checkVisible();
       fleetWorkspacesPage.sortableTable().checkLoadingIndicatorNotVisible();
-      fleetWorkspacesPage.sortableTable().checkRowCount(false, 100);
+      fleetWorkspacesPage.sortableTable().checkRowCount(false, 10);
 
       // filter by name
       fleetWorkspacesPage.sortableTable().filter(workspaceNameList[0]);
@@ -218,6 +229,8 @@ describe('Workspaces', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] },
 
     after(() => {
       workspaceNameList.forEach((r) => cy.deleteRancherResource('v3', 'fleetWorkspaces', r, false));
+      // Ensure the default rows per page value is set after running the tests
+      cy.tableRowsPerPageAndNamespaceFilter(100, 'local', 'none', '{"local":["all://user"]}');
     });
   });
 });

--- a/cypress/e2e/tests/pages/user-menu/account-api-keys.spec.ts
+++ b/cypress/e2e/tests/pages/user-menu/account-api-keys.spec.ts
@@ -105,12 +105,16 @@ describe('Account and API Keys', { testIsolation: 'off' }, () => {
   describe('List', { tags: ['@vai', '@userMenu', '@adminUser'] }, () => {
     const tokenDesc = 'e2e-test-description';
     const uniqueTokenDesc = 'aaa-e2e-test-description';
+    let initialCount: number;
 
     before('set up', () => {
+      cy.getRancherResource('v3', 'tokens').then((resp: Cypress.Response<any>) => {
+        initialCount = resp.body.data.length - 1;
+      });
       // create tokens
       let i = 0;
 
-      while (i < 100) {
+      while (i < 25) {
         cy.createToken(tokenDesc, 3600000, false).then((resp: Cypress.Response<any>) => {
           const tokenId = resp.body.id;
 
@@ -126,12 +130,17 @@ describe('Account and API Keys', { testIsolation: 'off' }, () => {
 
         tokenIdsList.push(tokenId);
       });
+      cy.tableRowsPerPageAndNamespaceFilter(10, 'local', 'none', '{\"local\":[]}');
     });
 
     it('pagination is visible and user is able to navigate through tokens data', () => {
-      // get tokens count
-      cy.getRancherResource('v3', 'tokens').then((resp: Cypress.Response<any>) => {
+      // check tokens count
+      const count = initialCount + 26;
+
+      cy.waitForRancherResources('v3', 'tokens', count).then((resp: Cypress.Response<any>) => {
         const count = resp.body.data.length - 1;
+
+        HomePagePo.goTo();
 
         AccountPagePo.navTo();
         accountPage.waitForPage();
@@ -147,7 +156,7 @@ describe('Account and API Keys', { testIsolation: 'off' }, () => {
 
         // check text before navigation
         accountPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`1 - 100 of ${ count } API Keys`);
+          expect(el.trim()).to.eq(`1 - 10 of ${ count } API Keys`);
         });
 
         // navigate to next page - right button
@@ -155,7 +164,7 @@ describe('Account and API Keys', { testIsolation: 'off' }, () => {
 
         // check text and buttons after navigation
         accountPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`101 - ${ count } of ${ count } API Keys`);
+          expect(el.trim()).to.eq(`11 - 20 of ${ count } API Keys`);
         });
         accountPage.sortableTable().pagination().beginningButton().isEnabled();
         accountPage.sortableTable().pagination().leftButton().isEnabled();
@@ -165,7 +174,7 @@ describe('Account and API Keys', { testIsolation: 'off' }, () => {
 
         // check text and buttons after navigation
         accountPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`1 - 100 of ${ count } API Keys`);
+          expect(el.trim()).to.eq(`1 - 10 of ${ count } API Keys`);
         });
         accountPage.sortableTable().pagination().beginningButton().isDisabled();
         accountPage.sortableTable().pagination().leftButton().isDisabled();
@@ -173,12 +182,9 @@ describe('Account and API Keys', { testIsolation: 'off' }, () => {
         // navigate to last page - end button
         accountPage.sortableTable().pagination().endButton().click();
 
-        // check row count on last page
-        accountPage.sortableTable().checkRowCount(false, count - 100);
-
         // check text after navigation
         accountPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`101 - ${ count } of ${ count } API Keys`);
+          expect(el.trim()).to.eq(`${ count - (count % 10) + 1 } - ${ count } of ${ count } API Keys`);
         });
 
         // navigate to first page - beginning button
@@ -186,7 +192,7 @@ describe('Account and API Keys', { testIsolation: 'off' }, () => {
 
         // check text and buttons after navigation
         accountPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`1 - 100 of ${ count } API Keys`);
+          expect(el.trim()).to.eq(`1 - 10 of ${ count } API Keys`);
         });
         accountPage.sortableTable().pagination().beginningButton().isDisabled();
         accountPage.sortableTable().pagination().leftButton().isDisabled();
@@ -199,7 +205,7 @@ describe('Account and API Keys', { testIsolation: 'off' }, () => {
 
       accountPage.sortableTable().checkVisible();
       accountPage.sortableTable().checkLoadingIndicatorNotVisible();
-      accountPage.sortableTable().checkRowCount(false, 100);
+      accountPage.sortableTable().checkRowCount(false, 10);
 
       // filter by access key (id)
       accountPage.sortableTable().filter(tokenIdsList[0]);
@@ -263,6 +269,8 @@ describe('Account and API Keys', { testIsolation: 'off' }, () => {
 
     after(() => {
       tokenIdsList.forEach((r) => cy.deleteRancherResource('v3', 'tokens', r, false));
+      // Ensure the default rows per page value is set after running the tests
+      cy.tableRowsPerPageAndNamespaceFilter(100, 'local', 'none', '{"local":["all://user"]}');
     });
   });
 });

--- a/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
@@ -122,21 +122,25 @@ describe('Roles Templates', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
 
       createClusterRole.waitForPage('roleContext=CLUSTER', 'grant-resources');
       createClusterRole.name().set(clusterRoleName);
-      createClusterRole.description().set('e2e-description');
+      createClusterRole.description().set('e2e-create-cluster-role');
       createClusterRole.selectCreatorDefaultRadioBtn(0);
       createClusterRole.selectLockedRadioBtn(0);
       createClusterRole.selectVerbs(0, 3);
       createClusterRole.selectVerbs(0, 4);
       createClusterRole.selectResourcesByLabelValue(0, 'ClusterRoles');
-      createClusterRole.saveAndWaitForRequests('POST', '/v3/roletemplates').then((res) => {
-        const clusterRoleId = res.response?.body.id;
 
-        // view role details
-        roles.waitForPage(undefined, fragment);
-        roles.list('CLUSTER').checkDefault(clusterRoleName, true);
-        roles.list('CLUSTER').details(clusterRoleName, 2).find('a').click();
+      const clusterRoleId = createClusterRole.saveAndWaitForRequests('POST', '/v3/roletemplates').then((res) => {
+        return res.response?.body.id;
+      });
 
-        const clusterRoleDetails = roles.detailRole(clusterRoleId);
+      // view role details
+      roles.waitForPage(undefined, fragment);
+      roles.list('CLUSTER').resourceTable().sortableTable().filter(`${ clusterRoleName }{enter}`);
+      roles.list('CLUSTER').checkDefault(clusterRoleName, true);
+      roles.list('CLUSTER').details(clusterRoleName, 2).find('a').click();
+
+      clusterRoleId.then((id) => {
+        const clusterRoleDetails = roles.detailRole(id);
 
         clusterRoleDetails.waitForPage();
         cy.contains(`Cluster - ${ clusterRoleName }`);
@@ -162,15 +166,18 @@ describe('Roles Templates', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
       createProjectRole.selectVerbs(0, 3);
       createProjectRole.selectVerbs(0, 4);
       createProjectRole.selectResourcesByLabelValue(0, 'Namespaces');
-      createProjectRole.saveAndWaitForRequests('POST', '/v3/roletemplates').then((res) => {
-        const projectRoleId = res.response?.body.id;
+      const projectRoleId = createProjectRole.saveAndWaitForRequests('POST', '/v3/roletemplates').then((res) => {
+        return res.response?.body.id;
+      });
 
-        // view role details
-        roles.waitForPage(undefined, fragment);
-        roles.list('NAMESPACE').checkDefault(projectRoleName, true);
-        roles.list('NAMESPACE').details(projectRoleName, 2).find('a').click();
+      // view role details
+      roles.waitForPage(undefined, fragment);
+      roles.list('NAMESPACE').resourceTable().sortableTable().filter(`${ projectRoleName }{enter}`);
+      roles.list('NAMESPACE').checkDefault(projectRoleName, true);
+      roles.list('NAMESPACE').details(projectRoleName, 2).find('a').click();
 
-        const projectRoleDetails = roles.detailRole(projectRoleId);
+      projectRoleId.then((id) => {
+        const projectRoleDetails = roles.detailRole(id);
 
         projectRoleDetails.waitForPage();
         cy.contains(`Project/Namespaces - ${ projectRoleName }`);
@@ -226,14 +233,19 @@ describe('Roles Templates', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
     const uniqueRoleName = 'aaa-e2e-test-name';
     const globalRolesIdsList = [];
     const rolesList = roles.list('GLOBAL');
+    const paginatedRoleTab = roles.paginatedTab('GLOBAL');
+    let initialCount: number;
 
     before('set up', () => {
       cy.login();
+      cy.getRancherResource('v1', 'management.cattle.io.globalroles').then((resp: Cypress.Response<any>) => {
+        initialCount = resp.body.count;
+      });
 
       // create global roles
       let i = 0;
 
-      while (i < 100) {
+      while (i < 25) {
         const globalRoleName = `e2e-${ Cypress._.uniqueId(Date.now().toString()) }`;
 
         cy.createGlobalRole(globalRoleName, ['events.k8s.io'], [], ['events'], ['get'], false, false).then((resp: Cypress.Response<any>) => {
@@ -251,114 +263,11 @@ describe('Roles Templates', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
 
         globalRolesIdsList.push(roleId);
       });
-    });
-
-    it('pagination is visible and user is able to navigate through global roles data', () => {
-      // get global roles count
-      cy.getRancherResource('v1', 'management.cattle.io.globalroles').then((resp: Cypress.Response<any>) => {
-        const count = resp.body.count;
-
-        usersPo.goTo(); // This is needed for the @vai only world
-        RolesPo.navTo();
-        roles.waitForPage();
-
-        // pagination is visible
-        rolesList.resourceTable().sortableTable().pagination()
-          .checkVisible();
-
-        // basic checks on navigation buttons
-        rolesList.resourceTable().sortableTable().pagination()
-          .beginningButton()
-          .isDisabled();
-        rolesList.resourceTable().sortableTable().pagination()
-          .leftButton()
-          .isDisabled();
-        rolesList.resourceTable().sortableTable().pagination()
-          .rightButton()
-          .isEnabled();
-        rolesList.resourceTable().sortableTable().pagination()
-          .endButton()
-          .isEnabled();
-
-        // check text before navigation
-        rolesList.resourceTable().sortableTable().pagination()
-          .paginationText()
-          .then((el) => {
-            expect(el.trim()).to.eq(`1 - 100 of ${ count } GlobalRoles`);
-          });
-
-        // navigate to next page - right button
-        rolesList.resourceTable().sortableTable().pagination()
-          .rightButton()
-          .click();
-
-        // check text and buttons after navigation
-        rolesList.resourceTable().sortableTable().pagination()
-          .paginationText()
-          .then((el) => {
-            expect(el.trim()).to.eq(`101 - ${ count } of ${ count } GlobalRoles`);
-          });
-        rolesList.resourceTable().sortableTable().pagination()
-          .beginningButton()
-          .isEnabled();
-        rolesList.resourceTable().sortableTable().pagination()
-          .leftButton()
-          .isEnabled();
-
-        // navigate to first page - left button
-        rolesList.resourceTable().sortableTable().pagination()
-          .leftButton()
-          .click();
-
-        // check text and buttons after navigation
-        rolesList.resourceTable().sortableTable().pagination()
-          .paginationText()
-          .then((el) => {
-            expect(el.trim()).to.eq(`1 - 100 of ${ count } GlobalRoles`);
-          });
-        rolesList.resourceTable().sortableTable().pagination()
-          .beginningButton()
-          .isDisabled();
-        rolesList.resourceTable().sortableTable().pagination()
-          .leftButton()
-          .isDisabled();
-
-        // navigate to last page - end button
-        rolesList.resourceTable().sortableTable().pagination()
-          .endButton()
-          .click();
-
-        // check row count on last page
-        rolesList.resourceTable().sortableTable().checkRowCount(false, count - 100);
-
-        // check text after navigation
-        rolesList.resourceTable().sortableTable().pagination()
-          .paginationText()
-          .then((el) => {
-            expect(el.trim()).to.eq(`101 - ${ count } of ${ count } GlobalRoles`);
-          });
-
-        // navigate to first page - beginning button
-        rolesList.resourceTable().sortableTable().pagination()
-          .beginningButton()
-          .click();
-
-        // check text and buttons after navigation
-        rolesList.resourceTable().sortableTable().pagination()
-          .paginationText()
-          .then((el) => {
-            expect(el.trim()).to.eq(`1 - 100 of ${ count } GlobalRoles`);
-          });
-        rolesList.resourceTable().sortableTable().pagination()
-          .beginningButton()
-          .isDisabled();
-        rolesList.resourceTable().sortableTable().pagination()
-          .leftButton()
-          .isDisabled();
-      });
+      cy.tableRowsPerPageAndNamespaceFilter(10, 'local', 'none', '{\"local\":[]}');
     });
 
     it('filter global roles', () => {
+      usersPo.goTo();
       RolesPo.navTo();
       roles.waitForPage();
 
@@ -383,6 +292,7 @@ describe('Roles Templates', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
     });
 
     it('sorting changes the order of paginated global roles data', () => {
+      usersPo.goTo();
       RolesPo.navTo();
       roles.waitForPage();
 
@@ -401,9 +311,7 @@ describe('Roles Templates', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
         .should('be.visible');
 
       // navigate to last page
-      rolesList.resourceTable().sortableTable().pagination()
-        .endButton()
-        .click();
+      paginatedRoleTab.endButton().click();
 
       // global role should NOT be visible on last page (sorted in ASC order)
       rolesList.resourceTable().sortableTable().rowElementWithName(uniqueRoleName)
@@ -420,14 +328,78 @@ describe('Roles Templates', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
         .should('not.exist');
 
       // navigate to last page
-      rolesList.resourceTable().sortableTable().pagination()
-        .endButton()
-        .click();
+      paginatedRoleTab.endButton().click();
 
       // global role should be visible on last page (sorted in DESC order)
       rolesList.resourceTable().sortableTable().rowElementWithName(uniqueRoleName)
         .scrollIntoView()
         .should('be.visible');
+    });
+
+    it('pagination is visible and user is able to navigate through global roles data', () => {
+      const count = initialCount + 26;
+
+      cy.waitForRancherResources('v1', 'management.cattle.io.globalroles', count).then((resp: Cypress.Response<any>) => {
+        usersPo.goTo(); // This is needed for the @vai only world
+        RolesPo.navTo();
+        roles.waitForPage();
+
+        // pagination is visible
+        paginatedRoleTab.checkVisible().scrollIntoView();
+
+        // basic checks on navigation buttons
+        paginatedRoleTab.leftButton().isDisabled();
+        paginatedRoleTab.rightButton().isEnabled();
+        paginatedRoleTab.endButton().isEnabled();
+
+        // check text before navigation
+        paginatedRoleTab.paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } GlobalRoles`);
+          });
+
+        // navigate to next page - right button
+        paginatedRoleTab.rightButton().click();
+
+        // check text and buttons after navigation
+        paginatedRoleTab.paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`11 - 20 of ${ count } GlobalRoles`);
+          });
+        paginatedRoleTab.beginningButton().isEnabled();
+        paginatedRoleTab.leftButton().isEnabled();
+
+        // navigate to first page - left button
+        paginatedRoleTab.leftButton().click();
+
+        // check text and buttons after navigation
+        paginatedRoleTab.paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } GlobalRoles`);
+          });
+        paginatedRoleTab.beginningButton().isDisabled();
+        paginatedRoleTab.leftButton().isDisabled();
+
+        // navigate to last page - end button
+        paginatedRoleTab.endButton().click();
+
+        // check text after navigation
+        paginatedRoleTab.paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`${ count - (count % 10) + 1 } - ${ count } of ${ count } GlobalRoles`);
+          });
+
+        // navigate to first page - beginning button
+        paginatedRoleTab.beginningButton().click();
+
+        // check text and buttons after navigation
+        paginatedRoleTab.paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } GlobalRoles`);
+          });
+        paginatedRoleTab.beginningButton().isDisabled();
+        paginatedRoleTab.leftButton().isDisabled();
+      });
     });
 
     it('pagination is hidden', () => {
@@ -440,12 +412,13 @@ describe('Roles Templates', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
       rolesList.resourceTable().sortableTable().checkVisible();
       rolesList.resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
       rolesList.resourceTable().sortableTable().checkRowCount(false, 2);
-      rolesList.resourceTable().sortableTable().pagination()
-        .checkNotExists();
+      paginatedRoleTab.checkNotExists();
     });
 
     after(() => {
       globalRolesIdsList.forEach((r) => cy.deleteRancherResource('v3', 'globalRoles', r, false));
+      // Ensure the default rows per page value is set after running the tests
+      cy.tableRowsPerPageAndNamespaceFilter(100, 'local', 'none', '{"local":["all://user"]}');
     });
   });
 

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -86,8 +86,11 @@ declare global {
       getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode?: number): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: any): Chainable;
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any): Chainable;
+      waitForRancherResources(prefix: 'v3' | 'v1', resourceType: string, expectedResourcesTotal: number): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1' | 'k8s', resourceType: string, resourceId: string, failOnStatusCode?: boolean): Chainable;
       deleteNodeTemplate(nodeTemplateId: string, timeout?: number)
+
+      tableRowsPerPageAndNamespaceFilter(rows: number, cluster: string, groupBy: string, namespacefilter: string)
 
       /**
        * update namespace filter

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -488,6 +488,34 @@ Cypress.Commands.add('createRancherResource', (prefix, resourceType, body) => {
     });
 });
 
+Cypress.Commands.add('waitForRancherResources', (prefix, resourceType, expectedResourcesTotal) => {
+  const url = `${ Cypress.env('api') }/${ prefix }/${ resourceType }`;
+  let retries = 20;
+
+  const retry = () => {
+    cy.request({
+      method:  'GET',
+      url,
+      headers: {
+        'x-api-csrf': token.value,
+        Accept:       'application/json'
+      },
+    })
+      .then((resp) => {
+        if (resp.body.count === expectedResourcesTotal) return resp;
+        else {
+          retries = retries - 1;
+          if (retries === 0) return resp;
+          // eslint-disable-next-line cypress/no-unnecessary-waiting
+          cy.wait(3000);
+          retry();
+        }
+      });
+  };
+
+  return retry();
+});
+
 /**
  * delete a node template
  */
@@ -863,4 +891,21 @@ Cypress.Commands.add('fetchRevision', () => {
     .then((res) => {
       return res.body.revision;
     });
+});
+
+Cypress.Commands.add('tableRowsPerPageAndNamespaceFilter', (rows: number, clusterName: string, groupBy: string, namespaceFilter: string) => {
+  return cy.getRancherResource('v3', 'users?me=true').then((resp: Cypress.Response<any>) => {
+    const userId = resp.body.data[0].id.trim();
+
+    cy.setRancherResource('v1', `userpreferences`, userId, {
+      id:   `${ userId }`,
+      type: 'userpreference',
+      data: {
+        cluster:         clusterName,
+        'per-page':      `${ rows }`,
+        'group-by':      groupBy,
+        'ns-by-cluster': namespaceFilter
+      }
+    });
+  });
 });


### PR DESCRIPTION
### Summary
Fixes https://github.com/rancher/qa-tasks/issues/1429
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Set the pagination to 10 rows per page.
Reduce the resources creation from 100 to 25 for the pagination tests.
Update the assertion logic accordingly.

### Technical notes summary
This change reduces the resources creation to speed up the pagination tests execution.

### Areas or cases that should be tested
Check the pagination tests pass the execution with the assertions updates.

### Notes

~~This doesn't include the Global Roles tests in the meantime as that page/table has an slight different layout using tabbed tables.~~ 

Found out the root cause of the issues with the Roles tests. Code is updated.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
