### PR TITLE
remove $set usage in eks provisioning and gatekeeper constraints

### DIFF
--- a/pkg/aks/util/__tests__/validators.test.ts
+++ b/pkg/aks/util/__tests__/validators.test.ts
@@ -1,5 +1,4 @@
 import * as validators from '@pkg/aks/util/validators';
-import { set } from '@shell/utils/object';
 import { AKSNodePool } from 'types';
 
 validators.requiredTranslation = (ctx, label) => `${ label } is required.`;

--- a/pkg/aks/util/__tests__/validators.test.ts
+++ b/pkg/aks/util/__tests__/validators.test.ts
@@ -11,7 +11,6 @@ const MOCK_TRANSLATION = 'abc';
 const mockCtx = {
   normanCluster: { },
   t:             () => MOCK_TRANSLATION,
-  $set:          set
 };
 
 describe('fx: requiredInCluster', () => {

--- a/pkg/eks/util/__tests__/validators.test.ts
+++ b/pkg/eks/util/__tests__/validators.test.ts
@@ -87,12 +87,10 @@ describe('validate EKS node group names', () => {
     [{
       nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'def' }],
       t:          mockTranslation,
-      $set:       () => {}
     } as any as CruEKSContext, null],
     [{
       nodeGroups: [{ nodegroupName: 'abc' }, { nodegroupName: 'abc' }, { nodegroupName: 'def' }],
       t:          mockTranslation,
-      $set:       () => {}
     } as any as CruEKSContext, 'eks.errors.nodeGroups.nameUnique']
   ])('should return an error if any node group within ctx has non-unique name, if not passed a name', (ctx, expected) => {
     const res = EKSValidators.nodeGroupNamesUnique(ctx)(undefined);

--- a/pkg/eks/util/validators.ts
+++ b/pkg/eks/util/validators.ts
@@ -1,7 +1,7 @@
+import { set } from '@shell/utils/object';
 import { EKSConfig, EKSNodeGroup } from 'types';
 
 export interface CruEKSContext {
-  $set: Function,
   t: Function,
   config: EKSConfig,
   nodeGroups: EKSNodeGroup[],
@@ -38,7 +38,7 @@ const nodeGroupNamesUnique = (ctx: CruEKSContext) => {
       const name = group.nodegroupName;
 
       if (names.filter((n) => n === name).length > 1) {
-        ctx.$set(group, '__nameUnique', false);
+        set(group, '__nameUnique', false);
         if (!out) {
           out = ctx.t('eks.errors.nodeGroups.nameUnique');
         }

--- a/shell/edit/constraints.gatekeeper.sh.constraint/index.vue
+++ b/shell/edit/constraints.gatekeeper.sh.constraint/index.vue
@@ -1,7 +1,7 @@
 <script>
 import merge from 'lodash/merge';
 import { ucFirst } from '@shell/utils/string';
-import { isSimpleKeyValue } from '@shell/utils/object';
+import { isSimpleKeyValue, set } from '@shell/utils/object';
 import { _CREATE, _VIEW } from '@shell/config/query-params';
 import { SCHEMA, NAMESPACE } from '@shell/config/types';
 import CreateEditView from '@shell/mixins/create-edit-view';
@@ -222,6 +222,9 @@ export default {
         this.value.spec.match.namespaces = [];
         this.value.spec.match.excludedNamespaces = [];
       }
+    },
+    set() {
+      return set;
     }
   }
 };
@@ -356,7 +359,7 @@ export default {
             v-model:value="parametersYaml"
             class="yaml-editor"
             :editor-mode="editorMode"
-            @newObject="$set(value.spec, 'parameters', $event)"
+            @newObject="set(value.spec, 'parameters', $event)"
           />
         </Tab>
       </Tabbed>

--- a/shell/edit/constraints.gatekeeper.sh.constraint/index.vue
+++ b/shell/edit/constraints.gatekeeper.sh.constraint/index.vue
@@ -223,8 +223,8 @@ export default {
         this.value.spec.match.excludedNamespaces = [];
       }
     },
-    set() {
-      return set;
+    setParameters(e) {
+      return set(this.value.spec, 'parameters', e);
     }
   }
 };
@@ -359,7 +359,7 @@ export default {
             v-model:value="parametersYaml"
             class="yaml-editor"
             :editor-mode="editorMode"
-            @newObject="set(value.spec, 'parameters', $event)"
+            @newObject="setParameters"
           />
         </Tab>
       </Tabbed>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12442

I'm not sure why these instances of `$set` weren't caught in the vue3 migration. I searched the codebase and only additional instance I found was in gatekeeper constraints

### Areas or cases that should be tested
In addition to what is described in #12442, check creating gatekeeper constraints with parameters defined

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
