### PR TITLE
Watch and compare route before re-invoking `fetch()` in ResourceDetail

### DIFF
--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -318,9 +318,12 @@ export default {
   },
 
   watch: {
-    '$route.query'(inNeu, inOld) {
-      const neu = clone(inNeu);
-      const old = clone(inOld);
+    '$route'(current, prev) {
+      if (current.name !== prev.name) {
+        return;
+      }
+      const neu = clone(current.query);
+      const old = clone(prev.query);
 
       delete neu[PREVIEW];
       delete old[PREVIEW];
@@ -331,10 +334,6 @@ export default {
       }
 
       const queryDiff = Object.keys(diff(neu, old));
-
-      if (Object.keys(neu).length <= 0) {
-        return;
-      }
 
       if (queryDiff.includes(MODE) || queryDiff.includes(AS)) {
         this.$fetch();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves an issue that was preventing the detail page from rendering. #12237 introduced a change that would prevent errors from being thrown if `fetch()` was invoked against a route without any keys in its query - a use case that was required for navigating between tabs in edit views.

This fix attempts to address a change in timing between route watchers and component unmounting by slightly modifying the approach taken in #12237 by watching the route and only allowing `fetch()` to re-invoke if the route hasn't changed. The differences observed appear to be related to:

- Vue2: Component unmounts before the route watcher invokes
- Vue3: Watcher triggers before the component unmounts, potentially raising unhandled exceptions during navigation between pages & tabs 

Fixes #12267 
Fixes #12275
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- watch `$route` instead of `$route.query` in ResourceDetail
- assert that `$route.name` hasn't changed before invoking `fetch()` 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

This modifies `fetch()` behavior for all edit components. Navigation between edit pages and tabs needs to be tested.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Navigation and data fetching for edit components. 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
