### PR TITLE
AKS - fix default pool name

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -926,7 +926,7 @@ export default defineComponent({
       const _id = randomStr();
 
       if (!this.nodePools.length) {
-        poolName = 'agentPool';
+        poolName = 'agentpool';
         // there must be at least one System pool so if it's the first pool, default to that
         mode = 'System' as AKSPoolMode;
       }

--- a/pkg/aks/components/__tests__/CruAks.test.ts
+++ b/pkg/aks/components/__tests__/CruAks.test.ts
@@ -3,9 +3,10 @@ import flushPromises from 'flush-promises';
 import { shallowMount, Wrapper } from '@vue/test-utils';
 import CruAks from '@pkg/aks/components/CruAks.vue';
 // eslint-disable-next-line jest/no-mocks-import
-import { mockRegions, mockVersionsSorted } from '@pkg/aks/util/__mocks__/aks';
+import { mockRegions, mockVersionsSorted } from '../../util/__mocks__/aks';
 import { AKSNodePool } from 'types';
 import { _EDIT, _CREATE } from '@shell/config/query-params';
+import { nodePoolNames } from '../../util/validators';
 
 const mockedValidationMixin = {
   computed: {
@@ -475,5 +476,22 @@ describe('aks provisioning form', () => {
     expect(wrapper.vm.$data.config.monitoring).toBeFalsy();
     expect(wrapper.vm.$data.config.logAnalyticsWorkspaceGroup).toBeNull();
     expect(wrapper.vm.$data.config.logAnalyticsWorkspaceName).toBeNull();
+  });
+
+  it('should use a valid value for the default pool name', async() => {
+    const wrapper = shallowMount(CruAks, {
+      propsData: { value: {}, mode: _CREATE },
+      ...requiredSetup()
+    });
+
+    await setCredential(wrapper);
+
+    wrapper.vm.addPool();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.nodePools).toHaveLength(1);
+    const nodeName = wrapper.vm.nodePools[0].name;
+
+    expect(nodePoolNames({ t: (str:string) => str })(nodeName)).toBeUndefined();
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11634 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR fixes the default name value used when an AKS node pool is added to a cluster with no pools.


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
