### PR TITLE
Fixed configmaps not creating

### DIFF
--- a/cypress/e2e/po/pages/explorer/config-map.po.ts
+++ b/cypress/e2e/po/pages/explorer/config-map.po.ts
@@ -41,4 +41,8 @@ export class ConfigMapPagePo extends PagePo {
   searchForConfigMap(name: string) {
     return this.list().resourceTable().sortableTable().filter(name);
   }
+
+  title() {
+    return this.self().get('.title h1').invoke('text');
+  }
 }

--- a/cypress/e2e/tests/pages/explorer2/storage/configmap.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/configmap.spec.ts
@@ -3,7 +3,7 @@ import ConfigMapPo from '@/cypress/e2e/po/components/storage/config-map.po';
 
 const configMapPage = new ConfigMapPagePo('local');
 
-describe.skip('[Vue3 Skip]: ConfigMap', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
+describe.skip('ConfigMap', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer2/storage/configmap.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/configmap.spec.ts
@@ -10,7 +10,7 @@ describe('ConfigMap', { testIsolation: 'off', tags: ['@explorer2', '@adminUser']
 
   it('has the correct title', () => {
     configMapPage.goTo();
-    configMapPage.waitForMastheadTitle('ConfigMaps');
+    configMapPage.title().should('include', `ConfigMaps`);
 
     cy.title().should('eq', 'Rancher - local - ConfigMaps');
   });

--- a/cypress/e2e/tests/pages/explorer2/storage/configmap.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/configmap.spec.ts
@@ -3,7 +3,7 @@ import ConfigMapPo from '@/cypress/e2e/po/components/storage/config-map.po';
 
 const configMapPage = new ConfigMapPagePo('local');
 
-describe.skip('ConfigMap', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
+describe('ConfigMap', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });

--- a/shell/edit/configmap.vue
+++ b/shell/edit/configmap.vue
@@ -8,9 +8,9 @@ import Tab from '@shell/components/Tabbed/Tab';
 import Tabbed from '@shell/components/Tabbed';
 
 export default {
-  name: 'CruConfigMap',
+  name:         'CruConfigMap',
   inheritAttrs: false,
-  components: {
+  components:   {
     CruResource,
     NameNsDescription,
     KeyValue,

--- a/shell/edit/configmap.vue
+++ b/shell/edit/configmap.vue
@@ -9,7 +9,7 @@ import Tabbed from '@shell/components/Tabbed';
 
 export default {
   name: 'CruConfigMap',
-
+  inheritAttrs: false,
   components: {
     CruResource,
     NameNsDescription,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11690 
Fixed configmap not creating and not being able to switch from form view to yaml. Reenabled the test.

<!-- Define findings related to the feature or bug issue. -->
waitForMastheadTitle in E2E test seem to only work for create/edit forms and not for lists.
without inheritAttrs: false, resource attribute is passed as a string and not an object, which makes schema fetching not work correctly

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
added inheritAttrs: false

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- creating a config map should work in Config Maps page
- it should be possible to switch from form view to edit as yaml view when creating a configMap

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
