### PR TITLE
Vue3 fix workload storage

### DIFF
--- a/cypress/e2e/blueprints/explorer/workloads/deployments/deployment-create.ts
+++ b/cypress/e2e/blueprints/explorer/workloads/deployments/deployment-create.ts
@@ -25,6 +25,36 @@ export const createDeploymentBlueprint = {
               }
             }
           }
+        ],
+        volumes: [
+          {
+            name:      'test-vol',
+            projected: {
+              defaultMode: 420,
+              sources:     [
+                {
+                  configMap: {
+                    items: [{ key: 'test-vol-key', path: 'test-vol-path' }],
+                    name:  'configmap-name'
+                  }
+                }
+              ]
+            }
+          },
+          {
+            name:      'test-vol1',
+            projected: {
+              defaultMode: 420,
+              sources:     [
+                {
+                  configMap: {
+                    items: [{ key: 'test-vol-key1', path: 'test-vol-path1' }],
+                    name:  'configmap-name1'
+                  }
+                }
+              ]
+            }
+          }
         ]
       },
       metadata: {

--- a/cypress/e2e/po/components/button-dropdown.po.ts
+++ b/cypress/e2e/po/components/button-dropdown.po.ts
@@ -1,4 +1,3 @@
-import ComponentPo from '@/cypress/e2e/po/components/component.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 
 export default class ButtonDropdownPo extends LabeledSelectPo {

--- a/cypress/e2e/po/components/button-dropdown.po.ts
+++ b/cypress/e2e/po/components/button-dropdown.po.ts
@@ -1,0 +1,8 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+
+export default class ButtonDropdownPo extends LabeledSelectPo {
+  toggle() {
+    return this.self().find('[data-testid="dropdown-button"]').click();
+  }
+}

--- a/cypress/e2e/po/components/labeled-select.po.ts
+++ b/cypress/e2e/po/components/labeled-select.po.ts
@@ -22,7 +22,9 @@ export default class LabeledSelectPo extends ComponentPo {
   }
 
   clickLabel(label: string) {
-    return this.getOptions().contains('li', label).click();
+    const labelRegex = new RegExp(`^${ label } $`, 'g');
+
+    return this.getOptions().contains(labelRegex).click();
   }
 
   /**

--- a/cypress/e2e/po/components/tabbed.po.ts
+++ b/cypress/e2e/po/components/tabbed.po.ts
@@ -10,7 +10,7 @@ export default class TabbedPo extends ComponentPo {
   }
 
   clickTabWithSelector(selector: string) {
-    return this.self().get(`${ selector }`).click();
+    return this.self().find(`${ selector }`).click();
   }
 
   allTabs() {

--- a/cypress/e2e/po/components/workloads/container-mount-paths.po.ts
+++ b/cypress/e2e/po/components/workloads/container-mount-paths.po.ts
@@ -1,5 +1,5 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
-import ButtonDropdownPo from '~/cypress/e2e/po/components/button-dropdown.po';
+import ButtonDropdownPo from '@/cypress/e2e/po/components/button-dropdown.po';
 import InputPo from '@/cypress/e2e/po/components/input.po';
 
 class ContainerMountPo extends ComponentPo {

--- a/cypress/e2e/po/components/workloads/container-mount-paths.po.ts
+++ b/cypress/e2e/po/components/workloads/container-mount-paths.po.ts
@@ -30,4 +30,8 @@ export default class ContainerMountPathPo extends ComponentPo {
   nthVolumeMount(i: number): ContainerMountPo {
     return new ContainerMountPo(`[data-testid="container-storage-mount-${ i }"]`);
   }
+
+  removeVolume(i: number) {
+    this.self().find(`[data-testid="container-storage-array-list"] [data-testid="remove-item-${ i }"]`).click();
+  }
 }

--- a/cypress/e2e/po/components/workloads/container-mount-paths.po.ts
+++ b/cypress/e2e/po/components/workloads/container-mount-paths.po.ts
@@ -1,0 +1,33 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import ButtonDropdownPo from '~/cypress/e2e/po/components/button-dropdown.po';
+import InputPo from '@/cypress/e2e/po/components/input.po';
+
+class ContainerMountPo extends ComponentPo {
+  constructor(selector = '.dashboard-root') {
+    super(selector);
+  }
+
+  nthMountPoint(i: number) {
+    return new InputPo(`[data-testid="mount-path-${ i }"] input:first-child`);
+  }
+}
+
+export default class ContainerMountPathPo extends ComponentPo {
+  constructor(selector = '.dashboard-root') {
+    super(selector);
+  }
+
+  addVolumeButton() : ButtonDropdownPo {
+    // return this.self().find('[data-testid="container-storage-add-button"]');
+    return new ButtonDropdownPo('[data-testid="container-storage-add-button"]');
+  }
+
+  addVolume(label: string) {
+    this.addVolumeButton().toggle();
+    this.addVolumeButton().clickOptionWithLabel(label);
+  }
+
+  nthVolumeMount(i: number): ContainerMountPo {
+    return new ContainerMountPo(`[data-testid="container-storage-mount-${ i }"]`);
+  }
+}

--- a/cypress/e2e/po/components/workloads/pod-storage.po.ts
+++ b/cypress/e2e/po/components/workloads/pod-storage.po.ts
@@ -1,4 +1,11 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import CodeMirrorPo from '@/cypress/e2e/po/components/code-mirror.po';
+
+class WorkloadVolumePo extends ComponentPo {
+  yamlEditor(): CodeMirrorPo {
+    return CodeMirrorPo.bySelector(this.self(), '[data-testid="yaml-editor-code-mirror"]');
+  }
+}
 
 export default class WorkloadPodStoragePo extends ComponentPo {
   constructor(selector = '.dashboard-root') {
@@ -6,6 +13,7 @@ export default class WorkloadPodStoragePo extends ComponentPo {
   }
 
   nthVolumeComponent(n: number) {
-    return this.self().find(`[data-testid="volume-component-${ n }"]`);
+    return new WorkloadVolumePo(`[data-testid="volume-component-${ n }"]`);
+    // return this.self().find(`[data-testid="volume-component-${ n }"]`);
   }
 }

--- a/cypress/e2e/po/components/workloads/pod-storage.po.ts
+++ b/cypress/e2e/po/components/workloads/pod-storage.po.ts
@@ -1,0 +1,11 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+
+export default class WorkloadPodStoragePo extends ComponentPo {
+  constructor(selector = '.dashboard-root') {
+    super(selector);
+  }
+
+  nthVolumeComponent(n: number) {
+    return this.self().find(`[data-testid="volume-component-${ n }"]`);
+  }
+}

--- a/cypress/e2e/po/components/workloads/pod-storage.po.ts
+++ b/cypress/e2e/po/components/workloads/pod-storage.po.ts
@@ -14,6 +14,5 @@ export default class WorkloadPodStoragePo extends ComponentPo {
 
   nthVolumeComponent(n: number) {
     return new WorkloadVolumePo(`[data-testid="volume-component-${ n }"]`);
-    // return this.self().find(`[data-testid="volume-component-${ n }"]`);
   }
 }

--- a/cypress/e2e/po/components/yaml-editor.po.ts
+++ b/cypress/e2e/po/components/yaml-editor.po.ts
@@ -1,0 +1,8 @@
+import CodeMirrorPo from '@/cypress/e2e/po/components/code-mirror.po';
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+
+export default class YamlEditorPo extends ComponentPo {
+  input(): CodeMirrorPo {
+    return CodeMirrorPo.bySelector(this.self(), '[data-testid="yaml-editor-code-mirror"]');
+  }
+}

--- a/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
@@ -6,8 +6,10 @@ import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import WorkloadPagePo from '@/cypress/e2e/po/pages/explorer/workloads.po';
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
+import WorkloadPodStoragePo from '@/cypress/e2e/po/components/workloads/pod-storage.po';
+import ContainerMountPathPo from '@/cypress/e2e/po/components/workloads/container-mount-paths.po';
 import { WorkloadType } from '@shell/types/fleet';
-import WorkloadPodStoragePo from '~/cypress/e2e/po/components/workloads/pod-storage.po';
+
 export class workloadDetailsPageBasePo extends PagePo {
   static url: string;
 
@@ -200,14 +202,17 @@ export class WorkloadsCreatePageBasePo extends PagePo {
    * @returns po for vertical tabs used to configure nth container
    */
   nthContainerTabs(containerIndex: number) {
-    // first two tabs are general and pod, so the nth container is the n+2 tab
-    this.horizontalTabs().clickNthTab(containerIndex + 2);
+    this.horizontalTabs().clickTabWithSelector(`>ul>li:nth-child(${ containerIndex + 3 })`);
 
     return new TabbedPo(`[data-testid="workload-container-tabs-${ containerIndex }"]`);
   }
 
   podStorage(): WorkloadPodStoragePo {
     return new WorkloadPodStoragePo();
+  }
+
+  containerStorage(): ContainerMountPathPo {
+    return new ContainerMountPathPo();
   }
 
   createWithUI(name: string, containerImage: string, namespace = 'default') {

--- a/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
@@ -194,6 +194,18 @@ export class WorkloadsCreatePageBasePo extends PagePo {
     return new TabbedPo('[data-testid="workload-pod-tabs"]');
   }
 
+  /**
+   *
+   * @param containerIndex
+   * @returns po for vertical tabs used to configure nth container
+   */
+  nthContainerTabs(containerIndex: number) {
+    // first two tabs are general and pod, so the nth container is the n+2 tab
+    this.horizontalTabs().clickNthTab(containerIndex + 2);
+
+    return new TabbedPo(`[data-testid="workload-container-tabs-${ containerIndex }"]`);
+  }
+
   podStorage(): WorkloadPodStoragePo {
     return new WorkloadPodStoragePo();
   }

--- a/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
@@ -5,7 +5,9 @@ import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import WorkloadPagePo from '@/cypress/e2e/po/pages/explorer/workloads.po';
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
+import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import { WorkloadType } from '@shell/types/fleet';
+import WorkloadPodStoragePo from '~/cypress/e2e/po/components/workloads/pod-storage.po';
 export class workloadDetailsPageBasePo extends PagePo {
   static url: string;
 
@@ -115,6 +117,10 @@ export class WorkloadsListPageBasePo extends PagePo {
     return this.sortableTable().rowActionMenuOpen(elemName).getMenuItem('Edit YAML').click();
   }
 
+  goToEditConfigPage(elemName: string) {
+    return this.sortableTable().rowActionMenuOpen(elemName).getMenuItem('Edit Config').click();
+  }
+
   private workload() {
     return new WorkloadPagePo();
   }
@@ -162,6 +168,34 @@ export class WorkloadsCreatePageBasePo extends PagePo {
 
   saveCreateForm(): AsyncButtonPo {
     return new AsyncButtonPo('[data-testid="form-save"]', this.self());
+  }
+
+  /**
+   *
+   * @returns po for the top level tabs in workloads ie general workload, pod, and one more per container
+   */
+  horizontalTabs(): TabbedPo {
+    return new TabbedPo('[data-testid="workload-horizontal-tabs"]');
+  }
+
+  /**
+   *
+   * @returns po for the vertical tabs within the first horizontal tab, ie non-pod workload configuration
+   */
+  generalTabs(): TabbedPo {
+    return new TabbedPo('[data-testid="workload-general-tabs"]');
+  }
+
+  /**
+   *
+   * @returns po for the vertical tabs within the pod tab
+   */
+  podTabs(): TabbedPo {
+    return new TabbedPo('[data-testid="workload-pod-tabs"]');
+  }
+
+  podStorage(): WorkloadPodStoragePo {
+    return new WorkloadPodStoragePo();
   }
 
   createWithUI(name: string, containerImage: string, namespace = 'default') {

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -46,7 +46,7 @@ describe('Cluster Explorer', () => {
       const { name: workloadName, namespace } = createDeploymentBlueprint.metadata;
       const workloadDetailsPage = new WorkloadsDeploymentsDetailsPagePo(workloadName);
 
-      beforeEach(() => {
+      before(() => {
         cy.intercept('GET', `/v1/apps.deployments/${ namespace }/${ workloadName }`).as('testWorkload');
         cy.intercept('GET', `/v1/apps.deployments/${ namespace }/${ workloadName }`).as('clonedPod');
 
@@ -57,9 +57,27 @@ describe('Cluster Explorer', () => {
         e2eWorkloads.push({ name: workloadName, namespace });
       });
 
+      // TODO nb remove or actually test something here
       it('Should be able to scale the number of pods', () => {
         workloadDetailsPage.goTo();
         workloadDetailsPage.mastheadTitle().should('contain', workloadName);
+      });
+
+      it('Should be able to view and edit configuration of volumes with no custom component', () => {
+        deploymentsListPage.goTo();
+        deploymentsListPage.goToEditConfigPage(workloadName);
+
+        const deploymentEditConfigPage = new WorkloadsDeploymentsCreatePagePo();
+
+        // open the pod tab
+        deploymentEditConfigPage.horizontalTabs().clickTabWithSelector('li#pod');
+
+        // open the pod storage tab
+        deploymentEditConfigPage.podTabs().clickTabWithSelector('li#storage');
+
+        // check that there is a component rendered for each workload volume and that that component has rendered some information about the volume
+        deploymentEditConfigPage.podStorage().nthVolumeComponent(0).should('contain', 'name: test-vol');
+        deploymentEditConfigPage.podStorage().nthVolumeComponent(1).should('contain', 'name: test-vol1');
       });
     });
 

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -42,12 +42,20 @@ describe('Cluster Explorer', () => {
       });
     });
 
-    describe('Update: Deployments', () => {
-      const { name: workloadName, namespace } = createDeploymentBlueprint.metadata;
-      const workloadDetailsPage = new WorkloadsDeploymentsDetailsPagePo(workloadName);
+    describe.skip('Update: Deployments', () => {
+      let workloadName;
+      let workloadDetailsPage;
+
+      const { namespace } = createDeploymentBlueprint.metadata;
       let deploymentEditConfigPage;
 
       beforeEach(() => {
+        workloadName = `e2e-deployment-${ Math.random().toString(36).substr(2, 6) }`;
+        const testDeployment = { ...createDeploymentBlueprint };
+
+        workloadDetailsPage = new WorkloadsDeploymentsDetailsPagePo(workloadName);
+
+        testDeployment.metadata.name = workloadName;
         deploymentsListPage.goTo();
         deploymentsListPage.createWithKubectl(createDeploymentBlueprint);
 
@@ -84,7 +92,7 @@ describe('Cluster Explorer', () => {
 
         cy.wait('@editDeployment').then(({ request, response }) => {
           expect(request.body.spec.template.spec.volumes[0]).to.deep.eq({ name: 'test-vol-changed' });
-          expect(response.body.spec.template.spec.volumes[0]).to.deep.eq({ name: 'test-vol-changed' });
+          expect(response.body.spec.template.spec.volumes[0]).to.deep.eq({ name: 'test-vol-changed', emptyDir: {} });
         });
       });
 
@@ -130,7 +138,10 @@ describe('Cluster Explorer', () => {
     // This is here because need to delete the workload after the test
     // But need to reuse the same workload for multiple tests
     after(() => {
+      // cy.login();
+
       deploymentsListPage?.goTo();
+      // deploymentsListPage.sortableTable().checkVisible();
       e2eWorkloads?.forEach(({ name, namespace }) => {
         deploymentsListPage.deleteWithKubectl(name, namespace);
       });

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -10,6 +10,8 @@ describe('Cluster Explorer', () => {
     let deploymentsListPage: WorkloadsDeploymentsListPagePo;
     let deploymentsCreatePage: WorkloadsDeploymentsCreatePagePo;
 
+    // collect name/namespace of all workloads created in this test suite & delete them afterwards
+    // edit deployment tests each create a workload per run to improve their retryability
     const e2eWorkloads: { name: string; namespace: string; }[] = [];
 
     beforeEach(() => {
@@ -23,7 +25,10 @@ describe('Cluster Explorer', () => {
       });
 
       it('should be able to create a new deployment with basic options', () => {
-        const { name, namespace } = deploymentCreateRequest.metadata;
+        const name = `e2e-deployment-${ Math.random().toString(36).substr(2, 6) }`;
+
+        deploymentCreateRequest.metadata.name = name;
+        const { namespace } = deploymentCreateRequest.metadata;
         const containerImage = 'nginx';
 
         deploymentsCreatePage.goTo();
@@ -31,7 +36,8 @@ describe('Cluster Explorer', () => {
         deploymentsCreatePage.createWithUI(name, containerImage, namespace);
 
         cy.wait('@createDeployment').then(({ request, response }) => {
-          expect(request.body).to.deep.eq(deploymentCreateRequest);
+          // comparing pod spec instead of the entire request body to avoid needing to compare labels that include the dynamic test name
+          expect(request.body.spec.template.spec).to.deep.eq(deploymentCreateRequest.spec.template.spec);
           expect(response.statusCode).to.eq(201);
           expect(response.body.metadata.name).to.eq(name);
           expect(response.body.metadata.namespace).to.eq(namespace);
@@ -42,7 +48,7 @@ describe('Cluster Explorer', () => {
       });
     });
 
-    describe.skip('Update: Deployments', () => {
+    describe('Update: Deployments', () => {
       let workloadName;
       let workloadDetailsPage;
 
@@ -86,34 +92,50 @@ describe('Cluster Explorer', () => {
           .should('contain', 'name: test-vol1');
 
         // now try editing
-        deploymentEditConfigPage.podStorage().nthVolumeComponent(0).yamlEditor().set('name: test-vol-changed');
+        deploymentEditConfigPage.podStorage().nthVolumeComponent(0).yamlEditor().set('name: test-vol-changed\nprojected:\n    defaultMode: 420');
+
+        // verify that the list of volumes in the container tab has updated
+        deploymentEditConfigPage.nthContainerTabs(0).clickTabWithSelector('li#storage');
+        deploymentEditConfigPage.containerStorage().addVolumeButton().toggle();
+        deploymentEditConfigPage.containerStorage().addVolumeButton().getOptions().should('contain', 'test-vol-changed (projected)');
+        deploymentEditConfigPage.containerStorage().addVolumeButton().getOptions().should('not.contain', 'test-vol (projected)');
 
         deploymentEditConfigPage.saveCreateForm().click();
 
         cy.wait('@editDeployment').then(({ request, response }) => {
-          expect(request.body.spec.template.spec.volumes[0]).to.deep.eq({ name: 'test-vol-changed' });
-          expect(response.body.spec.template.spec.volumes[0]).to.deep.eq({ name: 'test-vol-changed', emptyDir: {} });
+          expect(request.body.spec.template.spec.volumes[0]).to.deep.eq({ name: 'test-vol-changed', projected: { defaultMode: 420 } });
+          expect(response.body.spec.template.spec.volumes[0]).to.deep.eq({ name: 'test-vol-changed', projected: { defaultMode: 420, sources: null } });
         });
       });
 
       it('should be able to add container volume mounts', () => {
-        // select storage tab in first container tab
         deploymentEditConfigPage.nthContainerTabs(0).clickTabWithSelector('li#storage');
 
         deploymentEditConfigPage.containerStorage().addVolume('test-vol1');
 
         deploymentEditConfigPage.containerStorage().nthVolumeMount(0).nthMountPoint(0).set('test-123');
+
         deploymentEditConfigPage.saveCreateForm().click();
 
         cy.wait('@editDeployment').then(({ request, response }) => {
           expect(request.body.spec.template.spec.containers[0].volumeMounts).to.deep.eq([{ mountPath: 'test-123', name: 'test-vol1' }]);
           expect(response.body.spec.template.spec.containers[0].volumeMounts).to.deep.eq([{ mountPath: 'test-123', name: 'test-vol1' }]);
         });
+
+        // test removing volumes
+        deploymentsListPage.goToEditConfigPage(workloadName);
+        deploymentEditConfigPage.nthContainerTabs(0).clickTabWithSelector('li#storage');
+        deploymentEditConfigPage.containerStorage().removeVolume(0);
+        deploymentEditConfigPage.saveCreateForm().click();
+
+        cy.wait('@editDeployment').then(({ request, response }) => {
+          expect(request.body.spec.template.spec.containers[0].volumeMounts).to.deep.eq([]);
+          expect(response.body.spec.template.spec.containers[0].volumeMounts).to.eq(undefined);
+        });
       });
     });
 
     describe('List: Deployments', () => {
-      // To reduce test runtime, will use the same workload for all the tests
       it('Should list the workloads', () => {
         deploymentsListPage.goTo();
         e2eWorkloads.forEach(({ name }) => {
@@ -123,10 +145,9 @@ describe('Cluster Explorer', () => {
     });
 
     describe('Delete: Deployments', () => {
-      const deploymentName = deploymentCreateRequest.metadata.name;
-
-      // To reduce test runtime, will use the same workload for all the tests
       it('Should be able to delete a workload', () => {
+        const deploymentName = e2eWorkloads[0].name;
+
         deploymentsListPage.goTo();
 
         deploymentsListPage.listElementWithName(deploymentName).should('exist');
@@ -138,10 +159,7 @@ describe('Cluster Explorer', () => {
     // This is here because need to delete the workload after the test
     // But need to reuse the same workload for multiple tests
     after(() => {
-      // cy.login();
-
       deploymentsListPage?.goTo();
-      // deploymentsListPage.sortableTable().checkVisible();
       e2eWorkloads?.forEach(({ name, namespace }) => {
         deploymentsListPage.deleteWithKubectl(name, namespace);
       });

--- a/shell/components/ButtonDropdown.vue
+++ b/shell/components/ButtonDropdown.vue
@@ -204,6 +204,7 @@ export default {
         tabindex="-1"
         type="button"
         class="dropdown-button-two btn"
+        data-testid="dropdown-button"
         @click="ddButtonAction(option)"
         @focus="focusSearch"
       >

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -356,12 +356,12 @@ export default {
             >
               <ContainerMountPaths
                 v-model:value="podTemplateSpec"
+                v-model:container="allContainers[i]"
                 :namespace="value.metadata.namespace"
                 :register-before-hook="registerBeforeHook"
                 :mode="mode"
                 :secrets="namespacedSecrets"
                 :config-maps="namespacedConfigMaps"
-                :container="allContainers[i]"
                 :save-pvc-hook-name="savePvcHookName"
                 @removePvcForm="clearPvcFormState"
               />

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -169,6 +169,7 @@ export default {
         :show-tabs-add-remove="true"
         :default-tab="defaultTab"
         :flat="true"
+        data-testid="workload-horizontal-tabs"
         @changed="changed"
       >
         <Tab
@@ -182,6 +183,7 @@ export default {
           <Tabbed
             :side-tabs="true"
             :weight="99"
+            :data-testid="`workload-container-tabs-${i}`"
           >
             <Tab
               :label="t('workload.container.titles.general')"
@@ -372,7 +374,10 @@ export default {
           :name="nameDisplayFor(type)"
           :weight="99"
         >
-          <Tabbed :side-tabs="true">
+          <Tabbed
+            data-testid="workload-general-tabs"
+            :side-tabs="true"
+          >
             <Tab
               name="labels"
               label-key="generic.labelsAndAnnotations"
@@ -410,7 +415,10 @@ export default {
           :name="'pod'"
           :weight="98"
         >
-          <Tabbed :side-tabs="true">
+          <Tabbed
+            data-testid="workload-pod-tabs"
+            :side-tabs="true"
+          >
             <Tab
               :label="t('workload.storage.title')"
               name="storage"

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -78,12 +78,6 @@ export default {
           icon:    null
         }
       }), {});
-    },
-
-    refreshYamls() {
-      // if (this.$refs.storage) {
-      //   this.$refs.storage.refresh();
-      // }
     }
   }
 };
@@ -355,8 +349,8 @@ export default {
               :weight="tabWeightMap['storage']"
             >
               <ContainerMountPaths
-                v-model:value="podTemplateSpec"
                 v-model:container="allContainers[i]"
+                :value="podTemplateSpec"
                 :namespace="value.metadata.namespace"
                 :register-before-hook="registerBeforeHook"
                 :mode="mode"

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -78,6 +78,12 @@ export default {
           icon:    null
         }
       }), {});
+    },
+
+    refreshYamls() {
+      // if (this.$refs.storage) {
+      //   this.$refs.storage.refresh();
+      // }
     }
   }
 };
@@ -409,8 +415,10 @@ export default {
               :label="t('workload.storage.title')"
               name="storage"
               :weight="tabWeightMap['storage']"
+              @active="$refs.storage.refresh()"
             >
               <Storage
+                ref="storage"
                 v-model:value="podTemplateSpec"
                 :namespace="value.metadata.namespace"
                 :register-before-hook="registerBeforeHook"

--- a/shell/edit/workload/storage/ContainerMountPaths.vue
+++ b/shell/edit/workload/storage/ContainerMountPaths.vue
@@ -140,6 +140,7 @@ export default {
       v-model:value="selectedContainerVolumes"
       :add-allowed="false"
       :mode="mode"
+      data-testid="container-storage-array-list"
       @remove="removeVolume"
     >
       <!-- Custom/default storage volume form -->

--- a/shell/edit/workload/storage/ContainerMountPaths.vue
+++ b/shell/edit/workload/storage/ContainerMountPaths.vue
@@ -1,5 +1,5 @@
 <script>
-import { clone } from '@shell/utils/object';
+import { clone, set } from '@shell/utils/object';
 import { _VIEW } from '@shell/config/query-params';
 import { randomStr } from '@shell/utils/string';
 
@@ -8,7 +8,10 @@ import ButtonDropdown from '@shell/components/ButtonDropdown';
 import ArrayListGrouped from '@shell/components/form/ArrayListGrouped';
 
 export default {
-  name:       'ContainerMountPaths',
+  name: 'ContainerMountPaths',
+
+  emits: ['update:value', 'update:container'],
+
   components: {
     ArrayListGrouped, ButtonDropdown, Mount
   },
@@ -77,14 +80,24 @@ export default {
       }, []);
 
       this.container.volumeMounts = this.container.volumeMounts.filter((mount) => names.includes(mount.name));
+      // this.$emit('update:container', this.container);
     },
 
-    selectedContainerVolumes(neu, old) {
-      // removeObjects(this.value.volumes, old);
-      // addObjects(this.value.volumes, neu);
-      const names = neu.map((item) => item.name);
+    selectedContainerVolumes: {
+      deep: true,
+      handler(neu, old) {
+        console.log('*** container updating', neu);
+        // removeObjects(this.value.volumes, old);
+        // addObjects(this.value.volumes, neu);
+        const names = neu.map((item) => item.name);
+        const onlyNeuNames = this.container.volumeMounts.filter((mount) => names.includes(mount.name));
 
-      this.container.volumeMounts = this.container.volumeMounts.filter((mount) => names.includes(mount.name));
+        console.log(names, onlyNeuNames);
+        // set(this.container, 'volumeMounts', onlyNeuNames );
+        this.container.volumeMounts = this.container.volumeMounts.filter((mount) => names.includes(mount.name));
+        console.log('this.container', this.container);
+        // this.$emit('update:container', this.container);
+      }
     }
 
   },
@@ -133,6 +146,7 @@ export default {
     },
 
     selectVolume(event) {
+      debugger;
       const selectedVolume = this.value.volumes.find((vol) => vol.name === event.value);
 
       this.selectedContainerVolumes.push(selectedVolume);
@@ -140,6 +154,7 @@ export default {
       const { name } = selectedVolume;
 
       this.container.volumeMounts.push(name);
+      this.$emit('update:container', this.container);
     },
 
     addVolume(type) {

--- a/shell/edit/workload/storage/index.vue
+++ b/shell/edit/workload/storage/index.vue
@@ -282,12 +282,6 @@ export default {
               :data-testid="`volume-component-${props.i}`"
               :editor-mode="yamlEditorMode"
             />
-            <!-- <CodeMirror
-              :ref="`cm-${props.i}`"
-              :value="yamlDisplay(props.row.value)"
-              :options="{ readOnly: isView, cursorBlinkRate: -1 }"
-              :data-testid="`volume-component-${props.i}`"
-            /> -->
           </div>
         </div>
 

--- a/shell/edit/workload/storage/index.vue
+++ b/shell/edit/workload/storage/index.vue
@@ -126,6 +126,15 @@ export default {
   //   }
   // },
 
+  watch: {
+    '$route.hash': {
+      deep: true,
+      handler() {
+        this.refresh();
+      }
+    }
+  },
+
   methods: {
     /**
      * Initialize missing values for the container
@@ -223,8 +232,10 @@ export default {
 
     // codemirror needs to refresh if it is in a tab that wasn't visible on page load
     refresh() {
-      if (this.$refs.cm) {
-        this.$refs.cm.forEach((component) => component.refresh());
+      if (this.$refs) {
+        const cmRefs = Object.keys(this.$refs).filter((ref) => ref.startsWith('cm-'));
+
+        cmRefs.forEach((r) => this.$refs[r].refresh());
       }
     },
 
@@ -262,11 +273,13 @@ export default {
             :loading="loading"
             @removePvcForm="removePvcForm"
           />
-          <div v-else-if="isView">
+          <div
+            v-else
+          >
             <CodeMirror
-              ref="cm"
+              :ref="`cm-${props.i}`"
               :value="yamlDisplay(props.row.value)"
-              :options="{ readOnly: true, cursorBlinkRate: -1 }"
+              :options="{ readOnly: isView, cursorBlinkRate: -1 }"
             />
           </div>
         </div>

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -15,7 +15,8 @@ export const defaultContainer = {
     readOnlyRootFilesystem:   false,
     privileged:               false,
     allowPrivilegeEscalation: false,
-  }
+  },
+  volumeMounts: []
 };
 export default class Workload extends WorkloadService {
   // remove clone as yaml/edit as yaml until API supported


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11957 
Fixes #12020 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR includes a few fixes for pod and container storage. 

### Technical notes summary
#11957  - corrected issue with codemirror not rendering
#12020 - fixed issue with slot content not rendering + issues with prop mutation in ContainerMountPaths

### Areas or cases that should be tested
- view config of a workload with projected volume source 
- edit config of a workload with projected volume source 
- create/edit a workload with volumes and container volume mounts

You will need a deployment with a projected volume defined to test #11957

<details>
<summary>sample workload</summary>

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-multi-vol
  namespace: default
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      workload.user.cattle.io/workloadselector: apps.deployment-default-test-multi-vol
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        workload.user.cattle.io/workloadselector: apps.deployment-default-test-multi-vol
      namespace: default
    spec:
      containers:
        - image: nginx
          imagePullPolicy: Always
          name: container-0
          resources: {}
          securityContext:
            allowPrivilegeEscalation: false
            privileged: false
            readOnlyRootFilesystem: false
            runAsNonRoot: false
          terminationMessagePath: /dev/termination-log
          terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
      volumes:
        - name: projected-test
          projected:
            defaultMode: 420
            sources:
              - serviceAccountToken:
                  expirationSeconds: 9001
                  path: token
              - configMap:
                  items:
                    - key: key0
                      path: path0
                  name: confimap-name
        - name: projected-test-1
          projected:
            defaultMode: 420
            sources:
              - serviceAccountToken:
                  expirationSeconds: 9001
                  path: token
              - configMap:
                  items:
                    - key: key1
                      path: path1
                  name: confimap1-name
```

</details>

### Screenshot/Video

https://github.com/user-attachments/assets/e63ee7ae-1611-40bd-8577-afd1d8315ab0

![Screenshot 2024-09-30 at 8 02 37 AM](https://github.com/user-attachments/assets/60ef90a6-d65b-4fcd-9a9c-b1a4e6a7e38a)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
