### PR TITLE
Vue3: Fixed validation errors shown prematurely for Workload and Service forms

### DIFF
--- a/cypress/e2e/po/edit/services.po.ts
+++ b/cypress/e2e/po/edit/services.po.ts
@@ -1,0 +1,21 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+
+export default class WorkloadsCreateEditPo extends PagePo {
+  private static createPath(clusterId: string, id?: string ) {
+    const root = `/c/${ clusterId }/explorer/storage.k8s.io.storageclass/create`;
+
+    return id ? `${ root }/${ id }` : `${ root }/create`;
+  }
+
+  static goTo(path: string): Cypress.Chainable<Cypress.AUTWindow> {
+    throw new Error('invalid');
+  }
+
+  constructor(clusterId = '_', id?: string) {
+    super(WorkloadsCreateEditPo.createPath(clusterId, id));
+  }
+
+  errorBanner() {
+    return cy.get('#cru-errors');
+  }
+}

--- a/cypress/e2e/po/edit/workloads.po.ts
+++ b/cypress/e2e/po/edit/workloads.po.ts
@@ -1,0 +1,21 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+
+export default class WorkloadsCreateEditPo extends PagePo {
+  private static createPath(clusterId: string, id?: string ) {
+    const root = `/c/${ clusterId }/explorer/storage.k8s.io.storageclass/create`;
+
+    return id ? `${ root }/${ id }` : `${ root }/create`;
+  }
+
+  static goTo(path: string): Cypress.Chainable<Cypress.AUTWindow> {
+    throw new Error('invalid');
+  }
+
+  constructor(clusterId = '_', id?: string) {
+    super(WorkloadsCreateEditPo.createPath(clusterId, id));
+  }
+
+  errorBanner() {
+    return cy.get('#cru-errors');
+  }
+}

--- a/cypress/e2e/po/pages/explorer/services.po.ts
+++ b/cypress/e2e/po/pages/explorer/services.po.ts
@@ -2,6 +2,7 @@ import PagePo from '@/cypress/e2e/po/pages/page.po';
 import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+import ServicesCreateEditPo from '@/cypress/e2e/po/edit/services.po';
 
 export class ServicesPagePo extends PagePo {
   private static createPath(clusterId: string) {
@@ -36,5 +37,9 @@ export class ServicesPagePo extends PagePo {
 
   clickCreate() {
     return this.list().masthead().create();
+  }
+
+  createServicesForm(id? : string): ServicesCreateEditPo {
+    return new ServicesCreateEditPo(id);
   }
 }

--- a/cypress/e2e/po/pages/explorer/workloads.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads.po.ts
@@ -2,6 +2,8 @@ import PagePo from '@/cypress/e2e/po/pages/page.po';
 import ResourceTablePo from '@/cypress/e2e/po/components/resource-table.po';
 import Kubectl from '@/cypress/e2e/po/components/kubectl.po';
 import { HeaderPo } from '~/cypress/e2e/po/components/header.po';
+import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
+import WorkloadsCreateEditPo from '@/cypress/e2e/po/edit/workloads.po';
 export default class WorkloadPagePo extends PagePo {
   static createPath(clusterId: string) {
     return `/c/${ clusterId }/explorer/workload`;
@@ -39,5 +41,15 @@ export default class WorkloadPagePo extends PagePo {
 
   actionsHeader() {
     return new HeaderPo();
+  }
+
+  clickCreate() {
+    const baseResourceList = new BaseResourceList(this.self());
+
+    return baseResourceList.masthead().create();
+  }
+
+  createWorkloadsForm(id? : string): WorkloadsCreateEditPo {
+    return new WorkloadsCreateEditPo(id);
   }
 }

--- a/cypress/e2e/tests/pages/explorer/service-discovery/services.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/service-discovery/services.spec.ts
@@ -79,6 +79,12 @@ describe('Services', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }
       servicesPagePo.list().resourceTable().sortableTable().checkRowCount(false, 3);
     });
 
+    it('validation errors should not be shown when form is just opened', () => {
+      servicesPagePo.goTo();
+      servicesPagePo.clickCreate();
+      servicesPagePo.createServicesForm().errorBanner().should('not.exist');
+    });
+
     after('clean up', () => {
       cy.updateNamespaceFilter('local', 'none', '{"local":["all://user"]}');
     });

--- a/cypress/e2e/tests/pages/explorer2/workloads/workloads.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/workloads.spec.ts
@@ -31,4 +31,11 @@ describe('Workloads', { tags: ['@explorer2', '@adminUser'] }, () => {
 
     workload.mastheadTitle().should('contain', podName);
   });
+  it('Validation errors should not be shown when form is just opened', () => {
+    const workload = new WorkloadPagePo('local');
+
+    workload.goTo();
+    workload.clickCreate();
+    workload.createWorkloadsForm().errorBanner().should('not.exist');
+  });
 });

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6287,6 +6287,7 @@ workload:
     workload: Workload
     pods: Pods by State
     runs: Runs
