### PR TITLE
Fixing the tooltip selector used in the main-side-menu tests and renabled the test

### DIFF
--- a/cypress/e2e/po/side-bars/burger-side-menu.po.ts
+++ b/cypress/e2e/po/side-bars/burger-side-menu.po.ts
@@ -158,7 +158,7 @@ export default class BurgerMenuPo extends ComponentPo {
   }
 
   getClusterDescriptionTooltipContent(): Cypress.Chainable {
-    return cy.get('.menu-description-tooltip .tooltip-inner');
+    return cy.get('.v-popper__popper .v-popper__inner');
   }
 
   /**

--- a/cypress/e2e/tests/navigation/side-nav/main-side-menu.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/main-side-menu.spec.ts
@@ -72,7 +72,7 @@ describe('Side Menu: main', () => {
       cy.url().should('include', 'https://ranchermanager.docs.rancher.com/v2.9/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/rke1-vs-rke2-differences#cluster-api');
     });
 
-    it.skip('[Vue3 Skip]: Local cluster should show a name and description on the side menu and display a tooltip when hovering it show the full name and description', { tags: ['@navigation', '@adminUser'] }, () => {
+    it('Local cluster should show a name and description on the side menu and display a tooltip when hovering it show the full name and description', { tags: ['@navigation', '@adminUser'] }, () => {
       BurgerMenuPo.toggle();
 
       const burgerMenuPo = new BurgerMenuPo();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Re-instates one of the tests we were skipping from the vue3 merge.

Partially resolves https://github.com/rancher/dashboard/issues/11622#issue-2457901883

### Technical notes summary
Updates a selector used in one of the test pos to be inline with our new popover library.


### Areas or cases that should be tested
N/A

### Areas which could experience regressions
N/A

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
