### PR TITLE
Fixed UnitInput value not being set correctly in monitoring

### DIFF
--- a/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
@@ -136,7 +136,7 @@ describe('Git Repo', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] }, (
           prefPage.languageDropdownMenu().isOpened();
 
           cy.intercept('PUT', 'v1/userpreferences/*').as(`prefUpdateEnUs`);
-          prefPage.languageDropdownMenu().clickOption(1);
+          prefPage.languageDropdownMenu().clickOptionWithLabel('English');
           cy.wait('@prefUpdateEnUs').then(({ response }) => {
             expect(response?.statusCode).to.eq(200);
             expect(response?.body.data).to.have.property('locale', 'en-us');

--- a/shell/edit/monitoring.coreos.com.prometheusrule/AlertingRule.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/AlertingRule.vue
@@ -213,7 +213,7 @@ export default {
         return undefined;
       },
       set(v) {
-        this.value['for'] = [null, undefined].includes(v ? undefined : `${ v }s`);
+        this.value['for'] = [null, undefined].includes(v) ? undefined : `${ v }s`;
       }
     }
   },

--- a/shell/edit/monitoring.coreos.com.prometheusrule/index.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/index.vue
@@ -113,7 +113,7 @@ export default {
     },
 
     updateGroupInterval(group, interval) {
-      group['interval'] = [null, undefined].includes(interval ? undefined : `${ interval }s`);
+      group['interval'] = [null, undefined].includes(interval) ? undefined : `${ interval }s`;
     },
 
     getGroupInterval(interval) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12436 
<!-- Define findings related to the feature or bug issue. -->
Fixed 'Override Group Interval' and 'Wait to fire for' fields when creating Prometheus rule.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
During vue migration, .includes usage inside set became corrupted.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Make sure that 'Override Group Interval' and 'Wait to fire for' fields can be set correctly:

Install monitoring chart
Once chart installed successfully goto Monitoring->Advanced->PromethuesRules->Create Rule.
Create prometheus rules and add alerting rules with "wait to fire for" and "Override Group Interval" values.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
