### PR TITLE
[2.9]eks - allow node groups with 0 min size

### DIFF
--- a/pkg/eks/l10n/en-us.yaml
+++ b/pkg/eks/l10n/en-us.yaml
@@ -30,6 +30,7 @@ eks:
   errors:
     fetchingRegions: 'Error fetching regions: {err}'
     greaterThanZero: '{key} must be greater than zero.'
+    atLeastZero: '{key} must be at least zero.'
     minimumSubnets: You must use at least two subnets, and they should be in different availability zones.
     nodeGroups:
       nameUnique: Node group names must be unique within a cluster.

--- a/pkg/eks/l10n/en-us.yaml
+++ b/pkg/eks/l10n/en-us.yaml
@@ -71,7 +71,7 @@ eks:
     maxSize:
       label: Maximum ASG Size
     minSize:
-      label: Minumum ASG Size
+      label: Minimum ASG Size
     name:
       label: Node Group Name
     nodeRole:

--- a/pkg/eks/util/__tests__/validators.test.ts
+++ b/pkg/eks/util/__tests__/validators.test.ts
@@ -202,4 +202,23 @@ describe('validate EKS node group minimum and maximum size', () => {
 
     expect(res).toBe(errMsg);
   });
+
+  it('should return an error if the minimum size is less than 0', () => {
+    const ctx = {
+      config: { },
+      t:      mockTranslation,
+    } as any as CruEKSContext;
+
+    let res = EKSValidators.minSize(ctx)(-1);
+
+    expect(res).toBe('eks.errors.atLeastZero');
+
+    res = EKSValidators.minSize(ctx)(0);
+
+    expect(res).toBeNull();
+
+    res = EKSValidators.minSize(ctx)(1);
+
+    expect(res).toBeNull();
+  });
 });

--- a/pkg/eks/util/__tests__/validators.test.ts
+++ b/pkg/eks/util/__tests__/validators.test.ts
@@ -221,4 +221,20 @@ describe('validate EKS node group minimum and maximum size', () => {
 
     expect(res).toBeNull();
   });
+
+  it.each([
+    [[{ minSize: 1 }, { }], 'eks.errors.atLeastZero'],
+    [[{ minSize: 0 }, { minSize: -1 }], 'eks.errors.atLeastZero'],
+    [[{ minSize: 0 }, { minSize: 1 }], null]
+  ])('should return an error if any node pools have a minimum size less than 0', (nodeGroups, errMsg) => {
+    const ctx = {
+      config: { },
+      t:      mockTranslation,
+      nodeGroups
+    } as any as CruEKSContext;
+
+    const res = EKSValidators.minSize(ctx)();
+
+    expect(res).toBe(errMsg);
+  });
 });

--- a/pkg/eks/util/validators.ts
+++ b/pkg/eks/util/validators.ts
@@ -62,14 +62,14 @@ const maxSize = (ctx: CruEKSContext) => {
 };
 
 const minSize = (ctx: CruEKSContext) => {
-  return (size: number): null | string => {
+  return (size?: number): null | string => {
     const msg = ctx.t('eks.errors.atLeastZero', { key: ctx.t('eks.nodeGroups.minSize.label') });
 
     if (size !== undefined) {
       return size >= 0 ? null : msg;
     }
 
-    return !!ctx.nodeGroups.find((group) => !group.minSize || group.minSize < 0) ? msg : null;
+    return !!ctx.nodeGroups.find((group) => (!group.minSize && group.minSize !== 0) || group.minSize < 0) ? msg : null;
   };
 };
 

--- a/pkg/eks/util/validators.ts
+++ b/pkg/eks/util/validators.ts
@@ -63,13 +63,13 @@ const maxSize = (ctx: CruEKSContext) => {
 
 const minSize = (ctx: CruEKSContext) => {
   return (size: number): null | string => {
-    const msg = ctx.t('eks.errors.greaterThanZero', { key: ctx.t('eks.nodeGroups.minSize.label') });
+    const msg = ctx.t('eks.errors.atLeastZero', { key: ctx.t('eks.nodeGroups.minSize.label') });
 
     if (size !== undefined) {
-      return size > 0 ? null : msg;
+      return size >= 0 ? null : msg;
     }
 
-    return !!ctx.nodeGroups.find((group) => !group.minSize || group.minSize <= 0) ? msg : null;
+    return !!ctx.nodeGroups.find((group) => !group.minSize || group.minSize < 0) ? msg : null;
   };
 };
 


### PR DESCRIPTION

Fixes #11827
Backport of https://github.com/rancher/dashboard/pull/11858