### PR TITLE
fix eks logging checkbox event listeners

### DIFF
--- a/pkg/eks/components/Logging.vue
+++ b/pkg/eks/components/Logging.vue
@@ -65,7 +65,7 @@ export default defineComponent({
           :mode="mode"
           label-key="eks.audit.label"
           :tooltip="t('eks.audit.tooltip')"
-          @input="toggleType('audit')"
+          @update:value="toggleType('audit')"
         />
       </div>
       <div class="col span-2">
@@ -74,7 +74,7 @@ export default defineComponent({
           :mode="mode"
           label-key="eks.api.label"
           :tooltip="t('eks.api.tooltip')"
-          @input="toggleType('api')"
+          @update:value="toggleType('api')"
         />
       </div>
 
@@ -84,7 +84,7 @@ export default defineComponent({
           :mode="mode"
           label-key="eks.scheduler.label"
           :tooltip="t('eks.scheduler.tooltip')"
-          @input="toggleType('scheduler')"
+          @update:value="toggleType('scheduler')"
         />
       </div>
 
@@ -94,7 +94,7 @@ export default defineComponent({
           :mode="mode"
           label-key="eks.controllerManager.label"
           :tooltip="t('eks.controllerManager.tooltip')"
-          @input="toggleType('controllerManager')"
+          @update:value="toggleType('controllerManager')"
         />
       </div>
       <div class="col span-2">
@@ -103,7 +103,7 @@ export default defineComponent({
           :mode="mode"
           label-key="eks.authenticator.label"
           :tooltip="t('eks.authenticator.tooltip')"
-          @input="toggleType('authenticator')"
+          @update:value="toggleType('authenticator')"
         />
       </div>
     </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12482 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR fixes a vue3-related migration in the EKS provisioning form. I searched for other lingering `@input` listeners in the hosted provider packages, but looks like it was just this logging component.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
