### PR TITLE
update feature flag table test to dynamically check feature flag count

### DIFF
--- a/cypress/e2e/tests/pages/global-settings/feature-flags.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/feature-flags.spec.ts
@@ -216,7 +216,6 @@ describe('Feature Flags', { testIsolation: 'off' }, () => {
   describe('List', { tags: ['@vai', '@globalSettings', '@adminUser', '@standardUser'] }, () => {
     it('validate feature flags table header content', () => {
       FeatureFlagsPagePo.navTo();
-
       // check table headers are visible
       const expectedHeaders = ['State', 'Name', 'Description', 'Restart Required'];
 
@@ -229,7 +228,11 @@ describe('Feature Flags', { testIsolation: 'off' }, () => {
       featureFlagsPage.list().resourceTable().sortableTable().checkVisible();
       featureFlagsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
       featureFlagsPage.list().resourceTable().sortableTable().noRowsShouldNotExist();
-      featureFlagsPage.list().resourceTable().sortableTable().checkRowCount(false, 15);
+      cy.getRancherResource('v1', 'management.cattle.io.features').then((resp: Cypress.Response<any>) => {
+        const featureCount = resp.body.count;
+
+        featureFlagsPage.list().resourceTable().sortableTable().checkRowCount(false, featureCount);
+      });
     });
   });
 });


### PR DESCRIPTION
Feature flag test is failing eg https://github.com/rancher/dashboard/actions/runs/11260516944/job/31313511381 We have hardcoded the expected number of features as 15. The number of feature flags in rancher has increased to 16 https://github.com/rancher/rancher/pull/47437