### PR TITLE
Fix duplicate group and options when creating global, cluster and project/namespace roles

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4735,7 +4735,8 @@ rbac:
         noApiGroupClusterScope: Core K8s API, Cluster Scoped
         noApiGroupNamespaceScope: Core K8s API, Namespaced
         neuvector:
-          labelClusterScoped: NeuVector Permission
+          labelClusterScoped: NeuVector, Cluster Scoped
+          labelNamespaceScoped: NeuVector, Namespaced
         deprecatedLabel: (deprecated)
         resourceOptionInfo: The resource options are not a complete list of every resource available in every Rancher-managed Kubernetes cluster. Resources and API groups may need to be manually entered in advanced use cases.
         tableHeaders:

--- a/shell/components/auth/RoleDetailEdit.vue
+++ b/shell/components/auth/RoleDetailEdit.vue
@@ -14,7 +14,7 @@ import Tabbed from '@shell/components/Tabbed';
 import { ucFirst } from '@shell/utils/string';
 import SortableTable from '@shell/components/SortableTable';
 import { _CLONE, _DETAIL } from '@shell/config/query-params';
-import { SCOPED_RESOURCES } from '@shell/config/roles';
+import { SCOPED_RESOURCES, SCOPED_RESOURCE_GROUPS } from '@shell/config/roles';
 import { Banner } from '@components/Banner';
 
 import { SUBTYPE_MAPPING, VERBS } from '@shell/models/management.cattle.io.roletemplate';
