### PR TITLE
Ensure harvester cloud creds with expiration date of 0 are sorted correctly

### DIFF
--- a/shell/models/cloudcredential.js
+++ b/shell/models/cloudcredential.js
@@ -241,9 +241,9 @@ export default class CloudCredential extends NormanModel {
   }
 
   get expiresForSort() {
-    // Why not just `expires`? Ensures the correct sort order of 'no expiration' --> 'expired' --> 'expiring'
-    // (instead of expired --> expiring --> no expiration)
-    return this.expires || Number.MAX_SAFE_INTEGER;
+    // Why not just `expires`? Ensures the correct sort order of expired --> expiring --> never expires
+    // (instead of 'never expired' --> 'expired' --> 'expiring')
+    return this.expires !== undefined ? this.expires : Number.MAX_SAFE_INTEGER;
   }
 
   get expires() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Ensure harvester cloud creds with expiration date of 0 are sorted correctly

### Occurred changes and/or fixed issues
- Follows on from https://github.com/rancher/dashboard/pull/12335
  - and comment in https://github.com/rancher/dashboard/pull/12336
- sort order should be expired --> expiring --> never expires
- ensure expired 0 is not in the same bucket as never expires

### Areas or cases that should be tested
- Harvester Cloud Credential page with an expired annotation value of 0 appear immediately after / before (depending on sort order) expiring and then expired tokens 
  - I hacked `get expires()` for an easier production


### Screenshot/Video
![image](https://github.com/user-attachments/assets/82085365-ebfc-441d-8a09-9d478b71c74e)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
