### PR TITLE
Mutate growl stack in a reactive way

### DIFF
--- a/shell/store/growl.js
+++ b/shell/store/growl.js
@@ -18,11 +18,14 @@ export const getters = {
 
 export const mutations = {
   add(state, data) {
-    state.stack.push({
-      id:      state.nextId++,
-      started: (new Date().getTime()),
-      ...data
-    });
+    state.stack = [
+      ...state.stack,
+      {
+        id:      state.nextId++,
+        started: (new Date().getTime()),
+        ...data
+      }
+    ];
   },
 
   remove(state, id) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This replaces the growl `stack` array so that it's guaranteed the watcher in `shell/components/GrowlManager.vue` will more reliably trigger when changes are made.

https://github.com/rancher/dashboard/blob/9489da3568db485d75b2dae49b580df4c6099f2b/shell/components/GrowlManager.vue#L17-L25

Fixes #12097 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Use the spread operator to build a new array instead of using push to reliably trigger reactivity

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

While testing, I noted that the behavior was very inconsistent. There were times that the countdown timer would init and others where nothing would happen. 

We've seen this behavior in other areas where mutations methods aren't reliably triggering reactivity. I think that it makes sense to follow-up with a minimal repro to understand why exactly this can be an issue. The Vue docs explicitly state that we should be able to use `Array.push()` to mutate an array in a reactive way[^1].

[^1]: https://vuejs.org/guide/essentials/list.html#mutation-methods

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Growls

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Growls

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
