### PR TITLE
Fix Ingress Rule Path CSS

### DIFF
--- a/shell/edit/networking.k8s.io.ingress/RulePath.vue
+++ b/shell/edit/networking.k8s.io.ingress/RulePath.vue
@@ -181,36 +181,27 @@ export default {
   </div>
 </template>
 <style lang="scss" scoped>
+// TODO #11952: Correct deep statement
 $row-height: 40px;
-
-.labeled-input :deep(), :deep() .labeled-input {
-  padding: 0 !important;
-  height: 100%;
-  input.no-label {
-    height: calc($row-height - 2px);
-    padding: 10px;
-  }
-}
-.rule-path :deep() {
-  .col, INPUT {
-    height: $row-height;
-  }
-
-  .unlabeled-select {
+.rule-path {
+  :deep(.labeled-input), :deep(.labeled-input) {
+    padding: 0 !important;
     height: 100%;
-  }
 
-  .path-type {
-    .unlabeled-select {
-      min-width: 200px;
+    input.no-label {
+      height: calc($row-height - 2px);
+      padding: 10px;
     }
   }
 
-  &, .input-container {
+  :deep(.col), INPUT {
+    height: $row-height;
+  }
+  &, :deep(.input-container) {
     height: $row-height;
   }
 
-  .input-container .in-input.unlabeled-select {
+  :deep(.input-container) :deep(.in-input.unlabeled-select) {
     width: initial;
   }
 
@@ -218,11 +209,16 @@ $row-height: 40px;
     line-height: $row-height;
   }
 
-  .v-select INPUT {
+  :deep(.v-select) INPUT {
     height: 50px;
   }
-  .labeled-input {
+  :deep(.labeled-input) {
     padding-top: 6px;
+  }
+
+  :deep(.unlabeled-select) {
+    height: 100%;
+    min-width: 200px;
   }
 }
 </style>

--- a/shell/edit/networking.k8s.io.ingress/RulePath.vue
+++ b/shell/edit/networking.k8s.io.ingress/RulePath.vue
@@ -184,7 +184,7 @@ export default {
 // TODO #11952: Correct deep statement
 $row-height: 40px;
 .rule-path {
-  :deep(.labeled-input), :deep(.labeled-input) {
+  :deep(.labeled-input) {
     padding: 0 !important;
     height: 100%;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12011

Although I have not been able to reproduce a case where the definition breaks (https://codesandbox.io/p/sandbox/yy4cgk), this PR addresses the styling issue by correcting the `:deep()` definition got lost during the migration.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
Navigate to `Ingress edit > Rule path` (e.g.: `/c/local/explorer/networking.k8s.io.ingress/create#rules`

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

![Screenshot 2024-09-23 at 18 05 46](https://github.com/user-attachments/assets/7245a5df-9df9-48ab-ab52-e216e3ec0073)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