@@ -195,16 +195,17 @@ export default {
       const scopes = Object.keys(this.scopedResources);
 
       scopes.forEach((scope) => {
-        if (scope === 'globalScopedApiGroups' && this.value.type !== MANAGEMENT.GLOBAL_ROLE) {
+        if (scope === SCOPED_RESOURCE_GROUPS.GLOBAL && this.value.type !== MANAGEMENT.GLOBAL_ROLE) {
           // If we are not in the global role creation form,
           // skip adding the global-scoped resources.
           return;
         }
-        if (scope === 'clusterScopedApiGroups' && (this.value.type === RBAC.ROLE || this.value.subtype === NAMESPACE)) {
+        if (scope === SCOPED_RESOURCE_GROUPS.CLUSTER && (this.value.type === RBAC.ROLE || this.value.subtype === NAMESPACE)) {
           // If we are in a project/namespace role creation form,
           // additionally skip adding the cluster-scoped resources.
           return;
         }
+
         const apiGroupsInScope = this.scopedResources[scope];
 
         const apiGroupNames = Object.keys(apiGroupsInScope);
@@ -232,10 +233,11 @@ export default {
           }
 
           if (apiGroup === 'neuvectorApi') {
-            // NeuVector Permission CRD resources are cluster scoped
+            // Some NeuVector resources are namespaced, in which case they go under a different heading
             const labelForClusterScoped = this.t('rbac.roletemplate.tabs.grantResources.neuvector.labelClusterScoped');
+            const labelForNamespaceScoped = this.t('rbac.roletemplate.tabs.grantResources.neuvector.labelNamespaceScoped');
 
-            apiGroupLabel = labelForClusterScoped;
+            apiGroupLabel = scope.includes('cluster') ? labelForClusterScoped : labelForNamespaceScoped;
             apiGroupValue = 'permission.neuvector.com';
           }
 

--- a/shell/config/roles.ts
+++ b/shell/config/roles.ts
@@ -1,3 +1,17 @@
+export const enum SCOPED_RESOURCE_GROUPS {
+  GLOBAL = 'globalScopedApiGroups', // eslint-disable-line no-unused-vars
+  CLUSTER = 'clusterScopedApiGroups', // eslint-disable-line no-unused-vars
+  PROJECT_NAMESPACE = 'projectScopedApiGroups', // eslint-disable-line no-unused-vars
+}
+
+/**
+ * Resources users can select when creating grants when managing global, cluster and project/namespace roles
+ *
+ * **************NOTE*****************
+ * Global roles will show ALL entries
+ * Cluster roles will show cluster AND project/namespace entries
+ * Project/Namespace roles will show ONLY project/namespace entries
+ */
 export const SCOPED_RESOURCES = {
   // With this hardcoded list, it will be easier to curate a more useful
   // and human-understandable list of resources to choose from
@@ -13,7 +27,7 @@ export const SCOPED_RESOURCES = {
   // the global scoped list, and the project role creation form includes a
   // subset of the cluster scoped list.
 
-  globalScopedApiGroups: {
+  [SCOPED_RESOURCE_GROUPS.GLOBAL]: {
     // Global scoped resources are resources for
     // Rancher's global apps, mainly Cluster
     // Management and Continuous Delivery.
@@ -131,27 +145,8 @@ export const SCOPED_RESOURCES = {
         'Clusters'
       ]
     },
-    neuvectorApi: {
-      resources: [
-        'AdmissionControl',
-        'AuditEvents',
-        'Authentication',
-        'Authorization',
-        'CIScan',
-        'Cluster',
-        'Compliance',
-        'Events',
-        'Federation',
-        'RegistryScan',
-        'RuntimePolicy',
-        'RuntimeScan',
-        'SecurityEvents',
-        'SystemConfig',
-        'Vulnerability',
-      ]
-    }
   },
-  clusterScopedApiGroups: {
+  [SCOPED_RESOURCE_GROUPS.CLUSTER]: {
     // Cluster scoped resources are for non-namespaced
     // resources at the cluster level, for example,
     // storage resources.
@@ -221,24 +216,15 @@ export const SCOPED_RESOURCES = {
     neuvectorApi: {
       resources: [
         'AdmissionControl',
-        'AuditEvents',
         'Authentication',
-        'Authorization',
         'CIScan',
         'Cluster',
-        'Compliance',
-        'Events',
         'Federation',
-        'RegistryScan',
-        'RuntimePolicy',
-        'RuntimeScan',
-        'SecurityEvents',
-        'SystemConfig',
         'Vulnerability',
       ]
     }
   },
-  projectScopedApiGroups: {
+  [SCOPED_RESOURCE_GROUPS.PROJECT_NAMESPACE]: {
     // Project scoped resources include all other namespaced
     // resources.
     coreKubernetesApi: {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11646
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

Generally....
- When creating roles (global, cluster or project/namespace) users specify grants on specific resources
- To help users we provide a list of resources to select
- These resources come from a set of hardcoded list
  -  global - specifically global resources (basically resources expected to be in the local/upstream cluster)
  -  cluster - non-namespaced resources
  -  project/namespace - namespaced resources
- There's a component that handles role creation for the 3 different roles
  - We don't show only the respective global, cluster, or project/namespace resources for each context
    - global role - shows global, cluster and project/namespace options
    - cluster role - shows cluster and project/namespace options
    - project/namespace role - shows project/namespace options

Given above, the [PR](https://github.com/rancher/dashboard/pull/11527/files) broke a few things, both cause the drop down to fail and page to hang
- duplicate API groups (new cluster group plus cluster and project now all use same label)
- duplicate options (global, cluster and project/namespace resource options now contain duplicate entries)

Given above this PR
- Removes the global resources (i think neuvector is per cluster)
- Removes some of the cluster resources (i've tried to align the new labels with old)
- Brought back the cluster/namespace api group labels
- Slightly improves matching of resource group context names

### Areas or cases that should be tested
  1. Cluster Explorer > More Resources > RBAC > ClusterRoles
     - Should show list of cluster scoped resources and namespaced resources
     - Custom resource can be entered
  2. Cluster Explorer > More Resources > RBAC > Roles
     - Should show list of namespaced resources
     - Custom resource can be entered
  3. Users & Authentication > Roles > Global
     - Should show global, cluster and namespace scoped resources
     - Custom resource can be entered
  4. Users & Authentication > Roles > Cluster
     - Should show cluster and namespace scoped resources
     - Custom resource can be entered
 5. Users & Authentication > Roles > Projects & Namespaces
     - Should show only namespace scoped resources
     - Custom resource can be entered

Additionally the neuvector requirements are met around resources at different levels


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
