### PR TITLE
Add deepToRaw method for recursively converting proxy objects to raw

### DIFF
--- a/shell/plugins/steve/mutations.js
+++ b/shell/plugins/steve/mutations.js
@@ -13,6 +13,7 @@ import {
 import { perfLoadAll } from '@shell/plugins/steve/performanceTesting';
 import { classify } from '@shell/plugins/dashboard-store/classify';
 import SteveSchema from '@shell/models/steve-schema';
+import { deepToRaw } from '@shell/utils/object';
 
 function registerNamespace(state, namespace) {
   let cache = state.podsByNamespace[namespace];
@@ -145,7 +146,9 @@ export default {
 
       if (worker) {
         // Store raw json objects, not the proxies
-        worker.postMessage({ loadSchemas: data });
+        const rawData = deepToRaw(data);
+
+        worker.postMessage({ loadSchemas: rawData });
       }
     }
   },

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -8,7 +8,7 @@
  */
 
 import { addObject, clear, removeObject } from '@shell/utils/array';
-import { get } from '@shell/utils/object';
+import { get, deepToRaw } from '@shell/utils/object';
 import { SCHEMA, MANAGEMENT } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';
 import { CSRF } from '@shell/config/cookies';
@@ -179,9 +179,9 @@ export async function createWorker(store, ctx) {
 
   while (workerQueues[storeName]?.length) {
     const message = workerQueues[storeName].shift();
+    const safeMessage = deepToRaw(message);
 
-    // TODO: 11541: Web Worker communication fails due to Proxy objects in messages
-    store.$workers[storeName].postMessage(_.cloneDeep(message));
+    store.$workers[storeName].postMessage(safeMessage);
   }
 }
 

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -35,7 +35,6 @@ import { WORKER_MODES } from './worker';
 import acceptOrRejectSocketMessage from './accept-or-reject-socket-message';
 import { BLANK_CLUSTER, STORE } from '@shell/store/store-types.js';
 import paginationUtils from '@shell/utils/pagination-utils';
-import _ from 'lodash';
 
 // minimum length of time a disconnect notification is shown
 const MINIMUM_TIME_NOTIFIED = 3000;

--- a/shell/utils/__tests__/object.test.ts
+++ b/shell/utils/__tests__/object.test.ts
@@ -286,6 +286,38 @@ describe('fx: deepToRaw', () => {
     expect(isReactive(result)).toBe(false);
   });
 
+  it('should handle nested reactive properties', () => {
+    const data = reactive({
+      num:   1,
+      str:   'test',
+      bool:  true,
+      nil:   null,
+      undef: undefined,
+      arr:   [1, 2, { a: 3 }],
+      obj:   { nested: reactive({ a: 1 }) },
+      func:  null,
+      sym:   null,
+    });
+
+    const result = deepToRaw(data);
+
+    expect(result).toStrictEqual({
+      num:   1,
+      str:   'test',
+      bool:  true,
+      nil:   null,
+      undef: undefined,
+      arr:   [1, 2, { a: 3 }],
+      obj:   { nested: { a: 1 } },
+      func:  null,
+      sym:   null,
+    });
+
+    expect(isReactive(result)).toBe(false);
+    expect(isReactive(result.obj)).toBe(false);
+    expect(isReactive(result.obj.nested)).toBe(false);
+  });
+
   it('should handle circular references', () => {
     const obj: { name: string; [key: string]: any } = { name: 'Alice' };
 

--- a/shell/utils/__tests__/object.test.ts
+++ b/shell/utils/__tests__/object.test.ts
@@ -1,5 +1,6 @@
+import { reactive, isReactive } from 'vue';
 import {
-  clone, get, getter, isEmpty, toDictionary, remove, diff, definedKeys
+  clone, get, getter, isEmpty, toDictionary, remove, diff, definedKeys, deepToRaw
 } from '@shell/utils/object';
 
 describe('fx: get', () => {
@@ -225,5 +226,123 @@ describe('fx: definedKeys', () => {
     const expected = ['"foo"', '"baz"."bang.bop"'];
 
     expect(result).toStrictEqual(expected);
+  });
+});
+
+describe('fx: deepToRaw', () => {
+  it('should return primitives as is', () => {
+    expect(deepToRaw(null)).toBeNull();
+    expect(deepToRaw(undefined)).toBeUndefined();
+    expect(deepToRaw(42)).toBe(42);
+    expect(deepToRaw('test')).toBe('test');
+    expect(deepToRaw(true)).toBe(true);
+
+    const sym = Symbol('symbol');
+
+    expect(deepToRaw(sym)).toBe(sym);
+  });
+
+  it('should handle simple objects', () => {
+    const obj = { a: 1, b: 2 };
+    const result = deepToRaw(obj);
+
+    expect(result).toStrictEqual({ a: 1, b: 2 });
+    expect(result).not.toBe(obj); // Should not be the same reference
+  });
+
+  it('should handle arrays', () => {
+    const arr = [1, 2, 3];
+    const result = deepToRaw(arr);
+
+    expect(result).toStrictEqual([1, 2, 3]);
+    expect(result).not.toBe(arr); // Should not be the same reference
+  });
+
+  it('should handle nested objects', () => {
+    const obj = { a: { b: { c: 3 } } };
+    const result = deepToRaw(obj);
+
+    expect(result).toStrictEqual({ a: { b: { c: 3 } } });
+    expect(result).not.toBe(obj);
+    expect(result.a).not.toBe(obj.a);
+    expect(result.a.b).not.toBe(obj.a.b);
+  });
+
+  it('should handle nested arrays', () => {
+    const arr = [1, [2, [3]]];
+    const result = deepToRaw(arr);
+
+    expect(result).toStrictEqual([1, [2, [3]]]);
+    expect(result).not.toBe(arr);
+    expect(result[1]).not.toBe(arr[1]);
+  });
+
+  it('should handle reactive proxies (reactive object)', () => {
+    const reactiveObj = reactive({ a: 1, b: { c: 2 } });
+    const result = deepToRaw(reactiveObj);
+
+    expect(result).toStrictEqual({ a: 1, b: { c: 2 } });
+    expect(result).not.toBe(reactiveObj);
+    expect(isReactive(result)).toBe(false);
+  });
+
+  it('should handle circular references', () => {
+    const obj: { name: string; [key: string]: any } = { name: 'Alice' };
+
+    obj.self = obj; // Circular reference
+
+    const result = deepToRaw(obj);
+
+    expect(result).toStrictEqual({ name: 'Alice', self: result });
+  });
+
+  it('should handle objects with functions and symbols', () => {
+    const symbolKey = Symbol('key');
+    const obj = {
+      a:           1,
+      b() {},
+      [symbolKey]: 'symbolValue',
+    };
+
+    const result = deepToRaw(obj);
+
+    expect(result).toStrictEqual({ a: 1, b: null });
+    expect(result[symbolKey]).toBeUndefined(); // Symbols are skipped
+  });
+
+  it('should not mutate the original data', () => {
+    const obj = { a: { b: 2 } };
+    const original = JSON.stringify(obj);
+
+    deepToRaw(obj);
+    expect(JSON.stringify(obj)).toBe(original);
+  });
+
+  it('should handle complex data structures', () => {
+    const data = reactive({
+      num:   1,
+      str:   'test',
+      bool:  true,
+      nil:   null,
+      undef: undefined,
+      arr:   [1, 2, { a: 3 }],
+      obj:   { nested: { a: 1 } },
+      func:  () => {},
+      sym:   Symbol('sym'),
+    });
+
+    const result = deepToRaw(data);
+
+    expect(result).toStrictEqual({
+      num:   1,
+      str:   'test',
+      bool:  true,
+      nil:   null,
+      undef: undefined,
+      arr:   [1, 2, { a: 3 }],
+      obj:   { nested: { a: 1 } },
+      func:  null,
+      sym:   null,
+    });
   });
 });

--- a/shell/utils/object.js
+++ b/shell/utils/object.js
@@ -1,3 +1,4 @@
+import { toRaw } from 'vue';
 import cloneDeep from 'lodash/cloneDeep';
 import flattenDeep from 'lodash/flattenDeep';
 import compact from 'lodash/compact';
@@ -432,5 +433,37 @@ export function dropKeys(obj, keys) {
 
   for ( const k of keys ) {
     delete obj[k];
+  }
+}
+
+/**
+ * Recursively convert a reactive object to a raw object
+ * @param {*} obj
+ * @param {*} cache
+ * @returns
+ */
+export function deepToRaw(obj, cache = new WeakSet()) {
+  if (obj === null || typeof obj !== 'object') {
+    // If obj is null or a primitive, return it as is
+    return obj;
+  }
+
+  // If the object has already been processed, return it to prevent circular references
+  if (cache.has(obj)) {
+    return obj;
+  }
+  cache.add(obj);
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => deepToRaw(item, cache));
+  } else {
+    const rawObj = toRaw(obj);
+    const result = {};
+
+    for (const key in rawObj) {
+      result[key] = deepToRaw(rawObj[key], cache);
+    }
+
+    return result;
   }
 }

--- a/shell/utils/object.js
+++ b/shell/utils/object.js
@@ -461,7 +461,11 @@ export function deepToRaw(obj, cache = new WeakSet()) {
     const result = {};
 
     for (const key in rawObj) {
-      result[key] = deepToRaw(rawObj[key], cache);
+      if (typeof rawObj[key] === 'function' || typeof rawObj[key] === 'symbol') {
+        result[key] = null;
+      } else {
+        result[key] = deepToRaw(rawObj[key], cache);
+      }
     }
 
     return result;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12406 
Fixes #11541 
<!-- Define findings related to the feature or bug issue. -->

In Vue 3, the reactivity system uses proxies to make objects reactive. These proxies cannot be serialized or cloned using the structured clone algorithm, which is why we're encountering the `DataCloneError` when attempting to send data that includes these proxies via `postMessage`.

Unfortunately, it wasn't as simple as just converting the `data` object to a raw object and sending that to `postMessage` as there are nested reactive objects that wouldn't be converted in this way. So I implemented a method that would recursively convert all of the proxy objects into raw using Vue's provided `toRaw` method.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Added `deepToRaw` method to the `object` utils
- Before passing the data to loadSchemas, we convert all of the proxied objects to raw
- Replaced usage of lodash's `cloneDeep` when sending a message through `postMessage` to a store's worker

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Testing this is a little challenging, the only way to reproduce the issue locally was by constantly refreshing the page until the `Projects` label was missing from `Projects/Namespaces` menu item. When only the `Namespaces` menu item existed, that was caused due to the `rancherSchemas` status being `rejected` when initializing the `isRancher` variable within the `loadManagement` store action.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
I'm not sure if this will have a regression effect anywhere as the original comment above the `worker.postMessage` hook implied that the data was to be considered `raw` already. This new method only ensures that's the case by removing proxied objects.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
