### PR TITLE
Create new `ButtonMultiAction.vue` component

### DIFF
--- a/shell/components/ButtonMultiAction.vue
+++ b/shell/components/ButtonMultiAction.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { computed, defineEmits } from 'vue';
+
+defineEmits(['click']);
+
+type Props = {
+  borderless?: boolean;
+  invisible?: boolean;
+}
+
+const props = defineProps<Props>();
+
+const buttonClass = computed(() => {
+  return {
+    borderless: props?.borderless,
+    invisible:  props?.invisible,
+  };
+});
+</script>
+
+<template>
+  <button
+    type="button"
+    class="btn btn-sm role-multi-action actions"
+    :class="buttonClass"
+    @click="(e: Event) => $emit('click', e)"
+  >
+    <i class="icon icon-actions" />
+  </button>
+</template>
+
+<style lang="scss" scoped>
+.borderless {
+  background-color: transparent;
+  border: none;
+  &:hover, &:focus {
+    background-color: var(--accent-btn);
+    box-shadow: none;
+  }
+}
+</style>

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -10,6 +10,7 @@ import ExtensionPanel from '@shell/components/ExtensionPanel';
 import Masthead from '@shell/components/ResourceList/Masthead';
 import { mapPref, GROUP_RESOURCES, ALL_NAMESPACES } from '@shell/store/prefs';
 import MoveModal from '@shell/components/MoveModal';
+import ButtonMultiAction from '@shell/components/ButtonMultiAction.vue';
 
 import { NAMESPACE_FILTER_ALL_ORPHANS } from '@shell/utils/namespace-filter';
 import ResourceFetch from '@shell/mixins/resource-fetch';
@@ -18,7 +19,11 @@ import DOMPurify from 'dompurify';
 export default {
   name:       'ListProjectNamespace',
   components: {
-    ExtensionPanel, Masthead, MoveModal, ResourceTable
+    ExtensionPanel,
+    Masthead,
+    MoveModal,
+    ResourceTable,
+    ButtonMultiAction,
   },
   mixins: [ResourceFetch],
 
@@ -430,14 +435,12 @@ export default {
             >
               {{ t('projectNamespaces.createNamespace') }}
             </router-link>
-            <button
-              type="button"
-              class="project-action btn btn-sm role-multi-action actions mr-10"
-              :class="{invisible: !showProjectActionButton(group.group)}"
+            <ButtonMultiAction
+              class="project-action mr-10"
+              :borderless="true"
+              :invisible="!showProjectActionButton(group.group)"
               @click="showProjectAction($event, group.group)"
-            >
-              <i class="icon icon-actions" />
-            </button>
+            />
           </div>
         </div>
       </template>

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -22,6 +22,7 @@ import AdvancedFiltering from './advanced-filtering';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { getParent } from '@shell/utils/dom';
 import { FORMATTERS } from '@shell/components/SortableTable/sortable-config';
+import ButtonMultiAction from '@shell/components/ButtonMultiAction.vue';
 
 // Uncomment for table performance debugging
 // import tableDebug from './debug';
@@ -44,7 +45,12 @@ export default {
   emits: ['clickedActionButton', 'pagination-changed', 'group-value-change', 'selection', 'rowClick'],
 
   components: {
-    THead, Checkbox, AsyncButton, ActionDropdown, LabeledSelect
+    THead,
+    Checkbox,
+    AsyncButton,
+    ActionDropdown,
+    LabeledSelect,
+    ButtonMultiAction,
   },
   mixins: [
     filtering,
@@ -1415,18 +1421,15 @@ export default {
                     name="row-actions"
                     :row="row.row"
                   >
-                    <button
+                    <ButtonMultiAction
                       :id="`actionButton+${i}+${(row.row && row.row.name) ? row.row.name : ''}`"
                       :ref="`actionButton${i}`"
-                      :data-testid="componentTestid + '-' + i + '-action-button'"
                       aria-haspopup="true"
                       aria-expanded="false"
-                      type="button"
-                      class="btn btn-sm role-multi-action actions"
+                      :data-testid="componentTestid + '-' + i + '-action-button'"
+                      :borderless="true"
                       @click="handleActionButtonClick(i, $event)"
-                    >
-                      <i class="icon icon-actions" />
-                    </button>
+                    />
                   </slot>
                 </td>
               </tr>
@@ -1661,17 +1664,7 @@ export default {
     }
   }
 
-  // Remove colors from multi-action buttons in the table
   td {
-    .actions.role-multi-action {
-      background-color: transparent;
-      border: none;
-      &:hover, &:focus {
-        background-color: var(--accent-btn);
-        box-shadow: none;
-      }
-    }
-
     // Aligns with COLUMN_BREAKPOINTS
     @media only screen and (max-width: map-get($breakpoints, '--viewport-4')) {
       // HIDE column on sizes below 480px

--- a/shell/components/__tests__/ButtonMultiAction.test.ts
+++ b/shell/components/__tests__/ButtonMultiAction.test.ts
@@ -1,0 +1,31 @@
+import { shallowMount } from '@vue/test-utils';
+import ButtonMultiAction from '@shell/components/ButtonMultiAction.vue';
+
+describe('buttonMultiAction.vue', () => {
+  it('renders correct classes when props are provided', () => {
+    const wrapper = shallowMount(ButtonMultiAction, {
+      props: {
+        borderless: true,
+        invisible:  true,
+      },
+    });
+
+    expect(wrapper.find('button').classes()).toContain('borderless');
+    expect(wrapper.find('button').classes()).toContain('invisible');
+  });
+
+  it('renders correct classes when props are absent', () => {
+    const wrapper = shallowMount(ButtonMultiAction);
+
+    expect(wrapper.find('button').classes()).not.toContain('borderless');
+    expect(wrapper.find('button').classes()).not.toContain('invisible');
+  });
+
+  it('emits click event when button is clicked', () => {
+    const wrapper = shallowMount(ButtonMultiAction);
+
+    wrapper.find('button').trigger('click');
+
+    expect(wrapper.emitted('click')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This creates a new button component, `ButtonMultiAction.vue`, and replaces two targeted instances to address styling issues with Projects/Namespaces. 

There are other instances that can be replaced, but they have been left untouched to limit the scope of this change.

Fixes #12007 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Create new component, `ButtonMultiAction.vue`
- Replace in-table multi action button
- Replace in-table multi action button in `shell/components/ExplorerProjectsNamespaces.vue` 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

While investigating the issue, it became clear that there is a difference between how scoped styles are applied to slot content in Vue3 when compared to previous versions of Vue. Looking at the similarities between the two implementations told me that a component could be created.

An alternative approach would be to duplicate the class in `shell/components/ExplorerProjectsNamespaces.vue`. 

Relying on unscoped styles is another option, but I prefer the component-driven approach. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Projects/Namespaces
- Sortable Table

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Projects/Namespaces
- Sortable Table

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### This PR

![image](https://github.com/user-attachments/assets/a0b38659-618d-4166-be82-fa715822880a)

#### v2.9

![image](https://github.com/user-attachments/assets/f64f4e5a-78dd-46fc-a45a-e6c6066d4f0d)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
