### PR TITLE
Fix issue with Workspace dropdown in Firefox

### DIFF
--- a/shell/components/nav/WorkspaceSwitcher.vue
+++ b/shell/components/nav/WorkspaceSwitcher.vue
@@ -92,7 +92,6 @@ export default {
       ref="select"
       v-model:value="value"
       label="label"
-      :append-to-body="false"
       :options="options"
       :clearable="false"
       :reduce="(opt) => opt.value"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12388 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- remove `append-to-body="false"` from the Fleet workspace switcher to fix render issue of dropdown in Firefox

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The problem is that Firefox doesn't calculate the width well with this `inline` class presenthttps://github.com/rancher/dashboard/blob/master/shell/components/form/Select.vue#L244 when appending `v-select` dropdown to the element.
We could have removed the `inline` class, but I think it's less prone to risks if we just let the dropdown to be appended to the `body` element rather than the dropdown as it forces `v-select` to calculate both width and position and apply it to the element without any relative measurements like `%`.

Original work done in https://github.com/rancher/dashboard/pull/2170

https://vue-select.org/api/props.html#appendtobody

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- check workspace switcher for Fleet in Firefox

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- I can't find any scenario where we would have regressions, but better to test with all other browsers

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1800" alt="Screenshot 2024-10-30 at 10 54 04" src="https://github.com/user-attachments/assets/f0daa5ed-5412-40d7-905d-d868a95af433">

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
