### PR TITLE
Fix extension publishing workflows for Vue3 compatibility

### DIFF
--- a/.github/workflows/build-extension-catalog.yml
+++ b/.github/workflows/build-extension-catalog.yml
@@ -53,10 +53,8 @@ jobs:
       - name: Setup Nodejs with yarn caching
         uses: actions/setup-node@v4
         with:
+          node-version: '20'
           cache: yarn
-
-      - name: Setup yarn
-        run: npm install -g yarn
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -48,10 +48,8 @@ jobs:
       - name: Setup Nodejs with yarn caching
         uses: actions/setup-node@v4
         with:
+          node-version: '20'
           cache: yarn
-
-      - name: Setup yarn
-        run: npm install -g yarn
 
       - name: Install dependencies
         run: yarn

--- a/docusaurus/docs/extensions/extensions-getting-started.md
+++ b/docusaurus/docs/extensions/extensions-getting-started.md
@@ -324,9 +324,11 @@ Creating a Release for your extension is the official avenue for loading extensi
 
 We have created [workflows](https://github.com/rancher/dashboard/tree/master/creators/extension/app/files/.github/workflows) for [Github Actions](https://docs.github.com/en/actions) which will automatically build, package, and release your extension as a Helm chart for use within your Github repository, and an [Extension Catalog Image](./advanced/air-gapped-environments) (ECI) which is published into a specified container registry (`ghcr.io` by default). Depending on the use case, you can utilize the Github repository as a [Helm repository](https://helm.sh/docs/topics/chart_repository/) endpoint which we can use to consume the chart in Rancher, or you can import the ECI into the Extension Catalog list and serve the Helm charts locally.
 
-> **Note:** GitLab support is offered through leverging the ECI build. For configuration instructions, follow the setps in the [Gitlab Integration](./publishing#gitlab-integration) section.
+> **WARNING:** When using the provided Github workflows, the base skeleton application name (Found in the root level `package.json`) ___MUST___ be unique when compared with any extension packages found in `./pkg/*`. If an extension package name matches the base skeleton name the workflow will fail due to the "Parse Extension Name" step found in both the ["Build and Release Extension Charts"](https://github.com/rancher/dashboard/blob/422823e2b6868191b9bb33470e99e69ff058b72b/.github/workflows/build-extension-charts.yml#L59-L65) and ["Build and release Extension Catalog Image to registry"](https://github.com/rancher/dashboard/blob/422823e2b6868191b9bb33470e99e69ff058b72b/.github/workflows/build-extension-catalog.yml#L64-L70) workflows.
 
-> **Note:** If you wish to build and publish the Helm chart or the ECI manually or with specific configurations, you can follow the steps listed in the [Publishing an Extension](./publishing) section.
+> Note: GitLab support is offered through leverging the ECI build. For configuration instructions, follow the setps in the [Gitlab Integration](./publishing#gitlab-integration) section.
+
+> Note: If you wish to build and publish the Helm chart or the ECI manually or with specific configurations, you can follow the steps listed in the [Publishing an Extension](./publishing) section.
 
 ### Release Prerequisites
 

--- a/docusaurus/docs/extensions/publishing.md
+++ b/docusaurus/docs/extensions/publishing.md
@@ -11,6 +11,8 @@ As discussed in the [Getting Started](./extensions-getting-started#creating-a-re
 
 ## Automatic Approach - Triggering a Github Workflow on Tagged Release
 
+> **WARNING:** When using the provided Github workflows, the base skeleton application name (Found in the root level `package.json`) ___MUST___ be unique when compared with any extension packages found in `./pkg/*`. If an extension package name matches the base skeleton name the workflow will fail due to the "Parse Extension Name" step found in both the ["Build and Release Extension Charts"](https://github.com/rancher/dashboard/blob/422823e2b6868191b9bb33470e99e69ff058b72b/.github/workflows/build-extension-charts.yml#L59-L65) and ["Build and release Extension Catalog Image to registry"](https://github.com/rancher/dashboard/blob/422823e2b6868191b9bb33470e99e69ff058b72b/.github/workflows/build-extension-catalog.yml#L64-L70) workflows.
+
 If your extensions repository doesn't include a github workflow to automate the publishing procedure (ignore this step if you have it already), you can create one in `.github/workflows/build.yaml` on your extension folder, with the following content:
 
 ```yaml


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12031 
<!-- Define findings related to the feature or bug issue. -->

There were two issues with both chart and catalog workflows:
- Node version was not pinned to the proper version
- Yarn classic was being setup globally overriding corepack

Also, with the latest extension creator we now have the default action to create a skeleton application and extension package with the same name. Since this will cause errors with the automated `parse-tag-name` script, this needs to be documented and conveyed to the user.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Pinned Node version in both workflows to `20` 
- Removed global yarn setup
- Added warning about skeleton application naming scheme

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Create a new extension and repository
- Publish a new release for both an extension chart and catalog
- Ensure they both succeed

**Test runs**

- [_Build extension chart_](https://github.com/jordojordo/rancher-ext-vue3/actions/runs/11185015065)
- [_Build extension catalog_](https://github.com/jordojordo/rancher-ext-vue3/actions/runs/11184978755)



### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
