### PR TITLE
Add step to setup node prior to corepack enable

### DIFF
--- a/.github/workflows/release-shell-pkg.yaml
+++ b/.github/workflows/release-shell-pkg.yaml
@@ -17,6 +17,11 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      
+      - name: Setup target Node.js to enable Corepack
+        uses: actions/setup-node@v4
+        with:
+          node-version: '16.x'
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
An issue with enabling corepack in the publish-shell workflow before the node setup step is completed causes this error:
```console
build
/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22762
    throw new Error(
          ^

Error: Error when performing the request to https://registry.npmjs.org/yarn/latest; for troubleshooting help, see https://github.com/nodejs/corepack#troubleshooting
    at fetch (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22762:11)
    at async fetchAsJson (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22776:20)
    ... 4 lines matching cause stack trace ...
    at async Object.runMain (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:24232:5) {
  [cause]: TypeError: globalThis.fetch is not a function
  ```

[Example workflow run.](https://github.com/rancher/dashboard/actions/runs/10961833837)



### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
