### PR TITLE
Check for supported API version annotation when loading extensions

### DIFF
--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -142,6 +142,20 @@ export default class ExtensionsPagePo extends PagePo {
     return this.extensionCard(extensionName).getId(`extension-card-uninstall-btn-${ extensionName }`).click();
   }
 
+  extensionCardErrorTooltip(extensionName: string): Cypress.Chainable {
+    return this.extensionCard(extensionName).getId(`extension-card-error-${ extensionName }`);
+  }
+
+  extensionCardErrorTooltipContent(extensionName: string): Cypress.Chainable {
+    return this.extensionCardErrorTooltip(extensionName).trigger('mouseenter').then(() => {
+      return cy.get('.v-popper__popper.v-popper--theme-tooltip .v-popper__inner');
+    });
+  }
+
+  extensionCardInstallButton(extensionName: string): Cypress.Chainable {
+    return this.extensionCard(extensionName).getId(`extension-card-install-btn-${ extensionName }`);
+  }
+
   // ------------------ extension install modal ------------------
   extensionInstallModal() {
     return this.self().get('[data-modal="installPluginDialog"]');
@@ -203,6 +217,10 @@ export default class ExtensionsPagePo extends PagePo {
 
   extensionDetailsCloseClick(): Cypress.Chainable {
     return this.extensionDetails().getId('extension-details-close').click();
+  }
+
+  extensionDetailsErrorBanner(): Cypress.Chainable {
+    return this.extensionDetails().getId('extension-details-error');
   }
 
   // ------------------ extension tabs ------------------

--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -441,4 +441,162 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     extensionsPo.extensionCardClick(DISABLED_CACHE_EXTENSION_NAME);
     extensionsPo.extensionDetailsTitle().should('contain', DISABLED_CACHE_EXTENSION_NAME);
   });
+
+  it.skip('[Vue3 Skip]: Should display error for installed extension without required API version annotation', () => {
+    const extensionsPo = new ExtensionsPagePo();
+
+    extensionsPo.addExtensionsRepository('https://github.com/rancher/ui-plugin-examples', 'main', 'rancher-plugin-examples');
+
+    // Intercept the request fetching chart data to modify the 'clock' extension
+    cy.intercept('GET', '/v1/catalog.cattle.io.clusterrepos*', (req) => {
+      req.continue((res) => {
+        if (res.body && res.body.data) {
+          res.body.data.forEach((chart) => {
+            if (chart.metadata.name === 'clock') {
+              // Remove the required API annotation to simulate the missing condition
+              delete chart.versions[0].annotations['catalog.cattle.io/ui-extensions-version'];
+            }
+          });
+        }
+      });
+    });
+
+    extensionsPo.goTo();
+    extensionsPo.extensionTabAvailableClick();
+
+    extensionsPo.extensionCardInstallClick('clock');
+    extensionsPo.extensionInstallModal().should('be.visible');
+    extensionsPo.installModalInstallClick();
+
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
+
+    extensionsPo.extensionTabInstalledClick();
+
+    // Verify that the 'clock' extension card displays an error icon with tooltip
+    extensionsPo.extensionCardErrorTooltip('clock').should('exist');
+    extensionsPo.extensionCardErrorTooltipContent('clock').should('contain', 'This Extension is not compatible with the current Extensions API version');
+
+    extensionsPo.extensionCardClick('clock');
+
+    // Verify that the extension details display an error banner with the correct message
+    extensionsPo.extensionDetailsErrorBanner().should('contain', 'This Extension is not compatible with the current Extensions API version');
+
+    extensionsPo.extensionDetailsCloseClick();
+
+    extensionsPo.extensionCardUninstallClick('clock');
+    extensionsPo.extensionUninstallModal().should('be.visible');
+    extensionsPo.uninstallModaluninstallClick();
+
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
+
+    extensionsPo.extensionTabInstalledClick();
+    extensionsPo.extensionCard('clock').should('not.exist');
+  });
+
+  it.skip('[Vue3 Skip]: Should display error for installed extension with outdated required API version', () => {
+    const extensionsPo = new ExtensionsPagePo();
+
+    extensionsPo.addExtensionsRepository('https://github.com/rancher/ui-plugin-examples', 'main', 'rancher-plugin-examples');
+
+    // Intercept the request fetching chart data to modify the 'clock' extension
+    cy.intercept('GET', '/v1/catalog.cattle.io.clusterrepos*', (req) => {
+      req.continue((res) => {
+        if (res.body && res.body.data) {
+          res.body.data.forEach((chart) => {
+            if (chart.metadata.name === 'clock') {
+              // Set the required API version to a value less than UI_EXTENSIONS_API_VERSION
+              chart.versions[0].annotations['catalog.cattle.io/ui-extensions-version'] = '>=2.0.0';
+            }
+          });
+        }
+      });
+    });
+
+    extensionsPo.goTo();
+    extensionsPo.extensionTabAvailableClick();
+
+    extensionsPo.extensionCardInstallClick('clock');
+    extensionsPo.extensionInstallModal().should('be.visible');
+    extensionsPo.installModalInstallClick();
+
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
+
+    extensionsPo.extensionTabInstalledClick();
+
+    // Verify that the 'clock' extension card displays an error icon with tooltip
+    extensionsPo.extensionCardErrorTooltip('clock').should('exist');
+    extensionsPo.extensionCardErrorTooltipContent('clock').should('contain', 'This Extension is not compatible with the current Extensions API version');
+
+    extensionsPo.extensionCardClick('clock');
+
+    // Verify that the extension details display an error banner with the correct message
+    extensionsPo.extensionDetailsErrorBanner().should('contain', 'This Extension is not compatible with the current Extensions API version');
+
+    extensionsPo.extensionDetailsCloseClick();
+
+    extensionsPo.extensionCardUninstallClick('clock');
+    extensionsPo.extensionUninstallModal().should('be.visible');
+    extensionsPo.uninstallModaluninstallClick();
+
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
+
+    extensionsPo.extensionTabInstalledClick();
+    extensionsPo.extensionCard('clock').should('not.exist');
+  });
+
+  it.skip('[Vue3 Skip]: Should successfully install extension with satisfying required API version', () => {
+    const extensionsPo = new ExtensionsPagePo();
+
+    extensionsPo.addExtensionsRepository('https://github.com/rancher/ui-plugin-examples', 'main', 'rancher-plugin-examples');
+
+    // Intercept the request fetching chart data to modify the 'clock' extension
+    cy.intercept('GET', '/v1/catalog.cattle.io.clusterrepos*', (req) => {
+      req.continue((res) => {
+        if (res.body && res.body.data) {
+          res.body.data.forEach((chart) => {
+            if (chart.metadata.name === 'clock') {
+              // Set the required API version to a value that satisfies the UI version
+              chart.versions[0].annotations['catalog.cattle.io/ui-extensions-version'] = '>=3.0.0';
+            }
+          });
+        }
+      });
+    });
+
+    extensionsPo.goTo();
+    extensionsPo.extensionTabAvailableClick();
+
+    extensionsPo.extensionCardInstallClick('clock');
+    extensionsPo.extensionInstallModal().should('be.visible');
+    extensionsPo.installModalInstallClick();
+
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
+
+    extensionsPo.extensionTabInstalledClick();
+
+    // Verify that the 'clock' extension card does not display an error icon
+    extensionsPo.extensionCardErrorTooltip('clock').should('not.exist');
+
+    extensionsPo.extensionCardClick('clock');
+
+    // Verify that the extension details do not display an error banner
+    extensionsPo.extensionDetailsErrorBanner().should('not.exist');
+
+    extensionsPo.extensionDetailsCloseClick();
+
+    extensionsPo.extensionCardUninstallClick('clock');
+    extensionsPo.extensionUninstallModal().should('be.visible');
+    extensionsPo.uninstallModaluninstallClick();
+
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
+
+    extensionsPo.extensionTabInstalledClick();
+    extensionsPo.extensionCard('clock').should('not.exist');
+  });
 });

