### PR TITLE
Fix publish shell workflow node-version mismatch

### DIFF
--- a/.github/workflows/release-shell-pkg.yaml
+++ b/.github/workflows/release-shell-pkg.yaml
@@ -18,14 +18,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       
-      - name: Setup target Node.js to enable Corepack
-        uses: actions/setup-node@v4
-        with:
-          node-version: '16.x'
-
-      - name: Enable Corepack
-        run: corepack enable
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -38,9 +30,10 @@ jobs:
         run: ./.github/workflows/scripts/check-package-tag-version.sh
         shell: bash
 
-      - name: Validate Plugin build system
-        run: ./shell/scripts/test-plugins-build.sh
-        shell: bash
+      # Skipping due to node version mismatch
+      # - name: Validate Plugin build system
+      #   run: ./shell/scripts/test-plugins-build.sh
+      #   shell: bash
 
       # Reset the local (ci) repository state because
       # The previous step (Validate Plugin build system) changes


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This Fixes an issue with legacy shell package publishing that is caused by a node-version mismatch between the runner environment and verdaccio requirements.

Example [failed run](https://github.com/rancher/dashboard/actions/runs/11056962212/job/30719699143#step:7:40)

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Removed corepack enabling step and duplicate node env setup
- Skipped test-plugin-build step as verdaccio will not be compatible with the node env (`v16.20.2`)

<details>
<summary><b><i>Shell publish local test run</b></i></summary>

```console
$ act -W .github/workflows/release-shell-pkg.yaml --env GITHUB_REF_NAME=shell-pkg-v2.0.2-rc.1 --env GITHUB_REF=refs/tags/shell-pkg-v2.0.2-rc.1 -q
INFO[0000] Using docker host 'unix:///var/run/docker.sock', and daemon socket 'unix:///var/run/docker.sock' 
[Publish Shell Package/build] 🚀  Start image=catthehacker/ubuntu:act-latest
[Publish Shell Package/build]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=true
[Publish Shell Package/build] using DockerAuthConfig authentication for docker pull
[Publish Shell Package/build] pulling image 'docker.io/catthehacker/ubuntu:act-latest' () failed with credentials Error response from daemon: Head "https://registry-1.docker.io/v2/catthehacker/ubuntu/manifests/act-latest": unauthorized: incorrect username or password retrying without them, please check for stale docker config files
[Publish Shell Package/build]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Publish Shell Package/build]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Publish Shell Package/build]   🐳  docker exec cmd=[node --no-warnings -e console.log(process.execPath)] user= workdir=
[Publish Shell Package/build]   ☁  git clone 'https://github.com/actions/setup-node' # ref=v4
[Publish Shell Package/build] Non-terminating error while running 'git clone': some refs were not updated
[Publish Shell Package/build]   ☁  git clone 'https://github.com/actions/setup-node' # ref=v4
[Publish Shell Package/build] Non-terminating error while running 'git clone': some refs were not updated
[Publish Shell Package/build] ⭐ Run Main actions/checkout@v4
[Publish Shell Package/build]   🐳  docker cp src=/home/jordon/Documents/jordojordo/dashboard/. dst=/home/jordon/Documents/jordojordo/dashboard
[Publish Shell Package/build]   ✅  Success - Main actions/checkout@v4
[Publish Shell Package/build] ⭐ Run Main Setup Node.js
[Publish Shell Package/build]   🐳  docker cp src=/home/jordon/.cache/act/actions-setup-node@v4/ dst=/var/run/act/actions/actions-setup-node@v4/
[Publish Shell Package/build]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.4/x64/bin/node /var/run/act/actions/actions-setup-node@v4/dist/setup/index.js] user= workdir=
[Publish Shell Package/build]   💬  ::debug::isExplicit: 
[Publish Shell Package/build]   💬  ::debug::explicit? false
[Publish Shell Package/build]   💬  ::debug::isExplicit: 16.20.2
[Publish Shell Package/build]   💬  ::debug::explicit? true
[Publish Shell Package/build]   💬  ::debug::isExplicit: 18.20.4
[Publish Shell Package/build]   💬  ::debug::explicit? true
[Publish Shell Package/build]   💬  ::debug::isExplicit: 20.17.0
[Publish Shell Package/build]   💬  ::debug::explicit? true
[Publish Shell Package/build]   💬  ::debug::evaluating 3 versions
[Publish Shell Package/build]   💬  ::debug::matched: 16.20.2
[Publish Shell Package/build]   💬  ::debug::checking cache: /opt/hostedtoolcache/node/16.20.2/x64
[Publish Shell Package/build]   💬  ::debug::Found tool in cache node 16.20.2 x64
[Publish Shell Package/build]   ❓  ::group::Environment details
[Publish Shell Package/build]   ❓  ::endgroup::
[Publish Shell Package/build]   💬  ::debug::Consumed yarn version is 1.22.22 (working dir: "")
[Publish Shell Package/build]   💬  ::debug::yarn's cache folder "/usr/local/share/.cache/yarn/v6" configured for the root directory
[Publish Shell Package/build]   💬  ::debug::followSymbolicLinks 'true'
[Publish Shell Package/build]   💬  ::debug::followSymbolicLinks 'true'
[Publish Shell Package/build]   💬  ::debug::implicitDescendants 'true'
[Publish Shell Package/build]   💬  ::debug::matchDirectories 'true'
[Publish Shell Package/build]   💬  ::debug::omitBrokenSymbolicLinks 'true'
[Publish Shell Package/build]   💬  ::debug::Search path '/home/jordon/Documents/jordojordo/dashboard/yarn.lock'
[Publish Shell Package/build]   💬  ::debug::/home/jordon/Documents/jordojordo/dashboard/yarn.lock
[Publish Shell Package/build]   💬  ::debug::Found 1 files to hash.
[Publish Shell Package/build]   💬  ::debug::primary key is node-cache-Linux-yarn-dc0a8f421f9f12f0bf5305d4ca744d8f95db987c9717b99b0e2281f4f7305054
[Publish Shell Package/build]   💬  ::debug::check if "/home/jordon/Documents/jordojordo/dashboard" has locally managed yarn3 dependencies
[Publish Shell Package/build]   💬  ::debug::"/home/jordon/Documents/jordojordo/dashboard" dependencies are not managed by yarn 3 locally
[Publish Shell Package/build]   💬  ::debug::Resolved Keys:
[Publish Shell Package/build]   💬  ::debug::["node-cache-Linux-yarn-dc0a8f421f9f12f0bf5305d4ca744d8f95db987c9717b99b0e2281f4f7305054"]
[Publish Shell Package/build]   💬  ::debug::Checking zstd --quiet --version
[Publish Shell Package/build]   💬  ::debug::1.4.8
[Publish Shell Package/build]   💬  ::debug::zstd version: 1.4.8
[Publish Shell Package/build]   💬  ::debug::Resource Url: http://192.168.1.188:44423/_apis/artifactcache/cache?keys=node-cache-Linux-yarn-dc0a8f421f9f12f0bf5305d4ca744d8f95db987c9717b99b0e2281f4f7305054&version=84d7b02a61d0b31f347fcddab445d98204dc22e7f42a4366ff8a82ec6de1ae78
[Publish Shell Package/build]   💬  ::debug::Failed to delete archive: Error: ENOENT: no such file or directory, unlink ''
[Publish Shell Package/build]   ❓ add-matcher /run/act/actions/actions-setup-node@v4/.github/tsc.json
[Publish Shell Package/build]   ❓ add-matcher /run/act/actions/actions-setup-node@v4/.github/eslint-stylish.json
[Publish Shell Package/build]   ❓ add-matcher /run/act/actions/actions-setup-node@v4/.github/eslint-compact.json
[Publish Shell Package/build]   ✅  Success - Main Setup Node.js
[Publish Shell Package/build]   ⚙  ::set-output:: node-version=v16.20.2
[Publish Shell Package/build]   ⚙  ::set-output:: cache-hit=false
[Publish Shell Package/build]   ⚙  ::add-path:: /opt/hostedtoolcache/node/16.20.2/x64/bin
[Publish Shell Package/build] ⭐ Run Main Check Tags Version Matching
[Publish Shell Package/build]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/2.sh] user= workdir=
[Publish Shell Package/build]   ✅  Success - Main Check Tags Version Matching
[Publish Shell Package/build] ⭐ Run Main Reset repository (file system)
[Publish Shell Package/build]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/3] user= workdir=
[Publish Shell Package/build]   ✅  Success - Main Reset repository (file system)
[Publish Shell Package/build] ⭐ Run Main actions/setup-node@v4
[Publish Shell Package/build]   🐳  docker cp src=/home/jordon/.cache/act/actions-setup-node@v4/ dst=/var/run/act/actions/actions-setup-node@v4/
[Publish Shell Package/build]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.4/x64/bin/node /var/run/act/actions/actions-setup-node@v4/dist/setup/index.js] user= workdir=
[Publish Shell Package/build]   💬  ::debug::isExplicit: 
[Publish Shell Package/build]   💬  ::debug::explicit? false
[Publish Shell Package/build]   💬  ::debug::isExplicit: 16.20.2
[Publish Shell Package/build]   💬  ::debug::explicit? true
[Publish Shell Package/build]   💬  ::debug::isExplicit: 18.20.4
[Publish Shell Package/build]   💬  ::debug::explicit? true
[Publish Shell Package/build]   💬  ::debug::isExplicit: 20.17.0
[Publish Shell Package/build]   💬  ::debug::explicit? true
[Publish Shell Package/build]   💬  ::debug::evaluating 3 versions
[Publish Shell Package/build]   💬  ::debug::matched: 16.20.2
[Publish Shell Package/build]   💬  ::debug::checking cache: /opt/hostedtoolcache/node/16.20.2/x64
[Publish Shell Package/build]   💬  ::debug::Found tool in cache node 16.20.2 x64
[Publish Shell Package/build]   ❓  ::group::Environment details
[Publish Shell Package/build]   ❓  ::endgroup::
[Publish Shell Package/build]   💬  ::debug::Setting auth in /tmp/.npmrc
[Publish Shell Package/build]   ❓ add-matcher /run/act/actions/actions-setup-node@v4/.github/tsc.json
[Publish Shell Package/build]   ❓ add-matcher /run/act/actions/actions-setup-node@v4/.github/eslint-stylish.json
[Publish Shell Package/build]   ❓ add-matcher /run/act/actions/actions-setup-node@v4/.github/eslint-compact.json
[Publish Shell Package/build]   ✅  Success - Main actions/setup-node@v4
[Publish Shell Package/build]   ⚙  ::set-env:: NPM_CONFIG_USERCONFIG=/tmp/.npmrc
[Publish Shell Package/build]   ⚙  ::set-env:: NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX
[Publish Shell Package/build]   ⚙  ::set-output:: node-version=v16.20.2
[Publish Shell Package/build]   ⚙  ::add-path:: /opt/hostedtoolcache/node/16.20.2/x64/bin
[Publish Shell Package/build] ⭐ Run Main Install packages
[Publish Shell Package/build]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/5] user= workdir=
[Publish Shell Package/build]   ✅  Success - Main Install packages
[Publish Shell Package/build] ⭐ Run Main Simulate Publish Shell Package to npm
[Publish Shell Package/build]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/6] user= workdir=
[Publish Shell Package/build]   ✅  Success - Main Simulate Publish Shell Package to npm
[Publish Shell Package/build] ⭐ Run Post actions/setup-node@v4
[Publish Shell Package/build]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.4/x64/bin/node /var/run/act/actions/actions-setup-node@v4/dist/cache-save/index.js] user= workdir=
[Publish Shell Package/build]   💬  ::debug::Caching for '' is not supported
[Publish Shell Package/build]   ✅  Success - Post actions/setup-node@v4
[Publish Shell Package/build] ⭐ Run Post Setup Node.js
[Publish Shell Package/build]   🐳  docker exec cmd=[/opt/acttoolcache/node/18.20.4/x64/bin/node /var/run/act/actions/actions-setup-node@v4/dist/cache-save/index.js] user= workdir=
[Publish Shell Package/build]   💬  ::debug::Checking zstd --quiet --version
[Publish Shell Package/build]   💬  ::debug::1.4.8
[Publish Shell Package/build]   💬  ::debug::zstd version: 1.4.8
[Publish Shell Package/build]   💬  ::debug::implicitDescendants 'false'
[Publish Shell Package/build]   💬  ::debug::followSymbolicLinks 'true'
[Publish Shell Package/build]   💬  ::debug::implicitDescendants 'false'
[Publish Shell Package/build]   💬  ::debug::omitBrokenSymbolicLinks 'true'
[Publish Shell Package/build]   💬  ::debug::Search path '/usr/local/share/.cache/yarn/v6'
[Publish Shell Package/build]   💬  ::debug::Matched: ../../../../../usr/local/share/.cache/yarn/v6
[Publish Shell Package/build]   💬  ::debug::Cache Paths:
[Publish Shell Package/build]   💬  ::debug::["../../../../../usr/local/share/.cache/yarn/v6"]
[Publish Shell Package/build]   💬  ::debug::Archive Path: /tmp/522ef463-d504-49b7-88e0-77343232197d/cache.tzst
[Publish Shell Package/build]   💬  ::debug::File Size: 166057722
[Publish Shell Package/build]   💬  ::debug::Reserving Cache
[Publish Shell Package/build]   💬  ::debug::Resource Url: http://192.168.1.188:44423/_apis/artifactcache/caches
[Publish Shell Package/build]   💬  ::debug::Saving Cache (ID: 2)
[Publish Shell Package/build]   💬  ::debug::Upload cache
[Publish Shell Package/build]   💬  ::debug::Resource Url: http://192.168.1.188:44423/_apis/artifactcache/caches/2
[Publish Shell Package/build]   💬  ::debug::Upload concurrency: 4
[Publish Shell Package/build]   💬  ::debug::Upload chunk size: 33554432
[Publish Shell Package/build]   💬  ::debug::Awaiting all uploads
[Publish Shell Package/build]   💬  ::debug::Uploading chunk of size 33554432 bytes at offset 0 with content range: bytes 0-33554431/*
[Publish Shell Package/build]   💬  ::debug::Uploading chunk of size 33554432 bytes at offset 33554432 with content range: bytes 33554432-67108863/*
[Publish Shell Package/build]   💬  ::debug::Uploading chunk of size 33554432 bytes at offset 67108864 with content range: bytes 67108864-100663295/*
[Publish Shell Package/build]   💬  ::debug::Uploading chunk of size 33554432 bytes at offset 100663296 with content range: bytes 100663296-134217727/*
[Publish Shell Package/build]   💬  ::debug::Uploading chunk of size 31839994 bytes at offset 134217728 with content range: bytes 134217728-166057721/*
[Publish Shell Package/build]   💬  ::debug::Commiting cache
[Publish Shell Package/build]   💬  ::debug::Resource Url: http://192.168.1.188:44423/_apis/artifactcache/caches/2
[Publish Shell Package/build]   ✅  Success - Post Setup Node.js
[Publish Shell Package/build] Cleaning up container for job build
[Publish Shell Package/build] 🏁  Job succeeded
```

</details>

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
