### PR TITLE
Fix rke1-ui feature flag test

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -47,40 +47,43 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
   });
 
   // testing https://github.com/rancher/dashboard/issues/9823
-  it('Toggling the user preference "rke1-ui" to false should not display RKE toggle on cluster creation screen and hide RKE1 resources from nav', () => {
-    cy.intercept('GET', 'v1/management.cattle.io.features?*', {
-      type:         'collection',
-      resourceType: 'management.cattle.io.feature',
-      data:         [
-        {
-          id:     'rke1-ui',
-          type:   'management.cattle.io.feature',
-          kind:   'Feature',
-          spec:   { value: false },
-          status: {
-            default:     true,
-            description: 'Disable RKE1 provisioning',
-            dynamic:     false,
-            lockedValue: false
+  it('Toggling the feature flag "rke1-ui" to false should not display RKE toggle on cluster creation screen and hide RKE1 resources from nav', () => {
+    cy.fetchRevision().then((revision) => {
+      cy.intercept('GET', 'v1/management.cattle.io.features?*', {
+        type:         'collection',
+        resourceType: 'management.cattle.io.feature',
+        revision,
+        data:         [
+          {
+            id:     'rke1-ui',
+            type:   'management.cattle.io.feature',
+            kind:   'Feature',
+            spec:   { value: false },
+            status: {
+              default:     true,
+              description: 'Disable RKE1 provisioning',
+              dynamic:     false,
+              lockedValue: false
+            }
           }
-        }
-      ]
-    }).as('featuresGet');
+        ]
+      }).as('featuresGet');
 
-    const clusterCreate = new ClusterManagerCreatePagePo();
+      const clusterCreate = new ClusterManagerCreatePagePo();
 
-    clusterCreate.goTo();
-    clusterCreate.waitForPage();
+      clusterCreate.goTo();
+      clusterCreate.waitForPage();
 
-    // seems like the waitForPage does await for full DOM render, so let's wait for a simple assertion
-    // like "gridElementExists" to make sure we aren't creating a fake assertion with the toggle
-    clusterCreate.gridElementExistanceByName('Linode', 'exist');
-    clusterCreate.rkeToggleExistance('not.exist');
+      // seems like the waitForPage does await for full DOM render, so let's wait for a simple assertion
+      // like "gridElementExists" to make sure we aren't creating a fake assertion with the toggle
+      clusterCreate.gridElementExistanceByName('Linode', 'exist');
+      clusterCreate.rkeToggleExistance('not.exist');
 
-    const sideNav = new ProductNavPo();
+      const sideNav = new ProductNavPo();
 
-    // check that the nav group isn't visible anymore
-    sideNav.navToSideMenuGroupByLabelExistence('RKE1 Configuration', 'not.exist');
+      // check that the nav group isn't visible anymore
+      sideNav.navToSideMenuGroupByLabelExistence('RKE1 Configuration', 'not.exist');
+    });
   });
 
   describe('All providers', () => {

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -145,6 +145,11 @@ declare global {
 
       // Check css var
       shouldHaveCssVar(name: string, value: string);
+
+      /**
+       * Fetch the steve `revision` / timestamp of request
+       */
+      fetchRevision(): Chainable<string>;
     }
   }
 }

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -854,3 +854,13 @@ Cypress.Commands.add('createFleetWorkspace', (name: string, description?: string
       }
     });
 });
+
+/**
+ * Fetch the steve `revision` / timestamp of request
+ */
+Cypress.Commands.add('fetchRevision', () => {
+  return cy.getRancherResource('v1', 'management.cattle.io.settings', undefined, 200)
+    .then((res) => {
+      return res.body.revision;
+    });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Issue
- Request counted on a specific value of a specific feature flag
- This was supplied by intercepting the request for all FFs and returning the desired one
- However the FF response supplied missed the `revision`
- The `revision` is used to watch for changes to the resource from a given point in history
- If no revision is supplied rancher will return the current value
- In the FF world this meant the intercepted response was overwritten by the actual value

Solution
- Fetch the rancher specific revision up front and then add to the intercept

I am slightly intrigued why this now fails more / repeatidly. It could be a timing thing (test completed before the socket message containing the real value was processed, or gh runner now is more performant), update thing (nuxt et al changes could mean the socket message containing real value processed earlier), etc



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
