### PR TITLE
 remove references to window.c

### DIFF
--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -573,10 +573,6 @@ export default {
     }
   },
 
-  mounted() {
-    window.c = this;
-  },
-
   methods: {
     toggleScaleDownModal( event, resources ) {
       // Check if the user held alt key when an action is clicked.

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -147,11 +147,7 @@ export default {
   $loadingResources() {
     // results are filtered so we wouldn't get the correct count on indicator...
     return { loadIndeterminate: true };
-  },
-
-  mounted() {
-    window.c = this;
-  },
+  }
 };
 </script>
 

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -247,12 +247,6 @@ export default {
     }
   },
 
-  mounted() {
-    if ( typeof window !== 'undefined' ) {
-      window.c = this;
-    }
-  },
-
   methods: {
     colorForChart(chart) {
       const repos = this.repoOptions;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11311

`window.c` is defined then never referenced. The 3 edited pages still render without errors.

### Areas which could experience regressions
cluster list view
cluster detail view
apps & marketplace charts list



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
