### PR TITLE
Add `canPaginate` computed prop to components that use `LabeledFormElement` mixin

### DIFF
--- a/shell/components/form/InputWithSelect.vue
+++ b/shell/components/form/InputWithSelect.vue
@@ -94,6 +94,12 @@ export default {
     };
   },
 
+  computed: {
+    canPaginate() {
+      return false;
+    }
+  },
+
   methods: {
     focus() {
       const comp = this.$refs.text;

--- a/shell/components/form/Select.vue
+++ b/shell/components/form/Select.vue
@@ -9,7 +9,7 @@ export default {
   components: { LabeledTooltip },
   mixins:     [
     LabeledFormElement,
-    VueSelectOverrides
+    VueSelectOverrides,
   ],
   emits: ['createdListItem', 'on-focus', 'on-blur'],
   props: {
@@ -203,6 +203,9 @@ export default {
       } else {
         return undefined;
       }
+    },
+    canPaginate() {
+      return false;
     }
   }
 };

--- a/shell/components/form/ServiceNameSelect.vue
+++ b/shell/components/form/ServiceNameSelect.vue
@@ -85,8 +85,11 @@ export default {
 
     serviceName() {
       return this.reduce(this.selected);
-    }
+    },
 
+    canPaginate() {
+      return false;
+    },
   },
 
   methods: {

--- a/shell/components/form/__tests__/InputWithSelect.test.ts
+++ b/shell/components/form/__tests__/InputWithSelect.test.ts
@@ -1,0 +1,42 @@
+import { shallowMount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import InputWithSelect from '@shell/components/form/InputWithSelect.vue';
+
+const InputWithSelectComponent = InputWithSelect as ReturnType<typeof defineComponent>;
+
+describe('inputWithSelect.vue', () => {
+  let consoleWarn: any;
+
+  // eslint-disable-next-line jest/no-hooks
+  beforeAll(() => {
+    // eslint-disable-next-line no-console
+    consoleWarn = console.warn;
+  });
+
+  // eslint-disable-next-line jest/no-hooks
+  afterAll(() => {
+    // eslint-disable-next-line no-console
+    console.warn = consoleWarn;
+  });
+
+  it('does not throw a warning in the console', () => {
+    jest.spyOn(console, 'warn').mockImplementation();
+
+    shallowMount(
+      InputWithSelectComponent,
+      {
+        props: {
+          options: [
+            {
+              label: 'label1',
+              value: 'val1',
+            },
+          ]
+        }
+      }
+    );
+
+    // eslint-disable-next-line no-console
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});

--- a/shell/components/form/__tests__/Select.test.ts
+++ b/shell/components/form/__tests__/Select.test.ts
@@ -1,0 +1,30 @@
+import { shallowMount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import Select from '@shell/components/form/Select.vue';
+
+const SelectComponent = Select as ReturnType<typeof defineComponent>;
+
+describe('select.vue', () => {
+  let consoleWarn: any;
+
+  // eslint-disable-next-line jest/no-hooks
+  beforeAll(() => {
+    // eslint-disable-next-line no-console
+    consoleWarn = console.warn;
+  });
+
+  // eslint-disable-next-line jest/no-hooks
+  afterAll(() => {
+    // eslint-disable-next-line no-console
+    console.warn = consoleWarn;
+  });
+
+  it('does not throw a warning in the console', () => {
+    jest.spyOn(console, 'warn').mockImplementation();
+
+    shallowMount(SelectComponent);
+
+    // eslint-disable-next-line no-console
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});

--- a/shell/components/form/__tests__/ServiceNameSelect.test.ts
+++ b/shell/components/form/__tests__/ServiceNameSelect.test.ts
@@ -1,0 +1,42 @@
+import { shallowMount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import ServiceNameSelect from '@shell/components/form/ServiceNameSelect.vue';
+
+const ServiceNameSelectComponent = ServiceNameSelect as ReturnType<typeof defineComponent>;
+
+describe('serviceNameSelect.vue', () => {
+  let consoleWarn: any;
+
+  // eslint-disable-next-line jest/no-hooks
+  beforeAll(() => {
+    // eslint-disable-next-line no-console
+    consoleWarn = console.warn;
+  });
+
+  // eslint-disable-next-line jest/no-hooks
+  afterAll(() => {
+    // eslint-disable-next-line no-console
+    console.warn = consoleWarn;
+  });
+
+  it('does not throw a warning in the console', () => {
+    jest.spyOn(console, 'warn').mockImplementation();
+
+    shallowMount(
+      ServiceNameSelectComponent,
+      {
+        props: {
+          options: [
+            {
+              label: 'label1',
+              value: 'val1',
+            },
+          ]
+        }
+      }
+    );
+
+    // eslint-disable-next-line no-console
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This exposes the `canPaginate()` computed prop so that it can be accessed in the `labeled-form-element` mixin. 

`Select.vue` never had `canPaginate()` defined because it didn't make use of any mixin that defines this computed prop. 

Fixes #11722 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add `labeled-select-pagination` mixin to `Select.vue`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The warning printed to the console is Vue3 warning us that something is wrong with the design of our components:

```
labeled-form-element.ts:123 [Vue warn]: Property "canPaginate" was accessed during render but is not defined on instance. 
  at <Select value="minute" onUpdate:value=fn disabled=true  ... > 
  at <Token key=3 ref="comp" value= __WEBPACK_DEFAULT_EXPORT__ {type: 'token', __clone: true, metadata: {…}, $ctx: {…}}  ... > 
  at <AsyncComponentWrapper key=3 ref="comp" value= __WEBPACK_DEFAULT_EXPORT__ {type: 'token', __clone: true, metadata: {…}, $ctx: {…}}  ... > 
  at <Index store-override="rancher" resource-override="token" parent-route-override="account"  ... > 
  at <APIKeyCreate class="outlet" onVnodeUnmounted=fn<onVnodeUnmounted> ref=Ref< Proxy(Object) {…} > > 
  at <RouterView key="/account/create-key" class="outlet" > 
  at <IndentedPanel class="pt-20" > 
  at <Plain onVnodeUnmounted=fn<onVnodeUnmounted> ref=Ref< Proxy(Object) {_fetchDelay: 200, $fetch: ƒ, setCustomColor: ƒ, removeCustomColor: ƒ, setBodyClass: ƒ, …} > > 
  at <RouterView key=1 > 
  at <App>
```

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Any form that renders a select component

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Any form that renders a select component

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
