### PR TITLE
Fix Vue3: CIS Benchmark issues

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1177,6 +1177,7 @@ cis:
     total: Total
     warn: Warn
   scheduling:
+    title: Scheduling
     disable: Run scan once
     enable: Run scan on a schedule
   scoreWarning:
@@ -1185,6 +1186,7 @@ cis:
   testID: Test ID
   testsSkipped: Tests Skipped
   testsToSkip: Tests to Skip
+  alerting: Alerting
 
 cluster:
   jwtAuthentication:

--- a/shell/config/product/cis.js
+++ b/shell/config/product/cis.js
@@ -37,9 +37,9 @@ export function init(store) {
     {
       name:          'clusterScanProfile',
       label:         'Profile',
-      value:         'status.lastRunScanProfileName',
       formatter:     'Link',
-      formatterOpts: { options: { internal: true }, to: { name: 'c-cluster-product-resource-id', params: { resource: CIS.CLUSTER_SCAN_PROFILE } } },
+      formatterOpts: { options: { internal: true }, urlKey: 'scanProfileLink' },
+      value:         'status.lastRunScanProfileName',
       sort:          ['status.lastRunScanProfileName'],
     },
     {
@@ -115,7 +115,8 @@ export function init(store) {
       labelKey:      'cis.benchmarkVersion',
       value:         'spec.benchmarkVersion',
       formatter:     'Link',
-      formatterOpts: { options: { internal: true }, to: { name: 'c-cluster-product-resource-id', params: { resource: CIS.BENCHMARK } } },
+      formatterOpts: { options: { internal: true }, urlKey: 'benchmarkVersionLink' },
+      sort:          ['spec.benchmarkVersion'],
     },
     {
       name:     'skippedTests',

--- a/shell/edit/cis.cattle.io.clusterscan.vue
+++ b/shell/edit/cis.cattle.io.clusterscan.vue
@@ -12,7 +12,7 @@ import { allHash } from '@shell/utils/promise';
 import { Checkbox } from '@components/Form/Checkbox';
 import { RadioGroup } from '@components/Form/Radio';
 import { get } from '@shell/utils/object';
-import { _VIEW, _CREATE } from '@shell/config/query-params';
+import { _VIEW, _CREATE, _EDIT } from '@shell/config/query-params';
 import { isValidCron } from 'cron-validator';
 import { fetchSpecsScheduledScanConfig } from '@shell/models/cis.cattle.io.clusterscan';
 
@@ -39,6 +39,37 @@ export default {
   },
 
   async fetch() {
+    // we need to force-fetch the resource fields, otherwise on page refresh
+    // in the clusterscan edit/create views the "canBeScheduled" won't run properly
+    await this.schema.fetchResourceFields();
+
+    if (this.mode === _CREATE || this.mode === _EDIT) {
+      const includeScheduling = this.value.canBeScheduled();
+      const spec = this.value.spec || {};
+
+      spec.scanProfileName = null;
+      if (includeScheduling) {
+        spec.scoreWarning = 'pass';
+        spec.scheduledScanConfig = { scanAlertRule: {}, retentionCount: 3 };
+      }
+
+      this.value.spec = spec;
+    }
+
+    if (!this.value.metadata.name) {
+      this.value.metadata.generateName = 'scan-';
+    }
+    if (!this.value.spec.scheduledScanConfig) {
+      this.value.spec['scheduledScanConfig'] = { scanAlertRule: {} };
+    }
+    if (!this.value.spec.scheduledScanConfig.scanAlertRule) {
+      this.value.spec.scheduledScanConfig['scanAlertRule'] = { };
+    }
+
+    this.isScheduled = !!get(this.value, 'spec.scheduledScanConfig.cronSchedule');
+    this.scheduledScanConfig = this.value.spec.scheduledScanConfig;
+    this.scanAlertRule = this.value.spec.scheduledScanConfig.scanAlertRule;
+
     const hash = await allHash({
       profiles:               this.$store.dispatch('cluster/findAll', { type: CIS.CLUSTER_SCAN_PROFILE }),
       benchmarks:             this.$store.dispatch('cluster/findAll', { type: CIS.BENCHMARK }),
@@ -65,24 +96,13 @@ export default {
   },
 
   data() {
-    if (!this.value.metadata.name) {
-      this.value.metadata.generateName = 'scan-';
-    }
-    if (!this.value.spec.scheduledScanConfig) {
-      this.value.spec['scheduledScanConfig'] = { scanAlertRule: {} };
-    }
-    if (!this.value.spec.scheduledScanConfig.scanAlertRule) {
-      this.value.spec.scheduledScanConfig['scanAlertRule'] = { };
-    }
-    const isScheduled = !!get(this.value, 'spec.scheduledScanConfig.cronSchedule');
-
     return {
       allProfiles:         [],
       defaultConfigMap:    null,
-      scheduledScanConfig: this.value.spec.scheduledScanConfig,
-      scanAlertRule:       this.value.spec.scheduledScanConfig.scanAlertRule,
+      scheduledScanConfig: null,
+      scanAlertRule:       null,
       hasAlertManager:     false,
-      isScheduled
+      isScheduled:         null
     };
   },
 
@@ -281,7 +301,7 @@ export default {
       </div>
     </div>
     <template v-if="canBeScheduled">
-      <h3>Scheduling</h3>
+      <h3>{{ t('cis.scheduling.title') }}</h3>
       <div class="row mb-20">
         <div class="col">
           <RadioGroup
@@ -314,8 +334,8 @@ export default {
             />
           </div>
         </div>
-        <h3>
-          Alerting
+        <h3 class="mt-20">
+          {{ t('cis.alerting') }}
         </h3>
         <div class="row mb-20">
           <div class="col span-12">

--- a/shell/edit/cis.cattle.io.clusterscan.vue
+++ b/shell/edit/cis.cattle.io.clusterscan.vue
@@ -43,7 +43,7 @@ export default {
     // in the clusterscan edit/create views the "canBeScheduled" won't run properly
     await this.schema.fetchResourceFields();
 
-    if (this.mode === _CREATE || this.mode === _EDIT) {
+    if (this.realMode === _CREATE || this.realMode === _EDIT) {
       const includeScheduling = this.value.canBeScheduled();
       const spec = this.value.spec || {};
 

--- a/shell/models/cis.cattle.io.clusterscan.js
+++ b/shell/models/cis.cattle.io.clusterscan.js
@@ -1,8 +1,8 @@
-import { _CREATE, _EDIT } from '@shell/config/query-params';
+import { NAME as PRODUCT_NAME } from '@shell/config/product/cis';
 import { CIS } from '@shell/config/types';
 import { findBy } from '@shell/utils/array';
 import { downloadFile, generateZip } from '@shell/utils/download';
-import { get, isEmpty, set } from '@shell/utils/object';
+import { get, isEmpty } from '@shell/utils/object';
 import { sortBy } from '@shell/utils/sort';
 import day from 'dayjs';
 import SteveModel from '@shell/plugins/steve/steve-class';
@@ -75,20 +75,6 @@ export default class ClusterScan extends SteveModel {
     }
 
     return out;
-  }
-
-  applyDefaults(vm, mode) {
-    if (mode === _CREATE || mode === _EDIT) {
-      const includeScheduling = this.canBeScheduled();
-      const spec = this.spec || {};
-
-      spec.scanProfileName = null;
-      if (includeScheduling) {
-        spec.scoreWarning = 'pass';
-        spec.scheduledScanConfig = { scanAlertRule: {}, retentionCount: 3 };
-      }
-      set(this, 'spec', spec);
-    }
   }
 
   canBeScheduled() {
@@ -165,6 +151,21 @@ export default class ClusterScan extends SteveModel {
         downloadFile(`${ this.id }-reports`, zip, 'application/zip');
       });
     }
+  }
+
+  get scanProfileLink() {
+    if (this.status?.lastRunScanProfileName) {
+      return {
+        name:   'c-cluster-product-resource-id',
+        params: {
+          resource: CIS.CLUSTER_SCAN_PROFILE,
+          product:  PRODUCT_NAME,
+          id:       this.status?.lastRunScanProfileName
+        }
+      };
+    }
+
+    return {};
   }
 }
 

--- a/shell/models/cis.cattle.io.clusterscanprofile.js
+++ b/shell/models/cis.cattle.io.clusterscanprofile.js
@@ -1,5 +1,7 @@
 
 import SteveModel from '@shell/plugins/steve/steve-class';
+import { NAME as PRODUCT_NAME } from '@shell/config/product/cis';
+import { CIS } from '@shell/config/types';
 
 export default class CISProfile extends SteveModel {
   warnDeletionMessage(toRemove = []) {
@@ -10,5 +12,20 @@ export default class CISProfile extends SteveModel {
     const { skipTests = [] } = this.spec;
 
     return skipTests.length;
+  }
+
+  get benchmarkVersionLink() {
+    if (this.spec?.benchmarkVersion) {
+      return {
+        name:   'c-cluster-product-resource-id',
+        params: {
+          resource: CIS.BENCHMARK,
+          product:  PRODUCT_NAME,
+          id:       this.spec?.benchmarkVersion
+        }
+      };
+    }
+
+    return {};
   }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes  #11911, #11915     => ( epic  #11799 ) 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- modify `clusterscan` model to apply defaults on edit/create view instead of model because of schema diet changes ( `v1/schemaDefinitions` information is not available when hard refreshing the edit/create/detail views)
- add missing translations in `clusterscan` edit view
- fix broken links in `clusterscan` and `clusterscanprofile`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Install CIS Benchmark cluster tool helm chart
Cluster --> Tools --> install CIS Benchmark --> refresh
- Check all resource views in CIS Benchmark ( `clusterscan`, `clusterscanprofile`, `clusterscanbenchmark`)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
