### PR TITLE
Allow for loading dynamic components defined in extensions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
     "authprovider",
     "autoscroll",
     "banzaicloud",
+    "bulkable",
     "bundledeployment",
     "bundlenamespacemapping",
     "cacerts",

--- a/shell/core/plugin-helpers.ts
+++ b/shell/core/plugin-helpers.ts
@@ -1,3 +1,6 @@
+import { RouteLocation } from 'vue-router';
+import { ComponentOptionsMixin } from 'vue';
+
 import { ActionLocation, CardLocation, ExtensionPoint } from '@shell/core/types';
 import { isMac } from '@shell/utils/platform';
 import { ucFirst, randomStr } from '@shell/utils/string';
@@ -7,7 +10,16 @@ import {
 import { getProductFromRoute } from '@shell/utils/router';
 import { isEqual } from '@shell/utils/object';
 
-function checkRouteProduct($route, locationConfigParam) {
+/* eslint-disable no-unused-vars */
+enum LocationConfigParams {
+  _CONFIG = 'config',
+  _CREATE = 'create',
+  _DETAIL = 'detail',
+  _EDIT = 'edit',
+  _LIST = 'list',
+}
+
+function checkRouteProduct($route: RouteLocation, locationConfigParam: string) {
   const product = getProductFromRoute($route);
 
   // alias for the homepage
@@ -20,7 +32,7 @@ function checkRouteProduct($route, locationConfigParam) {
   return false;
 }
 
-function checkRouteMode({ name, query }, locationConfigParam) {
+function checkRouteMode({ name, query }: {name: string, query: any}, locationConfigParam: LocationConfigParams) {
   if (locationConfigParam === _EDIT && query.mode && query.mode === _EDIT && !query.as) {
     return true;
   } else if (locationConfigParam === _CONFIG && query.as && query.as === _CONFIG) {
@@ -38,7 +50,7 @@ function checkRouteMode({ name, query }, locationConfigParam) {
   return false;
 }
 
-function checkExtensionRouteBinding($route, locationConfig, context) {
+function checkExtensionRouteBinding($route: any, locationConfig: any, context: any) {
   // if no configuration is passed, consider it as global
   if (!Object.keys(locationConfig).length) {
     return true;
@@ -124,14 +136,20 @@ function checkExtensionRouteBinding($route, locationConfig, context) {
   return res;
 }
 
-export function getApplicableExtensionEnhancements(pluginCtx, actionType, uiArea, currRoute, translationCtx = pluginCtx, context) {
-  const extensionEnhancements = [];
+export function getApplicableExtensionEnhancements<T>(
+  pluginCtx: ComponentOptionsMixin,
+  actionType: ExtensionPoint,
+  uiArea: CardLocation | ActionLocation,
+  currRoute: RouteLocation,
+  translationCtx = pluginCtx,
+  context?: ComponentOptionsMixin): T[] {
+  const extensionEnhancements: T[] = [];
 
   // gate it so that we prevent errors on older versions of dashboard
   if (pluginCtx.$plugin?.getUIConfig) {
     const actions = pluginCtx.$plugin.getUIConfig(actionType, uiArea);
 
-    actions.forEach((action, i) => {
+    actions.forEach((action: any, i: number) => {
       if (checkExtensionRouteBinding(currRoute, action.locationConfig, context || {})) {
         // ADD CARD PLUGIN UI ENHANCEMENT
         if (actionType === ExtensionPoint.CARD) {
@@ -172,7 +190,7 @@ export function getApplicableExtensionEnhancements(pluginCtx, actionType, uiArea
               const keyboardCombo = isMac ? actions[i].shortcut.mac : actions[i].shortcut.windows ? actions[i].shortcut.windows : [];
               let scLabel = '';
 
-              keyboardCombo.forEach((key, i) => {
+              keyboardCombo.forEach((key: string, i: number) => {
                 if (i < keyboardCombo.length - 1) {
                   if (key === 'meta') {
                     key = '\u2318';


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This fixes an issue with rendering components that are lazy loaded via an extension configuration. For example:

```
  plugin.addCard(
    CardLocation.CLUSTER_DASHBOARD_CARD,
    { cluster: ['local'] },
    {
      label: 'some-label2',
      labelKey: 'plugin-examples.card-title-three',
      component: () => import('./components/MastheadDetailsComponent.vue')
    }
  );
```

`defineAsyncComponent` helps Vue handle the asynchronous nature of lazy loading and `markRaw` prevents Vue from making the component reactive, which can help with performance.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- wrap the component property for Card, Tab, and Panel in `defineAsyncComponent` and `markRaw`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- This has been tested with [extensions-api-demo](https://github.com/rancher/ui-plugin-examples/tree/main/pkg/extensions-api-demo)
- Other extensions should be tested and verified

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Loading extensions that might not lazy load components

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
