### PR TITLE
Ensure lists update when switching between workspaces with the same number of rows

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -37,7 +37,7 @@ import ButtonMultiAction from '@shell/components/ButtonMultiAction.vue';
 // --> filtering.js filteredRows
 // --> paging.js pageRows
 // --> grouping.js groupedRows
-// --> index.vue displayedRows
+// --> index.vue displayRows
 
 export default {
   name: 'SortableTable',
@@ -77,11 +77,13 @@ export default {
       type:     Array,
       required: true
     },
+
     rows: {
       // The array of objects to show
       type:     Array,
       required: true
     },
+
     keyField: {
       // Field that is unique for each row.
       type:    String,
@@ -285,9 +287,23 @@ export default {
       default: true
     },
 
+    /**
+     * Provide a unique key that will provide a new value given changes to the environment that
+     * should kick off an update to table rows (for instance resource list generation or change of namespace)
+     *
+     * This does not have to update given internal facets like sort order or direction
+     */
     sortGenerationFn: {
       type:    Function,
       default: null,
+    },
+
+    /**
+     * Can be used in place of sortGenerationFn
+     */
+    sortGeneration: {
+      type:    String,
+      default: null
     },
 
     /**

--- a/shell/components/SortableTable/sorting.js
+++ b/shell/components/SortableTable/sorting.js
@@ -39,9 +39,17 @@ export default {
 
       let key;
 
-      if ( this.sortGenerationFn ) {
-        key = `${ this.sortGenerationFn.apply(this) }/${ this.rows.length }/${ this.descending }/${ this.sortFields.join(',') }`;
+      // Why is sortGeneration needed when we have sortGenerationFn?
+      // 1. sortGenerationFn is called when this fn is kicked off and returns latest and greatest string (given things like namespace)
+      // 2. it can be kicked off with stale rows... which is then stored against latest string
+      // 3. when updates rows comes through... sortGenerationFn returns same string
+      // 4. we therefor think nothing has changed and return old, stale rows
+      // This is avoided by outside storage of sortGeneration against rows
+      // (it would be nice to have that hash on the rows object itself, but it gets messy)
+      const sortGenerationKey = this.sortGeneration || this.sortGenerationFn?.apply(this);
 
+      if ( sortGenerationKey) {
+        key = `${ sortGenerationKey }/${ this.rows.length }/${ this.descending }/${ this.sortFields.join(',') }`;
         if ( this.cacheKey === key ) {
           return this.cachedRows;
         }


### PR DESCRIPTION
 <!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12437
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Switching between fleet workspaces which contain the same number of resources will fail to update the rows
  - sometimes this would happen anyway, for instance the generation of the resource was updated
- Caused by change in reactivity with base [fn](https://github.com/rancher/dashboard/blob/master/shell/components/SortableTable/sorting.js#L35) in sortable table pagination pipeline
  - this was fired with stale rows (rows from old workspace) BUT would be cached against the new state (new workspace)
  - whenever the pipeline was triggered again (sans other changes) it would then return the cached stale rows
- fixed by providing a specific hash to use instead of one generated on demand (which fetched new state)
  - i've limited this to the workspace world to reduce impact / bugs

### Technical notes summary
- this is a quicker fix than re-rewriting the whole thing... or finding out why vue changed behaviour

### Areas or cases that should be tested
- Everything list based

### Areas which could experience regressions
- Everything list based

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
