### PR TITLE
[Backport] fix issue -printf mac os not working

### DIFF
--- a/shell/scripts/extension/bundle
+++ b/shell/scripts/extension/bundle
@@ -43,7 +43,7 @@ for d in ${BASE_DIR}/dist-pkg/*; do
   mkdir plugin && mv ./${pkg}/* ./plugin
   rm -rf ./${pkg}/* && mv ./plugin ./${pkg}
 
-  find ${pkg} -type f -printf '%P\n' | sort > ./${pkg}/files.txt
+  find ${pkg} -type f | sed "s|^${pkg}/||" | sort > ./${pkg}/files.txt
   popd > /dev/null
 
   cp -R ${BASE_DIR}/dist-pkg/${pkg} ${TMP}/container/plugin


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12153 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix issue `-printf` not working on mac os

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The reason for this is that the `-printf` option is not supported by the default`find` command on macOS because it uses the BSD version of find, which doesn't have this option. The `-printf` option is available in the GNU version of find, commonly found on Linux systems.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Follow instructions on issue

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
