### PR TITLE
Support standard user handling SAML SLO feature

### DIFF
--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -1118,7 +1118,7 @@ export default {
       display: flex;
       justify-content: space-between;
       padding: 10px;
-      color: var(--link);
+      color: var(--popover-text);
     }
 
     div.menu-separator {

--- a/shell/pages/auth/logout.vue
+++ b/shell/pages/auth/logout.vue
@@ -1,21 +1,19 @@
 <script>
-import { authProvidersInfo } from '@shell/utils/auth';
+import { configType } from '@shell/models/management.cattle.io.authconfig';
 
 export default {
   async fetch() {
-    const authInfo = await authProvidersInfo(this.$store);
+    const publicAuthProviders = await this.$store.dispatch('auth/getAuthProviders');
 
-    if (authInfo.enabled?.length) {
-      const authProvider = authInfo.enabled[0];
+    const samlAuthProvider = publicAuthProviders.find((authProvider) => configType[authProvider.id] === 'saml');
 
-      const {
-        logoutAllSupported, logoutAllEnabled, logoutAllForced, configType
-      } = authProvider;
+    if (!!samlAuthProvider) {
+      const { logoutAllSupported, logoutAllEnabled, logoutAllForced } = samlAuthProvider;
 
-      if (configType === 'saml' && logoutAllSupported && logoutAllEnabled && logoutAllForced) {
+      if (logoutAllSupported && logoutAllEnabled && logoutAllForced) {
         // SAML - force SLO (logout from all apps)
         await this.$store.dispatch('auth/logout', {
-          force: true, slo: true, provider: authProvider
+          force: true, slo: true, provider: samlAuthProvider
         }, { root: true });
       } else {
         // simple logout


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12314 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- adapt SAML logout logic to rely on info from public `authprovider` endpoint for SAML Single Logout feature
- Minor css fix on avatar drop menu `logout` item

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- can be tested with `v2.10-dae07ed09601506420c133a69d6e6d27bb7a53ec-head` Rancher image

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Follow repro steps in https://github.com/rancher/dashboard/issues/12314

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Test also with an `admin` role user. Test the different logout scenarios as well (logout from all, logout only from Rancher and change the auth config options so that the avatar link for `logout` does different types of logout without the presence of the modal)

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
