### PR TITLE
Split RKE2 Addon Configuration out into multiple tabs

### DIFF
--- a/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
@@ -423,8 +423,8 @@ describe('Settings', { testIsolation: 'off' }, () => {
     createRKE2ClusterPage.rkeToggle().set('RKE2/K3s');
 
     createRKE2ClusterPage.selectCustom(0);
-    createRKE2ClusterPage.clusterConfigurationTabs().clickTabWithSelector('[data-testid="btn-addons"]');
-    cy.contains(settings['system-default-registry'].new).should('exist');
+    createRKE2ClusterPage.clusterConfigurationTabs().clickTabWithSelector('[data-testid="btn-rke2-calico"]');
+    cy.contains(settings['system-default-registry'].new).should('exist'); // Note - this doesn't test anything. docker.io exists in the chart in all worlds, system-default-registry value does not
 
     const settingsPageBlank = new SettingsPagePo();
     const settingsEditBlank = settingsPageBlank.editSettings(undefined, 'system-default-registry');

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1193,17 +1193,39 @@ cluster:
     banner: "Service Account access with JWT authentication can be configured after cluster creation from <br>
       <code>Cluster Management > Advanced > JWT Authentication</code>"
   addonChart:
-    rancher-vsphere-cpi: vSphere CPI Configuration
-    rancher-vsphere-csi: vSphere CSI Configuration
-    rke2-calico: Calico Configuration
-    rke2-calico-crd: Calico Configuration
-    rke2-canal: Canal Configuration
-    rke2-cilium: Cilium Configuration
-    rke2-coredns: CoreDNS Configuration
-    rke2-ingress-nginx: NGINX Ingress Configuration
-    rke2-kube-proxy: Kube Proxy Configuration
-    rke2-metrics-server: Metrics Server Configuration
-    rke2-multus: Multus Configuration
+    rancher-vsphere-cpi:
+      label: vSphere CPI
+      configuration: vSphere CPI Configuration
+    rancher-vsphere-csi:
+      label: vSphere CSI
+      configuration: vSphere CSI Configuration
+    rke2-calico:
+      label: Calico
+      configuration: Calico Configuration
+    rke2-calico-crd:
+      label:  Calico
+      configuration: Calico Configuration
+    rke2-canal:
+      label: Canal
+      configuration: Canal Configuration
+    rke2-cilium:
+      label: Cilium
+      configuration: Cilium Configuration
+    rke2-coredns:
+      label: CoreDNS
+      configuration: CoreDNS Configuration
+    rke2-ingress-nginx:
+      label: NGINX
+      configuration: NGINX Ingress Configuration
+    rke2-kube-proxy:
+      label: Kube Proxy
+      configuration: Kube Proxy Configuration
+    rke2-metrics-server:
+      label: Metrics Server
+      configuration: Metrics Server Configuration
+    rke2-multus:
+      label: Multus
+      configuration: Multus Configuration
   agentEnvVars:
     label: Agent Environment
     detail: Add additional environment variables to the agent container.  This is most commonly useful for configuring a HTTP proxy.
@@ -1219,7 +1241,7 @@ cluster:
       label: Google
     rancher-vsphere:
       label: vSphere
-      note: '<b>Important:</b> Configure the vSphere Cloud Provider and Storage Provider options in the Add-On Config tab.'
+      note: '<b>Important:</b> Configure the vSphere Cloud Provider and Storage Provider options in the tabs on the left.'
     harvester:
       label: Harvester
   copyConfig: Copy KubeConfig to Clipboard
@@ -2092,7 +2114,7 @@ cluster:
       s3: s3
   tabs:
     ace: Authorized Endpoint
-    addons: Add-On Config
+    addOnAdditionalManifest: Additional Manifest
     advanced: Advanced
     agentEnv: Agent Environment Vars
     basic: Basics

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2419,8 +2419,10 @@ export default {
           name="additionalmanifest"
           label-key="cluster.tabs.addOnAdditionalManifest"
           :showHeader="false"
+          @active="refreshComponentWithYamls('additionalmanifest')"
         >
           <AddOnAdditionalManifest
+            ref="additionalmanifest"
             :value="value"
             :mode="mode"
             @additional-manifest-changed="updateAdditionalManifest"

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -29,7 +29,7 @@ import { sortBy } from '@shell/utils/sort';
 import { vspherePoolConfigMerge } from '@shell/machine-config/vmwarevsphere-pool-config-merge';
 
 import { compare, sortable } from '@shell/utils/version';
-import { isHarvesterSatisfiesVersion } from '@shell/utils/cluster';
+import { isHarvesterSatisfiesVersion, labelForAddon } from '@shell/utils/cluster';
 
 import { BadgeState } from '@components/BadgeState';
 import { Banner } from '@components/Banner';
@@ -62,6 +62,7 @@ import Registries from '@shell/edit/provisioning.cattle.io.cluster/tabs/registri
 import AddOnConfig from '@shell/edit/provisioning.cattle.io.cluster/tabs/AddOnConfig';
 import Advanced from '@shell/edit/provisioning.cattle.io.cluster/tabs/Advanced';
 import ClusterAppearance from '@shell/components/form/ClusterAppearance';
+import AddOnAdditionalManifest from '@shell/edit/provisioning.cattle.io.cluster/tabs/AddOnAdditionalManifest';
 
 const HARVESTER = 'harvester';
 const HARVESTER_CLOUD_PROVIDER = 'harvester-cloud-provider';
@@ -115,7 +116,8 @@ export default {
     Registries,
     AddOnConfig,
     Advanced,
-    ClusterAppearance
+    ClusterAppearance,
+    AddOnAdditionalManifest
   },
 
   mixins: [CreateEditView, FormValidation],
@@ -248,6 +250,7 @@ export default {
       machinePoolErrors:     {},
       allNamespaces:         [],
       extensionTabs:         getApplicableExtensionEnhancements(this, ExtensionPoint.TAB, TabLocation.CLUSTER_CREATE_RKE2, this.$route, this),
+      labelForAddon
     };
   },
 
@@ -1570,7 +1573,9 @@ export default {
     refreshComponentWithYamls(key) {
       const component = this.$refs[key];
 
-      if (component) {
+      if (Array.isArray(component) && component.length > 0) {
+        this.refreshYamls(component[0].$refs);
+      } else if (component) {
         this.refreshYamls(component.$refs);
       }
     },
@@ -2384,24 +2389,40 @@ export default {
           />
         </Tab>
 
-        <!-- Add-on Config -->
+        <!-- Add-on Configs -->
         <Tab
-          name="addons"
-          label-key="cluster.tabs.addons"
-          @active="showAddons('tab-addOnConfig')"
+          v-for="v in addonVersions"
+          :key="v.name"
+          :name="v.name"
+          :label="labelForAddon($store, v.name, false)"
+          :weight="9"
+          :showHeader="false"
+          @active="showAddons(v.name)"
         >
           <AddOnConfig
-            ref="tab-addOnConfig"
+            :ref="v.name"
             v-model:value="localValue"
             :mode="mode"
             :version-info="versionInfo"
-            :addon-versions="addonVersions"
+            :addon-version="v"
             :addons-rev="addonsRev"
             :user-chart-values-temp="userChartValuesTemp"
             :init-yaml-editor="initYamlEditor"
             @update:value="$emit('input', $event)"
             @update-questions="syncChartValues"
             @update-values="updateValues"
+          />
+        </Tab>
+
+        <!-- Add-on Additional Manifest -->
+        <Tab
+          name="additionalmanifest"
+          label-key="cluster.tabs.addOnAdditionalManifest"
+          :showHeader="false"
+        >
+          <AddOnAdditionalManifest
+            :value="value"
+            :mode="mode"
             @additional-manifest-changed="updateAdditionalManifest"
           />
         </Tab>

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/AddOnAdditionalManifest.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/AddOnAdditionalManifest.vue
@@ -2,6 +2,9 @@
 import YamlEditor from '@shell/components/YamlEditor';
 export default {
   components: { YamlEditor },
+
+  emits: ['additional-manifest-changed'],
+
   props: {
     mode: {
       type:     String,
@@ -12,6 +15,7 @@ export default {
       required: true,
     }
   },
+
   computed: {
     additionalManifest: {
       get() {
@@ -36,7 +40,7 @@ export default {
     </h3>
     <YamlEditor
       ref="yaml-additional"
-      v-model="additionalManifest"
+      v-model:value="additionalManifest"
       :editor-mode="mode === 'view' ? 'VIEW_CODE' : 'EDIT_CODE'"
       initial-yaml-values="# Additional Manifest YAML"
       class="yaml-editor"

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/AddOnAdditionalManifest.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/AddOnAdditionalManifest.vue
@@ -1,0 +1,45 @@
+<script>
+import YamlEditor from '@shell/components/YamlEditor';
+export default {
+  components: { YamlEditor },
+  props: {
+    mode: {
+      type:     String,
+      required: true,
+    },
+    value: {
+      type:     Object,
+      required: true,
+    }
+  },
+  computed: {
+    additionalManifest: {
+      get() {
+        return this.value.spec.rkeConfig.additionalManifest;
+      },
+      set(neu) {
+        this.$emit('additional-manifest-changed', neu);
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <div>
+    <h3>
+      {{ t('cluster.addOns.additionalManifest.title') }}
+      <i
+        v-clean-tooltip="t('cluster.addOns.additionalManifest.tooltip')"
+        class="icon icon-info"
+      />
+    </h3>
+    <YamlEditor
+      ref="yaml-additional"
+      v-model="additionalManifest"
+      :editor-mode="mode === 'view' ? 'VIEW_CODE' : 'EDIT_CODE'"
+      initial-yaml-values="# Additional Manifest YAML"
+      class="yaml-editor"
+    />
+  </div>
+</template>

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/AddOnConfig.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/AddOnConfig.vue
@@ -3,7 +3,7 @@ import { Banner } from '@components/Banner';
 
 import Questions from '@shell/components/Questions';
 import YamlEditor from '@shell/components/YamlEditor';
-import { camelToTitle } from '@shell/utils/string';
+import { labelForAddon } from '@shell/utils/cluster';
 import { _EDIT } from '@shell/config/query-params';
 
 export default {
@@ -31,8 +31,8 @@ export default {
       required: true,
     },
 
-    addonVersions: {
-      type:     Array,
+    addonVersion: {
+      type:     Object,
       required: false,
       default:  null
     },
@@ -52,28 +52,15 @@ export default {
 
   },
 
+  data() {
+    return { labelForAddon };
+  },
+
   computed: {
-    additionalManifest: {
-      get() {
-        return this.value.spec.rkeConfig.additionalManifest;
-      },
-      set(neu) {
-        this.$emit('additional-manifest-changed', neu);
-      }
-    },
     isEdit() {
       return this.mode === _EDIT;
-    },
-  },
-
-  methods: {
-
-    labelForAddon(name) {
-      const fallback = `${ camelToTitle(name.replace(/^(rke|rke2|rancher)-/, '')) } Configuration`;
-
-      return this.$store.getters['i18n/withFallback'](`cluster.addonChart."${ name }"`, null, fallback);
-    },
-  },
+    }
+  }
 };
 </script>
 
@@ -86,54 +73,32 @@ export default {
       {{ t('cluster.addOns.dependencyBanner') }}
     </Banner>
     <div
-      v-if="versionInfo && addonVersions.length"
+      v-if="versionInfo && addonVersion"
       :key="addonsRev"
     >
-      <div
-        v-for="(v, i) in addonVersions"
-        :key="i"
-      >
-        <h3>{{ labelForAddon(v.name) }}</h3>
-        <Questions
-          v-if="versionInfo[v.name] && versionInfo[v.name].questions && v.name && userChartValuesTemp[v.name]"
-          v-model:value="userChartValuesTemp[v.name]"
-          :emit="true"
-          in-store="management"
-          :mode="mode"
-          :tabbed="false"
-          :source="versionInfo[v.name]"
-          :target-namespace="value.metadata.namespace"
-          @updated="$emit('update-questions', v.name)"
-        />
-        <YamlEditor
-          v-else
-          ref="yaml-values"
-          :value="initYamlEditor(v.name)"
-          :scrolling="true"
-          :as-object="true"
-          :editor-mode="mode === 'view' ? 'VIEW_CODE' : 'EDIT_CODE'"
-          :hide-preview-buttons="true"
-          @update:value="data => $emit('update-values', v.name, data)"
-        />
-        <div class="spacer" />
-      </div>
-    </div>
-
-    <div>
-      <h3>
-        {{ t('cluster.addOns.additionalManifest.title') }}
-        <i
-          v-clean-tooltip="t('cluster.addOns.additionalManifest.tooltip')"
-          class="icon icon-info"
-        />
-      </h3>
-      <YamlEditor
-        ref="yaml-additional"
-        v-model:value="additionalManifest"
-        :editor-mode="mode === 'view' ? 'VIEW_CODE' : 'EDIT_CODE'"
-        initial-yaml-values="# Additional Manifest YAML"
-        class="yaml-editor"
+      <h3>{{ labelForAddon($store, addonVersion.name) }}</h3>
+      <Questions
+        v-if="versionInfo[addonVersion.name] && versionInfo[addonVersion.name].questions && addonVersion.name && userChartValuesTemp[addonVersion.name]"
+        v-model:value="userChartValuesTemp[addonVersion.name]"
+        :emit="true"
+        in-store="management"
+        :mode="mode"
+        :tabbed="false"
+        :source="versionInfo[addonVersion.name]"
+        :target-namespace="value.metadata.namespace"
+        @updated="$emit('update-questions', addonVersion.name)"
       />
+      <YamlEditor
+        v-else
+        ref="yaml-values"
+        :value="initYamlEditor(addonVersion.name)"
+        :scrolling="true"
+        :as-object="true"
+        :editor-mode="mode === 'view' ? 'VIEW_CODE' : 'EDIT_CODE'"
+        :hide-preview-buttons="true"
+        @input="data => $emit('update-values', addonVersion.name, data)"
+      />
+      <div class="spacer" />
     </div>
   </div>
 </template>

--- a/shell/utils/cluster.js
+++ b/shell/utils/cluster.js
@@ -1,4 +1,5 @@
 import semver from 'semver';
+import { camelToTitle } from '@shell/utils/string';
 import { CAPI } from '@shell/config/labels-annotations';
 import { MANAGEMENT, VIRTUAL_HARVESTER_PROVIDER } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';
@@ -89,4 +90,12 @@ export function abbreviateClusterName(input) {
   }
 
   return result;
+}
+
+export function labelForAddon(store, name, configuration = true) {
+  const addon = camelToTitle(name.replace(/^(rke|rke2|rancher)-/, ''));
+  const fallback = `${ addon } ${ configuration ? 'Configuration' : '' }`;
+  const key = `cluster.addonChart."${ name }"${ configuration ? '.configuration' : '.label' }`;
+
+  return store.getters['i18n/withFallback'](key, null, fallback);
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12066 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Moved `additionalManifest` section from `AddOnConfig.vue` to its own component, so it can be a separate tab.
Moved `labelForAddon` method to `shell/utils/cluster.js` in order to be re-used in couple of places as a helper.
Updated `rke2.vue` and `AddOnConfig.vue` in order to show separate tabs for each add-on configuration.

### Areas or cases that should be tested
- Addon configuration should be correctly applied when creating a cluster
  - Addon examples
    - each Container Network (see Basics tab) has it's own config
    - vSphere provider
  - This is specific per kube distro, kube version and cloud provider. Changing this combination may result in different chart values
- Additional Manifest should be correct applied when creating a cluster


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Provisioning clusters.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
