### PR TITLE
Fix sorting for user retention fields

### DIFF
--- a/shell/models/management.cattle.io.user.js
+++ b/shell/models/management.cattle.io.user.js
@@ -105,7 +105,7 @@ export default class User extends HybridModel {
    * @returns {number}
    */
   get userLastLogin() {
-    return this.metadata?.labels?.['cattle.io/last-login'] * 1000;
+    return this.metadata?.labels?.['cattle.io/last-login'] * 1000 || 0;
   }
 
   /**
@@ -113,7 +113,7 @@ export default class User extends HybridModel {
    * @returns {number}
    */
   get userDisabledIn() {
-    return this.metadata?.labels?.['cattle.io/disable-after'] * 1000;
+    return this.metadata?.labels?.['cattle.io/disable-after'] * 1000 || 0;
   }
 
   /**
@@ -129,7 +129,7 @@ export default class User extends HybridModel {
    * @returns {number}
    */
   get userDeletedIn() {
-    return this.metadata?.labels?.['cattle.io/delete-after'] * 1000;
+    return this.metadata?.labels?.['cattle.io/delete-after'] * 1000 || 0;
   }
 
   get state() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This fixes an issue with sorting user retention values in in the users table by defaulting to 0 in the event that the value would be `undefined`.

Fixes #12013 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Default to 0 instead of `undefined`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

It appears that sortable table does not sort nicely when working with values like `undefined`; the table will end up with a mixture of values that are sorted in seeming random order. This might be a good area to investigate in the future.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Sorting by Last Login, Disabled In, Deleted In in the users table 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Sorting by Last Login, Disabled In, Deleted In in the users table

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/user-attachments/assets/81bd6bff-673d-49e8-b56b-4352d221695d)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
