### PR TITLE
Update publish shell workflow to allow for independent release of either shell or creators packages

### DIFF
--- a/.github/workflows/release-shell-pkg.yaml
+++ b/.github/workflows/release-shell-pkg.yaml
@@ -29,9 +29,9 @@ jobs:
     - name: Check Tags Version Matching
       env:
         # TAG: ${{github.ref_name}}
-        TAG: "shell-pkg-v2.0.1"
+        TAG: shell-pkg-v2.0.1
       run: ./.github/workflows/scripts/check-package-tag-version.sh
-      shell: bash
+      # shell: bash
 
     - name: Validate Plugin build system
       run: ./shell/scripts/test-plugins-build.sh
@@ -60,5 +60,5 @@ jobs:
       run: ./shell/scripts/publish-shell.sh --npm
       env:
         # TAG: ${{github.ref_name}}
-        TAG: "shell-pkg-v2.0.1"
+        TAG: shell-pkg-v2.0.1
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-shell-pkg.yaml
+++ b/.github/workflows/release-shell-pkg.yaml
@@ -1,10 +1,6 @@
 name: Publish Shell Package
 
 on:
-  # TO DELETE!!! JUST FOR TESTING...
-  pull_request:
-    branches:
-      - master
   push:
     tags:
         - 'shell-pkg-v*'
@@ -28,10 +24,9 @@ jobs:
 
     - name: Check Tags Version Matching
       env:
-        # TAG: ${{github.ref_name}}
-        TAG: shell-pkg-v2.0.1
+        TAG: ${{github.ref_name}}
       run: ./.github/workflows/scripts/check-package-tag-version.sh
-      # shell: bash
+      shell: bash
 
     - name: Validate Plugin build system
       run: ./shell/scripts/test-plugins-build.sh
@@ -59,6 +54,5 @@ jobs:
     - name: Publish Shell Package to npm
       run: ./shell/scripts/publish-shell.sh --npm
       env:
-        # TAG: ${{github.ref_name}}
-        TAG: shell-pkg-v2.0.1
+        TAG: ${{github.ref_name}}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-shell-pkg.yaml
+++ b/.github/workflows/release-shell-pkg.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
         - 'shell-pkg-v*'
+        - 'creators-pkg-v*'
 
 jobs:
   build:
@@ -20,6 +21,10 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version-file: '.nvmrc'
+
+    - name: Check Tags Version Matching
+      run: ./.github/workflows/scripts/check-package-tag-version.sh
+      shell: bash
 
     - name: Validate Plugin build system
       run: ./shell/scripts/test-plugins-build.sh
@@ -47,4 +52,5 @@ jobs:
     - name: Publish Shell Package to npm
       run: ./shell/scripts/publish-shell.sh --npm
       env:
+        TAG: ${{github.ref_name}}
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-shell-pkg.yaml
+++ b/.github/workflows/release-shell-pkg.yaml
@@ -23,6 +23,8 @@ jobs:
         node-version-file: '.nvmrc'
 
     - name: Check Tags Version Matching
+      env:
+        TAG: ${{github.ref_name}}
       run: ./.github/workflows/scripts/check-package-tag-version.sh
       shell: bash
 

--- a/.github/workflows/release-shell-pkg.yaml
+++ b/.github/workflows/release-shell-pkg.yaml
@@ -1,6 +1,10 @@
 name: Publish Shell Package
 
 on:
+  # TO DELETE!!! JUST FOR TESTING...
+  pull_request:
+    branches:
+      - master
   push:
     tags:
         - 'shell-pkg-v*'
@@ -24,7 +28,8 @@ jobs:
 
     - name: Check Tags Version Matching
       env:
-        TAG: ${{github.ref_name}}
+        # TAG: ${{github.ref_name}}
+        TAG: shell-pkg-v2.0.1
       run: ./.github/workflows/scripts/check-package-tag-version.sh
       shell: bash
 
@@ -54,5 +59,6 @@ jobs:
     - name: Publish Shell Package to npm
       run: ./shell/scripts/publish-shell.sh --npm
       env:
-        TAG: ${{github.ref_name}}
+        # TAG: ${{github.ref_name}}
+        TAG: shell-pkg-v2.0.1
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-shell-pkg.yaml
+++ b/.github/workflows/release-shell-pkg.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Check Tags Version Matching
       env:
         # TAG: ${{github.ref_name}}
