### PR TITLE
Fix issues with loading chart steps

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -5,6 +5,7 @@ import isEqual from 'lodash/isEqual';
 import { mapPref, DIFF } from '@shell/store/prefs';
 import { mapFeature, MULTI_CLUSTER, LEGACY } from '@shell/store/features';
 import { mapGetters } from 'vuex';
+import { markRaw } from 'vue';
 import { Banner } from '@components/Banner';
 import ButtonGroup from '@shell/components/ButtonGroup';
 import ChartReadme from '@shell/components/ChartReadme';
@@ -931,19 +932,20 @@ export default {
     },
 
     async loadChartStep(customStep) {
-      // Broken in 2.10, see https://github.com/rancher/dashboard/issues/11898
-      const loaded = await customStep.component();
+      const importer = customStep;
+
+      const loaded = await importer.component.__asyncLoader();
       const withFallBack = this.$store.getters['i18n/withFallback'];
 
       return {
         name:      customStep.name,
-        label:     withFallBack(loaded?.default?.label, null, customStep.name),
-        subtext:   withFallBack(loaded?.default?.subtext, null, ''),
-        weight:    loaded?.default?.weight,
+        label:     withFallBack(loaded?.label, null, customStep.name),
+        subtext:   withFallBack(loaded?.subtext, null, ''),
+        weight:    loaded?.weight,
         ready:     false,
         hidden:    true,
         loading:   true,
-        component: customStep.component,
+        component: markRaw(customStep.component),
       };
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This ensures that custom chart steps will properly render in the install wizard by:

- awaiting the `__asyncLoader` function used internally by Vue to load the component
- updating how component props are accessed to comply with Vue3
- using `markRaw` to ensure that the Vue does not mark the component to load as a reactive object in data

Fixes #11898 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
 
The `__asyncLoader` property is an internal property that is used by Vue to load the component asynchronously. It's not intended to be used directly in code, but I don't think that we have a better approach for ensuring that an async component has loaded before accessing its props. This approach was pulled from a previous solution to address issues in resource list[^1].

[^1]: https://github.com/rancher/dashboard/commit/4f1eb7ee33fec906f7a990d0660c2df0844841fa 
 
### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Loading custom steps when installing charts (repro steps in associated issue)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Loading custom steps when installing charts

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
