### PR TITLE
Improve parsing of cluster badge color

### DIFF
--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -16,6 +16,8 @@ import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
 import { PINNED_CLUSTERS } from '@shell/store/prefs';
 import { copyTextToClipboard } from '@shell/utils/clipboard';
 
+const DEFAULT_BADGE_COLOR = '#707070';
+
 // See translation file cluster.providers for list of providers
 // If the logo is not named with the provider name, add an override here
 const PROVIDER_LOGO_OVERRIDE = {};
@@ -306,13 +308,22 @@ export default class MgmtCluster extends SteveModel {
       return undefined;
     }
 
-    const color = this.metadata?.annotations[CLUSTER_BADGE.COLOR] || '#7f7f7f';
+    let color = this.metadata?.annotations[CLUSTER_BADGE.COLOR] || DEFAULT_BADGE_COLOR;
     const iconText = this.metadata?.annotations[CLUSTER_BADGE.ICON_TEXT] || '';
+    let foregroundColor;
+
+    try {
+      foregroundColor = textColor(parseColor(color.trim())); // Remove any whitespace
+    } catch (_e) {
+      // If we could not parse the badge color, use the defaults
+      color = DEFAULT_BADGE_COLOR;
+      foregroundColor = textColor(parseColor(color));
+    }
 
     return {
       text:      comment || undefined,
       color,
-      textColor: textColor(parseColor(color)),
+      textColor: foregroundColor,
       iconText:  iconText.substr(0, 3)
     };
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12272 

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

Improves the parsing of the badge color annotation.

Note, I tweaked the default badge color, so that the text color chosen is white - this has better contrast.

### Areas or cases that should be tested

Test manually:

Edit the local cluster management resource from the kubectl shell, with:

`kubectl edit clusters.management.cattle.io local`

add annotations:

```
ui.rancher/badge-text: Example Text
ui.rancher/badge-color: '#ff0000     '
```

(note the trailing spaces)

Save the resource and verify that the cluster badge is shown correctly at the top:

![image](https://github.com/user-attachments/assets/8ae9ed49-6ba8-4c76-a129-e932565ae2ce)

update the badge annotation via the same shell method:

```
ui.rancher/badge-text: Example Text
ui.rancher/badge-color: '///'
```

Save the resource and verify that the cluster badge is shown correctly at the top with the default badge color:

![image](https://github.com/user-attachments/assets/4b14c9d5-4ec5-4ff0-992c-18bd19bc36fc)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
