### PR TITLE
Fix grafana links for rancher workload deployment

### DIFF
--- a/shell/models/__tests__/apps.deployment.test.ts
+++ b/shell/models/__tests__/apps.deployment.test.ts
@@ -1,0 +1,93 @@
+import Deployment from '@shell/models/apps.deployment';
+import { WORKLOAD_TYPES } from '@shell/config/types';
+
+describe('class Deployment', () => {
+  describe('replicaSetId', () => {
+    it.each([{
+      relationships: [],
+      expected:      undefined,
+    }, {
+      relationships: [{
+        rel:    'owner',
+        toType: WORKLOAD_TYPES.REPLICA_SET,
+        toId:   'rel-id'
+      }],
+      expected: 'rel-id',
+    }, {
+      relationships: [{
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-1',
+        message: 'ReplicaSet is available. Replicas: 1'
+      }],
+      expected: 'rel-id-1',
+    }, {
+      relationships: [{
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-1',
+        message: 'ReplicaSet is available. Replicas: 0'
+      }, {
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-2',
+        message: 'ReplicaSet is available. Replicas: 1'
+      }],
+      expected: 'rel-id-2',
+    }, {
+      relationships: [{
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-1',
+        message: 'Message without replicas count'
+      }, {
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-2',
+        message: 'Another message without replicas count'
+      }],
+      expected: 'rel-id-1',
+    }, {
+      relationships: [{
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-1',
+        message: 'ReplicaSet is available. Replicas: 0'
+      }, {
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-2',
+        message: 'ReplicaSet is available. Replicas: 0'
+      }],
+      expected: 'rel-id-1',
+    }, {
+      relationships: [{
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-1',
+        message: 'Message without replicas count'
+      }, {
+        rel:     'owner',
+        toType:  WORKLOAD_TYPES.REPLICA_SET,
+        toId:    'rel-id-2',
+        message: 'ReplicaSet is available. Replicas: 0'
+      }],
+      expected: 'rel-id-1',
+    }])('replicaSetId', ({ relationships, expected }) => {
+      const deploymentData = {
+        id:       'any-id',
+        type:     WORKLOAD_TYPES.DEPLOYMENT,
+        metadata: {
+          name:      'any-name',
+          namespace: 'any-namespace',
+          uid:       'any-uid',
+          relationships,
+        },
+      };
+
+      const deployment = new Deployment(deploymentData);
+
+      expect(deployment.replicaSetId).toStrictEqual(expected);
+    });
+  });
+});

--- a/shell/models/apps.deployment.js
+++ b/shell/models/apps.deployment.js
@@ -10,14 +10,28 @@ const IGNORED_ANNOTATIONS = [
   'deprecated.deployment.rollback.to',
 ];
 
+const replicasRegEx = /Replicas: (\d+)/;
+
 export default class Deployment extends Workload {
   get replicaSetId() {
-    const set = this.metadata?.relationships?.find((relationship) => {
-      return relationship.rel === 'owner' &&
-            relationship.toType === WORKLOAD_TYPES.REPLICA_SET;
+    const relationships = this.metadata?.relationships || [];
+
+    // Find all relevant ReplicaSet relationships
+    const replicaSetRelationships = relationships.filter((relationship) => relationship.rel === 'owner' && relationship.toType === WORKLOAD_TYPES.REPLICA_SET
+    );
+
+    // Filter the ReplicaSets based on replicas > 0
+    const activeReplicaSet = replicaSetRelationships.find((relationship) => {
+      const replicasMatch = relationship.message?.match(replicasRegEx);
+      const replicas = replicasMatch ? parseInt(replicasMatch[1], 10) : 0;
+
+      return replicas > 0;
     });
 
-    return set?.toId?.replace(`${ this.namespace }/`, '');
+    // If no active ReplicaSet is found, fall back to the first one from the list
+    const selectedReplicaSet = activeReplicaSet || replicaSetRelationships[0];
+
+    return selectedReplicaSet?.toId?.replace(`${ this.namespace }/`, '');
   }
 
   async rollBack(cluster, deployment, revision) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11319
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- This is a direct, cherry-pick backport of https://github.com/rancher/dashboard/pull/11297 (see for details)

### Technical notes summary
A good way to setup set
- Create a deployment in the default namespace
- `kubectl get rs` should show the replicas for the deployment (<deployment name>-<unique id>)
- edit the deployment (for example add a description)
- `kubectl get rs` should now show two replicas for the deployment. We're interested in the one that has desired/current/ready.
- Go to Deployments --> click on deployment --> Metrics tab --> (when grafana metrics are available) hover over any of the lines and it should show the replica set we're interested in (<replica set id>-<unique id>)

![image](https://github.com/user-attachments/assets/aa013fc4-9eac-4851-ac53-ad888b7a50ad)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
