### PR TITLE
Vue3: Fixed navigation active style not applied

### DIFF
--- a/cypress/e2e/tests/navigation/side-nav/product-side-nav.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/product-side-nav.spec.ts
@@ -2,9 +2,21 @@ import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import WorkloadPagePo from '@/cypress/e2e/po/pages/explorer/workloads.po';
+import { WorkloadsDeploymentsListPagePo } from '@/cypress/e2e/po/pages/explorer/workloads/workloads-deployments.po';
+import { createDeploymentBlueprint } from '@/cypress/e2e/blueprints/explorer/workloads/deployments/deployment-create';
+
+const { name: workloadName, namespace } = createDeploymentBlueprint.metadata;
+const deploymentsListPage = new WorkloadsDeploymentsListPagePo('local');
 
 Cypress.config();
 describe('Side navigation: Cluster ', { tags: ['@navigation', '@adminUser'] }, () => {
+  before(() => {
+    cy.login();
+    cy.intercept('GET', `/v1/apps.deployments/${ namespace }/${ workloadName }`).as('testWorkload');
+
+    deploymentsListPage.goTo();
+    deploymentsListPage.createWithKubectl(createDeploymentBlueprint);
+  });
   beforeEach(() => {
     cy.login();
 
@@ -52,6 +64,21 @@ describe('Side navigation: Cluster ', { tags: ['@navigation', '@adminUser'] }, (
     cy.get('@closedGroup').find('.router-link-active').should('have.length.gt', 0);
   });
 
+  it('Going into resource detail should keep relevant group active', () => {
+    const productNavPo = new ProductNavPo();
+
+    productNavPo.groups().get('.expanded').as('openGroup');
+
+    productNavPo.visibleNavTypes().eq(1).should('be.visible').click(); // Go into Workloads
+    const workload = new WorkloadPagePo('local');
+
+    workload.goTo();
+    workload.waitForPage();
+    workload.goToDetailsPage(workloadName);
+    cy.get('@openGroup').should('be.visible');
+    cy.get('@openGroup').find('.router-link-active').should('have.length.gt', 0);
+  });
+
   it('Should access to every navigation provided from the server link, including nested cases, without errors', () => {
     const productNavPo = new ProductNavPo();
     // iterate through top-level groups
@@ -96,5 +123,12 @@ describe('Side navigation: Cluster ', { tags: ['@navigation', '@adminUser'] }, (
       // Clicking back should take us back to workloads
       productNavPo.tabHeaders().eq(1).click(1, 1).then(() => cy.url().should('equal', workloadsUrl));
     });
+  });
+
+  after(() => {
+    cy.login();
+    deploymentsListPage?.goTo();
+
+    deploymentsListPage.deleteWithKubectl(workloadName, namespace);
   });
 });

--- a/shell/components/nav/Type.vue
+++ b/shell/components/nav/Type.vue
@@ -54,6 +54,13 @@ export default {
       const inStore = this.$store.getters['currentStore'](this.type.name);
 
       return this.$store.getters[`${ inStore }/count`]({ name: this.type.name });
+    },
+
+    isActive() {
+      const typeFullPath = this.$router.resolve(this.type.route)?.fullPath.toLowerCase();
+      const pageFullPath = this.$route.fullPath?.toLowerCase();
+
+      return (pageFullPath.indexOf(typeFullPath) >= 0);
     }
 
   },
@@ -81,7 +88,7 @@ export default {
   <router-link
     v-if="type.route"
     :key="type.name"
-    v-slot="{ href, navigate, isActive, isExactActive }"
+    v-slot="{ href, navigate,isExactActive }"
     custom
     :to="type.route"
   >

--- a/shell/components/nav/Type.vue
+++ b/shell/components/nav/Type.vue
@@ -60,15 +60,16 @@ export default {
       const typeFullPath = this.$router.resolve(this.type.route)?.fullPath.toLowerCase();
       const pageFullPath = this.$route.fullPath?.toLowerCase();
 
-      if( !this.type.exact) {
+      if ( !this.type.exact) {
         const typeSplit = typeFullPath.split('/');
         const pageSplit = pageFullPath.split('/');
 
         for (let index = 0; index < typeSplit.length; ++index) {
-            if( index >= pageSplit.length || typeSplit[index] !== pageSplit[index] ){
-                return false;
-            }
+          if ( index >= pageSplit.length || typeSplit[index] !== pageSplit[index] ) {
+            return false;
+          }
         }
+
         return true;
       }
 

--- a/shell/components/nav/Type.vue
+++ b/shell/components/nav/Type.vue
@@ -60,7 +60,19 @@ export default {
       const typeFullPath = this.$router.resolve(this.type.route)?.fullPath.toLowerCase();
       const pageFullPath = this.$route.fullPath?.toLowerCase();
 
-      return (pageFullPath.indexOf(typeFullPath) >= 0);
+      if( !this.type.exact) {
+        const typeSplit = typeFullPath.split('/');
+        const pageSplit = pageFullPath.split('/');
+
+        for (let index = 0; index < typeSplit.length; ++index) {
+            if( index >= pageSplit.length || typeSplit[index] !== pageSplit[index] ){
+                return false;
+            }
+        }
+        return true;
+      }
+
+      return typeFullPath === pageFullPath;
     }
 
   },

--- a/shell/components/nav/__tests__/Type.test.ts
+++ b/shell/components/nav/__tests__/Type.test.ts
@@ -2,7 +2,7 @@ import { nextTick } from 'vue';
 import { shallowMount, RouterLinkStub } from '@vue/test-utils';
 import Type from '@shell/components/nav/Type.vue';
 import { createChildRenderingRouterLinkStub } from '@shell/utils/unit-tests/ChildRenderingRouterLinkStub';
-import { TYPE_MODES } from '@shell/store/type-map';
+import { TYPE_MODES } from '@shell/store/type-map.js';
 
 // Configuration
 const activeClass = 'router-link-active';
@@ -25,6 +25,12 @@ describe('component: Type', () => {
         'cluster/count': () => defaultCount,
       }
     };
+    const routerMock = {
+      resolve: jest.fn((route) => {
+        return { fullPath: route };
+      })
+    };
+    const routeMock = { fullPath: 'route' };
 
     describe('should pass props correctly', () => {
       it('should forward Type props to router-link', () => {
@@ -33,8 +39,10 @@ describe('component: Type', () => {
 
           global: {
             directives: { cleanHtml: (identity) => identity },
-            mocks:      { $store: storeMock },
-            stubs:      { routerLink: RouterLinkStub },
+            mocks:      {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
+            stubs: { routerLink: RouterLinkStub },
           },
         });
 
@@ -51,7 +59,9 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
             stubs: { routerLink: createChildRenderingRouterLinkStub({ href: fakeHref }) },
           },
         });
@@ -69,8 +79,10 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
-            stubs: { routerLink: createChildRenderingRouterLinkStub({ isActive: true, navigate }) },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
+            stubs: { routerLink: createChildRenderingRouterLinkStub({ navigate }) },
           },
         });
 
@@ -90,8 +102,10 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
-            stubs: { routerLink: createChildRenderingRouterLinkStub({ isActive: false }) },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: { fullPath: 'bad' }
+            },
+            stubs: { routerLink: createChildRenderingRouterLinkStub() },
           },
         });
 
