### PR TITLE
fix gke provisioning form stale data

### DIFF
--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -185,7 +185,7 @@ export default defineComponent({
       syncUpstreamConfig('gke', this.normanCluster);
     }
     if (!this.normanCluster.gkeConfig) {
-      this.normanCluster['gkeConfig'] = { ...defaultGkeConfig };
+      this.normanCluster['gkeConfig'] = cloneDeep(defaultGkeConfig);
     }
     if (!this.normanCluster.gkeConfig.nodePools) {
       this.normanCluster.gkeConfig['nodePools'] = [{ ...cloneDeep(defaultNodePool), name: 'group-1' }];


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11864 

This PR updates the gke provisioning form to ensure that any default configuration applied when creating clusters _copies_ the defaults defined in the component instead of _modifying_ the default configuration object, so that when the component is reused, the default configuration has not been changed.

### Areas or cases that should be tested
1. Create a new GKE cluster and enable private cluster, private endpoint, and master authorized network (all under the advanced section of the networking tab)
2. After saving, go to create another GKE cluster: verify that the advanced networking section has been reset to default values (all 3 checkboxes unchecked)

### Areas which could experience regressions
none


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
