### PR TITLE
Fix -> Vue3: SAML SLO support - feature is broken

### DIFF
--- a/pkg/rancher-components/src/components/Form/TextArea/TextAreaAutoGrow.vue
+++ b/pkg/rancher-components/src/components/Form/TextArea/TextAreaAutoGrow.vue
@@ -172,6 +172,7 @@ export default defineComponent({
 <template>
   <textarea
     ref="ta"
+    :value="value"
     :data-testid="$attrs['data-testid'] ? $attrs['data-testid'] : 'text-area-auto-grow'"
     :disabled="isDisabled"
     :style="style"

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -735,8 +735,18 @@ export default {
                     <a :href="href">{{ t('nav.userMenu.accountAndKeys', {}, true) }}</a>
                   </li>
                 </router-link>
+                <!-- SLO modal -->
+                <li
+                  v-if="authEnabled && shouldShowSloLogoutModal"
+                  class="user-menu-item no-link"
+                  @click="showSloModal"
+                  @keypress.enter="showSloModal"
+                >
+                  <span>{{ t('nav.userMenu.logOut') }}</span>
+                </li>
+                <!-- logout -->
                 <router-link
-                  v-if="authEnabled"
+                  v-else-if="authEnabled"
                   v-slot="{ href, navigate }"
                   custom
                   :to="generateLogoutRoute"
@@ -1139,6 +1149,7 @@ export default {
       display: flex;
       justify-content: space-between;
       padding: 10px;
+      color: var(--link);
     }
 
     div.menu-separator {

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -125,19 +125,24 @@ export default {
       switch (neu) {
       case SLO_OPTION_VALUES.rancher:
         this.model.logoutAllEnabled = false;
-        this.$set(this.model, 'logoutAllForced', false);
+        this.model.logoutAllForced = false;
         break;
       case SLO_OPTION_VALUES.all:
-        this.$set(this.model, 'logoutAllEnabled', true);
-        this.$set(this.model, 'logoutAllForced', true);
+        this.model.logoutAllEnabled = true;
+        this.model.logoutAllForced = true;
         break;
       case SLO_OPTION_VALUES.both:
-        this.$set(this.model, 'logoutAllEnabled', true);
-        this.$set(this.model, 'logoutAllForced', false);
+        this.model.logoutAllEnabled = true;
+        this.model.logoutAllForced = false;
         break;
       }
     }
-  }
+  },
+  methods: {
+    onSelected(val, key) {
+      this.model[key] = val;
+    }
+  },
 };
 </script>
 
@@ -309,7 +314,7 @@ export default {
               class="role-tertiary add mt-5"
               :label="t('generic.readFromFile')"
               :mode="mode"
-              @selected="$set(model, 'spKey', $event)"
+              @selected="onSelected($event, 'spKey')"
             />
           </div>
           <div class="col span-4">
@@ -325,7 +330,7 @@ export default {
               class="role-tertiary add mt-5"
               :label="t('generic.readFromFile')"
               :mode="mode"
-              @selected="$set(model, 'spCert', $event)"
+              @selected="onSelected($event, 'spCert')"
             />
           </div>
           <div class="col span-4">
@@ -341,7 +346,7 @@ export default {
               class="role-tertiary add mt-5"
               :label="t('generic.readFromFile')"
               :mode="mode"
-              @selected="$set(model, 'idpMetadataContent', $event)"
+              @selected="onSelected($event, 'idpMetadataContent')"
             />
           </div>
         </div>
@@ -359,7 +364,7 @@ export default {
           <div class="row">
             <div class="col span-4">
               <RadioGroup
-                v-model="sloType"
+                v-model:value="sloType"
                 :mode="mode"
                 :options="sloOptions"
                 :disabled="!model.logoutAllSupported"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11766 
<!-- Define findings related to the feature or bug issue. -->
**Original work was done on this PR https://github.com/rancher/dashboard/pull/11182**

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add missing bits to make SAML SLO feature work (`Header` component missing a part of template)
- fix  `$set` notations on `saml.vue`
- fix problem of data propagation on the SAML auth providers for certificates where when you added a certificate the textarea wouldn't show the certificate data `TextAreaAutoGrow`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Follow instructions on https://github.com/rancher/dashboard/pull/11182

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- There some problems with the styling on the popover that comes from clicking on the avatar icon on the header, especially for different themes (light vs dark) but that's tracked already in https://github.com/rancher/dashboard/issues/11684

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1567" alt="Screenshot 2024-08-29 at 09 54 49" src="https://github.com/user-attachments/assets/04cb97d2-3200-4b4b-9363-4dc277fed029">
<img width="1567" alt="Screenshot 2024-08-29 at 09 54 56" src="https://github.com/user-attachments/assets/a778a3cf-58af-42ee-aafa-541045a957fa">
<img width="1567" alt="Screenshot 2024-08-29 at 09 55 12" src="https://github.com/user-attachments/assets/f7957bca-14fb-4d66-8a5d-9a80af55c4f9">
<img width="1567" alt="Screenshot 2024-08-29 at 09 55 56" src="https://github.com/user-attachments/assets/0cc43aef-a3ca-470e-8269-050e7e2acf14">
<img width="1567" alt="Screenshot 2024-08-29 at 10 28 19" src="https://github.com/user-attachments/assets/55fc57fd-595f-45d2-874c-b1ce736c8b50">



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
