### PR TITLE
Fix initial additionalManifest render issue

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2420,8 +2420,10 @@ export default {
           name="additionalmanifest"
           label-key="cluster.tabs.addOnAdditionalManifest"
           :showHeader="false"
+          @active="refreshComponentWithYamls('additionalmanifest')"
         >
           <AddOnAdditionalManifest
+            ref="additionalmanifest"
             :value="value"
             :mode="mode"
             @additional-manifest-changed="updateAdditionalManifest"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Contributes to #12067 
<!-- Define findings related to the feature or bug issue. -->

As part of the manual backport of #12067, the additionalmanifest component was missing the refresh yaml trigger that it had before being separated from Add-on config tab.
