### PR TITLE
Fix navigation guard for standalone extensions

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1,5 +1,6 @@
 <script>
 import { mapGetters } from 'vuex';
+import { defineAsyncComponent } from 'vue';
 import day from 'dayjs';
 import isEmpty from 'lodash/isEmpty';
 import { dasherize, ucFirst } from '@shell/utils/string';
@@ -682,7 +683,7 @@ export default {
                 const pluginFormatter = this.$plugin?.getDynamic('formatters', c.formatter);
 
                 if (pluginFormatter) {
-                  component = pluginFormatter;
+                  component = defineAsyncComponent(pluginFormatter);
                   needRef = true;
                 }
               }

--- a/shell/core/plugin-routes.ts
+++ b/shell/core/plugin-routes.ts
@@ -90,8 +90,7 @@ export class PluginRoutes {
       }
     });
 
-    // Remove all existing routes. Once we upgrade our router version we'll have access to clearRoutes() https://router.vuejs.org/api/interfaces/Router.html#clearRoutes
-    this.router.getRoutes().forEach((route: any) => this.router.removeRoute(route));
+    this.router.clearRoutes();
 
     const allRoutesToAdd = [...orderedPluginRoutes, ...allRoutes];
 

--- a/shell/core/plugin-routes.ts
+++ b/shell/core/plugin-routes.ts
@@ -66,6 +66,10 @@ export class PluginRoutes {
     // execute many times (nuxt middleware boils down to route.beforeEach). This issue was seen refreshing in a harvester cluster with a
     // dynamically loaded cluster
 
+    if (newRoutes.length === 0) {
+      return;
+    }
+
     const orderedPluginRoutes: RouteRecordRaw[] = [];
 
     // separate plugin routes that have parent and not, you want to push the new routes in REVERSE order to the front of the existing list so that the order of routes specified by the extension is preserved
@@ -85,10 +89,6 @@ export class PluginRoutes {
         orderedPluginRoutes.unshift(routeInfo.route);
       }
     });
-
-    if ( orderedPluginRoutes.length === 0) {
-      return;
-    }
 
     // Remove all existing routes. Once we upgrade our router version we'll have access to clearRoutes() https://router.vuejs.org/api/interfaces/Router.html#clearRoutes
     this.router.getRoutes().forEach((route: any) => this.router.removeRoute(route));

--- a/shell/mixins/fetch.client.js
+++ b/shell/mixins/fetch.client.js
@@ -6,7 +6,8 @@ export const addLifecycleHook = (vm, hook, fn) => {
   if (!vm.$options[hook]) {
     vm.$options[hook] = [];
   }
-  if (!vm.$options[hook].includes(fn)) {
+
+  if (Array.isArray(vm.$options[hook]) && !vm.$options[hook].includes(fn)) {
     vm.$options[hook].push(fn);
   }
 };

--- a/shell/package.json
+++ b/shell/package.json
@@ -124,7 +124,7 @@
     "url-parse": "1.5.10",
     "vue": "~3.2.13",
     "vue-resize": "0.4.5",
-    "vue-router": "~4.0.3",
+    "vue-router": "4.4.3",
     "vue-select": "4.0.0-beta.6",
     "vue-server-renderer": "2.7.16",
     "vue-template-compiler": "2.7.16",

--- a/shell/pages/index.vue
+++ b/shell/pages/index.vue
@@ -3,7 +3,7 @@ import { SEEN_WHATS_NEW } from '@shell/store/prefs';
 import { getVersionInfo } from '@shell/utils/version';
 
 const validRoute = (route, router) => {
-  return !!route && !!router.resolve(route)?.resolved?.matched?.length;
+  return !!route && !!router.resolve(route)?.matched?.length;
 };
 
 export default {

--- a/shell/pages/index.vue
+++ b/shell/pages/index.vue
@@ -4,7 +4,7 @@ import { getVersionInfo } from '@shell/utils/version';
 
 const resolveRoute = (route, router) => {
   try {
-    return route ? router.resolve(route) : null; 
+    return route ? router.resolve(route) : null;
   } catch (e) {
     return null;
   }

--- a/shell/pages/index.vue
+++ b/shell/pages/index.vue
@@ -2,8 +2,16 @@
 import { SEEN_WHATS_NEW } from '@shell/store/prefs';
 import { getVersionInfo } from '@shell/utils/version';
 
+const resolveRoute = (route, router) => {
+  try {
+    return route ? router.resolve(route) : null; 
+  } catch (e) {
+    return null;
+  }
+};
+
 const validRoute = (route, router) => {
-  return !!route && !!router.resolve(route)?.matched?.length;
+  return !!route && !!resolveRoute(route, router)?.matched?.length;
 };
 
 export default {
@@ -19,7 +27,7 @@ export default {
     }
 
     const afterLoginRouteObject = this.$store.getters['prefs/afterLoginRoute'];
-    const targetRoute = afterLoginRouteObject ? this.$router.resolve(afterLoginRouteObject) : null;
+    const targetRoute = resolveRoute(afterLoginRouteObject, this.$router);
 
     // If target route is /, then we will loop with endless redirect - so detect that here and
     // redirect to /home, which is what we would do below, if there was no `afterLoginRouteObject`


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/11795
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Bump `vue-router@4.4.3`
- Update router API calls and fix `resolveRoute` validation to avoid error in case of `afterLoginRoute` is invalid or doesn't exist.
- Fix `fetch.client.js`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Harvester standalone mode: the new shell should make Harvester extension loads without errors when used as separated UI
- Harvester built-in extension: the dashboard should work correctly when navigating to Virtualization Manager -> Harvester clusters
- Harvester extension installation: todo

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
