### PR TITLE
Set creator principal id annotation when creating projects and v3 clusters

### DIFF
--- a/cypress/e2e/blueprints/explorer/rbac/third-party-principals-get.ts
+++ b/cypress/e2e/blueprints/explorer/rbac/third-party-principals-get.ts
@@ -1,0 +1,42 @@
+const res = {
+  type:       'collection',
+  links:      { self: 'https://localhost:8005/v3/principals' },
+  actions:    { search: 'https://localhost:8005/v3/principals?action=search' },
+  pagination: { limit: 1000 },
+  sort:       {
+    order:   'asc',
+    reverse: 'https://localhost:8005/v3/principals?order=desc',
+    links:   {
+      loginName: 'https://localhost:8005/v3/principals?sort=loginName', name: 'https://localhost:8005/v3/principals?sort=name', principalType: 'https://localhost:8005/v3/principals?sort=principalType', profilePicture: 'https://localhost:8005/v3/principals?sort=profilePicture', profileURL: 'https://localhost:8005/v3/principals?sort=profileURL', provider: 'https://localhost:8005/v3/principals?sort=provider', uuid: 'https://localhost:8005/v3/principals?sort=uuid'
+    }
+  },
+  filters: {
+    created: null, creatorId: null, id: null, loginName: null, me: null, memberOf: null, name: null, principalType: null, profilePicture: null, profileURL: null, provider: null, removed: null, uuid: null
+  },
+  resourceType: 'principal',
+  data:         [
+    {
+      baseType:      'principal',
+      created:       null,
+      creatorId:     null,
+      id:            'github://1234567890',
+      links:         { self: 'https://localhost:8005/v3/principals/github:%2F%2F1234567890' },
+      loginName:     'admin',
+      me:            true,
+      memberOf:      false,
+      name:          'Default Admin',
+      principalType: 'user',
+      provider:      'github',
+      type:          'principal'
+    }
+  ]
+};
+
+export function spoofThirdPartyPrincipal(): Cypress.Chainable<Response> {
+  return cy.intercept('GET', '/v3/principals', (req) => {
+    req.reply({
+      statusCode: 200,
+      body:       res
+    });
+  }).as('spoofThirdPartyPrincipal');
+}

--- a/cypress/e2e/tests/pages/explorer2/project-namespace.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/project-namespace.spec.ts
@@ -56,7 +56,9 @@ describe('Projects/Namespaces', { tags: ['@explorer2', '@adminUser'] }, () => {
     });
 
     afterEach(() => {
-      cy.deleteRancherResource('v3', 'projects', cy.get('@projectName'));
+      cy.get('@projectName').then((projectName) => {
+        cy.deleteRancherResource('v3', 'projects', projectName, false);
+      });
     });
   });
 

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -157,14 +157,21 @@ export default defineComponent({
       // ensure any fields editable through this UI that have been altered in azure portal are shown here - see syncUpstreamConfig jsdoc for details
       if (!this.isNewOrUnprovisioned) {
         syncUpstreamConfig('aks', this.normanCluster);
-      } else {
-        this.value.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
+      } else if (!this.$store.getters['auth/principalId'].includes('local://')) {
+        if (!this.normanCluster.annotations) {
+          this.normanCluster.annotations = {};
+        }
+        this.normanCluster.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
       }
 
       // track original version on edit to ensure we don't offer k8s downgrades
       this.originalVersion = this.normanCluster?.aksConfig?.kubernetesVersion;
     } else {
       this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...defaultCluster }, { root: true });
