### PR TITLE
[Backport 2.9] - Fix reference to tsc binary when publishing shell

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/shell",
-  "version": "2.0.2-rc.1",
+  "version": "2.0.2-rc.2",
   "description": "Rancher Dashboard Shell",
   "repository": "https://github.com/rancherlabs/dashboard",
   "license": "Apache-2.0",

--- a/shell/scripts/publish-shell.sh
+++ b/shell/scripts/publish-shell.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
-BASE_DIR="$(
-  cd $SCRIPT_DIR && cd ../.. &
-  pwd
-)"
+BASE_DIR="$(cd $SCRIPT_DIR && cd ../.. && pwd)"
 SHELL_DIR=$BASE_DIR/shell/
 CREATORS_DIR=$BASE_DIR/creators/extension
 FORCE_PUBLISH_TO_NPM="false"

--- a/shell/scripts/typegen.sh
+++ b/shell/scripts/typegen.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-BASE_DIR="$( cd $SCRIPT_DIR && cd ../.. & pwd)"
+BASE_DIR="$(cd $SCRIPT_DIR && cd ../.. && pwd)"
 SHELL_DIR=$BASE_DIR/shell
 
 echo "Generating typescript definitions"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12187

The `node_modules/.bin` is no longer accessible due to a typo within the `BASE_DIR` variable

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Replaced the single `&` with a double `&&` in both publish-shell.sh and typegen.sh scripts 
- Added `pipefail` to `publish-shell` script to ensure it will exit when a command has an error

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Using a single ampersand & instead of a double ampersand && will run the preceding command in the background rather than sequentially. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Publishing of shell packages

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
