### PR TITLE
Hide JWT Authentication if user does not have access to the required type

### DIFF
--- a/cypress/e2e/po/side-bars/product-side-nav.po.ts
+++ b/cypress/e2e/po/side-bars/product-side-nav.po.ts
@@ -49,8 +49,9 @@ export default class ProductNavPo extends ComponentPo {
    * Check existence of menu side entry
    */
   checkSideMenuEntryByLabel(label: string, assertion: string): Cypress.Chainable {
-    return this.self().should('exist').find('.child.nav-type a .label').contains(label).should(assertion);
-  }  
+    return this.self().should('exist').find('.child.nav-type a .label').contains(label)
+      .should(assertion);
+  }
 
   /**
    * Check existence of menu group by label

--- a/cypress/e2e/po/side-bars/product-side-nav.po.ts
+++ b/cypress/e2e/po/side-bars/product-side-nav.po.ts
@@ -46,6 +46,13 @@ export default class ProductNavPo extends ComponentPo {
   }
 
   /**
+   * Check existence of menu side entry
+   */
+  checkSideMenuEntryByLabel(label: string, assertion: string): Cypress.Chainable {
+    return this.self().should('exist').find('.child.nav-type a .label').contains(label).should(assertion);
+  }  
+
+  /**
    * Check existence of menu group by label
    */
   navToSideMenuGroupByLabelExistence(label: string, assertion: string): Cypress.Chainable {

--- a/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
+++ b/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
@@ -156,7 +156,6 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
 });
 
 describe('JWT Authentication (Standard User)', { testIsolation: 'off', tags: ['@manager', '@standardUser', '@jenkins'] }, () => {
-
   before(() => {
     cy.login();
     HomePagePo.goTo();

--- a/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
+++ b/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
@@ -1,6 +1,8 @@
 
-import JWTAuthenticationPagePo from '@/cypress/e2e/po/pages/cluster-manager/jwt-authentication.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
+import JWTAuthenticationPagePo from '@/cypress/e2e/po/pages/cluster-manager/jwt-authentication.po';
 
 describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@adminUser', '@jenkins'] }, () => {
   const jwtAuthenticationPage = new JWTAuthenticationPagePo();
@@ -150,5 +152,27 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
         removeCluster1 = false;
       });
     }
+  });
+});
+
+describe('JWT Authentication (Standard User)', { testIsolation: 'off', tags: ['@manager', '@standardUser', '@jenkins'] }, () => {
+
+  before(() => {
+    cy.login();
+    HomePagePo.goTo();
+  });
+
+  it('should not have JWT Authentication side menu entry', () => {
+    const homePage = new HomePagePo();
+    const clusterManagerPage = new ClusterManagerListPagePo('_');
+
+    homePage.manageButton().click();
+    clusterManagerPage.waitForPage();
+
+    // Check navigation does not exist
+    const sideNav = new ProductNavPo();
+
+    sideNav.navToSideMenuGroupByLabel('Advanced');
+    sideNav.checkSideMenuEntryByLabel('JWT Authentication', 'not.exist');
   });
 });

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -124,6 +124,7 @@ export function init(store) {
   });
 
   virtualType({
+    ifHaveType: MANAGEMENT.CLUSTER_PROXY_CONFIG,
     labelKey:   'manager.jwtAuthentication.label',
     name:       VIRTUAL_TYPES.JWT_AUTHENTICATION,
     group:      'Root',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11461 

### Occurred changes and/or fixed issues

Simple fix to add the `ifHaveType` to the product configuration.

### Areas or cases that should be tested

Automated test added for standard user.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
