### PR TITLE
update vsphere machine config to use new networks endpoint

### DIFF
--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -138,10 +138,14 @@ export default {
     }
   },
   watch: {
-    value() {
-      this.lastUpdateWasFromValue = true;
-      this.rows = (this.value || []).map((v) => ({ value: v }));
+    value: {
+      deep: true,
+      handler() {
+        this.lastUpdateWasFromValue = true;
+        this.rows = (this.value || []).map((v) => ({ value: v }));
+      }
     },
+
     rows: {
       deep: true,
       handler(newValue, oldValue) {

--- a/shell/machine-config/vmwarevsphere.vue
+++ b/shell/machine-config/vmwarevsphere.vue
@@ -546,8 +546,10 @@ export default {
     async loadNetworks() {
       set(this, 'networksResults', null);
 
-      const options = await this.requestOptions('networks', this.value.datacenter);
-      const content = this.mapPathOptionsToContent(options);
+      const options = await this.requestOptions('networks-extended', this.value.datacenter);
+      const content = options.map((opt) => {
+        return { label: `${ opt.name } (${ opt.moid })`, value: opt.moid };
+      });
 
       this.resetValueIfNecessary('network', content, options, true);
 

--- a/shell/machine-config/vmwarevsphere.vue
+++ b/shell/machine-config/vmwarevsphere.vue
@@ -64,21 +64,26 @@ const networksToVappProperties = (networks) => {
   }
 
   return networks.reduce(networkToVappProperties, [
-    `guestinfo.dns.servers=\${dns:${ networks[0] }}`,
-    `guestinfo.dns.domains=\${searchPath:${ networks[0] }}`
+    `guestinfo.dns.servers=\${dns:${ nameOnly(networks[0]) }}`,
+    `guestinfo.dns.domains=\${searchPath:${ nameOnly(networks[0]) }}`
   ]);
 };
 
 const networkToVappProperties = (props, network, i) => {
   const n = i.toString();
+  const networkName = nameOnly(network);
 
   props.push(
-    `guestinfo.interface.${ n }.ip.0.address=ip:${ network }`,
-    `guestinfo.interface.${ n }.ip.0.netmask=\${netmask:${ network }}`,
-    `guestinfo.interface.${ n }.route.0.gateway=\${gateway:${ network }}`
+    `guestinfo.interface.${ n }.ip.0.address=ip:${ networkName }`,
+    `guestinfo.interface.${ n }.ip.0.netmask=\${netmask:${ networkName }}`,
+    `guestinfo.interface.${ n }.route.0.gateway=\${gateway:${ networkName }}`
   );
 
   return props;
+};
+
+const nameOnly = (network) => {
+  return network.split('/').pop();
 };
 
 /**

--- a/shell/machine-config/vmwarevsphere.vue
+++ b/shell/machine-config/vmwarevsphere.vue
@@ -387,10 +387,11 @@ export default {
         const defaultVappOptions = getDefaultVappOptions(this.networkNames || []);
 
         return this.updateVappOptions(defaultVappOptions);
-      } else if (value === VAPP_MODE.DISABLED) {
+      } else {
         this.updateVappOptions(INITIAL_VAPP_OPTIONS);
       }
     },
+
     validationErrors(value) {
       this.$emit('error', value);
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9817 
Fixes #12271 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the vsphere machine config to use networks' `moid` instead of `name`.  This requires the use a new endpoint for networks, `meta/vsphere/networks-extended`, which contains extra information.

### Technical notes summary
This PR also corrects a reactivity issue in ArrayList:

https://github.com/user-attachments/assets/a0ff1d3f-e66d-40d7-b761-87e2d983192d


### Areas or cases that should be tested
Create an RKE2 vsphere cluster and verify that:
 1. the machine pool is saved with the networks' moid instead of name
 2. you are able to select a network other than the default (first) option
 
Create an RKE2 vsphere cluster with at least 1 network and 'vapp' auto mode selected ('Use vapp to configure networks with network protocol profiles'), verify that the save request vapp properties reference the network name, not full path (and not moid), see https://github.com/rancher/dashboard/issues/12271#issuecomment-2415312325
 
I only had 1 network in my test environment so I added fake ones in the loadNetworks method to verify that I could add/remove different networks:

```
    async loadNetworks() {
      set(this, 'networksResults', null);

      const options = await this.requestOptions('networks-extended', this.value.datacenter);
      const content = options.map((opt) => {
        return { label: `${ opt.name } (${ opt.moid })`, value: opt.moid };
      });

      content.push({ label: 'abc-123-name (moid-123-abc)', value: 'moid-123-abc' });
      content.push({ label: 'abc-123-name (moid-456-def)', value: 'moid-456-def' });

      this.resetValueIfNecessary('network', content, options, true);

      set(this, 'networksResults', content);
    }
    
```

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
