### PR TITLE
[WIP] Fix issues with iFramed cluster pages

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -211,14 +211,15 @@ export default {
 
     emberLink() {
       if (this.value) {
-        if (this.value.provisioner) {
-          const matchingSubtype = this.subTypes.find((st) => st.id.toLowerCase() === this.value.provisioner.toLowerCase() || DRIVER_TO_IMPORT[st.id.toLowerCase()] === this.value.provisioner.toLowerCase());
+        // set subtype if editing non-local EKS/GKE/AKS cluster -- this ensures that the component provided by extension is loaded instead of iframing old ember ui
+        if (this.value.provisioner && !this.value.isLocal) {
+          const matchingSubtype = this.subTypes.find((st) => DRIVER_TO_IMPORT[st.id.toLowerCase()] === this.value.provisioner.toLowerCase());
 
           if (matchingSubtype) {
             this.selectType(matchingSubtype.id, false);
           }
         }
-        // For custom RKE2 clusters, don't load an Ember page.
+        // // For custom RKE2 clusters, don't load an Ember page.
         // It should be the dashboard.
         if ( this.value.isRke2 && ((this.value.isCustom && this.mode === _EDIT) || (this.value.isCustom && this.as === _CONFIG && this.mode === _VIEW) || (this.subType || '').toLowerCase() === 'custom')) {
           // For admins, this.value.isCustom is used to check if it is a custom cluster.

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -120,7 +120,7 @@ export default class MgmtCluster extends SteveModel {
     // Provisioner is the "<something>Config" in the model
     const provisioner = KONTAINER_TO_DRIVER[(this.provisioner || '').toLowerCase()] || this.provisioner;
 
-    if ( provisioner === 'rancherKubernetesEngine' || provisioner === 'rke') {
+    if ( provisioner === 'rancherKubernetesEngine' || (provisioner === 'rke' && !this.isLocal )) {
       // Look for a cloud provider in one of the node templates
       if ( this.machinePools?.[0] ) {
         provider = this.machinePools[0]?.nodeTemplate?.spec?.driver || null;


### PR DESCRIPTION
3 open issues all related to rendering the wrong iframed Ember page, or rendering the page with missing content:
https://github.com/rancher/dashboard/issues/12506
https://github.com/rancher/dashboard/issues/12541

possibly https://github.com/rancher/dashboard/issues/12339

The code used to determine which component to render when editing any given type of cluster is convoluted. There are inexplicable mappings required to keep iframed ember pages functional (why must aks map to azureaks? why is the provider query param sometimes import and sometimes import*ed*? Why is there an importProvider query param not used on imported clusters?) I am not even sure the above 3 issues have exactly the same root cause, but this area of dashboard code is so convoluted and prone to churn, I think they need to be addressed in tandem.

I think the above bugs came in via some combination of [this](https://github.com/mantis-toboggan-md/dashboard/commit/4cca5faf81dd658464b086c67894642f909ee6fc#diff-7655093720dda329bd1d1b72936a782cd7178edadbf55a7c1b8b58fb394f77cfR190) and [this](https://github.com/rancher/dashboard/pull/12177/files#diff-9be0247bdd17368e0b020b8ab4933b0c53f2f4bbdb0b1936066fa67703e519d4R121) PR. Limiting the scope of those changes seems to address #12506 and #12541  but not fully #12339 ( with this PR, I see the ember page as expected, but the 'mode' is wrong, create button shown instead of save)

Because I think the bugs are conntected to ember query params, I've collected data on the fields used to generate those query params, and what those query params are in 2.9-head ember standalone world - ember standalone has been removed from 2.10 but we can assume that these are the correct params the dashboard should be passing to ember. All below fields are on the relevant management cluster object, not the provisioning cluster object. If [providerForEmberParam](https://github.com/rancher/dashboard/blob/master/shell/models/management.cattle.io.cluster.js#L117) needs to be fixed, we need to verify that given the below status/config fields, the correct `provider` and `importProvider` query params are still set in every scenario.


| cluster type | status.provider | status.driver | spec.aksConfig/eksConfig/gkeConfig.imported | ember provider qp\* | ember importProvider qp\* |
|----|-----|-----|-----|-----|----|
local rke1 | rke | imported | n/a | import | other |
local rke2 | rke2 | rke2 | n/a | import | other |
local k3s | k3s | k3s | n/a | k3s | undefined | 
local hosted (eks)| eks | imported | undefined | import | other |
local MB ovh-downstream test cluster\** | '' | imported | undefined | import | other |
rke1 provisioned | 'rke' | rancherKubernetesEngine | n/a | digitalocean | undefined |
rke2 provisioned | rke2 | imported | n/a | n/a |  n/a |
k3s provisioned | k3s | imported | n/a |  n/a |  n/a |
hosted provisioned (aks) | aks | AKS | false | n/a | n/a | 
rke1 imported | rke | imported | n/a | imported | undefined |
rke2 imported | rke2 | rke2 | n/a | rke2 | undefined |
k3s imported | k3s | k3s | n/a | k3s | undefined |
hosted imported (aks) | aks | AKS |  true | azureaks | undefined |
3rd party kontainer provisioned | '' | ovhcloudmks | n/a | ovhcloudmks | undefined |

\* undefined => an iframed page should be used for this cluster, but this query param should be present; n/a=>iframed ember pages should not be used for this cluster
\** need to find out what this cluster actually is



Regarding ovh, once I get the right page to render I am seeing a console error that could be related
![Screenshot 2024-11-07 at 12 46 44 PM](https://github.com/user-attachments/assets/27f6ae2b-6628-494d-b1b7-4ec1f4782787)