### PR TITLE
Use `semver.coerce()` to get valid kubernetes version

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -160,7 +160,9 @@ export default defineComponent({
       }
 
       // track original version on edit to ensure we don't offer k8s downgrades
-      this.originalVersion = this.normanCluster?.aksConfig?.kubernetesVersion;
+      const kubernetesVersion = semver.coerce(this.normanCluster?.aksConfig?.kubernetesVersion);
+
+      this.originalVersion = kubernetesVersion;
     } else {
       this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...defaultCluster }, { root: true });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12525 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

This uses `semver.coerce()` to get a valid semantic version for the original Kubernetes version in `CruAks.vue`. The form could fail to render if the Kubernetes version is not a valid semver and `semver.coerce()` will correctly evaluate to a semantic version.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

In the production example, 1.29 is used for the Kubernetes version:

```
az aks create --resource-group th-rg --no-ssh-key --kubernetes-version 1.29 --name th-az-imported-293 --node-count 1 --location eastus
```

1.29 is a valid Kubernetes version and will default to the latest release[^1] (1.29.10 at the time of writing).

1.29 is stored in `aksConfig.kubernetesVersion`; this is not a valid `semver`, so an unhandled exception is thrown and the page fails to render correctly. 

It's entirely possible that `current-cluster-controllers-version` is the incorrect value to use for this case, but it was the only one that I found that evaluates to a valid semver with the expected kubernetes version of 1.29.10.

[^1]: https://kubernetes.io/releases/#release-v1-29

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- See reproduction steps in issue

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

We are changing the Kubernetes version used for the AKS form. If this annotation doesn't exist for any reason, we will experience the same behavior that's described in the issue. We can consider adding some sort of failure mode if the original Kubernetes isn't present or a valid semver. We can also consider adding some sort of fallback value in the event that it fails. 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
