### PR TITLE
Fix Edit Yaml Footer's layout issue

### DIFF
--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -68,11 +68,6 @@ export default {
       default: null,
     },
 
-    flexContent: {
-      type:    Boolean,
-      default: false,
-    },
-
     /**
      * Inherited global identifier prefix for tests
      * Define a term based on the parent component to avoid conflicts on multiple components
@@ -418,7 +413,6 @@ export default {
       :offer-preview="offerPreview"
       :done-route="doneRoute"
       :done-override="value.doneOverride"
-      :class="{'flex-content': flexContent}"
       @update:value="$emit('input', $event)"
     />
 
@@ -434,7 +428,6 @@ export default {
       :initial-value="initialModel"
       :live-value="liveModel"
       :real-mode="realMode"
-      :class="{'flex-content': flexContent}"
       @update:value="$emit('input', $event)"
       @set-subtype="setSubtype"
     />

--- a/shell/components/ResourceYaml.vue
+++ b/shell/components/ResourceYaml.vue
@@ -346,7 +346,7 @@ export default {
 </script>
 
 <template>
-  <div class="root resource-yaml">
+  <div class="root resource-yaml flex-content">
     <YamlEditor
       ref="yamleditor"
       v-model:value="currentYaml"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10880 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Removed `flexContent` prop that was added a long time ago but never really used. The issue wasn't limited to the Pods page, basically it was happening anywhere in the app if the yaml section was too short.
### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Any place that Yaml Editor is displayed.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
I did my best to make sure this doesn't break any pages by checking many places that the Yaml editor is displayed, but testing by a second person will be great.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/9ffd97ef-9061-4b1a-9d26-7fc7c8741738">

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
