### PR TITLE
fix ember routing for hosted clusters that are not EKS AKS nor GKE

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -211,8 +211,9 @@ export default {
 
     emberLink() {
       if (this.value) {
+        // set subtype if editing EKS/GKE/AKS cluster -- this ensures that the component provided by extension is loaded instead of iframing old ember ui
         if (this.value.provisioner) {
-          const matchingSubtype = this.subTypes.find((st) => st.id.toLowerCase() === this.value.provisioner.toLowerCase() || DRIVER_TO_IMPORT[st.id.toLowerCase()] === this.value.provisioner.toLowerCase());
+          const matchingSubtype = this.subTypes.find((st) => DRIVER_TO_IMPORT[st.id.toLowerCase()] === this.value.provisioner.toLowerCase());
 
           if (matchingSubtype) {
             this.selectType(matchingSubtype.id, false);


### PR DESCRIPTION

### Summary
Fixes #12541 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

This PR modifies a change that came in [here](https://github.com/mantis-toboggan-md/dashboard/commit/4cca5faf81dd658464b086c67894642f909ee6fc#diff-7655093720dda329bd1d1b72936a782cd7178edadbf55a7c1b8b58fb394f77cfR190) to support the AKS/EKS/GKE ui extensions, so other hosted providers are still able to load custom ember ui.

### Areas or cases that should be tested
Ensure that hosted 

### Areas which could experience regressions
create,edit, import existing aks/eks/gke clusters -- make sure the vue is still loading for these cluster types

### Screenshot/Video

https://github.com/user-attachments/assets/8849e5f7-2abf-418c-8234-d374766589f7


https://github.com/user-attachments/assets/b203edd1-ff35-4d34-99bd-6a8c4239e274



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
