### PR TITLE
[Automation] - Install libraries using apk if OS is Alpine

### DIFF
--- a/cypress/jenkins/transform-junit.sh
+++ b/cypress/jenkins/transform-junit.sh
@@ -2,7 +2,12 @@
 
 set -x
 
-pip3 install beautifulsoup4 requests lxml
+if cat /etc/os-release | grep -iq "Alpine Linux"; then
+  apk update
+  apk add --no-cache python3 py3-beautifulsoup4 py3-lxml py3-requests
+else
+  pip3 install beautifulsoup4 requests lxml
+fi
 
 pwd
 ls -al .


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Alpine doesn't allow libraries management using pip directly and encourage (enforces?) the use of their APK packages.
This will allow the transform of the XML Junit report used to report to Qase

### Testing done
Tested the install of the packages and the `python3` invocation in an AWS Alpine AMI.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
