### PR TITLE
Vue 3: Fixed Azure AD validation

### DIFF
--- a/shell/edit/auth/__tests__/azuread.test.ts
+++ b/shell/edit/auth/__tests__/azuread.test.ts
@@ -22,7 +22,7 @@ const invalidTokenEndpoint = 'aaaaBBBBaaaa';
 const invalidGraphEndpoint = 'aaaaBBBBaaaa';
 
 const mockModel = {
-  enabled:  true,
+  enabled:  false,
   id:       'azuread',
   endpoint: 'https://login.microsoftonline.com/',
   type:     'azureADConfig',
@@ -35,7 +35,7 @@ describe('edit: azureAD should', () => {
       return {
         isEnabling:     true,
         editConfig:     false,
-        model:          mockModel,
+        model:          { ...mockModel },
         serverSetting:  null,
         errors:         [],
         originalModel:  null,
@@ -79,7 +79,7 @@ describe('edit: azureAD should', () => {
     expect(saveButton.disabled).toBe(true);
   });
 
-  it.skip.each([
+  it.each([
     {
       tenantId:          '',
       applicationId:     '',
@@ -110,7 +110,7 @@ describe('edit: azureAD should', () => {
       applicationSecret: validAppSecret,
       result:            false
     },
-  ])('(Vue3 Skip) has "Create" button enabled and disabled depending on validation results when endpoint is standard', async(testCase) => {
+  ])('has "Create" button enabled and disabled depending on validation results when endpoint is standard', async(testCase) => {
     const tenantIdInputField = wrapper.find('[data-testid="input-azureAD-tenantId"]');
     const applicationIdInputField = wrapper.find('[data-testid="input-azureAD-applcationId"]');
     const applicationSecretInputField = wrapper.find('[data-testid="input-azureAD-applicationSecret"]');
@@ -121,11 +121,10 @@ describe('edit: azureAD should', () => {
     applicationSecretInputField.setValue(testCase.applicationSecret);
     await nextTick();
 
-    // TODO: This appears to be close.. It looks like form validation is failing for some reason on the final test iteration.
     expect(saveButton.disabled).toBe(testCase.result);
   });
 
-  it.skip.each([
+  it.each([
     {
       endpoint:      '',
       graphEndpoint: '',
@@ -203,7 +202,7 @@ describe('edit: azureAD should', () => {
       authEndpoint:  validAuthEndpoint,
       result:        false
     }
-  ])('(Vue3 Skip) has "Create" button enabled and disabled depending on validation results when endpoint is custom', async(testCase) => {
+  ])('has "Create" button enabled and disabled depending on validation results when endpoint is custom', async(testCase) => {
     const tenantIdInputField = wrapper.find('[data-testid="input-azureAD-tenantId"]');
     const applicationIdInputField = wrapper.find('[data-testid="input-azureAD-applcationId"]');
     const applicationSecretInputField = wrapper.find('[data-testid="input-azureAD-applicationSecret"]');
@@ -223,10 +222,10 @@ describe('edit: azureAD should', () => {
     await nextTick();
     expect(saveButton.disabled).toBe(true);
 
-    const endpointInputField = wrapper.find('[data-testid="input-azureAD-endpoint"]').find('input');
-    const graphEndpointInputField = wrapper.find('[data-testid="input-azureAD-graphEndpoint"]').find('input');
-    const tokenEndpointInputField = wrapper.find('[data-testid="input-azureAD-tokenEndpoint"]').find('input');
-    const authEndpointInputField = wrapper.find('[data-testid="input-azureAD-authEndpoint"]').find('input');
+    const endpointInputField = wrapper.find('[data-testid="input-azureAD-endpoint"]');
+    const graphEndpointInputField = wrapper.find('[data-testid="input-azureAD-graphEndpoint"]');
+    const tokenEndpointInputField = wrapper.find('[data-testid="input-azureAD-tokenEndpoint"]');
+    const authEndpointInputField = wrapper.find('[data-testid="input-azureAD-authEndpoint"]');
 
     endpointInputField.setValue(testCase.endpoint);
     graphEndpointInputField.setValue(testCase.graphEndpoint);

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -206,7 +206,7 @@ export default {
         const endpointType = this.oldEndpoint && endpoint !== 'custom' ? OLD_ENDPOINTS : ENDPOINT_MAPPING;
 
         Object.keys(endpointType[endpoint]).forEach((key) => {
-          this.model.key = endpointType[endpoint][key].replace(TENANT_ID_TOKEN, this.model.tenantId);
+          this.model[key] = endpointType[endpoint][key].replace(TENANT_ID_TOKEN, this.model.tenantId);
         });
       }
     },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11784 
<!-- Define findings related to the feature or bug issue. -->
Fixed Azure AD validation. Looks like migration code used wrong syntax

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Changed how key value is assigned

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Azure AD validation:
Users & Authentication -> Auth Provider -> Azure AD
1. Populating "Tenant id", "Application id", "Application secret" fields should enable "Enable" button with a default "Standard" endpoint.
2. Switching to "China" endpoint should keep "Enable" button enabled.
3. Switching to "Custom" endpoint should disable "Enable" button.
4. Populating the rest of the fields with valid values should enable "Enable" button back.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/e39362dd-19ce-432e-955f-99cb04ea3745

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
