### PR TITLE
Improve performance of home page when there are lots of clusters

### DIFF
--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -5,7 +5,7 @@ import { mount, Wrapper } from '@vue/test-utils';
 // DISCLAIMER: This should not be added here, although we have several store requests which are irrelevant
 const defaultStore = {
   'management/byId':         jest.fn(),
-  'management/schemaFor':    jest.fn(),
+  'management/schemaFor':    () => ({}),
   'i18n/t':                  jest.fn(),
   'features/get':            jest.fn(),
   'prefs/theme':             jest.fn(),
@@ -20,7 +20,11 @@ describe('topLevelMenu', () => {
       mocks: {
         $store: {
           getters: {
-            'management/all': () => [{ name: 'whatever' }],
+            'management/all': () => [{
+              name: 'whatever',
+              id:   'an-id1',
+              mgmt: { id: 'an-id1' },
+            }],
             ...defaultStore
           },
         },
@@ -48,21 +52,21 @@ describe('topLevelMenu', () => {
             'management/all': () => [
               {
                 name:        'x32-cwf5-name',
-                id:          'x32-cwf5-id',
+                id:          'an-id1',
                 mgmt:        { id: 'an-id1' },
                 nameDisplay: 'c-cluster',
                 isReady:     true
               },
               {
                 name:        'x33-cwf5-name',
-                id:          'x33-cwf5-id',
+                id:          'an-id2',
                 mgmt:        { id: 'an-id2' },
                 nameDisplay: 'a-cluster',
                 isReady:     true
               },
               {
                 name:        'x34-cwf5-name',
-                id:          'x34-cwf5-id',
+                id:          'an-id3',
                 mgmt:        { id: 'an-id3' },
                 nameDisplay: 'b-cluster',
                 isReady:     true
@@ -70,7 +74,7 @@ describe('topLevelMenu', () => {
               {
                 name:        'local-name',
                 id:          'local',
-                mgmt:        { id: 'an-id4' },
+                mgmt:        { id: 'local' },
                 nameDisplay: 'local',
                 isReady:     true
               },
@@ -103,21 +107,21 @@ describe('topLevelMenu', () => {
             'management/all': () => [
               {
                 name:        'x32-cwf5-name',
-                id:          'x32-cwf5-id',
+                id:          'an-id1',
                 mgmt:        { id: 'an-id1' },
                 nameDisplay: 'c-cluster',
                 isReady:     true
               },
               {
                 name:        'x33-cwf5-name',
-                id:          'x33-cwf5-id',
+                id:          'an-id2',
                 mgmt:        { id: 'an-id2' },
                 nameDisplay: 'a-cluster',
                 isReady:     false
               },
               {
                 name:        'x34-cwf5-name',
-                id:          'x34-cwf5-id',
+                id:          'an-id3',
                 mgmt:        { id: 'an-id3' },
                 nameDisplay: 'b-cluster',
                 isReady:     true
@@ -125,7 +129,7 @@ describe('topLevelMenu', () => {
               {
                 name:        'local-name',
                 id:          'local',
-                mgmt:        { id: 'an-id4' },
+                mgmt:        { id: 'local' },
                 nameDisplay: 'local',
                 isReady:     true
               },
@@ -158,7 +162,7 @@ describe('topLevelMenu', () => {
             'management/all': () => [
               {
                 name:        'x32-cwf5-name',
-                id:          'x32-cwf5-id',
+                id:          'an-id1',
                 mgmt:        { id: 'an-id1' },
                 nameDisplay: 'c-cluster',
                 isReady:     true,
@@ -166,7 +170,7 @@ describe('topLevelMenu', () => {
               },
               {
                 name:        'x33-cwf5-name',
-                id:          'x33-cwf5-id',
+                id:          'an-id2',
                 mgmt:        { id: 'an-id2' },
                 nameDisplay: 'a-cluster',
                 isReady:     true,
@@ -174,7 +178,7 @@ describe('topLevelMenu', () => {
               },
               {
                 name:        'x34-cwf5-name',
-                id:          'x34-cwf5-id',
+                id:          'an-id3',
                 mgmt:        { id: 'an-id3' },
                 nameDisplay: 'b-cluster',
                 isReady:     true,
@@ -183,7 +187,7 @@ describe('topLevelMenu', () => {
               {
                 name:        'local-name',
                 id:          'local',
-                mgmt:        { id: 'an-id4' },
+                mgmt:        { id: 'local' },
                 nameDisplay: 'local',
                 isReady:     true,
                 pinned:      true
@@ -217,7 +221,7 @@ describe('topLevelMenu', () => {
             'management/all': () => [
               {
                 name:        'x32-cwf5-name',
-                id:          'x32-cwf5-id',
+                id:          'an-id1',
                 mgmt:        { id: 'an-id1' },
                 nameDisplay: 'c-cluster',
                 isReady:     true,
@@ -225,7 +229,7 @@ describe('topLevelMenu', () => {
               },
               {
                 name:        'x33-cwf5-name',
-                id:          'x33-cwf5-id',
+                id:          'an-id2',
                 mgmt:        { id: 'an-id2' },
                 nameDisplay: 'a-cluster',
                 isReady:     true,
@@ -233,7 +237,7 @@ describe('topLevelMenu', () => {
               },
               {
                 name:        'x34-cwf5-name',
-                id:          'x34-cwf5-id',
+                id:          'an-id3',
                 mgmt:        { id: 'an-id3' },
                 nameDisplay: 'b-cluster',
                 isReady:     false,
@@ -242,7 +246,7 @@ describe('topLevelMenu', () => {
               {
                 name:        'local-name',
                 id:          'local',
-                mgmt:        { id: 'an-id4' },
+                mgmt:        { id: 'local' },
                 nameDisplay: 'local',
                 isReady:     true,
                 pinned:      true
@@ -333,7 +337,7 @@ describe('topLevelMenu', () => {
   it('should show description if it is available on the mgmt cluster (relevant for RKE1/ember world)', async() => {
     const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
       data: () => {
-        return { hasProvCluster: false, showPinClusters: true };
+        return { hasProvCluster: true, showPinClusters: true };
       },
       mocks: {
         $store: {
@@ -347,6 +351,7 @@ describe('topLevelMenu', () => {
               {
                 name:        'whatever',
                 id:          'an-id1',
+                mgmt:        { id: 'an-id1' },
                 description: 'some-description1',
                 nameDisplay: 'some-label',
                 isReady:     true,
@@ -356,6 +361,7 @@ describe('topLevelMenu', () => {
               {
                 name:        'whatever',
                 id:          'an-id2',
+                mgmt:        { id: 'an-id2' },
                 description: 'some-description2',
                 nameDisplay: 'some-label',
                 pinned:      true
@@ -364,6 +370,7 @@ describe('topLevelMenu', () => {
               {
                 name:        'whatever',
                 id:          'an-id3',
+                mgmt:        { id: 'an-id3' },
                 description: 'some-description3',
                 nameDisplay: 'some-label',
                 isReady:     true
@@ -372,6 +379,7 @@ describe('topLevelMenu', () => {
               {
                 name:        'whatever',
                 id:          'an-id4',
+                mgmt:        { id: 'an-id4' },
                 description: 'some-description4',
                 nameDisplay: 'some-label'
               },
@@ -430,11 +438,15 @@ describe('topLevelMenu', () => {
     describe('should displays a no results message if have clusters but', () => {
       it('given no matching clusters', () => {
         const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
-          data:  () => ({ clusterFilter: 'whatever' }),
+          data:  () => ({ hasProvCluster: true, clusterFilter: 'whatever' }),
           mocks: {
             $store: {
               getters: {
-                'management/all': () => [{ nameDisplay: 'something else' }],
+                'management/all': () => [{
+                  id:          'an-id1',
+                  mgmt:        { id: 'an-id1' },
+                  nameDisplay: 'something else'
+                }],
                 ...defaultStore
               },
             },
@@ -449,11 +461,16 @@ describe('topLevelMenu', () => {
 
       it('given no matched pinned clusters', () => {
         const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
-          data:  () => ({ clusterFilter: 'whatever' }),
+          data:  () => ({ hasProvCluster: true, clusterFilter: 'whatever' }),
           mocks: {
             $store: {
               getters: {
-                'management/all': () => [{ nameDisplay: 'something else', pinned: true }],
+                'management/all': () => [{
+                  id:          'an-id1',
+                  mgmt:        { id: 'an-id1' },
+                  nameDisplay: 'something else',
+                  pinned:      true
+                }],
                 ...defaultStore
               },
             },
@@ -471,11 +488,15 @@ describe('topLevelMenu', () => {
       it('given matching clusters', () => {
         const search = 'you found me';
         const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
-          data:  () => ({ clusterFilter: search }),
+          data:  () => ({ hasProvCluster: true, clusterFilter: search }),
           mocks: {
             $store: {
               getters: {
-                'management/all': () => [{ nameDisplay: search }],
+                'management/all': () => [{
+                  id:          'an-id1',
+                  mgmt:        { id: 'an-id1' },
+                  nameDisplay: search
+                }],
                 ...defaultStore
               },
             },
@@ -492,11 +513,16 @@ describe('topLevelMenu', () => {
       it('given clusters with status pinned', () => {
         const search = 'you found me';
         const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
-          data:  () => ({ clusterFilter: search }),
+          data:  () => ({ hasProvCluster: true, clusterFilter: search }),
           mocks: {
             $store: {
               getters: {
-                'management/all': () => [{ nameDisplay: search, pinned: true }],
+                'management/all': () => [{
+                  nameDisplay: search,
+                  pinned:      true,
+                  id:          'an-id1',
+                  mgmt:        { id: 'an-id1' },
+                }],
                 ...defaultStore
               },
             },

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -373,6 +373,7 @@ export default {
                 :rows="kubeClusters"
                 :headers="clusterHeaders"
                 :loading="!kubeClusters"
+                :paging="true"
               >
                 <template #header-left>
                   <div class="row table-heading">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11999
Fixes #12009


### Occurred changes and/or fixed issues
Issue one - No Local Pagination in Home Page clusters list
  - List has proven bad a performing at scale (~700 clusters can add CPU bottlenecks for searching, leaving page, etc of ~13 seconds)
  - Enable local pagination to render less and improve performance

Issue two - Burger menu clusters lists scale badly with lots of clusters
- Before PR
  - loop over all clusters 16 times
  - root clusters computed method call took ~700ms
    - i've seen this take over a second on other installs, and is called multiple times in a row, blocking UI until complete
- With PR
  - loop over all clusters 6 times (could be less, but we start hitting churn in other ways
  - root clusters computed method call takes ~85ms
  - Details
    - Root clusters list (2 loops dropped)
      - Key prov clusters by mgmt cluster id
        - Avoids loop to filter out mgmt clusters without prov clusters
        - Avoids loop to find prov cluster for a mgmt cluster
    - Unpinned cluster list (4 loops dropped)
      - combine filter for pinned, search and local into a single loop
    - Pinned cluster list (3 loops dropped)
      - combine filter for pinned and local into a single loop
    - Height of pinned cluster list (1 loop dropped)

### Technical notes summary
- Upstream / Latest Issue: #11995
- Upstream / Latest Issue: #11993

### Areas or cases that should be tested
- general pagination of clusters list in home page (paging, sorting, filtering, etc)
- general side nav cluster list (including searching and pining)
- both points above at scale (yaml file containing x amount of clusters can be provided by @richard-cox )


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
