### PR TITLE
Fix fleet cattle healthcheck

### DIFF
--- a/cypress/e2e/po/pages/explorer/cluster-dashboard.po.ts
+++ b/cypress/e2e/po/pages/explorer/cluster-dashboard.po.ts
@@ -63,4 +63,20 @@ export default class ClusterDashboardPagePo extends PagePo {
   clusterActionsHeader() {
     return new HeaderPo();
   }
+
+  fleetStatus() {
+    return cy.get('[data-testid="k8s-service-fleet"]');
+  }
+
+  etcdStatus() {
+    return cy.get('[data-testid="k8s-service-fleet"]');
+  }
+
+  schedulerStatus() {
+    return cy.get('[data-testid="k8s-service-fleet"]');
+  }
+
+  controllerManagerStatus() {
+    return cy.get('[data-testid="k8s-service-fleet"]');
+  }
 }

--- a/cypress/e2e/po/pages/explorer/cluster-dashboard.po.ts
+++ b/cypress/e2e/po/pages/explorer/cluster-dashboard.po.ts
@@ -69,14 +69,14 @@ export default class ClusterDashboardPagePo extends PagePo {
   }
 
   etcdStatus() {
-    return cy.get('[data-testid="k8s-service-fleet"]');
+    return cy.get('[data-testid="k8s-service-etcd"]');
   }
 
   schedulerStatus() {
-    return cy.get('[data-testid="k8s-service-fleet"]');
+    return cy.get('[data-testid="k8s-service-scheduler"]');
   }
 
   controllerManagerStatus() {
-    return cy.get('[data-testid="k8s-service-fleet"]');
+    return cy.get('[data-testid="k8s-service-controller-manager"]');
   }
 }

--- a/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
@@ -62,6 +62,12 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
     cy.title().should('eq', 'Rancher - local - Cluster Dashboard');
   });
 
+  it('shows fleet controller status', () => {
+    ClusterDashboardPagePo.navTo();
+    clusterDashboard.waitForPage(undefined, 'cluster-events');
+    clusterDashboard.fleetStatus().should('exist');
+  });
+
   it('can import a YAML successfully, using the header action "Import YAML"', () => {
     ClusterDashboardPagePo.navTo();
 
@@ -282,6 +288,73 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
       .each((el, i) => {
         expect(el.text().trim()).to.eq(expectedFullHeaders[i]);
       });
+  });
+
+  describe('Cluster dashboard with limited permissions', () => {
+    let stdProjectName;
+    let stdNsName;
+    let stdUsername;
+
+    beforeEach(() => {
+      stdProjectName = `standard-user-project${ +new Date() }`;
+      stdNsName = `standard-user-ns${ +new Date() }`;
+      stdUsername = `standard-user-${ +new Date() }`;
+      // log in as admin
+      cy.login();
+      cy.getRancherResource('v3', 'users?me=true').then((resp: Cypress.Response<any>) => {
+        const adminUserId = resp.body.data[0].id.trim();
+
+        // create project
+        cy.createProject(stdProjectName, 'local', adminUserId).then((resp: Cypress.Response<any>) => {
+          cy.wrap(resp.body.id.trim()).as('standardUserProject');
+
+          // create ns in project
+          cy.get<string>('@standardUserProject').then((projId) => {
+            cy.createNamespaceInProject(stdNsName, projId);
+
+            // create std user and assign to project
+            cy.createUser({
+              username:    stdUsername,
+              globalRole:  { role: 'user' },
+              projectRole: {
+                clusterId: 'local', projectName: stdProjectName, role: 'project-owner'
+              }
+            }).as('createUserRequest');
+          });
+        });
+      });
+      // log in as new standard user
+      cy.login(stdUsername, Cypress.env('password'), false);
+
+      // go to cluster dashboard
+      ClusterDashboardPagePo.navTo();
+      clusterDashboard.waitForPage(undefined, 'cluster-events');
+    });
+
+    // note - this would be 'fleet agent' on downstream clusters
+    it('does not show fleet controller status if the user does not have permission to view the fleet controller deployment', () => {
+      clusterDashboard.fleetStatus().should('not.exist');
+
+      clusterDashboard.etcdStatus().should('exist');
+      clusterDashboard.schedulerStatus().should('exist');
+      clusterDashboard.controllerManagerStatus().should('exist');
+    });
+
+    // log back in as admin and delete the project, ns, and user from previous test
+    afterEach(() => {
+      cy.login();
+      cy.deleteRancherResource('v1', 'namespaces', stdNsName);
+
+      cy.get('@standardUserProject').then((projectId) => {
+        cy.deleteRancherResource('v3', 'projects', projectId);
+      });
+
+      cy.get('@createUserRequest').then((req) => {
+        const userId = req.body.userPrincipalId.split('//').pop();
+
+        cy.deleteRancherResource('v3', 'users', userId);
+      });
+    });
   });
 
   after(function() {

--- a/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
@@ -64,7 +64,7 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
 
   it('shows fleet controller status', () => {
     ClusterDashboardPagePo.navTo();
-    clusterDashboard.waitForPage(undefined, 'cluster-events');
+    clusterDashboard.waitForPage();
     clusterDashboard.fleetStatus().should('exist');
   });
 
@@ -328,7 +328,7 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
 
       // go to cluster dashboard
       ClusterDashboardPagePo.navTo();
-      clusterDashboard.waitForPage(undefined, 'cluster-events');
+      clusterDashboard.waitForPage();
     });
 
     // note - this would be 'fleet agent' on downstream clusters

