### PR TITLE
Fix telemetry-opt e2e test

### DIFF
--- a/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
@@ -319,13 +319,17 @@ describe('Settings', { testIsolation: 'off' }, () => {
   it('can update telemetry-opt', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting: Prompt
     SettingsPagePo.navTo();
+
+    settingsPage.waitForPage();
+    settingsPage.settingsValue('telemetry-opt').contains('Opt-out of Telemetry');
+
     settingsPage.editSettingsByLabel('telemetry-opt');
 
     const settingsEdit = settingsPage.editSettings('local', 'telemetry-opt');
 
     settingsEdit.waitForPage();
     settingsEdit.title().contains('Setting: telemetry-opt').should('be.visible');
-    settingsEdit.useDefaultButton().should('be.disabled'); // button should be disabled for this settings option
+    settingsEdit.useDefaultButton().should('not.be.disabled');
     settingsEdit.selectSettingsByLabel('Prompt');
     settingsEdit.saveAndWait('telemetry-opt', 'prompt').then(({ request, response }) => {
       expect(response?.statusCode).to.eq(200);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- In Rancher `v2.11-3544e2a5117833c9b5dc66628af034322ead317c-head` version, the telemetry-opt default value is `out` -> UI `Opt-out of Telemetry`

![image](https://github.com/user-attachments/assets/2072772e-f29c-4770-9e56-37e43ed26c6c)

The `Use the default value` button should correctly be enabled.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
