### PR TITLE
Don't use pre-minified Vue version

### DIFF
--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -512,7 +512,7 @@ module.exports = function(dir, _appConfig) {
       config.resolve.alias['@pkg'] = path.join(dir, 'pkg');
       config.resolve.alias['./node_modules'] = path.join(dir, 'node_modules');
       config.resolve.alias['@components'] = COMPONENTS_DIR;
-      config.resolve.alias['vue$'] = path.resolve(process.cwd(), 'node_modules', 'vue', 'dist', dev ? 'vue.js' : 'vue.min.js');
+      config.resolve.alias['vue$'] = path.resolve(process.cwd(), 'node_modules', 'vue', 'dist', 'vue.js');
       config.resolve.modules.push(__dirname);
       config.plugins.push(getVirtualModules(dir, includePkg));
       config.plugins.push(getAutoImport());


### PR DESCRIPTION
### Summary
Fixes https://github.com/rancher/dashboard/issues/12306

This changes the way scripts are minified and source maps are computed. Instead of using a pre-minified Vue version, use the full version and minify it using the existing minifier.

That moves minification after source map creation, restoring expected resource map functionality.

### Occurred changes and/or fixed issues

|                                 | Original | With this PR |
|---------------------------------|----------|--------------|
| Javascript file size in dist/js | 13 MB    | 13 MB        |
| Source map file size in dist/js | 43 MB    | 45 MB        |
| Build time reported by yarn     | 110 s    | 75 s         |

File size change is modest, and occurs basically only in source maps which are not loaded by most users. Runtime is also shorter in my setup. All tests were run on 2.9.1.

### Technical notes summary

Should be completely transparent to non-developer users.

I hope this works.

### Areas or cases that should be tested

Regular test of a new Rancher version should be more than sufficient to catch any regressions, which by the way are not expected as the change uses a value that was already in place for development builds.

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
