### PR TITLE
Adding missing emits values to sortable table

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -41,7 +41,7 @@ import { FORMATTERS } from '@shell/components/SortableTable/sortable-config';
 export default {
   name: 'SortableTable',
 
-  emits: ['clickedActionButton', 'pagination-changed', 'group-value-change'],
+  emits: ['clickedActionButton', 'pagination-changed', 'group-value-change', 'selection', 'rowClick'],
 
   components: {
     THead, Checkbox, AsyncButton, ActionDropdown, LabeledSelect


### PR DESCRIPTION

### Summary
These emits were being done within the selection.js mixin. I looked through all the other mixins and didn't find additional emits.

I noticed this while working on harvester.

### Areas or cases that should be tested
You can try selecting items on listing pages and look to see if there's emit warnings in the console.

### Areas which could experience regressions
None, emits really don't seem to do much more than annotate interfaces. 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
