### PR TITLE
Only set immutable annotation on create of project

### DIFF
--- a/shell/edit/management.cattle.io.project.vue
+++ b/shell/edit/management.cattle.io.project.vue
@@ -103,7 +103,8 @@ export default {
     this.value.metadata['namespace'] = this.$store.getters['currentCluster'].id;
     this.value['spec'] = this.value.spec || {};
     this.value.spec['containerDefaultResourceLimit'] = this.value.spec.containerDefaultResourceLimit || {};
-    if (!this.$store.getters['auth/principalId'].includes('local://')) {
+    // norman (and matching steve) resources treat annotations containing `cattle.io` as immutable, so only do this for the create world
+    if (this.isCreate && !this.$store.getters['auth/principalId'].includes('local://')) {
       this.value.metadata.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
     }
   },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12287
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- introduced via https://github.com/rancher/dashboard/pull/12233
  - fix isn't required for changes to hosted providers as it's only added to the create part 
- on edit of a project, if the signed in user is not local, an immutable annotation was updated (norman like resource with annotation of cattle.io)
- fix is to only set annotation on create

### Areas or cases that should be tested
When signed in with an auth provider...
- edit the default project 
- create a new project
- edit new project

### Areas which could experience regressions
as above but for local user


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
