### PR TITLE
Remove duplicate global formatters matched by `require.context()`

### DIFF
--- a/shell/plugins/global-formatters.js
+++ b/shell/plugins/global-formatters.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-const components = require.context('@shell/components/formatter', false, /[A-Z]\w+\.(vue)$/);
+const components = require.context('@shell/components/formatter', false, /\.\/[A-Z]\w+\.(vue)$/);
 
 const globalFormatters = {
   install: (vueApp) => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This modifies the regular expression that matches components in `shell/plugins/global-formatters.js` so that only one set of components is matched by `require.context()`.

Fixes #11786 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Update the regular expression that matches global formatters

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Inspecting the components reveals that there are two sets of components that are matched by `require.context()`, for example:

```
./AppSummaryGraph.vue
components/formatter/AppSummaryGraph.vue
```

This looks to be a breaking change in Webpack5, but documentation about this breaking change is hard to find, but a comment left in a webpack issue somewhat confirms this change in behavior[^1].

[^1]: https://github.com/webpack/webpack/issues/12087#issuecomment-737872247 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Loading global formatters

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Loading global formatters

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
