### PR TITLE
Fix two node driver based issues

### DIFF
--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
@@ -1,5 +1,6 @@
 import ToggleSwitchPo from '@/cypress/e2e/po/components/toggle-switch.po';
 import ClusterManagerCreateImportPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/cluster-create-import.po';
+import BannersPo from '~/cypress/e2e/po/components/banners.po';
 
 /**
  * Covers core functionality that's common to the dashboard's create cluster pages
@@ -63,5 +64,9 @@ export default class ClusterManagerCreatePagePo extends ClusterManagerCreateImpo
 
   customClusterRegistrationCmd(cmd: string) {
     return `ssh -i custom_node.key -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" root@${ Cypress.env('customNodeIp') } \"nohup ${ cmd }\"`;
+  }
+
+  credentialsBanner() {
+    return new BannersPo(this.self().find('.banner').contains(`Ok, Let's create a new credential`));
   }
 }

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
@@ -1,6 +1,6 @@
 import ToggleSwitchPo from '@/cypress/e2e/po/components/toggle-switch.po';
 import ClusterManagerCreateImportPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/cluster-create-import.po';
-import BannersPo from '~/cypress/e2e/po/components/banners.po';
+import BannersPo from '@/cypress/e2e/po/components/banners.po';
 
 /**
  * Covers core functionality that's common to the dashboard's create cluster pages

--- a/cypress/e2e/tests/pages/global-settings/peformance.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/peformance.spec.ts
@@ -2,7 +2,7 @@ import { PerformancePagePo } from '@/cypress/e2e/po/pages/global-settings/perfor
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 
 const performancePage = new PerformancePagePo();
-const performanceSettingsOrginal = [];
+const performanceSettingsOriginal = [];
 
 describe('Performance', { testIsolation: 'off', tags: ['@globalSettings', '@adminUser'] }, () => {
   before('get default performance settings', () => {
@@ -12,7 +12,7 @@ describe('Performance', { testIsolation: 'off', tags: ['@globalSettings', '@admi
     cy.getRancherResource('v1', 'management.cattle.io.settings', 'ui-performance', null).then((resp: Cypress.Response<any>) => {
       const body = resp.body;
 
-      performanceSettingsOrginal.push(body);
+      performanceSettingsOriginal.push(body);
     });
   });
 
@@ -32,7 +32,7 @@ describe('Performance', { testIsolation: 'off', tags: ['@globalSettings', '@admi
       cy.reload();
 
       // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(6000); // We wait for the modal to show
+      cy.wait(7000); // We wait for the modal to show // FIXME: should wait for modal to open
 
       expect(performancePage.inactivityModalCard().getModal().should('exist'));
 
@@ -228,8 +228,8 @@ describe('Performance', { testIsolation: 'off', tags: ['@globalSettings', '@admi
       const response = resp.body.metadata;
 
       // update original data before sending request
-      performanceSettingsOrginal[0].metadata.resourceVersion = response.resourceVersion;
-      cy.setRancherResource('v1', 'management.cattle.io.settings', 'ui-performance', performanceSettingsOrginal[0]);
+      performanceSettingsOriginal[0].metadata.resourceVersion = response.resourceVersion;
+      cy.setRancherResource('v1', 'management.cattle.io.settings', 'ui-performance', performanceSettingsOriginal[0]);
     });
   });
 });

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -650,38 +650,80 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
   });
 
   describe('Credential Step', () => {
-    it('should show credential step when `addCloudCredential` is true', () => {
-      cy.intercept({
-        method: 'GET',
-        path:   `/v1/management.cattle.io.nodedrivers*`,
-      }, (req) => {
-        req.continue((res) => {
-          res.body.data = nodeDriveResponse(false).data;
+    describe('should always show credentials', () => {
+      const driver = 'nutanix';
+
+      it('should show credential step when `addCloudCredential` is true', () => {
+        cy.intercept({
+          method: 'GET',
+          path:   `/v1/management.cattle.io.nodedrivers*`,
+        }, (req) => {
+          req.continue((res) => {
+            res.body.data = nodeDriveResponse(true, driver).data;
+          });
         });
+        const clusterCreate = new ClusterManagerCreatePagePo();
+
+        clusterCreate.goTo(`type=${ driver }&rkeType=rke2`);
+        clusterCreate.waitForPage();
+
+        clusterCreate.credentialsBanner().checkExists();
       });
-      const clusterCreate = new ClusterManagerCreatePagePo();
 
-      clusterCreate.goTo(`type=nutanix&rkeType=rke2`);
-      clusterCreate.waitForPage();
+      it('should show credential step when `addCloudCredential` is false', () => {
+        cy.intercept({
+          method: 'GET',
+          path:   `/v1/management.cattle.io.nodedrivers*`,
+        }, (req) => {
+          req.continue((res) => {
+            res.body.data = nodeDriveResponse(false, driver).data;
+          });
+        });
+        const clusterCreate = new ClusterManagerCreatePagePo();
 
-      clusterCreate.self().find('[data-testid="form"]').should('exist');
+        clusterCreate.goTo(`type=${ driver }&rkeType=rke2`);
+        clusterCreate.waitForPage();
+
+        clusterCreate.credentialsBanner().checkExists();
+      });
     });
 
-    it('should NOT show credential step when `addCloudCredential` is false', () => {
-      cy.intercept({
-        method: 'GET',
-        path:   `/v1/management.cattle.io.nodedrivers*`,
-      }, (req) => {
-        req.continue((res) => {
-          res.body.data = nodeDriveResponse(true).data;
+    const driver2 = 'outscale';
+
+    describe('should show on condition of addCloudCredential', () => {
+      it('should show credential step when `addCloudCredential` is true', () => {
+        cy.intercept({
+          method: 'GET',
+          path:   `/v1/management.cattle.io.nodedrivers*`,
+        }, (req) => {
+          req.continue((res) => {
+            res.body.data = nodeDriveResponse(true, driver2).data;
+          });
         });
+        const clusterCreate = new ClusterManagerCreatePagePo();
+
+        clusterCreate.goTo(`type=${ driver2 }&rkeType=rke2`);
+        clusterCreate.waitForPage();
+
+        clusterCreate.credentialsBanner().checkExists();
       });
-      const clusterCreate = new ClusterManagerCreatePagePo();
 
-      clusterCreate.goTo(`type=nutanix&rkeType=rke2`);
-      clusterCreate.waitForPage();
+      it('should NOT show credential step when `addCloudCredential` is false', () => {
+        cy.intercept({
+          method: 'GET',
+          path:   `/v1/management.cattle.io.nodedrivers*`,
+        }, (req) => {
+          req.continue((res) => {
+            res.body.data = nodeDriveResponse(false, driver2).data;
+          });
+        });
+        const clusterCreate = new ClusterManagerCreatePagePo();
 
-      clusterCreate.self().find('[data-testid="select-credential"]').should('exist');
+        clusterCreate.goTo(`type=${ driver2 }&rkeType=rke2`);
+        clusterCreate.waitForPage();
+
+        clusterCreate.credentialsBanner().checkNotExists();
+      });
     });
   });
 });

--- a/cypress/e2e/tests/pages/manager/mock-responses.ts
+++ b/cypress/e2e/tests/pages/manager/mock-responses.ts
@@ -1,4 +1,4 @@
-export function nodeDriveResponse(addCloudCredential: boolean): any {
+export function nodeDriveResponse(addCloudCredential: boolean, driver: string): any {
   return {
     type:         'collection',
     links:        { self: '/v1/management.cattle.io.nodedrivers' },
@@ -7,10 +7,10 @@ export function nodeDriveResponse(addCloudCredential: boolean): any {
     count:        1,
     data:         [
       {
-        id:    'nutanix',
+        id:    driver,
         type:  'management.cattle.io.nodedriver',
         links: {
-          remove: 'blocked', self: '/v1/management.cattle.io.nodedrivers/nutanix', update: 'blocked', view: '/v1/management.cattle.io.nodedrivers/nutanix'
+          remove: 'blocked', self: `/v1/management.cattle.io.nodedrivers/${ driver }`, update: 'blocked', view: `/v1/management.cattle.io.nodedrivers/${ driver }`
         },
         apiVersion: 'management.cattle.io/v3',
         kind:       'NodeDriver',
@@ -19,15 +19,15 @@ export function nodeDriveResponse(addCloudCredential: boolean): any {
             'lifecycle.cattle.io/create.node-driver-controller': 'true', privateCredentialFields: 'password', publicCredentialFields: 'endpoint,username,port'
           },
           creationTimestamp: '2024-01-26T18:32:57Z',
-          fields:            ['nutanix', '10d'],
+          fields:            [driver, '10d'],
           finalizers:        ['controller.cattle.io/node-driver-controller'],
           generation:        5,
           labels:            { 'cattle.io/creator': 'norman' },
-          name:              'nutanix',
+          name:              driver,
           relationships:     [{
-            toId: 'nutanixcredentialconfig', toType: 'management.cattle.io.dynamicschema', rel: 'owner', state: 'active', message: 'Resource is current'
+            toId: `${ driver }credentialconfig`, toType: 'management.cattle.io.dynamicschema', rel: 'owner', state: 'active', message: 'Resource is current'
           }, {
-            toId: 'nutanixconfig', toType: 'management.cattle.io.dynamicschema', rel: 'owner', state: 'active', message: 'Resource is current'
+            toId: `${ driver }config`, toType: 'management.cattle.io.dynamicschema', rel: 'owner', state: 'active', message: 'Resource is current'
           }],
           resourceVersion: '3117786',
           state:           {
@@ -36,12 +36,12 @@ export function nodeDriveResponse(addCloudCredential: boolean): any {
           uid: 'c4da5a49-ecc5-4d74-88a8-1a991a586adb'
         },
         spec: {
-          active: true, addCloudCredential, builtin: false, checksum: '65dbf92e2df2b4c6d1a6b1f77c542f2cb13a052a62f236eeee697a1151ede62c', description: '', displayName: 'nutanix', externalId: '', uiUrl: 'https://nutanix.github.io/rancher-ui-driver/v3.4.0/component.js', url: 'https://github.com/nutanix/docker-machine/releases/download/v3.4.0/docker-machine-driver-nutanix', whitelistDomains: ['nutanix.github.io']
+          active: true, addCloudCredential, builtin: false, checksum: '65dbf92e2df2b4c6d1a6b1f77c542f2cb13a052a62f236eeee697a1151ede62c', description: '', displayName: driver, externalId: '', uiUrl: `https://${ driver }.github.io/rancher-ui-driver/v3.4.0/component.js`, url: `https://github.com/${ driver }/docker-machine/releases/download/v3.4.0/docker-machine-driver-${ driver }`, whitelistDomains: [`${ driver }.github.io`]
         },
         status: {
           appliedChecksum:             '65dbf92e2df2b4c6d1a6b1f77c542f2cb13a052a62f236eeee697a1151ede62c',
           appliedDockerMachineVersion: '',
-          appliedURL:                  'https://github.com/nutanix/docker-machine/releases/download/v3.4.0/docker-machine-driver-nutanix',
+          appliedURL:                  `https://github.com/${ driver }/docker-machine/releases/download/v3.4.0/docker-machine-driver-${ driver }`,
           conditions:                  [{
             error: false, lastUpdateTime: '2024-02-02T22:14:36Z', status: 'True', transitioning: false, type: 'Active'
           }, {

--- a/docusaurus/docs/extensions/api/components/node-drivers.md
+++ b/docusaurus/docs/extensions/api/components/node-drivers.md
@@ -4,7 +4,8 @@ Rancher allows UI to be created for custom Node Drivers by registering component
 
 - `cloud-credential`
   - defines a custom component for collecting data for a cloud credential for a given node driver
-  - If no cloud credentials are required, the extension can just set the component to `false`
+  - if cloud credentials are required, override any existing credential setting by setting the value to `true`
+  - if no cloud credentials are required, the extension can just set the component to `false`
 - `machine-config`
   - defined a custom component for the machine pool configuration for a cloud credential for a given node driver
 

--- a/shell/components/Questions/index.vue
+++ b/shell/components/Questions/index.vue
@@ -45,9 +45,9 @@ export function componentForQuestion(q) {
 
   if ( knownTypes[type] ) {
     return type;
-  } else if ( type.startsWith('array[') ) { // This only really works for array[string|multiline], but close enough for now.
+  } else if ( type.startsWith('array') ) { // This only really works for array[string|multiline], but close enough for now.
     return ArrayType;
-  } else if ( type.startsWith('map[') ) { // Same, only works with map[string|multiline]
+  } else if ( type.startsWith('map') ) { // Same, only works with map[string|multiline]
     return MapType;
   } else if ( type.startsWith('reference[') ) { // Same, only works with map[string|multiline]
     return ReferenceType;

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -42,6 +42,7 @@ import Tabbed from '@shell/components/Tabbed';
 import { canViewClusterMembershipEditor } from '@shell/components/form/Members/ClusterMembershipEditor';
 import semver from 'semver';
 
+import { CLOUD_CREDENTIAL_OVERRIDE } from '@shell/models/nodedriver';
 import { SETTING } from '@shell/config/settings';
 import { base64Encode } from '@shell/utils/crypto';
 import { CAPI as CAPI_ANNOTATIONS, CLUSTER_BADGE } from '@shell/config/labels-annotations';
@@ -407,11 +408,22 @@ export default {
     },
 
     needCredential() {
-      if (this.provider === 'custom' || this.provider === 'import' || this.isElementalCluster || this.mode === _VIEW || (this.providerConfig?.spec?.builtin === false && this.providerConfig?.spec?.addCloudCredential === false)) {
+      // Check non-provider specific config
+      if (
+        this.provider === 'custom' ||
+        this.provider === 'import' ||
+        this.isElementalCluster || // Elemental cluster can make use of `cloud-credential`: false
+        this.mode === _VIEW
+      ) {
         return false;
       }
 
-      if (this.customCredentialComponentRequired === false) {
+      // Check provider specific config
+      if (this.cloudCredentialsOverride === true || this.cloudCredentialsOverride === false) {
+        return this.cloudCredentialsOverride;
+      }
+
+      if (this.providerConfig?.spec?.builtin === false && this.providerConfig?.spec?.addCloudCredential === false) {
         return false;
       }
 
@@ -419,10 +431,21 @@ export default {
     },
 
     /**
-     * Only for extensions - extension can register a 'false' cloud credential to indicate that a cloud credential is not needed
+     * Override the native way of determining if cloud credentials are required (builtin ++ node driver spec.addCloudCredentials)
+     *
+     * 1) Override via extensions
+     *    - `true` or actual component - return true
+     *    - `false` - return false
+     * 2) Override via hardcoded setting
      */
