### PR TITLE
Fix e2e tests failing on 2.9 because of extension version that shouldn't be available to install

### DIFF
--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -112,7 +112,7 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
 
   describe('CLI Downloads', () => {
     // Shouldn't be needed with https://github.com/rancher/dashboard/issues/11393
-    const expectedLinkStatusCode = 404;
+    const expectedLinkStatusCode = 200;
 
     // workaround to make the following CLI tests work https://github.com/cypress-io/cypress/issues/8089#issuecomment-1585159023
     beforeEach(() => {

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4250,7 +4250,7 @@ inactivity:
 plugins:
   incompatibleRancherVersion: "The latest version of this extension ({ version }) is not compatible with the current Rancher version ({ rancherVersion })."
   incompatibleKubeVersion: "The latest version of this extension ({ version }) is not compatible with the current Kube version ({ kubeVersion })."
-  incompatibleHost: 'The latest version of this extension ({ version }) does not have a host matching with "{ host }".'
+  incompatibleHost: 'The latest version of this extension ({ version }) has a host of "{ host }" which is not compatible with this application "{ mainHost }".'
   currentInstalledVersionBlockedByKubeVersion: "This version is not compatible with the current Kubernetes version ({ kubeVersion }  Vs  { kubeVersionToCheck })."
   labels:
     builtin: Built-in

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4250,6 +4250,7 @@ inactivity:
 plugins:
   incompatibleRancherVersion: "The latest version of this extension ({ version }) is not compatible with the current Rancher version ({ rancherVersion })."
   incompatibleKubeVersion: "The latest version of this extension ({ version }) is not compatible with the current Kube version ({ kubeVersion })."
+  incompatibleHost: "The latest version of this extension ({ version }) does not have a host matching with ({ host })."
   currentInstalledVersionBlockedByKubeVersion: "This version is not compatible with the current Kubernetes version ({ kubeVersion }  Vs  { kubeVersionToCheck })."
   labels:
     builtin: Built-in

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4250,7 +4250,7 @@ inactivity:
 plugins:
   incompatibleRancherVersion: "The latest version of this extension ({ version }) is not compatible with the current Rancher version ({ rancherVersion })."
   incompatibleKubeVersion: "The latest version of this extension ({ version }) is not compatible with the current Kube version ({ kubeVersion })."
-  incompatibleHost: "The latest version of this extension ({ version }) does not have a host matching with ({ host })."
+  incompatibleHost: 'The latest version of this extension ({ version }) does not have a host matching with "{ host }".'
   currentInstalledVersionBlockedByKubeVersion: "This version is not compatible with the current Kubernetes version ({ kubeVersion }  Vs  { kubeVersionToCheck })."
   labels:
     builtin: Built-in

--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -96,12 +96,10 @@ export function uiPluginAnnotation(chart, name) {
  */
 function parseRancherVersion(v) {
   let parsedRancherVersion = semver.coerce(v)?.version;
-
+  const splitArr = parsedRancherVersion.split('.');
   // this is a scenario where we are on a "head" version of some sort... we can't infer the patch version from it
   // so we apply a big patch version number to make sure we follow through with the minor
-  if (v.includes('-') && parsedRancherVersion.split('.')?.length === 3) {
-    const splitArr = parsedRancherVersion.split('.');
-
+  if (v.includes('-') && splitArr?.length === 3) {
     parsedRancherVersion = `${ splitArr[0] }.${ splitArr[1] }.999`;
   }
 
@@ -171,6 +169,7 @@ export function isSupportedChartVersion(versionsData, returnObj = false) {
 
   versionObj.isCompatibleWithUi = true;
   versionObj.isCompatibleWithKubeVersion = true;
+  versionObj.isCompatibleWithHost = true;
 
   // we aren't on a "published" version of Rancher and therefore in a "-head" or similar
   // Backend will NOT block an extension version from being available IF we are on HEAD versions!!
@@ -199,7 +198,7 @@ export function isSupportedChartVersion(versionsData, returnObj = false) {
       return false;
     }
     versionObj.isCompatibleWithHost = false;
-    versionObj.requiredHost = UI_PLUGIN_HOST_APP;
+    versionObj.requiredHost = requiredHost;
 
     if (returnObj) {
       return versionObj;

--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -95,13 +95,14 @@ export function uiPluginAnnotation(chart, name) {
  * Parse the rancher version string
  */
 function parseRancherVersion(v) {
-  let parsedRancherVersion = semver.coerce(v)?.version
+  let parsedRancherVersion = semver.coerce(v)?.version;
 
   // this is a scenario where we are on a "head" version of some sort... we can't infer the patch version from it
-  // so we apply a big patch version number to make sure we follow through with the minor 
-  if (v.includes('-') && parsedRancherVersion.split('.')?.length === 3 && parsedRancherVersion.split('.')?.[2] === '0') {
+  // so we apply a big patch version number to make sure we follow through with the minor
+  if (v.includes('-') && parsedRancherVersion.split('.')?.length === 3) {
     const splitArr = parsedRancherVersion.split('.');
-    parsedRancherVersion = `${splitArr[0]}.${splitArr[1]}.999`;
+
+    parsedRancherVersion = `${ splitArr[0] }.${ splitArr[1] }.999`;
   }
 
   return parsedRancherVersion;
@@ -174,16 +175,16 @@ export function isSupportedChartVersion(versionsData, returnObj = false) {
   // we aren't on a "published" version of Rancher and therefore in a "-head" or similar
   // Backend will NOT block an extension version from being available IF we are on HEAD versions!!
   // we need to enforce that check if we are on a HEAD world
-  if (rancherVersion && rancherVersion.includes('-')) {    
+  if (rancherVersion && rancherVersion.includes('-')) {
     const requiredRancherVersion = version.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.RANCHER_VERSION];
- 
+
     if (parsedRancherVersion && !semver.satisfies(parsedRancherVersion, requiredRancherVersion)) {
       if (!returnObj) {
         return false;
       }
       versionObj.isCompatibleWithUi = false;
       versionObj.requiredUiVersion = requiredRancherVersion;
-  
+
       if (returnObj) {
         return versionObj;
       }

--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -97,6 +97,7 @@ export function uiPluginAnnotation(chart, name) {
 function parseRancherVersion(v) {
   let parsedRancherVersion = semver.coerce(v)?.version;
   const splitArr = parsedRancherVersion.split('.');
+
   // this is a scenario where we are on a "head" version of some sort... we can't infer the patch version from it
   // so we apply a big patch version number to make sure we follow through with the minor
   if (v.includes('-') && splitArr?.length === 3) {

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -286,7 +286,7 @@ export default {
           } else if (!item.isCompatibleWithKubeVersion) {
             item.incompatibleKubeVersion = this.t('plugins.incompatibleKubeVersion', { version: latestNotCompatible.version, kubeVersion: latestNotCompatible.requiredKubeVersion }, true);
           } else if (!item.isCompatibleWithHost) {
-            item.incompatibleHost = this.t('plugins.incompatibleHost', { version: latestNotCompatible.version, host: UI_PLUGIN_HOST_APP }, true);
+            item.incompatibleHost = this.t('plugins.incompatibleHost', { version: latestNotCompatible.version, host: latestNotCompatible.requiredHost, mainHost: UI_PLUGIN_HOST_APP }, true);
           }
         }
 

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -286,7 +286,9 @@ export default {
           } else if (!item.isCompatibleWithKubeVersion) {
             item.incompatibleKubeVersion = this.t('plugins.incompatibleKubeVersion', { version: latestNotCompatible.version, kubeVersion: latestNotCompatible.requiredKubeVersion }, true);
           } else if (!item.isCompatibleWithHost) {
-            item.incompatibleHost = this.t('plugins.incompatibleHost', { version: latestNotCompatible.version, host: latestNotCompatible.requiredHost, mainHost: UI_PLUGIN_HOST_APP }, true);
+            item.incompatibleHost = this.t('plugins.incompatibleHost', {
+              version: latestNotCompatible.version, host: latestNotCompatible.requiredHost, mainHost: UI_PLUGIN_HOST_APP
+            }, true);
           }
         }
 

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -31,12 +31,12 @@ import {
   uiPluginAnnotation,
   uiPluginHasAnnotation,
   isSupportedChartVersion,
-  isChartVersionAvailableForInstall,
   isChartVersionHigher,
   UI_PLUGIN_NAMESPACE,
   UI_PLUGIN_CHART_ANNOTATIONS,
   UI_PLUGINS_REPO_URL,
-  UI_PLUGINS_PARTNERS_REPO_URL
+  UI_PLUGINS_PARTNERS_REPO_URL,
+  UI_PLUGIN_HOST_APP
 } from '@shell/config/uiplugins';
 import TabTitle from '@shell/components/TabTitle';
 
@@ -260,12 +260,12 @@ export default {
         item.chart = chart;
 
         // Filter the versions available to install (plugins-api version and current dashboard version)
-        item.installableVersions = item.versions.filter((version) => isSupportedChartVersion({ version, kubeVersion: this.kubeVersion }) && isChartVersionAvailableForInstall({
+        item.installableVersions = item.versions.filter((version) => isSupportedChartVersion({
           version, rancherVersion: this.rancherVersion, kubeVersion: this.kubeVersion
         }));
 
         // add prop to version object if version is compatible with the current dashboard version
-        item.versions = item.versions.map((version) => isChartVersionAvailableForInstall({
+        item.versions = item.versions.map((version) => isSupportedChartVersion({
           version, rancherVersion: this.rancherVersion, kubeVersion: this.kubeVersion
         }, true));
 
@@ -285,6 +285,8 @@ export default {
             item.incompatibleRancherVersion = this.t('plugins.incompatibleRancherVersion', { version: latestNotCompatible.version, rancherVersion: latestNotCompatible.requiredUiVersion }, true);
           } else if (!item.isCompatibleWithKubeVersion) {
             item.incompatibleKubeVersion = this.t('plugins.incompatibleKubeVersion', { version: latestNotCompatible.version, kubeVersion: latestNotCompatible.requiredKubeVersion }, true);
+          } else if (!item.isCompatibleWithHost) {
+            item.incompatibleHost = this.t('plugins.incompatibleHost', { version: latestNotCompatible.version, host: UI_PLUGIN_HOST_APP }, true);
           }
         }
 
@@ -855,6 +857,10 @@ export default {
                         v-else-if="plugin.incompatibleKubeVersion"
                         class="incompatible"
                       >{{ plugin.incompatibleKubeVersion }}</p>
+                      <p
+                        v-else-if="plugin.incompatibleHost"
+                        class="incompatible"
+                      >{{ plugin.incompatibleHost }}</p>
                     </span>
                   </div>
                   <!-- plugin badges -->


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11996 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix problem with `semver.satifies` and version strings with suffixes by removing them using `semver.coerce` (removes `-rcXXX`, `-head`, `-013565asd123sdf34-head`, etc)
- have special logic to do a rancher version check as in `-head` versions of Rancher, the rancher version check is not employed by the backend, therefore we can't rely on it and do it on the frontend side
- remove duplicated method `isChartVersionAvailableForInstall ` as it was duplicated with `isSupportedChartVersion ` and adjust logic
- This will also fix a related problem that Elemental QA just reported. Check issue body

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- Will need forward-porting to `master`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
