### PR TITLE
[backport 2.9] fix issue banner extensions prime users not being displayed

### DIFF
--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -60,7 +60,8 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     extensionsPo.goTo();
     extensionsPo.waitForTitle();
 
-    cy.title().should('eq', 'Rancher Prime - Extensions');
+    // in this case, vendor is Rancher because title depends on many different variables such as brand and settings
+    cy.title().should('eq', 'Rancher - Extensions');
 
     extensionsPo.repoBanner().checkVisible();
   });

--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -29,12 +29,40 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     extensionsPo.addExtensionsRepository('https://github.com/rancher/ui-plugin-examples', 'main', 'rancher-plugin-examples');
   });
 
-  it('has the correct title', () => {
+  it('has the correct title for Prime users and should display banner on main extensions screen EVEN IF setting is empty string', () => {
+    cy.getRancherResource('v3', 'setting', 'display-add-extension-repos-banner', null).then((resp: Cypress.Response<any>) => {
+      const notFound = resp.status === 404;
+      const requiredValue = resp.body?.value === '';
+
+      if (notFound || requiredValue) {
+        cy.log('Good test state', '/v3/setting/display-add-extension-repos-banner', resp.status, JSON.stringify(resp?.body || {}));
+      } else {
+        cy.log('Bad test state', '/v3/setting/display-add-extension-repos-banner', resp.status, JSON.stringify(resp?.body || {}));
+
+        return cy.setRancherResource('v3', 'setting', 'display-add-extension-repos-banner', {
+          ...resp.body,
+          value: ''
+        });
+      }
+    });
+
+    cy.intercept('GET', '/rancherversion', {
+      statusCode: 200,
+      body:       {
+        Version:      '9bf6631da',
+        GitCommit:    '9bf6631da',
+        RancherPrime: 'true'
+      }
+    });
+
     const extensionsPo = new ExtensionsPagePo();
 
     extensionsPo.goTo();
+    extensionsPo.waitForTitle();
 
-    cy.title().should('eq', 'Rancher - Extensions');
+    cy.title().should('eq', 'Rancher Prime - Extensions');
+
+    extensionsPo.repoBanner().checkVisible();
   });
 
   it('Should check the feature flag', () => {

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -153,7 +153,8 @@ export default {
     },
 
     showAddReposBanner() {
-      const hasExtensionReposBannerSetting = this.addExtensionReposBannerSetting?.value === 'true';
+      // because of https://github.com/rancher/rancher/pull/45894 we need to consider other start values
+      const hasExtensionReposBannerSetting = this.addExtensionReposBannerSetting?.value === 'true' || this.addExtensionReposBannerSetting?.value === '' || this.addExtensionReposBannerSetting?.value === undefined;
       const uiPluginsRepoNotFound = isRancherPrime() && !this.repos?.find((r) => r.urlDisplay === UI_PLUGINS_REPO_URL);
       const uiPluginsPartnersRepoNotFound = !this.repos?.find((r) => r.urlDisplay === UI_PLUGINS_PARTNERS_REPO_URL);
 
@@ -623,7 +624,8 @@ export default {
     },
 
     updateAddReposSetting() {
-      if (this.addExtensionReposBannerSetting?.value === 'true') {
+      // because of https://github.com/rancher/rancher/pull/45894 we need to consider other start values
+      if (this.addExtensionReposBannerSetting?.value === 'true' || this.addExtensionReposBannerSetting?.value === '' || this.addExtensionReposBannerSetting?.value === undefined) {
         this.addExtensionReposBannerSetting.value = 'false';
         this.addExtensionReposBannerSetting.save();
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12398  
<!-- Define findings related to the feature or bug issue. -->


### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix issue banner extensions prime users not being displayed due to setting value being defined as an empty string by backend 
- add e2e test

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Check issue description for repro steps

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="2494" alt="Screenshot 2024-10-28 at 17 37 09" src="https://github.com/user-attachments/assets/c21a03ef-1808-4132-ab71-e96aa93123e8">
<img width="2494" alt="Screenshot 2024-10-28 at 17 36 43" src="https://github.com/user-attachments/assets/41ebfb07-0a96-48da-b05e-5210955ec99f">


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
