### PR TITLE
Prevent `fetch` when navigating on pages that contain `ResourceDetail`

### DIFF
--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -332,7 +332,11 @@ export default {
 
       const queryDiff = Object.keys(diff(neu, old));
 
-      if ( queryDiff.includes(MODE) || queryDiff.includes(AS)) {
+      if (Object.keys(neu).length <= 0) {
+        return;
+      }
+
+      if (queryDiff.includes(MODE) || queryDiff.includes(AS)) {
         this.$fetch();
       }
     },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This prevents ResourceDetail from invoking `fetch()` when navigating back. 

This PR applies existing work performed in #11986 to `shell/components/ResourceDetail/index.vue`.

Fixes #12219 
Fixes #12073
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- add a guard to the `$route.query` watcher to prevent fetch from navigating when routing back

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- We previously encountered this error in other areas, see #11986 for more details
- ResourceDetail is the only remaining component that needs to be addressed to resolve the problem

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

ResourceDetail involves almost every edit component in Dashboard.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Routing back in for edit components of Dashboard could break. 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
