### PR TITLE
[UI] - Adding logic to enable init.sh execution on Alpine Linux

### DIFF
--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -3,6 +3,10 @@
 set -x
 set -e
 
+if cat /etc/os-release | grep -iq "Alpine Linux"; then
+ apk update && apk add --no-cache gcompat g++ make
+fi
+
 OS="$(uname -s)"
 case "${OS}" in
     Linux*)     MACHINE=amd64;;
@@ -55,8 +59,11 @@ mv semver "${WORKSPACE}/bin"
 
 ls -al "${WORKSPACE}"
 export PATH=$PATH:"${WORKSPACE}/go/bin:${WORKSPACE}/bin"
+export GOROOT="${WORKSPACE}/go"
 echo "${PATH}"
 
+
+ls -al "${WORKSPACE}/go"
 go version
 
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
First part of https://github.com/rancher/qa-tasks/issues/1549

### Occurred changes and/or fixed issues
Adding logic to execute the Jenkins CI initialization script on Alpine Linux images. This allows the execution on the new runners.
Explicitly set the `GOROOT` to the downloaded golang extracted tar.
Everything else is shell agnostic and runs transparently in then `ash` shell.

### Technical notes summary
Alpine Linux isn't binary compatible by default with the golang Linux binaries as it ships with the C lib `musl`. The go binaries require `glibc`. Adding `gcompat` fix this.

### Areas or cases that should be tested
Jenkins

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] ~~The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes~~
