### PR TITLE
include gke zone in list of extra locations

### DIFF
--- a/pkg/gke/components/Config.vue
+++ b/pkg/gke/components/Config.vue
@@ -204,7 +204,7 @@ export default defineComponent({
           this.$emit('update:region', this.defaultRegion);
         } else {
           this.$emit('update:region', null);
-          this.$emit('update:zone', this.defaultZone);
+          this.setZone({ name: this.defaultZone });
         }
       }
     },
@@ -389,6 +389,8 @@ export default defineComponent({
     setZone(neu: {name: string}) {
       this.selectedZone = neu;
       this.$emit('update:zone', neu.name);
+
+      this.$emit('update:locations', [neu.name]);
     },
 
     setExtraZone(add: boolean, zone: string) {
@@ -443,6 +445,7 @@ export default defineComponent({
           :value="zone"
           :disabled="!isNewOrUnprovisioned"
           :loading="loadingZones"
+          data-testid="gke-zone-select"
           @selecting="setZone"
         />
       </div>
@@ -462,7 +465,7 @@ export default defineComponent({
           :label="zoneOpt.name"
           :value="locations.includes(zoneOpt.name)"
           :data-testid="`gke-extra-zones-${zoneOpt.name}`"
-          :disabled="!isNewOrUnprovisioned"
+          :disabled="isView"
           class="extra-zone-checkbox"
           @update:value="e=>setExtraZone(e, zoneOpt.name)"
         />

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -100,7 +100,7 @@ const defaultGkeConfig = {
   },
   kubernetesVersion:        '',
   labels:                   {},
-  locations:                [],
+  locations:                [DEFAULT_GCP_ZONE],
   loggingService:           'logging.googleapis.com/kubernetes',
   maintenanceWindow:        '',
   masterAuthorizedNetworks: { enabled: false, cidrBlocks: [] },

--- a/pkg/gke/components/__tests__/Config.test.ts
+++ b/pkg/gke/components/__tests__/Config.test.ts
@@ -4,15 +4,6 @@ import flushPromises from 'flush-promises';
 import Config from '@pkg/gke/components/Config.vue';
 import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 
-// const mockedValidationMixin = {
-//   computed: {
-//     fvFormIsValid:                jest.fn(),
-//     type:                         jest.fn(),
-//     fvUnreportedValidationErrors: jest.fn(),
-//   },
-//   methods: { fvGetAndReportPathRules: jest.fn() }
-// };
-
 const mockedStore = (versionSetting: any) => {
   return {
     getters: {
@@ -207,5 +198,30 @@ describe('gke Config', () => {
     });
 
     expect(Object.keys(checkedNotInLocations)).toHaveLength(0);
+  });
+
+  it('should add newly selected zone to the list of extra zones (gkeConfig.locations) and remove old extra zones', async() => {
+    const setup = requiredSetup();
+
+    const wrapper = shallowMount(Config, {
+      propsData: {
+        zone:              'us-east1-b',
+        region:            '',
+        cloudCredentialId: '',
+        projectId:         'test-project',
+        locations:         ['us-east1-a']
+      },
+      ...setup
+    });
+
+    wrapper.setProps({ cloudCredentialId: 'abc' });
+    await flushPromises();
+
+    const zoneSelect = wrapper.getComponent('[data-testid="gke-zone-select"]');
+
+    zoneSelect.vm.$emit('selecting', { name: 'us-east4-b' });
+
+    await flushPromises();
+    expect(wrapper.emitted('update:locations')[0][0]).toStrictEqual(['us-east4-b']);
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12261 
Fixes #12260 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
updates the GKE provisioning form so that when a user selects a zone, the `locations` field (which otherwise maps to the list of extra zones) includes that zone. 


### Areas or cases that should be tested
1. Create a 'zonal' GKE cluster without adding zones (default configuration), wait for the cluster to become active
2. Once the cluster has finished provisioning verify that you can edit it and add extra zones (`gkeConfig.locations` in the save request), and that the cluster is eventually 'active' again
3. Create a new 'zonal' gke cluster and define extra zones initially
4. Wait for the cluster to provision; verify that you can add/remove extra zones

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
