### PR TITLE
Fixed cluster list in burger menu having unnecessary horizontal scroll

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -998,7 +998,7 @@ export default {
     }
 
      &.menu-open {
-      width: 300px;
+      width: 315px;
       box-shadow: 3px 1px 3px var(--shadow);
     }
 
@@ -1034,7 +1034,7 @@ export default {
       display: flex;
       flex-direction: column;
       margin: 10px 0;
-      width: 300px;
+      width: 315px;
       overflow: auto;
 
       .option {

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -1069,6 +1069,7 @@ export default {
           line-height: normal;
 
           & > p {
+            width: 182px;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
@@ -1116,9 +1117,11 @@ export default {
 
         > i, > img {
           display: block;
-          width: 42px;
           font-size: $icon-size;
           margin-right: 14px;
+          &.group-icon {
+            width: 42px;
+          }
         }
 
         .rancher-provider-icon,
@@ -1307,7 +1310,6 @@ export default {
         }
         .pin {
           display: block;
-          margin-right: 0;
         }
       }
 

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -1309,7 +1309,6 @@ export default {
           display: block;
           margin-right: 0;
         }
-
       }
 
       .category {

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -920,7 +920,7 @@ export default {
     // needs !important so that we can
     // offset the tooltip a bit so it doesn't
     // overlap the pin icon and cause bad UX
-    left: 35px !important;
+    left: 48px !important;
   }
 
   .localeSelector, .footer-tooltip {

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -998,7 +998,7 @@ export default {
     }
 
      &.menu-open {
-      width: 315px;
+      width: 300px;
       box-shadow: 3px 1px 3px var(--shadow);
     }
 
@@ -1034,7 +1034,7 @@ export default {
       display: flex;
       flex-direction: column;
       margin: 10px 0;
-      width: 315px;
+      width: 300px;
       overflow: auto;
 
       .option {
@@ -1069,7 +1069,6 @@ export default {
           line-height: normal;
 
           & > p {
-            width: 195px;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
@@ -1308,7 +1307,9 @@ export default {
         }
         .pin {
           display: block;
+          margin-right: 0;
         }
+
       }
 
       .category {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11809 
<!-- Define findings related to the feature or bug issue. -->
Changed width setting so that it doesn't need scroller on smaller screens. 
Tested on Chrome, Firefox and Safari

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
N/A

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Burger menu:
- Check cluster list with burger menu with 1 cluster both open and collapsed. Try different window sizes.
- Add more clusters (ie import custom clusters) until it requires virtual scroll in the side menu. Repeat step 1.
No horizontal scroll should be visible, clusters should be able to get pinned, layout should seem reasonable.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
N/A

### Screenshot/Video
https://github.com/user-attachments/assets/e69cff4c-0597-4750-96dc-2e5884c8fd77
https://github.com/user-attachments/assets/fc64477b-a471-408a-bcc2-1efcc2a42356

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
