### PR TITLE
LabeledSelect: Filter `$attrs` applied to `v-select`

### DIFF
--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -134,7 +134,18 @@ export default {
     _options() {
       // If we're paginated show the page as provided by `paginate`. See label-select-pagination mixin
       return this.canPaginate ? this.page : this.options;
-    }
+    },
+
+    filteredAttrs() {
+      const {
+        class: _class,
+        taggable,
+        multiple,
+        ...rest
+      } = this.$attrs;
+
+      return rest;
+    },
   },
 
   methods: {
@@ -285,7 +296,7 @@ export default {
     </div>
     <v-select
       ref="select-input"
-      v-bind="$attrs"
+      v-bind="filteredAttrs"
       class="inline"
       :append-to-body="appendToBody"
       :calculate-position="positionDropdown"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This filters the attrs that have already been applied to the wrapper `div` of `LabeledSelect` so that they don't get applied to the inner `v-select`.

This duplicate application was causing additional classes like `mr-10` & `in-input` to be applied to both the wrapper `div` and `v-select`, causing visual regressions when custom classes were applied.  

Fixes #11954 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Filter attrs to be applied to `v-select` in `LabeledSelect.vue`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- This looks related to issues that were addressed by #11869

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- This changes all instances of `LabeledSelect`, so we will need to assert that other usages haven't regressed

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- All instances of `LabeledSelect`

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
