### PR TITLE
[Backport v2.9] Fix cloud-credential expiry display

### DIFF
--- a/shell/models/cloudcredential.js
+++ b/shell/models/cloudcredential.js
@@ -241,9 +241,10 @@ export default class CloudCredential extends NormanModel {
   }
 
   get expiresForSort() {
-    // Why not just `expires`? Ensures the correct sort order of 'no expiration' --> 'expired' --> 'expiring'
-    // (instead of expired --> expiring --> no expiration)
-    return this.expires || Number.MAX_SAFE_INTEGER;
+    // Why not just `expires`?
+    // Ensures the correct sort order:
+    // 'expired' --> 'expiring soon' --> 'never expires'
+    return this.expires !== undefined ? this.expires : Number.MAX_SAFE_INTEGER;
   }
 
   get expires() {

--- a/shell/models/cloudcredential.js
+++ b/shell/models/cloudcredential.js
@@ -296,7 +296,7 @@ export default class CloudCredential extends NormanModel {
   }
 
   get expiresIn() {
-    if (!this.expires) {
+    if (this.expires === undefined) {
       return null;
     }
 


### PR DESCRIPTION
Fix cloud-credential being displayed if the expiry annotation has a Unix timestamp of "0".

When Rancher is upgraded and there are cloud-credentials for a Harvester cluster without a token (e.g. when the token expired and purged or was manually removed), the cloud-credential's expiry will be updated with a Unix timestamp of "0" (i.e. as if the token had expired at 00:00 AM on Jan 1st 1970), since the actual time of expiry of the token can not be determined.
This fix makes the UI display such a cloud credential correctly as "expired".

### Summary
Related to: https://github.com/rancher/rancher/issues/47583
Related to: https://github.com/rancher/rancher/issues/47667

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
When the cloud-credential annotation `rancher.io/expiration-timestamp` has the value `"0"`, the getter function `expires()` will return an integer `0`. In Javascript, this is a falsy value, therefore the condition
```
if (!this.expires)
```
is met and the getter function `expiresIn()` returns `null` instead of the expected time difference (also an integer `0`, indicating that the cloud-credential is expired).
By checking not against falsiness, but against `undefined` explicitly in the getter function `expiresIn()`, the correct time difference is returned and the cloud-credential will be displayed correctly as expired.

**Update**:
The same problem of `this.expires` being falsy when it has the value `0` befalls the `expiresForSort()` function too. Here the fix is to also check explicitly if `this.expires` is `undefined` instead.

### Areas or cases that should be tested
- Rancher Upgrade
- Cloud Credential expiry
- Cloud Credential list sorting

Local testing done via `yarn dev` with Firefox

1. Install Harvester (e.g. v1.3.2)
1. Install Rancher v2.9.2
1. Import Harvester cluster into Rancher for virtualization management 
1. Set default kubeconfig TTL to a short period (e.g. 10 minutes)
1. Create new cloud-credential
1. Wait for cloud-credential to expire and the associated kubeconfig-token to be removed. Alternatively just delete the token
1. Upgrade Rancher

Outcome before the fix:
The UI displays the cloud-credential, but omits the warning that it is expired. Nevertheless, there is the menu option to renew it.

Expected outcome with this fix:
The UI should display the cloud-credential as expired and offer a menu option to renew it.
The list of cloud-credentials should correctly sort into 'expired' --> 'expires soon' --> 'never expires' or vice versa, when sorted by that column.

### Areas which could experience regressions
- cloud credential display, renewal

### Screenshot/Video
Before:
![Screenshot at 2024-10-23 13-02-09](https://github.com/user-attachments/assets/94f90794-f2cc-461c-8c17-4fb272a0f849)

After:
![Screenshot at 2024-10-23 13-01-44](https://github.com/user-attachments/assets/d9ae548d-b441-47b0-b730-cd98c2458219)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
