### PR TITLE
Ensure we don't lose values on edit of cluster scan resources

### DIFF
--- a/shell/edit/cis.cattle.io.clusterscan.vue
+++ b/shell/edit/cis.cattle.io.clusterscan.vue
@@ -12,7 +12,7 @@ import { allHash } from '@shell/utils/promise';
 import { Checkbox } from '@components/Form/Checkbox';
 import { RadioGroup } from '@components/Form/Radio';
 import { get } from '@shell/utils/object';
-import { _VIEW, _CREATE, _EDIT } from '@shell/config/query-params';
+import { _VIEW, _CREATE } from '@shell/config/query-params';
 import { isValidCron } from 'cron-validator';
 import { fetchSpecsScheduledScanConfig } from '@shell/models/cis.cattle.io.clusterscan';
 
@@ -43,7 +43,8 @@ export default {
     // in the clusterscan edit/create views the "canBeScheduled" won't run properly
     await this.schema.fetchResourceFields();
 
-    if (this.realMode === _CREATE || this.realMode === _EDIT) {
+    // Only initialize on create or if we don't have a spec object (added for resilience)
+    if (this.realMode === _CREATE || !this.value.spec) {
       const includeScheduling = this.value.canBeScheduled();
       const spec = this.value.spec || {};
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12411

Note: https://github.com/rancher/dashboard/issues/12412 is required to fix the specific issue on that field.
 
### Occurred changes and/or fixed issues

We were previously clearing out the `spec` of the resource on edit. Don't know why.

This PR updates that so that we preserve the data in the resource on edit

### Areas or cases that should be tested

Test as per the issue above.

Due to time constraints, this will need manual testing.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