--- a/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
@@ -25,9 +25,12 @@ describe('page: cluster dashboard', () => {
             'cluster/inError':   () => false,
             'cluster/schemaFor': jest.fn(),
             'cluster/canList':   jest.fn(),
-            'cluster/all':       jest.fn(),
-            'i18n/exists':       jest.fn(),
-            'i18n/t':            (label: string) => label === 'generic.provisioning' ? '—' : jest.fn()(),
+            'cluster/byId':      () => {
+              return {};
+            },
+            'cluster/all': jest.fn(),
+            'i18n/exists': jest.fn(),
+            'i18n/t':      (label: string) => label === 'generic.provisioning' ? '—' : jest.fn()(),
           }
         }
       },

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -115,13 +115,6 @@ export default {
       if (this.currentCluster.isLocal && this.$store.getters['management/schemaFor'](MANAGEMENT.NODE)) {
         this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE });
       }
-
-      // // this.canViewAgents = this.$store.getters['cluster/canList'](WORKLOAD_TYPES.DEPLOYMENT) && this.$store.getters['cluster/canList'](WORKLOAD_TYPES.STATEFUL_SET);
-      // this.canViewAgents = this.$store.getters['cluster/byId'](NAMESPACE, 'cattle-fleet-system') || (!this.currentCluster.isLocal && this.$store.getters['cluster/byId'](NAMESPACE, 'cattle-system'));
-
-      // if (this.canViewAgents) {
-      //   this.loadAgents();
-      // }
     }
   },
 
@@ -139,7 +132,6 @@ export default {
       cattleDeployment:   'loading',
       fleetDeployment:    'loading',
       fleetStatefulSet:   'loading',
-      // canViewAgents:      false,
       disconnected:       false,
       events:             [],
       nodeMetrics:        [],
@@ -527,19 +519,6 @@ export default {
           this.disconnected = !!this.$store.getters['cluster/inError']({ type: NODE });
         }, 1000);
       }
-
-      // if (this.currentCluster.isLocal) {
-      //     this.setAgentResource('fleetDeployment', WORKLOAD_TYPES.DEPLOYMENT, 'cattle-fleet-system/fleet-controller');
-      //     this.setAgentResource('fleetStatefulSet', WORKLOAD_TYPES.STATEFUL_SET, 'cattle-fleet-local-system/fleet-agent');
-      // } else {
-      //     this.setAgentResource('fleetStatefulSet', WORKLOAD_TYPES.STATEFUL_SET, 'cattle-fleet-system/fleet-agent');
-      //     this.setAgentResource('cattleDeployment', WORKLOAD_TYPES.DEPLOYMENT, 'cattle-system/cattle-cluster-agent');
-
-      //   // Scaling Up/Down cattle deployment causes web sockets disconnection;
-      //   this.interval = setInterval(() => {
-      //     this.disconnected = !!this.$store.getters['cluster/inError']({ type: NODE });
-      //   }, 1000);
-      // }
     },
 
     async setAgentResource(agent, type, id) {

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -116,11 +116,12 @@ export default {
         this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE });
       }
 
-      this.canViewAgents = this.$store.getters['cluster/canList'](WORKLOAD_TYPES.DEPLOYMENT) && this.$store.getters['cluster/canList'](WORKLOAD_TYPES.STATEFUL_SET);
+      // // this.canViewAgents = this.$store.getters['cluster/canList'](WORKLOAD_TYPES.DEPLOYMENT) && this.$store.getters['cluster/canList'](WORKLOAD_TYPES.STATEFUL_SET);
+      // this.canViewAgents = this.$store.getters['cluster/byId'](NAMESPACE, 'cattle-fleet-system') || (!this.currentCluster.isLocal && this.$store.getters['cluster/byId'](NAMESPACE, 'cattle-system'));
 
-      if (this.canViewAgents) {
-        this.loadAgents();
-      }
+      // if (this.canViewAgents) {
+      //   this.loadAgents();
+      // }
     }
   },
 
