### PR TITLE
Fix a problem with deleting role templates from their detail pages

### DIFF
--- a/cypress/e2e/po/detail/management.cattle.io.roletemplate.po.ts
+++ b/cypress/e2e/po/detail/management.cattle.io.roletemplate.po.ts
@@ -1,10 +1,17 @@
 import RoleDetailPo from '@/cypress/e2e/po/detail/role.po';
 import RoleTemplateEditPo from '@/cypress/e2e/po/edit/management.cattle.io.roletemplate.po';
 import ResourceDetailPo from '@/cypress/e2e/po/edit/resource-detail.po';
+import ActionMenu from '@/cypress/e2e/po/components/action-menu.po';
 
 class RoleTemplateDetailComponentPo extends ResourceDetailPo {
   userCreateEditView(clusterId: string, userId?: string ) {
     return new RoleTemplateEditPo(clusterId, userId);
+  }
+
+  openMastheadActionMenu() {
+    this.self().get('[data-testid="mathead-action-menu"]').click();
+
+    return new ActionMenu(undefined);
   }
 }
 

--- a/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
@@ -228,6 +228,25 @@ describe('Roles Templates', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
       promptRemove.warning().first().should('contain.text', 'Caution:'); // Check warning message content
     });
 
+    it('can delete a role template from the detail page', () => {
+      // Delete role and verify role is removed from list
+      roles.waitForRequests();
+      const oneRoleTemplateId = roleTemplatesToDelete.splice(0, 1)[0];
+      const detailPage = roles.detailRole(oneRoleTemplateId);
+
+      detailPage.goTo();
+      detailPage.waitForPage();
+
+      const actionMenu = detailPage.detail().openMastheadActionMenu();
+
+      actionMenu.clickMenuItem(5);
+
+      const promptRemove = new PromptRemove();
+
+      promptRemove.remove();
+      roles.list('CLUSTER').elementWithName(oneRoleTemplateId).should('not.exist');
+    });
+
     it('can delete a role template', () => {
     // Delete role and verify role is removed from list
       roles.waitForRequests();

--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -105,8 +105,8 @@ export default {
         return null;
       }
 
-      if (this.toRemove[0].doneLocationRemove) {
-        return this.toRemove[0].doneLocationRemove;
+      if (this.toRemove[0].doneOverride) {
+        return this.toRemove[0].doneOverride;
       }
 
       const currentRoute = this.toRemove[0].currentRoute();

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -521,6 +521,7 @@ export default {
             <button
               v-if="isView"
               ref="actions"
+              data-testid="mathead-action-menu"
               aria-haspopup="true"
               type="button"
               class="btn role-multi-action actions"


### PR DESCRIPTION
We were attempting to navigate back to a non-existent page when deleting role templates from their corresponding detail pages. This caused the Prompt Remove dialog to show an error button and not close.

https://github.com/rancher/dashboard/issues/12217

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
