### PR TITLE
Fix annotation changes not being reactive

### DIFF
--- a/shell/edit/monitoring.coreos.com.prometheusrule/AlertingRule.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/AlertingRule.vue
@@ -102,7 +102,7 @@ export default {
           if (isEmpty(this.value?.annotations)) {
             this.value['annotations'] = { summary: '' };
           } else {
-            this.value.annotations['summary'] = '';
+            this.value.annotations = { ...this.value.annotations, summary: '' };
           }
         } else {
           this.value.annotations['summary'] = '';
@@ -124,7 +124,7 @@ export default {
           if (isEmpty(this.value?.annotations)) {
             this.value['annotations'] = { message: '' };
           } else {
-            this.value.annotations['message'] = '';
+            this.value.annotations = { ...this.value.annotations, message: '' };
           }
         } else {
           this.value.annotations['message'] = '';
@@ -146,7 +146,7 @@ export default {
           if (isEmpty(this.value?.annotations)) {
             this.value['annotations'] = { description: '' };
           } else {
-            this.value.annotations['description'] = '';
+            this.value.annotations = { ...this.value.annotations, description: '' };
           }
         } else {
           this.value.annotations['description'] = '';
@@ -168,7 +168,7 @@ export default {
           if (isEmpty(this.value?.annotations)) {
             this.value['annotations'] = { runbook_url: '' };
           } else {
-            this.value.annotations['runbook_url'] = '';
+            this.value.annotations = { ...this.value.annotations, runbook_url: '' };
           }
         } else {
           this.value.annotations['runbook_url'] = '';


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12453 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
There was an issue with vue's reactivity detecting the deep nested changes on `this.value.annotation`, tried updating the whole annotations object to fix the issue.
### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/f2103eba-292f-415e-83e2-6108097cd42b



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
