### PR TITLE
Fixed UnitInput value not updating

### DIFF
--- a/shell/edit/cis.cattle.io.clusterscan.vue
+++ b/shell/edit/cis.cattle.io.clusterscan.vue
@@ -326,7 +326,7 @@ export default {
           </div>
           <div class="col span-6">
             <UnitInput
-              v-model.number="scheduledScanConfig.retentionCount"
+              v-model:value="scheduledScanConfig.retentionCount"
               :suffix="t('cis.reports')"
               type="number"
               :mode="mode"

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1663,9 +1663,10 @@ export default {
           class="mt-10"
         >
           <UnitInput
-            v-model.number="customCmdOpts.timeout"
+            v-model:value="customCmdOpts.timeout"
             :label="t('catalog.install.helm.timeout.label')"
             :suffix="t('catalog.install.helm.timeout.unit', {value: customCmdOpts.timeout})"
+            type="number"
           />
         </div>
         <div
@@ -1674,9 +1675,10 @@ export default {
         >
           <UnitInput
             v-if="existing"
-            v-model.number="customCmdOpts.historyMax"
+            v-model:value="customCmdOpts.historyMax"
             :label="t('catalog.install.helm.historyMax.label')"
             :suffix="t('catalog.install.helm.historyMax.unit', {value: customCmdOpts.historyMax})"
+            type="number"
           />
         </div>
         <div


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12412
Fixes #12416

<!-- Define findings related to the feature or bug issue. -->
UnitInput controls with value set as v-model.number didn't get updated correctly during migration. If control doesn't have corresponding @input event, value was not getting updated. 

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
N/A

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
See linked issues for reproduction steps


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
