### PR TITLE
Enabling several E2E tests that were disabled for the vue3 migration

### DIFF
--- a/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
@@ -10,7 +10,7 @@ import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
 const fakeProvClusterId = 'some-fake-cluster-id';
 const fakeMgmtClusterId = 'some-fake-mgmt-id';
 
-describe.skip('[Vue3 Skip]: Git Repo', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] }, () => {
+describe('Git Repo', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] }, () => {
   describe('Create', () => {
     const listPage = new FleetGitRepoListPagePo();
     const gitRepoCreatePage = new GitRepoCreatePo('_');
@@ -108,7 +108,9 @@ describe.skip('[Vue3 Skip]: Git Repo', { testIsolation: 'off', tags: ['@fleet', 
           prefPage.languageDropdownMenu().toggle();
           prefPage.languageDropdownMenu().isOpened();
 
-          cy.intercept('PUT', 'v1/userpreferences/*').as(`prefUpdateZhHans`);
+          cy.intercept({
+            method: 'PUT', url: 'v1/userpreferences/*', times: 1
+          }).as(`prefUpdateZhHans`);
           prefPage.languageDropdownMenu().clickOption(2);
           cy.wait('@prefUpdateZhHans').then(({ response }) => {
             expect(response?.statusCode).to.eq(200);

--- a/cypress/e2e/tests/pages/generic/diagnostic.spec.ts
+++ b/cypress/e2e/tests/pages/generic/diagnostic.spec.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 const downloadsFolder = Cypress.config('downloadsFolder');
 
-describe.skip('[Vue3 Skip]: Diagnostics Page', { tags: ['@generic', '@adminUser'] }, () => {
+describe('Diagnostics Page', { tags: ['@generic', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
@@ -14,7 +14,7 @@ const accountPage = new AccountPagePo();
 const clusterList = new ClusterManagerListPagePo();
 const burgerMenu = new BurgerMenuPo();
 const settingsOrginal = [];
-let removeServerUrl = false;
+const removeServerUrl = false;
 
 describe('Settings', { testIsolation: 'off' }, () => {
   before(() => {
@@ -224,9 +224,10 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('ui-offline-preferred').contains(settings['ui-offline-preferred'].original);
   });
 
-  it.skip('[Vue3 Skip]: can update ui-brand', { tags: ['@globalSettings', '@adminUser'] }, () => {
-    const rancherLogo = '/img/rancher-logo.66cf5910.svg';
-    const suseRancherLogo = '/img/rancher-logo.055089a3.svg';
+  it('can update ui-brand', { tags: ['@globalSettings', '@adminUser'] }, () => {
+    // We probably want a better way to distinguish between rancher and suse logos. I'm doing this as part of the vue3 migration and trying to keep things as similar as possible.
+    const rancherLogoWidth = 142;
+    const suseRancherLogoWidth = 82;
 
     // Update setting
     SettingsPagePo.navTo();
@@ -243,15 +244,17 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     // Check logos in top-level navigation header for updated logo
     BurgerMenuPo.toggle();
-    burgerMenu.brandLogoImage().should('be.visible').then((el) => {
-      expect(el).to.have.attr('src').includes(suseRancherLogo);
-    });
+    burgerMenu.brandLogoImage()
+      .should('be.visible')
+      .invoke('outerWidth').then((str) => parseInt(str))
+      .should('eq', suseRancherLogoWidth);
     BurgerMenuPo.toggle();
 
     HomePagePo.navTo();
-    burgerMenu.headerBrandLogoImage().should('be.visible').then((el) => {
-      expect(el).to.have.attr('src').includes(suseRancherLogo);
-    });
+    burgerMenu.headerBrandLogoImage()
+      .should('be.visible')
+      .invoke('outerWidth').then((str) => parseInt(str))
+      .should('eq', suseRancherLogoWidth);
     BurgerMenuPo.toggle();
 
     // Reset
@@ -269,14 +272,12 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     // Check logos in top-level navigation header for updated logo
     HomePagePo.navTo();
-    burgerMenu.headerBrandLogoImage().should('be.visible').then((el) => {
-      expect(el).to.have.attr('src').includes(rancherLogo);
-    });
+    burgerMenu.headerBrandLogoImage().should('be.visible').invoke('outerWidth').then((str) => parseInt(str))
+      .should('eq', rancherLogoWidth);
 
     BurgerMenuPo.toggle();
-    burgerMenu.brandLogoImage().should('be.visible').then((el) => {
-      expect(el).to.have.attr('src').includes(rancherLogo);
-    });
+    burgerMenu.brandLogoImage().should('be.visible').invoke('outerWidth').then((str) => parseInt(str))
+      .should('eq', rancherLogoWidth);
   });
 
   it('can update cluster-template-enforcement', { tags: ['@globalSettings', '@adminUser'] }, () => {
@@ -434,7 +435,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('k3s-based-upgrader-uninstall-concurrency').contains(settings['k3s-based-upgrader-uninstall-concurrency'].original);
   });
 
-  it.skip('[Vue3 Skip]: can update system-default-registry', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it('can update system-default-registry', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('system-default-registry');

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -199,7 +199,7 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     cy.contains(`${ this.repoName }ssh`).should('not.exist');
   });
 
-  it.skip('[Vue3 Skip]: can create an oci repository with basic auth', function() {
+  it('can create an oci repository with basic auth', function() {
     ChartRepositoriesPagePo.navTo();
     repositoriesPage.waitForPage();
     repositoriesPage.waitForGoTo('/v1/catalog.cattle.io.clusterrepos?exclude=metadata.managedFields');

--- a/shell/pages/diagnostic.vue
+++ b/shell/pages/diagnostic.vue
@@ -151,7 +151,6 @@ export default {
         responseTimes:     this.responseTimes
       };
 
-      console.log('eeeeeeee', Object.keys(data.storeMapping));
       downloadFile(fileName, JSON.stringify(data), 'application/json')
         .then(() => btnCb(true))
         .catch(() => btnCb(false));

--- a/shell/pages/diagnostic.vue
+++ b/shell/pages/diagnostic.vue
@@ -151,6 +151,7 @@ export default {
         responseTimes:     this.responseTimes
       };
 
+      console.log('eeeeeeee', Object.keys(data.storeMapping));
       downloadFile(fileName, JSON.stringify(data), 'application/json')
         .then(() => btnCb(true))
         .catch(() => btnCb(false));
@@ -215,6 +216,7 @@ export default {
         'linode',
         'targetRoute', // contains circular references, isn't useful (added later to store)
         '$router', // also contains a circular reference to $store, not useful for diagnostics
+        '$route', // also contains a circular reference to $store, not useful for diagnostics
       ];
 
       const clearListsKeys = [


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Re-enabling Diagnostics Page e2e test
- Re-enabling can create an oci repository with basic auth e2e test
- Re-enabling the Git Repo e2e tests
- Enabling two more e2e tests in settings-p2

### Technical notes summary
$route had a circular reference so I added it to a list of other fields that shouldn't be serialized.

### Areas or cases that should be tested
The tests are doing that already

### Areas which could experience regressions
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
