### PR TITLE
Add alpha and beta `dist-tags` to `@rancher/components` release workflow

### DIFF
--- a/.github/workflows/release-rancher-components.yml
+++ b/.github/workflows/release-rancher-components.yml
@@ -36,6 +36,14 @@ jobs:
       run: yarn test:ci ./pkg/rancher-components
 
     - name: Publish to npm
-      run: yarn publish:lib
+      run: |
+        echo "$GITHUB_REF_NAME"
+        if [[ $GITHUB_REF_NAME == components-v*alpha.* ]]; then
+          yarn publish:lib --tag alpha
+        elif [[ $GITHUB_REF_NAME == components-v*beta.* ]]; then
+          yarn publish:lib --tag beta
+        else
+          yarn publish:lib
+        fi
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/pkg/rancher-components/package.json
+++ b/pkg/rancher-components/package.json
@@ -2,7 +2,7 @@
   "name": "@rancher/components",
   "repository": "git://github.com:rancher/dashboard.git",
   "license": "Apache-2.0",
-  "version": "0.2.1-alpha.0",
+  "version": "0.3.0-alpha.1",
   "module": "./main.js",
   "main": "./dist/@rancher/components.umd.min.js",
   "files": [

--- a/pkg/rancher-components/package.json
+++ b/pkg/rancher-components/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@rancher/components",
-  "repository": "git://github.com:rancher/dashboard.git",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/rancher/dashboard.git"
+  },
   "license": "Apache-2.0",
   "version": "0.3.0-alpha.1",
   "module": "./main.js",


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates the `@rancher/components` release workflow so that releases tagged with `alpha.x` or `beta.x` will include a `dist-tag`[^1] on publish. `dist-tags` help by preventing users from inadvertently installing unstable versions published to npm.

[^1]: https://docs.npmjs.com/adding-dist-tags-to-packages

Fixes #11710
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add alpha and beta `dist-tags` to `@rancher/components` release workflow

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Releasing `@rancher/components`

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
