### PR TITLE
Vue3: API Key Create Page: vertical spacing issue

### DIFF
--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -247,6 +247,7 @@ export default {
   <div
     ref="select"
     class="labeled-select"
+    v-bind="$attrs"
     :class="{
       disabled: isView || disabled,
       focused,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11720 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add `v-bind="$attrs"` to outermost container of `LabeledSelect`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Problem was that the class `mt-20` that was specified in the view for the api key https://github.com/rancher/dashboard/blob/master/shell/edit/token.vue#L188-L193 was not being passed to the component. 
<img width="2478" alt="Screenshot 2024-08-28 at 16 44 10" src="https://github.com/user-attachments/assets/d73aa6b0-bc58-4692-8070-5c5219c5ef14">

I think that I applied the correct fix, but someone with more experience on the Vue3 migration should chime in as a reviewer, because of possible unwanted side-effects.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