-        TAG: shell-pkg-v2.0.1
+        TAG: "shell-pkg-v2.0.1"
       run: ./.github/workflows/scripts/check-package-tag-version.sh
       shell: bash
 
@@ -60,5 +60,5 @@ jobs:
       run: ./shell/scripts/publish-shell.sh --npm
       env:
         # TAG: ${{github.ref_name}}
-        TAG: shell-pkg-v2.0.1
+        TAG: "shell-pkg-v2.0.1"
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/scripts/check-package-tag-version.sh
+++ b/.github/workflows/scripts/check-package-tag-version.sh
@@ -20,7 +20,7 @@ echo "PKG_VERSION ${PKG_VERSION}"
 
 # version comparison checks
 case $PKG_NAME in
-  shell)
+  "shell")
     SHELL_VERSION=$(jq -r .version ${SHELL_DIR}/package.json)
     if [ "$SHELL_VERSION" == "$PKG_VERSION" ]; then
       echo "tag check: shell versions match"
@@ -30,7 +30,7 @@ case $PKG_NAME in
       exit 1
     fi
     ;;
-  creators)
+  "creators")
     CREATORS_VERSION=$(jq -r .version ${CREATORS_DIR}/package.json)
     if [ "$CREATORS_VERSION" == "$PKG_VERSION" ]; then
       echo "tag check: creators versions match"

--- a/.github/workflows/scripts/check-package-tag-version.sh
+++ b/.github/workflows/scripts/check-package-tag-version.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+echo "Checking package tag version matching"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+BASE_DIR="$(
+  cd $SCRIPT_DIR && cd ../.. &
+  pwd
+)"
+SHELL_DIR=$BASE_DIR/shell
+CREATORS_DIR=$BASE_DIR/shell/creators/extension
+
+# let's get the package name and version from the tag
+cat "BASE_DIR: ${BASE_DIR}" 
+cat "TAG: ${TAG}"
+
+IFS='-pkg-v'
+
+read -r TEMP_STR <<<$TAG
+
+echo "TEMP_STR ${TEMP_STR}"
+
+IFS=' '
+
+read -r PKG_NAME PKG_VERSION <<<$TEMP_STR
+
+echo "PKG_NAME ${PKG_NAME}"
+echo "PKG_VERSION ${PKG_VERSION}"
+
+if [ "$PKG_NAME" == "shell" ]; then
+  SHELL_VERSION=$(jq -r .version ${SHELL_DIR}/package.json)
+  if [ "$SHELL_VERSION" == "$PKG_VERSION" ]; then
+    echo "tag check: shell versions match"
+    exit 0
+  else 
+    echo "Version mismatch for the shell package publish => shell: ${SHELL_VERSION} vs tag: ${PKG_VERSION}. Please redo the tagging properly"
+    exit 1
+  fi
+elif [[ "$PKG_NAME" == "creators" ]]; then
+  CREATORS_VERSION=$(jq -r .version ${CREATORS_DIR}/package.json)
+  if [ "$CREATORS_VERSION" == "$PKG_VERSION" ]; then
+    echo "tag check: creators versions match"
+    exit 0
+  else 
+    echo "Version mismatch for the creators package publish => creators: ${CREATORS_VERSION} vs tag: ${PKG_VERSION}. Please redo the tagging properly"
+    exit 1
+  fi
+else 
+  echo "something went wrong with the tagging or versioning => TAG: ${TAG} , PKG_NAME: ${PKG_NAME}, PKG_VERSION: ${PKG_VERSION}"
+  exit 1
+fi

--- a/.github/workflows/scripts/check-package-tag-version.sh
+++ b/.github/workflows/scripts/check-package-tag-version.sh
@@ -12,17 +12,8 @@ CREATORS_DIR=$BASE_DIR/shell/creators/extension
 echo "TAG ${TAG}"
 
 # let's get the package name and version from the tag
-# first step string split
-IFS='-pkg-v'
-
-read -r TEMP_STR <<<$TAG
-
-echo "TEMP_STR ${TEMP_STR}"
-
-# final step string split
-IFS=' '
-
-read -r PKG_NAME PKG_VERSION <<<$TEMP_STR
+PKG_NAME=$(sed 's/-pkg-v.*//' <<<$TAG)
+PKG_VERSION=$(sed 's/.*-pkg-v//'<<<$TAG)
 
 echo "PKG_NAME ${PKG_NAME}"
 echo "PKG_VERSION ${PKG_VERSION}"

