### PR TITLE
Re-enabling `Registries for RKE2` e2e test 

### DIFF
--- a/cypress/e2e/tests/pages/manager/registries.spec.ts
+++ b/cypress/e2e/tests/pages/manager/registries.spec.ts
@@ -5,7 +5,7 @@ import { machineSelectorConfigPayload, registriesWithSecretPayload } from '@/cyp
 const registryHost = 'docker.io';
 const registryAuthHost = 'a.registry.com';
 
-describe.skip('[Vue3 Skip]: Registries for RKE2', { tags: ['@manager', '@adminUser'] }, () => {
+describe('Registries for RKE2', { tags: ['@manager', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
     cy.createE2EResourceName('cluster').as('clusterName');

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/registries/RegistryConfigs.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/registries/RegistryConfigs.vue
@@ -154,7 +154,6 @@ export default {
               :mode="mode"
               :data-testid="`registry-auth-host-input-${i}`"
             />
-
             <SelectOrCreateAuthSecret
               v-model:value="row.value.authConfigSecretName"
               :register-before-hook="wrapRegisterBeforeHook"
@@ -168,6 +167,7 @@ export default {
               generate-name="registryconfig-auth-"
               :data-testid="`registry-auth-select-or-create-${i}`"
               :cache-secrets="true"
+              @update:value="update"
             />
           </div>
           <div class="col span-6">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
We weren't updating the model correctly in the RegistryConfigs, this fixes the updating and re-enables the appropriate test.

### Areas which could experience regressions
Possibly the Registry tabs in some resources like rke2.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
