### PR TITLE
Fix yaml editor styling

### DIFF
--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -66,6 +66,7 @@ export default {
 
       if (this.asTextArea) {
         out.lineNumbers = false;
+        out.foldGutter = false;
         out.tabSize = 0;
         out.extraKeys = { Tab: false };
       }
@@ -282,15 +283,9 @@ export default {
         color: var(--primary-text);
         background-color: var(--primary);
       }
-
-      .CodeMirror-gutter-wrapper,
-      .CodeMirror-gutters>*{
-        display:none;
-      }
     }
   }
 
-  // add selector here to ensure lower rules that lost .vue-codemirror selector still have enough specificity to override library's styling
   .code-mirror .codemirror-container {
     z-index: 0;
     font-size: inherit !important;
@@ -358,92 +353,9 @@ export default {
       background: none
     }
 
-    // &.as-text-area {
-    //   min-height: 40px;
-    //   position: relative;
-    //   display: block;
-    //   box-sizing: border-box;
-    //   width: 100%;
-    //   padding: 10px;
-    //   background-color: var(--input-bg);
-    //   border-radius: var(--border-radius);
-    //   border: solid var(--border-width) var(--input-border);
-    //   color: var(--input-text);
+    .CodeMirror-foldgutter:empty {
+      display: none;
+    }
 
-    //   &:hover {
-    //     border-color: var(--input-hover-border);
-    //   }
-
-    //   &:focus, &.focus {
-    //     outline: none;
-    //     border-color: var(--outline);
-    //   }
-
-    //   .CodeMirror-wrap pre {
-    //     word-break: break-word;
-    //   }
-    //   .CodeMirror-code {
-    //     .CodeMirror-line {
-    //       &:not(:last-child)>span:after,
-    //       .cm-markdown-single-trailing-space-odd:before,
-    //       .cm-markdown-single-trailing-space-even:before {
-    //         color: var(--muted);
-    //         position: absolute;
-    //         line-height: 20px;
-    //         pointer-events: none;
-    //       }
-    //       &:not(:last-child)>span:after {
-    //         content: '↵';
-    //         margin-left: 2px;
-    //       }
-    //       .cm-markdown-single-trailing-space-odd:before,
-    //       .cm-markdown-single-trailing-space-even:before {
-    //         font-weight: bold;
-    //         content: '·';
-    //       }
-    //     }
-    //   }
-
-    //   .CodeMirror-lines {
-    //     color: var(--input-text);
-    //     padding: 0;
-
-    //     .CodeMirror-line > span > span {
-    //       &.cm-overlay {
-    //         font-family: monospace;
-    //       }
-    //     }
-
-    //     .CodeMirror-line > span {
-    //       font-family: $body-font;
-    //     }
-    //   }
-
-    //   .CodeMirror-sizer {
-    //     min-height: 20px;
-    //   }
-
-    //   .CodeMirror-selected {
-    //     background-color: var(--primary) !important;
-    //   }
-
-    //   .CodeMirror-selectedtext {
-    //     color: var(--primary-text);
-    //   }
-
-    //   .CodeMirror-line::selection,
-    //   .CodeMirror-line > span::selection,
-    //   .CodeMirror-line > span > span::selection {
-    //     color: var(--primary-text);
-    //     background-color: var(--primary);
-    //   }
-
-    //   .CodeMirror-line::-moz-selection,
-    //   .CodeMirror-line > span::-moz-selection,
-    //   .CodeMirror-line > span > span::-moz-selection {
-    //     color: var(--primary-text);
-    //     background-color: var(--primary);
-    //   }
-    // }
   }
 </style>