+  error: Pod { name } Security Policy Violation { policy }
   gaugeStates:
     succeeded: Successful
     running: Running

--- a/shell/edit/service.vue
+++ b/shell/edit/service.vue
@@ -107,7 +107,8 @@ export default {
         SESSION_AFFINITY_ACTION_VALUES
       ),
       fvFormRuleSets:            [],
-      fvReportedValidationPaths: ['spec']
+      fvReportedValidationPaths: ['spec'],
+      closedErrorMessages:       []
     };
   },
 
@@ -207,6 +208,13 @@ export default {
 
       return out;
     },
+    errorMessages() {
+      if (!this.serviceType) {
+        return [];
+      }
+
+      return this.fvUnreportedValidationErrors.filter((e) => !this.closedErrorMessages.includes(e));
+    }
   },
 
   watch: {
@@ -340,7 +348,7 @@ export default {
     :selected-subtype="serviceType"
     :subtypes="defaultServiceTypes"
     :validation-passed="fvFormIsValid"
-    :errors="fvUnreportedValidationErrors"
+    :errors="errorMessages"
     :apply-hooks="applyHooks"
     :description="t('servicesPage.serviceListDescription')"
     @error="(e) => (errors = e)"

--- a/shell/edit/workload/__tests__/index.test.ts
+++ b/shell/edit/workload/__tests__/index.test.ts
@@ -7,15 +7,17 @@ describe('component: Workload', () => {
   it.each([
     [
       `pods \"test\" is forbidden: violates PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"container-0\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container \"container-0\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (container \"container-0\" must not set securityContext.runAsNonRoot=false), seccompProfile (pod or container \"container-0\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")`,
-      `Pod "test" Security Policy Violation "restricted:latest"`
+      `workload.error, \"test\",\"restricted:latest\"`
     ]
   ])('should map error message into object', (oldMessage, newMessage) => {
     const mockedValidationMixin = {
       methods: {
         fvFormIsValid:                jest.fn(),
         type:                         jest.fn(),
-        fvUnreportedValidationErrors: jest.fn(),
         fvGetAndReportPathRules:      jest.fn(),
+      },
+      computed:{
+        fvUnreportedValidationErrors: jest.fn().mockReturnValue([]),
       }
     };
     const mockedCREMixin = {};
@@ -70,7 +72,9 @@ describe('component: Workload', () => {
             getters: {
               'cluster/schemaFor': jest.fn(),
               'type-map/labelFor': jest.fn(),
-              'i18n/t':            jest.fn(),
+              'i18n/t': (text: string, v: {[key:string]: string}) => {
+                return `${ text }, ${ Object.values(v || {}) }`;
+              },
             },
           },
         },

--- a/shell/edit/workload/__tests__/index.test.ts
+++ b/shell/edit/workload/__tests__/index.test.ts
@@ -12,13 +12,11 @@ describe('component: Workload', () => {
   ])('should map error message into object', (oldMessage, newMessage) => {
     const mockedValidationMixin = {
       methods: {
-        fvFormIsValid:                jest.fn(),
-        type:                         jest.fn(),
-        fvGetAndReportPathRules:      jest.fn(),
+        fvFormIsValid:           jest.fn(),
+        type:                    jest.fn(),
+        fvGetAndReportPathRules: jest.fn(),
       },
-      computed:{
-        fvUnreportedValidationErrors: jest.fn().mockReturnValue([]),
-      }
+      computed: { fvUnreportedValidationErrors: jest.fn().mockReturnValue([]) }
     };
     const mockedCREMixin = {};
     const mockedWorkloadMixin = {
@@ -72,7 +70,7 @@ describe('component: Workload', () => {
             getters: {
               'cluster/schemaFor': jest.fn(),
               'type-map/labelFor': jest.fn(),
-              'i18n/t': (text: string, v: {[key:string]: string}) => {
+              'i18n/t':            (text: string, v: {[key:string]: string}) => {
                 return `${ text }, ${ Object.values(v || {}) }`;
               },
             },

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -2,6 +2,7 @@
 import CreateEditView from '@shell/mixins/create-edit-view';
 import FormValidation from '@shell/mixins/form-validation';
 import WorkLoadMixin from '@shell/edit/workload/mixins/workload';
+import { mapGetters } from 'vuex';
 
 export default {
   name:   'Workload',
@@ -21,11 +22,11 @@ export default {
     return { selectedName: null, closedErrorMessages: [] };
   },
   computed: {
+    ...mapGetters({ t: 'i18n/t' }),
     errorMessages() {
       if (!this.type) {
         return [];
       }
-
       return this.fvUnreportedValidationErrors.filter((e) => !this.closedErrorMessages.includes(e));
     }
   },
@@ -59,7 +60,6 @@ export default {
 
         return {
           message: this.t('workload.error', { name, policy }),
-          icon:    'icon-pod_security'
         };
       }
       default:

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -27,6 +27,7 @@ export default {
       if (!this.type) {
         return [];
       }
+
       return this.fvUnreportedValidationErrors.filter((e) => !this.closedErrorMessages.includes(e));
     }
   },
@@ -58,9 +59,7 @@ export default {
         const name = match[0];
         const policy = match[1];
 
-        return {
-          message: this.t('workload.error', { name, policy }),
-        };
+        return { message: this.t('workload.error', { name, policy }) };
       }
       default:
         break;

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -18,7 +18,16 @@ export default {
     },
   },
   data() {
-    return { selectedName: null };
+    return { selectedName: null, closedErrorMessages: [] };
+  },
+  computed: {
+    errorMessages() {
+      if (!this.type) {
+        return [];
+      }
+
+      return this.fvUnreportedValidationErrors.filter((e) => !this.closedErrorMessages.includes(e));
+    }
   },
   methods: {
     changed(tab) {
@@ -49,7 +58,7 @@ export default {
         const policy = match[1];
 
         return {
-          message: `Pod ${ name } Security Policy Violation ${ policy }`,
+          message: this.t('workload.error', { name, policy }),
           icon:    'icon-pod_security'
         };
       }
@@ -85,7 +94,7 @@ export default {
       :selected-subtype="type"
       :resource="value"
       :mode="mode"
-      :errors="fvUnreportedValidationErrors"
+      :errors="errorMessages"
       :done-route="doneRoute"
       :subtypes="workloadSubTypes"
       :apply-hooks="applyHooks"
@@ -93,9 +102,8 @@ export default {
       :errors-map="getErrorsMap(fvUnreportedValidationErrors)"
       @finish="save"
       @select-type="selectType"
-      @error="e=>errors = e"
+      @error="(_, closedError) => closedErrorMessages.push(closedError)"
     >
-      <!-- <pre>{{ JSON.stringify(allContainers, null, 2) }}</pre> -->
       <NameNsDescription
         :value="value"
         :mode="mode"
@@ -177,7 +185,6 @@ export default {
             >
               <template
                 #tab-header-right
-                class="tab-content-controls"
               >
                 <button
                   v-if="allContainers.length > 1 && !isView"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11889 
<!-- Define findings related to the feature or bug issue. -->
Fixed validation errors being shown before the form. Overall, this is more of a temporary solution and validation should be standardized and re-implemented in a more consistent way.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Additionally, addressed the error messages not closing.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Workloads create page should not show a validation error before type is selected
- Service create page should not show a validation error before type is selected

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
N/A

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1363" alt="Screenshot 2024-09-17 at 4 57 22 PM" src="https://github.com/user-attachments/assets/6933b9c4-15a7-45e0-93b3-a89e7de1e1d5">

<img width="1400" alt="Screenshot 2024-09-17 at 4 57 07 PM" src="https://github.com/user-attachments/assets/7e853ab7-82ee-4158-b532-4727c026de2e">


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
