### PR TITLE
Ensure fetch is not called when navigating backwards

### DIFF
--- a/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
@@ -84,4 +84,39 @@ describe('Apps/Charts', { tags: ['@explorer', '@adminUser'] }, () => {
     // checking the warning banner to be visible
     chartPage.deprecationAndExperimentalWarning().banner().should('exist').and('be.visible');
   });
+
+  it('should call fetch when route query changes with valid parameters', () => {
+    const chartName = 'Logging';
+
+    chartsPage.getChartByName(chartName).should('exist').and('be.visible').click();
+
+    const chartPage = new ChartPage();
+    chartPage.waitForPage();
+
+    // Set up intercept for the network request triggered by $fetch
+    cy.intercept('GET', '**/v1/catalog.cattle.io.clusterrepos/**').as('fetchChartData');
+
+    chartPage.selectVersion('103.1.1+up4.4.0');
+
+    cy.wait('@fetchChartData').its('response.statusCode').should('eq', 200);
+  });
+
+  it('should not call fetch when navigating back to charts page', () => {
+    const chartName = 'Logging';
+
+    chartsPage.getChartByName(chartName).should('exist').and('be.visible').click();
+
+    const chartPage = new ChartPage();
+    chartPage.waitForPage();
+
+    // Set up intercept for the network request triggered by $fetch
+    cy.intercept('GET', '**/v1/catalog.cattle.io.clusterrepos/**').as('fetchChartData');
+
+    // Navigate back to the charts page
+    cy.go('back');
+    chartsPage.waitForPage();
+
+    // Verify that the network request was not made after navigating back
+    cy.get('@fetchChartData.all').should('have.length', 0);
+  });
 });

--- a/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
@@ -91,6 +91,7 @@ describe('Apps/Charts', { tags: ['@explorer', '@adminUser'] }, () => {
     chartsPage.getChartByName(chartName).should('exist').and('be.visible').click();
 
     const chartPage = new ChartPage();
+
     chartPage.waitForPage();
 
     // Set up intercept for the network request triggered by $fetch
@@ -107,6 +108,7 @@ describe('Apps/Charts', { tags: ['@explorer', '@adminUser'] }, () => {
     chartsPage.getChartByName(chartName).should('exist').and('be.visible').click();
 
     const chartPage = new ChartPage();
+
     chartPage.waitForPage();
 
     // Set up intercept for the network request triggered by $fetch

--- a/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
@@ -119,14 +119,13 @@ describe('Apps/Charts', { tags: ['@explorer', '@adminUser'] }, () => {
 
     chartPage.waitForPage();
 
-    // Set up intercept for the network request triggered by $fetch
-    cy.intercept('GET', '**/v1/catalog.cattle.io.clusterrepos/**').as('fetchChartData');
-
     // Navigate back to the charts page
     cy.go('back');
     chartsPage.waitForPage();
 
-    // Verify that the network request was not made after navigating back
-    cy.get('@fetchChartData.all').should('have.length', 0);
+    // Set up intercept after navigating back
+    cy.intercept('GET', '**/v1/catalog.cattle.io.clusterrepos/**').as('fetchChartDataAfterBack');
+
+    cy.get('@fetchChartDataAfterBack.all').should('have.length', 0);
   });
 });

--- a/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
@@ -88,7 +88,11 @@ describe('Apps/Charts', { tags: ['@explorer', '@adminUser'] }, () => {
   it('should call fetch when route query changes with valid parameters', () => {
     const chartName = 'Logging';
 
-    chartsPage.getChartByName(chartName).should('exist').and('be.visible').click();
+    chartsPage.getChartByName(chartName)
+      .should('exist')
+      .scrollIntoView()
+      .should('be.visible')
+      .click();
 
     const chartPage = new ChartPage();
 
@@ -105,7 +109,11 @@ describe('Apps/Charts', { tags: ['@explorer', '@adminUser'] }, () => {
   it('should not call fetch when navigating back to charts page', () => {
     const chartName = 'Logging';
 
-    chartsPage.getChartByName(chartName).should('exist').and('be.visible').click();
+    chartsPage.getChartByName(chartName)
+      .should('exist')
+      .scrollIntoView()
+      .should('be.visible')
+      .click();
 
     const chartPage = new ChartPage();
 

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -115,7 +115,9 @@ export default {
 
   watch: {
     '$route.query'(neu, old) {
-      if ( !isEqual(neu, old) ) {
+      // If the query changes, refetch the chart
+      // When going back to app list, the query is empty and we don't want to refetch
+      if ( !isEqual(neu, old) && Object.keys(neu).length > 0 ) {
         this.$fetch();
       }
     },

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -744,7 +744,9 @@ export default {
 
   watch: {
     '$route.query'(neu, old) {
-      if ( !isEqual(neu, old) ) {
+      // If the query changes, refetch the chart
+      // When going back to app list, the query is empty and we don't want to refetch
+      if ( !isEqual(neu, old) && Object.keys(neu).length > 0 ) {
         this.$fetch();
         this.showSlideIn = false;
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11931
<!-- Define findings related to the feature or bug issue. -->

The issue was caused due to a watch on the `$route.query` object, when that changed we would call `$fetch` a second time before leaving the page.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added a condition to check for an empty query object before calling `$fetch`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
When navigating backwards (from `apps/charts/chart` to `apps/charts`) the query object is empty, the watch is still used when the route contains the query, e.g. when selecting a different version from the Readme view.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Navigate to `apps/charts`
- Select a chart
- Ensure the version select still works
- Navigate back to the charts page
- Ensure no errors are logged in the console

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


https://github.com/user-attachments/assets/abac7e37-fdb2-4765-a79b-faa113fc3be4



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
