### PR TITLE
Change from api.neuvector.com to permission.neuvector.com api group a…

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4729,8 +4729,7 @@ rbac:
         noApiGroupClusterScope: Core K8s API, Cluster Scoped
         noApiGroupNamespaceScope: Core K8s API, Namespaced
         neuvector:
-          labelClusterScoped: NeuVector, Cluster Scoped
-          labelNamespaceScoped: NeuVector, Namespaced
+          labelClusterScoped: NeuVector Permission
         deprecatedLabel: (deprecated)
         resourceOptionInfo: The resource options are not a complete list of every resource available in every Rancher-managed Kubernetes cluster. Resources and API groups may need to be manually entered in advanced use cases.
         tableHeaders:

--- a/shell/components/auth/RoleDetailEdit.vue
+++ b/shell/components/auth/RoleDetailEdit.vue
@@ -232,12 +232,11 @@ export default {
           }
 
           if (apiGroup === 'neuvectorApi') {
-            // Some NeuVector resources are namespaced, in which case they go under a different heading
+            // NeuVector Permission CRD resources are cluster scoped
             const labelForClusterScoped = this.t('rbac.roletemplate.tabs.grantResources.neuvector.labelClusterScoped');
-            const labelForNamespaceScoped = this.t('rbac.roletemplate.tabs.grantResources.neuvector.labelNamespaceScoped');
 
-            apiGroupLabel = scope.includes('cluster') ? labelForClusterScoped : labelForNamespaceScoped;
-            apiGroupValue = 'api.neuvector.com';
+            apiGroupLabel = labelForClusterScoped;
+            apiGroupValue = 'permission.neuvector.com';
           }
 
           options.push({

--- a/shell/config/roles.ts
+++ b/shell/config/roles.ts
@@ -130,6 +130,25 @@ export const SCOPED_RESOURCES = {
       resources: [
         'Clusters'
       ]
+    },
+    neuvectorApi: {
+      resources: [
+        'AdmissionControl',
+        'AuditEvents',
+        'Authentication',
+        'Authorization',
+        'CIScan',
+        'Cluster',
+        'Compliance',
+        'Events',
+        'Federation',
+        'RegistryScan',
+        'RuntimePolicy',
+        'RuntimeScan',
+        'SecurityEvents',
+        'SystemConfig',
+        'Vulnerability',
+      ]
     }
   },
   clusterScopedApiGroups: {
@@ -201,11 +220,21 @@ export const SCOPED_RESOURCES = {
     },
     neuvectorApi: {
       resources: [
-        'nv-perm.admctrl',
-        'nv-perm.authentication',
-        'nv-perm.ci-scan',
-        'nv-perm.fed',
-        'nv-perm.vulnerability'
+        'AdmissionControl',
+        'AuditEvents',
+        'Authentication',
+        'Authorization',
+        'CIScan',
+        'Cluster',
+        'Compliance',
+        'Events',
+        'Federation',
+        'RegistryScan',
+        'RuntimePolicy',
+        'RuntimeScan',
+        'SecurityEvents',
+        'SystemConfig',
+        'Vulnerability',
       ]
     }
   },
@@ -378,16 +407,16 @@ export const SCOPED_RESOURCES = {
     },
     neuvectorApi: {
       resources: [
-        'nv-perm.all-permissions',
-        'nv-perm.audit-events',
-        'nv-perm.authorization',
-        'nv-perm.compliance',
-        'nv-perm.events',
-        'nv-perm.reg-scan',
-        'nv-perm.rt-policy',
-        'nv-perm.rt-scan',
-        'nv-perm.security-events',
-        'nv-perm.config',
+        'AuditEvents',
+        'Authorization',
+        'Compliance',
+        'Events',
+        'Namespace',
+        'RegistryScan',
+        'RuntimePolicy',
+        'RuntimeScan',
+        'SecurityEvents',
+        'SystemConfig',
       ]
     }
   }


### PR DESCRIPTION
…nd leverage CRD, not CR, for NeuVector-realted resource in role creation
(backport from https://github.com/rancher/dashboard/pull/11527)

The 1st NeuVector/Rancher SSO design uses a CR for each NeuVector permission.
It causes Rancher UI to display the raw nv-perm.xyz strings in the resource drop-down menu of Role creation pages:
(see https://github.com/rancher/dashboard/pull/11184)

nv-perm.all-permissions
nv-perm.admctrl
nv-perm.audit-events
nv-perm.authentication
nv-perm.authorization
nv-perm.ci-scan
nv-perm.compliance
nv-perm.events
nv-perm.fed
nv-perm.reg-scan
nv-perm.rt-policy
nv-perm.rt-scan
nv-perm.security-events
nv-perm.config
nv-perm.vulnerability

This PR is to change NeuVector apiGroup from api.neuvector.com to permission.neuvector.com and leverage one CRD per NeuVector permission:

> kubectl api-resources | grep permission.neuvector.com
admissioncontrol                                 permission.neuvector.com/v1            false        AdmissionControl
auditevents                                      permission.neuvector.com/v1            false        AuditEvents
authentication                                   permission.neuvector.com/v1            false        Authentication
authorization                                    permission.neuvector.com/v1            false        Authorization
ciscan                                           permission.neuvector.com/v1            false        CIScan
cluster                                          permission.neuvector.com/v1            false        Cluster
compliance                                       permission.neuvector.com/v1            false        Compliance
events                                           permission.neuvector.com/v1            false        Events
federation                                       permission.neuvector.com/v1            false        Federation
namespace                                        permission.neuvector.com/v1            false        Namespace
registryscan                                     permission.neuvector.com/v1            false        RegistryScan
runtimepolicy                                    permission.neuvector.com/v1            false        RuntimePolicy
runtimescan                                      permission.neuvector.com/v1            false        RuntimeScan
securityevents                                   permission.neuvector.com/v1            false        SecurityEvents
systemconfig                                     permission.neuvector.com/v1            false        SystemConfig
vulnerability                                    permission.neuvector.com/v1            false        Vulnerability