--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -178,6 +178,7 @@ export default {
         :value="value"
         :options="combinedOptions"
         :disabled="isDisabled"
+        :original-style="true"
         @ready="onReady"
         @input="onInput"
         @changes="onChanges"
@@ -196,6 +197,7 @@ export default {
 
   .codemirror-container {
     z-index: 0;
+    font-size: inherit !important;
 
     // Keyboard mapping overlap
     .keymap.overlay {

--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -57,7 +57,7 @@ export default {
         theme:                   `base16-${ theme }`,
         lineNumbers:             true,
         line:                    true,
-        styleActiveLine:         true,
+        styleActiveLine:         false,
         lineWrapping:            true,
         foldGutter:              true,
         styleSelectedText:       true,
@@ -195,73 +195,8 @@ export default {
 <style lang="scss">
   $code-mirror-animation-time: 0.1s;
 
-  .codemirror-container {
-    z-index: 0;
-    font-size: inherit !important;
-
-    // Keyboard mapping overlap
-    .keymap.overlay {
-      position: absolute;
-      display: flex;
-      top: 7px;
-      right: 7px;
-      z-index: 1;
-      cursor: pointer;
-
-      .keymap-indicator {
-        width: 48px;
-        height: 32px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        border: 1px solid transparent;
-        color: var(--darker);
-        background-color: var(--overlay-bg);
-        font-size: 12px;
-
-        .close-indicator {
-          width: 0;
-
-          .icon-close {
-            color: var(--primary);
-            opacity: 0;
-          }
-        }
-
-        .keymap-icon {
-          font-size: 24px;
-          opacity: 0.8;
-          transition: margin-right $code-mirror-animation-time ease-in-out;
-        }
-
-        &:hover {
-          border: 1px solid var(--primary);
-          border-radius: var(--border-radius);;
-
-          .close-indicator {
-            margin-left: -6px;
-            width: auto;
-
-            .icon-close {
-              opacity: 1;
-              transition: opacity $code-mirror-animation-time ease-in-out $code-mirror-animation-time; // Only animate when being shown
-            }
-          }
-
-          .keymap-icon {
-            opacity: 0.6;
-            margin-right: 10px;
-          }
-        }
-      }
-    }
-
-    .vue-codemirror .CodeMirror {
-      height: initial;
-      background: none
-    }
-
-    &.as-text-area {
+  .code-mirror {
+    &.as-text-area .codemirror-container{
       min-height: 40px;
       position: relative;
       display: block;
@@ -347,6 +282,168 @@ export default {
         color: var(--primary-text);
         background-color: var(--primary);
       }
+
+      .CodeMirror-gutter-wrapper,
+      .CodeMirror-gutters>*{
+        display:none;
+      }
     }
+  }
+
+  // add selector here to ensure lower rules that lost .vue-codemirror selector still have enough specificity to override library's styling
+  .code-mirror .codemirror-container {
+    z-index: 0;
+    font-size: inherit !important;
+
+    // Keyboard mapping overlap
+    .keymap.overlay {
+      position: absolute;
+      display: flex;
+      top: 7px;
+      right: 7px;
+      z-index: 1;
+      cursor: pointer;
+
+      .keymap-indicator {
+        width: 48px;
+        height: 32px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid transparent;
+        color: var(--darker);
+        background-color: var(--overlay-bg);
+        font-size: 12px;
+
+        .close-indicator {
+          width: 0;
+
+          .icon-close {
+            color: var(--primary);
+            opacity: 0;
+          }
+        }
+
+        .keymap-icon {
+          font-size: 24px;
+          opacity: 0.8;
+          transition: margin-right $code-mirror-animation-time ease-in-out;
+        }
+
+        &:hover {
+          border: 1px solid var(--primary);
+          border-radius: var(--border-radius);;
+
+          .close-indicator {
+            margin-left: -6px;
+            width: auto;
+
+            .icon-close {
+              opacity: 1;
+              transition: opacity $code-mirror-animation-time ease-in-out $code-mirror-animation-time; // Only animate when being shown
+            }
+          }
+
+          .keymap-icon {
+            opacity: 0.6;
+            margin-right: 10px;
+          }
+        }
+      }
+    }
+
+    //rm no longer extant selector
+    .CodeMirror {
+      height: initial;
+      background: none
+    }
+
+    // &.as-text-area {
+    //   min-height: 40px;
+    //   position: relative;
+    //   display: block;
+    //   box-sizing: border-box;
+    //   width: 100%;
+    //   padding: 10px;
+    //   background-color: var(--input-bg);
+    //   border-radius: var(--border-radius);
+    //   border: solid var(--border-width) var(--input-border);
+    //   color: var(--input-text);
+
+    //   &:hover {
+    //     border-color: var(--input-hover-border);
+    //   }
+
+    //   &:focus, &.focus {
+    //     outline: none;
+    //     border-color: var(--outline);
+    //   }
+
+    //   .CodeMirror-wrap pre {
+    //     word-break: break-word;
+    //   }
+    //   .CodeMirror-code {
+    //     .CodeMirror-line {
+    //       &:not(:last-child)>span:after,
+    //       .cm-markdown-single-trailing-space-odd:before,
+    //       .cm-markdown-single-trailing-space-even:before {
+    //         color: var(--muted);
+    //         position: absolute;
+    //         line-height: 20px;
+    //         pointer-events: none;
+    //       }
+    //       &:not(:last-child)>span:after {
+    //         content: '↵';
+    //         margin-left: 2px;
+    //       }
+    //       .cm-markdown-single-trailing-space-odd:before,
+    //       .cm-markdown-single-trailing-space-even:before {
+    //         font-weight: bold;
+    //         content: '·';
+    //       }
+    //     }
+    //   }
+
+    //   .CodeMirror-lines {
+    //     color: var(--input-text);
+    //     padding: 0;
+
+    //     .CodeMirror-line > span > span {
+    //       &.cm-overlay {
+    //         font-family: monospace;
+    //       }
+    //     }
+
+    //     .CodeMirror-line > span {
+    //       font-family: $body-font;
+    //     }
+    //   }
+
+    //   .CodeMirror-sizer {
+    //     min-height: 20px;
+    //   }
+
+    //   .CodeMirror-selected {
+    //     background-color: var(--primary) !important;
+    //   }
+
+    //   .CodeMirror-selectedtext {
+    //     color: var(--primary-text);
+    //   }
+
+    //   .CodeMirror-line::selection,
+    //   .CodeMirror-line > span::selection,
+    //   .CodeMirror-line > span > span::selection {
+    //     color: var(--primary-text);
+    //     background-color: var(--primary);
+    //   }
+
+    //   .CodeMirror-line::-moz-selection,
+    //   .CodeMirror-line > span::-moz-selection,
+    //   .CodeMirror-line > span > span::-moz-selection {
+    //     color: var(--primary-text);
+    //     background-color: var(--primary);
+    //   }
+    // }
   }
 </style>

--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -283,6 +283,10 @@ export default {
         color: var(--primary-text);
         background-color: var(--primary);
       }
+
+      .CodeMirror-gutters .CodeMirror-foldgutter:empty {
+        display: none;
+      }
     }
   }
 
@@ -353,8 +357,8 @@ export default {
       background: none
     }
 
-    .CodeMirror-foldgutter:empty {
-      display: none;
+    .CodeMirror-gutters {
+      background: inherit;
     }
 
   }

--- a/shell/components/YamlEditor.vue
+++ b/shell/components/YamlEditor.vue
@@ -103,7 +103,7 @@ export default {
         mode:            'yaml',
         lint:            !readOnly,
         lineNumbers:     !readOnly,
-        styleActiveLine: true,
+        styleActiveLine: false,
         tabSize:         2,
         indentWithTabs:  false,
         cursorBlinkRate: ( readOnly ? -1 : 530 ),


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11701 


### Occurred changes and/or fixed issues
This PR fixes Codemirror styling (used in yaml editor and a couple other places). There were two main issues: this new library introduced new styles, which can be overwritten via prop (added here). The new library also had a hardcoded font value the old did not. 

I also noticed some Codemirror elements are arranged differently. I left all this alone, I wouldn't consider it a bug and it looks better now anyway:
(old)
![Screenshot 2024-09-03 at 9 20 51 AM](https://github.com/user-attachments/assets/ec0afd60-0c5a-4f58-af9b-31ea4fbb2945)
(new)
![Screenshot 2024-09-03 at 9 20 46 AM](https://github.com/user-attachments/assets/14da122b-6cad-4e07-a1c6-f8f96823c6a4)


The resize nullpx nullpx message reported in #11701 is a known issue with the library https://github.com/rennzhang/codemirror-editor-vue3/issues/54

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
'View as Yaml' and 'Edit as Yaml' pages
Create/edit a configmap with json values
Detail view of a resource with json annotations



### Screenshot/Video

(old)
![Screenshot 2024-09-04 at 9 23 42 AM](https://github.com/user-attachments/assets/fa936b97-83ee-4d75-a96b-57c1b34e72d5)

(new)
![Screenshot 2024-09-04 at 9 18 19 AM](https://github.com/user-attachments/assets/3ea3332d-e43c-4470-ab5e-c8716c9845f0)

(old)
![Screenshot 2024-09-04 at 9 18 08 AM](https://github.com/user-attachments/assets/89b6bab1-bba7-4318-83ec-9fc77efb1f3e)

(new)
![Screenshot 2024-09-04 at 9 25 04 AM](https://github.com/user-attachments/assets/20026aba-8fef-4d40-9225-16e427950426)

(old)
![Screenshot 2024-09-04 at 9 26 08 AM](https://github.com/user-attachments/assets/64426a63-1b20-4276-9b26-e53ee8c3b172)

(new)
![Screenshot 2024-09-04 at 10 10 11 AM](https://github.com/user-attachments/assets/f852050f-f593-47ac-8f32-45ec80e78e0c)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
