### PR TITLE
Remove breaking `template` from Workload Pod Resource tab

### DIFF
--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -421,7 +421,7 @@ export default {
               name="resources"
               :weight="tabWeightMap['resources']"
             >
-              <template>
+              <div>
                 <div>
                   <h3 class="mb-10">
                     <t k="workload.scheduling.titles.tolerations" />
@@ -456,7 +456,7 @@ export default {
                     </div>
                   </div>
                 </div>
-              </template>
+              </div>
             </Tab>
             <Tab
               :label="t('workload.container.titles.podScheduling')"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11850
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Ensure the Workload --> Container --> Resources tab populates correctly
- cause was `template` element related (single `template` in a `Tab`)

### Technical notes summary
i've gone through the other usages of Tab with a nested Template, there are others but they work... (shell/detail/secret.vue, shell/detail/node.vue)

### Areas or cases that should be tested
Deployment, Pod, Job, etc container Resources tab renders correctly

### Screenshot/Video
See issue

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
