### PR TITLE
Resolve issues with workload pod storage

### DIFF
--- a/shell/components/ButtonDropdown.vue
+++ b/shell/components/ButtonDropdown.vue
@@ -181,7 +181,7 @@ export default {
     :clearable="false"
     :close-on-select="closeOnSelect"
     :filterable="false"
-    :value="buttonLabel"
+    :modelValue="buttonLabel"
     :options="dropdownOptions"
     :map-keydown="mappedKeys"
     :get-option-key="
@@ -191,7 +191,7 @@ export default {
     :selectable="selectable"
     @search:blur="onBlur"
     @search:focus="onFocus"
-    @update:value="$emit('click-action', $event)"
+    @update:modelValue="$emit('click-action', $event)"
   >
     <template #no-options>
       <slot name="no-options" />

--- a/shell/components/ButtonDropdown.vue
+++ b/shell/components/ButtonDropdown.vue
@@ -211,14 +211,15 @@ export default {
     <!-- Pass down templates provided by the caller -->
     <template
       v-for="(_, slot) of $slots"
+      #[slot]="scope"
       :key="slot"
-      v-slot:[slot]="scope"
     >
-      <slot
-        v-if="slot !== 'selected-option'"
-        :name="slot"
-        v-bind="scope"
-      />
+      <template v-if="slot !== 'selected-option' && typeof $slots[slot] === 'function'">
+        <slot
+          :name="slot"
+          v-bind="scope"
+        />
+      </template>
     </template>
   </v-select>
 </template>

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -598,12 +598,13 @@ export default {
                   <!-- Pass down templates provided by the caller -->
                   <template
                     v-for="(_, slot) of $slots"
+                    #[slot]="scope"
                     :key="slot"
                   >
                     <template v-if="shouldProvideSlot(slot)">
                       <slot
                         :name="slot"
-                        v-bind="{ ...$slots[slot]() }"
+                        v-bind="scope"
                       />
                     </template>
                   </template>
@@ -681,12 +682,13 @@ export default {
             <!-- Pass down templates provided by the caller -->
             <template
               v-for="(_, slot) of $slots"
+              #[slot]="scope"
               :key="slot"
             >
               <template v-if="shouldProvideSlot(slot)">
                 <slot
                   :name="slot"
-                  v-bind="{ ...$slots[slot]() }"
+                  v-bind="scope"
                 />
               </template>
             </template>

--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -86,7 +86,7 @@ export default {
     }
   },
   data() {
-    const input = (this.value || []).slice();
+    const input = (Array.isArray(this.value) ? this.value : []).slice();
     const rows = [];
 
     for ( const value of input ) {

--- a/shell/components/form/ArrayListGrouped.vue
+++ b/shell/components/form/ArrayListGrouped.vue
@@ -95,12 +95,15 @@ export default {
     <!-- Pass down templates provided by the caller -->
     <template
       v-for="(_, slot) of $slots"
-      v-slot:[slot]="scope"
+      #[slot]="scope"
+      :key="slot"
     >
-      <slot
-        :name="slot"
-        v-bind="scope"
-      />
+      <template v-if="typeof $slots[slot] === 'function'">
+        <slot
+          :name="slot"
+          v-bind="scope"
+        />
+      </template>
     </template>
   </ArrayList>
 </template>

--- a/shell/components/form/ArrayListGrouped.vue
+++ b/shell/components/form/ArrayListGrouped.vue
@@ -37,7 +37,16 @@ export default {
       type:    String,
       default: _EDIT,
     },
+
+    value: {
+      type:    Object,
+      default: () => {
+        return {};
+      },
+    },
   },
+
+  emits: ['update:value', 'add', 'remove'],
 
   computed: {
     isView() {
@@ -67,6 +76,7 @@ export default {
 <template>
   <ArrayList
     class="array-list-grouped"
+    :value="value"
     v-bind="$attrs"
     :add-allowed="canAdd && !isView"
     :mode="mode"

--- a/shell/edit/workload/storage/index.vue
+++ b/shell/edit/workload/storage/index.vue
@@ -144,33 +144,19 @@ export default {
 
     addVolume(type) {
       const name = `vol-${ randomStr(5).toLowerCase() }`;
+      const newVolume = { name, _type: type };
 
       if (type === 'createPVC') {
-        this.value.volumes.push({
-          _type:                 'createPVC',
-          persistentVolumeClaim: {},
-          name,
-        });
+        newVolume.persistentVolumeClaim = {};
       } else if (type === 'csi') {
-        this.value.volumes.push({
-          _type: type,
-          csi:   { volumeAttributes: {} },
-          name,
-        });
+        newVolume.csi = { volumeAttributes: {} };
       } else if (type === 'emptyDir') {
-        this.value.volumes.push({
-          _type:    type,
-          emptyDir: { medium: '' },
-          name,
-        });
+        newVolume.emptyDir = { medium: '' };
       } else {
-        this.value.volumes.push({
-          _type:  type,
-          [type]: {},
-          name,
-        });
+        newVolume[type] = {};
       }
 
+      this.value.volumes = [...this.value.volumes, newVolume];
       // this.container.volumeMounts.push({ name });
     },
 

--- a/shell/edit/workload/storage/index.vue
+++ b/shell/edit/workload/storage/index.vue
@@ -6,6 +6,7 @@ import CodeMirror from '@shell/components/CodeMirror';
 import jsyaml from 'js-yaml';
 import ArrayListGrouped from '@shell/components/form/ArrayListGrouped';
 import { randomStr } from '@shell/utils/string';
+import { uniq } from '@shell/utils/array';
 
 export default {
   name: 'Storage',
@@ -89,13 +90,13 @@ export default {
       const customVolumeTypes = require
         .context('@shell/edit/workload/storage', false, /^.*\.vue$/)
         .keys()
-        .map((path) => path.replace(/(\.\/)|(.vue)/g, ''))
+        .map((path) => path.replace(/(\.\/)|(.vue)/g, '').split('/').findLast(() => true))
         .filter((file) => !excludedFiles.includes(file));
 
-      return [
+      return uniq([
         ...customVolumeTypes,
         ...defaultVolumeTypes
-      ]
+      ])
         .sort()
         .map((volumeType) => ({
           label:  this.t(`workload.storage.subtypes.${ volumeType }`),


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves several issues associated with the Pod Storage tab under when creating new deployments:

- `ButtonDropdown.vue` now renders a label
- `ButtonDropdown.vue` now renders a list volumes
- Selecting a volume now renders the associated form in `ArrayListGrouped.vue`

Fixes #11787
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Several issues are resolved in this PR:

- Updates the slot syntax to be more consistent with `CruResource.vue`. This should help with accurately rendering slot content when we iterate over component slots.
- `v-select` now makes use of `modelValue`/`update:modelValue` for two-way data binding. This is consistent with the Vue3 migration guide.
- This approach uses the spread operator to create a new array instead of using push. It appears that using push on a nested property of a reactive object was not triggering Vue's reactivity in this instance, while creating a new array does the job.
- Add missing `value` prop in `ArrayListGrouped.vue`
- Normalize `customVolumeTypes` paths for storage `ButtonDropdown`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Storage
- ButtonDropdown
- ArrayList
- ArrayListGrouped

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Storage
- ButtonDropdown
- ArrayList
- ArrayListGrouped

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