--- a/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
+++ b/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
@@ -189,6 +189,7 @@ export default {
             v-if="info.error"
             color="error"
             :label="info.error"
+            data-testid="extension-details-error"
             class="mt-10"
           />
           <Banner

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -888,6 +888,7 @@ export default {
                     <div
                       v-clean-tooltip="plugin.error"
                       class="plugin-error"
+                      :data-testid="`extension-card-error-${plugin.name}`"
                     >
                       <i class="icon icon-warning" />
                     </div>

--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -362,6 +362,10 @@ const getVirtualModulesAutoImport = (dir) => {
   return new VirtualModulesPlugin(autoImportTypes);
 };
 
+// Get current shell version
+const shellPkgRawData = fs.readFileSync(path.join(__dirname, 'package.json'));
+const shellPkgData = JSON.parse(shellPkgRawData);
+
 /**
  * DefinePlugin does string replacement within our code. We may want to consider replacing it with something else. In code we'll see something like
  * process.env.commit even though process and env aren't even defined objects. This could cause people to be mislead.
@@ -377,6 +381,7 @@ const createEnvVariablesPlugin = (routerBasePath, rancherEnv) => new webpack.Def
   'process.env.rancherEnv':                JSON.stringify(rancherEnv),
   'process.env.harvesterPkgUrl':           JSON.stringify(process.env.HARVESTER_PKG_URL),
   'process.env.api':                       JSON.stringify(api),
+  'process.env.UI_EXTENSIONS_API_VERSION': JSON.stringify(shellPkgData.version),
   // Store the Router Base as env variable that we can use in `shell/config/router.js`
   'process.env.routerBase':                JSON.stringify(routerBasePath),
   __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11695 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Replaced the environment variable injection for `UI_EXTENSIONS_API_VERSION` in `vue.config.js`
- Updated the condition to load an extension based on the extensions api version annotation
  - Now when an extension does __not__  contain the `catalog.cattle.io/ui-extensions-version` annotation it will now be considered a legacy extension, and will not be loaded
  - This annotation will now be required for Vue3 extensions and will need to have a version `>= 3.0.0`
- Added a small method to coerce the `UI_EXTENSIONS_API_VERSION` to remove any pre-release modifiers

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Load an extension with the required API version `>= 3.0.0`
- Load an extension with the required API version `>= 2.0.0` 
- Load an extension without the `catalog.cattle.io/ui-extensions-version` annotation

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![1](https://github.com/user-attachments/assets/c14e585c-6e8a-41d5-9f89-6fb6af70d488)
![2](https://github.com/user-attachments/assets/cca62928-30db-48e6-9635-bf101f898434)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
