### PR TITLE
Remove extra `<template>` tags from components

### DIFF
--- a/shell/components/form/Labels.vue
+++ b/shell/components/form/Labels.vue
@@ -97,19 +97,17 @@ export default {
             name="labels"
             :toggler="toggler"
           >
-            <template>
-              <KeyValue
-                key="labels"
-                :value="value.labels"
-                :protected-keys="value.systemLabels || []"
-                :toggle-filter="toggler"
-                :add-label="t('labels.addLabel')"
-                :mode="mode"
-                :read-allowed="false"
-                :value-can-be-empty="true"
-                @update:value="value.setLabels($event)"
-              />
-            </template>
+            <KeyValue
+              key="labels"
+              :value="value.labels"
+              :protected-keys="value.systemLabels || []"
+              :toggle-filter="toggler"
+              :add-label="t('labels.addLabel')"
+              :mode="mode"
+              :read-allowed="false"
+              :value-can-be-empty="true"
+              @update:value="value.setLabels($event)"
+            />
           </slot>
         </div>
       </div>

--- a/shell/components/formatter/InternalExternalIP.vue
+++ b/shell/components/formatter/InternalExternalIP.vue
@@ -38,21 +38,19 @@ export default {
       -
     </template>
     /
-    <template>
-      <template v-if="internalSameAsExternal && isIp(row.internalIp)">
-        {{ t('tableHeaders.internalIpSameAsExternal') }}
-      </template>
-      <template v-else-if="isIp(row.internalIp)">
-        {{ row.internalIp }}<CopyToClipboard
-          label-as="tooltip"
-          :text="row.internalIp"
-          class="icon-btn"
-          action-color="bg-transparent"
-        />
-      </template>
-      <template v-else>
-        -
-      </template>
+    <template v-if="internalSameAsExternal && isIp(row.internalIp)">
+      {{ t('tableHeaders.internalIpSameAsExternal') }}
+    </template>
+    <template v-else-if="isIp(row.internalIp)">
+      {{ row.internalIp }}<CopyToClipboard
+        label-as="tooltip"
+        :text="row.internalIp"
+        class="icon-btn"
+        action-color="bg-transparent"
+      />
+    </template>
+    <template v-else>
+      -
     </template>
   </span>
 </template>

--- a/shell/detail/helm.cattle.io.projecthelmchart.vue
+++ b/shell/detail/helm.cattle.io.projecthelmchart.vue
@@ -137,12 +137,10 @@ export default {
         :label="t('monitoring.overview.alertsList.label')"
         :weight="2"
       >
-        <template>
-          <AlertTable
-            :monitoring-namespace="monitoringNamespace"
-            :alert-service-endpoint="alertServiceEndpoint"
-          />
-        </template>
+        <AlertTable
+          :monitoring-namespace="monitoringNamespace"
+          :alert-service-endpoint="alertServiceEndpoint"
+        />
       </Tab>
       <template #tab-row-extras>
         <div class="tab-row-footer">

--- a/shell/edit/auth/ldap/config.vue
+++ b/shell/edit/auth/ldap/config.vue
@@ -95,305 +95,303 @@ export default {
 
 <template>
   <div @update:value="$emit('update:value', model)">
-    <template>
-      <div class="row mb-20">
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="hostname"
-            required
-            :mode="mode"
-            :hoover-tooltip="true"
-            :tooltip="t('authConfig.ldap.hostname.hint')"
-            :label="t('authConfig.ldap.hostname.label')"
-            :placeholder="t('authConfig.ldap.hostname.placeholder')"
-          />
-        </div>
-        <div class="col span-4">
-          <LabeledInput
-            :value="model.port"
-            type="number"
-            required
-            :min="0"
-            :step="1"
-            :mode="mode"
-            :label="t('authConfig.ldap.port')"
-            @update:value="e=>$set(model, 'port', e.replace(/[^0-9]*/g, ''))"
-          />
-        </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="hostname"
+          required
+          :mode="mode"
+          :hoover-tooltip="true"
+          :tooltip="t('authConfig.ldap.hostname.hint')"
+          :label="t('authConfig.ldap.hostname.label')"
+          :placeholder="t('authConfig.ldap.hostname.placeholder')"
+        />
+      </div>
+      <div class="col span-4">
+        <LabeledInput
+          :value="model.port"
+          type="number"
+          required
+          :min="0"
+          :step="1"
+          :mode="mode"
+          :label="t('authConfig.ldap.port')"
+          @update:value="e=>$set(model, 'port', e.replace(/[^0-9]*/g, ''))"
+        />
+      </div>
 
-        <div class="col">
-          <Checkbox
-            v-model:value="model.tls"
-            :mode="mode"
-            class="full-height"
-            :label="t('authConfig.ldap.tls')"
-          />
-        </div>
-        <div class="col span-1">
-          <Checkbox
-            v-model:value="model.starttls"
-            :tooltip="t('authConfig.ldap.starttls.tip')"
-            :mode="mode"
-            class="full-height"
-            :label="t('authConfig.ldap.starttls.label')"
-          />
-        </div>
+      <div class="col">
+        <Checkbox
+          v-model:value="model.tls"
+          :mode="mode"
+          class="full-height"
+          :label="t('authConfig.ldap.tls')"
+        />
       </div>
-      <div
-        v-if="model.tls || model.starttls"
-        class="row mb-20"
-      >
-        <div class="col span-12">
-          <LabeledInput
-            v-model:value="model.certificate"
-            required
-            type="multiline"
-            :mode="mode"
-            :label="t('authConfig.ldap.cert')"
-          />
-          <FileSelector
-            class="role-tertiary add mt-5"
-            :label="t('generic.readFromFile')"
-            :mode="mode"
-            @selected="$set(model, 'certificate', $event)"
-          />
-        </div>
+      <div class="col span-1">
+        <Checkbox
+          v-model:value="model.starttls"
+          :tooltip="t('authConfig.ldap.starttls.tip')"
+          :mode="mode"
+          class="full-height"
+          :label="t('authConfig.ldap.starttls.label')"
+        />
       </div>
-      <div class="row mb-20">
-        <div class="col span-6">
-          <UnitInput
-            v-model:value="model.connectionTimeout"
-            required
-            :mode="mode"
-            :label="t('authConfig.ldap.serverConnectionTimeout')"
-            suffix="milliseconds"
-          />
-        </div>
+    </div>
+    <div
+      v-if="model.tls || model.starttls"
+      class="row mb-20"
+    >
+      <div class="col span-12">
+        <LabeledInput
+          v-model:value="model.certificate"
+          required
+          type="multiline"
+          :mode="mode"
+          :label="t('authConfig.ldap.cert')"
+        />
+        <FileSelector
+          class="role-tertiary add mt-5"
+          :label="t('generic.readFromFile')"
+          :mode="mode"
+          @selected="$set(model, 'certificate', $event)"
+        />
       </div>
-      <Banner
-        color="info"
-        :label="t('authConfig.ldap.serviceAccountInfo')"
-      />
-      <div class="row mb-20">
-        <div
-          v-if="type==='activedirectory'"
-          class="col span-6"
-        >
-          <LabeledInput
-            v-model:value="model.serviceAccountUsername"
-            required
-            :mode="mode"
-            :label="t('authConfig.ldap.serviceAccountDN')"
-          />
-        </div>
-
-        <div
-          v-else
-          class="col span-6"
-        >
-          <LabeledInput
-            v-model:value="model.serviceAccountDistinguishedName"
-            required
-            :mode="mode"
-            :label="t('authConfig.ldap.serviceAccountDN')"
-          />
-        </div>
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.serviceAccountPassword"
-            required
-            type="password"
-            :mode="mode"
-            :label="t('authConfig.ldap.serviceAccountPassword')"
-          />
-        </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <UnitInput
+          v-model:value="model.connectionTimeout"
+          required
+          :mode="mode"
+          :label="t('authConfig.ldap.serverConnectionTimeout')"
+          suffix="milliseconds"
+        />
       </div>
+    </div>
+    <Banner
+      color="info"
+      :label="t('authConfig.ldap.serviceAccountInfo')"
+    />
+    <div class="row mb-20">
       <div
         v-if="type==='activedirectory'"
-        class="row mb-20"
+        class="col span-6"
       >
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.defaultLoginDomain"
-            :hoover-tooltip="true"
-            :tooltip="t('authConfig.ldap.defaultLoginDomain.hint')"
-            :placeholder="t('authConfig.ldap.defaultLoginDomain.placeholder')"
-            :mode="mode"
-            :label="t('authConfig.ldap.defaultLoginDomain.label')"
-          />
-        </div>
-      </div>
-      <div class="row mb-20">
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.userSearchBase"
-            required
-            :mode="mode"
-            :label="t('authConfig.ldap.userSearchBase.label')"
-            :placeholder="t('authConfig.ldap.userSearchBase.placeholder')"
-          />
-        </div>
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.groupSearchBase"
-            :mode="mode"
-            :placeholder="t('authConfig.ldap.groupSearchBase.placeholder')"
-            :label="t('authConfig.ldap.groupSearchBase.label')"
-          />
-        </div>
+        <LabeledInput
+          v-model:value="model.serviceAccountUsername"
+          required
+          :mode="mode"
+          :label="t('authConfig.ldap.serviceAccountDN')"
+        />
       </div>
 
-      <div class="row">
-        <h3>  {{ t('authConfig.ldap.customizeSchema') }}</h3>
+      <div
+        v-else
+        class="col span-6"
+      >
+        <LabeledInput
+          v-model:value="model.serviceAccountDistinguishedName"
+          required
+          :mode="mode"
+          :label="t('authConfig.ldap.serviceAccountDN')"
+        />
       </div>
-      <Banner
-        v-if="type === OKTA && isCreate"
-        class="row"
-        color="info"
-        label-key="authConfig.ldap.oktaSchema"
-      />
-      <div class="row">
-        <div class="col span-6">
-          <h4>{{ t('authConfig.ldap.users') }}</h4>
-        </div>
-        <div class="col span-6">
-          <h4>{{ t('authConfig.ldap.groups') }}</h4>
-        </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.serviceAccountPassword"
+          required
+          type="password"
+          :mode="mode"
+          :label="t('authConfig.ldap.serviceAccountPassword')"
+        />
       </div>
-      <div class="row mb-20">
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.userObjectClass"
-            :mode="mode"
-            :label="t('authConfig.ldap.objectClass')"
-          />
-        </div>
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.groupObjectClass"
-            :mode="mode"
-            :label="t('authConfig.ldap.objectClass')"
-          />
-        </div>
+    </div>
+    <div
+      v-if="type==='activedirectory'"
+      class="row mb-20"
+    >
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.defaultLoginDomain"
+          :hoover-tooltip="true"
+          :tooltip="t('authConfig.ldap.defaultLoginDomain.hint')"
+          :placeholder="t('authConfig.ldap.defaultLoginDomain.placeholder')"
+          :mode="mode"
+          :label="t('authConfig.ldap.defaultLoginDomain.label')"
+        />
       </div>
-      <div class="row mb-20">
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.userNameAttribute"
-            :mode="mode"
-            :label="t('authConfig.ldap.usernameAttribute')"
-          />
-        </div>
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.groupNameAttribute"
-            :mode="mode"
-            :label="t('authConfig.ldap.nameAttribute')"
-          />
-        </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.userSearchBase"
+          required
+          :mode="mode"
+          :label="t('authConfig.ldap.userSearchBase.label')"
+          :placeholder="t('authConfig.ldap.userSearchBase.placeholder')"
+        />
       </div>
-      <div class="row mb-20">
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.userLoginAttribute"
-            :mode="mode"
-            :label="t('authConfig.ldap.loginAttribute')"
-          />
-        </div>
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.groupMemberUserAttribute"
-            :mode="mode"
-            :label="t('authConfig.ldap.groupMemberUserAttribute')"
-          />
-        </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.groupSearchBase"
+          :mode="mode"
+          :placeholder="t('authConfig.ldap.groupSearchBase.placeholder')"
+          :label="t('authConfig.ldap.groupSearchBase.label')"
+        />
       </div>
-      <div class="row mb-20">
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.userMemberAttribute"
-            :mode="mode"
-            :label="t('authConfig.ldap.userMemberAttribute')"
-          />
-        </div>
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.groupSearchAttribute"
-            :mode="mode"
-            :label="t('authConfig.ldap.searchAttribute')"
-          />
-        </div>
+    </div>
+
+    <div class="row">
+      <h3>  {{ t('authConfig.ldap.customizeSchema') }}</h3>
+    </div>
+    <Banner
+      v-if="type === OKTA && isCreate"
+      class="row"
+      color="info"
+      label-key="authConfig.ldap.oktaSchema"
+    />
+    <div class="row">
+      <div class="col span-6">
+        <h4>{{ t('authConfig.ldap.users') }}</h4>
       </div>
-      <div class="row mb-20">
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.userSearchAttribute"
-            :mode="mode"
-            :label="t('authConfig.ldap.searchAttribute')"
-          />
-        </div>
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.groupSearchFilter"
-            :mode="mode"
-            :label="t('authConfig.ldap.searchFilter')"
-          />
-        </div>
+      <div class="col span-6">
+        <h4>{{ t('authConfig.ldap.groups') }}</h4>
       </div>
-      <div class="row mb-20">
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.userSearchFilter"
-            :mode="mode"
-            :label="t('authConfig.ldap.searchFilter')"
-          />
-        </div>
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.groupMemberMappingAttribute"
-            :mode="mode"
-            :label="t('authConfig.ldap.groupMemberMappingAttribute')"
-          />
-        </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.userObjectClass"
+          :mode="mode"
+          :label="t('authConfig.ldap.objectClass')"
+        />
       </div>
-      <div class="row mb-20">
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.userEnabledAttribute"
-            :mode="mode"
-            :label="t('authConfig.ldap.userEnabledAttribute')"
-          />
-        </div>
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.groupDNAttribute"
-            :mode="mode"
-            :label="t('authConfig.ldap.groupDNAttribute')"
-          />
-        </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.groupObjectClass"
+          :mode="mode"
+          :label="t('authConfig.ldap.objectClass')"
+        />
       </div>
-      <div class="row mb-20">
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="model.disabledStatusBitmask"
-            :mode="mode"
-            :label="t('authConfig.ldap.disabledStatusBitmask')"
-          />
-        </div>
-        <div
-          v-if="!isSamlProvider"
-          class=" col span-6"
-        >
-          <RadioGroup
-            v-model:value="model.nestedGroupMembershipEnabled"
-            :mode="mode"
-            name="nested"
-            class="full-height"
-            :options="[true, false]"
-            :labels="[t('authConfig.ldap.nestedGroupMembership.options.nested'), t('authConfig.ldap.nestedGroupMembership.options.direct')]"
-          />
-        </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.userNameAttribute"
+          :mode="mode"
+          :label="t('authConfig.ldap.usernameAttribute')"
+        />
       </div>
-    </template>
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.groupNameAttribute"
+          :mode="mode"
+          :label="t('authConfig.ldap.nameAttribute')"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.userLoginAttribute"
+          :mode="mode"
+          :label="t('authConfig.ldap.loginAttribute')"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.groupMemberUserAttribute"
+          :mode="mode"
+          :label="t('authConfig.ldap.groupMemberUserAttribute')"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.userMemberAttribute"
+          :mode="mode"
+          :label="t('authConfig.ldap.userMemberAttribute')"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.groupSearchAttribute"
+          :mode="mode"
+          :label="t('authConfig.ldap.searchAttribute')"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.userSearchAttribute"
+          :mode="mode"
+          :label="t('authConfig.ldap.searchAttribute')"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.groupSearchFilter"
+          :mode="mode"
+          :label="t('authConfig.ldap.searchFilter')"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.userSearchFilter"
+          :mode="mode"
+          :label="t('authConfig.ldap.searchFilter')"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.groupMemberMappingAttribute"
+          :mode="mode"
+          :label="t('authConfig.ldap.groupMemberMappingAttribute')"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.userEnabledAttribute"
+          :mode="mode"
+          :label="t('authConfig.ldap.userEnabledAttribute')"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.groupDNAttribute"
+          :mode="mode"
+          :label="t('authConfig.ldap.groupDNAttribute')"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="model.disabledStatusBitmask"
+          :mode="mode"
+          :label="t('authConfig.ldap.disabledStatusBitmask')"
+        />
+      </div>
+      <div
+        v-if="!isSamlProvider"
+        class=" col span-6"
+      >
+        <RadioGroup
+          v-model:value="model.nestedGroupMembershipEnabled"
+          :mode="mode"
+          name="nested"
+          class="full-height"
+          :options="[true, false]"
+          :labels="[t('authConfig.ldap.nestedGroupMembership.options.nested'), t('authConfig.ldap.nestedGroupMembership.options.direct')]"
+        />
+      </div>
+    </div>
   </div>
 </template>

--- a/shell/edit/cis.cattle.io.clusterscan.vue
+++ b/shell/edit/cis.cattle.io.clusterscan.vue
@@ -245,101 +245,99 @@ export default {
     @finish="saveScan"
     @error="e=>errors = e"
   >
-    <template>
-      <Banner
-        v-if="!validProfiles.length"
-        color="warning"
-        :label="t('cis.noProfiles')"
-      />
+    <Banner
+      v-if="!validProfiles.length"
+      color="warning"
+      :label="t('cis.noProfiles')"
+    />
 
+    <div
+      v-else
+      class="row mb-20"
+    >
+      <div class="col span-6">
+        <LabeledSelect
+          v-model:value="value.spec.scanProfileName"
+          :mode="mode"
+          :label="t('cis.profile')"
+          :options="validProfiles"
+        />
+      </div>
       <div
-        v-else
-        class="row mb-20"
+        v-if="canBeScheduled"
+        class="col span-6"
       >
-        <div class="col span-6">
-          <LabeledSelect
-            v-model:value="value.spec.scanProfileName"
-            :mode="mode"
-            :label="t('cis.profile')"
-            :options="validProfiles"
-          />
-        </div>
-        <div
-          v-if="canBeScheduled"
-          class="col span-6"
-        >
-          <span>{{ t('cis.scoreWarning.label') }}</span> <i
-            v-clean-tooltip="t('cis.scoreWarning.protip')"
-            class="icon icon-info"
-          />
+        <span>{{ t('cis.scoreWarning.label') }}</span> <i
+          v-clean-tooltip="t('cis.scoreWarning.protip')"
+          class="icon icon-info"
+        />
+        <RadioGroup
+          v-model:value="value.spec.scoreWarning"
+          :mode="mode"
+          name="scoreWarning"
+          :options="['pass', 'fail']"
+          :labels="[t('cis.scan.pass'), t('cis.scan.fail')]"
+        />
+      </div>
+    </div>
+    <template v-if="canBeScheduled">
+      <h3>Scheduling</h3>
+      <div class="row mb-20">
+        <div class="col">
           <RadioGroup
-            v-model:value="value.spec.scoreWarning"
+            v-model:value="isScheduled"
             :mode="mode"
-            name="scoreWarning"
-            :options="['pass', 'fail']"
-            :labels="[t('cis.scan.pass'), t('cis.scan.fail')]"
+            name="scheduling"
+            :options="[ {value: false, label: t('cis.scheduling.disable')}, {value: true, label: t('cis.scheduling.enable')}]"
           />
         </div>
       </div>
-      <template v-if="canBeScheduled">
-        <h3>Scheduling</h3>
+      <template v-if="isScheduled">
         <div class="row mb-20">
-          <div class="col">
-            <RadioGroup
-              v-model:value="isScheduled"
+          <div class="col span-6">
+            <LabeledInput
+              v-model:value="scheduledScanConfig.cronSchedule"
+              required
               :mode="mode"
-              name="scheduling"
-              :options="[ {value: false, label: t('cis.scheduling.disable')}, {value: true, label: t('cis.scheduling.enable')}]"
+              :label="t('cis.cronSchedule.label')"
+              :placeholder="t('cis.cronSchedule.placeholder')"
+              type="cron"
+            />
+          </div>
+          <div class="col span-6">
+            <UnitInput
+              v-model.number="scheduledScanConfig.retentionCount"
+              :suffix="t('cis.reports')"
+              type="number"
+              :mode="mode"
+              :label="t('cis.retention')"
             />
           </div>
         </div>
-        <template v-if="isScheduled">
-          <div class="row mb-20">
-            <div class="col span-6">
-              <LabeledInput
-                v-model:value="scheduledScanConfig.cronSchedule"
-                required
-                :mode="mode"
-                :label="t('cis.cronSchedule.label')"
-                :placeholder="t('cis.cronSchedule.placeholder')"
-                type="cron"
-              />
-            </div>
-            <div class="col span-6">
-              <UnitInput
-                v-model.number="scheduledScanConfig.retentionCount"
-                :suffix="t('cis.reports')"
-                type="number"
-                :mode="mode"
-                :label="t('cis.retention')"
-              />
-            </div>
+        <h3>
+          Alerting
+        </h3>
+        <div class="row mb-20">
+          <div class="col span-12">
+            <Banner
+              v-if="scanAlertRule.alertOnFailure || scanAlertRule.alertOnComplete"
+              class="mt-0"
+              :color="hasAlertManager ? 'info' : 'warning'"
+            >
+              <span v-clean-html="t('cis.alertNeeded', {link: monitoringUrl}, true)" />
+            </banner>
+            <Checkbox
+              v-model:value="scanAlertRule.alertOnComplete"
+              :mode="mode"
+              :label="t('cis.alertOnComplete')"
+            />
+            <Checkbox
+              v-model:value="scanAlertRule.alertOnFailure"
+              :mode="mode"
+              :label="t('cis.alertOnFailure')"
+            />
           </div>
-          <h3>
-            Alerting
-          </h3>
-          <div class="row mb-20">
-            <div class="col span-12">
-              <Banner
-                v-if="scanAlertRule.alertOnFailure || scanAlertRule.alertOnComplete"
-                class="mt-0"
-                :color="hasAlertManager ? 'info' : 'warning'"
-              >
-                <span v-clean-html="t('cis.alertNeeded', {link: monitoringUrl}, true)" />
-              </banner>
-              <Checkbox
-                v-model:value="scanAlertRule.alertOnComplete"
-                :mode="mode"
-                :label="t('cis.alertOnComplete')"
-              />
-              <Checkbox
-                v-model:value="scanAlertRule.alertOnFailure"
-                :mode="mode"
-                :label="t('cis.alertOnFailure')"
-              />
-            </div>
-          </div>
-        </template>
+        </div>
       </template>
     </template>
   </CruResource>

--- a/shell/edit/cis.cattle.io.clusterscanprofile.vue
+++ b/shell/edit/cis.cattle.io.clusterscanprofile.vue
@@ -113,40 +113,38 @@ export default {
       @finish="save"
       @error="e=>errors = e"
     >
-      <template>
-        <div class="spacer" />
-        <div class="row">
-          <div class="col span-12">
-            <NameNsDescription
-              :mode="mode"
-              :value="value"
-              :namespaced="false"
-              @change="name=value.metadata.name"
-            />
-          </div>
+      <div class="spacer" />
+      <div class="row">
+        <div class="col span-12">
+          <NameNsDescription
+            :mode="mode"
+            :value="value"
+            :namespaced="false"
+            @change="name=value.metadata.name"
+          />
         </div>
-        <div class="row">
-          <div class="col span-6">
-            <LabeledSelect
-              v-model:value="value.spec.benchmarkVersion"
-              :mode="mode"
-              :label="t('cis.benchmarkVersion')"
-              :options="compatibleBenchmarkNames"
-            />
-          </div>
+      </div>
+      <div class="row">
+        <div class="col span-6">
+          <LabeledSelect
+            v-model:value="value.spec.benchmarkVersion"
+            :mode="mode"
+            :label="t('cis.benchmarkVersion')"
+            :options="compatibleBenchmarkNames"
+          />
         </div>
-        <div class="spacer" />
-        <div class="row">
-          <div class="col span-6">
-            <ArrayList
-              v-model:value="value.spec.skipTests"
-              :title="t('cis.testsToSkip')"
-              :value-placeholder="t('cis.testID')"
-              :mode="mode"
-            />
-          </div>
+      </div>
+      <div class="spacer" />
+      <div class="row">
+        <div class="col span-6">
+          <ArrayList
+            v-model:value="value.spec.skipTests"
+            :title="t('cis.testsToSkip')"
+            :value-placeholder="t('cis.testID')"
+            :mode="mode"
+          />
         </div>
-      </template>
+      </div>
     </CruResource>
   </div>
 </template>

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/registries/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/registries/index.vue
@@ -112,39 +112,37 @@ export default {
         />
       </div>
     </div>
-    <template>
-      <div
-        v-if="showCustomRegistryInput"
-        class="row"
+    <div
+      v-if="showCustomRegistryInput"
+      class="row"
+    >
+      <AdvancedSection
+        class="col span-12 advanced"
+        :is-open-by-default="showCustomRegistryAdvancedInput"
+        :mode="mode"
+        data-testid="registries-advanced-section"
       >
-        <AdvancedSection
-          class="col span-12 advanced"
-          :is-open-by-default="showCustomRegistryAdvancedInput"
+        <Banner
+          :closable="false"
+          class="cluster-tools-tip"
+          color="info"
+          :label-key="value.isK3s ? 'cluster.privateRegistry.docsLinkK3s' : 'cluster.privateRegistry.docsLinkRke2'"
+        />
+        <RegistryMirrors
+          :value="value"
+          class="mt-20"
           :mode="mode"
-          data-testid="registries-advanced-section"
-        >
-          <Banner
-            :closable="false"
-            class="cluster-tools-tip"
-            color="info"
-            :label-key="value.isK3s ? 'cluster.privateRegistry.docsLinkK3s' : 'cluster.privateRegistry.docsLinkRke2'"
-          />
-          <RegistryMirrors
-            :value="value"
-            class="mt-20"
-            :mode="mode"
-            @update:value="$emit('input', $event)"
-          />
-          <RegistryConfigs
-            :value="value"
-            class="mt-20"
-            :mode="mode"
-            :cluster-register-before-hook="registerBeforeHook"
-            @update:value="$emit('input', $event)"
-            @updateConfigs="$emit('update-configs-changed', $event)"
-          />
-        </AdvancedSection>
-      </div>
-    </template>
+          @update:value="$emit('input', $event)"
+        />
+        <RegistryConfigs
+          :value="value"
+          class="mt-20"
+          :mode="mode"
+          :cluster-register-before-hook="registerBeforeHook"
+          @update:value="$emit('input', $event)"
+          @updateConfigs="$emit('update-configs-changed', $event)"
+        />
+      </AdvancedSection>
+    </div>
   </div>
 </template>

--- a/shell/edit/resources.cattle.io.backup.vue
+++ b/shell/edit/resources.cattle.io.backup.vue
@@ -205,117 +205,115 @@ export default {
     :errors="fvUnreportedValidationErrors"
     @finish="save"
   >
-    <template>
-      <NameNsDescription
-        :mode="mode"
-        :value="value"
-        :namespaced="false"
-        :rules="{name: fvGetAndReportPathRules('metadata.name')}"
-        @change="name=value.metadata.name"
-      />
-      <template v-if="!!resourceSet">
-        <div class="bordered-section">
-          <RadioGroup
-            v-model:value="setSchedule"
-            :mode="mode"
-            :label="t('backupRestoreOperator.schedule.label')"
-            name="setSchedule"
-            :options="[false, true]"
-            :labels="[t('backupRestoreOperator.schedule.options.disabled'), t('backupRestoreOperator.schedule.options.enabled')]"
-          />
-          <div
-            v-if="setSchedule"
-            class="row mt-10 mb-10"
-          >
-            <div class="col span-6">
-              <LabeledInput
-                v-model:value="value.spec.schedule"
-                type="cron"
-                :mode="mode"
-                :label="t('backupRestoreOperator.schedule.label')"
-                :placeholder="t('backupRestoreOperator.schedule.placeholder')"
-              />
-            </div>
-            <div class="col span-6">
-              <UnitInput
-                v-model:value="value.spec.retentionCount"
-                :suffix="t('backupRestoreOperator.retentionCount.units', {count: value.spec.retentionCount || 0})"
-                :mode="mode"
-                :label="t('backupRestoreOperator.retentionCount.label')"
-              />
-            </div>
+    <NameNsDescription
+      :mode="mode"
+      :value="value"
+      :namespaced="false"
+      :rules="{name: fvGetAndReportPathRules('metadata.name')}"
+      @change="name=value.metadata.name"
+    />
+    <template v-if="!!resourceSet">
+      <div class="bordered-section">
+        <RadioGroup
+          v-model:value="setSchedule"
+          :mode="mode"
+          :label="t('backupRestoreOperator.schedule.label')"
+          name="setSchedule"
+          :options="[false, true]"
+          :labels="[t('backupRestoreOperator.schedule.options.disabled'), t('backupRestoreOperator.schedule.options.enabled')]"
+        />
+        <div
+          v-if="setSchedule"
+          class="row mt-10 mb-10"
+        >
+          <div class="col span-6">
+            <LabeledInput
+              v-model:value="value.spec.schedule"
+              type="cron"
+              :mode="mode"
+              :label="t('backupRestoreOperator.schedule.label')"
+              :placeholder="t('backupRestoreOperator.schedule.placeholder')"
+            />
+          </div>
+          <div class="col span-6">
+            <UnitInput
+              v-model:value="value.spec.retentionCount"
+              :suffix="t('backupRestoreOperator.retentionCount.units', {count: value.spec.retentionCount || 0})"
+              :mode="mode"
+              :label="t('backupRestoreOperator.retentionCount.label')"
+            />
           </div>
         </div>
+      </div>
 
-        <div class="bordered-section">
-          <div class="row">
-            <div class="col span-12">
-              <RadioGroup
-                v-model:value="useEncryption"
-                name="useEncryption"
-                :label="t('backupRestoreOperator.encryption')"
-                :options="encryptionOptions.options"
-                :labels="encryptionOptions.labels"
-                :mode="mode"
-              />
-            </div>
-          </div>
-          <div
-            v-if="useEncryption"
-            :style="{'align-items':'center'}"
-            class="row mt-10"
-          >
-            <div class="col span-6">
-              <LabeledSelect
-                v-model:value="value.spec.encryptionConfigSecretName"
-                :tooltip="t('backupRestoreOperator.encryptionConfigName.backuptip', { ns: chartNamespace}, true)"
-                :hover-tooltip="true"
-                :mode="mode"
-                :options="encryptionSecretNames"
-                :label="t('backupRestoreOperator.encryptionConfigName.label')"
-              />
-            </div>
-          </div>
-        </div>
-
+      <div class="bordered-section">
         <div class="row">
           <div class="col span-12">
-            <span
-              v-if="isView"
-              class="text-label"
-            >{{ t('backupRestoreOperator.s3.titles.location') }}</span>
             <RadioGroup
-              v-else
-              v-model:value="storageSource"
-              name="storageSource"
-              :label="t('backupRestoreOperator.s3.titles.location')"
-              :options="storageOptions.options"
-              :labels="storageOptions.labels"
+              v-model:value="useEncryption"
+              name="useEncryption"
+              :label="t('backupRestoreOperator.encryption')"
+              :options="encryptionOptions.options"
+              :labels="encryptionOptions.labels"
               :mode="mode"
             />
           </div>
         </div>
-
-        <template v-if="storageSource !== 'useDefault'">
-          <div class="row mt-10">
-            <div class="col span-12">
-              <S3
-                :value="s3"
-                :mode="mode"
-              />
-            </div>
+        <div
+          v-if="useEncryption"
+          :style="{'align-items':'center'}"
+          class="row mt-10"
+        >
+          <div class="col span-6">
+            <LabeledSelect
+              v-model:value="value.spec.encryptionConfigSecretName"
+              :tooltip="t('backupRestoreOperator.encryptionConfigName.backuptip', { ns: chartNamespace}, true)"
+              :hover-tooltip="true"
+              :mode="mode"
+              :options="encryptionSecretNames"
+              :label="t('backupRestoreOperator.encryptionConfigName.label')"
+            />
           </div>
-        </template>
-        <template v-else-if="isView">
-          <span>{{ t('generic.default') }}</span>
-        </template>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col span-12">
+          <span
+            v-if="isView"
+            class="text-label"
+          >{{ t('backupRestoreOperator.s3.titles.location') }}</span>
+          <RadioGroup
+            v-else
+            v-model:value="storageSource"
+            name="storageSource"
+            :label="t('backupRestoreOperator.s3.titles.location')"
+            :options="storageOptions.options"
+            :labels="storageOptions.labels"
+            :mode="mode"
+          />
+        </div>
+      </div>
+
+      <template v-if="storageSource !== 'useDefault'">
+        <div class="row mt-10">
+          <div class="col span-12">
+            <S3
+              :value="s3"
+              :mode="mode"
+            />
+          </div>
+        </div>
       </template>
-      <Banner
-        v-else
-        color="error"
-      >
-        <span v-clean-html="t('backupRestoreOperator.noResourceSet')" />
-      </Banner>
+      <template v-else-if="isView">
+        <span>{{ t('generic.default') }}</span>
+      </template>
     </template>
+    <Banner
+      v-else
+      color="error"
+    >
+      <span v-clean-html="t('backupRestoreOperator.noResourceSet')" />
+    </Banner>
   </CruResource>
 </template>

--- a/shell/edit/resources.cattle.io.restore.vue
+++ b/shell/edit/resources.cattle.io.restore.vue
@@ -218,111 +218,109 @@ export default {
     :mode="mode"
     @finish="save"
   >
-    <template>
-      <div>
-        <div class="row mb-10">
-          <div class="col span-12">
-            <RadioGroup
-              v-model:value="storageSource"
-              name="storageSource"
-              :label="t('backupRestoreOperator.s3.titles.backupLocation')"
-              :options="radioOptions.options"
-              :labels="radioOptions.labels"
-              :mode="mode"
-            />
-          </div>
-        </div>
-        <template v-if="storageSource === 'configureS3'">
-          <S3
-            v-model:value="s3"
+    <div>
+      <div class="row mb-10">
+        <div class="col span-12">
+          <RadioGroup
+            v-model:value="storageSource"
+            name="storageSource"
+            :label="t('backupRestoreOperator.s3.titles.backupLocation')"
+            :options="radioOptions.options"
+            :labels="radioOptions.labels"
             :mode="mode"
           />
-        </template>
-        <div
-          v-else-if="storageSource==='useBackup'"
-          class="row mb-10"
-        >
-          <div class="col span-6">
-            <LabeledSelect
-              :disabled="!availableBackups.length"
-              :value="targetBackup"
-              :options="availableBackups"
-              :mode="mode"
-              option-label="metadata.name"
-              :label="t('backupRestoreOperator.targetBackup')"
-              @update:value="updateTargetBackup"
-            />
-          </div>
         </div>
       </div>
-      <div class="spacer" />
+      <template v-if="storageSource === 'configureS3'">
+        <S3
+          v-model:value="s3"
+          :mode="mode"
+        />
+      </template>
+      <div
+        v-else-if="storageSource==='useBackup'"
+        class="row mb-10"
+      >
+        <div class="col span-6">
+          <LabeledSelect
+            :disabled="!availableBackups.length"
+            :value="targetBackup"
+            :options="availableBackups"
+            :mode="mode"
+            option-label="metadata.name"
+            :label="t('backupRestoreOperator.targetBackup')"
+            @update:value="updateTargetBackup"
+          />
+        </div>
+      </div>
+    </div>
+    <div class="spacer" />
 
-      <div>
-        <div
-          :style="{'align-items':'center'}"
-          class="row mb-10"
-        >
-          <div class="col span-6">
-            <LabeledInput
-              v-model:value="value.spec.backupFilename"
-              :spellcheck="false"
-              required
-              :mode="mode"
-              :label="t('backupRestoreOperator.backupFilename')"
-            />
-          </div>
-          <div class="col span-6">
-            <LabeledSelect
-              v-if="isEncrypted"
-              v-model:value="value.spec.encryptionConfigSecretName"
-              :status="mode === 'view' ? null : 'warning'"
-              :tooltip="mode === 'view' ? null : t('backupRestoreOperator.encryptionConfigName.restoretip')"
-              :hover-tooltip="true"
-              :mode="mode"
-              :options="encryptionSecretNames"
-              :label="t('backupRestoreOperator.encryptionConfigName.label')"
-            />
-          </div>
+    <div>
+      <div
+        :style="{'align-items':'center'}"
+        class="row mb-10"
+      >
+        <div class="col span-6">
+          <LabeledInput
+            v-model:value="value.spec.backupFilename"
+            :spellcheck="false"
+            required
+            :mode="mode"
+            :label="t('backupRestoreOperator.backupFilename')"
+          />
         </div>
-        <div
-          :style="{'align-items':'center'}"
-          class="row"
-        >
-          <div class="col span-6">
-            <Checkbox
-              v-model:value="value.spec.prune"
-              class="mb-5"
-              :label="t('backupRestoreOperator.prune.label')"
-              :mode="mode"
-            >
-              <template #label>
-                <span
-                  v-clean-tooltip="t('backupRestoreOperator.prune.tip')"
-                  class="text-label"
-                >
-                  {{ t('backupRestoreOperator.prune.label') }} <i class="icon icon-info" />
-                </span>
-              </template>
-            </Checkbox>
-            <UnitInput
-              v-if="value.spec.prune"
-              v-model:value="value.spec.deleteTimeoutSeconds"
-              :suffix="t('suffix.seconds', {count: value.spec.deleteTimeoutSeconds})"
-              :mode="mode"
-              :label="t('backupRestoreOperator.deleteTimeout.label')"
-            >
-              <template #label>
-                <label
-                  v-clean-tooltip="t('backupRestoreOperator.deleteTimeout.tip')"
-                  class="v-popper--has-tooltip"
-                >
-                  {{ t('backupRestoreOperator.deleteTimeout.label') }} <i class="icon icon-info" />
-                </label>
-              </template>
-            </UnitInput>
-          </div>
+        <div class="col span-6">
+          <LabeledSelect
+            v-if="isEncrypted"
+            v-model:value="value.spec.encryptionConfigSecretName"
+            :status="mode === 'view' ? null : 'warning'"
+            :tooltip="mode === 'view' ? null : t('backupRestoreOperator.encryptionConfigName.restoretip')"
+            :hover-tooltip="true"
+            :mode="mode"
+            :options="encryptionSecretNames"
+            :label="t('backupRestoreOperator.encryptionConfigName.label')"
+          />
         </div>
       </div>
-    </template>
+      <div
+        :style="{'align-items':'center'}"
+        class="row"
+      >
+        <div class="col span-6">
+          <Checkbox
+            v-model:value="value.spec.prune"
+            class="mb-5"
+            :label="t('backupRestoreOperator.prune.label')"
+            :mode="mode"
+          >
+            <template #label>
+              <span
+                v-clean-tooltip="t('backupRestoreOperator.prune.tip')"
+                class="text-label"
+              >
+                {{ t('backupRestoreOperator.prune.label') }} <i class="icon icon-info" />
+              </span>
+            </template>
+          </Checkbox>
+          <UnitInput
+            v-if="value.spec.prune"
+            v-model:value="value.spec.deleteTimeoutSeconds"
+            :suffix="t('suffix.seconds', {count: value.spec.deleteTimeoutSeconds})"
+            :mode="mode"
+            :label="t('backupRestoreOperator.deleteTimeout.label')"
+          >
+            <template #label>
+              <label
+                v-clean-tooltip="t('backupRestoreOperator.deleteTimeout.tip')"
+                class="v-popper--has-tooltip"
+              >
+                {{ t('backupRestoreOperator.deleteTimeout.label') }} <i class="icon icon-info" />
+              </label>
+            </template>
+          </UnitInput>
+        </div>
+      </div>
+    </div>
   </CruResource>
 </template>

--- a/shell/pages/c/_cluster/uiplugins/AddExtensionRepos.vue
+++ b/shell/pages/c/_cluster/uiplugins/AddExtensionRepos.vue
@@ -117,48 +117,46 @@ export default {
     @okay="doAddRepos"
     @closed="isDialogActive = false"
   >
-    <template>
-      <p class="mb-20">
-        {{ t('plugins.addRepos.prompt', {}, true) }}
-      </p>
-      <!-- Official repo -->
+    <p class="mb-20">
+      {{ t('plugins.addRepos.prompt', {}, true) }}
+    </p>
+    <!-- Official repo -->
+    <div
+      v-if="prime"
+      class="mb-15"
+    >
+      <Checkbox
+        v-model:value="addRepos.official"
+        :disabled="hasRancherUIPluginsRepo"
+        :primary="true"
+        label-key="plugins.setup.install.addRancherRepo"
+        data-testid="add-extensions-repos-modal-add-official-repo"
+      />
       <div
-        v-if="prime"
-        class="mb-15"
+        v-if="hasRancherUIPluginsRepo"
+        class="checkbox-info"
       >
-        <Checkbox
-          v-model:value="addRepos.official"
-          :disabled="hasRancherUIPluginsRepo"
-          :primary="true"
-          label-key="plugins.setup.install.addRancherRepo"
-          data-testid="add-extensions-repos-modal-add-official-repo"
-        />
-        <div
-          v-if="hasRancherUIPluginsRepo"
-          class="checkbox-info"
-        >
-          ({{ t('plugins.setup.installed') }})
-        </div>
+        ({{ t('plugins.setup.installed') }})
       </div>
-      <!-- Partners repo -->
+    </div>
+    <!-- Partners repo -->
+    <div
+      class="mb-15"
+    >
+      <Checkbox
+        v-model:value="addRepos.partners"
+        :disabled="hasRancherUIPartnersPluginsRepo"
+        :primary="true"
+        label-key="plugins.setup.install.addPartnersRancherRepo"
+        data-testid="add-extensions-repos-modal-add-partners-repo"
+      />
       <div
-        class="mb-15"
+        v-if="hasRancherUIPartnersPluginsRepo"
+        class="checkbox-info"
       >
-        <Checkbox
-          v-model:value="addRepos.partners"
-          :disabled="hasRancherUIPartnersPluginsRepo"
-          :primary="true"
-          label-key="plugins.setup.install.addPartnersRancherRepo"
-          data-testid="add-extensions-repos-modal-add-partners-repo"
-        />
-        <div
-          v-if="hasRancherUIPartnersPluginsRepo"
-          class="checkbox-info"
-        >
-          ({{ t('plugins.setup.installed') }})
-        </div>
+        ({{ t('plugins.setup.installed') }})
       </div>
-    </template>
+    </div>
   </Dialog>
 </template>
 <style lang="scss" scoped>

--- a/shell/promptRemove/management.cattle.io.roletemplate.vue
+++ b/shell/promptRemove/management.cattle.io.roletemplate.vue
@@ -21,11 +21,9 @@ export default {
 
 <template>
   <div>
-    <template>
-      {{ t('promptRemove.attemptingToRemove', { type }) }} <span
-        v-clean-html="resourceNames(names, plusMore, t)"
-      />
-    </template>
+    {{ t('promptRemove.attemptingToRemove', { type }) }} <span
+      v-clean-html="resourceNames(names, plusMore, t)"
+    />
     <div
       v-if="info"
       class="text info mb-10 mt-20"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves a breaking change in Vue3 that treats `<template>` tags with no special directives as plain elements[^1] by removing the extra `<template>` tags from each component.

> `<template>` tags with no special directives (v-if/else-if/else, v-for, or v-slot) are now treated as plain elements and will result in a native `<template>` element instead of rendering its inner content.

This PR addresses more than just the CIS Benchmark, but I decided to address all of these instances after identifying the root cause to be the same for each occurrence 

Fixes #11910
Fixes #11913
Fixes #11912

[^1]: https://v3-migration.vuejs.org/breaking-changes/#other-minor-changes

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- remove extra `<template>` tags from components

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

It might be a good idea to replace these instances of `<template>` with `<div>` tags instead.. We might have to evaluate each instance individually.

I hacked together the following for detecting files that contain more than one instance of `<template>`

```
➤ grep -rc --exclude-dir=node_modules/ '<template>' . | grep -v ":0" | grep -v ":1"
./shell/components/TabTitle.vue:2
./shell/components/form/Labels.vue:2
./shell/components/formatter/InternalExternalIP.vue:2
./shell/detail/helm.cattle.io.projecthelmchart.vue:2
./shell/edit/auth/ldap/config.vue:2
./shell/edit/provisioning.cattle.io.cluster/tabs/registries/index.vue:2
./shell/edit/cis.cattle.io.clusterscan.vue:2
./shell/edit/cis.cattle.io.clusterscanprofile.vue:2
./shell/edit/resources.cattle.io.backup.vue:2
./shell/edit/resources.cattle.io.restore.vue:2
./shell/pages/c/_cluster/uiplugins/AddExtensionRepos.vue:2
./shell/promptRemove/management.cattle.io.roletemplate.vue:2
```

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

It would be best to confirm that each component changed does not regress in any way.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Each component that has been change could possibly regress as a result of this change.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
