### PR TITLE
Allow users to specify that an array list is required

### DIFF
--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -80,6 +80,10 @@ export default {
       type:    Boolean,
       default: false,
     },
+    required: {
+      type:    Boolean,
+      default: false
+    },
     rules: {
       default:   () => [],
       type:      Array,
@@ -230,6 +234,10 @@ export default {
       <slot name="title">
         <h3>
           {{ title }}
+          <span
+            v-if="required"
+            class="required"
+          >*</span>
           <i
             v-if="showProtip"
             v-clean-tooltip="protip"
@@ -369,6 +377,11 @@ export default {
   .title {
     margin-bottom: 10px;
   }
+
+  .required {
+    color: var(--error);
+  }
+
   .box {
     display: grid;
     grid-template-columns: auto $array-list-remove-margin;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This is in support of Harvester. The forked version of ArrayListSelect was using this field in this way:
![image](https://github.com/user-attachments/assets/1805c171-6aa1-4bc9-9d98-5b5be193c4d1)

### Areas or cases that should be tested
You can add the required field to any array list which has a title.

### Areas which could experience regressions
Shouldn't be any. Respects the existing default of false.

### Screenshot/Video
This change adds the exact same visual that was present in harvester even though I don't love it:
![arraylist-required](https://github.com/user-attachments/assets/99329176-2182-4d66-9f78-0d9a250d4de9)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
