### PR TITLE
automation: split explorer tests into two buckets

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,6 +76,7 @@ jobs:
           ['@navigation', '@extensions'],
           ['@charts'],
           ['@explorer'],
+          ['@explorer2'],
           ['@fleet'],
           ['@generic', '@globalSettings'],
           ['@manager'],

--- a/cypress/e2e/tests/pages/explorer/more-resources/api/custom-resource-definitions.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/more-resources/api/custom-resource-definitions.spec.ts
@@ -100,9 +100,16 @@ describe('CustomResourceDefinitions', { testIsolation: 'off', tags: ['@explorer'
         // navigate to last page - end button
         crdsPage.sortableTable().pagination().endButton().click();
 
+        // row count on last page
+        let lastPageCount = count % 10;
+
+        if (lastPageCount === 0) {
+          lastPageCount = 10;
+        }
+
         // check text after navigation
         crdsPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.contain(`${ count - (count % 10) + 1 } - ${ count } of ${ count } CustomResourceDefinitions`);
+          expect(el.trim()).to.contain(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } CustomResourceDefinitions`);
         });
 
         // navigate to first page - beginning button

--- a/cypress/e2e/tests/pages/explorer2/cluster-project-members.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/cluster-project-members.spec.ts
@@ -7,7 +7,7 @@ const runPrefix = `e2e-test-${ runTimestamp }`;
 const username = `${ runPrefix }-cluster-proj-member`;
 const standardPassword = 'standard-password';
 
-describe.skip('[Vue3 Skip]: Cluster Project and Members', { tags: ['@explorer', '@adminUser'] }, () => {
+describe.skip('[Vue3 Skip]: Cluster Project and Members', { tags: ['@explorer2', '@adminUser'] }, () => {
   it('Members added to both Cluster Membership should not show "Loading..." next to their names', () => {
     const usersAdmin = new UsersPo('_');
     const userCreate = usersAdmin.createEdit();

--- a/cypress/e2e/tests/pages/explorer2/cluster-tools.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/cluster-tools.spec.ts
@@ -5,7 +5,7 @@ import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 
 const clusterTools = new ClusterToolsPagePo('local');
 
-describe('Cluster Tools', { tags: ['@explorer', '@adminUser'] }, () => {
+describe('Cluster Tools', { tags: ['@explorer2', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer2/index.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/index.spec.ts
@@ -1,6 +1,6 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 
-describe('Explorer Index', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, () => {
+describe('Explorer Index', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
   before(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer2/namespace-picker.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/namespace-picker.spec.ts
@@ -21,7 +21,7 @@ describe('Namespace picker', { testIsolation: 'off' }, () => {
     namespacePicker.closeDropdown();
   });
 
-  it('can filter workloads by project/namespace from the picker dropdown', { tags: ['@explorer', '@adminUser'] }, () => {
+  it('can filter workloads by project/namespace from the picker dropdown', { tags: ['@explorer2', '@adminUser'] }, () => {
     // Verify 'Namespace: cattle-fleet-system' appears once when filtering by Namespace
     // Verify multiple namespaces within Project: System display when filtering by Project
 
@@ -61,7 +61,7 @@ describe('Namespace picker', { testIsolation: 'off' }, () => {
     workloadsPodPage.sortableTable().groupElementWithName('cattle-fleet-system').scrollIntoView().should('be.visible');
   });
 
-  it('can select only one of the top 5 resource filters at a time', { tags: ['@explorer', '@adminUser', '@standardUser'] }, () => {
+  it('can select only one of the top 5 resource filters at a time', { tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {
     // Verify that user can only select one of the first 5 options
 
     namespacePicker.toggle();
@@ -92,7 +92,7 @@ describe('Namespace picker', { testIsolation: 'off' }, () => {
     namespacePicker.checkIcon().should('have.length', 1);
   });
 
-  it('can select multiple projects/namespaces', { tags: ['@explorer', '@adminUser'] }, () => {
+  it('can select multiple projects/namespaces', { tags: ['@explorer2', '@adminUser'] }, () => {
     // Verify that user can select multiple options (other than the first 5 options)
 
     namespacePicker.toggle();
@@ -126,7 +126,7 @@ describe('Namespace picker', { testIsolation: 'off' }, () => {
     namespacePicker.moreOptionsSelected().should('have.class', 'v-popper--has-tooltip');
   });
 
-  it('can deselect options', { tags: ['@explorer', '@adminUser', '@standardUser'] }, () => {
+  it('can deselect options', { tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {
     namespacePicker.toggle();
 
     // Select 'default' option
@@ -153,7 +153,7 @@ describe('Namespace picker', { testIsolation: 'off' }, () => {
     namespacePicker.checkIcon().should('have.length', 1);
   });
 
-  it('can filter options by name', { tags: ['@explorer', '@adminUser', '@standardUser'] }, () => {
+  it('can filter options by name', { tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {
     namespacePicker.toggle();
 
     // filter 'cattle-fleet'
@@ -174,7 +174,7 @@ describe('Namespace picker', { testIsolation: 'off' }, () => {
     namespacePicker.checkIcon().should('have.length', 1);
   });
 
-  it('newly created project/namespace appears in namespace picker', { tags: ['@explorer', '@adminUser'] }, () => {
+  it('newly created project/namespace appears in namespace picker', { tags: ['@explorer2', '@adminUser'] }, () => {
     const projName = `project${ +new Date() }`;
     const nsName = `namespace${ +new Date() }`;
 

--- a/cypress/e2e/tests/pages/explorer2/node-list.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/node-list.spec.ts
@@ -4,7 +4,7 @@ import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dash
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 
-describe('Nodes list', { tags: ['@explorer', '@adminUser'], testIsolation: 'off' }, () => {
+describe('Nodes list', { tags: ['@explorer2', '@adminUser'], testIsolation: 'off' }, () => {
   before(() => {
     cy.login();
     HomePagePo.goTo();

--- a/cypress/e2e/tests/pages/explorer2/project-namespace.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/project-namespace.spec.ts
@@ -1,6 +1,6 @@
 import ProjectsNamespacesPagePo from '@/cypress/e2e/po/pages/explorer/projects-namespaces.po';
 
-describe('Projects/Namespaces', { tags: ['@explorer', '@adminUser'] }, () => {
+describe('Projects/Namespaces', { tags: ['@explorer2', '@adminUser'] }, () => {
   const projectsNamespacesPage = new ProjectsNamespacesPagePo('local');
 
   beforeEach(() => {

--- a/cypress/e2e/tests/pages/explorer2/resource-search.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/resource-search.spec.ts
@@ -6,7 +6,7 @@ import { ConfigMapPagePo } from '@/cypress/e2e/po/pages/explorer/config-map.po';
 
 const clusterDashboard = new ClusterDashboardPagePo('local');
 
-describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@adminUser', '@standardUser'] }, () => {
+describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {
   before(() => {
     cy.login();
     HomePagePo.goTo();

--- a/cypress/e2e/tests/pages/explorer2/storage/configmap.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/configmap.spec.ts
@@ -3,7 +3,7 @@ import ConfigMapPo from '@/cypress/e2e/po/components/storage/config-map.po';
 
 const configMapPage = new ConfigMapPagePo('local');
 
-describe.skip('[Vue3 Skip]: ConfigMap', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, () => {
+describe.skip('[Vue3 Skip]: ConfigMap', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer2/storage/persistent-volume-claims.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/persistent-volume-claims.spec.ts
@@ -3,7 +3,7 @@ import { PersistentVolumeClaimsPagePo } from '@/cypress/e2e/po/pages/explorer/pe
 
 const persistentVolumeClaimsPage = new PersistentVolumeClaimsPagePo();
 
-describe('PersistentVolumeClaims', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, () => {
+describe('PersistentVolumeClaims', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
   before(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer2/storage/persistent-volumes.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/persistent-volumes.spec.ts
@@ -3,7 +3,7 @@ import { generatePersistentVolumesDataSmall, persistentVolumesNoData } from '@/c
 
 const persistentVolumesPagePo = new PersistentVolumesPagePo();
 
-describe('PersistentVolumes', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, () => {
+describe('PersistentVolumes', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
   before(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer2/storage/storage-classes.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/storage-classes.spec.ts
@@ -3,7 +3,7 @@ import { StorageClassesPagePo } from '@/cypress/e2e/po/pages/explorer/storage-cl
 
 const storageClassesPagePo = new StorageClassesPagePo();
 
-describe('StorageClasses', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, () => {
+describe('StorageClasses', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
   before(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer2/workloads/daemonsets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/daemonsets.spec.ts
@@ -1,6 +1,6 @@
 import { WorkloadsDaemonsetsListPagePo, WorkLoadsDaemonsetsEditPagePo } from '@/cypress/e2e/po/pages/explorer/workloads-daemonsets.po';
 
-describe('Cluster Explorer', { tags: ['@explorer', '@adminUser'] }, () => {
+describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -6,7 +6,7 @@ describe('Cluster Explorer', () => {
     cy.login();
   });
 
-  describe('Workloads', { tags: ['@explorer', '@standardUser', '@adminUser', '@flaky'] }, () => {
+  describe('Workloads', { tags: ['@explorer2', '@standardUser', '@adminUser', '@flaky'] }, () => {
     let deploymentsListPage: WorkloadsDeploymentsListPagePo;
     let deploymentsCreatePage: WorkloadsDeploymentsCreatePagePo;
 

--- a/cypress/e2e/tests/pages/explorer2/workloads/jobs.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/jobs.spec.ts
@@ -1,6 +1,6 @@
 import { WorkloadsJobsListPagePo, WorkLoadsJobDetailsPagePo } from '@/cypress/e2e/po/pages/explorer/workloads-jobs.po';
 
-describe('Cluster Explorer', { tags: ['@explorer', '@adminUser'] }, () => {
+describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer2/workloads/pods.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/pods.spec.ts
@@ -5,7 +5,7 @@ import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import { generatePodsDataSmall } from '@/cypress/e2e/blueprints/explorer/workloads/pods/pods-get';
 
-describe('Pods', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, () => {
+describe('Pods', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
   const workloadsPodPage = new WorkloadsPodsListPagePo('local');
 
   before(() => {
@@ -100,9 +100,16 @@ describe('Pods', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, ()
         // navigate to last page - end button
         workloadsPodPage.sortableTable().pagination().endButton().click();
 
+        // row count on last page
+        let lastPageCount = count % 10;
+
+        if (lastPageCount === 0) {
+          lastPageCount = 10;
+        }
+
         // check text after navigation
         workloadsPodPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`${ count - (count % 10) + 1 } - ${ count } of ${ count } Pods`);
+          expect(el.trim()).to.eq(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } Pods`);
         });
 
         // navigate to first page - beginning button

