### PR TITLE
Fix RKE1 upgrading via template

### DIFF
--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -118,7 +118,7 @@ export default class MgmtCluster extends SteveModel {
     // Provisioner is the "<something>Config" in the model
     const provisioner = KONTAINER_TO_DRIVER[(this.provisioner || '').toLowerCase()] || this.provisioner;
 
-    if ( provisioner === 'rancherKubernetesEngine' ) {
+    if ( provisioner === 'rancherKubernetesEngine' || provisioner === 'rke') {
       // Look for a cloud provider in one of the node templates
       if ( this.machinePools?.[0] ) {
         provider = this.machinePools[0]?.nodeTemplate?.spec?.driver || null;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11874 

### Technical notes summary
The dashboard is setting the wrong value for the `provider` query param when loading some ember pages. It looks like the bug came in here https://github.com/rancher/dashboard/pull/9868/files#diff-9be0247bdd17368e0b020b8ab4933b0c53f2f4bbdb0b1936066fa67703e519d4R91 

It seems that #11874 is happening because when a new cluster template revision is selected, some ember components re-initialize, and at that second partial load, the incorrect `provider` query param causes ember to not load rke1 form components. There's probably something messy going on over in Ember, but fixing the query param being sent over seems the safest solution, vs digging into ember route-changing logic.

### Areas or cases that should be tested
Verify that the right create/edit pages load for the following cluster types:

- RKE1 custom
- RKE2 custom
- RKE1 provisioned
- RKE2 provisioned
- Generic imported
- AKS/EKS/GKE imported (1 of the 3)
- AKS/EKS/GKE provisioned (1 of the 3)

For RKE1 clusters, verify that when using an RKE1 template users can select new template versions and the form is updated accordingly

### Areas which could experience regressions
- Creating/editing any cluster types that use ember pages
- the 'provider' column in the cluster list

### Screenshot/Video
this pr:
![Screenshot 2024-10-08 at 10 47 49 AM](https://github.com/user-attachments/assets/b05eccbb-f02b-406d-b3d8-664fc98f5939)

release-2.9:
![Screenshot 2024-10-08 at 10 47 42 AM](https://github.com/user-attachments/assets/5bf5de5b-77c7-4e24-accc-6167bee259f0)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
