### PR TITLE
Fix GKE clusterIpv4CidrBlock and clusterSecondaryRangeName fields

### DIFF
--- a/pkg/gke/components/Networking.vue
+++ b/pkg/gke/components/Networking.vue
@@ -523,7 +523,7 @@ export default defineComponent({
           this.$emit('update:clusterIpv4CidrBlock', '');
         } else {
           this.$emit('update:clusterSecondaryRangeName', neu.rangeName);
-          this.$emit('update:clusterIpv4CidrBlock', neu.ipCidrRange);
+          this.$emit('update:clusterIpv4CidrBlock', '');
         }
       }
     },
@@ -547,7 +547,7 @@ export default defineComponent({
           this.$emit('update:servicesIpv4CidrBlock', '');
         } else {
           this.$emit('update:servicesSecondaryRangeName', neu.rangeName);
-          this.$emit('update:servicesIpv4CidrBlock', neu.ipCidrRange);
+          this.$emit('update:servicesIpv4CidrBlock', '');
         }
       }
     },
@@ -618,12 +618,13 @@ export default defineComponent({
       <div class="col span-6">
         <LabeledSelect
           v-if="!!subnetwork"
-          v-model:value="selectedClusterSecondaryRangeName"
+          :value="selectedClusterSecondaryRangeName"
           :mode="mode"
           :options="clusterSecondaryRangeOptions"
           label-key="gke.clusterSecondaryRangeName.label"
           :disabled="!isNewOrUnprovisioned"
           data-testid="gke-cluster-secondary-range-name-select"
+          @update:value="e=>selectedClusterSecondaryRangeName = e"
         />
         <LabeledInput
           v-else
@@ -638,7 +639,7 @@ export default defineComponent({
       </div>
       <div class="col span-6">
         <LabeledInput
-          :value="clusterIpv4CidrBlock"
+          :value="disableClusterIpv4CidrBlock ? selectedClusterSecondaryRangeName.ipCidrRange : clusterIpv4CidrBlock"
           :mode="mode"
           label-key="gke.clusterIpv4CidrBlock.label"
           :placeholder="t('gke.clusterIpv4Cidr.placeholder')"
@@ -671,7 +672,7 @@ export default defineComponent({
       </div>
       <div class="col span-6">
         <LabeledInput
-          :value="servicesIpv4CidrBlock"
+          :value="disableServicesIpv4CidrBlock ? selectedClusterSecondaryRangeName.ipCidrRange : servicesIpv4CidrBlock"
           :mode="mode"
           label-key="gke.servicesIpv4CidrBlock.label"
           :placeholder="t('gke.clusterIpv4Cidr.placeholder')"

--- a/pkg/gke/components/__tests__/Networking.test.ts
+++ b/pkg/gke/components/__tests__/Networking.test.ts
@@ -175,13 +175,12 @@ describe('gke Networking', () => {
 
     const wrapper = shallowMount(Networking, {
       propsData: {
-        zone:                      'test-zone',
-        region:                    'test-region',
-        cloudCredentialId:         '',
-        projectId:                 'test-project',
-        network:                   'test-network',
-        subnetwork:                'test-network-subnet',
-        clusterSecondaryRangeName: 'range-1'
+        zone:              'test-zone',
+        region:            'test-region',
+        cloudCredentialId: '',
+        projectId:         'test-project',
+        network:           'test-network',
+        subnetwork:        'test-network-subnet',
       },
       ...setup
     });
@@ -190,8 +189,27 @@ describe('gke Networking', () => {
     await flushPromises();
 
     const clusterSecondaryCIDRInput = wrapper.getComponent('[data-testid="gke-cluster-secondary-range-cidr-input"]');
+    const clusterSecondaryRangeSelect = wrapper.getComponent('[data-testid="gke-cluster-secondary-range-name-select"]');
+
+    expect(clusterSecondaryCIDRInput.props('disabled')).toBe(false);
+    expect(clusterSecondaryCIDRInput.props('value')).toBe('');
+    const opt = {
+      ipCidrRange: '10.0.1.0/24',
+      label:       'range-1 (10.0.1.0/24)',
+      rangeName:   'range-1'
+    };
+
+    clusterSecondaryRangeSelect.vm.$emit('update:value', opt);
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('update:clusterSecondaryRangeName')[0][0]).toBe('range-1');
+    expect(wrapper.emitted('update:clusterIpv4CidrBlock')[0][0]).toBe('');
+    wrapper.setProps({ clusterSecondaryRangeName: 'range-1' });
+    await wrapper.vm.$nextTick();
 
     expect(clusterSecondaryCIDRInput.props('disabled')).toBe(true);
+    expect(clusterSecondaryCIDRInput.props('value')).toBe('10.0.1.0/24');
 
     wrapper.setProps({ clusterSecondaryRangeName: '' });
     await wrapper.vm.$nextTick();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #8749 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
GKE provisioning form no longer sets `clusterIpv4CidrBlock` ('Pod Secondary CIDR Block') when `clusterSecondaryRangeName` ('Pod Secondary Address Range') is set and no longer sets `servicesIpv4CidrBlock` when `servicesSecondaryRangeName` is set



### Areas or cases that should be tested
Create a new gke cluster and select a Pod Secondary Address Range: the Pod Secondary CIDR Block input should be populated, but disabled, and the save request should include an empty string for `clusterIpv4CidrBlock`. Same deal with Services Secondary Address Range and `servicesIpv4CidrBlock`.


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
