### PR TITLE
Vue 3: Fixed cancelling adding members returns to the wrong page

### DIFF
--- a/cypress/e2e/po/pages/explorer/cluster-project-members.po.ts
+++ b/cypress/e2e/po/pages/explorer/cluster-project-members.po.ts
@@ -32,6 +32,10 @@ export default class ClusterProjectMembersPo extends PagePo {
     return new AsyncButtonPo('[data-testid="form-save"]', this.self());
   }
 
+  cancelCreateForm(): AsyncButtonPo {
+    return new AsyncButtonPo('[data-testid="form-cancel"]', this.self());
+  }
+
   resourcesList() {
     return new BaseResourceList(this.self());
   }

--- a/cypress/e2e/tests/pages/explorer2/cluster-project-members.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/cluster-project-members.spec.ts
@@ -1,5 +1,6 @@
 import UsersPo from '@/cypress/e2e/po/pages/users-and-auth/users.po';
 import ClusterProjectMembersPo from '@/cypress/e2e/po/pages/explorer/cluster-project-members.po';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 
 const runTimestamp = +new Date();
 const runPrefix = `e2e-test-${ runTimestamp }`;
@@ -7,13 +8,13 @@ const runPrefix = `e2e-test-${ runTimestamp }`;
 const username = `${ runPrefix }-cluster-proj-member`;
 const standardPassword = 'standard-password';
 
-describe.skip('[Vue3 Skip]: Cluster Project and Members', { tags: ['@explorer2', '@adminUser'] }, () => {
+describe('Cluster Project and Members', { tags: ['@explorer2', '@adminUser'] }, () => {
+  beforeEach(() => {
+    cy.login();
+  });
   it('Members added to both Cluster Membership should not show "Loading..." next to their names', () => {
     const usersAdmin = new UsersPo('_');
     const userCreate = usersAdmin.createEdit();
-
-    // this will login as admin
-    cy.login();
 
     // create a standard user
     usersAdmin.goTo();
@@ -53,5 +54,17 @@ describe.skip('[Vue3 Skip]: Cluster Project and Members', { tags: ['@explorer2',
         expect(sanitizedName).to.equal(username);
       });
     });
+  });
+  it('Clicking cancel should return to Cluster and Project members ', () => {
+    HomePagePo.goTo();
+    const clusterMembership = new ClusterProjectMembersPo('local', 'cluster-membership');
+
+    clusterMembership.navToClusterMenuEntry('local');
+    // if we do not wait for the cluster page to load, then we get the old side nav from Users & Authentication
+    clusterMembership.waitForPageWithSpecificUrl('/c/local/explorer');
+    clusterMembership.navToSideMenuEntryByLabel('Cluster and Project Members');
+    clusterMembership.triggerAddClusterOrProjectMemberAction();
+    clusterMembership.cancelCreateForm().click();
+    clusterMembership.waitForPageWithExactUrl();
   });
 });

--- a/shell/edit/management.cattle.io.clusterroletemplatebinding.vue
+++ b/shell/edit/management.cattle.io.clusterroletemplatebinding.vue
@@ -12,6 +12,7 @@ export default {
     CruResource,
     Loading,
   },
+  inheritAttrs: false,
 
   mixins: [CreateEditView],
   async fetch() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11821 
<!-- Define findings related to the feature or bug issue. -->
Passed attributes were incorrect

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added "inheritAttrs: false,"

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Adding project and cluster members

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
No other areas should be affected.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
