### PR TITLE
Harvester shell integration - remove LocaleSelector when is Harvester standalone UI

### DIFF
--- a/shell/components/LandingPagePreference.vue
+++ b/shell/components/LandingPagePreference.vue
@@ -119,8 +119,8 @@ export default {
             :label="option.label"
             :val="false"
             :value="afterLoginRoute=== 'home' || afterLoginRoute === 'last-visited'"
+            :v-bind="$attrs"
             @update:value="afterLoginRoute = false"
-            v-on="listeners"
           />
           <Select
             v-model:value="routeFromDropdown"

--- a/shell/components/LandingPagePreference.vue
+++ b/shell/components/LandingPagePreference.vue
@@ -113,7 +113,7 @@ export default {
       :options="routeRadioOptions"
       @update:value="updateLoginRoute"
     >
-      <template #2="{option, listeners}">
+      <template #2="{option}">
         <div class="custom-page">
           <RadioButton
             :label="option.label"

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -64,12 +64,8 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['isSingleProduct']),
+    ...mapGetters(['isStandaloneHarvester']),
     ...mapGetters({ t: 'i18n/t', hasMultipleLocales: 'i18n/hasMultipleLocales' }),
-
-    isHarvester() {
-      return this.isSingleProduct?.productName === 'harvester';
-    },
 
     loggedOutSuccessMsg() {
       if (this.isSlo) {
@@ -502,7 +498,7 @@ export default {
           </div>
         </template>
         <div
-          v-if="showLocaleSelector && hasMultipleLocales && !isHarvester"
+          v-if="showLocaleSelector && hasMultipleLocales && !isStandaloneHarvester"
           class="locale-selector"
         >
           <LocaleSelector

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -64,7 +64,12 @@ export default {
   },
 
   computed: {
-    ...mapGetters({ t: 'i18n/t' }),
+    ...mapGetters(['isSingleProduct']),
+    ...mapGetters({ t: 'i18n/t', hasMultipleLocales: 'i18n/hasMultipleLocales' }),
+
+    isHarvester() {
+      return this.isSingleProduct?.productName === 'harvester';
+    },
 
     loggedOutSuccessMsg() {
       if (this.isSlo) {
@@ -497,7 +502,7 @@ export default {
           </div>
         </template>
         <div
-          v-if="showLocaleSelector"
+          v-if="showLocaleSelector && hasMultipleLocales && !isHarvester"
           class="locale-selector"
         >
           <LocaleSelector

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -40,6 +40,11 @@ export default {
     scalingDownPrompt: mapPref(SCALE_POOL_PROMPT),
 
     ...mapGetters(['isSingleProduct']),
+    ...mapGetters({ hasMultipleLocales: 'i18n/hasMultipleLocales' }),
+
+    isHarvester() {
+      return this.isSingleProduct?.productName === 'harvester';
+    },
 
     theme: {
       get() {
@@ -182,7 +187,10 @@ export default {
     </h1>
 
     <!-- Language -->
-    <div class="mt-10 mb-10">
+    <div
+      v-if="hasMultipleLocales && !isHarvester"
+      class="mt-10 mb-10"
+    >
       <h4 v-t="'prefs.language'" />
       <div class="row">
         <div class="col span-4">
@@ -194,7 +202,6 @@ export default {
     </div>
     <!-- Theme -->
     <div class="mt-10 mb-10">
-      <hr>
       <h4 v-t="'prefs.theme.label'" />
       <ButtonGroup
         v-model:value="theme"
@@ -262,7 +269,10 @@ export default {
       </div>
     </div>
     <!-- Confirmation setting -->
-    <div class="col adv-features mt-10 mb-10">
+    <div
+      v-if="!isSingleProduct"
+      class="col adv-features mt-10 mb-10"
+    >
       <hr>
       <h4 v-t="'prefs.confirmationSetting.title'" />
       <Checkbox
@@ -282,13 +292,15 @@ export default {
         :label="t('prefs.advFeatures.viewInApi', {}, true)"
         class="mt-10"
       />
-      <br>
-      <Checkbox
-        v-model:value="allNamespaces"
-        data-testid="prefs__allNamespaces"
-        :label="t('prefs.advFeatures.allNamespaces', {}, true)"
-        class="mt-20"
-      />
+      <template v-if="!isHarvester">
+        <br>
+        <Checkbox
+          v-model:value="allNamespaces"
+          data-testid="prefs__allNamespaces"
+          :label="t('prefs.advFeatures.allNamespaces', {}, true)"
+          class="mt-20"
+        />
+      </template>
       <br>
       <Checkbox
         v-model:value="themeShortcut"

--- a/shell/store/i18n.js
+++ b/shell/store/i18n.js
@@ -58,7 +58,11 @@ export const getters = {
     return out;
   },
 
-  t: (state) => (key, args, language) => {
+  hasMultipleLocales(state) {
+    return state.available.length > 1;
+  },
+
+  t: state => (key, args, language) => {
     if (state.selected === NONE && !language) {
       return `%${ key }%`;
     }
@@ -333,7 +337,7 @@ export const actions = {
 
     commit('setSelected', locale);
 
-    // Ony update the preference if the locale changed
+    // Only update the preference if the locale changed
     if (currentLocale !== locale) {
       dispatch('prefs/set', {
         key:   'locale',

--- a/shell/store/i18n.js
+++ b/shell/store/i18n.js
@@ -62,7 +62,7 @@ export const getters = {
     return state.available.length > 1;
   },
 
-  t: state => (key, args, language) => {
+  t: (state) => (key, args, language) => {
     if (state.selected === NONE && !language) {
       return `%${ key }%`;
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Contributes to https://github.com/rancher/dashboard/issues/12347
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
