### PR TITLE
[2.9] aks node pools - allow 0 count when autoscaling is enabled

### DIFF
--- a/pkg/aks/components/AksNodePool.vue
+++ b/pkg/aks/components/AksNodePool.vue
@@ -171,6 +171,10 @@ export default defineComponent({
 
     availabilityZonesSupport() {
       return this.validAZ ? undefined : this.t('aks.errors.availabilityZones');
+    },
+
+    poolCountValidator(){
+      return val=>this.validationRules?.count?.[0](val, this.pool.enableAutoScaling)
     }
   },
 });
@@ -301,7 +305,7 @@ export default defineComponent({
           type="number"
           :mode="mode"
           label-key="aks.nodePools.count.label"
-          :rules="[val=>validationRules.count[0](val, pool.enableAutoScaling)]"
+          :rules="[poolCountValidator]"
           :min="pool.enableAutoScaling ? 0 : 1"
           :max="1000"
         />

--- a/pkg/aks/components/AksNodePool.vue
+++ b/pkg/aks/components/AksNodePool.vue
@@ -173,8 +173,8 @@ export default defineComponent({
       return this.validAZ ? undefined : this.t('aks.errors.availabilityZones');
     },
 
-    poolCountValidator(){
-      return val=>this.validationRules?.count?.[0](val, this.pool.enableAutoScaling)
+    poolCountValidator() {
+      return (val: number) => this.validationRules?.count?.[0](val, this.pool.enableAutoScaling);
     }
   },
 });

--- a/pkg/aks/components/AksNodePool.vue
+++ b/pkg/aks/components/AksNodePool.vue
@@ -297,18 +297,18 @@ export default defineComponent({
     >
       <div class="col span-3">
         <LabeledInput
-          v-model.number="pool.count"
+          v-model:value.number="pool.count"
           type="number"
           :mode="mode"
           label-key="aks.nodePools.count.label"
-          :rules="validationRules.count"
-          :min="1"
-          :max="100"
+          :rules="[val=>validationRules.count[0](val, pool.enableAutoScaling)]"
+          :min="pool.enableAutoScaling ? 0 : 1"
+          :max="1000"
         />
       </div>
       <div class="col span-3">
         <LabeledInput
-          v-model.number="pool.maxPods"
+          v-model:value.number="pool.maxPods"
           type="number"
           :mode="mode"
           label-key="aks.nodePools.maxPods.label"
@@ -334,24 +334,24 @@ export default defineComponent({
       <template v-if="pool.enableAutoScaling">
         <div class="col span-3">
           <LabeledInput
-            v-model.number="pool.minCount"
+            v-model:value.number="pool.minCount"
             type="number"
             :mode="mode"
             label-key="aks.nodePools.minCount.label"
             :rules="validationRules.min"
-            :min="1"
-            :max="100"
+            :min="0"
+            :max="1000"
           />
         </div>
         <div class="col span-3">
           <LabeledInput
-            v-model.number="pool.maxCount"
+            v-model:value.number="pool.maxCount"
             type="number"
             :mode="mode"
             label-key="aks.nodePools.maxCount.label"
             :rules="validationRules.max"
-            :min="1"
-            :max="100"
+            :min="0"
+            :max="1000"
           />
         </div>
       </template>

--- a/pkg/aks/components/AksNodePool.vue
+++ b/pkg/aks/components/AksNodePool.vue
@@ -297,7 +297,7 @@ export default defineComponent({
     >
       <div class="col span-3">
         <LabeledInput
-          v-model:value.number="pool.count"
+          v-model.number="pool.count"
           type="number"
           :mode="mode"
           label-key="aks.nodePools.count.label"
@@ -308,7 +308,7 @@ export default defineComponent({
       </div>
       <div class="col span-3">
         <LabeledInput
-          v-model:value.number="pool.maxPods"
+          v-model.number="pool.maxPods"
           type="number"
           :mode="mode"
           label-key="aks.nodePools.maxPods.label"
@@ -334,7 +334,7 @@ export default defineComponent({
       <template v-if="pool.enableAutoScaling">
         <div class="col span-3">
           <LabeledInput
-            v-model:value.number="pool.minCount"
+            v-model.number="pool.minCount"
             type="number"
             :mode="mode"
             label-key="aks.nodePools.minCount.label"
@@ -345,7 +345,7 @@ export default defineComponent({
         </div>
         <div class="col span-3">
           <LabeledInput
-            v-model:value.number="pool.maxCount"
+            v-model.number="pool.maxCount"
             type="number"
             :mode="mode"
             label-key="aks.nodePools.maxCount.label"

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -433,16 +433,29 @@ export default defineComponent({
           return this.canUseAvailabilityZones || !isUsingAvailabilityZones ? undefined : this.t('aks.errors.availabilityZones');
         },
 
-        poolCount: (count?: number) => {
+        poolCount: (count?: number, autoscale = false) => {
+          let min = 1;
+          let errMsg = this.t('aks.errors.poolCount');
+
+          if (autoscale) {
+            min = 0;
+            errMsg = this.t('aks.errors.poolAutoscaleCount');
+          }
           if (count || count === 0) {
-            return count >= 1 ? undefined : this.t('aks.errors.poolCount');
+            return count >= min ? undefined : errMsg;
           } else {
             let allValid = true;
 
             this.nodePools.forEach((pool: AKSNodePool) => {
-              const { count = 0 } = pool;
+              const { count = 0, enableAutoScaling } = pool;
 
-              if (count < 1) {
+              if (enableAutoScaling) {
+                min = 0;
+              } else {
+                min = 1;
+              }
+
+              if (count < min) {
                 this.$set(pool._validation, '_validCount', false);
                 allValid = false;
               } else {
@@ -456,14 +469,14 @@ export default defineComponent({
 
         poolMin: (min?:number) => {
           if (min || min === 0) {
-            return min <= 0 || min > 100 ? this.t('aks.errors.poolMin') : undefined;
+            return min < 0 || min > 1000 ? this.t('aks.errors.poolMin') : undefined;
           } else {
             let allValid = true;
 
             this.nodePools.forEach((pool: AKSNodePool) => {
               const poolMin = pool.minCount || 0;
 
-              if (pool.enableAutoScaling && (poolMin <= 0 || poolMin > 100)) {
+              if (pool.enableAutoScaling && (poolMin < 0 || poolMin > 1000)) {
                 this.$set(pool._validation, '_validMin', false);
                 allValid = false;
               } else {
@@ -477,14 +490,14 @@ export default defineComponent({
 
         poolMax: (max?:number) => {
           if (max || max === 0) {
-            return max <= 0 || max > 100 ? this.t('aks.errors.poolMax') : undefined;
+            return max < 0 || max > 1000 ? this.t('aks.errors.poolMax') : undefined;
           } else {
             let allValid = true;
 
             this.nodePools.forEach((pool: AKSNodePool) => {
               const poolMax = pool.maxCount || 0;
 
-              if (pool.enableAutoScaling && (poolMax <= 0 || poolMax > 100)) {
+              if (pool.enableAutoScaling && (poolMax < 0 || poolMax > 1000)) {
                 this.$set(pool._validation, '_validMax', false);
                 allValid = false;
               } else {

--- a/pkg/aks/l10n/en-us.yaml
+++ b/pkg/aks/l10n/en-us.yaml
@@ -166,7 +166,7 @@ aks:
     poolCount: Node count must be at least one when autoscaling is disabled.
     poolAutoscaleCount: Node count cannot be less than zero.
     poolMinMax: The minimum number of nodes must be less than or equal to the maximum number of nodes, and the node count must be between or equal to the minimum and maximum.
-    poolMin: The minimum number of nodes must be greater than 0 and at most 100.
-    poolMax: The maximum number of nodes must be greater than 0 and at most 100.
+    poolMin: The minimum number of nodes must be greater than 0 and at most 1000.
+    poolMax: The maximum number of nodes must be greater than 0 and at most 1000.
     poolTaints: Taints must have both a key and value defined.
     poolNamesUnique: Node pool names must be unique.

--- a/pkg/aks/l10n/en-us.yaml
+++ b/pkg/aks/l10n/en-us.yaml
@@ -163,7 +163,8 @@ aks:
     availabilityZones: Availability zones are not available in the selected region.
     privateDnsZone: Private DNS Zone Resource ID must be in the format /subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCEGROUP_NAME/providers/Microsoft.Network/privateDnsZones/PRIVATE_DNS_ZONE_NAME. The Private DNS Zone Resource Name must be in the format privatelink.REGION.azmk8s.io, SUBZONE.privatelink.REGION.azmk8s.io, private.REGION.azmk8s.io, or SUBZONE.private.REGION.azmk8s.io
     poolName: Node pool names must be 1-12 characters long, consist only of lowercase letters and numbers, and start with a letter.
-    poolCount: Node count must be at least one.
+    poolCount: Node count must be at least one when autoscaling is disabled.
+    poolAutoscaleCount: Node count cannot be less than zero.
     poolMinMax: The minimum number of nodes must be less than or equal to the maximum number of nodes, and the node count must be between or equal to the minimum and maximum.
     poolMin: The minimum number of nodes must be greater than 0 and at most 100.
     poolMax: The maximum number of nodes must be greater than 0 and at most 100.

--- a/pkg/aks/util/validators.ts
+++ b/pkg/aks/util/validators.ts
@@ -4,7 +4,7 @@
  * Due to current limitations of the fv mixin
  */
 
-import { get } from '@shell/utils/object';
+import { get, set } from '@shell/utils/object';
 import { LoadBalancerSku, OutboundType, AKSNodePool } from '../types';
 
 // no need to try to validate any fields if the user is still selecting a credential and the rest of the form isn't visible
@@ -152,11 +152,11 @@ export const nodePoolNames = (ctx: any) => {
         const name = pool.name || '';
 
         if (!isValid(name)) {
-          ctx.$set(pool._validation, '_validName', false);
+          set(pool._validation, '_validName', false);
 
           allAvailable = false;
         } else {
-          ctx.$set(pool._validation, '_validName', true);
+          set(pool._validation, '_validName', true);
         }
       });
       if (!allAvailable) {


### PR DESCRIPTION
Fixes https://github.com/rancher/dashboard/issues/11848

Backport of https://github.com/rancher/dashboard/pull/11855 minus some vue3 v-model syntax.