--- a/.github/workflows/scripts/check-package-tag-version.sh
+++ b/.github/workflows/scripts/check-package-tag-version.sh
@@ -12,32 +12,36 @@ CREATORS_DIR=$BASE_DIR/shell/creators/extension
 echo "TAG ${TAG}"
 
 # let's get the package name and version from the tag
-PKG_NAME=$(sed 's/-pkg-v.*//' <<<$TAG)
-PKG_VERSION=$(sed 's/.*-pkg-v//'<<<$TAG)
+PKG_NAME=$(sed 's/-pkg-v.*//' <<< "$TAG")
+PKG_VERSION=$(sed 's/.*-pkg-v//'<<< "$TAG")
 
 echo "PKG_NAME ${PKG_NAME}"
 echo "PKG_VERSION ${PKG_VERSION}"
 
 # version comparison checks
-if [ "$PKG_NAME" == "shell" ]; then
-  SHELL_VERSION=$(jq -r .version ${SHELL_DIR}/package.json)
-  if [ "$SHELL_VERSION" == "$PKG_VERSION" ]; then
-    echo "tag check: shell versions match"
-    exit 0
-  else 
-    echo "Version mismatch for the shell package publish => shell: ${SHELL_VERSION} vs tag: ${PKG_VERSION}. Please redo the tagging properly"
+case $PKG_NAME in
+  shell)
+    SHELL_VERSION=$(jq -r .version ${SHELL_DIR}/package.json)
+    if [ "$SHELL_VERSION" == "$PKG_VERSION" ]; then
+      echo "tag check: shell versions match"
+      exit 0
+    else 
+      echo "Version mismatch for the shell package publish => shell: ${SHELL_VERSION} vs tag: ${PKG_VERSION}. Please redo the tagging properly"
+      exit 1
+    fi
+    ;;
+  creators)
+    CREATORS_VERSION=$(jq -r .version ${CREATORS_DIR}/package.json)
+    if [ "$CREATORS_VERSION" == "$PKG_VERSION" ]; then
+      echo "tag check: creators versions match"
+      exit 0
+    else 
+      echo "Version mismatch for the creators package publish => creators: ${CREATORS_VERSION} vs tag: ${PKG_VERSION}. Please redo the tagging properly"
+      exit 1
+    fi
+    ;;
+  *)
+    echo "something went wrong with the tagging or versioning => TAG: ${TAG} , PKG_NAME: ${PKG_NAME}, PKG_VERSION: ${PKG_VERSION}"
     exit 1
-  fi
-elif [[ "$PKG_NAME" == "creators" ]]; then
-  CREATORS_VERSION=$(jq -r .version ${CREATORS_DIR}/package.json)
-  if [ "$CREATORS_VERSION" == "$PKG_VERSION" ]; then
-    echo "tag check: creators versions match"
-    exit 0
-  else 
-    echo "Version mismatch for the creators package publish => creators: ${CREATORS_VERSION} vs tag: ${PKG_VERSION}. Please redo the tagging properly"
-    exit 1
-  fi
-else 
-  echo "something went wrong with the tagging or versioning => TAG: ${TAG} , PKG_NAME: ${PKG_NAME}, PKG_VERSION: ${PKG_VERSION}"
-  exit 1
-fi
+    ;;
+esac

--- a/.github/workflows/scripts/check-package-tag-version.sh
+++ b/.github/workflows/scripts/check-package-tag-version.sh
@@ -9,16 +9,17 @@ BASE_DIR="$(
 SHELL_DIR=$BASE_DIR/shell
 CREATORS_DIR=$BASE_DIR/shell/creators/extension
 
-# let's get the package name and version from the tag
-cat "BASE_DIR: ${BASE_DIR}" 
-cat "TAG: ${TAG}"
+echo "TAG ${TAG}"
 
+# let's get the package name and version from the tag
+# first step string split
 IFS='-pkg-v'
 
 read -r TEMP_STR <<<$TAG
 
 echo "TEMP_STR ${TEMP_STR}"
 
+# final step string split
 IFS=' '
 
 read -r PKG_NAME PKG_VERSION <<<$TEMP_STR
@@ -26,6 +27,7 @@ read -r PKG_NAME PKG_VERSION <<<$TEMP_STR
 echo "PKG_NAME ${PKG_NAME}"
 echo "PKG_VERSION ${PKG_VERSION}"
 
+# version comparison checks
 if [ "$PKG_NAME" == "shell" ]; then
   SHELL_VERSION=$(jq -r .version ${SHELL_DIR}/package.json)
   if [ "$SHELL_VERSION" == "$PKG_VERSION" ]; then

