### PR TITLE
Simplify InputOrDisplay.vue component

### DIFF
--- a/shell/components/InputOrDisplay.vue
+++ b/shell/components/InputOrDisplay.vue
@@ -1,5 +1,4 @@
 <script>
-import { h, computed } from 'vue';
 import { _VIEW } from '@shell/config/query-params';
 
 export default {
@@ -18,30 +17,36 @@ export default {
       default: 'edit'
     }
   },
-  setup(props, { slots }) {
-    const isView = computed(() => props.mode === _VIEW);
+  computed: {
+    isView() {
+      return this.mode === _VIEW;
+    },
 
-    const displayValue = computed(() => {
-      if (Array.isArray(props.value) && props.value.length === 0) {
+    displayValue() {
+      if (Array.isArray(this.value) && this.value.length === 0) {
         return '';
       } else {
-        return props.value;
+        return this.value;
       }
-    });
-
-    return () => {
-      if (isView.value) {
-        return h('div', { class: 'label' }, [
-          h('div', { class: 'text-label' }, slots.name ? slots.name : props.name),
-          h('div', { class: 'value' }, slots.value ? slots.value : displayValue.value)
-        ]);
-      } else {
-        return slots.default;
-      }
-    };
+    }
   }
 };
 </script>
+
+<template>
+  <div
+    v-if="isView"
+    class="label"
+  >
+    <div class="text-label">
+      {{ $slots.name || name }}
+    </div>
+    <div class="value">
+      {{ $slots.value || displayValue }}
+    </div>
+  </div>
+  <slot v-else />
+</template>
 
 <style lang="scss" scoped>
 .label {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

On Harvester, we have some errors when using the `InputOrDisplay` component as a container - probably something related to the use of `setup` function or dynamic HTML build.

https://github.com/torchiaf/harvester/blob/62da7658669d156d63b0d385a2978ab9d37637de/pkg/harvester/edit/kubevirt.io.virtualmachine/VirtualMachineCpuMemory.vue#L81-L94

![image](https://github.com/user-attachments/assets/0f93bb32-40de-4bb1-a872-962bd9772b9f)

The current PR just simplify the implementation and fixes the issue.

After

![image](https://github.com/user-attachments/assets/2c68d0f5-beb2-4d78-ae65-2ce5d619a338)

<!-- Define findings related to the feature or bug issue. -->

