### PR TITLE
Test v-model.number usage in 2.10 / vue3 world - fix broken unitInput

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
@@ -317,7 +317,7 @@ export default {
             />
           </h3>
           <UnitInput
-            v-model.number="unhealthyNodeTimeoutInteger"
+            v-model:value="unhealthyNodeTimeoutInteger"
             :hide-arrows="true"
             :placeholder="t('containerResourceLimit.cpuPlaceholder')"
             :mode="mode"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12428 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix unit input for `unhealthy node timeout` on machine pools in cluster provisioning

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Been checking all the usages of `v-model.number` and:

  - `shell/components/form/Ports.vue` -> Component not used in dashboard code (hasn't been touched in quite a while codewise)
  - `shell/components/form/ServicePorts.vue` -> used in edit view of `services` and works fine
  - `shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue` -> Used in cluster provisioning machine pools and was broken (object of this fix)

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- test unit input for `unhealthy node timeout` on machine pools in cluster provisioning

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/d235b588-6b26-4ffc-998f-c83f10b3b749


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
