### PR TITLE
FIX: Vue3 => Error info when creating NavLink is not shown to user

### DIFF
--- a/shell/edit/ui.cattle.io.navlink.vue
+++ b/shell/edit/ui.cattle.io.navlink.vue
@@ -20,9 +20,10 @@ const LINK_TARGET_BLANK = '_blank';
 const LINK_TARGET_SELF = '_self';
 
 export default {
-  emits:      ['update:value.spec.iconSrc ', 'input'],
-  mixins:     [CreateEditView, FormValidation],
-  components: {
+  emits:        ['update:value.spec.iconSrc ', 'input'],
+  mixins:       [CreateEditView, FormValidation],
+  inheritAttrs: false,
+  components:   {
     CruResource,
     LabeledInput,
     RadioGroup,
@@ -279,184 +280,182 @@ export default {
 </script>
 
 <template>
-  <div>
-    <CruResource
-      :can-yaml="!isCreate"
+  <CruResource
+    :can-yaml="!isCreate"
+    :mode="mode"
+    :resource="value"
+    :errors="fvUnreportedValidationErrors"
+    :cancel-event="true"
+    :validation-passed="fvFormIsValid"
+    data-testid="Navlink-CRU"
+    @error="e=>errors = e"
+    @finish="save"
+    @cancel="done()"
+  >
+    <NameNsDescription
+      :value="value"
+      :namespaced="false"
+      :namespace-disabled="true"
       :mode="mode"
-      :resource="value"
-      :errors="fvUnreportedValidationErrors"
-      :cancel-event="true"
-      :validation-passed="fvFormIsValid"
-      data-testid="Navlink-CRU"
-      @error="e=>errors = e"
-      @finish="save"
-      @cancel="done()"
-    >
-      <NameNsDescription
-        :value="value"
-        :namespaced="false"
-        :namespace-disabled="true"
-        :mode="mode"
-        name-key="metadata.name"
-        description-key="spec.label"
-        name-label="navLink.name.label"
-        name-placeholder="navLink.name.placeholder"
-        description-label="navLink.label.label"
-        description-placeholder="navLink.label.placeholder"
-        data-testid="Navlink-name-field"
-        :rules="{ name: fvGetAndReportPathRules('metadata.name'), namespace: [], description: [] }"
-        @update:value="$emit('input', $event)"
-      />
+      name-key="metadata.name"
+      description-key="spec.label"
+      name-label="navLink.name.label"
+      name-placeholder="navLink.name.placeholder"
+      description-label="navLink.label.label"
+      description-placeholder="navLink.label.placeholder"
+      data-testid="Navlink-name-field"
+      :rules="{ name: fvGetAndReportPathRules('metadata.name'), namespace: [], description: [] }"
+      @update:value="$emit('input', $event)"
+    />
 
-      <div class="spacer" />
-      <h2 v-t="'navLink.tabs.link.label'" />
-      <div class="row mb-20">
-        <div class="col span-6">
-          <RadioGroup
-            v-model:value="linkType"
-            name="type"
-            :mode="mode"
-            :options="urlTypeOptions"
-            data-testid="Navlink-link-radiogroup"
-          />
-        </div>
-      </div>
-
-      <template v-if="isURL">
-        <div class="row mb-20">
-          <LabeledInput
-            v-model:value="value.spec.toURL"
-            :mode="mode"
-            :label="t('navLink.tabs.link.toURL.label')"
-            :required="isURL"
-            :placeholder="t('navLink.tabs.link.toURL.placeholder')"
-            :rules="fvGetAndReportPathRules('spec.toURL')"
-            data-testid="Navlink-url-field"
-          />
-        </div>
-      </template>
-      <template v-if="isService">
-        <div class="row mb-20">
-          <div class="col span-2">
-            <LabeledSelect
-              v-model:value="value.spec.toService.scheme"
-              :mode="mode"
-              :label="t('navLink.tabs.link.toService.scheme.label')"
-              :required="isService"
-              :options="protocolsOptions"
-              :placeholder="t('navLink.tabs.link.toService.scheme.placeholder')"
-              :rules="fvGetAndReportPathRules('spec.toService.scheme')"
-              data-testid="Navlink-scheme-field"
-            />
-          </div>
-          <div class="col span-5">
-            <LabeledSelect
-              v-model:value="currentService"
-              :mode="mode"
-              :label="t('navLink.tabs.link.toService.service.label')"
-              :options="mappedServices"
-              :required="isService"
-              :placeholder="t('navLink.tabs.link.toService.service.placeholder')"
-              :rules="fvGetAndReportPathRules('spec.toService.namespace')"
-              data-testid="Navlink-currentService-field"
-              @update:value="setService"
-            />
-          </div>
-          <div class="col span-2">
-            <LabeledInput
-              v-model:value="value.spec.toService.port"
-              :mode="mode"
-              :label="t('navLink.tabs.link.toService.port.label')"
-              type="number"
-              :placeholder="t('navLink.tabs.link.toService.port.placeholder')"
-            />
-          </div>
-          <div class="col span-3">
-            <LabeledInput
-              v-model:value="value.spec.toService.path"
-              :mode="mode"
-              :label="t('navLink.tabs.link.toService.path.label')"
-              :placeholder="t('navLink.tabs.link.toService.path.placeholder')"
-            />
-          </div>
-        </div>
-      </template>
-      <div class="spacer" />
-      <h2 v-t="'navLink.tabs.target.label'" />
-      <div class="row mb-20">
-        <div class="col span-6">
-          <RadioGroup
-            v-model:value="currentTarget"
-            name="type"
-            :mode="mode"
-            :options="targetOptions"
-            @update:value="setTargetValue($event)"
-          />
-        </div>
-        <div class="col span-6">
-          <LabeledInput
-            v-if="isNamedWindow"
-            v-model:value="targetName"
-            :mode="mode"
-            :label="t('navLink.tabs.target.namedValue.label')"
-            @update:value="setTargetValue($event);"
-          />
-        </div>
-      </div>
-      <div class="spacer" />
-      <h2 v-t="'navLink.tabs.group.label'" />
-
-      <div class="row mb-20">
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="value.spec.group"
-            :mode="mode"
-            :tooltip="t('navLink.tabs.group.group.tooltip')"
-            :label="t('navLink.tabs.group.group.label')"
-          />
-        </div>
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="value.spec.sideLabel"
-            :mode="mode"
-            :label="t('navLink.tabs.group.sideLabel.label')"
-          />
-        </div>
-      </div>
-
-      <div class="row mb-20">
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="value.spec.description"
-            :mode="mode"
-            :label="t('navLink.tabs.group.description.label')"
-          />
-        </div>
-      </div>
-
-      <h4 v-t="'navLink.tabs.groupImage.label'" />
-      <div class="row">
-        <label class="text-label">
-          {{ t('navLink.tabs.groupImage.iconSrc.tip', {}, true) }}
-        </label>
-      </div>
-      <div class="row">
-        <FileImageSelector
-          v-model:value="value.spec.iconSrc"
-          :read-as-data-url="true"
+    <div class="spacer" />
+    <h2 v-t="'navLink.tabs.link.label'" />
+    <div class="row mb-20">
+      <div class="col span-6">
+        <RadioGroup
+          v-model:value="linkType"
+          name="type"
           :mode="mode"
-          :label="t('navLink.tabs.groupImage.iconSrc.label')"
-          accept="image/jpeg,image/png,image/svg+xml"
-          @error="setImageError"
-          @update:value="setIcon"
+          :options="urlTypeOptions"
+          data-testid="Navlink-link-radiogroup"
         />
       </div>
-      <Banner
-        v-if="imageError"
-        color="error"
-      >
-        {{ imageErrorMessage }}
-      </Banner>
-    </CruResource>
-  </div>
+    </div>
+
+    <template v-if="isURL">
+      <div class="row mb-20">
+        <LabeledInput
+          v-model:value="value.spec.toURL"
+          :mode="mode"
+          :label="t('navLink.tabs.link.toURL.label')"
+          :required="isURL"
+          :placeholder="t('navLink.tabs.link.toURL.placeholder')"
+          :rules="fvGetAndReportPathRules('spec.toURL')"
+          data-testid="Navlink-url-field"
+        />
+      </div>
+    </template>
+    <template v-if="isService">
+      <div class="row mb-20">
+        <div class="col span-2">
+          <LabeledSelect
+            v-model:value="value.spec.toService.scheme"
+            :mode="mode"
+            :label="t('navLink.tabs.link.toService.scheme.label')"
+            :required="isService"
+            :options="protocolsOptions"
+            :placeholder="t('navLink.tabs.link.toService.scheme.placeholder')"
+            :rules="fvGetAndReportPathRules('spec.toService.scheme')"
+            data-testid="Navlink-scheme-field"
+          />
+        </div>
+        <div class="col span-5">
+          <LabeledSelect
+            v-model:value="currentService"
+            :mode="mode"
+            :label="t('navLink.tabs.link.toService.service.label')"
+            :options="mappedServices"
+            :required="isService"
+            :placeholder="t('navLink.tabs.link.toService.service.placeholder')"
+            :rules="fvGetAndReportPathRules('spec.toService.namespace')"
+            data-testid="Navlink-currentService-field"
+            @update:value="setService"
+          />
+        </div>
+        <div class="col span-2">
+          <LabeledInput
+            v-model:value="value.spec.toService.port"
+            :mode="mode"
+            :label="t('navLink.tabs.link.toService.port.label')"
+            type="number"
+            :placeholder="t('navLink.tabs.link.toService.port.placeholder')"
+          />
+        </div>
+        <div class="col span-3">
+          <LabeledInput
+            v-model:value="value.spec.toService.path"
+            :mode="mode"
+            :label="t('navLink.tabs.link.toService.path.label')"
+            :placeholder="t('navLink.tabs.link.toService.path.placeholder')"
+          />
+        </div>
+      </div>
+    </template>
+    <div class="spacer" />
+    <h2 v-t="'navLink.tabs.target.label'" />
+    <div class="row mb-20">
+      <div class="col span-6">
+        <RadioGroup
+          v-model:value="currentTarget"
+          name="type"
+          :mode="mode"
+          :options="targetOptions"
+          @update:value="setTargetValue($event)"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-if="isNamedWindow"
+          v-model:value="targetName"
+          :mode="mode"
+          :label="t('navLink.tabs.target.namedValue.label')"
+          @update:value="setTargetValue($event);"
+        />
+      </div>
+    </div>
+    <div class="spacer" />
+    <h2 v-t="'navLink.tabs.group.label'" />
+
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="value.spec.group"
+          :mode="mode"
+          :tooltip="t('navLink.tabs.group.group.tooltip')"
+          :label="t('navLink.tabs.group.group.label')"
+        />
+      </div>
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="value.spec.sideLabel"
+          :mode="mode"
+          :label="t('navLink.tabs.group.sideLabel.label')"
+        />
+      </div>
+    </div>
+
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="value.spec.description"
+          :mode="mode"
+          :label="t('navLink.tabs.group.description.label')"
+        />
+      </div>
+    </div>
+
+    <h4 v-t="'navLink.tabs.groupImage.label'" />
+    <div class="row">
+      <label class="text-label">
+        {{ t('navLink.tabs.groupImage.iconSrc.tip', {}, true) }}
+      </label>
+    </div>
+    <div class="row">
+      <FileImageSelector
+        v-model:value="value.spec.iconSrc"
+        :read-as-data-url="true"
+        :mode="mode"
+        :label="t('navLink.tabs.groupImage.iconSrc.label')"
+        accept="image/jpeg,image/png,image/svg+xml"
+        @error="setImageError"
+        @update:value="setIcon"
+      />
+    </div>
+    <Banner
+      v-if="imageError"
+      color="error"
+    >
+      {{ imageErrorMessage }}
+    </Banner>
+  </CruResource>
 </template>

--- a/shell/edit/ui.cattle.io.navlink.vue
+++ b/shell/edit/ui.cattle.io.navlink.vue
@@ -279,182 +279,184 @@ export default {
 </script>
 
 <template>
-  <CruResource
-    :can-yaml="!isCreate"
-    :mode="mode"
-    :resource="value"
-    :errors="fvUnreportedValidationErrors"
-    :cancel-event="true"
-    :validation-passed="fvFormIsValid"
-    data-testid="Navlink-CRU"
-    @error="e=>errors = e"
-    @finish="save"
-    @cancel="done()"
-  >
-    <NameNsDescription
-      :value="value"
-      :namespaced="false"
-      :namespace-disabled="true"
+  <div>
+    <CruResource
+      :can-yaml="!isCreate"
       :mode="mode"
-      name-key="metadata.name"
-      description-key="spec.label"
-      name-label="navLink.name.label"
-      name-placeholder="navLink.name.placeholder"
-      description-label="navLink.label.label"
-      description-placeholder="navLink.label.placeholder"
-      data-testid="Navlink-name-field"
-      :rules="{ name: fvGetAndReportPathRules('metadata.name'), namespace: [], description: [] }"
-      @update:value="$emit('input', $event)"
-    />
-
-    <div class="spacer" />
-    <h2 v-t="'navLink.tabs.link.label'" />
-    <div class="row mb-20">
-      <div class="col span-6">
-        <RadioGroup
-          v-model:value="linkType"
-          name="type"
-          :mode="mode"
-          :options="urlTypeOptions"
-          data-testid="Navlink-link-radiogroup"
-        />
-      </div>
-    </div>
-
-    <template v-if="isURL">
-      <div class="row mb-20">
-        <LabeledInput
-          v-model:value="value.spec.toURL"
-          :mode="mode"
-          :label="t('navLink.tabs.link.toURL.label')"
-          :required="isURL"
-          :placeholder="t('navLink.tabs.link.toURL.placeholder')"
-          :rules="fvGetAndReportPathRules('spec.toURL')"
-          data-testid="Navlink-url-field"
-        />
-      </div>
-    </template>
-    <template v-if="isService">
-      <div class="row mb-20">
-        <div class="col span-2">
-          <LabeledSelect
-            v-model:value="value.spec.toService.scheme"
-            :mode="mode"
-            :label="t('navLink.tabs.link.toService.scheme.label')"
-            :required="isService"
-            :options="protocolsOptions"
-            :placeholder="t('navLink.tabs.link.toService.scheme.placeholder')"
-            :rules="fvGetAndReportPathRules('spec.toService.scheme')"
-            data-testid="Navlink-scheme-field"
-          />
-        </div>
-        <div class="col span-5">
-          <LabeledSelect
-            v-model:value="currentService"
-            :mode="mode"
-            :label="t('navLink.tabs.link.toService.service.label')"
-            :options="mappedServices"
-            :required="isService"
-            :placeholder="t('navLink.tabs.link.toService.service.placeholder')"
-            :rules="fvGetAndReportPathRules('spec.toService.namespace')"
-            data-testid="Navlink-currentService-field"
-            @update:value="setService"
-          />
-        </div>
-        <div class="col span-2">
-          <LabeledInput
-            v-model:value="value.spec.toService.port"
-            :mode="mode"
-            :label="t('navLink.tabs.link.toService.port.label')"
-            type="number"
-            :placeholder="t('navLink.tabs.link.toService.port.placeholder')"
-          />
-        </div>
-        <div class="col span-3">
-          <LabeledInput
-            v-model:value="value.spec.toService.path"
-            :mode="mode"
-            :label="t('navLink.tabs.link.toService.path.label')"
-            :placeholder="t('navLink.tabs.link.toService.path.placeholder')"
-          />
-        </div>
-      </div>
-    </template>
-    <div class="spacer" />
-    <h2 v-t="'navLink.tabs.target.label'" />
-    <div class="row mb-20">
-      <div class="col span-6">
-        <RadioGroup
-          v-model:value="currentTarget"
-          name="type"
-          :mode="mode"
-          :options="targetOptions"
-          @update:value="setTargetValue($event)"
-        />
-      </div>
-      <div class="col span-6">
-        <LabeledInput
-          v-if="isNamedWindow"
-          v-model:value="targetName"
-          :mode="mode"
-          :label="t('navLink.tabs.target.namedValue.label')"
-          @update:value="setTargetValue($event);"
-        />
-      </div>
-    </div>
-    <div class="spacer" />
-    <h2 v-t="'navLink.tabs.group.label'" />
-
-    <div class="row mb-20">
-      <div class="col span-6">
-        <LabeledInput
-          v-model:value="value.spec.group"
-          :mode="mode"
-          :tooltip="t('navLink.tabs.group.group.tooltip')"
-          :label="t('navLink.tabs.group.group.label')"
-        />
-      </div>
-      <div class="col span-6">
-        <LabeledInput
-          v-model:value="value.spec.sideLabel"
-          :mode="mode"
-          :label="t('navLink.tabs.group.sideLabel.label')"
-        />
-      </div>
-    </div>
-
-    <div class="row mb-20">
-      <div class="col span-6">
-        <LabeledInput
-          v-model:value="value.spec.description"
-          :mode="mode"
-          :label="t('navLink.tabs.group.description.label')"
-        />
-      </div>
-    </div>
-
-    <h4 v-t="'navLink.tabs.groupImage.label'" />
-    <div class="row">
-      <label class="text-label">
-        {{ t('navLink.tabs.groupImage.iconSrc.tip', {}, true) }}
-      </label>
-    </div>
-    <div class="row">
-      <FileImageSelector
-        v-model:value="value.spec.iconSrc"
-        :read-as-data-url="true"
-        :mode="mode"
-        :label="t('navLink.tabs.groupImage.iconSrc.label')"
-        accept="image/jpeg,image/png,image/svg+xml"
-        @error="setImageError"
-        @update:value="setIcon"
-      />
-    </div>
-    <Banner
-      v-if="imageError"
-      color="error"
+      :resource="value"
+      :errors="fvUnreportedValidationErrors"
+      :cancel-event="true"
+      :validation-passed="fvFormIsValid"
+      data-testid="Navlink-CRU"
+      @error="e=>errors = e"
+      @finish="save"
+      @cancel="done()"
     >
-      {{ imageErrorMessage }}
-    </Banner>
-  </CruResource>
+      <NameNsDescription
+        :value="value"
+        :namespaced="false"
+        :namespace-disabled="true"
+        :mode="mode"
+        name-key="metadata.name"
+        description-key="spec.label"
+        name-label="navLink.name.label"
+        name-placeholder="navLink.name.placeholder"
+        description-label="navLink.label.label"
+        description-placeholder="navLink.label.placeholder"
+        data-testid="Navlink-name-field"
+        :rules="{ name: fvGetAndReportPathRules('metadata.name'), namespace: [], description: [] }"
+        @update:value="$emit('input', $event)"
+      />
+
+      <div class="spacer" />
+      <h2 v-t="'navLink.tabs.link.label'" />
+      <div class="row mb-20">
+        <div class="col span-6">
+          <RadioGroup
+            v-model:value="linkType"
+            name="type"
+            :mode="mode"
+            :options="urlTypeOptions"
+            data-testid="Navlink-link-radiogroup"
+          />
+        </div>
+      </div>
+
+      <template v-if="isURL">
+        <div class="row mb-20">
+          <LabeledInput
+            v-model:value="value.spec.toURL"
+            :mode="mode"
+            :label="t('navLink.tabs.link.toURL.label')"
+            :required="isURL"
+            :placeholder="t('navLink.tabs.link.toURL.placeholder')"
+            :rules="fvGetAndReportPathRules('spec.toURL')"
+            data-testid="Navlink-url-field"
+          />
+        </div>
+      </template>
+      <template v-if="isService">
+        <div class="row mb-20">
+          <div class="col span-2">
+            <LabeledSelect
+              v-model:value="value.spec.toService.scheme"
+              :mode="mode"
+              :label="t('navLink.tabs.link.toService.scheme.label')"
+              :required="isService"
+              :options="protocolsOptions"
+              :placeholder="t('navLink.tabs.link.toService.scheme.placeholder')"
+              :rules="fvGetAndReportPathRules('spec.toService.scheme')"
+              data-testid="Navlink-scheme-field"
+            />
+          </div>
+          <div class="col span-5">
+            <LabeledSelect
+              v-model:value="currentService"
+              :mode="mode"
+              :label="t('navLink.tabs.link.toService.service.label')"
+              :options="mappedServices"
+              :required="isService"
+              :placeholder="t('navLink.tabs.link.toService.service.placeholder')"
+              :rules="fvGetAndReportPathRules('spec.toService.namespace')"
+              data-testid="Navlink-currentService-field"
+              @update:value="setService"
+            />
+          </div>
+          <div class="col span-2">
+            <LabeledInput
+              v-model:value="value.spec.toService.port"
+              :mode="mode"
+              :label="t('navLink.tabs.link.toService.port.label')"
+              type="number"
+              :placeholder="t('navLink.tabs.link.toService.port.placeholder')"
+            />
+          </div>
+          <div class="col span-3">
+            <LabeledInput
+              v-model:value="value.spec.toService.path"
+              :mode="mode"
+              :label="t('navLink.tabs.link.toService.path.label')"
+              :placeholder="t('navLink.tabs.link.toService.path.placeholder')"
+            />
+          </div>
+        </div>
+      </template>
+      <div class="spacer" />
+      <h2 v-t="'navLink.tabs.target.label'" />
+      <div class="row mb-20">
+        <div class="col span-6">
+          <RadioGroup
+            v-model:value="currentTarget"
+            name="type"
+            :mode="mode"
+            :options="targetOptions"
+            @update:value="setTargetValue($event)"
+          />
+        </div>
+        <div class="col span-6">
+          <LabeledInput
+            v-if="isNamedWindow"
+            v-model:value="targetName"
+            :mode="mode"
+            :label="t('navLink.tabs.target.namedValue.label')"
+            @update:value="setTargetValue($event);"
+          />
+        </div>
+      </div>
+      <div class="spacer" />
+      <h2 v-t="'navLink.tabs.group.label'" />
+
+      <div class="row mb-20">
+        <div class="col span-6">
+          <LabeledInput
+            v-model:value="value.spec.group"
+            :mode="mode"
+            :tooltip="t('navLink.tabs.group.group.tooltip')"
+            :label="t('navLink.tabs.group.group.label')"
+          />
+        </div>
+        <div class="col span-6">
+          <LabeledInput
+            v-model:value="value.spec.sideLabel"
+            :mode="mode"
+            :label="t('navLink.tabs.group.sideLabel.label')"
+          />
+        </div>
+      </div>
+
+      <div class="row mb-20">
+        <div class="col span-6">
+          <LabeledInput
+            v-model:value="value.spec.description"
+            :mode="mode"
+            :label="t('navLink.tabs.group.description.label')"
+          />
+        </div>
+      </div>
+
+      <h4 v-t="'navLink.tabs.groupImage.label'" />
+      <div class="row">
+        <label class="text-label">
+          {{ t('navLink.tabs.groupImage.iconSrc.tip', {}, true) }}
+        </label>
+      </div>
+      <div class="row">
+        <FileImageSelector
+          v-model:value="value.spec.iconSrc"
+          :read-as-data-url="true"
+          :mode="mode"
+          :label="t('navLink.tabs.groupImage.iconSrc.label')"
+          accept="image/jpeg,image/png,image/svg+xml"
+          @error="setImageError"
+          @update:value="setIcon"
+        />
+      </div>
+      <Banner
+        v-if="imageError"
+        color="error"
+      >
+        {{ imageErrorMessage }}
+      </Banner>
+    </CruResource>
+  </div>
 </template>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11937 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Add top-level non-custom element in order to fix error information when creating NavLink is not shown to user

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Although the changes look bigger, what was needed to make it work was just adding a `div` as the outermost container to wrap the `CruResource` component. No errors were being thrown, so I don't know the root cause for this.
Also, it may be important to cover all of the `CruResource` usages to check if it's a general problem or not and act accordingly.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Cluster Explorer --> Header `Resource Search` --> type in NavLink --> click on NavLink --> Create
- Enter `AAA` for the name --> Enter anything for `Destination URL` --> Create
- Should show the error from the network request to the user


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/84a1d175-54e1-463e-a95c-b2b2cd514952


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
