### PR TITLE
Ensure we check for correct status code when testing cli download links

### DIFF
--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -111,6 +111,9 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
   });
 
   describe('CLI Downloads', () => {
+    // Shouldn't be needed with https://github.com/rancher/dashboard/issues/11393
+    const expectedLinkStatusCode = 404;
+
     // workaround to make the following CLI tests work https://github.com/cypress-io/cypress/issues/8089#issuecomment-1585159023
     beforeEach(() => {
       aboutPage.goTo();
@@ -125,7 +128,7 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
           el.attr('download', '');
         }).click();
         cy.wait('@download').then(({ request, response }) => {
-          expect(response?.statusCode).to.eq(200);
+          expect(response?.statusCode).to.eq(expectedLinkStatusCode);
           expect(request.url).includes(macOsVersion);
         });
       });
@@ -139,7 +142,7 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
           el.attr('download', '');
         }).click();
         cy.wait('@download').then(({ request, response }) => {
-          expect(response?.statusCode).to.eq(200);
+          expect(response?.statusCode).to.eq(expectedLinkStatusCode);
           expect(request.url).includes(linuxVersion);
         });
       });
@@ -153,7 +156,7 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
           el.attr('download', '');
         }).click();
         cy.wait('@download').then(({ request, response }) => {
-          expect(response?.statusCode).to.eq(200);
+          expect(response?.statusCode).to.eq(expectedLinkStatusCode);
           expect(request.url).includes(windowsVersion);
         });
       });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Forward port of https://github.com/rancher/dashboard/pull/11941 (see for details)

Needed as we still use a v2.9-head rancher for e2e tests in master (https://github.com/rancher/dashboard/blob/master/scripts/e2e-docker-start#L10)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
