### PR TITLE
Fix height of rows containing Select compoent/s

### DIFF
--- a/shell/assets/styles/base/_variables.scss
+++ b/shell/assets/styles/base/_variables.scss
@@ -7,6 +7,7 @@ $max-width: 1440px !default;
 $min-width: 75% !default;
 $input-height: 61px;
 $unlabeled-input-height: 40px;
+$unlabaled-select-padding: 3px 0;
 
 $input-padding-lg: 18px;
 $input-padding-sm: 10px;

--- a/shell/assets/styles/global/_select.scss
+++ b/shell/assets/styles/global/_select.scss
@@ -142,7 +142,7 @@
   background-color: var(--input-bg);
   border-radius: var(--border-radius);
   color: var(--input-text);
-  padding: 3px 0;
+  padding: $unlabaled-select-padding;
 
   .vs--single .vs__selected-options {
     flex-wrap: nowrap;

--- a/shell/components/auth/RoleDetailEdit.vue
+++ b/shell/components/auth/RoleDetailEdit.vue
@@ -16,6 +16,7 @@ import SortableTable from '@shell/components/SortableTable';
 import { _CLONE, _DETAIL } from '@shell/config/query-params';
 import { SCOPED_RESOURCES, SCOPED_RESOURCE_GROUPS } from '@shell/config/roles';
 import { Banner } from '@components/Banner';
+import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 
 import { SUBTYPE_MAPPING, VERBS } from '@shell/models/management.cattle.io.roletemplate';
 import Loading from '@shell/components/Loading';
@@ -63,7 +64,8 @@ export default {
     SortableTable,
     Loading,
     Error,
-    Banner
+    Banner,
+    LabeledInput
   },
 
   mixins: [CreateEditView, FormValidation],
@@ -706,6 +708,7 @@ export default {
                     :options="verbOptions"
                     :multiple="true"
                     :mode="mode"
+                    :compact="true"
                     :data-testid="`grant-resources-verbs${props.i}`"
                     @update:value="updateSelectValue(props.row.value, 'verbs', $event)"
                   />
@@ -719,31 +722,32 @@ export default {
                     :searchable="true"
                     :taggable="true"
                     :mode="mode"
+                    :compact="true"
                     :data-testid="`grant-resources-resources${props.i}`"
                     @update:value="setRule('resources', props.row.value, $event)"
                     @createdListItem="setRule('resources', props.row.value, $event)"
                   />
                 </div>
                 <div :class="ruleClass">
-                  <input
+                  <LabeledInput
                     :value="getRule('apiGroups', props.row.value)"
                     :disabled="isBuiltin"
                     :mode="mode"
                     :data-testid="`grant-resources-api-groups${props.i}`"
                     @input="setRule('apiGroups', props.row.value, $event.target.value)"
-                  >
+                  />
                 </div>
                 <div
                   v-if="!isNamespaced"
                   :class="ruleClass"
                 >
-                  <input
+                  <LabeledInput
                     :value="getRule('nonResourceURLs', props.row.value)"
                     :disabled="isBuiltin"
                     :mode="mode"
                     :data-testid="`grant-resources-non-resource-urls${props.i}`"
                     @input="setRule('nonResourceURLs', props.row.value, $event.target.value)"
-                  >
+                  />
                 </div>
               </div>
             </template>
@@ -777,6 +781,7 @@ export default {
                     option-key="value"
                     option-label="label"
                     :mode="mode"
+                    :compact="true"
                     @on-focus="selectFocused = props.i"
                     @on-blur="selectFocused = null"
                   />
@@ -813,18 +818,9 @@ export default {
     }
 
     .columns {
-      & > .col {
-        &:not(:first-of-type) {
-          height: $input-height;
-        }
-
-        &:first-of-type {
-          min-height: $input-height;
-        }
-
-        & > * {
-          height: 100%;
-        }
+      .col > .unlabeled-select:not(.taggable) {
+        // override the odd padding-top from shell/assets/styles/global/_select.scss
+        padding: $unlabaled-select-padding
       }
     }
   }

--- a/shell/components/form/Select.vue
+++ b/shell/components/form/Select.vue
@@ -81,6 +81,11 @@ export default {
       type:    Boolean,
       default: true
     },
+
+    compact: {
+      type:    Boolean,
+      default: null
+    },
   },
 
   methods: {
@@ -206,6 +211,11 @@ export default {
     },
     canPaginate() {
       return false;
+    },
+    deClassedAttrs() {
+      const { class: _, ...rest } = this.$attrs;
+
+      return rest;
     }
   }
 };
@@ -222,13 +232,14 @@ export default {
       [status]: status,
       taggable: $attrs.taggable,
       taggable: $attrs.multiple,
+      'compact-input': compact,
       [$attrs.class]: $attrs.class
     }"
     @focus="focusSearch"
   >
     <v-select
       ref="select-input"
-      v-bind="$attrs"
+      v-bind="deClassedAttrs"
       class="inline"
       :class="{'select-input-view': mode === 'view'}"
       :autoscroll="true"
@@ -325,5 +336,10 @@ export default {
     }
 
     @include input-status-color;
+
+    &.compact-input {
+      min-height: $unlabeled-input-height;
+      line-height: $input-line-height;
+    }
   }
 </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Resolve two bug
##### Bug 1 - Height of create role resource tab's input fields are too high
##### Bug 2 - Height of create project resource quotas tab's input fields are too high

I've bundled these two together as they're the same problem, however different issues. If needs be can investigate splitting in two with the hope there's no overlap 

### Occurred changes and/or fixed issues

##### Bug 1 -  Improve the height of Create Role Resource Tab's input fields
- Remove custom code, use new generic code that follows 'compact' concept used elsewhere
- Apply to all four fields in row
- Also fix a bug where selecting verbs such that another row is shown would grow height of all other inputs in row

##### Bug 2 - Fix height of Create Project Resource Quotes input fields
- How it worked/works
  - Vue2
    - Part 1 - Component would inherit attributes, such as class from owning element. For example classes applied to `<Select` would be applied to the first element within the Select component
    - Part 2 - $attrs property does not contain some properties from the parent, such as class
  - Vue3
    - Part 1 - Component does not inherit attributes of owning element
    - Part 2 - $attrs property contains all properties of parent, including class
- Bug
  - We fixed part one (vue3 components do not pass down parent component class), but not part two (vue3 $attrs contain class, so class was applied in other places)
  - Specifically in Select component class was being passed down from parent class. Due to fix for part one it was applied to parent component, however given part two also to the v-select
  - solution is to fix part two (chop out class)


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
- As per bug description

### Areas which could experience regressions
- Might be worth checking a sprinkling of other Select places

### Screenshot/Video
##### Bug 1 -  Improve the height of Create Role Resource Tab's input fields

Before
![image](https://github.com/user-attachments/assets/9f423fcd-2a86-4c5a-9e45-8f0ada3d63f8)

After
![image](https://github.com/user-attachments/assets/190eba16-b62d-4593-ac6e-ecab0ec28385)


##### Bug 2 - Fix height of Create Project Resource Quotes input fields

Before
![image](https://github.com/user-attachments/assets/ca808784-f949-431d-84e2-833f547f2fe9)

After
![image](https://github.com/user-attachments/assets/47942a9f-5fa2-4f68-a86e-ae2f43835dde)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
