### PR TITLE
[Automation] - Fix naming after a change was reverted on corral-packages

### DIFF
--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -135,7 +135,7 @@ create_initial_clusters() {
 
   corral config vars set instance_type "${AWS_INSTANCE_TYPE}"
   corral config vars set aws_hostname_prefix "jenkins-${prefix_random}"
-  echo "Corral Package string: ${CERT_MANAGER_VERSION}-${RANCHER_VERSION//v}-${K3S_KUBERNETES_VERSION}"
+  echo "Corral Package string: ${K3S_KUBERNETES_VERSION}-${RANCHER_VERSION//v}-${CERT_MANAGER_VERSION}"
   corral config vars set aws_hostname_prefix "jenkins-${prefix_random}-i"
   corral config vars set server_count 1
   corral create --skip-cleanup --recreate --debug importcluster \
@@ -144,7 +144,7 @@ create_initial_clusters() {
   corral config vars set aws_hostname_prefix "jenkins-${prefix_random}"
   corral config vars set server_count "${SERVER_COUNT:-3}"
   corral create --skip-cleanup --recreate --debug rancher \
-    "dist/aws-k3s-rancher-${CERT_MANAGER_VERSION}-${RANCHER_VERSION//v}-${K3S_KUBERNETES_VERSION}"
+    "dist/aws-k3s-rancher-${K3S_KUBERNETES_VERSION}-${RANCHER_VERSION//v}-${CERT_MANAGER_VERSION}"
 }
 
 


### PR DESCRIPTION
### Summary

Upstream corral package commit was reverted.
https://github.com/rancherlabs/corral-packages/pull/58

### Occurred changes and/or fixed issues
naming of generated packages is affected. Reverting to original after upstream was reverted.

### Technical notes summary
Fix Jenkins CI

### Areas or cases that should be tested
Jenkins

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to Jenkins

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
