### PR TITLE
Revert Refactoring the plain element <input> data bindings

### DIFF
--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -347,7 +347,7 @@ export default defineComponent({
         autocomplete="off"
         autocapitalize="off"
         :data-lpignore="ignorePasswordManagers"
-        @input="($plainInputEvent) => onInput($plainInputEvent)"
+        @input="onInput"
         @focus="onFocus"
         @blur="onBlur"
         @change="onChange"

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1136,11 +1136,10 @@ export default {
             >
               <input
                 ref="advancedSearchQuery"
-                :value="advFilterSearchTerm"
+                v-model="advFilterSearchTerm"
                 type="search"
                 class="advanced-search-box"
                 :placeholder="t('sortableTable.filterFor')"
-                @input="($plainInputEvent) => advFilterSearchTerm = $plainInputEvent.target.value"
               >
               <div class="middle-block">
                 <span>{{ t('sortableTable.in') }}</span>
@@ -1178,11 +1177,10 @@ export default {
           <input
             v-else-if="search"
             ref="searchQuery"
-            :value="eventualSearchQuery"
+            v-model="eventualSearchQuery"
             type="search"
             class="input-sm search-box"
             :placeholder="t('sortableTable.search')"
-            @input="($plainInputEvent) => eventualSearchQuery = $plainInputEvent.target.value"
           >
           <slot name="header-button" />
         </div>

--- a/shell/components/auth/RoleDetailEdit.vue
+++ b/shell/components/auth/RoleDetailEdit.vue
@@ -730,7 +730,7 @@ export default {
                     :disabled="isBuiltin"
                     :mode="mode"
                     :data-testid="`grant-resources-api-groups${props.i}`"
-                    @input="($plainInputEvent) => setRule('apiGroups', props.row.value, $plainInputEvent.target.value)"
+                    @input="setRule('apiGroups', props.row.value, $event.target.value)"
                   >
                 </div>
                 <div
@@ -742,7 +742,7 @@ export default {
                     :disabled="isBuiltin"
                     :mode="mode"
                     :data-testid="`grant-resources-non-resource-urls${props.i}`"
-                    @input="($plainInputEvent) => setRule('nonResourceURLs', props.row.value, $plainInputEvent.target.value)"
+                    @input="setRule('nonResourceURLs', props.row.value, $event.target.value)"
                   >
                 </div>
               </div>

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -728,7 +728,7 @@ export default {
               />
               <input
                 v-else
-                :value="row[valueName]"
+                v-model="row[valueName]"
                 :disabled="isView || disabled || isProtected(row.key)"
                 :type="valueConcealed ? 'password' : 'text'"
                 :placeholder="_valuePlaceholder"
@@ -736,7 +736,7 @@ export default {
                 autocapitalize="off"
                 spellcheck="false"
                 :data-testid="`input-kv-item-value-${i}`"
-                @input="($plainInputEvent) => queueUpdate($plainInputEvent)"
+                @input="queueUpdate"
               >
               <FileSelector
                 v-if="parseValueFromFile && readAllowed && !isView && isValueFieldEmpty(row[valueName])"

--- a/shell/components/form/MatchExpressions.vue
+++ b/shell/components/form/MatchExpressions.vue
@@ -346,11 +346,11 @@ export default {
         </div>
         <input
           v-else
-          :value="row.values"
+          v-model="row.values"
           :mode="mode"
           :disabled="row.operator==='Exists' || row.operator==='DoesNotExist'"
           :data-testid="`input-match-expression-values-control-${index}`"
-          @input="($plainInputEvent) => update($plainInputEvent)"
+          @input="update"
         >
       </div>
       <div

--- a/shell/components/form/Ports.vue
+++ b/shell/components/form/Ports.vue
@@ -156,12 +156,12 @@ export default {
             <input
               v-else
               ref="port"
-              :value="row.port"
+              v-model.number="row.port"
               type="number"
               min="1"
               max="65535"
               placeholder="e.g. 8080"
-              @input="($plainInputEvent) => queueUpdate($plainInputEvent)"
+              @input="queueUpdate"
             >
           </td>
           <td class="protocol">
@@ -195,12 +195,12 @@ export default {
             <span v-if="isView">{{ row.targetPort }}</span>
             <input
               v-else
-              :value="row.targetPort"
+              v-model.number="row.targetPort"
               type="number"
               min="1"
               max="65535"
               placeholder="e.g. 80"
-              @input="($plainInputEvent) => queueUpdate($plainInputEvent)"
+              @input="queueUpdate"
             >
           </td>
           <td class="expose">

--- a/shell/components/form/ServicePorts.vue
+++ b/shell/components/form/ServicePorts.vue
@@ -183,10 +183,10 @@ export default {
           <input
             v-else
             ref="port-name"
-            :value="row.name"
+            v-model.number="row.name"
             type="text"
             :placeholder="t('servicePorts.rules.name.placeholder')"
-            @input="($plainInputEvent) => queueUpdate($plainInputEvent)"
+            @input="queueUpdate"
           >
         </div>
         <div class="port">
@@ -194,12 +194,12 @@ export default {
           <input
             v-else
             ref="port"
-            :value="row.port"
+            v-model.number="row.port"
             type="number"
             min="1"
             max="65535"
             :placeholder="t('servicePorts.rules.listening.placeholder')"
-            @input="($plainInputEvent) => queueUpdate($plainInputEvent)"
+            @input="queueUpdate"
           >
         </div>
         <div
@@ -218,9 +218,9 @@ export default {
           <span v-if="isView">{{ row.targetPort }}</span>
           <input
             v-else
-            :value="row.targetPort"
+            v-model="row.targetPort"
             :placeholder="t('servicePorts.rules.target.placeholder')"
-            @input="($plainInputEvent) => queueUpdate($plainInputEvent)"
+            @input="queueUpdate"
           >
         </div>
         <div
@@ -230,12 +230,12 @@ export default {
           <span v-if="isView">{{ row.nodePort }}</span>
           <input
             v-else
-            :value="row.nodePort"
+            v-model.number="row.nodePort"
             type="number"
             min="1"
             max="65535"
             :placeholder="t('servicePorts.rules.node.placeholder')"
-            @input="($plainInputEvent) => queueUpdate($plainInputEvent)"
+            @input="queueUpdate"
           >
         </div>
         <div

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -527,9 +527,8 @@ export default {
               >
                 <input
                   ref="clusterFilter"
-                  :value="clusterFilter"
+                  v-model="clusterFilter"
                   :placeholder="t('nav.search.placeholder')"
-                  @input="($plainInputEvent) => clusterFilter = $plainInputEvent.target.value"
                 >
                 <i
                   class="magnifier icon icon-search"

--- a/shell/components/nav/WindowManager/ContainerLogs.vue
+++ b/shell/components/nav/WindowManager/ContainerLogs.vue
@@ -646,11 +646,10 @@ export default {
 
         <div class="log-action log-action-group ml-5">
           <input
-            :value="search"
+            v-model="search"
             class="input-sm"
             type="search"
             :placeholder="t('wm.containerLogs.search')"
-            @input="($plainInputEvent) => search = $plainInputEvent.target.value"
           >
         </div>
 

--- a/shell/dialog/ForceMachineRemoveDialog.vue
+++ b/shell/dialog/ForceMachineRemoveDialog.vue
@@ -90,9 +90,8 @@ export default {
         </div>
         <input
           id="confirm"
-          :value="confirmName"
+          v-model="confirmName"
           type="text"
-          @input="($plainInputEvent) => confirmName = $plainInputEvent"
         >
         <div class="text-info mt-20">
           {{ protip }}

--- a/shell/edit/networking.k8s.io.ingress/RulePath.vue
+++ b/shell/edit/networking.k8s.io.ingress/RulePath.vue
@@ -129,9 +129,9 @@ export default {
     >
       <input
         ref="first"
-        :value="path"
+        v-model="path"
         :placeholder="t('ingress.rules.path.placeholder', undefined, true)"
-        @input="($plainInputEvent) => {path = $plainInputEvent.target.value; queueUpdate($plainInputEvent);}"
+        @input="queueUpdate"
       >
     </div>
     <div

--- a/shell/edit/token.vue
+++ b/shell/edit/token.vue
@@ -206,11 +206,10 @@ export default {
         />
         <div class="ml-20 mt-10 expiry">
           <input
-            :value="form.customExpiry"
+            v-model="form.customExpiry"
             :disabled="form.expiryType !== 'custom'"
             type="number"
             :mode="mode"
-            @input="($plainInputEvent) => form.customExpiry = $plainInputEvent"
           >
           <Select
             v-model:value="form.customExpiryUnits"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This reverts the remaining changes from 7f1536d9cff20b73b8b42a703886f170a50fda5f, where we modified `v-model` usage for html elements to reduce errors when running the migration script.

After encountering a second issue related to this change (#11723), I thought it was best to revert the change so that we could get back to the original behavior.

Fixes #11723 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- reverts commit 7f1536d9cff20b73b8b42a703886f170a50fda5f

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Each element should behave as it did before 7f1536d9cff20b73b8b42a703886f170a50fda5f was introduced

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- double check each modified component is not mutating a prop via `v-model`

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