--- a/cypress/e2e/tests/pages/explorer2/workloads/workloads.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/workloads.spec.ts
@@ -5,7 +5,7 @@ import WorkloadPagePo from '@/cypress/e2e/po/pages/explorer/workloads.po';
 
 const podName = 'some-pod-name';
 
-describe('Workloads', { tags: ['@explorer', '@adminUser'] }, () => {
+describe('Workloads', { tags: ['@explorer2', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/user-menu/account-api-keys.spec.ts
+++ b/cypress/e2e/tests/pages/user-menu/account-api-keys.spec.ts
@@ -182,9 +182,16 @@ describe('Account and API Keys', { testIsolation: 'off' }, () => {
         // navigate to last page - end button
         accountPage.sortableTable().pagination().endButton().click();
 
+        // row count on last page
+        let lastPageCount = count % 10;
+
+        if (lastPageCount === 0) {
+          lastPageCount = 10;
+        }
+
         // check text after navigation
         accountPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`${ count - (count % 10) + 1 } - ${ count } of ${ count } API Keys`);
+          expect(el.trim()).to.eq(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } API Keys`);
         });
 
         // navigate to first page - beginning button

--- a/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
@@ -383,10 +383,17 @@ describe('Roles Templates', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
         // navigate to last page - end button
         paginatedRoleTab.endButton().click();
 
+        // row count on last page
+        let lastPageCount = count % 10;
+
+        if (lastPageCount === 0) {
+          lastPageCount = 10;
+        }
+
         // check text after navigation
         paginatedRoleTab.paginationText()
           .then((el) => {
-            expect(el.trim()).to.eq(`${ count - (count % 10) + 1 } - ${ count } of ${ count } GlobalRoles`);
+            expect(el.trim()).to.eq(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } GlobalRoles`);
           });
 
         // navigate to first page - beginning button

--- a/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
@@ -374,11 +374,18 @@ describe('Users', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
           .endButton()
           .click();
 
+        // row count on last page
+        let lastPageCount = count % 10;
+
+        if (lastPageCount === 0) {
+          lastPageCount = 10;
+        }
+
         // check text after navigation
         usersPo.list().resourceTable().sortableTable().pagination()
           .paginationText()
           .then((el) => {
-            expect(el.trim()).to.eq(`${ count - (count % 10) + 1 } - ${ count } of ${ count } Users`);
+            expect(el.trim()).to.eq(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } Users`);
           });
 
         // navigate to first page - beginning button

--- a/cypress/e2e/tests/setup/rancher-setup.spec.ts
+++ b/cypress/e2e/tests/setup/rancher-setup.spec.ts
@@ -6,7 +6,7 @@ import { serverUrlLocalhostCases, urlWithTrailingForwardSlash, httpUrl, nonUrlCa
 
 // Cypress or the GrepTags avoid to run multiples times the same test for each tag used.
 // This is a temporary solution till initialization is not handled as a test
-describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@setup', '@components', '@navigation', '@charts', '@explorer', '@extensions', '@fleet', '@generic', '@globalSettings', '@manager', '@userMenu', '@usersAndAuths', '@elemental', '@vai'] }, () => {
+describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@setup', '@components', '@navigation', '@charts', '@explorer', '@explorer2', '@extensions', '@fleet', '@generic', '@globalSettings', '@manager', '@userMenu', '@usersAndAuths', '@elemental', '@vai'] }, () => {
   const rancherSetupLoginPage = new RancherSetupLoginPagePo();
   const rancherSetupConfigurePage = new RancherSetupConfigurePage();
   const homePage = new HomePagePo();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1423

Currently, the explorer test run for admin takes 27 minutes to complete so we need to split explorer tests into two buckets for efficiency (based on PR review https://github.com/rancher/dashboard/pull/11374#pullrequestreview-2171608065)
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
