### PR TITLE
Fix header tooltip styles

### DIFF
--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -1077,4 +1077,54 @@ export default {
     color: var(--secondary);
   }
 
+  .user-menu {
+    :deep(.v-popper__arrow-container) {
+      display: none;
+    }
+
+    :deep(.v-popper__inner) {
+      padding: 10px 0 10px 0;
+    }
+
+    :deep(.v-popper) {
+      display: flex;
+    }
+  }
+
+  .user-menu-item {
+    a, &.no-link > span {
+      cursor: pointer;
+      padding: 0px 10px;
+
+      &:hover {
+        background-color: var(--dropdown-hover-bg);
+        color: var(--dropdown-hover-text);
+        text-decoration: none;
+      }
+
+      // When the menu item is focused, pop the margin and compensate the padding, so that
+      // the focus border appears within the menu
+      &:focus {
+        margin: 0 2px;
+        padding: 10px 8px;
+      }
+    }
+
+    &.no-link > span {
+      display: flex;
+      justify-content: space-between;
+      padding: 10px;
+      color: var(--link);
+    }
+
+    div.menu-separator {
+      cursor: default;
+      padding: 4px 0;
+
+      .menu-separator-line {
+        background-color: var(--border);
+        height: 1px;
+      }
+    }
+  }
 </style>

--- a/shell/components/nav/HeaderPageActionMenu.vue
+++ b/shell/components/nav/HeaderPageActionMenu.vue
@@ -36,6 +36,7 @@ const handleBlurEvent = (event: KeyboardEvent) => {
     :flip="false"
     :placement="'bottom-end'"
     :distance="-6"
+    :container="'.page-actions'"
   >
     <i
       data-testid="page-actions-menu"
@@ -75,10 +76,13 @@ const handleBlurEvent = (event: KeyboardEvent) => {
       </div>
     </template>
   </v-dropdown>
+  <div class="page-actions">
+    <!--Empty container for mounting popper content-->
+  </div>
 </template>
 
 <style lang="scss" scoped>
-  .v-popper__popper {
+  .page-actions :deep(.v-popper__popper) {
     .v-popper__wrapper {
       .v-popper__arrow-container {
         display: none;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This fixes regressions in header tooltips that were introduced in #12076 by reintroducing styles that were removed from the `Header.vue` and overriding styles in `HeaderPageActionMenu.vue` with the deep selector. 

Fixes #12174 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Reintroduce styles to `Header.vue` that were removed in #12076
- Attach popover to div in `HeaderPageActionMenu.vue` so that styles can be accessed via `deep` selector 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

It became obvious that the original implementation only worked because of the global styles bug that was corrected in #12172. This PR aims to undo some changes and fix the header popover styles so that they won't regress from 2.9. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Header changes have affected different areas of dashboard in the past, it's important to make sure that the following are styled as expected:

- Page header for the entire application
- Section headers for different areas of Dashboard
- Table headers used throughout dashbord

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- See areas to be tested

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
