### PR TITLE
Restore Nuxt global variable for Harvester compatibility

### DIFF
--- a/shell/initialize/App.vue
+++ b/shell/initialize/App.vue
@@ -15,6 +15,19 @@ export default {
     // add to window so we can listen when ready
     window.$globalApp = this;
 
+    // This is needed for Harvester https://github.com/rancher/dashboard/issues/10681
+    const isHarvester = this.$globalApp?.$store.getters['currentCluster']?.isHarvester;
+
+    if (!isHarvester) {
+      Object.defineProperty(window, '$nuxt', {
+        get() {
+          console.warn('window.$nuxt is deprecated. It would be best to stop using globalState all together. For an alternative you can use window.$globalApp.'); // eslint-disable-line no-console
+
+          return window.$globalApp;
+        }
+      });
+    }
+
     this.refreshOnlineStatus();
     // Setup the listeners
     window.addEventListener('online', this.refreshOnlineStatus);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11617

Issue can be reviewed with dev release https://github.com/rancher/dashboard/tree/nuxt-removal-dev
It contains the same picked commit.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
