### PR TITLE
Fix race condition when opening namespace selector

### DIFF
--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -679,6 +679,12 @@ export default {
 
       return null;
     },
+    onFocus(e) {
+      // differentiates between focused by mouse click vs keyboard navigation so doesn't cause a race condition
+      if (e.relatedTarget !== null) {
+        this.open();
+      }
+    },
   }
 };
 </script>
@@ -689,7 +695,7 @@ export default {
     class="ns-filter"
     data-testid="namespaces-filter"
     tabindex="0"
-    @focus="open()"
+    @focus="onFocus($event)"
   >
     <div
       v-if="isOpen"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11683 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
There was a race condition when clicking on the namespace selector to open it. The focus event listener on the wrapper element was calling the `open()` method(this's been added for opening the selector by keyboard navigation) then another click event listener triggers the `toggle()` method. In `toggle()` the `isOpen` is already `true` because of the focus event being triggered first so it closes the selector. A condition added to the focus event to differentiate between keyboard navigation and mouse click when the selector gets opened.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Use different ways to open/close the namespace selector like by clicking and keyboard navigation.
### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Using keyboard navigation to open the selector.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
