### PR TITLE
[2.9] Use BundleDeployment status to calculate GitRepo resources

### DIFF
--- a/cypress/e2e/tests/pages/fleet/advanced/bundles.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/advanced/bundles.spec.ts
@@ -52,7 +52,7 @@ describe('Bundles', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] }, ()
       fleetBundleeDetailsPage.waitForPage();
 
       // check table headers
-      const expectedHeadersDetailsViewEvents = ['Name'];
+      const expectedHeadersDetailsViewEvents = ['State', 'API Version', 'Kind', 'Name', 'Namespace'];
 
       fleetBundleeDetailsPage.list().resourceTable().sortableTable()
         .tableHeaderRow()

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -171,7 +171,8 @@ export default {
           },
           bundle: {
             inStoreType: 'management',
-            type:        FLEET.BUNDLE
+            type:        FLEET.BUNDLE,
+            opt:         { excludeFields: ['metadata.managedFields', 'spec.resources'] },
           },
 
           bundleDeployment: {

--- a/shell/components/fleet/FleetRepos.vue
+++ b/shell/components/fleet/FleetRepos.vue
@@ -16,7 +16,6 @@ import {
   FLEET_REPO_PER_CLUSTER_STATE
 
 } from '@shell/config/table-headers';
-import { FLEET } from '@shell/config/labels-annotations';
 import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 
 // i18n-ignore repoDisplay

--- a/shell/components/fleet/FleetRepos.vue
+++ b/shell/components/fleet/FleetRepos.vue
@@ -118,12 +118,6 @@ export default {
     parseTargetMode(row) {
       return row.targetInfo?.mode === 'clusterGroup' ? this.t('fleet.gitRepo.warningTooltip.clusterGroup') : this.t('fleet.gitRepo.warningTooltip.cluster');
     },
-
-    clusterViewResourceStatus(row) {
-      return row.clusterResourceStatus.find((c) => {
-        return c.metadata?.labels[FLEET.CLUSTER_NAME] === this.clusterId;
-      });
-    }
   },
 };
 </script>

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -111,6 +111,7 @@ export const FLEET = {
   CLUSTER_NAME:         'management.cattle.io/cluster-name',
   BUNDLE_ID:            'fleet.cattle.io/bundle-id',
   MANAGED:              'fleet.cattle.io/managed',
+  CLUSTER_NAMESPACE:    'fleet.cattle.io/cluster-namespace',
   CLUSTER:              'fleet.cattle.io/cluster'
 };
 

--- a/shell/detail/fleet.cattle.io.bundle.vue
+++ b/shell/detail/fleet.cattle.io.bundle.vue
@@ -17,7 +17,7 @@ export default {
       return this.value?.status?.resourceKey || [];
     },
     resourceCount() {
-      return this.value.status?.summary?.desiredReady || 0;
+      return this.bundleResources.length;
     },
   }
 };

--- a/shell/detail/fleet.cattle.io.bundle.vue
+++ b/shell/detail/fleet.cattle.io.bundle.vue
@@ -1,15 +1,11 @@
 <script>
 import FleetBundleResources from '@shell/components/fleet/FleetBundleResources.vue';