+
+      if (!this.$store.getters['auth/principalId'].includes('local://')) {
+        this.normanCluster.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
+      }
     }
     if (!this.normanCluster.aksConfig) {
       this.normanCluster['aksConfig'] = { ...defaultAksConfig };

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -55,6 +55,7 @@ import {
   nodePoolNamesUnique,
   nodePoolCount
 } from '../util/validators';
+import { CREATOR_PRINCIPAL_ID } from '@shell/config/labels-annotations';
 
 export const defaultNodePool = {
   availabilityZones:     ['1', '2', '3'],
@@ -95,6 +96,7 @@ const defaultCluster = {
   enableClusterMonitoring: false,
   enableNetworkPolicy:     false,
   labels:                  {},
+  annotations:             {},
   windowsPreferedCluster:  false,
 };
 
@@ -155,6 +157,8 @@ export default defineComponent({
       // ensure any fields editable through this UI that have been altered in azure portal are shown here - see syncUpstreamConfig jsdoc for details
       if (!this.isNewOrUnprovisioned) {
         syncUpstreamConfig('aks', this.normanCluster);
+      } else {
+        this.value.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
       }
 
       // track original version on edit to ensure we don't offer k8s downgrades

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -157,11 +157,6 @@ export default defineComponent({
       // ensure any fields editable through this UI that have been altered in azure portal are shown here - see syncUpstreamConfig jsdoc for details
       if (!this.isNewOrUnprovisioned) {
         syncUpstreamConfig('aks', this.normanCluster);
-      } else if (!this.$store.getters['auth/principalId'].includes('local://')) {
-        if (!this.normanCluster.annotations) {
-          this.normanCluster.annotations = {};
-        }
-        this.normanCluster.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
       }
 
       // track original version on edit to ensure we don't offer k8s downgrades

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -124,13 +124,14 @@ export default defineComponent({
       // ensure any fields editable through this UI that have been altered in aws are shown here - see syncUpstreamConfig jsdoc for details
       if (!this.isNewOrUnprovisioned) {
         syncUpstreamConfig('eks', this.normanCluster);
-      } else {
-        this.value.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
       }
       // track original version on edit to ensure we don't offer k8s downgrades
       this.originalVersion = this.normanCluster?.eksConfig?.kubernetesVersion || '';
     } else {
       this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...DEFAULT_CLUSTER }, { root: true });
+      if (!this.$store.getters['auth/principalId'].includes('local://')) {
+        this.normanCluster.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
+      }
     }
 
     if (!this.normanCluster.eksConfig) {

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -27,6 +27,7 @@ import Config from './Config.vue';
 import Networking from './Networking.vue';
 import AccountAccess from './AccountAccess.vue';
 import EKSValidators from '../util/validators';
+import { CREATOR_PRINCIPAL_ID } from '@shell/config/labels-annotations';
 
 const DEFAULT_CLUSTER = {
   dockerRootDir:                       '/var/lib/docker',
@@ -34,6 +35,7 @@ const DEFAULT_CLUSTER = {
   enableClusterMonitoring:             false,
   enableNetworkPolicy:                 false,
   labels:                              {},
+  annotations:                         {},
   windowsPreferedCluster:              false,
   fleetAgentDeploymentCustomization:   {},
   clusterAgentDeploymentCustomization: {}
@@ -122,6 +124,8 @@ export default defineComponent({
       // ensure any fields editable through this UI that have been altered in aws are shown here - see syncUpstreamConfig jsdoc for details
       if (!this.isNewOrUnprovisioned) {
         syncUpstreamConfig('eks', this.normanCluster);
+      } else {
+        this.value.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
       }
       // track original version on edit to ensure we don't offer k8s downgrades
       this.originalVersion = this.normanCluster?.eksConfig?.kubernetesVersion || '';

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -176,12 +176,13 @@ export default defineComponent({
       this.originalVersion = this.normanCluster?.gkeConfig?.kubernetesVersion;
     } else {
       this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...defaultCluster }, { root: true });
+      if (!this.$store.getters['auth/principalId'].includes('local://')) {
+        this.normanCluster.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
+      }
     }
     // ensure any fields editable through this UI that have been altered in aws are shown here - see syncUpstreamConfig jsdoc for details
     if (!this.isNewOrUnprovisioned) {
       syncUpstreamConfig('gke', this.normanCluster);
-    } else {
-      this.value.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
     }
     if (!this.normanCluster.gkeConfig) {
       this.normanCluster['gkeConfig'] = { ...defaultGkeConfig };

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -37,6 +37,7 @@ import {
   clusterNameChars, clusterNameStartEnd, requiredInCluster, ipv4WithCidr, ipv4oripv6WithCidr, GKEInitialCount
 } from '../util/validators';
 import { diffUpstreamSpec, syncUpstreamConfig } from '@shell/utils/kontainer';
+import { CREATOR_PRINCIPAL_ID } from '@shell/config/labels-annotations';
 
 const defaultMachineType = 'n1-standard-2';
 
@@ -124,6 +125,7 @@ const defaultCluster = {
   enableClusterMonitoring: false,
   enableNetworkPolicy:     false,
   labels:                  {},
+  annotations:             {},
   windowsPreferedCluster:  false,
 };
 
@@ -178,6 +180,8 @@ export default defineComponent({
     // ensure any fields editable through this UI that have been altered in aws are shown here - see syncUpstreamConfig jsdoc for details
     if (!this.isNewOrUnprovisioned) {
       syncUpstreamConfig('gke', this.normanCluster);
+    } else {
+      this.value.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
     }
     if (!this.normanCluster.gkeConfig) {
       this.normanCluster['gkeConfig'] = { ...defaultGkeConfig };

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -11,6 +11,7 @@ export const CATTLE_PUBLIC_ENDPOINTS = 'field.cattle.io/publicEndpoints';
 export const TARGET_WORKLOADS = 'field.cattle.io/targetWorkloadIds';
 export const UI_MANAGED = 'management.cattle.io/ui-managed';
 export const CREATOR_ID = 'field.cattle.io/creatorId';
+export const CREATOR_PRINCIPAL_ID = 'field.cattle.io/creator-principal-name';
 export const RESOURCE_QUOTA = 'field.cattle.io/resourceQuota';
 export const AZURE_MIGRATED = 'auth.cattle.io/azuread-endpoint-migrated';
 export const WORKSPACE_ANNOTATION = 'objectset.rio.cattle.io/id';

--- a/shell/edit/management.cattle.io.project.vue
+++ b/shell/edit/management.cattle.io.project.vue
@@ -103,8 +103,9 @@ export default {
     this.value.metadata['namespace'] = this.$store.getters['currentCluster'].id;
     this.value['spec'] = this.value.spec || {};
     this.value.spec['containerDefaultResourceLimit'] = this.value.spec.containerDefaultResourceLimit || {};
-
-    this.value.metadata.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
+    if (!this.$store.getters['auth/principalId'].includes('local://')) {
+      this.value.metadata.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
+    }
   },
   methods: {
     async save(saveCb) {

--- a/shell/edit/management.cattle.io.project.vue
+++ b/shell/edit/management.cattle.io.project.vue
@@ -14,7 +14,7 @@ import { MANAGEMENT } from '@shell/config/types';
 import { NAME } from '@shell/config/product/explorer';
 import { PROJECT_ID, _VIEW, _CREATE, _EDIT } from '@shell/config/query-params';
 import ProjectMembershipEditor, { canViewProjectMembershipEditor } from '@shell/components/form/Members/ProjectMembershipEditor';
-
+import { CREATOR_PRINCIPAL_ID } from '@shell/config/labels-annotations';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import { Banner } from '@components/Banner';
 
@@ -103,6 +103,8 @@ export default {
     this.value.metadata['namespace'] = this.$store.getters['currentCluster'].id;
     this.value['spec'] = this.value.spec || {};
     this.value.spec['containerDefaultResourceLimit'] = this.value.spec.containerDefaultResourceLimit || {};
+
+    this.value.metadata.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
   },
   methods: {
     async save(saveCb) {

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -12,7 +12,7 @@ import { mapGetters } from 'vuex';
 import { sortBy } from '@shell/utils/sort';
 import { PROVISIONER, _RKE1, _RKE2 } from '@shell/store/prefs';
 import { filterAndArrangeCharts } from '@shell/store/catalog';
-import { CATALOG } from '@shell/config/labels-annotations';
+import { CATALOG, CREATOR_PRINCIPAL_ID } from '@shell/config/labels-annotations';
 import { CAPI, MANAGEMENT, DEFAULT_WORKSPACE } from '@shell/config/types';
 import { mapFeature, RKE2 as RKE2_FEATURE, RKE1_UI } from '@shell/store/features';
 import { allHash } from '@shell/utils/promise';
@@ -123,6 +123,10 @@ export default {
       if ( !this.value.metadata ) {
         this.value.metadata = {};
       }
+      if (!this.value.metadata.annotations) {
+        this.value.metadata.annotations = {};
+      }
+      this.value.metadata.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
 
       this.value.metadata.namespace = DEFAULT_WORKSPACE;
     }

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -12,7 +12,7 @@ import { mapGetters } from 'vuex';
 import { sortBy } from '@shell/utils/sort';
 import { PROVISIONER, _RKE1, _RKE2 } from '@shell/store/prefs';
 import { filterAndArrangeCharts } from '@shell/store/catalog';
-import { CATALOG, CREATOR_PRINCIPAL_ID } from '@shell/config/labels-annotations';
+import { CATALOG } from '@shell/config/labels-annotations';
 import { CAPI, MANAGEMENT, DEFAULT_WORKSPACE } from '@shell/config/types';
 import { mapFeature, RKE2 as RKE2_FEATURE, RKE1_UI } from '@shell/store/features';
 import { allHash } from '@shell/utils/promise';
@@ -123,10 +123,6 @@ export default {
       if ( !this.value.metadata ) {
         this.value.metadata = {};
       }
-      if (!this.value.metadata.annotations) {
-        this.value.metadata.annotations = {};
-      }
-      this.value.metadata.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
 
       this.value.metadata.namespace = DEFAULT_WORKSPACE;
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11852 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR adds an annotation to projects and v3 clusters when using third-party auth. There is a corresponding [ember PR](https://github.com/rancher/ui/pull/5180) which covers rke1 clusters and importing aks/eks/gke clusters


### Areas or cases that should be tested
Using local auth, verify that no principal id annotation is set when creating projects and aks/eks/gke clusters. Using third party auth, verify that the `field.cattle.io/creator-principal-name` is set when creating projects and aks/eks/gke clusters.



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