--- a/shell/creators/extension/package.json
+++ b/shell/creators/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rancher/create-extension",
   "description": "Rancher UI Extension generator",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "author": "SUSE",
   "private": false,

--- a/shell/scripts/publish-shell.sh
+++ b/shell/scripts/publish-shell.sh
@@ -7,7 +7,7 @@ BASE_DIR="$(
 )"
 SHELL_DIR=$BASE_DIR/shell/
 CREATORS_DIR=$BASE_DIR/shell/creators/extension
-PUBLISH_ARGS="--no-git-tag-version --access public $PUBLISH_ARGS"
+PUBLISH_ARGS="--no-git-tag-version --access public $NPM_TAG"
 FORCE_PUBLISH_TO_NPM="false"
 DEFAULT_YARN_REGISTRY="https://registry.npmjs.org"
 
@@ -44,6 +44,11 @@ function publish() {
   # because of the check in the "Check Tags Version Matching" step in the workflow
   if [ -n "$3" ]; then
     PKG_VERSION=$3
+  fi
+
+  # if the PKG_VERSION has a - it means it will be a pre-release
+  if [[ $PKG_VERSION == *"-"* ]]; then
+    PUBLISH_ARGS="--no-git-tag-version --access public --tag pre-release"
   fi
 
   echo "Publishing ${NAME} from ${FOLDER}"

--- a/shell/scripts/publish-shell.sh
+++ b/shell/scripts/publish-shell.sh
@@ -11,7 +11,7 @@ PUBLISH_ARGS="--no-git-tag-version --access public $PUBLISH_ARGS"
 FORCE_PUBLISH_TO_NPM="false"
 DEFAULT_YARN_REGISTRY="https://registry.npmjs.org"
 
-# if TAG doesn't exist, we can exit as it's needed for any type of publish
+# if TAG doesn't exist, we can exit as it's needed for any type of publish.
 if [ -z "$TAG" ]; then
   echo "You need to set the TAG variable first!"
   exit 1

--- a/shell/scripts/publish-shell.sh
+++ b/shell/scripts/publish-shell.sh
@@ -30,27 +30,38 @@ fi
 # before publishing
 
 # To set a token for NPM registry auth: `npm config set //registry.npmjs.org/:_authToken <TOKEN>``
-
 PKG_DIST=$BASE_DIR/dist-pkg/creators
 mkdir -p ${PKG_DIST}
 rm -rf ${PKG_DIST}/extension
 
 pushd ${SHELL_DIR} >/dev/null
 
-PKG_VERSION=$(node -p "require('./package.json').version")
-popd >/dev/null
+# if TAG doesn't exist, then we are on one of the other flows that use publish-shell
+# which require the overwrite of the released version of the creators package
+if [ -z "$TAG" ]; then
+  PKG_VERSION=$(node -p "require('./package.json').version")
+  popd >/dev/null
 
-echo "Publishing version: $PKG_VERSION"
+  echo "Publishing shell and creators pkg with same version: $PKG_VERSION"
 
-cp -R ${SHELL_DIR}/creators/extension ${PKG_DIST}
+  cp -R ${SHELL_DIR}/creators/extension ${PKG_DIST}
 
-sed -i.bak -e "s/\"0.0.0/"\"$PKG_VERSION"/g" ${PKG_DIST}/extension/package.json
+  sed -i.bak -e "s/\"0.0.0/"\"$PKG_VERSION"/g" ${PKG_DIST}/extension/package.json
 
-rm ${PKG_DIST}/extension/package.json.bak
+  rm ${PKG_DIST}/extension/package.json.bak
+fi
 
 function publish() {
   NAME=$1
   FOLDER=$2
+
+  # if we pass a third arg, that is the version number
+  # that we want to actually publish on NPM
+  # they should match with the package.json version stated 
+  # because of the check in the "Check Tags Version Matching" step in the workflow
+  if [ -n "$3" ]; then
+    PKG_VERSION=$3
+  fi
 
   echo "Publishing ${NAME} from ${FOLDER}"
   pushd ${FOLDER} >/dev/null
@@ -78,7 +89,7 @@ function publish() {
   # Make a note of dependency versions, if required
   node ${SCRIPT_DIR}/record-deps.js
 
-  yarn publish . --new-version ${PKG_VERSION} ${PUBLISH_ARGS}
+  # yarn publish . --new-version ${PKG_VERSION} ${PUBLISH_ARGS}
   RET=$?
 
   popd >/dev/null
@@ -92,10 +103,48 @@ function publish() {
 # Generate the type definitions for the shell
 ${SCRIPT_DIR}/typegen.sh
 
-# Publish the packages - don't tag the git repo and don't auto-increment the version number
-publish "Shell" ${SHELL_DIR}
-publish "Extension creator" ${PKG_DIST}/extension/
 
-echo "Done"
+# Since the publish-shell script is used in a couple of different places
+# we have to be careful not to disrupt it's logic too much
+# otherwise we risk breaking those other flows
+
+# if tag exists, then we call the publish we need with an extra argument
+# this is the path of the release-shell-pkg workflow
+if [ -n "$TAG" ]; then
+  echo "TAG ${TAG}"
+  # let's get the package name
+  # first step string split
+  IFS='-pkg-v'
+
+  read -r TEMP_STR <<<$TAG
+
+  echo "TEMP_STR ${TEMP_STR}"
+
+  # final step string split
+  IFS=' '
+
+  read -r PKG_NAME PKG_V <<<$TEMP_STR
+
+  echo "PKG_NAME ${PKG_NAME}"
+  echo "PKG_V ${PKG_V}"
+
+  # there can only be two types of tags, which have been verified in the workflow
+  # with the "Check Tags Version Matching" step in the workflow
+  if [ "$PKG_NAME" == "shell" ]; then
+    echo "Publishing only Shell pkg via tagged release"
+    publish "Shell" ${SHELL_DIR} ${PKG_V}
+  else
+    echo "Publishing only Creators pkg via tagged release"
+    publish "Extension creator" ${PKG_DIST}/extension/ ${PKG_V}
+  fi
+else
+  # other workflows...
+  # Publish the packages - don't tag the git repo and don't auto-increment the version number
+  publish "Shell" ${SHELL_DIR}
+  publish "Extension creator" ${PKG_DIST}/extension/
+
+  echo "Done"
+fi
+
 
 

--- a/shell/scripts/publish-shell.sh
+++ b/shell/scripts/publish-shell.sh
@@ -112,18 +112,10 @@ ${SCRIPT_DIR}/typegen.sh
 # this is the path of the release-shell-pkg workflow
 if [ -n "$TAG" ]; then
   echo "TAG ${TAG}"
-  # let's get the package name
-  # first step string split
-  IFS='-pkg-v'
-
-  read -r TEMP_STR <<<$TAG
-
-  echo "TEMP_STR ${TEMP_STR}"
-
-  # final step string split
-  IFS=' '
-
-  read -r PKG_NAME PKG_V <<<$TEMP_STR
+  
+  # let's get the package name and version from the tag
+  PKG_NAME=$(sed 's/-pkg-v.*//' <<<$TAG)
+  PKG_V=$(sed 's/.*-pkg-v//'<<<$TAG)
 
   echo "PKG_NAME ${PKG_NAME}"
   echo "PKG_V ${PKG_V}"

--- a/shell/scripts/publish-shell.sh
+++ b/shell/scripts/publish-shell.sh
@@ -6,6 +6,7 @@ BASE_DIR="$(
   pwd
 )"
 SHELL_DIR=$BASE_DIR/shell/
+CREATORS_DIR=$BASE_DIR/shell/creators/extension
 PUBLISH_ARGS="--no-git-tag-version --access public $PUBLISH_ARGS"
 FORCE_PUBLISH_TO_NPM="false"
 DEFAULT_YARN_REGISTRY="https://registry.npmjs.org"
@@ -30,15 +31,6 @@ fi
 if [ "$FORCE_PUBLISH_TO_NPM" == "true" ]; then
   export YARN_REGISTRY=$DEFAULT_YARN_REGISTRY
 fi
-
-# We use the version from the shell package for the creator packages
-# Need to copy them to a temporary location, so we can patch the version number
-# before publishing
-
-# To set a token for NPM registry auth: `npm config set //registry.npmjs.org/:_authToken <TOKEN>``
-PKG_DIST=$BASE_DIR/dist-pkg/creators
-mkdir -p ${PKG_DIST}
-rm -rf ${PKG_DIST}/extension
 
 pushd ${SHELL_DIR} >/dev/null
 
@@ -92,13 +84,13 @@ echo "PKG_V ${PKG_V}"
 
 # version comparison checks
 case $PKG_NAME in
-  shell)
+  "shell")
     echo "Publishing only Shell pkg via tagged release"
     publish "Shell" ${SHELL_DIR} ${PKG_V}
     ;;
-  creators)
+  "creators")
     echo "Publishing only Creators pkg via tagged release"
