### PR TITLE
Fix errors not showing in fleet git repo form

### DIFF
--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -34,6 +34,8 @@ const _SPECIFY = 'specify';
 export default {
   name: 'CruGitRepo',
 
+  inheritAttrs: false,
+
   emits: ['input'],
 
   components: {


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12391
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Missed from
- https://github.com/rancher/dashboard/pull/11956#issuecomment-2422936450
- https://github.com/rancher/dashboard/issues/12298
- https://github.com/rancher/dashboard/pull/12299

### Technical notes summary
i could reproduce this in release-2.9 head

### Areas or cases that should be tested
git repo create / edit with failures
given recent git repo url change though to reproduce an easy error try creating a git repo with a name of an existing one

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
