### PR TITLE
[Backport 2.9] Adding translation for OVHCloud Managed Kubernetes Service

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1918,6 +1918,7 @@ cluster:
     oracleoke: Oracle OKE
     otc: Open Telekom Cloud
     other: Other
+    ovhcloudmks: OVHcloud MKS
     packet: Equinix Metal
     pinganyunecs: Pinganyun ECS
     pnap: phoenixNAP

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -1796,6 +1796,7 @@ cluster:
     oracleoke: Oracle OKE
     otc: Open Telekom Cloud
     other: 其他
+    ovhcloudmks: OVHcloud MKS
     packet: Equinix Metal
     pinganyunecs: 平安云 ECS
     pnap: phoenixNAP


### PR DESCRIPTION
2.9 Backport of #12021

Signed-off-by: Mohamed Belgaied Hassine <belgaied2@hotmail.com>

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This PR adds a translation for `ovhcloudmks` kontainer driver, so that it can show correctly `OVHcloud MKS` in the UI.
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes 
Adds 2 lines with a mapping ovhcloudmks: OVHCloud MKS in the translation yaml files.

### Technical notes summary
Simple

### Areas or cases that should be tested
Nothing in particular, OVH will test this.

### Areas which could experience regressions
Risk is extremely low for regressions

### Checklist
- [X] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [X] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] tests are not needed
- [x] there are no UX changes
