### PR TITLE
Fix agentConfig checkbox input

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/Advanced.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/Advanced.test.ts
@@ -128,6 +128,32 @@ describe('component: Advanced', () => {
 
         expect(checkbox.value).toBe('true');
       });
+
+      it(`should update agentConfig when 'protect-kernel-defaults' exists`, async() => {
+        const value = clone(PROV_CLUSTER);
+
+        value.spec.rkeConfig.machineGlobalConfig['protect-kernel-defaults'] = false;
+        value.spec.rkeConfig.machineSelectorConfig = [{
+          config:               { 'protect-kernel-defaults': true },
+          machineLabelSelector: {}
+        }];
+        value.agentConfig = value.spec.rkeConfig.machineSelectorConfig[0].config;
+
+        mountOptions.propsData.mode = _EDIT; // Use edit mode to allow interactions
+        mountOptions.propsData.value = value;
+
+        wrapper = mount(Advanced, mountOptions);
+
+        const checkboxLabel = wrapper
+          .find(`[data-testid="protect-kernel-defaults"]`)
+          .find('label');
+
+        checkboxLabel.trigger('click');
+        await wrapper.vm.$nextTick();
+
+        // Verify that agentConfig is updated
+        expect(value.spec.rkeConfig.machineSelectorConfig[0].config['protect-kernel-defaults']).toBe(false);
+      });
     });
 
     describe(`'kubelet-arg'`, () => {

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
@@ -80,10 +80,14 @@ export default {
       return i !== 0 || !this.agentConfig;
     },
     showEmptyKubeletArg(config) {
-      return !this.serverArg?.['kubelet-arg']?.length && !config?.['kubelet-arg']?.length;
+      return !this.serverArgs?.['kubelet-arg']?.length && !config?.['kubelet-arg']?.length;
     },
     onInputProtectKernelDefaults(value) {
-      this.agentConfig ? this.agentConfig = value : this.serverConfig['protect-kernel-defaults'] = value;
+      if (this.agentConfig && this.agentConfig['protect-kernel-defaults'] !== undefined ) {
+        this.agentConfig['protect-kernel-defaults'] = value;
+      } else {
+        this.serverConfig['protect-kernel-defaults'] = value;
+      }
     }
   }
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12368 
<!-- Define findings related to the feature or bug issue. -->
`agentConfig` is not an empty object and attempting to update the object to true will fail, the input should update the `protect-kernel-defaults` property within the object.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Added an extra condition to check for the `agentConfig['protect-kernel-defaults']` property
- Fixed `serverArg` property in `showEmptyKubeletArg` method to `serverArgs`.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
