### PR TITLE
fix e2e chrome installation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -93,9 +93,10 @@ jobs:
       # Leaving this here again in case we need to pin to a specific Chrome version in the future
       - name: Install Chrome 127
         run: |
-          sudo apt-get install -y wget
+          sudo apt-get install -y wget libu2f-udev
           cd /tmp
-          wget -q http://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_127.0.6533.72-1_amd64.deb
+          wget -q http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_127.0.6533.72-1_amd64.deb
+          sudo dpkg -i google-chrome-stable_127.0.6533.72-1_amd64.deb
           sudo apt-get install -y --allow-downgrades ./google-chrome-stable_127.0.6533.72-1_amd64.deb
           google-chrome --version
 


### PR DESCRIPTION
We are replacing the download server because of frequent unavailability.