### PR TITLE
Fix home page cluster description scaling issue

### DIFF
--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -10,7 +10,7 @@ import { addParams } from '@shell/utils/url';
 import { isEmpty } from '@shell/utils/object';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import { isHarvesterCluster } from '@shell/utils/cluster';
-import HybridModel from '@shell/plugins/steve/hybrid-class';
+import SteveModel from '@shell/plugins/steve/steve-class';
 import { LINUX, WINDOWS } from '@shell/store/catalog';
 import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
 import { PINNED_CLUSTERS } from '@shell/store/prefs';
@@ -27,7 +27,7 @@ function findRelationship(verb, type, relationships = []) {
   return relationships.find((r) => r[from] === type)?.[id];
 }
 
-export default class MgmtCluster extends HybridModel {
+export default class MgmtCluster extends SteveModel {
   get details() {
     const out = [
       {

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -986,4 +986,8 @@ export default class ProvCluster extends SteveModel {
       'spec.rkeConfig.machinePools.dynamicSchemaSpec',
     ];
   }
+
+  get description() {
+    return super.description || this.mgmt?.description;
+  }
 }

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -91,10 +91,6 @@ export default {
     ...mapGetters(['currentCluster', 'defaultClusterId', 'releaseNotesUrl']),
     mcm: mapFeature(MULTI_CLUSTER),
 
-    mgmtClusters() {
-      return this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
-    },
-
     provClusters() {
       return this.$store.getters['management/all'](CAPI.RANCHER_CLUSTER);
     },
@@ -211,15 +207,7 @@ export default {
     },
 
     kubeClusters() {
-      const filteredClusters = filterHiddenLocalCluster(filterOnlyKubernetesClusters(this.provClusters || [], this.$store), this.$store);
-
-      return filteredClusters.map((provCluster) => {
-        const mgmtCluster = this.mgmtClusters?.find((c) => provCluster.mgmt?.id === c.id);
-
-        provCluster.description = provCluster.description || mgmtCluster?.description;
-
-        return provCluster;
-      });
+      return filterHiddenLocalCluster(filterOnlyKubernetesClusters(this.provClusters || [], this.$store), this.$store);
     }
   },
 

--- a/shell/plugins/steve/hybrid-class.js
+++ b/shell/plugins/steve/hybrid-class.js
@@ -1,4 +1,4 @@
-import { ANNOTATIONS_TO_IGNORE_REGEX, LABELS_TO_IGNORE_REGEX, DESCRIPTION } from '@shell/config/labels-annotations';
+import { ANNOTATIONS_TO_IGNORE_REGEX, LABELS_TO_IGNORE_REGEX } from '@shell/config/labels-annotations';
 import omitBy from 'lodash/omitBy';
 import pickBy from 'lodash/pickBy';
 import Vue from 'vue';

--- a/shell/plugins/steve/hybrid-class.js
+++ b/shell/plugins/steve/hybrid-class.js
@@ -100,8 +100,4 @@ export default class HybridModel extends Resource {
   get state() {
     return this.stateObj?.name || 'unknown';
   }
-
-  get description() {
-    return this.metadata?.annotations?.[DESCRIPTION] || this.spec?.description || this._description;
-  }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11588
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- mgmt cluster is a steve resource, so can inherit the steve model
  - this resolve the issue of mgmt cluster not having a description
- prv cluster uses it's own description, falls back on mgmt description
  - custom stuff on home screen not needed
  - fixes description on detail page of legacy clusters
- remove description from hybrid model
  - this contains steve references and isn't needed

### Technical notes summary
home page prov.description --> prov's description from extended steve model || mgmt's description from extended steve model

### Areas or cases that should be tested
- One of EKS/AKS/GKE cluster created in old ui AND RKE2 cluster description should display on 
  - home page cluster list
  - side nav 
  - cluster's detail page

### Screenshot/Video
![image](https://github.com/user-attachments/assets/0eaede48-e88d-494b-8821-c42c1f5fbc7e)

![image](https://github.com/user-attachments/assets/09e73b74-e9c4-4641-9efa-1a7e96ce49b9)

![image](https://github.com/user-attachments/assets/51d5e0f0-21e5-4e1d-883b-2e0f80833964)

![image](https://github.com/user-attachments/assets/94c8ed25-07b8-4140-9d01-ca6dc6d05d97)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
  - Automated tests have been written for description in
    - https://github.com/rancher/dashboard/pull/10487/files
    - https://github.com/rancher/dashboard/pull/10782/files
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
