### PR TITLE
Allow the namespace filter to be selected after making selection in the dropdown

### DIFF
--- a/cypress/e2e/po/components/namespace-filter.po.ts
+++ b/cypress/e2e/po/components/namespace-filter.po.ts
@@ -30,7 +30,7 @@ export class NamespaceFilterPo extends ComponentPo {
   }
 
   searchByName(label: string) {
-    return this.self().find('.ns-controls > .ns-input').clear().type(label);
+    return this.self().find('.ns-controls > .ns-input > .ns-filter-input').clear().type(label);
   }
 
   clearSearchFilter() {

--- a/cypress/e2e/tests/pages/explorer2/namespace-picker.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/namespace-picker.spec.ts
@@ -154,6 +154,18 @@ describe('Namespace picker', { testIsolation: 'off' }, () => {
     namespacePicker.checkIcon().should('have.length', 1);
   });
 
+  it('can filter after making a selection', { tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {
+    namespacePicker.toggle();
+
+    // Select 'Project: Default'
+    namespacePicker.clickOptionByLabel('Project: Default');
+    namespacePicker.isChecked('Project: Default');
+    namespacePicker.checkIcon().should('have.length', 1);
+
+    namespacePicker.searchByName('default');
+    namespacePicker.getOptions().find('.ns-option').should('have.length.gte', 2);
+  });
+
   it('can filter options by name', { tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {
     namespacePicker.toggle();
 

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -597,10 +597,13 @@ export default {
     open() {
       this.isOpen = true;
       this.$nextTick(() => {
-        this.$refs.filter.focus();
+        this.focusFilter();
       });
       this.addCloseKeyHandler();
       this.layout();
+    },
+    focusFilter() {
+      this.$refs.filter.focus();
     },
     close() {
       this.isOpen = false;
@@ -798,6 +801,7 @@ export default {
             v-model="filter"
             tabindex="0"
             class="ns-filter-input"
+            @click="focusFilter"
             @keydown="inputKeyHandler($event)"
           >
           <i


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds a `@click` event handler to the namespace filter input. Doing this allows the input to be selected after making a selection in the dropdown.

Fixes #11928 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add a `@click` handler to `ns-filter-input` input

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This regression was introduced in #11762, which added a `@click.prevent` handler to prevent multiple events from quickly toggling the namespace filter dropdown from opened to closed. 

An alternative solution to this PR would be to revert the change made in #11762 and redesign the solution entirely. I thought the solution presented in this PR to be more straightforward, the tradeoff being that it requires the special case for the `@click` handler. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Namespace Filter

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
