### PR TITLE
Use `v-model` for data binding on in Jump.vue

### DIFF
--- a/cypress/e2e/tests/pages/explorer/resource-search.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/resource-search.spec.ts
@@ -6,7 +6,7 @@ import { ConfigMapPagePo } from '@/cypress/e2e/po/pages/explorer/config-map.po';
 
 const clusterDashboard = new ClusterDashboardPagePo('local');
 
-describe.skip('[Vue3 Skip]: Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@adminUser', '@standardUser'] }, () => {
+describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@adminUser', '@standardUser'] }, () => {
   before(() => {
     cy.login();
     HomePagePo.goTo();
@@ -33,7 +33,7 @@ describe.skip('[Vue3 Skip]: Cluster Dashboard', { testIsolation: 'off', tags: ['
     dialog.checkNotExists();
   });
 
-  it('can show resource dialog when namespace chooser is open', () => {
+  it.skip('can show resource dialog when namespace chooser is open', () => {
     const namespacePicker = new NamespaceFilterPo();
 
     namespacePicker.toggle();

--- a/shell/components/nav/Jump.vue
+++ b/shell/components/nav/Jump.vue
@@ -71,7 +71,7 @@ export default {
   <div>
     <input
       ref="input"
-      :value="value"
+      v-model="value"
       :placeholder="t('nav.resourceSearch.placeholder')"
       class="search"
       @keyup.esc="$emit('closeSearch')"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This was changed in 7f1536d9cff20b73b8b42a703886f170a50fda5f and it appears that we didn't need this change for `Jump.vue` because `value` is declared as a data prop. Reverting back to `v-model` resolves the issue.

Fixes #11700 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- reintroduce two-way data binding in `Jump.vue`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Resource Search

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- N/A

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/6092cfee-4675-48a6-bfef-546e4e7f1dad

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