@@ -107,7 +121,9 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
             stubs: { routerLink: createChildRenderingRouterLinkStub({ isExactActive: false }) },
           },
         });
@@ -124,7 +140,9 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
             stubs: { routerLink: createChildRenderingRouterLinkStub() },
           },
         });
@@ -143,8 +161,10 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
-            stubs: { routerLink: createChildRenderingRouterLinkStub({ isActive: true }) },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
+            stubs: { routerLink: createChildRenderingRouterLinkStub() },
           },
         });
 
@@ -160,7 +180,9 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
             stubs: { routerLink: createChildRenderingRouterLinkStub({ isExactActive: true }) },
           },
         });
@@ -177,7 +199,9 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
             stubs: { routerLink: createChildRenderingRouterLinkStub() },
           },
         });
@@ -194,7 +218,9 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
             stubs: { routerLink: createChildRenderingRouterLinkStub() },
           },
         });
@@ -211,7 +237,9 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
             stubs: { routerLink: createChildRenderingRouterLinkStub() },
           },
         });
@@ -230,7 +258,9 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
 
             stubs: {
               routerLink: createChildRenderingRouterLinkStub(),
@@ -256,7 +286,9 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
 
             stubs: {
               routerLink: createChildRenderingRouterLinkStub(),
@@ -277,7 +309,9 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
 
             stubs: {
               routerLink: createChildRenderingRouterLinkStub(),
@@ -306,7 +340,9 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
 
             stubs: {
               routerLink: createChildRenderingRouterLinkStub(),
@@ -327,7 +363,9 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
 
             stubs: {
               routerLink: createChildRenderingRouterLinkStub(),
@@ -355,7 +393,9 @@ describe('component: Type', () => {
                   currentStore:    () => 'cluster',
                   'cluster/count': () => null,
                 }
-              }
+              },
+              $router: routerMock,
+              $route:  routeMock
             },
 
             stubs: {
@@ -379,7 +419,9 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
 
             stubs: {
               routerLink: createChildRenderingRouterLinkStub(),
@@ -400,7 +442,9 @@ describe('component: Type', () => {
           global: {
             directives: { cleanHtml: (identity) => identity },
 
-            mocks: { $store: storeMock },
+            mocks: {
+              $store: storeMock, $router: routerMock, $route: routeMock
+            },
 
             stubs: {
               routerLink: createChildRenderingRouterLinkStub(),


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11904 
<!-- Define findings related to the feature or bug issue. -->
In Vue 3, isActive behavior has changed:
https://router.vuejs.org/guide/essentials/active-links#When-are-links-active-
https://v3.router.vuejs.org/api/#active-class

Created computed property that matches old behavior to use instead of router's isActive.

Note: If you navigate to workloads, close group tab and re-open it again, 'Workload' tab is not highlighted. This is unrelated to Vue3 migration and can be reproduced on 2.9. It is not part of this fix and we might want to address it in the future.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Changed behavior to match Vue2

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Go to "Local" cluster -> Workloads -> Pods
2. Click on any pod to go into "Details" page
3. "Pods" should still be selected in side nav

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Side bar navigation

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/c16fb751-e5ac-4ddc-9f86-a1b271744800


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
