### PR TITLE
EKS - validate that at least one node group is defined

### DIFF
--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -63,7 +63,7 @@ export const DEFAULT_NODE_GROUP_CONFIG = {
   _isNew:               true,
 };
 
-const DEFAULT_EKS_CONFIG = {
+export const DEFAULT_EKS_CONFIG = {
   publicAccess:        true,
   privateAccess:       false,
   publicAccessSources: [],

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -206,6 +206,10 @@ export default defineComponent({
         path:  'minMaxDesired',
         rules: ['minMaxDesired', 'minLessThanMax']
       },
+      {
+        path:  'nodeGroupsRequired',
+        rules: ['nodeGroupsRequired']
+      }
       ],
 
       loadingInstanceTypes:   false,
@@ -273,8 +277,10 @@ export default defineComponent({
     ...mapGetters({ t: 'i18n/t' }),
 
     fvExtraRules(): {[key:string]: Function} {
+      let out: any = {};
+
       if (this.hasCredential) {
-        return {
+        out = {
           nameRequired:           EKSValidators.clusterNameRequired(this),
           nodeGroupNamesRequired: EKSValidators.nodeGroupNamesRequired(this),
           nodeGroupNamesUnique:   EKSValidators.nodeGroupNamesUnique(this),
@@ -288,9 +294,12 @@ export default defineComponent({
           minMaxDesired:          EKSValidators.minMaxDesired(this),
           minLessThanMax:         EKSValidators.minLessThanMax(this),
         };
+        if (!this.config?.imported) {
+          out.nodeGroupsRequired = EKSValidators.nodeGroupsRequired(this);
+        }
       }
 
-      return {};
+      return out;
     },
 
     // upstreamSpec will be null if the user created a cluster with some invalid options such that it ultimately fails to create anything in aks

--- a/pkg/eks/l10n/en-us.yaml
+++ b/pkg/eks/l10n/en-us.yaml
@@ -36,6 +36,7 @@ eks:
     publicOrPrivate: At least one of public or private access must be enabled.
     minMaxDesired: The node group desired size may not be less than the minimum size nor greater than the maximum size.
     minLessThanMax: The node group minimum size may not be greater than the maximum size.
+    nodeGroupsRequired: Clusters must have at least one node group.
   label: Amazon EKS
   nodeGroups:
     desiredSize:

--- a/pkg/eks/util/validators.ts
+++ b/pkg/eks/util/validators.ts
@@ -161,6 +161,14 @@ const minLessThanMax = (ctx: CruEKSContext) => {
   };
 };
 
+const nodeGroupsRequired = (ctx: CruEKSContext) => {
+  return (): string | undefined => {
+    const nodeGroups = ctx.nodeGroups || [];
+
+    return !nodeGroups.length ? ctx.t('eks.errors.nodeGroupsRequired') : undefined;
+  };
+};
+
 export default {
   clusterNameRequired,
   nodeGroupNamesRequired,
@@ -173,5 +181,6 @@ export default {
   subnets,
   publicPrivateAccess,
   minMaxDesired,
-  minLessThanMax
+  minLessThanMax,
+  nodeGroupsRequired
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11570 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This issue adds form validation to prevent users from saving EKS clusters with no node groups defined. This validation is not applied to imported EKS clusters because they may not require managed node groups.

### Areas or cases that should be tested
* when editing EKS clusters provisioned through Rancher, users shouldn't be able to save clusters with no node groups
* users should still be able to save clusters with no node groups if the clusters are imported



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
