### PR TITLE
[Automation] - Forcing use of node 16 for branches 2.9 and below. Bump kubectl client

### DIFF
--- a/cypress/jenkins/Dockerfile.ci
+++ b/cypress/jenkins/Dockerfile.ci
@@ -1,6 +1,6 @@
 FROM cypress/factory
 
-ARG KUBECTL_VERSION=v1.27.10
+ARG KUBECTL_VERSION=v1.29.8
 ARG CURL_VERSION=v8.6.0
 
 RUN wget https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl && \

--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -34,7 +34,7 @@ HELM_VERSION="${HELM_VERSION:-3.13.2}"
 NODEJS_VERSION="${NODEJS_VERSION:-14.19.1}"
 CYPRESS_VERSION="${CYPRESS_VERSION:-13.2.0}"
 YARN_VERSION="${YARN_VERSION:-1.22.19}"
-KUBECTL_VERSION="${KUBECTL_VERSION:-v1.27.10}"
+KUBECTL_VERSION="${KUBECTL_VERSION:-v1.29.8}"
 YQ_BIN="mikefarah/yq/releases/latest/download/yq_linux_amd64"
 
 mkdir -p "${WORKSPACE}/bin"
@@ -47,6 +47,10 @@ chmod +x "${CORRAL}"
 
 curl -L -o "${GO_PKG_FILENAME}" "${GO_DL_PACKAGE}"
 tar -C "${WORKSPACE}" -xzf "${GO_PKG_FILENAME}"
+
+curl -sSL https://raw.githubusercontent.com/parleer/semver-bash/latest/semver -o semver
+chmod +x semver
+mv semver "${WORKSPACE}/bin"
 
 ls -al "${WORKSPACE}"
 export PATH=$PATH:"${WORKSPACE}/go/bin:${WORKSPACE}/bin"
@@ -163,6 +167,9 @@ if [[ "${JOB_TYPE}" == "existing" ]]; then
 fi
 
 echo "Rancher type: ${RANCHER_TYPE}"
+
+override_node=$(semver lt "${RANCHER_VERSION}" "2.9.99")
+if [[ ${override_node} -eq 0 && RANCHER_IMAGE_TAG != "head" ]]; then NODEJS_VERSION="16.20.2"; fi
 
 corral config vars set rancher_type "${RANCHER_TYPE}"
 corral config vars set nodejs_version "${NODEJS_VERSION}"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Force use of a common node version `16` for releases 2.9 and below down to 2.7.
Bumping kubectl to a newer version as each version support one version up and down. This to mitigate any kubectl client errors during setup.

### Occurred changes and/or fixed issues
Jenkins pipelines that are `release-2.9` and older fail to use `node 20` which is a new requirement on `master` / `latest` 

### Areas or cases that should be tested
Jenkins pipelines

### Areas which could experience regressions
CI

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
