### PR TITLE
Fix style regression in header component

### DIFF
--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -958,6 +958,28 @@ export default {
         }
       }
 
+      :deep(.actions) {
+        align-items: center;
+        cursor: pointer;
+        display: flex;
+
+        > I {
+          font-size: 18px;
+          padding: 6px;
+          &:hover {
+            color: var(--link);
+          }
+        }
+
+        :deep(.v-popper:focus) {
+          outline: 0;
+        }
+
+        .dropdown {
+          margin: 0 -10px;
+        }
+      }
+
       .header-spacer {
         background-color: var(--header-bg);
         position: relative;

--- a/shell/components/nav/HeaderPageActionMenu.vue
+++ b/shell/components/nav/HeaderPageActionMenu.vue
@@ -131,28 +131,6 @@ const handleBlurEvent = (event: KeyboardEvent) => {
     }
   }
 
-  .actions {
-    align-items: center;
-    cursor: pointer;
-    display: flex;
-
-    > I {
-      font-size: 18px;
-      padding: 6px;
-      &:hover {
-        color: var(--link);
-      }
-    }
-
-    :deep(.v-popper:focus) {
-      outline: 0;
-    }
-
-    .dropdown {
-      margin: 0 -10px;
-    }
-  }
-
   .list-unstyled {
     li {
       a {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This properly scopes styles for `.actions` in the header to `HEADER.rd-header-right`. 

A regression in header styles was introduced in #12076 where a new component was created for the header actions. The styles associated with the actions were migrated over into the new component, removing this specificity; headers used throughout Dashboard then contained actions with the following styles to cause a center alignment:

```
        align-items: center;
        cursor: pointer;
        display: flex;
```

Fixes #12108 
Fixes #12162
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Remove offending styles for the action class from `HeaderPageActionMenu.vue`
- Reintroduce styles for the action class to `Header.vue` 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This is a CSS specificity issue where we have a special case to control actions in the page header vs. actions that are used in different section headers.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- The actions menu in the page header should remain unchanged from the previous implementation
- See the associated issue for more test cases, the headers for different sections should no longer be center aligned

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Headers used throughout Dashboard

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
