### PR TITLE
Fix keymap icon positioning in codemirror

### DIFF
--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -292,17 +292,30 @@ export default {
     }
   }
 
-  .code-mirror .codemirror-container {
-    z-index: 0;
-    font-size: inherit !important;
+  .code-mirror {
+    position: relative;
 
-    // Keyboard mapping overlap
+    .codemirror-container {
+      z-index: 0;
+      font-size: inherit !important;
+
+      //rm no longer extant selector
+      .CodeMirror {
+        height: initial;
+        background: none
+      }
+
+      .CodeMirror-gutters {
+        background: inherit;
+      }
+    }
+
     .keymap.overlay {
       position: absolute;
       display: flex;
       top: 7px;
       right: 7px;
-      z-index: 1;
+      z-index: 5000;
       cursor: pointer;
 
       .keymap-indicator {
@@ -352,16 +365,6 @@ export default {
         }
       }
     }
-
-    //rm no longer extant selector
-    .CodeMirror {
-      height: initial;
-      background: none
-    }
-
-    .CodeMirror-gutters {
-      background: inherit;
-    }
-
   }
+
 </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This modifies the CSS in `shell/components/CodeMirror.vue` so that styles can properly be applied to the keymap icons.

`.codemirror-container` and `.keymap.overlay` are siblings in the rendered DOM output. This change in styles reflects that.

There's now duplication in the grouping of our `.code-mirror` styles in `CodeMirror.vue`. I'm opting to leave the separate to reduce the amount of churn in this change, but I'm completely open to merging the two groups if we feel that's the best for future maintenance. 

Fixes #12195
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Refactor styles in `shell/components/CodeMirror.vue`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- CodeMirror styles
- CodeMirror with keymaps defined

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- CodeMirror styles

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/user-attachments/assets/cd67c9e1-e70e-4cca-a83f-32a7a0182b30)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
