### PR TITLE
Correct key for version info assigment

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1546,7 +1546,7 @@ export default {
             versionName: entry.version,
           });
 
-          this.versionInfo.chartName = res;
+          this.versionInfo[chartName] = res;
           const key = this.chartVersionKey(chartName);
 
           if (!this.userChartValues[key]) {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1563,7 +1563,7 @@ export default {
       this.addonNames.forEach((name) => {
         const chartValues = this.versionInfo[name]?.questions ? this.initYamlEditor(name) : {};
 
-        this.userChartValuesTemp.name = chartValues;
+        this.userChartValuesTemp[name] = chartValues;
       });
       this.refreshComponentWithYamls(key);
     },
@@ -1589,7 +1589,7 @@ export default {
     },
 
     updateValues(name, values) {
-      this.userChartValuesTemp.name = values;
+      this.userChartValuesTemp[name] = values;
       this.syncChartValues(name);
     },
 
@@ -1873,7 +1873,7 @@ export default {
         const userValues = this.userChartValues[key];
 
         if (userValues) {
-          rkeConfig.chartValues.name = userValues;
+          rkeConfig.chartValues[name] = userValues;
         }
       });
     },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This corrects the key used for version info assignment from `chartName` to a computed property name. This regression was introduced during the initial Vue3 migration push while attempting to get a functional RKE2 provisioning[^1]

This also corrects keys that were incorrectly replaced at the time. 

[^1]: https://github.com/rancher/dashboard/commit/31646c2eae647c090accdc1e777f247779f6cc6f#diff-6836ab4af70ed1f33db60d2de9a0087b636d7604c3f1cf6bb6525f50f16a69aeR1544

Fixes #12016 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Update all invalid instances where set was replace and a computed property name should have been used

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- We might want to double-check the linked commit[^1] for any other instances that might have been overlooked

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- RKE2 cluster provisioning (instructions in linked issue)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- RKE2 cluster provisioning

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
