### PR TITLE
Data Directories should not be editable after creation

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1475,6 +1475,7 @@ cluster:
     placeholder: A unique name for the cluster
   directoryConfig:
     title: Data directory configuration
+    banner: Data directory configuration can not be changed once the cluster has been created
     radioInput:
       defaultLabel: Use default data directory configuration
       commonLabel: Use a common base directory for data directory configuration (sub-directories will be used for the system-agent, provisioning and distro paths)

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/DirectoryConfig.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/DirectoryConfig.test.ts
@@ -113,7 +113,7 @@ describe('component: DirectoryConfig', () => {
     expect(wrapper.vm.value.k8sDistro).toStrictEqual(k8sDistroValue);
   });
 
-  it('should render the component with configuration being an empty object, without errors and radio be of value DATA_DIR_RADIO_OPTIONS.DEFAULT (edit scenario)', () => {
+  it('should render the component with configuration being an empty object, without errors and radio be of value DATA_DIR_RADIO_OPTIONS.CUSTOM (edit scenario)', () => {
     const newMountOptions = clone(mountOptions);
 
     newMountOptions.propsData.value = {};
@@ -131,17 +131,21 @@ describe('component: DirectoryConfig', () => {
     const k8sDistroInput = wrapper.find('[data-testid="rke2-directory-config-k8sDistro-data-dir"]');
 
     expect(title.exists()).toBe(true);
-    expect(radioInput.exists()).toBe(true);
+    expect(radioInput.isVisible()).toBe(false);
 
-    expect(wrapper.vm.dataConfigRadioValue).toBe(DATA_DIR_RADIO_OPTIONS.DEFAULT);
+    expect(wrapper.vm.dataConfigRadioValue).toBe(DATA_DIR_RADIO_OPTIONS.CUSTOM);
 
     // since we have all of the vars empty, then the inputs should not be there
-    expect(systemAgentInput.exists()).toBe(false);
-    expect(provisioningInput.exists()).toBe(false);
-    expect(k8sDistroInput.exists()).toBe(false);
+    expect(systemAgentInput.exists()).toBe(true);
+    expect(provisioningInput.exists()).toBe(true);
+    expect(k8sDistroInput.exists()).toBe(true);
+
+    expect(systemAgentInput.attributes().disabled).toBeDefined();
+    expect(provisioningInput.attributes().disabled).toBeDefined();
+    expect(k8sDistroInput.attributes().disabled).toBeDefined();
   });
 
-  it('radio input should be set to DATA_DIR_RADIO_OPTIONS.CUSTOM with all data dir values existing and different (edit scenario)', async() => {
+  it('radio input should be set to DATA_DIR_RADIO_OPTIONS.CUSTOM with all data dir values existing and different (edit scenario)', () => {
     const newMountOptions = clone(mountOptions);
     const inputPath = 'some-data-dir';
 
@@ -157,13 +161,19 @@ describe('component: DirectoryConfig', () => {
 
     expect(wrapper.vm.dataConfigRadioValue).toBe(DATA_DIR_RADIO_OPTIONS.CUSTOM);
 
+    const radioInput = wrapper.find('[data-testid="rke2-directory-config-radio-input"]');
     const systemAgentInput = wrapper.find('[data-testid="rke2-directory-config-systemAgent-data-dir"]');
     const provisioningInput = wrapper.find('[data-testid="rke2-directory-config-provisioning-data-dir"]');
     const k8sDistroInput = wrapper.find('[data-testid="rke2-directory-config-k8sDistro-data-dir"]');
 
+    expect(radioInput.isVisible()).toBe(false);
     expect(systemAgentInput.isVisible()).toBe(true);
     expect(provisioningInput.isVisible()).toBe(true);
     expect(k8sDistroInput.isVisible()).toBe(true);
+
+    expect(systemAgentInput.attributes().disabled).toBeDefined();
+    expect(provisioningInput.attributes().disabled).toBeDefined();
+    expect(k8sDistroInput.attributes().disabled).toBeDefined();
 
     expect(wrapper.vm.value.systemAgent).toStrictEqual(`${ inputPath }/${ DEFAULT_SUBDIRS.AGENT }`);
     expect(wrapper.vm.value.provisioning).toStrictEqual(`${ inputPath }/${ DEFAULT_SUBDIRS.PROVISIONING }`);

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
@@ -1,8 +1,9 @@
 
 <script>
 import { LabeledInput } from '@components/Form/LabeledInput';
-import { _CREATE } from '@shell/config/query-params';
+import { _CREATE, _EDIT } from '@shell/config/query-params';
 import RadioGroup from '@components/Form/Radio/RadioGroup.vue';
+import { Banner } from '@components/Banner';
 
 export const DATA_DIR_RADIO_OPTIONS = {
   DEFAULT: 'defaultDataDir',
@@ -23,7 +24,8 @@ export default {
   name:       'DirectoryConfig',
   components: {
     LabeledInput,
-    RadioGroup
+    RadioGroup,
+    Banner
   },
   props: {
     mode: {
@@ -50,9 +52,7 @@ export default {
     }
 
     if (this.mode !== _CREATE) {
-      if (this.value?.systemAgent?.length || this.value?.provisioning?.length || this.value?.k8sDistro?.length) {
-        dataConfigRadioValue = DATA_DIR_RADIO_OPTIONS.CUSTOM;
-      }
+      dataConfigRadioValue = DATA_DIR_RADIO_OPTIONS.CUSTOM;
     }
 
     return {
@@ -85,6 +85,9 @@ export default {
     }
   },
   computed: {
+    isDisabled() {
+      return this.mode === _EDIT;
+    },
     dataConfigRadioOptions() {
       const defaultDataDirOption = {
         value: DATA_DIR_RADIO_OPTIONS.DEFAULT,
@@ -148,10 +151,17 @@ export default {
 <template>
   <div class="row">
     <div class="col span-8">
-      <h3 class="mb-20">
+      <h3>
         {{ t('cluster.directoryConfig.title') }}
       </h3>
+      <Banner
+        class="mb-20"
+        :closable="false"
+        color="info"
+        label-key="cluster.directoryConfig.banner"
+      />
       <RadioGroup
+        v-show="!isDisabled"
         :value="dataConfigRadioValue"
         class="mb-10"
         :mode="mode"
@@ -167,6 +177,7 @@ export default {
         :mode="mode"
         :label="t('cluster.directoryConfig.common.label')"
         :tooltip="t('cluster.directoryConfig.common.tooltip')"
+        :disabled="isDisabled"
         data-testid="rke2-directory-config-common-data-dir"
       />
       <div v-if="dataConfigRadioValue === DATA_DIR_RADIO_OPTIONS.CUSTOM">
@@ -176,6 +187,7 @@ export default {
           :mode="mode"
           :label="t('cluster.directoryConfig.systemAgent.label')"
           :tooltip="t('cluster.directoryConfig.systemAgent.tooltip')"
+          :disabled="isDisabled"
           data-testid="rke2-directory-config-systemAgent-data-dir"
         />
         <LabeledInput
@@ -184,6 +196,7 @@ export default {
           :mode="mode"
           :label="t('cluster.directoryConfig.provisioning.label')"
           :tooltip="t('cluster.directoryConfig.provisioning.tooltip')"
+          :disabled="isDisabled"
           data-testid="rke2-directory-config-provisioning-data-dir"
         />
         <LabeledInput
@@ -192,6 +205,7 @@ export default {
           :mode="mode"
           :label="t('cluster.directoryConfig.k8sDistro.label')"
           :tooltip="t('cluster.directoryConfig.k8sDistro.tooltip')"
+          :disabled="isDisabled"
           data-testid="rke2-directory-config-k8sDistro-data-dir"
         />
       </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12455 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- disable Data Directories inputs in edit mode
- update unit tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- create a cluster with some Data Directories config (RKE2)
- edit that cluster and check that inputs are disabled and radio options are hidden

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="2496" alt="Screenshot 2024-11-14 at 17 37 21" src="https://github.com/user-attachments/assets/3d46fd52-d76a-469e-977e-a9a750268b66">

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
