### PR TITLE
Fix humongous height of inputs in array list

### DIFF
--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -375,7 +375,7 @@ export default {
     .value {
       flex: 1;
       INPUT {
-        height: $input-height;
+        height: $unlabeled-input-height;
       }
     }
   }

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -931,6 +931,7 @@ export default {
     },
 
     async loadChartStep(customStep) {
+      // Broken in 2.10, see https://github.com/rancher/dashboard/issues/11898
       const loaded = await customStep.component();
       const withFallBack = this.$store.getters['i18n/withFallback'];
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11927

Reduce the height of humongous `input` elements in the ArrayList component

### Occurred changes and/or fixed issues
- use the correct `$unlabeled-input-height` variable for the height of a basic input field
- previously this was `$input-height`, designed for input with a label

Additionally
- Sneaked in a comment linking to an issue in another bit of code (which will help anyone who tries to utilise it)


#### Before
![image](https://github.com/user-attachments/assets/292de4c7-9093-4b69-8350-89c84cf5cfaf)

Fleet Create Repo
![image](https://github.com/user-attachments/assets/8b5fb5b8-2b44-47d7-8487-faba4967462d)

OPA Gateway Constraint
![image](https://github.com/user-attachments/assets/4ed397df-45de-4dac-ae60-7d9316a33cd5)

Storage Class Customize Mount Options
![image](https://github.com/user-attachments/assets/9652d58e-f03b-4c5f-a240-297f608fbeb9)


#### After
![image](https://github.com/user-attachments/assets/87284c19-d9fc-434f-96d2-afb3c1c9d13c)

Fleet Create Repo
![image](https://github.com/user-attachments/assets/fbb2d69e-c83d-47f6-aca8-1317597bb3f3)

OPA Gateway Constraint
![image](https://github.com/user-attachments/assets/ed2ea45c-b3de-4689-8a0c-71e194c1633d)

Auth Provider Allowed Principals (unchanged)
![image](https://github.com/user-attachments/assets/081bf745-a920-4fdb-9cfa-5254d72b5583)

Storage Class Customize Mount Options
![image](https://github.com/user-attachments/assets/462a49f0-d37c-4a0a-9fbe-2cdbb1c2f188)


### Areas or cases that should be tested
- Cluster Management --> Clusters --> Create --> RKE2 --> Cluster Configuration Advanced --> view all inputs in tab


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
