### PR TITLE
Add `inheritAttrs: false` to edit components

### DIFF
--- a/shell/edit/cis.cattle.io.clusterscanbenchmark.vue
+++ b/shell/edit/cis.cattle.io.clusterscanbenchmark.vue
@@ -18,6 +18,8 @@ export default {
 
   mixins: [createEditView],
 
+  inheritAttrs: false,
+
   props: {
     value: {
       type:    Object,

--- a/shell/edit/constraints.gatekeeper.sh.constraint/index.vue
+++ b/shell/edit/constraints.gatekeeper.sh.constraint/index.vue
@@ -48,6 +48,8 @@ export default {
 
   mixins: [CreateEditView],
 
+  inheritAttrs: false,
+
   props: {
     value: {
       type:     Object,

--- a/shell/edit/fleet.cattle.io.cluster.vue
+++ b/shell/edit/fleet.cattle.io.cluster.vue
@@ -20,6 +20,8 @@ export default {
     NameNsDescription,
   },
 
+  inheritAttrs: false,
+
   mixins: [CreateEditView],
 
   props: {
@@ -53,6 +55,7 @@ export default {
   methods: {
     async save(buttonDone) {
       try {
+        this.errors = [];
         await this.value.save();
 
         await this.normanCluster.save();
@@ -60,6 +63,7 @@ export default {
         this.done();
         buttonDone(true);
       } catch (e) {
+        this.errors.push(e);
         buttonDone(false);
       }
     },

--- a/shell/edit/helm.cattle.io.projecthelmchart.vue
+++ b/shell/edit/helm.cattle.io.projecthelmchart.vue
@@ -21,6 +21,8 @@ export default {
 
   mixins: [createEditView],
 
+  inheritAttrs: false,
+
   props: {
     value: {
       type:     Object,

--- a/shell/edit/k8s.cni.cncf.io.networkattachmentdefinition.vue
+++ b/shell/edit/k8s.cni.cncf.io.networkattachmentdefinition.vue
@@ -22,6 +22,8 @@ export default {
 
   mixins: [CreateEditView],
 
+  inheritAttrs: false,
+
   props: {
     value: {
       type:     Object,

--- a/shell/edit/kontainerDriver.vue
+++ b/shell/edit/kontainerDriver.vue
@@ -15,6 +15,8 @@ export default {
 
   mixins: [CreateEditView, FormValidation],
 
+  inheritAttrs: false,
+
   data() {
     return {
       fvFormRuleSets: [

--- a/shell/edit/logging-flow/index.vue
+++ b/shell/edit/logging-flow/index.vue
@@ -50,6 +50,8 @@ export default {
 
   mixins: [CreateEditView],
 
+  inheritAttrs: false,
+
   async fetch() {
     const hasAccessToClusterOutputs = this.$store.getters[`cluster/schemaFor`](LOGGING.CLUSTER_OUTPUT);
     const hasAccessToOutputs = this.$store.getters[`cluster/schemaFor`](LOGGING.OUTPUT);

--- a/shell/edit/management.cattle.io.projectroletemplatebinding.vue
+++ b/shell/edit/management.cattle.io.projectroletemplatebinding.vue
@@ -11,7 +11,8 @@ export default {
     ProjectMemberEditor,
   },
 
-  mixins: [CreateEditView],
+  mixins:       [CreateEditView],
+  inheritAttrs: false,
   async fetch() {
     await this.$store.dispatch('management/findAll', { type: MANAGEMENT.USER });
     this.projects = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.PROJECT });

--- a/shell/edit/management.cattle.io.user.vue
+++ b/shell/edit/management.cattle.io.user.vue
@@ -14,9 +14,12 @@ export default {
   components: {
     ChangePassword, GlobalRoleBindings, CruResource, LabeledInput, Loading
   },
+
   mixins: [
     CreateEditView
   ],
+
+  inheritAttrs: false,
 
   data() {
     const showGlobalRoles = !!this.$store.getters[`management/schemaFor`](MANAGEMENT.GLOBAL_ROLE);

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
@@ -30,6 +30,8 @@ export default {
 
   mixins: [CreateEditView],
 
+  inheritAttrs: false,
+
   async fetch() {
     const inStore = this.$store.getters['currentProduct'].inStore;
     const alertmanagerConfigId = this.value.id;

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
@@ -105,6 +105,8 @@ export default {
 
   mixins: [CreateEditView, FormValidation],
 
+  inheritAttrs: false,
+
   async fetch() {
     /**
      * example receiver value:

--- a/shell/edit/monitoring.coreos.com.prometheusrule/index.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/index.vue
@@ -29,6 +29,8 @@ export default {
 
   mixins: [CreateEditView, FormValidation],
 
+  inheritAttrs: false,
+
   props: {
     value: {
       type:     Object,

--- a/shell/edit/monitoring.coreos.com.receiver/index.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/index.vue
@@ -37,6 +37,8 @@ export default {
 
   mixins: [CreateEditView],
 
+  inheritAttrs: false,
+
   async fetch() {
     await this.$store.dispatch('cluster/findAll', { type: MONITORING.SPOOFED.ROUTE });
   },

--- a/shell/edit/monitoring.coreos.com.route.vue
+++ b/shell/edit/monitoring.coreos.com.route.vue
@@ -35,6 +35,8 @@ export default {
 
   mixins: [CreateEditView],
 
+  inheritAttrs: false,
+
   async fetch() {
     const receivers = this.$store.dispatch('cluster/findAll', { type: MONITORING.SPOOFED.RECEIVER });
     const routes = this.$store.dispatch('cluster/findAll', { type: MONITORING.SPOOFED.ROUTE });

--- a/shell/edit/networking.istio.io.destinationrule/index.vue
+++ b/shell/edit/networking.istio.io.destinationrule/index.vue
@@ -24,6 +24,8 @@ export default {
 
   mixins: [CreateEditView],
 
+  inheritAttrs: false,
+
   created() {
     if (!get(this.value, 'spec.trafficPolicy.loadBalancer')) {
       set(this.value, 'spec.trafficPolicy.loadBalancer', { simple: 'ROUND_ROBIN' });

--- a/shell/edit/nodeDriver.vue
+++ b/shell/edit/nodeDriver.vue
@@ -15,6 +15,8 @@ export default {
 
   mixins: [CreateEditView, FormValidation],
 
+  inheritAttrs: false,
+
   data() {
     return {
       fvFormRuleSets: [

--- a/shell/edit/provisioning.cattle.io.cluster/import.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/import.vue
@@ -36,6 +36,8 @@ export default {
 
   mixins: [CreateEditView],
 
+  inheritAttrs: false,
+
   props: {
     mode: {
       type:     String,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves an issue with Vue 3 fallthrough attributes overwriting props for root-level ancestor components by adding `inheritAttrs: false` to each component in question. Adding `inheritAttrs: false` to the component allows us to specify that fallthrough attributes should not be automatically applied to the root-level element in a component.

Fixes #12298 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add `inheritAttrs: false` to components that might have a conflict with fallthrough attributes and the `errors` prop in root-level components

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

See #12298 for additional notes on why certain components were not modified. We can still opt to add `inheritAttrs: false` to these components, but I'm of the mindset that it's better to only apply the change if it is needed.

See https://github.com/rancher/dashboard/pull/11956#issuecomment-2400878330 for a more in-depth discussion about this behavior. In short, the root cause has to do with a change in how Vue 3 applies fallthrough attributes to root-level ancestor components - preferring to use the fallthrough attribute if there is a conflicting prop present.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

This modifies a wide range of components and aims to resolve issues with presenting errors on the page if a form fails to submit. In most cases, an invalid name can be supplied and we can confirm whether or not an error is rendered on the page when the form fails to submit.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Since this adds `inheritAttrs: false`, no fallthrough attributes will be applied to the root-level component, this means that the component will not receive attributes like `class`, `style`, etc.. In past applications, this has not been an issue for edit components, but we should take not of any possible visual regressions that might occur as a result of this change.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
