### PR TITLE
Allow extensions to override node provider icons for cloud credentials

### DIFF
--- a/shell/edit/cloudcredential.vue
+++ b/shell/edit/cloudcredential.vue
@@ -152,13 +152,17 @@ export default {
       }
 
       for ( const id of types ) {
-        let bannerImage, bannerAbbrv;
+        let bannerAbbrv;
 
-        try {
-          bannerImage = require(`~shell/assets/images/providers/${ id }.svg`);
-        } catch (e) {
-          bannerImage = null;
-          bannerAbbrv = this.initialDisplayFor(id);
+        let bannerImage = this.$store.app.$plugin.getDynamic('image', `providers/${ id }.svg`);
+
+        if (!bannerImage) {
+          try {
+            bannerImage = require(`~shell/assets/images/providers/${ id }.svg`);
+          } catch (e) {
+            bannerImage = null;
+            bannerAbbrv = this.initialDisplayFor(id);
+          }
         }
 
         out.push({


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11721 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This PR allows extensions to override the icons for node providers on the create cloud credentials screen.

This introduces the ability to override via:
```
plugin.register('image', 'providers/YOUR_PROVIDER_NAME.svg', require('./PATH_TO_YOUR_ICON/WHATEVER_ICON_NAME.svg'));
```

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

For QA, test when you go to the cloud credentias creation screen, that the icons display correctly, e.g.:

<img width="1373" alt="image" src="https://github.com/user-attachments/assets/5c105fe4-8941-45f9-be06-e5adfcbe90a2">

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
