### PR TITLE
[FEAT] Added support for cluster-repo-name label for app upgrades

### DIFF
--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -91,11 +91,12 @@ export const CATALOG = {
   _CLUSTER_TPL:  'cluster-template',
   _CLUSTER_TOOL: 'cluster-tool',
 
-  COMPONENT:        'catalog.cattle.io/ui-component',
-  SOURCE_REPO_TYPE: 'catalog.cattle.io/ui-source-repo-type',
-  SOURCE_REPO_NAME: 'catalog.cattle.io/ui-source-repo',
-  COLOR:            'catalog.cattle.io/ui-color',
-  DISPLAY_NAME:     'catalog.cattle.io/display-name',
+  COMPONENT:         'catalog.cattle.io/ui-component',
+  SOURCE_REPO_TYPE:  'catalog.cattle.io/ui-source-repo-type',
+  SOURCE_REPO_NAME:  'catalog.cattle.io/ui-source-repo',
+  COLOR:             'catalog.cattle.io/ui-color',
+  DISPLAY_NAME:      'catalog.cattle.io/display-name',
+  CLUSTER_REPO_NAME: 'catalog.cattle.io/cluster-repo-name',
 
   SUPPORTED_OS: 'catalog.cattle.io/os',
   PERMITTED_OS: 'catalog.cattle.io/permits-os',

--- a/shell/models/catalog.cattle.io.app.js
+++ b/shell/models/catalog.cattle.io.app.js
@@ -55,12 +55,13 @@ export default class CatalogApp extends SteveModel {
     }
 
     const chartName = chart.metadata?.name;
-    const preferRepoType = chart.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_TYPE];
-    const preferRepoName = chart.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_NAME];
+    const repoName = chart.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_NAME] || this.metadata?.labels?.[CATALOG_ANNOTATIONS.CLUSTER_REPO_NAME];
+    const preferRepoType = chart.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_TYPE] || 'cluster';
+
     const match = this.$rootGetters['catalog/chart']({
       chartName,
+      repoName,
       preferRepoType,
-      preferRepoName,
       includeHidden
     });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11675 
<!-- Define findings related to the feature or bug issue. -->
Adjusted matchingChart function to return chart with matching repository. This ensures that we do not prompt for upgrade apps that have higher version in an unrelated repo.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
1. Added support for new label catalog.cattle.io/cluster-repo-name
2. Changed preferedChartName to chartName to make searching for matching chart return chart with correct repo 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Add 2 repositories:
test1: https://eva-vashkevich.github.io/helm_test/
test2: https://eva-vashkevich.github.io/helm_test2/

2. Go to Charts and install "cert-manager" version 0.1.0 from both repos call it cert-man1 and cert-man2
3. Go to "installed apps" and check that only cert-man2 has upgrade available
4. Go to repositories and remove "test1"
5. Go to "installed apps" and confirm again that only cert-man2 has upgrade available 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Chart upgrades
- Potentially Kubewarden

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
