### PR TITLE
Rename `resource` to `resourceType` in `ResourceDetail`

### DIFF
--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -85,9 +85,9 @@ export default {
     const store = this.$store;
     const route = this.$route;
     const params = route.params;
-    let resource = this.resourceOverride || params.resource;
+    let resourceType = this.resourceOverride || params.resource;
 
-    const inStore = this.storeOverride || store.getters['currentStore'](resource);
+    const inStore = this.storeOverride || store.getters['currentStore'](resourceType);
     const realMode = this.realMode;
 
     // eslint-disable-next-line prefer-const
@@ -98,10 +98,10 @@ export default {
     // know about:  view, edit, create (stage, import and clone become "create")
     const mode = ([_CLONE, _IMPORT, _STAGE].includes(realMode) ? _CREATE : realMode);
 
-    const getGraphConfig = store.getters['type-map/hasGraph'](resource);
+    const getGraphConfig = store.getters['type-map/hasGraph'](resourceType);
     const hasGraph = !!getGraphConfig;
-    const hasCustomDetail = store.getters['type-map/hasCustomDetail'](resource, id);
-    const hasCustomEdit = store.getters['type-map/hasCustomEdit'](resource, id);
+    const hasCustomDetail = store.getters['type-map/hasCustomDetail'](resourceType, id);
+    const hasCustomEdit = store.getters['type-map/hasCustomEdit'](resourceType, id);
 
     const schemas = store.getters[`${ inStore }/all`](SCHEMA);
 
@@ -122,16 +122,16 @@ export default {
 
     this.as = as;
 
-    const options = store.getters[`type-map/optionsFor`](resource);
+    const options = store.getters[`type-map/optionsFor`](resourceType);
 
     this.showMasthead = [_CREATE, _EDIT].includes(mode) ? options.resourceEditMasthead : true;
     const canViewYaml = options.canYaml;
 
     if ( options.resource ) {
-      resource = options.resource;
+      resourceType = options.resource;
     }
 
-    const schema = store.getters[`${ inStore }/schemaFor`](resource);
+    const schema = store.getters[`${ inStore }/schemaFor`](resourceType);
     let model, initialModel, liveModel, yaml;
 
     if ( realMode === _CREATE || realMode === _IMPORT ) {
@@ -139,7 +139,7 @@ export default {
         namespace = store.getters['defaultNamespace'];
       }
 
-      const data = { type: resource };
+      const data = { type: resourceType };
 
       if ( schema?.attributes?.namespaced ) {
         data.metadata = { namespace };
@@ -160,7 +160,7 @@ export default {
           await schema.fetchResourceFields();
         }
 
-        yaml = createYaml(schemas, resource, data);
+        yaml = createYaml(schemas, resourceType, data);
       }
     } else {
       if ( as === _GRAPH ) {
@@ -192,13 +192,13 @@ export default {
 
       try {
         liveModel = await store.dispatch(`${ inStore }/find`, {
-          type: resource,
+          type: resourceType,
           id:   fqid,
           opt:  { watch: true }
         });
       } catch (e) {
         if (e.status === 404 || e.status === 403) {
-          store.dispatch('loadingError', new Error(this.t('nav.failWhale.resourceIdNotFound', { resource, fqid }, true)));
+          store.dispatch('loadingError', new Error(this.t('nav.failWhale.resourceIdNotFound', { resource: resourceType, fqid }, true)));
         }
         liveModel = {};
         notFound = fqid;
@@ -235,7 +235,7 @@ export default {
       hasCustomDetail,
       hasCustomEdit,
       canViewYaml,
-      resource,
+      resourceType,
       as,
       yaml,
       initialModel,
@@ -262,7 +262,7 @@ export default {
       hasGraph:        null,
       hasCustomDetail: null,
       hasCustomEdit:   null,
-      resource:        null,
+      resourceType:    null,
       asYaml:          null,
       yaml:            null,
       liveModel:       null,
@@ -379,7 +379,7 @@ export default {
   <div v-else>
     <Masthead
       v-if="showMasthead"
-      :resource="resource"
+      :resource="resourceType"
       :value="liveModel"
       :mode="mode"
       :real-mode="realMode"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves an issue that we've been seeing in edit components where the `resource` data prop, being passed to dynamically rendered components via `v-bind="$data"`, is overwriting props in a grandchild component at the root of the child. The root cause of this issue is directly attributed to how Vue3 manages fallthrough attributes[^1][^2].

[^1]: https://vuejs.org/guide/components/attrs.html#fallthrough-attributes
[^2]: https://vuejs.org/api/built-in-directives.html#v-bind

Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- rename `resource` to `resourceType` to prevent `resource` colliding with granchild props as a fallthrough attribute

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I'm identifying all instances of `resource:` in our edit components with the following

```
grep -rc --exclude-dir=node_modules/ 'resource:' shell/edit/ | grep -v ":0"
shell/edit/__tests__/monitoring.coreos.com.prometheusrule.test.ts:1
shell/edit/autoscaling.horizontalpodautoscaler/metrics-row.vue:1
shell/edit/autoscaling.horizontalpodautoscaler/resource-metric.vue:1
shell/edit/fleet.cattle.io.cluster.vue:1
shell/edit/logging.banzaicloud.io.output/__tests__/logging.banzaicloud.io.output.test.ts:1
shell/edit/management.cattle.io.projectroletemplatebinding.vue:1
shell/edit/monitoring.coreos.com.receiver/index.vue:1
shell/edit/monitoring.coreos.com.route.vue:1
shell/edit/networking.k8s.io.ingress/Certificates.vue:1
shell/edit/provisioning.cattle.io.cluster/import.vue:2
shell/edit/provisioning.cattle.io.cluster/index.vue:1
shell/edit/provisioning.cattle.io.cluster/rke2.vue:5
shell/edit/workload/mixins/workload.js:1
shell/edit/management.cattle.io.project.vue:2
```

We have two potential alternatives to this change:

1. Add `inheritAttrs: false` to each component under `shell/edit` to disable attribute fallthrough behavior
2. Use either `v-bind.attr="$data"` or `v-bind.prop="$data"` to prevent the fallthrough behavior[^2]

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

This change affects every component that can feasibly be rendered by `ResourceDetail.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Any components with an actual `resource` prop that might be dynamically rendered via:

https://github.com/rancher/dashboard/blob/f634802dfe32a7ebfaccefcc366a50d009900e74/shell/components/ResourceDetail/index.vue#L420-L435 

It's difficult to assert that this is a safe approach without any form of contract between components that we can dynamically render and `ResourceDetail`. 

We would also need to assert that any mixins associated with any given component does not also declare a `resource` prop.

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
