### PR TITLE
Fixed httpget options not showing up

### DIFF
--- a/shell/components/form/HookOption.vue
+++ b/shell/components/form/HookOption.vue
@@ -150,35 +150,33 @@ export default {
     <template v-if="selectHook === 'httpGet'">
       <h4>{{ t('workload.container.lifecycleHook.httpGet.title') }}</h4>
       <div class="var-row">
-        <template @update:value="update">
-          <LabeledInput
-            v-model:value="value.httpGet.host"
-            :label="t('workload.container.lifecycleHook.httpGet.host.label')"
-            :placeholder="t('workload.container.lifecycleHook.httpGet.host.placeholder')"
-            :mode="mode"
-          />
-          <LabeledInput
-            v-model:value="value.httpGet.path"
-            :label="t('workload.container.lifecycleHook.httpGet.path.label')"
-            :placeholder="t('workload.container.lifecycleHook.httpGet.path.placeholder')"
-            :mode="mode"
-          />
-          <LabeledInput
-            v-model:value.number="value.httpGet.port"
-            type="number"
-            :label="t('workload.container.lifecycleHook.httpGet.port.label')"
-            :placeholder="t('workload.container.lifecycleHook.httpGet.port.placeholder')"
-            :mode="mode"
-            required
-          />
-          <LabeledSelect
-            v-model:value="value.httpGet.scheme"
-            :label="t('workload.container.lifecycleHook.httpGet.scheme.label')"
-            :placeholder="t('workload.container.lifecycleHook.httpGet.scheme.placeholder')"
-            :options="schemeOptions"
-            :mode="mode"
-          />
-        </template>
+        <LabeledInput
+          v-model:value="value.httpGet.host"
+          :label="t('workload.container.lifecycleHook.httpGet.host.label')"
+          :placeholder="t('workload.container.lifecycleHook.httpGet.host.placeholder')"
+          :mode="mode"
+        />
+        <LabeledInput
+          v-model:value="value.httpGet.path"
+          :label="t('workload.container.lifecycleHook.httpGet.path.label')"
+          :placeholder="t('workload.container.lifecycleHook.httpGet.path.placeholder')"
+          :mode="mode"
+        />
+        <LabeledInput
+          v-model:value.number="value.httpGet.port"
+          type="number"
+          :label="t('workload.container.lifecycleHook.httpGet.port.label')"
+          :placeholder="t('workload.container.lifecycleHook.httpGet.port.placeholder')"
+          :mode="mode"
+          required
+        />
+        <LabeledSelect
+          v-model:value="value.httpGet.scheme"
+          :label="t('workload.container.lifecycleHook.httpGet.scheme.label')"
+          :placeholder="t('workload.container.lifecycleHook.httpGet.scheme.placeholder')"
+          :options="schemeOptions"
+          :mode="mode"
+        />
       </div>
 
       <h4>{{ t('workload.container.lifecycleHook.httpHeaders.title') }}</h4>

--- a/shell/components/form/HookOption.vue
+++ b/shell/components/form/HookOption.vue
@@ -155,12 +155,14 @@ export default {
           :label="t('workload.container.lifecycleHook.httpGet.host.label')"
           :placeholder="t('workload.container.lifecycleHook.httpGet.host.placeholder')"
           :mode="mode"
+          @update:value="update"
         />
         <LabeledInput
           v-model:value="value.httpGet.path"
           :label="t('workload.container.lifecycleHook.httpGet.path.label')"
           :placeholder="t('workload.container.lifecycleHook.httpGet.path.placeholder')"
           :mode="mode"
+          @update:value="update"
         />
         <LabeledInput
           v-model:value.number="value.httpGet.port"
@@ -169,6 +171,7 @@ export default {
           :placeholder="t('workload.container.lifecycleHook.httpGet.port.placeholder')"
           :mode="mode"
           required
+          @update:value="update"
         />
         <LabeledSelect
           v-model:value="value.httpGet.scheme"
@@ -176,6 +179,7 @@ export default {
           :placeholder="t('workload.container.lifecycleHook.httpGet.scheme.placeholder')"
           :options="schemeOptions"
           :mode="mode"
+          @update:value="update"
         />
       </div>
 

--- a/shell/components/form/LifecycleHooks.vue
+++ b/shell/components/form/LifecycleHooks.vue
@@ -69,7 +69,7 @@ export default {
       <HookOption
         v-model:value="postStart"
         :mode="mode"
-        @input="update"
+        @update:value="update"
       />
     </div>
 
@@ -80,7 +80,7 @@ export default {
       <HookOption
         v-model:value="preStop"
         :mode="mode"
-        @input="update"
+        @update:value="update"
       />
     </div>
   </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12383 
<!-- Define findings related to the feature or bug issue. -->
Fixed httpget fileds not rendering when creating a workload.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Removed inner template tag since it looks like it was redundant.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Inner template and its content was treated by Vue as an HTML template element as described in
https://vuejs.org/api/built-in-special-elements#template , so it wasn't rendered.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Workloads -> Deployments -> General ->Lifecycle Hooks
For both PodStart and PodStop if "Create HTTP request" is selected, HttpGet configuration should be visible, editable and if saved, it should be respected. 
Same applies to editing existing configuration


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Just workloads should be affected

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="803" alt="Screenshot 2024-10-28 at 3 35 53 PM" src="https://github.com/user-attachments/assets/54ca76e1-c6fc-4ce9-a4d8-307c32809bef">

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
