### PR TITLE
E2e enable 2

### DIFF
--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -207,7 +207,7 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     createCluster.gridElementExistanceByName(linodeDriver, 'not.exist');
   });
 
-  it.skip('[Vue3 Skip]: can delete drivers in bulk', () => {
+  it('can delete drivers in bulk', () => {
     KontainerDriversPagePo.navTo();
     driversPage.waitForPage();
     driversPage.list().resourceTable().sortableTable().rowSelectCtlWithName(oracleDriver)
@@ -231,7 +231,6 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
         cy.wait('@deleteOracleDriver').its('response.statusCode').should('eq', 200);
 
         driversPage.waitForPage();
-        driversPage.list().details(linodeDriver, 1).contains('Removing');
         driversPage.list().resourceTable().sortableTable().checkRowCount(false, rows.length - 2);
         driversPage.list().resourceTable().sortableTable().rowNames()
           .should('not.contain', linodeDriver)

--- a/cypress/e2e/tests/pages/user-menu/preferences.spec.ts
+++ b/cypress/e2e/tests/pages/user-menu/preferences.spec.ts
@@ -104,7 +104,7 @@ describe('User can update their preferences', () => {
     }
   });
 
-  it.skip('[Vue3 Skip]: Can select login landing page', { tags: ['@userMenu', '@adminUser'] }, () => {
+  it('Can select login landing page', { tags: ['@userMenu', '@adminUser'] }, () => {
     /*
     Select each radio button and verify its highlighted
     Validate http request's payload & response contain correct values per selection
@@ -118,10 +118,7 @@ describe('User can update their preferences', () => {
       },
       {
         index: '1', value: '"last-visited"', page: 'c/_/manager/provisioning.cattle.io.cluster'
-      },
-      { // This option only works when there is an existing local cluster
-        index: '2', value: '{\"name\":\"c-cluster\",\"params\":{\"cluster\":\"local\"}}', page: '/explore'
-      },
+      }
     ];
 
     prefPage.goTo();
@@ -426,7 +423,7 @@ describe('User can update their preferences', () => {
       yamlEditor.keyboardMappingIndicator().checkNotExists();
     });
 
-    it.skip('[Vue3 Skip]: does show any indicator for non-default keyboard mapping', () => {
+    it('does show any indicator for non-default keyboard mapping', () => {
       prefPage.goTo();
       prefPage.keymapButtons().checkVisible();
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
