### PR TITLE
Use `fullColspan` for `projectsWithoutNamespaces`

### DIFF
--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -477,24 +477,24 @@ export default {
       <template
         v-for="(project, i) in projectsWithoutNamespaces"
         :key="i"
-        v-slot:[slotName(project)]
+        #[slotName(project)]="{ fullColspan }"
       >
         <tr
           class="main-row"
         >
           <td
             class="empty text-center"
-            colspan="5"
+            :colspan="fullColspan"
           >
             {{ t('projectNamespaces.noNamespaces') }}
           </td>
         </tr>
       </template>
-      <template #main-row:fake-empty>
+      <template #main-row:fake-empty="{ fullColspan }">
         <tr class="main-row">
           <td
             class="empty text-center"
-            colspan="5"
+            :colspan="fullColspan"
           >
             {{ t('projectNamespaces.noProjectNoNamespaces') }}
           </td>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This uses the `fullColspan` slot prop for calculating the `colspan` of empty content slots in `shell/components/ExplorerProjectsNamespaces.vue`; `fullColspan` allows for properly filling available space in the table when columns are dynamically added via extensions.

Fixes #11474 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Replace `colspan="5"` with `:colspan="fullColspan"` for both empty content slots in `shell/components/ExplorerProjectsNamespaces.vue`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Projects & Namespaces

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Projects & Namespaces

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Without extension installed

![image](https://github.com/user-attachments/assets/6b41912c-b515-4405-b86d-b39477514e97)

#### With extension installed (extra column)

![image](https://github.com/user-attachments/assets/fadcec1f-43c5-4cb8-8142-55fcda3baf23)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