-import SortableTable from '@shell/components/SortableTable';
 
 export default {
   name: 'FleetBundleDetail',
 
-  components: {
-    FleetBundleResources,
-    SortableTable,
-  },
-  props: {
+  components: { FleetBundleResources },
+  props:      {
     value: {
       type:     Object,
       required: true,

--- a/shell/detail/fleet.cattle.io.bundle.vue
+++ b/shell/detail/fleet.cattle.io.bundle.vue
@@ -15,7 +15,7 @@ export default {
 
   computed: {
     bundleResources() {
-      return FleetUtils.bundleResources(this.value?.status);
+      return FleetUtils.resourcesFromBundleStatus(this.value?.status);
     },
     resourceCount() {
       return this.bundleResources.length;

--- a/shell/detail/fleet.cattle.io.bundle.vue
+++ b/shell/detail/fleet.cattle.io.bundle.vue
@@ -1,5 +1,4 @@
 <script>
-import { FLEET } from '@shell/config/types';
 import FleetBundleResources from '@shell/components/fleet/FleetBundleResources.vue';
 import SortableTable from '@shell/components/SortableTable';
 
@@ -17,61 +16,13 @@ export default {
     }
   },
 
-  data() {
-    return { repo: null };
-  },
-
-  async fetch() {
-    const { namespace, labels } = this.value.metadata;
-    const repoName = `${ namespace }/${ labels['fleet.cattle.io/repo-name'] }`;
-
-    if (this.hasRepoLabel) {
-      this.repo = await this.$store.dispatch('management/find', { type: FLEET.GIT_REPO, id: repoName });
-    }
-  },
-
   computed: {
-    hasRepoLabel() {
-      return !!(this.value?.metadata?.labels && this.value?.metadata?.labels['fleet.cattle.io/repo-name']);
-    },
     bundleResources() {
-      if (this.hasRepoLabel) {
-        const bundleResourceIds = this.bundleResourceIds;
-
-        return this.repo?.status?.resources?.filter((resource) => {
-          return bundleResourceIds.includes(resource.name);
-        });
-      } else if (this.value?.spec?.resources?.length) {
-        return this.value?.spec?.resources.map((item) => {
-          return {
-            content: item.content,
-            name:    item.name.includes('.') ? item.name.split('.')[0] : item.name
-          };
-        });
-      }
-
-      return [];
-    },
-    resourceHeaders() {
-      return [
-        {
-          name:     'name',
-          value:    'name',
-          sort:     ['name'],
-          labelKey: 'tableHeaders.name',
-        },
-      ];
+      return this.value?.status?.resourceKey || [];
     },
     resourceCount() {
-      return (this.bundleResources && this.bundleResources.length) || this.value?.spec?.resources?.length;
+      return this.value.status?.summary?.desiredReady || 0;
     },
-    bundleResourceIds() {
-      if (this.value.status?.resourceKey) {
-        return this.value?.status?.resourceKey.map((item) => item.name);
-      }
-
-      return [];
-    }
   }
 };
 
@@ -84,18 +35,7 @@ export default {
       <span>{{ resourceCount }}</span>
     </div>
     <FleetBundleResources
-      v-if="hasRepoLabel"
       :value="bundleResources"
-    />
-    <SortableTable
-      v-else
-      :rows="bundleResources"
-      :headers="resourceHeaders"
-      :table-actions="false"
-      :row-actions="false"
-      key-field="tableKey"
-      default-sort-by="state"
-      :paged="true"
     />
   </div>
 </template>

--- a/shell/detail/fleet.cattle.io.bundle.vue
+++ b/shell/detail/fleet.cattle.io.bundle.vue
@@ -1,5 +1,6 @@
 <script>
 import FleetBundleResources from '@shell/components/fleet/FleetBundleResources.vue';
+import { bundleResources } from '@shell/utils/fleet';
 
 export default {
   name: 'FleetBundleDetail',
@@ -14,7 +15,7 @@ export default {
 
   computed: {
     bundleResources() {
-      return this.value?.status?.resourceKey || [];
+      return bundleResources(this.value?.status);
     },
     resourceCount() {
       return this.bundleResources.length;

--- a/shell/detail/fleet.cattle.io.bundle.vue
+++ b/shell/detail/fleet.cattle.io.bundle.vue
@@ -1,6 +1,6 @@
 <script>
 import FleetBundleResources from '@shell/components/fleet/FleetBundleResources.vue';
-import { bundleResources } from '@shell/utils/fleet';
+import FleetUtils from '@shell/utils/fleet';
 
 export default {
   name: 'FleetBundleDetail',
@@ -15,7 +15,7 @@ export default {
 
   computed: {
     bundleResources() {
-      return bundleResources(this.value?.status);
+      return FleetUtils.bundleResources(this.value?.status);
     },
     resourceCount() {
       return this.bundleResources.length;

--- a/shell/detail/fleet.cattle.io.gitrepo.vue
+++ b/shell/detail/fleet.cattle.io.gitrepo.vue
@@ -80,7 +80,8 @@ export default {
     const allDispatches = await checkSchemasForFindAllHash({
       allBundles: {
         inStoreType: 'management',
-        type:        FLEET.BUNDLE
+        type:        FLEET.BUNDLE,
+        opt:         { excludeFields: ['metadata.managedFields', 'spec.resources'] },
       },
 
       allBundleDeployments: {

--- a/shell/models/fleet.cattle.io.bundle.js
+++ b/shell/models/fleet.cattle.io.bundle.js
@@ -30,7 +30,9 @@ export default class FleetBundle extends SteveModel {
   }
 
   get repoName() {
-    return this.metadata.labels['fleet.cattle.io/repo-name'];
+    const labels = this.metadata?.labels || {};
+
+    return labels['fleet.cattle.io/repo-name'];
   }
 
   get targetClusters() {

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -335,7 +335,7 @@ export default class GitRepo extends SteveModel {
     for (const bd of bundleDeployments) {
       let clusterId = FleetUtils.clusterIdFromBundleDeploymentLabels(bd.metadata?.labels);
       const c = clusters[clusterId];
-      const resources = FleetUtils.bundleDeploymentResources(bd.status);
+      const resources = FleetUtils.resourcesFromBundleDeploymentStatus(bd.status);
 
       resources.forEach((r) => {
         const id = FleetUtils.resourceId(r);

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -42,7 +42,7 @@ function bundleDeploymentResources(status) {
   const modified = [];
 
   for (const r of status?.modifiedStatus || []) {
-    const state = r.create ? STATES_ENUM.MISSING : r.delete ? STATES_ENUM.ORPHANED : STATES_ENUM.MODIFIED;
+    const state = r.missing ? STATES_ENUM.MISSING : r.delete ? STATES_ENUM.ORPHANED : STATES_ENUM.MODIFIED;
     const found = resources[resourceKey(r)];
 
     // Depending on the state, the same resource can appear in both fields

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -11,7 +11,7 @@ import {
   colorForState, mapStateToEnum, primaryDisplayStatusFromCount, stateDisplay, stateSort
 } from '@shell/plugins/dashboard-store/resource-class';
 import { NAME } from '@shell/config/product/explorer';
-import { bundleDeploymentResources, resourceId, resourceType, clusterIdFromBundleDeploymentLabels } from '@shell/utils/fleet';
+import FleetUtils from '@shell/utils/fleet';
 
 function quacksLikeAHash(str) {
   if (str.match(/^[a-f0-9]{40,}$/i)) {
@@ -333,12 +333,13 @@ export default class GitRepo extends SteveModel {
     const out = [];
 
     for (const bd of bundleDeployments) {
-      const c = clusters[clusterIdFromBundleDeploymentLabels(bd.metadata?.labels)];
-      const resources = bundleDeploymentResources(bd.status);
+      let clusterId = FleetUtils.clusterIdFromBundleDeploymentLabels(bd.metadata?.labels);
+      const c = clusters[clusterId];
+      const resources = FleetUtils.bundleDeploymentResources(bd.status);
 
       resources.forEach((r) => {
-        const id = resourceId(r);
-        const type = resourceType(r);
+        const id = FleetUtils.resourceId(r);
+        const type = FleetUtils.resourceType(r);
         const state = r.state;
 
         const color = colorForState(state).replace('text-', 'bg-');

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -335,6 +335,11 @@ export default class GitRepo extends SteveModel {
     for (const bd of bundleDeployments) {
       const clusterId = FleetUtils.clusterIdFromBundleDeploymentLabels(bd.metadata?.labels);
       const c = clusters[clusterId];
+
+      if (!c) {
+        continue;
+      }
+
       const resources = FleetUtils.resourcesFromBundleDeploymentStatus(bd.status);
 
       resources.forEach((r) => {

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -358,13 +358,17 @@ export default class GitRepo extends SteveModel {
   }
 
   get resourcesStatuses() {
-    const clusters = this.targetClusters || [];
     const bundleDeployments = this.bundleDeployments || [];
+    const clusters = (this.targetClusters || []).reduce((res, c) => {
+      res[c.id] = c;
+
+      return res;
+    }, {});
 
     const out = [];
 
     for (const bd of bundleDeployments) {
-      const c = clusters.find((c) => clusterIdFromLabels(bd.metadata?.labels) === c.id);
+      const c = clusters[clusterIdFromLabels(bd.metadata?.labels)];
       const resources = bundleDeploymentResources(bd.status);
 
       resources.forEach((r) => {

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -333,7 +333,7 @@ export default class GitRepo extends SteveModel {
     const out = [];
 
     for (const bd of bundleDeployments) {
-      let clusterId = FleetUtils.clusterIdFromBundleDeploymentLabels(bd.metadata?.labels);
+      const clusterId = FleetUtils.clusterIdFromBundleDeploymentLabels(bd.metadata?.labels);
       const c = clusters[clusterId];
       const resources = FleetUtils.resourcesFromBundleDeploymentStatus(bd.status);
 

--- a/shell/pages/c/_cluster/fleet/index.vue
+++ b/shell/pages/c/_cluster/fleet/index.vue
@@ -40,6 +40,7 @@ export default {
       allBundles: {
         inStoreType: 'management',
         type:        FLEET.BUNDLE,
+        opt:         { excludeFields: ['metadata.managedFields', 'spec.resources'] },
       },
       gitRepos: {
         inStoreType: 'management',

--- a/shell/types/resources/fleet.d.ts
+++ b/shell/types/resources/fleet.d.ts
@@ -1,9 +1,12 @@
-export interface BundleDeploymentResource {
+export interface ResourceKey {
   kind: string,
   apiVersion: string,
   namespace?: string,
   name: string,
-  createdAt: string,
+}
+
+export interface BundleDeploymentResource extends ResourceKey {
+  createdAt?: string,
 }
 
 export interface ModifiedStatus {

--- a/shell/types/resources/fleet.d.ts
+++ b/shell/types/resources/fleet.d.ts
@@ -1,0 +1,17 @@
+export interface BundleDeploymentResource {
+  kind: string,
+  apiVersion: string,
+  namespace?: string,
+  name: string,
+  createdAt: string,
+}
+
+export interface ModifiedStatus {
+  kind: string,
+  apiVersion: string,
+  namespace?: string,
+  name: string,
+  missing?: boolean,
+  delete?: boolean,
+  patch: string,
+}

--- a/shell/types/resources/fleet.d.ts
+++ b/shell/types/resources/fleet.d.ts
@@ -9,11 +9,7 @@ export interface BundleDeploymentResource extends ResourceKey {
   createdAt?: string,
 }
 
-export interface ModifiedStatus {
-  kind: string,
-  apiVersion: string,
-  namespace?: string,
-  name: string,
+export interface ModifiedStatus extends ResourceKey {
   missing?: boolean,
   delete?: boolean,
   patch: string,

--- a/shell/types/resources/fleet.d.ts
+++ b/shell/types/resources/fleet.d.ts
@@ -15,3 +15,7 @@ export interface ModifiedStatus {
   delete?: boolean,
   patch: string,
 }
+
+export interface NonReadyBundle {
+  modifiedStatus: ModifiedStatus[],
+}

--- a/shell/types/resources/fleet.d.ts
+++ b/shell/types/resources/fleet.d.ts
@@ -9,19 +9,25 @@ export interface BundleDeploymentResource extends BundleResourceKey {
   createdAt?: string,
 }
 
-export interface BundleDeploymentModifiedStatus extends BundleResourceKey {
+export interface BundleModifiedResource extends BundleResourceKey {
   missing?: boolean,
   delete?: boolean,
   patch: string,
 }
 
+export interface BundleNonReadyResource extends BundleResourceKey {
+  summary: { [state: string]: string }
+}
+
 export interface BundleNonReadyBundle {
-  modifiedStatus: BundleDeploymentModifiedStatus[],
+  modifiedStatus: BundleModifiedResource[],
+  nonReadyStatus: BundleNonReadyResource[],
 }
 
 export interface BundleDeploymentStatus {
   resources?: BundleDeploymentResource[],
-  modifiedStatus?: BundleDeploymentModifiedStatus[],
+  modifiedStatus?: BundleModifiedResource[],
+  nonReadyStatus?: BundleNonReadyResource[],
 }
 
 export interface BundleStatusSummary {

--- a/shell/types/resources/fleet.d.ts
+++ b/shell/types/resources/fleet.d.ts
@@ -1,20 +1,20 @@
-export interface ResourceKey {
+export interface BundleResourceKey {
   kind: string,
   apiVersion: string,
   namespace?: string,
   name: string,
 }
 
-export interface BundleDeploymentResource extends ResourceKey {
+export interface BundleDeploymentResource extends BundleResourceKey {
   createdAt?: string,
 }
 
-export interface ModifiedStatus extends ResourceKey {
+export interface BundleDeploymentModifiedStatus extends BundleResourceKey {
   missing?: boolean,
   delete?: boolean,
   patch: string,
 }
 
-export interface NonReadyBundle {
-  modifiedStatus: ModifiedStatus[],
+export interface BundleNonReadyBundle {
+  modifiedStatus: BundleDeploymentModifiedStatus[],
 }

--- a/shell/types/resources/fleet.d.ts
+++ b/shell/types/resources/fleet.d.ts
@@ -18,3 +18,17 @@ export interface BundleDeploymentModifiedStatus extends BundleResourceKey {
 export interface BundleNonReadyBundle {
   modifiedStatus: BundleDeploymentModifiedStatus[],
 }
+
+export interface BundleDeploymentStatus {
+  resources?: BundleDeploymentResource[],
+  modifiedStatus?: BundleDeploymentModifiedStatus[],
+}
+
+export interface BundleStatusSummary {
+  nonReadyResources?: BundleNonReadyBundle[],
+}
+
+export interface BundleStatus {
+  resourceKey?: BundleResourceKey[],
+  summary?: BundleStatusSummary,
+}

--- a/shell/utils/auth.js
+++ b/shell/utils/auth.js
@@ -99,7 +99,7 @@ export const checkSchemasForFindAllHash = (types, store) => {
     const validSchema = value.schemaValidator ? value.schemaValidator(schema) : !!schema;
 
     if (validSchema) {
-      hash[key] = store.dispatch(`${ value.inStoreType }/findAll`, { type: value.type } );
+      hash[key] = store.dispatch(`${ value.inStoreType }/findAll`, { type: value.type, opt: value.opt } );
     }
   }
 

--- a/shell/utils/fleet.ts
+++ b/shell/utils/fleet.ts
@@ -44,17 +44,19 @@ export function bundleDeploymentResources(status: BundleDeploymentStatus): Resou
   return modified.concat(Object.values(resources));
 }
 
+interface StatesCounter { [state: string]: number }
+
+const newCounter = (): StatesCounter => ({
+  [STATES_ENUM.READY]:    0,
+  [STATES_ENUM.MISSING]:  0,
+  [STATES_ENUM.ORPHANED]: 0,
+  [STATES_ENUM.MODIFIED]: 0,
+});
+
 /**
  * bundleResources extracts the list of resources deployed by a Bundle
  */
 export function bundleResources(status: BundleStatus): Resource[] {
-  type counter = { [state: string]: number };
-  const newCounter = (): counter => ({
-    [STATES_ENUM.READY]:    0,
-    [STATES_ENUM.MISSING]:  0,
-    [STATES_ENUM.ORPHANED]: 0,
-    [STATES_ENUM.MODIFIED]: 0,
-  });
   // The state of every resource is spread all over the bundle status.
   // resourceKey contains one entry per resource AND cluster (built by Fleet from all the child BundleDeployments).
   // However, those entries do not contain the cluster that they belong to, leading to duplicate entries

--- a/shell/utils/fleet.ts
+++ b/shell/utils/fleet.ts
@@ -26,7 +26,9 @@ function resourceKey(r: BundleDeploymentResource): string {
   return `${ r.kind }/${ r.namespace }/${ r.name }`;
 }
 
-// bundleDeploymentResources extracts the list of resources deployed by a BundleDeployment
+/**
+ * bundleDeploymentResources extracts the list of resources deployed by a BundleDeployment
+ */
 export function bundleDeploymentResources(status: BundleDeploymentStatus): Resource[] {
   // status.resources includes of resources that were deployed by Fleet *and still exist in the cluster*
   // Use a map to avoid `find` over and over again
@@ -53,7 +55,9 @@ export function bundleDeploymentResources(status: BundleDeploymentStatus): Resou
   return modified.concat(Object.values(resources));
 }
 
-// bundleResources extracts the list of resources deployed by a Bundle
+/**
+ * bundleResources extracts the list of resources deployed by a Bundle
+ */
 export function bundleResources(status: BundleStatus): Resource[] {
   const newCounter = (): Object<string, number> => ({
     [STATES_ENUM.READY]:    0,
@@ -112,8 +116,11 @@ export function bundleResources(status: BundleStatus): Resource[] {
   }, []);
 }
 
-// ported from https://github.com/rancher/fleet/blob/v0.10.0/internal/cmd/controller/grutil/resourcekey.go#L116-L128
+/**
+ * resourceType normalizes APIVersion and Kind from a Resources into a single string
+ */
 export function resourceType(r: Resource): string {
+  // ported from https://github.com/rancher/fleet/blob/v0.10.0/internal/cmd/controller/grutil/resourcekey.go#L116-L128
   const type = r.kind.toLowerCase();
 
   if (!r.APIVersion || r.APIVersion === 'v1') {

--- a/shell/utils/fleet.ts
+++ b/shell/utils/fleet.ts
@@ -2,10 +2,8 @@ import { BundleDeploymentResource, ModifiedStatus, NonReadyBundle, ResourceKey }
 import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 import { FLEET as FLEET_ANNOTATIONS } from '@shell/config/labels-annotations';
 
-type state = STATES_ENUM.READY | STATES_ENUM.MODIFIED | STATES_ENUM.MISSING | STATES_ENUM.ORPHANED;
-
 interface Resource extends BundleDeploymentResource {
-  state: state,
+  state: string,
 }
 
 interface BundleDeploymentStatus {

--- a/shell/utils/fleet.ts
+++ b/shell/utils/fleet.ts
@@ -1,23 +1,14 @@
-import { BundleDeploymentResource, BundleDeploymentModifiedStatus, BundleNonReadyBundle, BundleResourceKey } from '@shell/types/resources/fleet';
+import {
+  BundleDeploymentResource,
+  BundleResourceKey,
+  BundleDeploymentStatus,
+  BundleStatus,
+} from '@shell/types/resources/fleet';
 import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 import { FLEET as FLEET_ANNOTATIONS } from '@shell/config/labels-annotations';
 
 interface Resource extends BundleDeploymentResource {
   state: string,
-}
-
-interface BundleDeploymentStatus {
-  resources?: BundleDeploymentResource[],
-  modifiedStatus?: BundleDeploymentModifiedStatus[],
-}
-
-interface BundleStatusSummary {
-  nonReadyResources?: BundleNonReadyBundle[],
-}
-
-interface BundleStatus {
-  resourceKey?: BundleResourceKey[],
-  summary?: BundleStatusSummary,
 }
 
 function resourceKey(r: BundleResourceKey): string {
@@ -78,7 +69,7 @@ export function bundleResources(status: BundleStatus): Resource[] {
     res[k].count[STATES_ENUM.READY]++;
 
     return res;
-  }, {} as { [resourceKey: string]: { r: BundleResourceKey, count: counter } });
+  }, {} as { [resourceKey: string]: { r: BundleResourceKey, count: StatesCounter } });
 
   // 2. Non-ready resources are counted differently and may also appear in resourceKey, depending on their state
   for (const bundle of status.summary?.nonReadyResources || []) {

--- a/shell/utils/fleet.ts
+++ b/shell/utils/fleet.ts
@@ -55,30 +55,61 @@ export function bundleDeploymentResources(status: BundleDeploymentStatus): Resou
 
 // bundleResources extracts the list of resources deployed by a Bundle
 export function bundleResources(status: BundleStatus): Resource[] {
-  const resources = (status.resourceKey || []).map((r) => {
-    r.state = STATES_ENUM.READY;
-
-    return r;
+  const newCounter = (): Object<string, number> => ({
+    [STATES_ENUM.READY]:    0,
+    [STATES_ENUM.MISSING]:  0,
+    [STATES_ENUM.ORPHANED]: 0,
+    [STATES_ENUM.MODIFIED]: 0,
   });
-
   // The state of every resource is spread all over the bundle status.
   // resourceKey contains one entry per resource AND cluster (built by Fleet from all the child BundleDeployments).
   // However, those entries do not contain the cluster that they belong to, leading to duplicate entries
-  for (const bundle of status.summary?.nonReadyResources || []) {
-    for (const mod of bundle.modifiedStatus || []) {
-      if (mod.missing) {
-        resources.unshift(Object.assign({ state: STATES_ENUM.MISSING }, mod));
-      } else {
-        // There may be duplicate entries, pick the first one matching the condition
-        const r = resources.find((r) => r.state === STATES_ENUM.READY &&
-          resourceType(r) === resourceType(mod) && resourceId(r) === resourceId(mod));
 
-        r.state = mod.delete ? STATES_ENUM.ORPHANED : STATES_ENUM.MODIFIED;
+  // 1. Fold resourceKey by using a unique key, initializing counters for multiple occurrences of the same resource
+  const resources = (status.resourceKey || []).reduce((res, r) => {
+    const k = resourceKey(r);
+
+    if (!res[k]) {
+      res[k] = { r, count: newCounter() };
+    }
+    res[k].count[STATES_ENUM.READY]++;
+
+    return res;
+  }, {});
+
+  // 2. Non-ready resources are counted differently and may also appear in resourceKey, depending on their state
+  for (const bundle of status.summary?.nonReadyResources || []) {
+    for (const r of bundle.modifiedStatus || []) {
+      const k = resourceKey(r);
+
+      if (!resources[k]) {
+        resources[k] = { r, count: newCounter() };
+      }
+
+      if (r.missing) {
+        resources[k].count[STATES_ENUM.MISSING]++;
+      } else if (r.delete) {
+        resources[k].count[STATES_ENUM.READY]--;
+        resources[k].count[STATES_ENUM.ORPHANED]++;
+      } else {
+        resources[k].count[STATES_ENUM.READY]--;
+        resources[k].count[STATES_ENUM.MODIFIED]++;
       }
     }
   }
 
-  return resources;
+  // 3. Unfold back to an array of resources for display
+  return Object.values(resources).reduce((res, e) => {
+    const { r, count } = e;
+
+    for (const state in count) {
+      for (let x = 0; x < count[state]; x++) {
+        res.push(Object.assign({ state }, r));
+      }
+    }
+
+    return res;
+  }, []);
 }
 
 // ported from https://github.com/rancher/fleet/blob/v0.10.0/internal/cmd/controller/grutil/resourcekey.go#L116-L128

--- a/shell/utils/fleet.ts
+++ b/shell/utils/fleet.ts
@@ -48,9 +48,9 @@ class Fleet {
   }
 
   /**
-   * bundleDeploymentResources extracts the list of resources deployed by a BundleDeployment
+   * resourcesFromBundleDeploymentStatus extracts the list of resources deployed by a BundleDeployment
    */
-  bundleDeploymentResources(status: BundleDeploymentStatus): Resource[] {
+  resourcesFromBundleDeploymentStatus(status: BundleDeploymentStatus): Resource[] {
     // status.resources includes of resources that were deployed by Fleet *and still exist in the cluster*
     // Use a map to avoid `find` over and over again
     const resources = (status?.resources || []).reduce((res, r) => {
@@ -85,9 +85,9 @@ class Fleet {
   }
 
   /**
-   * bundleResources extracts the list of resources deployed by a Bundle
+   * resourcesFromBundleStatus extracts the list of resources deployed by a Bundle
    */
-  bundleResources(status: BundleStatus): Resource[] {
+  resourcesFromBundleStatus(status: BundleStatus): Resource[] {
     // The state of every resource is spread all over the bundle status.
     // resourceKey contains one entry per resource AND cluster (built by Fleet from all the child BundleDeployments).
     // However, those entries do not contain the cluster that they belong to, leading to duplicate entries

--- a/shell/utils/fleet.ts
+++ b/shell/utils/fleet.ts
@@ -1,4 +1,4 @@
-import { BundleDeploymentResource, ModifiedStatus, NonReadyBundle, ResourceKey } from '@shell/types/resources/fleet';
+import { BundleDeploymentResource, BundleDeploymentModifiedStatus, BundleNonReadyBundle, BundleResourceKey } from '@shell/types/resources/fleet';
 import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 import { FLEET as FLEET_ANNOTATIONS } from '@shell/config/labels-annotations';
 
@@ -8,19 +8,19 @@ interface Resource extends BundleDeploymentResource {
 
 interface BundleDeploymentStatus {
   resources?: BundleDeploymentResource[],
-  modifiedStatus?: ModifiedStatus[],
+  modifiedStatus?: BundleDeploymentModifiedStatus[],
 }
 
 interface BundleStatusSummary {
-  nonReadyResources?: NonReadyBundle[],
+  nonReadyResources?: BundleNonReadyBundle[],
 }
 
 interface BundleStatus {
-  resourceKey?: ResourceKey[],
+  resourceKey?: BundleResourceKey[],
   summary?: BundleStatusSummary,
 }
 
-function resourceKey(r: ResourceKey): string {
+function resourceKey(r: BundleResourceKey): string {
   return `${ r.kind }/${ r.namespace }/${ r.name }`;
 }
 
@@ -78,7 +78,7 @@ export function bundleResources(status: BundleStatus): Resource[] {
     res[k].count[STATES_ENUM.READY]++;
 
     return res;
-  }, {} as { [resourceKey: string]: { r: ResourceKey, count: counter } });
+  }, {} as { [resourceKey: string]: { r: BundleResourceKey, count: counter } });
 
   // 2. Non-ready resources are counted differently and may also appear in resourceKey, depending on their state
   for (const bundle of status.summary?.nonReadyResources || []) {
@@ -86,7 +86,7 @@ export function bundleResources(status: BundleStatus): Resource[] {
       const k = resourceKey(r);
 
       if (!resources[k]) {
-        resources[k] = { r: r as ResourceKey, count: newCounter() };
+        resources[k] = { r: r as BundleResourceKey, count: newCounter() };
       }
 
       if (r.missing) {

--- a/shell/utils/fleet.ts
+++ b/shell/utils/fleet.ts
@@ -1,0 +1,69 @@
+import { BundleDeploymentResource, ModifiedStatus } from '@shell/types/resources/fleet';
+import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
+import { FLEET as FLEET_ANNOTATIONS } from '@shell/config/labels-annotations';
+
+type state = STATES_ENUM.READY | STATES_ENUM.MODIFIED | STATES_ENUM.MISSING | STATES_ENUM.ORPHANED;
+
+interface Resource extends BundleDeploymentResource {
+  state: state,
+}
+
+interface BundleDeploymentStatus {
+  resources?: BundleDeploymentResource[],
+  modifiedStatus?: ModifiedStatus[],
+}
+
+// bundleDeploymentResources extracts the list of resources deployed by a BundleDeployment
+export function bundleDeploymentResources(status: BundleDeploymentStatus): Resource[] {
+  // Use a map to avoid `find` over and over again
+  const resourceKey = (r) => `${ r.kind }/${ r.namespace }/${ r.name }`;
+
+  // status.resources includes of resources that were deployed by Fleet *and still exist in the cluster*
+  const resources = (status?.resources || []).reduce((res, r) => {
+    res[resourceKey(r)] = Object.assign({ state: STATES_ENUM.READY }, r);
+
+    return res;
+  }, {});
+
+  const modified = [];
+
+  for (const r of status?.modifiedStatus || []) {
+    const state = r.missing ? STATES_ENUM.MISSING : r.delete ? STATES_ENUM.ORPHANED : STATES_ENUM.MODIFIED;
+    const found = resources[resourceKey(r)];
+
+    // Depending on the state, the same resource can appear in both fields
+    if (found) {
+      found.state = state;
+    } else {
+      modified.push(Object.assign({ state }, r));
+    }
+  }
+
+  return modified.concat(Object.values(resources));
+}
+
+// ported from https://github.com/rancher/fleet/blob/v0.10.0/internal/cmd/controller/grutil/resourcekey.go#L116-L128
+export function resourceType(r: Resource): string {
+  const type = r.kind.toLowerCase();
+
+  if (!r.APIVersion || r.APIVersion === 'v1') {
+    return type;
+  }
+
+  return `${ r.APIVersion.split('/', 2)[0] }.${ type }`;
+}
+
+export function resourceId(r: Resource): string {
+  return r.namespace ? `${ r.namespace }/${ r.name }` : r.name;
+}
+
+type Labels = {
+  [key: string]: string,
+}
+
+export function clusterIdFromBundleDeploymentLabels(labels?: Labels): string {
+  const clusterNamespace = labels?.[FLEET_ANNOTATIONS.CLUSTER_NAMESPACE];
+  const clusterName = labels?.[FLEET_ANNOTATIONS.CLUSTER];
+
+  return `${ clusterNamespace }/${ clusterName }`;
+}

--- a/shell/utils/fleet.ts
+++ b/shell/utils/fleet.ts
@@ -22,12 +22,14 @@ interface BundleStatus {
   summary?: BundleStatusSummary,
 }
 
+function resourceKey(r: BundleDeploymentResource): string {
+  return `${ r.kind }/${ r.namespace }/${ r.name }`;
+}
+
 // bundleDeploymentResources extracts the list of resources deployed by a BundleDeployment
 export function bundleDeploymentResources(status: BundleDeploymentStatus): Resource[] {
-  // Use a map to avoid `find` over and over again
-  const resourceKey = (r) => `${ r.kind }/${ r.namespace }/${ r.name }`;
-
   // status.resources includes of resources that were deployed by Fleet *and still exist in the cluster*
+  // Use a map to avoid `find` over and over again
   const resources = (status?.resources || []).reduce((res, r) => {
     res[resourceKey(r)] = Object.assign({ state: STATES_ENUM.READY }, r);
 

--- a/shell/utils/fleet.ts
+++ b/shell/utils/fleet.ts
@@ -11,45 +11,8 @@ interface Resource extends BundleDeploymentResource {
   state: string,
 }
 
-function resourceKey(r: BundleResourceKey): string {
-  return `${ r.kind }/${ r.namespace }/${ r.name }`;
-}
-
-/**
- * bundleDeploymentResources extracts the list of resources deployed by a BundleDeployment
- */
-export function bundleDeploymentResources(status: BundleDeploymentStatus): Resource[] {
-  // status.resources includes of resources that were deployed by Fleet *and still exist in the cluster*
-  // Use a map to avoid `find` over and over again
-  const resources = (status?.resources || []).reduce((res, r) => {
-    res[resourceKey(r)] = Object.assign({ state: STATES_ENUM.READY }, r);
-
-    return res;
-  }, {} as { [resourceKey: string]: Resource });
-
-  const modified: Resource[] = [];
-
-  for (const r of status?.modifiedStatus || []) {
-    const state = r.missing ? STATES_ENUM.MISSING : r.delete ? STATES_ENUM.ORPHANED : STATES_ENUM.MODIFIED;
-    const found: Resource = resources[resourceKey(r)];
-
-    // Depending on the state, the same resource can appear in both fields
-    if (found) {
-      found.state = state;
-    } else {
-      modified.push(Object.assign({ state }, r));
-    }
-  }
-  for (const r of status?.nonReadyStatus || []) {
-    const state = r.summary?.state || STATES_ENUM.UNKNOWN;
-    const found: Resource = resources[resourceKey(r)];
-
-    if (found) {
-      found.state = state;
-    }
-  }
-
-  return modified.concat(Object.values(resources));
+type Labels = {
+  [key: string]: string,
 }
 
 interface StatesCounter { [state: string]: number }
@@ -61,93 +24,136 @@ function incr(counter: StatesCounter, state: string) {
   counter[state]++;
 }
 
-/**
- * bundleResources extracts the list of resources deployed by a Bundle
- */
-export function bundleResources(status: BundleStatus): Resource[] {
-  // The state of every resource is spread all over the bundle status.
-  // resourceKey contains one entry per resource AND cluster (built by Fleet from all the child BundleDeployments).
-  // However, those entries do not contain the cluster that they belong to, leading to duplicate entries
+function resourceKey(r: BundleResourceKey): string {
+  return `${ r.kind }/${ r.namespace }/${ r.name }`;
+}
 
-  // 1. Fold resourceKey by using a unique key, initializing counters for multiple occurrences of the same resource
-  const resources = (status.resourceKey || []).reduce((res, r) => {
-    const k = resourceKey(r);
+class Fleet {
+  resourceId(r: BundleResourceKey): string {
+    return r.namespace ? `${ r.namespace }/${ r.name }` : r.name;
+  }
 
-    if (!res[k]) {
-      res[k] = { r, count: {} };
+  /**
+   * resourceType normalizes APIVersion and Kind from a Resources into a single string
+   */
+  resourceType(r: Resource): string {
+    // ported from https://github.com/rancher/fleet/blob/v0.10.0/internal/cmd/controller/grutil/resourcekey.go#L116-L128
+    const type = r.kind.toLowerCase();
+
+    if (!r.apiVersion || r.apiVersion === 'v1') {
+      return type;
     }
-    incr(res[k].count, STATES_ENUM.READY);
 
-    return res;
-  }, {} as { [resourceKey: string]: { r: BundleResourceKey, count: StatesCounter } });
+    return `${ r.apiVersion.split('/', 2)[0] }.${ type }`;
+  }
 
-  // 2. Non-ready resources are counted differently and may also appear in resourceKey, depending on their state
-  for (const bundle of status.summary?.nonReadyResources || []) {
-    for (const r of bundle.modifiedStatus || []) {
-      const k = resourceKey(r);
+  /**
+   * bundleDeploymentResources extracts the list of resources deployed by a BundleDeployment
+   */
+  bundleDeploymentResources(status: BundleDeploymentStatus): Resource[] {
+    // status.resources includes of resources that were deployed by Fleet *and still exist in the cluster*
+    // Use a map to avoid `find` over and over again
+    const resources = (status?.resources || []).reduce((res, r) => {
+      res[resourceKey(r)] = Object.assign({ state: STATES_ENUM.READY }, r);
 
-      if (!resources[k]) {
-        resources[k] = { r, count: {} };
-      }
+      return res;
+    }, {} as { [resourceKey: string]: Resource });
 
-      if (r.missing) {
-        incr(resources[k].count, STATES_ENUM.MISSING);
-      } else if (r.delete) {
-        resources[k].count[STATES_ENUM.READY]--;
-        incr(resources[k].count, STATES_ENUM.ORPHANED);
+    const modified: Resource[] = [];
+
+    for (const r of status?.modifiedStatus || []) {
+      const state = r.missing ? STATES_ENUM.MISSING : r.delete ? STATES_ENUM.ORPHANED : STATES_ENUM.MODIFIED;
+      const found: Resource = resources[resourceKey(r)];
+
+      // Depending on the state, the same resource can appear in both fields
+      if (found) {
+        found.state = state;
       } else {
-        resources[k].count[STATES_ENUM.READY]--;
-        incr(resources[k].count, STATES_ENUM.MODIFIED);
+        modified.push(Object.assign({ state }, r));
       }
     }
-    for (const r of bundle.nonReadyStatus || []) {
-      const k = resourceKey(r);
+    for (const r of status?.nonReadyStatus || []) {
       const state = r.summary?.state || STATES_ENUM.UNKNOWN;
+      const found: Resource = resources[resourceKey(r)];
 
-      resources[k].count[STATES_ENUM.READY]--;
-      incr(resources[k].count, state);
-    }
-  }
-
-  // 3. Unfold back to an array of resources for display
-  return Object.values(resources).reduce((res, e) => {
-    const { r, count } = e;
-
-    for (const state in count) {
-      for (let x = 0; x < count[state]; x++) {
-        res.push(Object.assign({ state }, r));
+      if (found) {
+        found.state = state;
       }
     }
 
-    return res;
-  }, [] as Resource[]);
-}
-
-/**
- * resourceType normalizes APIVersion and Kind from a Resources into a single string
- */
-export function resourceType(r: Resource): string {
-  // ported from https://github.com/rancher/fleet/blob/v0.10.0/internal/cmd/controller/grutil/resourcekey.go#L116-L128
-  const type = r.kind.toLowerCase();
-
-  if (!r.apiVersion || r.apiVersion === 'v1') {
-    return type;
+    return modified.concat(Object.values(resources));
   }
 
-  return `${ r.apiVersion.split('/', 2)[0] }.${ type }`;
+  /**
+   * bundleResources extracts the list of resources deployed by a Bundle
+   */
+  bundleResources(status: BundleStatus): Resource[] {
+    // The state of every resource is spread all over the bundle status.
+    // resourceKey contains one entry per resource AND cluster (built by Fleet from all the child BundleDeployments).
+    // However, those entries do not contain the cluster that they belong to, leading to duplicate entries
+
+    // 1. Fold resourceKey by using a unique key, initializing counters for multiple occurrences of the same resource
+    const resources = (status.resourceKey || []).reduce((res, r) => {
+      const k = resourceKey(r);
+
+      if (!res[k]) {
+        res[k] = { r, count: {} };
+      }
+      incr(res[k].count, STATES_ENUM.READY);
+
+      return res;
+    }, {} as { [resourceKey: string]: { r: BundleResourceKey, count: StatesCounter } });
+
+    // 2. Non-ready resources are counted differently and may also appear in resourceKey, depending on their state
+    for (const bundle of status.summary?.nonReadyResources || []) {
+      for (const r of bundle.modifiedStatus || []) {
+        const k = resourceKey(r);
+
+        if (!resources[k]) {
+          resources[k] = { r, count: {} };
+        }
+
+        if (r.missing) {
+          incr(resources[k].count, STATES_ENUM.MISSING);
+        } else if (r.delete) {
+          resources[k].count[STATES_ENUM.READY]--;
+          incr(resources[k].count, STATES_ENUM.ORPHANED);
+        } else {
+          resources[k].count[STATES_ENUM.READY]--;
+          incr(resources[k].count, STATES_ENUM.MODIFIED);
+        }
+      }
+      for (const r of bundle.nonReadyStatus || []) {
+        const k = resourceKey(r);
+        const state = r.summary?.state || STATES_ENUM.UNKNOWN;
+
+        resources[k].count[STATES_ENUM.READY]--;
+        incr(resources[k].count, state);
+      }
+    }
+
+    // 3. Unfold back to an array of resources for display
+    return Object.values(resources).reduce((res, e) => {
+      const { r, count } = e;
+
+      for (const state in count) {
+        for (let x = 0; x < count[state]; x++) {
+          res.push(Object.assign({ state }, r));
+        }
+      }
+
+      return res;
+    }, [] as Resource[]);
+  }
+
+  clusterIdFromBundleDeploymentLabels(labels?: Labels): string {
+    const clusterNamespace = labels?.[FLEET_ANNOTATIONS.CLUSTER_NAMESPACE];
+    const clusterName = labels?.[FLEET_ANNOTATIONS.CLUSTER];
+
+    return `${ clusterNamespace }/${ clusterName }`;
+  }
 }
 
-export function resourceId(r: Resource): string {
-  return r.namespace ? `${ r.namespace }/${ r.name }` : r.name;
-}
+const instance = new Fleet();
 
-type Labels = {
-  [key: string]: string,
-}
-
-export function clusterIdFromBundleDeploymentLabels(labels?: Labels): string {
-  const clusterNamespace = labels?.[FLEET_ANNOTATIONS.CLUSTER_NAMESPACE];
-  const clusterName = labels?.[FLEET_ANNOTATIONS.CLUSTER];
-
-  return `${ clusterNamespace }/${ clusterName }`;
-}
+export default instance;

--- a/shell/utils/fleet.ts
+++ b/shell/utils/fleet.ts
@@ -1,4 +1,4 @@
-import { BundleDeploymentResource, ModifiedStatus, NonReadyBundle } from '@shell/types/resources/fleet';
+import { BundleDeploymentResource, ModifiedStatus, NonReadyBundle, ResourceKey } from '@shell/types/resources/fleet';
 import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 import { FLEET as FLEET_ANNOTATIONS } from '@shell/config/labels-annotations';
 
@@ -18,7 +18,7 @@ interface BundleStatusSummary {
 }
 
 interface BundleStatus {
-  resourceKey?: BundleDeploymentResource[],
+  resourceKey?: ResourceKey[],
   summary?: BundleStatusSummary,
 }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/12517
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
GitRepo details include a tab for `Resources`, which iterates over the list of `status.resources` in the `GitRepo` object. However, this is inaccurate, since the source of truth for resources are `BundleDeployments`, as they may vary depending on the target cluster customization.

### Technical notes summary
 - The code used `find` to pick just the first bundle deployment matching the cluster label, which is totally wrong. Now we iterate directly on bundle deployments instead, then pick the target cluster as necessary.
 - The biggest part of the `Bundles` payload is the `spec.resources`, as it basically contains all the raw chart contents. I've modified the getter to make steve omit that field.
   - In order to allow this, I also had to refactor the Bundle view to not use the spec for listing resources (and use the status instead).

### Areas or cases that should be tested

 - Continuous Delivery: GitRepos
 - Continuous Delivery: Advanced > Bundles

### Areas which could experience regressions

This PR actually aims to provide the same output while changing how the information is computed.

### Screenshot/Video

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [X] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [X] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
