### PR TITLE
[backport-2.9]: Fix a problem with deleting role templates from their detail pages

### DIFF
--- a/cypress/e2e/po/detail/management.cattle.io.roletemplate.po.ts
+++ b/cypress/e2e/po/detail/management.cattle.io.roletemplate.po.ts
@@ -1,10 +1,17 @@
 import RoleDetailPo from '@/cypress/e2e/po/detail/role.po';
 import RoleTemplateEditPo from '@/cypress/e2e/po/edit/management.cattle.io.roletemplate.po';
 import ResourceDetailPo from '@/cypress/e2e/po/edit/resource-detail.po';
+import ActionMenu from '@/cypress/e2e/po/components/action-menu.po';
 
 class RoleTemplateDetailComponentPo extends ResourceDetailPo {
   userCreateEditView(clusterId: string, userId?: string ) {
     return new RoleTemplateEditPo(clusterId, userId);
+  }
+
+  openMastheadActionMenu() {
+    this.self().get('[data-testid="mathead-action-menu"]').click();
+
+    return new ActionMenu(undefined);
   }
 }
 

--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -300,7 +300,12 @@ export default {
     },
     done() {
       if ( this.cachedDoneLocation && !isEmpty(this.cachedDoneLocation) ) {
-        this.currentRouter.push(this.cachedDoneLocation);
+        // Only push if the route will change otherwise we'll get a `NavigationDuplicated` exception
+        const resolvedRoute = this.currentRouter.resolve(this.cachedDoneLocation);
+
+        if (resolvedRoute.resolved.fullPath !== this.$route.fullPath) {
+          this.currentRouter.push(this.cachedDoneLocation);
+        }
       }
       this.close();
     },

--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -105,8 +105,8 @@ export default {
         return null;
       }
 
-      if (this.toRemove[0].doneLocationRemove) {
-        return this.toRemove[0].doneLocationRemove;
+      if (this.toRemove[0].doneOverride) {
+        return this.toRemove[0].doneOverride;
       }
 
       const currentRoute = this.toRemove[0].currentRoute();

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -516,6 +516,7 @@ export default {
             <button
               v-if="isView"
               ref="actions"
+              data-testid="mathead-action-menu"
               aria-haspopup="true"
               type="button"
               class="btn role-multi-action actions"


### PR DESCRIPTION
backport of https://github.com/rancher/dashboard/pull/12270

fixes: https://github.com/rancher/dashboard/issues/12218

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
