### PR TITLE
[backport v2.8.10] CSI/CPI pre-bootstrap secrets are being created when the feature flag is disabled

### DIFF
--- a/shell/store/features.js
+++ b/shell/store/features.js
@@ -32,6 +32,7 @@ export const FLEET = create('continuous-delivery', true);
 export const HARVESTER = create('harvester', true);
 export const HARVESTER_CONTAINER = create('harvester-baremetal-container-workload', false);
 export const FLEET_WORKSPACE_BACK = create('provisioningv2-fleet-workspace-back-population', false);
+export const PROVISIONING_PRE_BOOTSTRAP = create('provisioningprebootstrap', false);
 
 // Not currently used.. no point defining ones we don't use
 // export const EMBEDDED_CLUSTER_API = create('embedded-cluster-api', true);

--- a/shell/utils/v-sphere.ts
+++ b/shell/utils/v-sphere.ts
@@ -1,5 +1,8 @@
 import merge from 'lodash/merge';
 import { SECRET } from '@shell/config/types';
+import { PROVISIONING_PRE_BOOTSTRAP } from '@shell/store/features';
+
+export const VMWARE_VSPHERE = 'vmwarevsphere';
 
 type Rke2Component = {
     versionInfo: any;
@@ -7,6 +10,7 @@ type Rke2Component = {
     chartVersionKey: (chartName: string) => string;
     value: any;
     isEdit: boolean;
+    provider: string;
     $store: any,
 }
 
@@ -88,10 +92,28 @@ class VSphereUtils {
     };
   }
 
+  private handleVsphereSecret({ $store, provider }: { $store: any, provider: string}): boolean {
+    if (provider !== VMWARE_VSPHERE) {
+      return false;
+    }
+
+    const isPrebootstrapEnabled = $store.getters['features/get'](PROVISIONING_PRE_BOOTSTRAP);
+
+    if (!isPrebootstrapEnabled) {
+      return false;
+    }
+
+    return true;
+  }
+
   /**
     * Create upstream vsphere cpi secret to sync downstream
     */
   async handleVsphereCpiSecret(rke2Component: Rke2Component) {
+    if (!this.handleVsphereSecret(rke2Component)) {
+      return;
+    }
+
     const generateName = `${ rootGenerateName }cpi-`;
     const downstreamName = 'rancher-vsphere-cpi-credentials';
     const downstreamNamespace = 'kube-system';
@@ -165,6 +187,10 @@ class VSphereUtils {
     * Create upstream vsphere csi secret to sync downstream
     */
   async handleVsphereCsiSecret(rke2Component: Rke2Component) {
+    if (!this.handleVsphereSecret(rke2Component)) {
+      return;
+    }
+
     const generateName = `${ rootGenerateName }csi-`;
     const downstreamName = 'rancher-vsphere-csi-credentials';
     const downstreamNamespace = 'kube-system';


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12545
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- cherry-pick backport of https://github.com/rancher/dashboard/pull/12547
  - note no changes in rke2.vue required (newer versions do not look at vpshere provider string

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
