### PR TITLE
Fix e2e failing due to unavailable cli binaries

### DIFF
--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -112,7 +112,8 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
 
   describe('CLI Downloads', () => {
     // Shouldn't be needed with https://github.com/rancher/dashboard/issues/11393
-    const expectedLinkStatusCode = 200;
+    // Change back to 200 when binaries are available - see https://github.com/rancher/dashboard/issues/12576
+    const expectedLinkStatusCode = 404;
 
     // workaround to make the following CLI tests work https://github.com/cypress-io/cypress/issues/8089#issuecomment-1585159023
     beforeEach(() => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- head points to 2.10.0 cli binaries, which aren't available
  - v2.10-head points at 2.9.0 binaries which are available
- this causes are e2e tests that check links (amongst other things) to 404
- so now we check for 404 and need to change back to 200 when the binaries are there
  - https://github.com/rancher/dashboard/issues/12576

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
