### PR TITLE
vue3 - fix detail page routing 

### DIFF
--- a/cypress/e2e/po/pages/explorer/nodes.po.ts
+++ b/cypress/e2e/po/pages/explorer/nodes.po.ts
@@ -1,5 +1,6 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 import NodesListPo from '@/cypress/e2e/po/lists/nodes-list.po';
+import ResourceTablePo from '@/cypress/e2e/po/components/resource-table.po';
 
 export class NodesPagePo extends PagePo {
   private static createPath(clusterId: string) {
@@ -16,5 +17,11 @@ export class NodesPagePo extends PagePo {
 
   nodesList(): NodesListPo {
     return new NodesListPo('[data-testid="sortable-table-list-container"]');
+  }
+
+  goToDetailsPage(elemName: string) {
+    const resourceTable = new ResourceTablePo(this.self());
+
+    return resourceTable.sortableTable().detailsPageLinkWithName(elemName).click();
   }
 }

--- a/cypress/e2e/tests/pages/explorer2/nodes/node-detail.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/nodes/node-detail.spec.ts
@@ -1,0 +1,36 @@
+import ResourceTable from '@/cypress/e2e/po//components/resource-table.po';
+import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dashboard.po';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+
+describe('Node detail', { tags: ['@explorer2', '@adminUser'], testIsolation: 'off' }, () => {
+  before(() => {
+    cy.login();
+    HomePagePo.goTo();
+  });
+
+  it('should still show the node detail view when the page is refreshed', () => {
+    ClusterDashboardPagePo.navTo();
+
+    const nav = new ProductNavPo();
+
+    nav.navToSideMenuEntryByLabel('Nodes');
+
+    cy.contains('.title > h1', 'Nodes').should('be.visible');
+
+    const nodeList = new ResourceTable('[data-testid="cluster-node-list"]');
+
+    nodeList.sortableTable().checkVisible();
+
+    // Wait for loading indicator to go
+    nodeList.sortableTable().checkLoadingIndicatorNotVisible();
+
+    nodeList.sortableTable().rowElementLink(0, 2).click();
+    cy.get('.title .primaryheader h1').should('be.visible');
+    cy.get('.title .primaryheader h1').invoke('text').should('contain', 'Node:');
+    cy.reload();
+    // check that the page rendered is a detail view
+    cy.get('.title .primaryheader h1').should('be.visible');
+    cy.get('.title .primaryheader h1').invoke('text').should('contain', 'Node:');
+  });
+});

--- a/cypress/e2e/tests/pages/explorer2/nodes/node-list.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/nodes/node-list.spec.ts
@@ -38,7 +38,7 @@ describe('Nodes list', { tags: ['@explorer2', '@adminUser'], testIsolation: 'off
     // Wait for loading indicator to go
     nodeList.sortableTable().checkLoadingIndicatorNotVisible();
 
-    // Check table has 2 tows
+    // Check table has 2 rows
     cy.get<number>('@count').then((count) => {
       nodeList.sortableTable().rowElements({ timeout: 2500 }).should((rows: any) => {
         expect(rows).not.to.equal(undefined);

--- a/shell/config/router/routes.js
+++ b/shell/config/router/routes.js
@@ -498,7 +498,7 @@ export default [
         component: () => interopDefault(import('@shell/pages/c/_cluster/_product/_resource/_id.vue')),
         name:      'c-cluster-product-resource-id'
       }, {
-        path:      '/c/:cluster/:product/:resource/:namespace/:id?',
+        path:      '/c/:cluster/:product/:resource/:namespace/:id',
         component: () => interopDefault(import('@shell/pages/c/_cluster/_product/_resource/_namespace/_id.vue')),
         name:      'c-cluster-product-resource-namespace-id'
       }]


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11815 

### Technical notes summary
The node detail page route should match `/c/:cluster/:product/:resource/:id` and instead it's matched to `/c/:cluster/:product/:resource/:namespace/:id?` , where the node id is parsed as a namespace parameter instead, and a create page is rendered (because there's no resource id passed to ResourceDetail). You can see this with the [vue-router path-checker tool](https://paths.esm.dev/?p=AAMeJY2BucBsIOAKAGcUuE7AA7APpglgkqImqy_rmqKsTloCFBDRBJrE4FqncVqZeq0BMATYCzBHabo4CI3mBwBk&t=/c/local/explorer/nodes/some-node-id%23pods#).


vue-router behaviour seems to have changed in v4. Though this wasn't called out in the migration guide, note that [this section](https://v3.router.vuejs.org/guide/essentials/dynamic-matching.html#matching-priority) about priority is not present in the [v4 equivalent docs](https://router.vuejs.org/guide/essentials/route-matching-syntax.html). From what I can tell route order is no longer enough to determine priority. Fortunately in this case we can just remove the optional modifier on the id param so un-namespaced resource detail views no longer match the namespaced route as well.

I found that this bug affected other non-namespaced detail views. I could not find other issues in our routing caused by the vue-router change through manual testing nor checking the vue-router path checker tool linked above.

### Areas or cases that should be tested
Navigate to and refresh the page of namespaced and unnamespaced resource detail views.

### Areas which could experience regressions
I don't think we have pages that would need to use the component `shell/pages/c/_cluster/_product/_resource/_namespace/_id.vue` but do not provide an id param.



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
