### PR TITLE
Fix for auto-imported components from extensions

### DIFF
--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -152,6 +152,7 @@ import { sortBy } from '@shell/utils/sort';
 import { haveV2Monitoring } from '@shell/utils/monitoring';
 import { NEU_VECTOR_NAMESPACE } from '@shell/config/product/neuvector';
 import { createHeaders, rowValueGetter } from '@shell/store/type-map.utils';
+import { defineAsyncComponent } from 'vue';
 
 export const NAMESPACED = 'namespaced';
 export const CLUSTER_LEVEL = 'cluster';
@@ -2044,10 +2045,10 @@ function loadExtension(rootState, kind, key, fallback) {
 
   if (ext) {
     if (typeof ext === 'function') {
-      return ext;
+      return defineAsyncComponent(ext);
     }
 
-    return () => ext;
+    return () => defineAsyncComponent(ext);
   }
 
   return fallback(key);


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
We need to wrap the auto-imported components with `defineAsyncComponent` so it behaves like all of the native components. This should fix the auto imports from directories like lists, edit, detail etc.

### Areas or cases that should be tested
Any vue3 extension which made resource overrides using the list, edit, detail etc directories.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
