### PR TITLE
Avoid embedding web-worker polyfill

### DIFF
--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -131,11 +131,11 @@ const instrumentCode = () => {
 };
 
 const getLoaders = (SHELL_ABS) => [
-  // Ensure there is a fallback for browsers that don't support web workers
+  // no fallback for pre-2013 browsers https://caniuse.com/webworkers
   {
     test:    /web-worker.[a-z-]+.js/i,
     loader:  'worker-loader',
-    options: { inline: 'fallback' },
+    options: { inline: 'no-fallback' },
   },
   // Handler for csv files (e.g. ec2 instance data)
   {


### PR DESCRIPTION
### Summary

Fixes: #12511

**TL;DR**: Drop the web-worker polyfill. It's for ancient browsers and confuses tooling that works with performance captures.


**QA NOTE**: No user visible change expected, this is only to aid developers interpreting performance captures, eg. following https://github.com/rancherlabs/rancher-process/blob/main/docs/documentation/howtos/browser_performance_capture.md

### Technical notes summary
The BLOB code from web-worker is minified, and contains source maps that are then passed over by webpack - that creates a situation of minified code inside BLOB inside minified code which confuses some tools, eg.

https://github.com/jantimon/chrome-profile-sourcemap-resolver/pull/4

That could be fixed, but the only reason to do so would be supporting very old (pre-2013) browsers, so we are better off removing the polyfill altogether.

### Areas or cases that should be tested
Nothing in particular, exisiting tests should abundantly cover this.

### Areas which could experience regressions

None expected.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
