### PR TITLE
fix fleet summary tooltip styling

### DIFF
--- a/shell/assets/styles/global/_tooltip.scss
+++ b/shell/assets/styles/global/_tooltip.scss
@@ -141,7 +141,7 @@
 .v-popper__popper.v-popper--theme-dropdown {
   z-index: z-index('tooltip');
 
-  &.containerLogsDropdown {
+  &.containerLogsDropdown, &.fleet-summary-tooltip{
     .v-popper__arrow-container {
       display: none;
     }

--- a/shell/components/fleet/FleetStatus.vue
+++ b/shell/components/fleet/FleetStatus.vue
@@ -150,7 +150,7 @@ function toPercent(value, min, max) {
           {{ title }}
         </div>
         <div
-          class="dropdwon resources-dropdown"
+          class="resources-dropdown"
           tabindex="0"
           @blur="showMenu(false)"
           @click="showMenu(true)"
@@ -158,12 +158,13 @@ function toPercent(value, min, max) {
         >
           <v-dropdown
             ref="popover"
-            placement="bottom-end"
+            placement="bottom"
             offset="-10"
             :triggers="[]"
             :delay="{show: 0, hide: 0}"
             :flip="false"
             :container="false"
+            popper-class="fleet-summary-tooltip"
           >
             <div class="meta-title">
               {{ meta.readyCount }} / {{ meta.total }} {{ title }} ready <i class="icon toggle icon-chevron-down" />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11967
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
It seems most issues with this dropdown have been fixed, likely by https://github.com/rancher/dashboard/pull/11880. This PR removes a lingering arrow. Compared to 2.9 there is a slightly larger margin at the top of the dropdown but I think it needed it - previously the dropdown appeared to be touching the summary text (see screenshots)


### Areas or cases that should be tested
Fleet summary count dropdowns

### Areas which could experience regressions
none

### Screenshot/Video
this PR:
![Screenshot 2024-10-02 at 2 48 53 PM](https://github.com/user-attachments/assets/9c5f50ac-d5c2-4b28-af38-034f247f5b0e)

In 2.9:
![Screenshot 2024-10-02 at 2 52 16 PM](https://github.com/user-attachments/assets/a7772569-8047-432d-9684-83fede010190)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
