### PR TITLE
Adjust Rancher Backups default encryption setting value

### DIFF
--- a/shell/edit/resources.cattle.io.backup.vue
+++ b/shell/edit/resources.cattle.io.backup.vue
@@ -88,7 +88,7 @@ export default {
       this.value['spec'] = { retentionCount: 10 };
     }
     let s3 = {};
-    let useEncryption = false;
+    let useEncryption = true;
     let setSchedule = false;
     let storageSource = 'useDefault';
 

--- a/shell/edit/resources.cattle.io.backup.vue
+++ b/shell/edit/resources.cattle.io.backup.vue
@@ -13,7 +13,7 @@ import S3 from '@shell/chart/rancher-backup/S3';
 import { mapGetters } from 'vuex';
 import { SECRET, BACKUP_RESTORE, CATALOG } from '@shell/config/types';
 import { allHash } from '@shell/utils/promise';
-import { NAMESPACE, _VIEW } from '@shell/config/query-params';
+import { NAMESPACE, _VIEW, _CREATE } from '@shell/config/query-params';
 import { sortBy } from '@shell/utils/sort';
 import { get } from '@shell/utils/object';
 import { formatEncryptionSecretNames } from '@shell/utils/formatter';
@@ -88,7 +88,7 @@ export default {
       this.value['spec'] = { retentionCount: 10 };
     }
     let s3 = {};
-    let useEncryption = true;
+    let useEncryption = this.mode === _CREATE;
     let setSchedule = false;
     let storageSource = 'useDefault';
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/backup-restore-operator/issues/554

This change seeks to make the default form value match the one we cite as recommended on the page.
Because Rancher Backups may contain secrets this visual nudge towards encryption reinforces our recommendation.
Many users may be hosting their own S3 they feel is secure enough and can easily opt-out still.

### Occurred changes and/or fixed issues
The larger concept here is that our defaults currently opt for ease of use over security.
This minor change aligns more with best-practice will only adding a very small friction for users opting out of higher security via encryption.

### Technical notes summary
Any GUI tests that expect `useEncryption` to be false by default will see a different default option.

### Areas or cases that should be tested
Unless already covered by tests, I'm not sure if changing the default needs to be covered by testing.
This isn't seeking to make any functional changes just how we present the default empty form in the UI.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
I don't believe this is applicable.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