-    customCredentialComponentRequired() {
-      return this.$plugin.getDynamic('cloud-credential', this.provider);
+    cloudCredentialsOverride() {
+      const cloudCredential = this.$plugin.getDynamic('cloud-credential', this.provider);
+
+      if (cloudCredential === undefined) {
+        return CLOUD_CREDENTIAL_OVERRIDE[this.provider];
+      }
+
+      return !!cloudCredential;
     },
 
     hasMachinePools() {

--- a/shell/models/nodedriver.js
+++ b/shell/models/nodedriver.js
@@ -1,5 +1,10 @@
 import Driver from '@shell/models/driver';
 
+/**
+ * Overrides for spec.addCloudCredential
+ */
+export const CLOUD_CREDENTIAL_OVERRIDE = { nutanix: true };
+
 export default class NodeDriver extends Driver {
   get doneRoute() {
     return 'c-cluster-manager-driver-nodedriver';

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -2021,8 +2021,10 @@ function hasCustom(state, rootState, kind, key, fallback) {
     return cache[key];
   }
 
-  // Check to see if the custom kind is provided by a plugin
-  if (!!rootState.$plugin.getDynamic(kind, key)) {
+  // Check to see if the custom kind is provided by a plugin (ignore booleans)
+  const pluginComponent = rootState.$plugin.getDynamic(kind, key);
+
+  if (typeof pluginComponent !== 'boolean' && !!pluginComponent) {
     cache[key] = true;
 
     return cache[key];


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11982
Fixes #11983

### Occurred changes and/or fixed issues
I've combined these fixed into a single change, mainly to reduce testing overhead (and also given the size of the second fix)

Fix 1 - Allow node driver addCloudCredentials property to be overriden
- Node drivers will [now](https://github.com/rancher/dashboard/pull/10403) skip cloud cred requirment when creating a cluster given the node drivers spec.addCloudCredentials value
- However some drivers included in rancher have the incorrect value (see [here](https://github.com/rancher/rancher/blob/7bd6951a7d07f8b00b61811fd89cc673319f85b4/pkg/data/management/machinedriver_data.go#L140))
- To avoid tracking down all providers allow a workaround
  - Allow ui extensions to override the addCloudCredentials value by supplying `plugin.register('cloud-credential', '<provider>', true|false);`
  - For providers we're aware of that need credentials hardcode a value 

Fix 2 - Ensure dynamically generated node forms show input fields that provide array of strings when the node driver field requests an array of string
- This is a follow on from the schema diet change
- The notation of a resource field that indicates if an array of that type was changed from, for example, `type: array[string]` to `type: array, subType: string`
- There's discussion to revert this, but in the short term we can just update how the questions component determines if it's an array or not

### Technical notes summary
- The ideal fix is to ensure node driver owners update Rancher machinedriver_data (see link above), however that will take a while to track down

### Areas or cases that should be tested
- Test case 1 - SHOULD show cloud credentials
  - For these tests cases
    - Create cloud credentials via the cloud credentials list
    - Create cloud credentials via the create cluster flow
  - For these providers
    - Digital Ocean and Amazon EC2
        - should render custom forms
        - Works already everywhere
    - Nutanix 
        - should render generic form
        - Works given the PR
    - Outscale (given test ui extension)
        - Load `cloud-credentials-on` extension from https://github.com/richard-cox/ui-plugin-examples/tree/main-richard
- Test case 2 - should NOT show cloud credentials
  - For these test cases
    - Should not prompt for cloud credentials when creating an cluster
  - For these providers
    - EC2 (given test ui extension)
      - Load `cloud-credentials-off` extension from https://github.com/richard-cox/ui-plugin-examples/tree/main-richard
      - should render custom form
- Test case 3 - other areas that use Questions
  - One of the best is when installing apps and the chart has a questions.yaml, a form will be generated ad shown in the Edit Options tab of the Values step of the install chart wizard
    - Longhorn is a good one, however haven't found one that uses array yet


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
