### PR TITLE
Remove custom positioning of tooltip arrows

### DIFF
--- a/shell/assets/styles/global/_tooltip.scss
+++ b/shell/assets/styles/global/_tooltip.scss
@@ -15,10 +15,7 @@
   }
 
   .v-popper__arrow-container {
-    width: 0;
-    height: 0;
     border: 0 solid transparent;
-    position: absolute;
     z-index: 1;
 
     .v-popper__arrow-inner {
@@ -30,9 +27,7 @@
     .v-popper__arrow-container {
 
       .v-popper__arrow-outer {
-        border-bottom-width: 0;
         border-top-color: var(--tooltip-bg);
-        left: -$triangle-inner-size;
       }
     }
   }
@@ -42,9 +37,7 @@
     .v-popper__arrow-container {
 
       .v-popper__arrow-outer {
-        border-top-width: 0;
         border-bottom-color: var(--tooltip-bg);
-        left: -$triangle-inner-size;
         background: transparent;
       }
     }
@@ -55,8 +48,6 @@
 
       .v-popper__arrow-outer {
         border-right-color: var(--tooltip-bg);
-        top: -$triangle-inner-size;
-        border-left-width: 0;
       }
     }
   }
@@ -65,9 +56,7 @@
     .v-popper__arrow-container {
 
       .v-popper__arrow-outer {
-        border-right-width: 0;
         border-left-color: var(--tooltip-bg);
-        top: -$triangle-inner-size;
       }
     }
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This removes custom positioning of tooltip arrows that appears to have been causing regressions in tooltip arrow styles dependent upon placement. 

Fixes #12197
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Remove css attributes related to positioning for tooltip arrow and arrow container

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I can assume that this was broken across the board with previous versions of `v-tooltip`, but these styles appear to be no longer needed now that we have migrated to `floating-vue`.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

These are global styles that affect all tooltips used throughout dashboard.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

The scope of this changes addresses all tooltips. We will want to confirm that arrows are properly located for tooltips that render

- to the top
- to the bottom
- to the left
- to the right
- a large amount of content
- a small amount of content

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Common tooltips rendered on screen

![image](https://github.com/user-attachments/assets/aa1fafe0-d724-40b6-b289-60c9f4b07281)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
