### PR TITLE
Clone `defaultContainer` to apply defaults for workload forms

### DIFF
--- a/shell/edit/workload/mixins/workload.js
+++ b/shell/edit/workload/mixins/workload.js
@@ -947,7 +947,7 @@ export default {
         nameNumber++;
       }
       const container = {
-        ...defaultContainer,
+        ...structuredClone(defaultContainer),
         name:   `container-${ nameNumber }`,
         active: true
       };

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -110,7 +110,7 @@ export default class Workload extends WorkloadService {
         spec.template = {
           spec: {
             restartPolicy:  this.type === WORKLOAD_TYPES.JOB ? 'Never' : 'Always',
-            containers:     [{ ...defaultContainer }],
+            containers:     [{ ...structuredClone(defaultContainer) }],
             initContainers: []
           }
         };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This clones `defaultContainer` to prevent this object from being modified by reference in container forms.

`defaultContainer` retains its values even after navigating away from the workload create form. This behavior was not observed in Vue2, and it requires further investigation to fully understand.

To address this issue in the short term, using `structuredClone` to create a deep copy of defaultContainer ensures that modifications to the container do not persist after navigating away from the form.

Fixes #12243 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- clone `defaultContainer` when applying defaults to workload forms

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

See case in attached issue.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This fixes an existing regression, I don't foresee this causing issues elsewhere. 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
