### PR TITLE
[Automation] - Add the Automation Status as "Automated" to UI Cases

### DIFF
--- a/cypress/jenkins/junit_to_qase.py
+++ b/cypress/jenkins/junit_to_qase.py
@@ -244,10 +244,12 @@ def create_testcases_under_suite(case_entities, suite_title_from_junit, suite_id
             # if the result from junit has a description, add it
             # This part is where the error message goes if we want it in the Test Case description
             testcase_value = results[suite_title_from_junit][ct]
-            req_body = {'title': ct,
-                        'is_flaky': 0,
-                        'automation': 1,
-                        'custom_field': {
+            req_body = {"title": ct,
+                        "is_flaky": 0,
+                        "automation": 0,
+                        "isManual": 1,
+                        "isToBeAutomated": False,
+                        "custom_field": {
                             "14": TEST_SOURCE,
                             "15": "{0}/{1}".format(suite_title_from_junit, ct)},
                         "suite_id": suite_id}
@@ -268,6 +270,9 @@ def create_testcases_under_suite(case_entities, suite_title_from_junit, suite_id
             case_id_from_title = case_title_and_id[ct]
             cases_ids.append(case_id_from_title)
             req_body = {"suite_id": suite_id,
+                        "automation": 0,
+                        "isManual": 1,
+                        "isToBeAutomated": False,
                         "custom_field": {
                                 "14": TEST_SOURCE,
                                 "15": "{0}/{1}".format(suite_title_from_junit, ct)


### PR DESCRIPTION
### Summary
Fixes https://github.com/rancher/qa-tasks/issues/1542

### Occurred changes and/or fixed issues
Adding the Automation status toUI  Cases in Qase


### Technical notes summary
The API documentation is very ambiguous as to what values and which post data keys should be included or updated to update the Automation Status.

Here's a comparison:


![Screenshot from 2024-09-16 11-00-24](https://github.com/user-attachments/assets/18e85a4a-ad9a-4a4c-8813-0839dcd5d867)

- The left request data is pushed on new Cases that has the Automation Status: **Automated.**
- The right pane is for new Cases with Automation Status: **Manual**.

This change updates the New case POST as the left pane.
Also this change updates the Existing case PATCH as the left pane too.


### Areas which could experience regressions
Jenkins Qase reporting

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [ x The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] ~~The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes~~
