### PR TITLE
[2.9] remove upper limit on kube version for default annotations on extensions

### DIFF
--- a/shell/scripts/extension/helm/charts/ui-plugin-server/Chart.yaml
+++ b/shell/scripts/extension/helm/charts/ui-plugin-server/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
-  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.29.0-0'
+  catalog.cattle.io/kube-version: '>= 1.16.0-0'
   catalog.cattle.io/namespace: cattle-ui-plugin-system # Must prefix with cattle- and suffix with -system=
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux, windows


### PR DESCRIPTION
Backport of https://github.com/rancher/dashboard/pull/11768

