### PR TITLE
Fix InstallCodeMirror export

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "cache-loader": "4.1.0",
     "clipboard-polyfill": "4.0.1",
     "codemirror": "5.65.17",
-    "codemirror-editor-vue3": "2.7.0",
+    "codemirror-editor-vue3": "2.7.1",
     "color": "4.2.3",
     "cookie": "0.5.0",
     "cookie-universal": "2.2.2",

--- a/shell/initialize/install-plugins.js
+++ b/shell/initialize/install-plugins.js
@@ -17,7 +17,7 @@ import config from '@shell/utils/config';
 import axiosShell from '@shell/plugins/axios';
 import backButton from '@shell/plugins/back-button';
 import codeMirror from '@shell/plugins/codemirror-loader';
-import { InstallCodemirro } from 'codemirror-editor-vue3';
+import { InstallCodeMirror } from 'codemirror-editor-vue3';
 import * as intNumber from '@shell/directives/int-number';
 import nuxtClientInit from '@shell/plugins/nuxt-client-init';
 import plugin from '@shell/plugins/plugin';
@@ -38,7 +38,7 @@ export async function installPlugins(vueApp) {
   vueApp.use(VueResize);
   vueApp.use(FloatingVue, floatingVueOptions);
   vueApp.use(ShortKey, { prevent: ['input', 'textarea', 'select'] });
-  vueApp.use(InstallCodemirro);
+  vueApp.use(InstallCodeMirror);
   vueApp.component('v-select', vSelect);
 }
 

--- a/shell/package.json
+++ b/shell/package.json
@@ -56,7 +56,7 @@
     "browser-env": "3.3.0",
     "clipboard-polyfill": "4.0.1",
     "codemirror": ">=5.64.0 <6",
-    "codemirror-editor-vue3": "^2.7.0",
+    "codemirror-editor-vue3": "2.7.1",
     "cookie": "0.5.0",
     "cookie-universal": "2.2.2",
     "core-js": "3.25.3",

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -3938,10 +3938,15 @@
   optionalDependencies:
     prettier "^1.18.2 || ^2.0.0"
 
-"@vue/devtools-api@^6.0.0", "@vue/devtools-api@^6.0.0-beta.11":
+"@vue/devtools-api@^6.0.0-beta.11":
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.6.3.tgz#b23a588154cba8986bba82b6e1d0248bde3fd1a0"
   integrity sha512-0MiMsFma/HqA6g3KLKn+AGpL1kgKhFWszC9U29NfpWK5LE7bjeXxySWJrOJ77hBz+TBrBQ7o4QJqbPbqbs8rJw==
+
+"@vue/devtools-api@^6.6.3":
+  version "6.6.4"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.6.4.tgz#cbe97fe0162b365edc1dba80e173f90492535343"
+  integrity sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==
 
 "@vue/reactivity-transform@3.2.47":
   version "3.2.47"
@@ -12965,12 +12970,12 @@ vue-resize@^2.0.0-alpha.1:
   resolved "https://registry.yarnpkg.com/vue-resize/-/vue-resize-2.0.0-alpha.1.tgz#43eeb79e74febe932b9b20c5c57e0ebc14e2df3a"
   integrity sha512-7+iqOueLU7uc9NrMfrzbG8hwMqchfVfSzpVlCMeJQe4pyibqyoifDNbKTZvwxZKDvGkB+PdFeKvnGZMoEb8esg==
 
-vue-router@~4.0.3:
-  version "4.0.16"
-  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-4.0.16.tgz#9477beeeef36e80e04d041a1738801a55e6e862e"
-  integrity sha512-JcO7cb8QJLBWE+DfxGUL3xUDOae/8nhM1KVdnudadTAORbuxIC/xAydC5Zr/VLHUDQi1ppuTF5/rjBGzgzrJNA==
+vue-router@4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-4.4.3.tgz#58a39dc804632bfb6d26f052aa8f6718bd130299"
+  integrity sha512-sv6wmNKx2j3aqJQDMxLFzs/u/mjA9Z5LCgy6BE0f7yFWMjrPLnS/sPNn8ARY/FXw6byV18EFutn5lTO6+UsV5A==
   dependencies:
-    "@vue/devtools-api" "^6.0.0"
+    "@vue/devtools-api" "^6.6.3"
 
 vue-select@4.0.0-beta.6:
   version "4.0.0-beta.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5704,10 +5704,10 @@ co@^4.6.0:
   resolved "https://registry.npmjs.org/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
 
-codemirror-editor-vue3@2.7.0:
-  version "2.7.0"
-  resolved "https://registry.npmjs.org/codemirror-editor-vue3/-/codemirror-editor-vue3-2.7.0.tgz#873e0d971d9016c9328b16d3eb0c818c96af59b6"
-  integrity sha512-mAx2CPCshARMXjIb9Bl/jhSzcVGAjh9JqLCB9+9hGPPW/lObHWLJD7DgNd0xJnw2Vrm9shHIS/ch74MwmDGrtA==
+codemirror-editor-vue3@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/codemirror-editor-vue3/-/codemirror-editor-vue3-2.7.1.tgz#48d41515cb3c47e2c84200414c2bf0f267dac15e"
+  integrity sha512-nUlSUPu22ugrvNNy86w4GhUswZk0qi0DsPGC8srG88LllJahXlZslHD8ikaLwp8Y1Ho6gW2STiYZe8ilW2rPLg==
   dependencies:
     "@unocss/transformer-directives" "^0.58.8"
     "@wdns/vue-code-block" "^2.3.2"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
When running an extension locally in the dev environment with the latest Vue3 changes that uses the CodeMirror plugin, you will get an warning in the console:

```console
 warning  in ./node_modules/@rancher/shell/initialize/install-plugins.js

export 'InstallCodemirro' (imported as 'InstallCodemirro') was not found in 'codemirror-editor-vue3' (possible exports: CodeMirror, GlobalCmComponent, InstallCodeMirror, VueCodemirror, createLinkMark, createLog, createLogMark, createTitle, default, getLinkMarks, getLocalTime, getLogMark, logErrorType)
```

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This fixes the import and export for `InstallCodeMirror`.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
An extension using the CodeMirror plugin.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
