### PR TITLE
[backport v2.9.5] RKE2 cluster provision: Data Directories should not be editable after creation

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1467,6 +1467,14 @@ cluster:
     placeholder: A unique name for the cluster
   directoryConfig:
     title: Data directory configuration
+    banner: Data directory configuration can not be changed once the cluster has been created
+    radioInput:
+      defaultLabel: Use default data directory configuration
+      commonLabel: Use a common base directory for data directory configuration (sub-directories will be used for the system-agent, provisioning and distro paths)
+      customLabel: Use custom data directories
+    common: 
+      label: Data directory base path
+      tooltip: Data directory base path. We will append the sub-directories appropriate for each directory (/agent, /provisioning and either /rke2 or /k3s)
     systemAgent: 
       label: System-agent directory path
       tooltip: Data directory for the system-agent connection info and plans

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/DirectoryConfig.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/DirectoryConfig.test.ts
@@ -1,6 +1,7 @@
+import { nextTick } from 'vue';
 /* eslint-disable jest/no-hooks */
 import { mount, Wrapper } from '@vue/test-utils';
-import DirectoryConfig from '@shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue';
+import DirectoryConfig, { DATA_DIR_RADIO_OPTIONS, DEFAULT_SUBDIRS } from '@shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue';
 import { _EDIT, _CREATE } from '@shell/config/query-params';
 import { clone } from '@shell/utils/object';
 
