### PR TITLE
fix bug with LabeledSelect with "multiple" attribute

### DIFF
--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -140,7 +140,6 @@ export default {
       const {
         class: _class,
         taggable,
-        multiple,
         ...rest
       } = this.$attrs;
 

--- a/shell/components/form/__tests__/LabeledSelect.test.ts
+++ b/shell/components/form/__tests__/LabeledSelect.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
+import { defineComponent } from 'vue';
 
 describe('component: LabeledSelect', () => {
   describe('should display correct label', () => {
@@ -133,6 +134,47 @@ describe('component: LabeledSelect', () => {
         // Component is from a library and class is not going to be changed
         expect(wrapper.find('.vs__selected').text()).toBe(translation);
       });
+    });
+  });
+
+  describe('given attributes from parent element', () => {
+    it('should not pass classes to the select element', () => {
+      const customClass = 'bananas';
+      const ParentComponent = defineComponent({
+        components: { LabeledSelect },
+        template:   `<LabeledSelect class="${ customClass }" />`,
+      });
+      const wrapper = mount(ParentComponent);
+      const input = wrapper.find('.v-select');
+
+      expect(input.classes).not.toContain(customClass);
+    });
+
+    it.each([
+      [true, ['bananas']],
+      [false, 'bananas'],
+    ])('given multiple as %p, should emit %p', async(multiple, expectation) => {
+      const ParentComponent = defineComponent({
+        components: { LabeledSelect },
+        template:   `
+          <LabeledSelect
+            v-model:value="myValue"
+            :multiple="${ multiple }"
+            :options="options"
+            :appendToBody="false"
+          />`,
+        data: () => ({
+          myValue: [],
+          options: ['bananas']
+        })
+      });
+      const wrapper = mount(ParentComponent);
+
+      // https://test-utils.vuejs.org/guide/essentials/event-handling#Asserting-the-arguments-of-the-event
+      await wrapper.find('input').trigger('focus');
+      await wrapper.find('.vs__dropdown-option').trigger('click');
+
+      expect(wrapper.vm.$data.myValue).toStrictEqual(expectation);
     });
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12117 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix issue with `LabeledSelect` in mode multiple by allowing the binding of the attribute to the element `v-select` that was incorrectly being filtered out

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Test repro case(s) in issue + test some other areas that use `LabeledSelect` with `multiple="true"`

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Just to discard any regressions, do a quick test of different instances of `LabeledSelect`, even if they don't use  `multiple="true"`

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
