### PR TITLE
Ensure loading indicator doesn't show outside it's context

### DIFF
--- a/shell/assets/styles/base/_variables.scss
+++ b/shell/assets/styles/base/_variables.scss
@@ -24,10 +24,19 @@ $z-indexes: (
   overContent: 2,
   hoverOverContent: 3,
 
-  mainHeader: 12,
-
   tableGroup: 10,
   fixedTableHeader: 11,
+
+  // ---- Boundary for central content (in `<main>`)
+
+  // This covers both relative and content modes of the loading indicator
+  loading: 12,
+
+  // Users can click on shell in header and show shell even with most loading indicators showing,
+  // so add it above them
+  windowsManager: 13,
+
+  mainHeader: 14,
 
   modalOverlay: 20,
   modalContent: 21,
@@ -37,8 +46,7 @@ $z-indexes: (
   dropdownOverlay: 40,
   dropdownContent: 41,
 
-  loadingOverlay: 50,
-  loadingContent: 51
+  loadingMain: 51
 );
 
 // Usage Example:

--- a/shell/assets/styles/global/_layout.scss
+++ b/shell/assets/styles/global/_layout.scss
@@ -115,7 +115,7 @@ HEADER {
 .wm {
   grid-area: wm;
   overflow-y: hidden;
-  z-index: 1;
+  z-index: z-index('windowsManager');
 }
 
 .localeSelector {

--- a/shell/components/Loading.vue
+++ b/shell/components/Loading.vue
@@ -68,10 +68,13 @@ export default {
     left: 0;
     right: 0;
     text-align: center;
-    z-index: z-index('loadingContent');
+
+    // Covers both default `content` mode, an often used `relative` mode and any other value of mode
+    z-index: z-index('loading');
 
     &-main-mode {
       top: var(--header-height);
+      z-index: z-index('loadingMain');
     }
 
     &-content-mode {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #5245
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Windows Manager sits below side nav and main screen content
  - shell, log streaming
- The relative and content loading indicator covers a specific area or the main screen content
- Bug - relative and content loading indicator appears over windows manager
- Fix
  - apply different z-index to main and other modes of loading indicator
  - assign a higher z-index to windows manager (higher than main screen content)


### Technical notes summary
Tested
- mode - relative
  - shell/chart/monitoring/index.vue
  - shell/components/Wizard.vue
  - shell/components/nav/GlobalLoading.vue
  - shell/pages/auth/login.vue
- mode - content
  - shell/pages/c/_cluster/monitoring/index.vue
  - shell/edit/namespace.vue - shell/pages/c/_cluster/settings/banners.vue
- mode - main
  - not actually used... and currently broken (new burger menu is under it)
- outside content (such as burger menu, namespace filter, user avatar, etc) correctly shows above relative and content loading indicator
- wm drag and drop (working in vue3!)

### Areas or cases that should be tested
This impacts places where we show the `Loading...` text in the centre of a opaque area. I've tested a lot above but via tweaking code. It would sense to maybe click around playing with the network tool throttling controls

### Areas which could experience regressions
Loading indicator, window manager (kube shell, container shell, container logs, helm chart logs)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
