### PR TITLE
ContainerShell window manager fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "ufo": "0.7.11",
     "unfetch": "4.2.0",
     "url-parse": "1.5.10",
-    "vue-resize": "0.4.5",
+    "vue3-resize": "0.2.0",
     "vue-router": "4.4.3",
     "vue-select": "4.0.0-beta.6",
     "vue-server-renderer": "2.6.14",

--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -105,7 +105,7 @@ export default {
 
     focus() {
       if ( this.$refs.codeMirrorRef ) {
-        this.$refs.codeMirrorRef.codemirror.focus();
+        this.$refs.codeMirrorRef.cminstance.focus();
       }
     },
 
@@ -141,7 +141,7 @@ export default {
 
     updateValue(value) {
       if ( this.$refs.codeMirrorRef ) {
-        this.$refs.codeMirrorRef.codemirror.doc.setValue(value);
+        this.$refs.codeMirrorRef.cminstance.doc.setValue(value);
       }
     },
 

--- a/shell/components/nav/WindowManager/ContainerShell.vue
+++ b/shell/components/nav/WindowManager/ContainerShell.vue
@@ -474,20 +474,14 @@ export default {
   .shell-body {
     padding: calc(2 * var(--outline-width));
     height: 100%;
-
-    & > .terminal.focus {
-      outline: var(--outline-width) solid var(--outline);
-    }
   }
 
-  .containerPicker {
-    :deep() &.unlabeled-select {
-      display: inline-block;
-      min-width: 200px;
-      height: 30px;
-      min-height: 30px;
-      width: initial;
-    }
+  .containerPicker.unlabeled-select {
+    display: inline-block;
+    min-width: 200px;
+    height: 30px;
+    min-height: 30px;
+    width: initial;
   }
 
   .status {

--- a/shell/initialize/install-plugins.js
+++ b/shell/initialize/install-plugins.js
@@ -2,7 +2,7 @@ import PortalVue from 'portal-vue';
 import Vue3Resize from 'vue3-resize';
 import FloatingVue from 'floating-vue';
 import vSelect from 'vue-select';
-import 'vue3-resize/dist/vue3-resize.css'
+import 'vue3-resize/dist/vue3-resize.css';
 
 // import '@shell/plugins/extend-router';
 import '@shell/plugins/formatters';

--- a/shell/initialize/install-plugins.js
+++ b/shell/initialize/install-plugins.js
@@ -1,8 +1,8 @@
 import PortalVue from 'portal-vue';
-import VueResize from 'vue-resize';
+import Vue3Resize from 'vue3-resize';
 import FloatingVue from 'floating-vue';
 import vSelect from 'vue-select';
-import 'vue-resize/dist/vue-resize.css';
+import 'vue3-resize/dist/vue3-resize.css'
 
 // import '@shell/plugins/extend-router';
 import '@shell/plugins/formatters';
@@ -35,7 +35,7 @@ import { floatingVueOptions } from '@shell/plugins/floating-vue';
 export async function installPlugins(vueApp) {
   vueApp.use(globalFormatters);
   vueApp.use(PortalVue);
-  vueApp.use(VueResize);
+  vueApp.use(Vue3Resize);
   vueApp.use(FloatingVue, floatingVueOptions);
   vueApp.use(ShortKey, { prevent: ['input', 'textarea', 'select'] });
   vueApp.use(InstallCodeMirror);

--- a/shell/package.json
+++ b/shell/package.json
@@ -123,7 +123,7 @@
     "unfetch": "4.2.0",
     "url-parse": "1.5.10",
     "vue": "~3.2.13",
-    "vue-resize": "0.4.5",
+    "vue3-resize": "0.2.0",
     "vue-router": "4.4.3",
     "vue-select": "4.0.0-beta.6",
     "vue-server-renderer": "2.7.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14652,11 +14652,6 @@ vue-loader@^17.0.0:
     hash-sum "^2.0.0"
     watchpack "^2.4.0"
 
-vue-resize@0.4.5:
-  version "0.4.5"
-  resolved "https://registry.npmjs.org/vue-resize/-/vue-resize-0.4.5.tgz#4777a23042e3c05620d9cbda01c0b3cc5e32dcea"
-  integrity sha512-bhP7MlgJQ8TIkZJXAfDf78uJO+mEI3CaLABLjv0WNzr4CcGRGPIAItyWYnP6LsPA4Oq0WE+suidNs6dgpO4RHg==
-
 vue-resize@^2.0.0-alpha.1:
   version "2.0.0-alpha.1"
   resolved "https://registry.npmjs.org/vue-resize/-/vue-resize-2.0.0-alpha.1.tgz#43eeb79e74febe932b9b20c5c57e0ebc14e2df3a"
@@ -14708,6 +14703,11 @@ vue-template-es2015-compiler@^1.9.0:
   version "1.9.1"
   resolved "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
+
+vue3-resize@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/vue3-resize/-/vue3-resize-0.2.0.tgz#a1f06468cb7add911dfe3cb980984fa865ea1c8b"
+  integrity sha512-vZkbEv4PjMEWFV0igAxCvdSIH9hrIJjXyJ9XPTxH0cS/L2/VW1dLVORMWJKU0VXHpHiYKwskB62ju7aBQMVpOQ==
 
 vue3-virtual-scroll-list@0.2.1:
   version "0.2.1"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11812 
Fixes #11970 
Fixes #11932
<!-- Define findings related to the feature or bug issue. -->

This fixes the styling issues for the kubectl and container shell windows, the errors in the console created by the `resize-observer` component, and the Yaml editor being unable to show diffs.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Removed lingering outline style for terminal focus
- Fixed class selector targeting `.unlabeled-select` with the `:deep()` method while using an un-scoped style tag
- Errors in the console were caused by the `resize-observer`
  - They were related to using the outdated library for `vue-resize` which is pinned to Vue 2
  - Updated the vue-resize library to `vue3-resize` 
- Fixed the naming scheme of the `codeMirrorRef` instance to `cminstance`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
I was unable to get the `scoped` style to work within the ContainerShell component, which is odd considering the ContainerLogs component could use scoped styles, or at least the `:deep()` method works correctly in that component.

I decided to fix the CodeMirror ref issue in this PR as the `resize-observer` component is also used in the FileDiff component utilized by the YamlEditor.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- kubectl shell
- pod container shell
- Yaml editor for any resource

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

__Kubectl shell__
![kubectl-shell](https://github.com/user-attachments/assets/8dbe9da2-8612-4962-a709-8372bdb0d6e3)

__Container shell__
![container-shell](https://github.com/user-attachments/assets/4dcc5294-0475-4cf0-a1e9-2b90443ec00c)

__Yaml editor__

https://github.com/user-attachments/assets/23621f12-6ff2-44fa-9b1e-8eb67f1c7a01




### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