@@ -14,7 +15,8 @@ describe('component: DirectoryConfig', () => {
         provisioning: '',
         k8sDistro:    '',
       },
-      mode: _CREATE,
+      k8sVersion: 'k3s',
+      mode:       _CREATE,
     },
     mocks: {
       $store: {
@@ -33,48 +35,88 @@ describe('component: DirectoryConfig', () => {
     );
 
     const title = wrapper.find('h3');
+    const radioInput = wrapper.find('[data-testid="rke2-directory-config-radio-input"]');
+    const commonInput = wrapper.find('[data-testid="rke2-directory-config-common-data-dir"]');
     const systemAgentInput = wrapper.find('[data-testid="rke2-directory-config-systemAgent-data-dir"]');
     const provisioningInput = wrapper.find('[data-testid="rke2-directory-config-provisioning-data-dir"]');
     const k8sDistroInput = wrapper.find('[data-testid="rke2-directory-config-k8sDistro-data-dir"]');
 
     expect(title.exists()).toBe(true);
+    expect(radioInput.exists()).toBe(true);
 
-    expect(systemAgentInput.exists()).toBe(true);
-    expect(provisioningInput.exists()).toBe(true);
-    expect(k8sDistroInput.exists()).toBe(true);
+    // for the default config, the default radio input should be "default"
+    expect(wrapper.vm.dataConfigRadioValue).toBe(DATA_DIR_RADIO_OPTIONS.DEFAULT);
+
+    // since we have all of the vars empty, then the inputs should not be there
+    expect(commonInput.exists()).toBe(false);
+    expect(systemAgentInput.exists()).toBe(false);
+    expect(provisioningInput.exists()).toBe(false);
+    expect(k8sDistroInput.exists()).toBe(false);
   });
 
-  it('updating each individual data dir should set the correct values on each data dir variable', async() => {
+  it('updating common base directory should set the correct values on each data dir variable', async() => {
+    const newMountOptions = clone(mountOptions);
+
     wrapper = mount(
       DirectoryConfig,
-      mountOptions
+      {
+        ...newMountOptions,
+        // couldn't use setData, so this is the next best solution
+        data() {
+          return { dataConfigRadioValue: DATA_DIR_RADIO_OPTIONS.COMMON };
+        }
+      }
     );
 
     const inputPath = 'some-data-dir';
+    const commonInput = wrapper.find('[data-testid="rke2-directory-config-common-data-dir"]');
+
+    // update base dir value
+    expect(commonInput.exists()).toBe(true);
+    commonInput.setValue(inputPath);
+    await nextTick();
+
+    expect(wrapper.vm.value.systemAgent).toStrictEqual(`${ inputPath }/${ DEFAULT_SUBDIRS.AGENT }`);
+    expect(wrapper.vm.value.provisioning).toStrictEqual(`${ inputPath }/${ DEFAULT_SUBDIRS.PROVISIONING }`);
+    expect(wrapper.vm.value.k8sDistro).toStrictEqual(`${ inputPath }/${ DEFAULT_SUBDIRS.K8S_DISTRO_K3S }`);
+  });
+
+  it('updating each individual data dir should set the correct values on each data dir variable', async() => {
+    const newMountOptions = clone(mountOptions);
+
+    wrapper = mount(
+      DirectoryConfig,
+      {
+        ...newMountOptions,
+        // couldn't use setData, so this is the next best solution
+        data() {
+          return { dataConfigRadioValue: DATA_DIR_RADIO_OPTIONS.CUSTOM };
+        }
+      }
+    );
+    const inputPath = 'some-data-dir';
+    const agentValue = `${ inputPath }/${ DEFAULT_SUBDIRS.AGENT }`;
+    const provisioningValue = `${ inputPath }/${ DEFAULT_SUBDIRS.PROVISIONING }`;
+    const k8sDistroValue = `${ inputPath }/${ DEFAULT_SUBDIRS.K8S_DISTRO_RKE2 }`;
 
     const systemAgentInput = wrapper.find('[data-testid="rke2-directory-config-systemAgent-data-dir"]');
     const provisioningInput = wrapper.find('[data-testid="rke2-directory-config-provisioning-data-dir"]');
     const k8sDistroInput = wrapper.find('[data-testid="rke2-directory-config-k8sDistro-data-dir"]');
 
-    systemAgentInput.setValue(inputPath);
-    provisioningInput.setValue(inputPath);
-    k8sDistroInput.setValue(inputPath);
-    await wrapper.vm.$nextTick();
+    systemAgentInput.setValue(agentValue);
+    provisioningInput.setValue(provisioningValue);
+    k8sDistroInput.setValue(k8sDistroValue);
+    await nextTick();
 
-    expect(wrapper.vm.value.systemAgent).toStrictEqual(inputPath);
-    expect(wrapper.vm.value.provisioning).toStrictEqual(inputPath);
-    expect(wrapper.vm.value.k8sDistro).toStrictEqual(inputPath);
+    expect(wrapper.vm.value.systemAgent).toStrictEqual(agentValue);
+    expect(wrapper.vm.value.provisioning).toStrictEqual(provisioningValue);
+    expect(wrapper.vm.value.k8sDistro).toStrictEqual(k8sDistroValue);
   });
 
-  it('on a mode different than _CREATE all visible inputs should be disabled (with different values)', () => {
+  it('should render the component with configuration being an empty object, without errors and radio be of value DATA_DIR_RADIO_OPTIONS.CUSTOM (edit scenario)', () => {
     const newMountOptions = clone(mountOptions);
-    const inputPath1 = 'some-data-dir1';
-    const inputPath2 = 'some-data-dir2';
-    const inputPath3 = 'some-data-dir3';
 
-    newMountOptions.propsData.value.systemAgent = inputPath1;
-    newMountOptions.propsData.value.provisioning = inputPath2;
-    newMountOptions.propsData.value.k8sDistro = inputPath3;
+    newMountOptions.propsData.value = {};
     newMountOptions.propsData.mode = _EDIT;
 
     wrapper = mount(
@@ -82,16 +124,59 @@ describe('component: DirectoryConfig', () => {
       newMountOptions
     );
 
+    const title = wrapper.find('h3');
+    const radioInput = wrapper.find('[data-testid="rke2-directory-config-radio-input"]');
     const systemAgentInput = wrapper.find('[data-testid="rke2-directory-config-systemAgent-data-dir"]');
     const provisioningInput = wrapper.find('[data-testid="rke2-directory-config-provisioning-data-dir"]');
     const k8sDistroInput = wrapper.find('[data-testid="rke2-directory-config-k8sDistro-data-dir"]');
 
+    expect(title.exists()).toBe(true);
+    expect(radioInput.isVisible()).toBe(false);
+
+    expect(wrapper.vm.dataConfigRadioValue).toBe(DATA_DIR_RADIO_OPTIONS.CUSTOM);
+
+    // since we have all of the vars empty, then the inputs should not be there
     expect(systemAgentInput.exists()).toBe(true);
     expect(provisioningInput.exists()).toBe(true);
     expect(k8sDistroInput.exists()).toBe(true);
 
-    expect(systemAgentInput.attributes('disabled')).toBe('disabled');
-    expect(provisioningInput.attributes('disabled')).toBe('disabled');
-    expect(k8sDistroInput.attributes('disabled')).toBe('disabled');
+    expect(systemAgentInput.attributes().disabled).toBeDefined();
+    expect(provisioningInput.attributes().disabled).toBeDefined();
+    expect(k8sDistroInput.attributes().disabled).toBeDefined();
+  });
+
+  it('radio input should be set to DATA_DIR_RADIO_OPTIONS.CUSTOM with all data dir values existing and different (edit scenario)', () => {
+    const newMountOptions = clone(mountOptions);
+    const inputPath = 'some-data-dir';
+
+    newMountOptions.propsData.value.systemAgent = `${ inputPath }/${ DEFAULT_SUBDIRS.AGENT }`;
+    newMountOptions.propsData.value.provisioning = `${ inputPath }/${ DEFAULT_SUBDIRS.PROVISIONING }`;
+    newMountOptions.propsData.value.k8sDistro = `${ inputPath }/${ DEFAULT_SUBDIRS.K8S_DISTRO_K3S }`;
+    newMountOptions.propsData.mode = _EDIT;
+
+    wrapper = mount(
+      DirectoryConfig,
+      newMountOptions
+    );
+
+    expect(wrapper.vm.dataConfigRadioValue).toBe(DATA_DIR_RADIO_OPTIONS.CUSTOM);
+
+    const radioInput = wrapper.find('[data-testid="rke2-directory-config-radio-input"]');
+    const systemAgentInput = wrapper.find('[data-testid="rke2-directory-config-systemAgent-data-dir"]');
+    const provisioningInput = wrapper.find('[data-testid="rke2-directory-config-provisioning-data-dir"]');
+    const k8sDistroInput = wrapper.find('[data-testid="rke2-directory-config-k8sDistro-data-dir"]');
+
+    expect(radioInput.isVisible()).toBe(false);
+    expect(systemAgentInput.isVisible()).toBe(true);
+    expect(provisioningInput.isVisible()).toBe(true);
+    expect(k8sDistroInput.isVisible()).toBe(true);
+
+    expect(systemAgentInput.attributes().disabled).toBeDefined();
+    expect(provisioningInput.attributes().disabled).toBeDefined();
+    expect(k8sDistroInput.attributes().disabled).toBeDefined();
+
+    expect(wrapper.vm.value.systemAgent).toStrictEqual(`${ inputPath }/${ DEFAULT_SUBDIRS.AGENT }`);
+    expect(wrapper.vm.value.provisioning).toStrictEqual(`${ inputPath }/${ DEFAULT_SUBDIRS.PROVISIONING }`);
+    expect(wrapper.vm.value.k8sDistro).toStrictEqual(`${ inputPath }/${ DEFAULT_SUBDIRS.K8S_DISTRO_K3S }`);
   });
 });

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Advanced.vue
@@ -101,6 +101,7 @@ export default {
     <template v-if="haveArgInfo">
       <DirectoryConfig
         v-model="value.spec.rkeConfig.dataDirectories"
+        :k8s-version="value.spec.kubernetesVersion"
         :mode="mode"
       />
       <h3>{{ t('cluster.advanced.argInfo.title') }}</h3>

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
@@ -1,13 +1,39 @@
 
 <script>
 import { LabeledInput } from '@components/Form/LabeledInput';
-import { _CREATE } from '@shell/config/query-params';
+import { _CREATE, _EDIT } from '@shell/config/query-params';
+import RadioGroup from '@components/Form/Radio/RadioGroup.vue';
+import { Banner } from '@components/Banner';
+
+export const DATA_DIR_RADIO_OPTIONS = {
+  DEFAULT: 'defaultDataDir',
+  COMMON:  'commonBaseDataDir',
+  CUSTOM:  'customDataDir',
+};
+
+export const DEFAULT_COMMON_BASE_PATH = '/var/lib/rancher';
+
+export const DEFAULT_SUBDIRS = {
+  AGENT:           'agent',
+  PROVISIONING:    'provisioning',
+  K8S_DISTRO_RKE2: 'rke2',
+  K8S_DISTRO_K3S:  'k3s',
+};
 
 export default {
   name:       'DirectoryConfig',
-  components: { LabeledInput },
-  props:      {
+  components: {
+    LabeledInput,
+    RadioGroup,
+    Banner
+  },
+  props: {
     mode: {
+      type:     String,
+      required: true,
+    },
+
+    k8sVersion: {
       type:     String,
       required: true,
     },
@@ -17,47 +43,172 @@ export default {
       required: true,
     },
   },
-  computed: {
-    disableEditInput() {
-      return this.mode !== _CREATE;
+  data() {
+    let dataConfigRadioValue = DATA_DIR_RADIO_OPTIONS.DEFAULT;
+    let k8sDistroSubDir = DEFAULT_SUBDIRS.K8S_DISTRO_RKE2;
+
+    if (this.k8sVersion && this.k8sVersion.includes('k3s')) {
+      k8sDistroSubDir = DEFAULT_SUBDIRS.K8S_DISTRO_K3S;
     }
-  }
+
+    if (this.mode !== _CREATE) {
+      dataConfigRadioValue = DATA_DIR_RADIO_OPTIONS.CUSTOM;
+    }
+
+    return {
+      DATA_DIR_RADIO_OPTIONS,
+      dataConfigRadioValue,
+      k8sDistroSubDir,
+      commonConfig: '',
+    };
+  },
+  watch: {
+    commonConfig(neu) {
+      if (neu && neu.length && this.dataConfigRadioValue === DATA_DIR_RADIO_OPTIONS.COMMON) {
+        this.value.systemAgent = `${ neu }/${ DEFAULT_SUBDIRS.AGENT }`;
+        this.value.provisioning = `${ neu }/${ DEFAULT_SUBDIRS.PROVISIONING }`;
+        this.value.k8sDistro = `${ neu }/${ this.k8sDistroSubDir }`;
+      }
+    },
+    k8sVersion: {
+      handler(neu) {
+        if (neu && neu.includes('k3s')) {
+          this.k8sDistroSubDir = DEFAULT_SUBDIRS.K8S_DISTRO_K3S;
+        } else {
+          this.k8sDistroSubDir = DEFAULT_SUBDIRS.K8S_DISTRO_RKE2;
+        }
+
+        if (this.value.k8sDistro) {
+          this.value.k8sDistro = `${ neu }/${ this.k8sDistroSubDir }`;
+        }
+      }
+    }
+  },
+  computed: {
+    isDisabled() {
+      return this.mode === _EDIT;
+    },
+    dataConfigRadioOptions() {
+      const defaultDataDirOption = {
+        value: DATA_DIR_RADIO_OPTIONS.DEFAULT,
+        label: this.t('cluster.directoryConfig.radioInput.defaultLabel')
+      };
+      const customDataDirOption = {
+        value: DATA_DIR_RADIO_OPTIONS.CUSTOM,
+        label: this.t('cluster.directoryConfig.radioInput.customLabel')
+      };
+
+      if (this.mode === _CREATE) {
+        return [
+          defaultDataDirOption,
+          { value: DATA_DIR_RADIO_OPTIONS.COMMON, label: this.t('cluster.directoryConfig.radioInput.commonLabel') },
+          customDataDirOption
+        ];
+      } else {
+        return [
+          defaultDataDirOption,
+          customDataDirOption
+        ];
+      }
+    }
+  },
+  methods: {
+    handleRadioInput(val) {
+      switch (val) {
+      case DATA_DIR_RADIO_OPTIONS.DEFAULT:
+        if (this.mode === _CREATE) {
+          this.commonConfig = '';
+        }
+        this.value.systemAgent = '';
+        this.value.provisioning = '';
+        this.value.k8sDistro = '';
+
+        this.dataConfigRadioValue = DATA_DIR_RADIO_OPTIONS.DEFAULT;
+        break;
+      case DATA_DIR_RADIO_OPTIONS.COMMON:
+        this.commonConfig = DEFAULT_COMMON_BASE_PATH;
+
+        this.dataConfigRadioValue = DATA_DIR_RADIO_OPTIONS.COMMON;
+        break;
+      // default is custom config
+      default:
+        if (this.mode === _CREATE) {
+          this.commonConfig = '';
+        }
+
+        this.value.systemAgent = '';
+        this.value.provisioning = '';
+        this.value.k8sDistro = '';
+
+        this.dataConfigRadioValue = DATA_DIR_RADIO_OPTIONS.CUSTOM;
+        break;
+      }
+    }
+  },
 };
 </script>
 
 <template>
   <div class="row">
     <div class="col span-8">
-      <h3 class="mb-20">
+      <h3>
         {{ t('cluster.directoryConfig.title') }}
       </h3>
-      <LabeledInput
-        v-model="value.systemAgent"
+      <Banner
         class="mb-20"
+        :closable="false"
+        color="info"
+        label-key="cluster.directoryConfig.banner"
+      />
+      <RadioGroup
+        v-show="!isDisabled"
+        :value="dataConfigRadioValue"
+        class="mb-10"
         :mode="mode"
-        :label="t('cluster.directoryConfig.systemAgent.label')"
-        :tooltip="t('cluster.directoryConfig.systemAgent.tooltip')"
-        :disabled="disableEditInput"
-        data-testid="rke2-directory-config-systemAgent-data-dir"
+        :options="dataConfigRadioOptions"
+        name="directory-config-radio"
+        data-testid="rke2-directory-config-radio-input"
+        @input="handleRadioInput"
       />
       <LabeledInput
-        v-model="value.provisioning"
+        v-if="dataConfigRadioValue === DATA_DIR_RADIO_OPTIONS.COMMON"
+        v-model="commonConfig"
         class="mb-20"
         :mode="mode"
-        :label="t('cluster.directoryConfig.provisioning.label')"
-        :tooltip="t('cluster.directoryConfig.provisioning.tooltip')"
-        :disabled="disableEditInput"
-        data-testid="rke2-directory-config-provisioning-data-dir"
+        :label="t('cluster.directoryConfig.common.label')"
+        :tooltip="t('cluster.directoryConfig.common.tooltip')"
+        :disabled="isDisabled"
+        data-testid="rke2-directory-config-common-data-dir"
       />
-      <LabeledInput
-        v-model="value.k8sDistro"
-        class="mb-20"
-        :mode="mode"
-        :label="t('cluster.directoryConfig.k8sDistro.label')"
-        :tooltip="t('cluster.directoryConfig.k8sDistro.tooltip')"
-        :disabled="disableEditInput"
-        data-testid="rke2-directory-config-k8sDistro-data-dir"
-      />
+      <div v-if="dataConfigRadioValue === DATA_DIR_RADIO_OPTIONS.CUSTOM">
+        <LabeledInput
+          v-model="value.systemAgent"
+          class="mb-20"
+          :mode="mode"
+          :label="t('cluster.directoryConfig.systemAgent.label')"
+          :tooltip="t('cluster.directoryConfig.systemAgent.tooltip')"
+          :disabled="isDisabled"
+          data-testid="rke2-directory-config-systemAgent-data-dir"
+        />
+        <LabeledInput
+          v-model="value.provisioning"
+          class="mb-20"
+          :mode="mode"
+          :label="t('cluster.directoryConfig.provisioning.label')"
+          :tooltip="t('cluster.directoryConfig.provisioning.tooltip')"
+          :disabled="isDisabled"
+          data-testid="rke2-directory-config-provisioning-data-dir"
+        />
+        <LabeledInput
+          v-model="value.k8sDistro"
+          class="mb-20"
+          :mode="mode"
+          :label="t('cluster.directoryConfig.k8sDistro.label')"
+          :tooltip="t('cluster.directoryConfig.k8sDistro.tooltip')"
+          :disabled="isDisabled"
+          data-testid="rke2-directory-config-k8sDistro-data-dir"
+        />
+      </div>
       <div class="mb-40" />
     </div>
   </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12617 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Updated UI for Data Directories to match v2.10 (also takes into account k8s version type when creating the base k8s distro folder from default)
- disable Data Directories inputs in edit mode
- update unit tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- create a cluster with some Data Directories config (RKE2)
- edit that cluster and check that inputs are disabled and radio options are hidden

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

**UI before**

<img width="2073" alt="before_CREATE" src="https://github.com/user-attachments/assets/ece26531-52a9-4eca-b1cf-fd469927cefd">
<img width="2073" alt="before_EDIT" src="https://github.com/user-attachments/assets/3df46696-5221-4945-af89-bbf9cd81c2ed">

**UI after**
<img width="1566" alt="after_EDIT" src="https://github.com/user-attachments/assets/a0ed8945-78bd-4be3-9832-a6d5f18f628f">
<img width="2394" alt="1_after_CREATE" src="https://github.com/user-attachments/assets/293a885e-16a5-4684-b791-93e2a09a3801">
<img width="2394" alt="2_after_CREATE" src="https://github.com/user-attachments/assets/8a13f5fd-aeba-4707-91b7-80095074d71f">
<img width="2394" alt="3_after_CREATE" src="https://github.com/user-attachments/assets/3a176f90-c99c-4cb6-9e29-3b2d2c88427f">


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes