### PR TITLE
Fix check-plugins-build workflow

### DIFF
--- a/creators/extension/app/app.package.json
+++ b/creators/extension/app/app.package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": false,
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "dependencies": {
     "cache-loader": "^4.1.0",
@@ -12,6 +12,7 @@
     "node-polyfill-webpack-plugin": "^3.0.0"
   },
   "resolutions": {
+    "@types/node": "~20.10.0",
     "d3-color": "3.1.0",
     "ejs": "3.1.9",
     "follow-redirects": "1.15.2",

--- a/creators/extension/app/files/tsconfig.json
+++ b/creators/extension/app/files/tsconfig.json
@@ -10,7 +10,7 @@
     ],
     "esModuleInterop": true,
     "allowJs": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "strict": true,
     "noEmit": true,
     "baseUrl": ".",
@@ -28,7 +28,7 @@
     "typeRoots": [
       "./node_modules",
       "./node_modules/@rancher/shell/types"
-    ],    
+    ],
     "types": [
       "@types/node",
       "cypress",

--- a/creators/extension/app/package.json
+++ b/creators/extension/app/package.json
@@ -11,7 +11,7 @@
     "init"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "_requires": [
     "core-js",

--- a/creators/extension/package.json
+++ b/creators/extension/package.json
@@ -13,7 +13,7 @@
     "init"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "_requires": [
     "core-js",

--- a/creators/extension/pkg/package.json
+++ b/creators/extension/pkg/package.json
@@ -11,7 +11,7 @@
     "init"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "resolutions": {
     "d3-color": "3.1.0",

--- a/creators/extension/update/package.json
+++ b/creators/extension/update/package.json
@@ -12,7 +12,7 @@
     "upgrade"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "fs-extra": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "node": ">=20.0.0"
   },
   "workspaces": [
-    "pkg/rancher-components",
-    "creators/extension"
+    "pkg/rancher-components"
   ],
   "scripts": {
     "build-pkg": "yarn lint && ./shell/scripts/build-pkg.sh",


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This will fix the `check-plugins-build` workflow. There were a few of issues introduced with #11758, including:
- `creators/extension` added to the dashboard workspaces
- `@types/node` resolution causing build errors
- Source maps being added to the build artifacts

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Removed the `creators/extension` from the workspaces
- Pinned node version to `>= 20` for all creators and extension packages
- Added a resolution to the `creators/extension/app/app.package.json` for `"@types/node": "~20.10.0" ( [See supported tag](https://www.npmjs.com/package/@types/node?activeTab=versions) based on our typescript version `4.5` )
- Changed the `sourceMap` property in the `creators/extension/app/files/tsconfig.json` to `false`


### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
