### PR TITLE
[Automation] - Fixing typo and do not deploy Rancher when existing is used and init cluster is yes

### DIFF
--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -122,7 +122,9 @@ create_initial_clusters() {
   corral config vars set server_count "${SERVER_COUNT:-3}"
   corral config vars set agent_count "${AGENT_COUNT:-0}"
   corral config vars delete rancher_host
-  RANCHER_HOST="jenkins-${prefix_random}.${AWS_ROUTE53_ZONE}"
+  if [[ "${JOB_TYPE}" == "recurring" ]]; then
+    RANCHER_HOST="jenkins-${prefix_random}.${AWS_ROUTE53_ZONE}"
+  fi
 
   K3S_KUBERNETES_VERSION="${K3S_KUBERNETES_VERSION//+/-}"
   make init
@@ -147,8 +149,10 @@ create_initial_clusters() {
   corral config vars set imported_kubeconfig $(corral vars importcluster kubeconfig)
   corral config vars set aws_hostname_prefix "jenkins-${prefix_random}"
   corral config vars set server_count "${SERVER_COUNT:-3}"
-  corral create --skip-cleanup --recreate --debug rancher \
-    "dist/aws-k3s-rancher-${K3S_KUBERNETES_VERSION}-${RANCHER_VERSION//v}-${CERT_MANAGER_VERSION}"
+  if [[ "${JOB_TYPE}" == "recurring" ]]; then
+    corral create --skip-cleanup --recreate --debug rancher \
+      "dist/aws-k3s-rancher-${K3S_KUBERNETES_VERSION}-${RANCHER_VERSION//v}-${CERT_MANAGER_VERSION}"
+  fi
 }
 
 
@@ -169,7 +173,7 @@ fi
 echo "Rancher type: ${RANCHER_TYPE}"
 
 override_node=$(semver lt "${RANCHER_VERSION}" "2.9.99")
-if [[ ${override_node} -eq 0 && RANCHER_IMAGE_TAG != "head" ]]; then NODEJS_VERSION="16.20.2"; fi
+if [[ ${override_node} -eq 0 && "${RANCHER_IMAGE_TAG}" != "head" ]]; then NODEJS_VERSION="16.20.2"; fi
 
 corral config vars set rancher_type "${RANCHER_TYPE}"
 corral config vars set nodejs_version "${NODEJS_VERSION}"


### PR DESCRIPTION
### Summary

A couple of adjustments, one typo fix and improve logic on Job Type existing which we don't need a Rancher built.

### Occurred changes and/or fixed issues
update the Jenkins initi script

### Areas or cases that should be tested
CI Jenkins

### Areas which could experience regressions
CI Jenkins init

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [ ] ~The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed~
- [ ] ~The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes~
