### PR TITLE
Replace `beforeDestroy` lifecycle option with `beforeUnmount`

### DIFF
--- a/shell/components/SortableTable/actions.js
+++ b/shell/components/SortableTable/actions.js
@@ -18,7 +18,7 @@ export default {
     };
   },
 
-  beforeDestroy() {
+  beforeUnmount() {
     window.removeEventListener('resize', this.onWindowResize);
   },
 

--- a/shell/components/SortableTable/selection.js
+++ b/shell/components/SortableTable/selection.js
@@ -20,7 +20,7 @@ export default {
     table.addEventListener('contextmenu', this._onRowContextBound);
   },
 
-  beforeDestroy() {
+  beforeUnmount() {
     const table = this.$el.querySelector('TABLE');
 
     table.removeEventListener('click', this._onRowClickBound);

--- a/shell/mixins/browser-tab-visibility.js
+++ b/shell/mixins/browser-tab-visibility.js
@@ -25,7 +25,7 @@ export default {
   mounted() {
     this.setTabVisibilityListener(true);
   },
-  beforeDestroy() {
+  beforeUnmount() {
     this.setTabVisibilityListener(false);
   },
 };

--- a/shell/mixins/metric-poller.js
+++ b/shell/mixins/metric-poller.js
@@ -13,7 +13,7 @@ export default {
     this.metricPoller.start();
   },
 
-  beforeDestroy() {
+  beforeUnmount() {
     this.metricPoller.stop();
   },
 };

--- a/shell/mixins/resource-fetch.js
+++ b/shell/mixins/resource-fetch.js
@@ -48,7 +48,7 @@ export default {
     };
   },
 
-  beforeDestroy() {
+  beforeUnmount() {
     // make sure this only runs once, for the initialized instance
     if (this.init) {
       // clear up the store to make sure we aren't storing anything that might interfere with the next rendered list view


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This replaces any remaining `beforeDestroy` lifecycle options with `beforeDestroy`, as mentioned in the Vue 3 migration guide[^1]. This change should also properly clean up the metrics poller, resolving the attached issue.

Fixes #12292 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Replace `beforeDestroy` lifecycle option with `beforeUnmount`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I searched for instances of `destroyed` in Dashboard, but did not find any. I'm not aware of any other lifecycle options that would need to update at this point.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

A lot of these lifecycle hooks are used in mixins. There's a good example to test in the associated issue, but also consider testing

- Sortable Table
- Resource Fetch
- Browser Tab Visibility

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This should be fixing regressions in each of the affected areas, as `beforeDestroy` is no longer a valid hook.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
