### PR TITLE
[2.10] Forward port: Fix broken extension point to add replace home page

### DIFF
--- a/shell/config/router/routes.js
+++ b/shell/config/router/routes.js
@@ -53,6 +53,7 @@ export default [
     path:      '/',
     component: () => interopDefault(import('@shell/components/templates/home.vue')),
     meta:      { requiresAuthentication: true },
+    name:      'home_layout',
     children:  [
       {
         path:      '/home',

--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -132,6 +132,11 @@ export class Plugin implements IPlugin {
         console.warn(`Layouts have been deprecated. We still have parent routes which use the same name and styling as the previous layouts. You should specify a parent, we're currently setting the parent to 'default'`); // eslint-disable-line no-console
         parentOverride = 'default';
       }
+
+      // Fix for Home page components with wrong layout - need to ensure the parentOverride is set
+      if (typelessRoute.component && typelessRoute.name === 'home' && typelessRoute.path === '/home') {
+        parentOverride = 'home_layout';
+      }
     }
 
     route.meta = {


### PR DESCRIPTION
Forward port of https://github.com/rancher/dashboard/pull/11655

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11658

Extensions that replace the home page are broken.

### Occurred changes and/or fixed issues

The issue is that the home page was moved to a new parent route for layout.

The home page example uses the 'plain' layout which is incorrect.

This PR:

- Adds a name to the layout used for the homepage (`home_layout`)
- Updates the `addRoute` method so that if the home route is being changed, we set the parent route to `home_layout`

### Areas or cases that should be tested

Adding an extension that changes the home page.

To Test:

- Add the Helm repository for the examples - see: https://github.com/rancher/ui-plugin-examples
- Install the hompage example
- Refresh the browser and go to the home page
- Validate that the home page has changed to the example
- Uninstall the homepage extension
- Reload
- Verify that the homepage shows the default one
### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
