### PR TITLE
Compare against both base-version and base@version

### DIFF
--- a/shell/scripts/extension/parse-tag-name
+++ b/shell/scripts/extension/parse-tag-name
@@ -6,10 +6,10 @@ GITHUB_WORKFLOW_TYPE=$3
 
 # Ensure "catalog" workflow release tag name does not match a pkg/<pkg-name>
 if [[ "${GITHUB_WORKFLOW_TYPE}" == "catalog" ]]; then
-  for d in pkg/*/ ; do
+  for d in pkg/*/; do
     pkg=$(basename $d)
 
-    PKG_VERSION=$(jq -r .version pkg/${pkg}/package.json)
+    PKG_VERSION=$(jq -r .version pkg/${pkg}/package.json) || exit 1
     PKG_NAME="${pkg}-${PKG_VERSION}"
 
     if [[ "${GITHUB_RELEASE_TAG}" == "${PKG_NAME}" ]]; then
@@ -23,7 +23,8 @@ else
   BASE_EXT=$(jq -r .name package.json)
   EXT_VERSION=$(jq -r .version package.json)
 
-  if [[ "${GITHUB_RELEASE_TAG}" == "${BASE_EXT}-${EXT_VERSION}" ]]; then
+  if [[ "${GITHUB_RELEASE_TAG}" == "${BASE_EXT}-${EXT_VERSION}" ||
+    "${GITHUB_RELEASE_TAG}" == "${BASE_EXT}@${EXT_VERSION}" ]]; then
     echo -e "tag: ${GITHUB_RELEASE_TAG}"
     gh run cancel ${GITHUB_RUN_ID}
   fi


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
I am investigating the possibility of integrating https://github.com/semantic-release/semantic-release tool to automate versioning of https://github.com/StackVista/rancher-extension-stackstate and for that matter I wish I can use [`changeset tag`](https://github.com/changesets/changesets/blob/main/docs/command-line-options.md#tag) command but the caveat is that it formats the tag as `name@version` and not `name-version` as required by the workflow. 

I'd like to propose a change to match both tag formats, it should not hurt to have them simultaneously.
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->


### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
