### PR TITLE
Prevent mousedown event from triggering focus in NamespaceFilter.vue

### DIFF
--- a/cypress/e2e/po/components/namespace-filter.po.ts
+++ b/cypress/e2e/po/components/namespace-filter.po.ts
@@ -5,7 +5,7 @@ export class NamespaceFilterPo extends ComponentPo {
   }
 
   toggle() {
-    return this.self().click({ force: true });
+    return this.namespaceDropdown().click({ force: true });
   }
 
   getOptions(): Cypress.Chainable {

--- a/cypress/e2e/tests/pages/explorer2/namespace-picker.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/namespace-picker.spec.ts
@@ -12,6 +12,7 @@ describe('Namespace picker', { testIsolation: 'off' }, () => {
   });
 
   beforeEach('set up', () => {
+    HomePagePo.goTo();
     ClusterDashboardPagePo.navTo();
 
     // reset namespace picker to default state

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -689,6 +689,7 @@ export default {
     class="ns-filter"
     data-testid="namespaces-filter"
     tabindex="0"
+    @mousedown.prevent
     @focus="open()"
   >
     <div


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This prevents the mousedown event from triggering focus to fix an issue where the focus event would open the NamespaceFilter dropdown and the subsequent click event would toggle the dropdown to closed. 

Fixes #11683 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add mousedown.prevent to the containing div that manages focus for the NamespaceFilter component

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- The focus event and the click event were both triggering, causing the dropdown to open and immediately close

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- NamespaceFilter component

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- NamespaceFilter component

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
