### PR TITLE
Don't provide default slot to `CruResourceFooter`

### DIFF
--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -416,6 +416,10 @@ export default {
       if (this.preventEnterSubmit) {
         event.preventDefault();
       }
+    },
+
+    shouldProvideSlot(slot) {
+      return slot !== 'default' && typeof this.$slots[slot] === 'function';
     }
   },
 
@@ -596,7 +600,7 @@ export default {
                     v-for="(_, slot) of $slots"
                     :key="slot"
                   >
-                    <template v-if="typeof $slots[slot] === 'function'">
+                    <template v-if="shouldProvideSlot(slot)">
                       <slot
                         :name="slot"
                         v-bind="{ ...$slots[slot]() }"
@@ -679,7 +683,7 @@ export default {
               v-for="(_, slot) of $slots"
               :key="slot"
             >
-              <template v-if="typeof $slots[slot] === 'function'">
+              <template v-if="shouldProvideSlot(slot)">
                 <slot
                   :name="slot"
                   v-bind="{ ...$slots[slot]() }"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves the issue of `CruResource` rendering duplicate templates by excluding the default slot from being provided to `CruResourceFooter`.

Fixes #11716
Fixes #11741
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- don't expose the default slot in `CruResourceFooter`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This behavior is directly related to Vue3 Slot Unification[^1] and is only an issue in instances where we iterate over slots.

In Vue2, this template would iterate over scoped slots via `v-for="(_, slot) of $scopedSlots"`. Since `$scopedSlots` has been merged with `$slots` in Vue3, we are now inadvertently picking up the default slot along with the rest. 

In previous instances of this error, we filtered for scoped slots via `v-if="typeof $slots[slot] === 'function'"`. For the offending instances addressed in this PR, `default` was also being treated as a scoped slot and we still don't want to render it in our templates.

[^1]: https://v3-migration.vuejs.org/breaking-changes/slots-unification#slots-unification

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- any form that makes use of `CruResource` and `CruResourceFooter`
- examples listed in issues

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->


- any form that makes use of `CruResource` and `CruResourceFooter`
- examples listed in issues

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
