### PR TITLE
Update AKS region data

### DIFF
--- a/pkg/aks/util/aks.ts
+++ b/pkg/aks/util/aks.ts
@@ -20,12 +20,10 @@ export const regionsWithAvailabilityZones = {
   japaneast:          true,
   eastus:             true,
   norwayeast:         true,
-  koreacentral:       true,
   eastus2:            true,
   northeurope:        true,
   southeastasia:      true,
-  southcentral:       true,
-  us:                 true,
+  southcentralus:     true,
   uksouth:            true,
   eastasia:           true,
   usgovvirginia:      true,
@@ -33,9 +31,13 @@ export const regionsWithAvailabilityZones = {
   chinanorth3:        true,
   westus2:            true,
   swedencentral:      true,
+  koreacentral:       true,
   westus3:            true,
   switzerlandnorth:   true,
-  polandcentral:      true
+  newzealandnorth:    true,
+  mexicocentral:      true,
+  polandcentral:      true,
+  spaincentral:       true,
 } as any;
 
 /**


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11817 

### Occurred changes and/or fixed issues
This PR removes the incorrect regions southcentral and us and adds 

- japanwest
- southcentralus
- newzealandnorth
- mexicocentral
- spaincentral

### Areas or cases that should be tested
1. The AKS cluster creation region dropdown should include the above regions under the first section of the list, 'Regions with Availability Zone Support
2. When one of the above regions is selected, the user should be able to configure node group availability zones, and the availability zone input shouldn't show any errors.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
