### PR TITLE
Reduce flakiness in explorer/apps/repositories.spec.ts

### DIFF
--- a/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
@@ -56,7 +56,13 @@ describe('Apps', () => {
 
         // Ensure this runs after an attempt, rather than all attemps (`after` only runs once after all cypress retries)
         afterEach(() => {
-          reposToDelete.forEach((r) => cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', r, false));
+          for(let repo of reposToDelete){
+            cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', repo, false).then((res: Cypress.Response<any>)=>{
+              if(res.status === 201){
+                reposToDelete.splice(reposToDelete.indexOf(repo), 1)
+              }
+            })
+          }
         });
       });
 

--- a/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
@@ -56,12 +56,12 @@ describe('Apps', () => {
 
         // Ensure this runs after an attempt, rather than all attemps (`after` only runs once after all cypress retries)
         afterEach(() => {
-          for(let repo of reposToDelete){
-            cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', repo, false).then((res: Cypress.Response<any>)=>{
-              if(res.status === 201){
-                reposToDelete.splice(reposToDelete.indexOf(repo), 1)
+          for (const repo of reposToDelete) {
+            cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', repo, false).then((res: Cypress.Response<any>) => {
+              if (res.status === 201) {
+                reposToDelete.splice(reposToDelete.indexOf(repo), 1);
               }
-            })
+            });
           }
         });
       });

--- a/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
@@ -56,7 +56,7 @@ describe('Apps', () => {
 
         // Ensure this runs after an attempt, rather than all attemps (`after` only runs once after all cypress retries)
         afterEach(() => {
-          reposToDelete.forEach((r) => cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', r));
+          reposToDelete.forEach((r) => cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', r, false));
         });
       });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Partially addresses https://github.com/rancher/dashboard/issues/12099

This PR corrects some retry logic in one of the e2e tests I'm seeing fail often.

You an see an example of this failure on our sorry cypress instance `.../instance/7a973f49-6fff-40d3-8054-9c5aa95a653b/test/r7
`

Each time this test runs it adds a repo name to `reposToDelete`. After each attempt, the afterEach hook tries to delete all repos in `reposToDelete`. If the test fails and retries, the afterEach hook will be retrying a repo deletion, get a 404 not found, and error out. 

The simplest fix here seems to be to ignore these errors in afterEach. We could also refactor the test so it only attempts to delete one repo each run.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
