### PR TITLE
Update what's new message for 2.10

### DIFF
--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -43,7 +43,7 @@ describe('Home Page', () => {
       homePage.restoreAndWait();
 
       cy.getRancherResource('v1', 'management.cattle.io.settings', 'server-version').then((resp: Cypress.Response<any>) => {
-        homePage.changelog().self().contains('Learn more about the improvements and new capabilities in this version.');
+        homePage.changelog().self().contains('Learn more about the improvements and new capabilities in this version');
         homePage.whatsNewBannerLink().contains(`What's new in ${ CURRENT_RANCHER_VERSION }`);
 
         homePage.whatsNewBannerLink().invoke('attr', 'href').then((releaseNotesUrl) => {

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2995,7 +2995,7 @@ landing:
       other {cores}}
     cpuUsed: CPU Used
     memoryUsed: Memory Used
-  seeWhatsNew: Learn more about the improvements and new capabilities in this version.
+  seeWhatsNew: Learn more about the improvements and new capabilities in this version and read about the UI framework migration in 2.10
   whatsNewLink: "What's new in 2.10"
   learnMore: Learn More
   support: Support


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12083 

### Occurred changes and/or fixed issues

Updated the what's new message for 2.10 and updated the version number in the link.

See screenshot.

Kept the message short - `Learn more about the improvements and new capabilities in this version and read about the UI framework migration in 2.10`

We will need to update the docs with more information.

To test, log in and view the updated banner on the home page. If it is hidden, click on the three dots icon in the top-right of the page and click on 'Restore hidden cards'.

I have updated the version number in the Chinese translation but not the message. This translation will be removed at a later date/time.

### Screenshot/Video
![image](https://github.com/user-attachments/assets/059f7d12-7e8d-4352-87fa-6b92f19b6a88)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