-    publish "Extension creator" ${PKG_DIST}/extension/ ${PKG_V}
+    publish "Extension creator" ${CREATORS_DIR} ${PKG_V}
     ;;
   *)
     echo "something went wrong with the tagging name => TAG: ${TAG} , PKG_NAME: ${PKG_NAME}. Admissable names are 'shell' and 'creator'"

--- a/shell/scripts/publish-shell.sh
+++ b/shell/scripts/publish-shell.sh
@@ -6,7 +6,6 @@ BASE_DIR="$(
   pwd
 )"
 SHELL_DIR=$BASE_DIR/shell/
-TMP_DIR=$BASE_DIR/tmp
 PUBLISH_ARGS="--no-git-tag-version --access public $PUBLISH_ARGS"
 FORCE_PUBLISH_TO_NPM="false"
 DEFAULT_YARN_REGISTRY="https://registry.npmjs.org"

--- a/shell/scripts/publish-shell.sh
+++ b/shell/scripts/publish-shell.sh
@@ -89,7 +89,7 @@ function publish() {
   # Make a note of dependency versions, if required
   node ${SCRIPT_DIR}/record-deps.js
 
-  # yarn publish . --new-version ${PKG_VERSION} ${PUBLISH_ARGS}
+  yarn publish . --new-version ${PKG_VERSION} ${PUBLISH_ARGS}
   RET=$?
 
   popd >/dev/null

--- a/shell/scripts/test-plugins-build.sh
+++ b/shell/scripts/test-plugins-build.sh
@@ -88,9 +88,15 @@ rm ${SHELL_DIR}/package.json.bak
 # We might have bumped the version number but its not published yet, so this will fail
 sed -i.bak -e "s/\"version\": \"[0-9]*.[0-9]*.[0-9]*\(-alpha\.[0-9]*\|-release[0-9]*.[0-9]*.[0-9]*\|-rc\.[0-9]*\)\{0,1\}\",/\"version\": \"${SHELL_VERSION}\",/g" ${BASE_DIR}/pkg/rancher-components/package.json
 
-# Publish shell
-echo "Publishing shell packages to local registry"
+# Publish shell pkg (tag is needed as publish-shell is optimized to work with release-shell-pkg workflow)
+echo "Publishing Shell package to local registry"
 yarn install
+export TAG="shell-pkg-${SHELL_VERSION}"
+${SHELL_DIR}/scripts/publish-shell.sh
+
+# Publish creators pkg (tag is needed as publish-shell is optimized to work with release-shell-pkg workflow)
+echo "Publishing Creators package to local registry"
+export TAG="creators-pkg-${SHELL_VERSION}"
 ${SHELL_DIR}/scripts/publish-shell.sh
 
 # Publish rancher components

--- a/shell/scripts/test-plugins-build.sh
+++ b/shell/scripts/test-plugins-build.sh
@@ -91,12 +91,12 @@ sed -i.bak -e "s/\"version\": \"[0-9]*.[0-9]*.[0-9]*\(-alpha\.[0-9]*\|-release[0
 # Publish shell pkg (tag is needed as publish-shell is optimized to work with release-shell-pkg workflow)
 echo "Publishing Shell package to local registry"
 yarn install
-export TAG="shell-pkg-${SHELL_VERSION}"
+export TAG="shell-pkg-v${SHELL_VERSION}"
 ${SHELL_DIR}/scripts/publish-shell.sh
 
 # Publish creators pkg (tag is needed as publish-shell is optimized to work with release-shell-pkg workflow)
 echo "Publishing Creators package to local registry"
-export TAG="creators-pkg-${SHELL_VERSION}"
+export TAG="creators-pkg-v${SHELL_VERSION}"
 ${SHELL_DIR}/scripts/publish-shell.sh
 
 # Publish rancher components


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11694 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add step for checking tag version matching on publish shell workflow -> `check-package-tag-version.sh`
- update `publish-shell` script to allow for independent publish of either `Shell` or `Creators` packages to NPM
- remove unused `TMP_DIR` var in `publish-shell` script
- update creators package version to match what was published on NPM

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- you can run a check for the `check-package-tag-version.sh` script by running it manually with a `TAG` of your choice, such as:
```
export TAG=shell-pkg-v2.0.1 && .github/workflows/scripts/check-package-tag-version.sh
```

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
