### PR TITLE
Enabling the Kontainer-Driver's `can delete drivers in bulk` e2e test.

### DIFF
--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -207,7 +207,7 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     createCluster.gridElementExistanceByName(linodeDriver, 'not.exist');
   });
 
-  it.skip('[Vue3 Skip]: can delete drivers in bulk', () => {
+  it('can delete drivers in bulk', () => {
     KontainerDriversPagePo.navTo();
     driversPage.waitForPage();
     driversPage.list().resourceTable().sortableTable().rowSelectCtlWithName(oracleDriver)
@@ -231,7 +231,6 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
         cy.wait('@deleteOracleDriver').its('response.statusCode').should('eq', 200);
 
         driversPage.waitForPage();
-        driversPage.list().details(linodeDriver, 1).contains('Removing');
         driversPage.list().resourceTable().sortableTable().checkRowCount(false, rows.length - 2);
         driversPage.list().resourceTable().sortableTable().rowNames()
           .should('not.contain', linodeDriver)


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
 Enabling the Kontainer-Driver's can delete drivers in bulk e2e test. #12286 

### Technical notes summary
This was disabled because it would block the workflow when we first migrated to vue3. We're now re-enabling those tests.

### Areas or cases that should be tested
None, only an e2e test was modified.

### Areas which could experience regressions
None, only an e2e test was modified.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