@@ -138,7 +139,7 @@ export default {
       cattleDeployment:   'loading',
       fleetDeployment:    'loading',
       fleetStatefulSet:   'loading',
-      canViewAgents:      false,
+      // canViewAgents:      false,
       disconnected:       false,
       events:             [],
       nodeMetrics:        [],
@@ -172,6 +173,17 @@ export default {
     clearInterval(this.interval);
   },
 
+  watch: {
+    canViewAgents: {
+      handler(neu, old) {
+        if (neu && !old) {
+          this.loadAgents();
+        }
+      },
+      immediate: true
+    }
+  },
+
   computed: {
     ...mapGetters(['currentCluster']),
     ...monitoringStatus(),
@@ -182,6 +194,22 @@ export default {
 
     mgmtNodes() {
       return this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
+    },
+
+    fleetAgentNamespace() {
+      return this.$store.getters['cluster/byId'](NAMESPACE, 'cattle-fleet-system');
+    },
+
+    cattleAgentNamespace() {
+      if (this.currentCluster.isLocal) {
+        return;
+      }
+
+      return this.$store.getters['cluster/byId'](NAMESPACE, 'cattle-system');
+    },
+
+    canViewAgents() {
+      return !!this.fleetAgentNamespace || (!this.currentCluster.isLocal && this.cattleAgentNamespace);
     },
 
     showClusterTools() {
@@ -268,15 +296,15 @@ export default {
         });
       });
 
-      if (this.canViewAgents) {
-        if (!this.currentCluster.isLocal) {
-          services.push({
-            name:     'cattle',
-            status:   this.cattleStatus,
-            labelKey: 'clusterIndexPage.sections.componentStatus.cattle',
-          });
-        }
+      if (this.cattleAgentNamespace) {
+        services.push({
+          name:     'cattle',
+          status:   this.cattleStatus,
+          labelKey: 'clusterIndexPage.sections.componentStatus.cattle',
+        });
+      }
 
+      if (this.fleetAgentNamespace) {
         services.push({
           name:     'fleet',
           status:   this.fleetStatus,
@@ -485,18 +513,33 @@ export default {
 
   methods: {
     loadAgents() {
-      if (this.currentCluster.isLocal) {
-        this.setAgentResource('fleetDeployment', WORKLOAD_TYPES.DEPLOYMENT, 'cattle-fleet-system/fleet-controller');
-        this.setAgentResource('fleetStatefulSet', WORKLOAD_TYPES.STATEFUL_SET, 'cattle-fleet-local-system/fleet-agent');
-      } else {
-        this.setAgentResource('fleetStatefulSet', WORKLOAD_TYPES.STATEFUL_SET, 'cattle-fleet-system/fleet-agent');
+      if (this.fleetAgentNamespace) {
+        if (this.currentCluster.isLocal) {
+          this.setAgentResource('fleetDeployment', WORKLOAD_TYPES.DEPLOYMENT, 'cattle-fleet-system/fleet-controller');
+          this.setAgentResource('fleetStatefulSet', WORKLOAD_TYPES.STATEFUL_SET, 'cattle-fleet-local-system/fleet-agent');
+        } else {
+          this.setAgentResource('fleetStatefulSet', WORKLOAD_TYPES.STATEFUL_SET, 'cattle-fleet-system/fleet-agent');
+        }
+      }
+      if (this.cattleAgentNamespace) {
         this.setAgentResource('cattleDeployment', WORKLOAD_TYPES.DEPLOYMENT, 'cattle-system/cattle-cluster-agent');
-
-        // Scaling Up/Down cattle deployment causes web sockets disconnection;
         this.interval = setInterval(() => {
           this.disconnected = !!this.$store.getters['cluster/inError']({ type: NODE });
         }, 1000);
       }
+
+      // if (this.currentCluster.isLocal) {
+      //     this.setAgentResource('fleetDeployment', WORKLOAD_TYPES.DEPLOYMENT, 'cattle-fleet-system/fleet-controller');
+      //     this.setAgentResource('fleetStatefulSet', WORKLOAD_TYPES.STATEFUL_SET, 'cattle-fleet-local-system/fleet-agent');
+      // } else {
+      //     this.setAgentResource('fleetStatefulSet', WORKLOAD_TYPES.STATEFUL_SET, 'cattle-fleet-system/fleet-agent');
+      //     this.setAgentResource('cattleDeployment', WORKLOAD_TYPES.DEPLOYMENT, 'cattle-system/cattle-cluster-agent');
+
+      //   // Scaling Up/Down cattle deployment causes web sockets disconnection;
+      //   this.interval = setInterval(() => {
+      //     this.disconnected = !!this.$store.getters['cluster/inError']({ type: NODE });
+      //   }, 1000);
+      // }
     },
 
     async setAgentResource(agent, type, id) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12259 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR tweaks the logic used to show fleet and cattle agent statuses on the cluster explorer dashboard. Previously we checked that the user was able to list deployments; now we check that they can see the namespace the deployments would be in.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
Cluster explorer dashboard with both local and downstream clusters (local will not show cattle agent), both as admin and a user with project membership only, as outlined in #12259 



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
