### PR TITLE
Update model reactivety

### DIFF
--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -1,4 +1,4 @@
-import { markRaw, reactive, toRaw, toRef } from 'vue';
+import { markRaw, reactive } from 'vue';
 import { addObject, addObjects, clear, removeObject } from '@shell/utils/array';
 import { SCHEMA, COUNT } from '@shell/config/types';
 import { normalizeType, keyFieldFor } from '@shell/plugins/dashboard-store/normalize';
@@ -46,17 +46,17 @@ function registerType(state, type) {
 }
 
 export function replace(existing, data) {
-  const keyMap = {};
+  const existingPropertyMap = {};
 
   for ( const k of Object.keys(existing) ) {
     delete existing[k];
-    keyMap[k] = true;
+    existingPropertyMap[k] = true;
   }
 
   let newProperty = false;
 
   for ( const k of Object.keys(data) ) {
-    if (!newProperty && !keyMap[k]) {
+    if (!newProperty && !existingPropertyMap[k]) {
       newProperty = true;
     }
 

--- a/shell/plugins/dashboard-store/mutations.js
+++ b/shell/plugins/dashboard-store/mutations.js
@@ -1,4 +1,4 @@
-import { markRaw, reactive } from 'vue';
+import { markRaw, reactive, toRaw, toRef } from 'vue';
 import { addObject, addObjects, clear, removeObject } from '@shell/utils/array';
 import { SCHEMA, COUNT } from '@shell/config/types';
 import { normalizeType, keyFieldFor } from '@shell/plugins/dashboard-store/normalize';
@@ -46,15 +46,24 @@ function registerType(state, type) {
 }
 
 export function replace(existing, data) {
+  const keyMap = {};
+
   for ( const k of Object.keys(existing) ) {
     delete existing[k];
+    keyMap[k] = true;
   }
 
+  let newProperty = false;
+
   for ( const k of Object.keys(data) ) {
+    if (!newProperty && !keyMap[k]) {
+      newProperty = true;
+    }
+
     existing[k] = data[k];
   }
 
-  return existing;
+  return newProperty ? reactive(existing) : existing;
 }
 
 function replaceResource(existing, data, getters) {
@@ -125,7 +134,7 @@ export function load(state, {
       entry = replaceResource(entry, data, getters);
     } else {
       // There's no entry, make a new proxy
-      entry = classify(ctx, data);
+      entry = reactive(classify(ctx, data));
     }
   }
 
@@ -268,7 +277,7 @@ export function batchChanges(state, { ctx, batch }) {
         if (normalizedType === SCHEMA) {
           addSchemaIndexFields(resource);
         }
-        const classyResource = classify(ctx, resource);
+        const classyResource = reactive(classify(ctx, resource));
 
         if (index === undefined) {
           typeCache.list.push(classyResource);
@@ -396,6 +405,9 @@ export default {
     }
   },
 
+  /**
+   * Load the results of a request that used a selector (like label)
+   */
   loadSelector(state, {
     type, entries, ctx, selector, revision
   }) {
@@ -412,6 +424,9 @@ export default {
     cache.revision = revision || 0;
   },
 
+  /**
+   * Load the results of a request to fetch all resources or all resources in a namespace
+   */
   loadAll,
 
   /**
@@ -441,8 +456,14 @@ export default {
     });
   },
 
+  /**
+   * Load resources, but don't set `haveAll`
+   */
   loadAdd,
 
+  /**
+   * Load the results of a request for a page. Often used to exercise advanced filtering
+   */
   loadPage(state, {
     type,
     data,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12189
Fixes #12194
Fixes #12192
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- `reactive` was applied to objects that made it into the store via loadAll (or loadPage)
- objects that are assigned to a component `data` object should also be reactive
- however there are scenarios where changes to existing or new properties on these object did not trigger reactivity (computed, watch, etc)
- fix is two parts
  - Ensure all model instances that make it into the store are reactive
    - where we just stick something from `classify` straight into the store... wrap it with reactive
    - this covers almost all `loadX` functions (multi, selector, merge, add) and batchChanges
  - Ensure new properties added to a reactive object aren't ignored
    - in `replace` re-reactive the object if there's new properties

### Technical notes summary



### Areas or cases that should be tested
- As per issue

### Areas which could experience regressions
- Creating a resource, updating the resource in another browser and the resource automatically updates 
- View a resource list, in another browser create a resource of that type and resource list should update
- View a resource, in another browser update the resource and the resource detail should update

The above can be tested with `configmaps`

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
  - I've marked the issue as QA/None given the manual setup required. The final validation will come via the elemental extension
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
