### PR TITLE
Remove tests from bundle

### DIFF
--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -551,6 +551,8 @@ module.exports = function(dir, _appConfig) {
       // The static assets need to be in the built assets directory in order to get served (primarily the favicon)
       config.plugins.push(new CopyWebpackPlugin({ patterns: [{ from: path.join(SHELL_ABS, 'static'), to: '.' }] }));
 
+      config.plugins.push(new webpack.IgnorePlugin({ resourceRegExp: /\/__tests__\// }));
+
       config.resolve.extensions.push(...['.tsx', '.ts', '.js', '.vue', '.scss']);
       config.watchOptions = {
         ...(config.watchOptions || {}),


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This removes tests from Dashboard's main bundle.

Fixes #12244 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Use webpack ignore plugin to omit all `__tests__` directories

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I found test files in production builds dating all the way back to v2.8.2. I'm unsure if we always contained test files, but it's clear to me that they need to be removed.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Confirm that tests are removed from build artifacts
- Search for common test patterns to make sure tests aren't missed
- `yarn analyze` can help to confirm, alternatively inspect the primary `index.js` for deployed versions of Dashboard

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- NA

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

- Taken from `webpack-bundle-analyzer`

![image](https://github.com/user-attachments/assets/05955488-7883-48ee-b3e7-f258f9fa9b40)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
