### PR TITLE
Handle more accurate schemaDefinition cache updating error response

### DIFF
--- a/shell/models/steve-schema.ts
+++ b/shell/models/steve-schema.ts
@@ -160,7 +160,7 @@ export default class SteveSchema extends Schema {
         url
       });
     } catch (e: any) {
-      if ( e?._status === 500) {
+      if (e?._status === 500 || e?._status === 503) {
         // Rancher could be updating it's definition cache, attempt a few times
         await wait(2000);
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11615
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- /schemaDefinition requests can fail due to cache recreation
- previously this would return a 500 and we'd try a number of times again hoping cache comes back up
- the status code is now a more accurate 503, so plug that in
- i saw some cases where 500 recovers, so keeping that in there

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
