### PR TITLE
Fix logging flow rules

### DIFF
--- a/shell/edit/logging-flow/index.vue
+++ b/shell/edit/logging-flow/index.vue
@@ -14,7 +14,7 @@ import { allHash } from '@shell/utils/promise';
 import { isArray } from '@shell/utils/array';
 import { matchRuleIsPopulated } from '@shell/models/logging.banzaicloud.io.flow';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
-import { clone, set } from '@shell/utils/object';
+import { clone } from '@shell/utils/object';
 import isEmpty from 'lodash/isEmpty';
 import ArrayListGrouped from '@shell/components/form/ArrayListGrouped';
 import { exceptionToErrorsArray } from '@shell/utils/error';
@@ -75,7 +75,7 @@ export default {
     const schemas = this.$store.getters['cluster/all'](SCHEMA);
     let filtersYaml;
 
-    set(this.value, 'spec', this.value.spec || {});
+    this.value.spec = this.value.spec || {};
 
     if ( this.value.spec.filters?.length ) {
       filtersYaml = jsyaml.dump(this.value.spec.filters);
@@ -219,7 +219,7 @@ export default {
           }
         });
 
-        set(this.value.spec, 'match', matches);
+        this.value.spec.match = matches;
       }
     },
     filtersYaml: {
@@ -229,9 +229,9 @@ export default {
           const filterJson = jsyaml.load(this.filtersYaml);
 
           if ( isArray(filterJson) ) {
-            set(this.value.spec, 'filters', filterJson);
+            this.value.spec.filters = filterJson;
           } else {
-            set(this.value.spec, 'filters', undefined);
+            this.value.spec.filters = undefined;
           }
         } catch (e) {
           this.errors = exceptionToErrorsArray(e);
@@ -241,13 +241,13 @@ export default {
     globalOutputRefs: {
       deep: true,
       handler() {
-        set(this.value.spec, 'globalOutputRefs', this.globalOutputRefs);
+        this.value.spec.globalOutputRefs = this.globalOutputRefs;
       }
     },
     localOutputRefs: {
       deep: true,
       handler() {
-        set(this.value.spec, 'localOutputRefs', this.localOutputRefs);
+        this.value.spec.localOutputRefs = this.localOutputRefs;
       }
     }
   },

--- a/shell/edit/logging-flow/index.vue
+++ b/shell/edit/logging-flow/index.vue
@@ -262,7 +262,7 @@ export default {
 
   methods: {
     addMatch(include) {
-      this.matches.push(emptyMatch(include));
+      this.matches = [...this.matches, emptyMatch(include)];
     },
 
     removeMatch(idx) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves an issue with adding a include / exclude pod card to the list when creating a new flow for the logging chart.

Fixes #11933 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- replace `set()` usage with assignment
- create a new array to ensure that reactivity is triggered for `matches`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

We encountered a similar issue related to using push that was resolved in #11788

- https://github.com/rancher/dashboard/pull/11788/files#diff-ac9d14c56bc5c1631a8b0bb855b7d34cb69d9d1be89f1c3b72c31f03381939f7R160

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Logging (see issue description)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Logging (see issue description)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
