### PR TITLE
Show Unsupported Azure warning message only if Azure is an option

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -337,10 +337,11 @@ describe('component: rke2', () => {
   });
 
   it.each([
-    ['v1.25.0+k3s1', 'azure', true],
-    ['v1.31.0+k3s1', 'harvester', true],
-    ['v1.29.0+k3s1', 'harvester', false],
-  ])('should set isAzureProviderUnsupported', (k8s, cloudProvider, value) => {
+    ['v1.25.0+k3s1', [{ value: 'aws' }, { value: 'azure' }], 'azure', true],
+    ['v1.31.0+k3s1', [{ value: 'aws' }, { value: 'azure' }], 'harvester', true],
+    ['v1.29.0+k3s1', [{ value: 'aws' }, { value: 'azure' }], 'harvester', false],
+    ['v1.31.0+k3s1', [{ value: 'aws' }], 'azure', false],
+  ])('should set isAzureProviderUnsupported', (k8s, providerOptions, cloudProvider, value) => {
     const wrapper = mount(rke2, {
       propsData: {
         mode:  _CREATE,
@@ -353,7 +354,13 @@ describe('component: rke2', () => {
         },
         provider: 'custom'
       },
-      data:   () => ({}),
+      data:     () => ({}),
+      computed: {
+        ...rke2.computed,
+        cloudProviderOptions() {
+          return providerOptions;
+        },
+      },
       global: {
         mocks: {
           ...defaultMocks,
@@ -364,7 +371,7 @@ describe('component: rke2', () => {
       }
     });
 
-    expect((wrapper.vm as any).isAzureProviderUnsupported).toBe(value);
+    expect(wrapper.vm.isAzureProviderUnsupported).toBe(value);
   });
 
   it.each([

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -652,7 +652,10 @@ export default {
     },
 
     isAzureProviderUnsupported() {
-      return isAzureK8sUnsupported(this.value.spec.kubernetesVersion) || this.agentConfig['cloud-provider-name'] === 'azure';
+      const isAzureAvailable = !!this.cloudProviderOptions.find((p) => p.value === 'azure');
+      const isAzureSelected = this.agentConfig['cloud-provider-name'] === 'azure';
+
+      return isAzureAvailable && (isAzureK8sUnsupported(this.value.spec.kubernetesVersion) || isAzureSelected);
     },
 
     canAzureMigrateOnEdit() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Contributes to https://github.com/rancher/dashboard/issues/11360
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

The Unsupported Azure warning banner is showing up for all providers https://github.com/rancher/dashboard/issues/11360#issuecomment-2274228896

We are limiting the warning message to show up only if Azure is included in the cloud providers option.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
