### PR TITLE
Disable check for generic icon for Logging chart

### DIFF
--- a/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
@@ -60,7 +60,8 @@ describe('Apps/Charts', { tags: ['@explorer', '@adminUser'] }, () => {
     chartsPage.chartsFilterReposSelect().enableOptionWithLabelForChartReposFilter('All');
     chartsPage.checkChartGenericIcon('Alerting Driver', false);
     chartsPage.checkChartGenericIcon('CIS Benchmark', false);
-    chartsPage.checkChartGenericIcon('Logging', false);
+    // TODO: #12625 - Logging chart has generic icon
+    // chartsPage.checkChartGenericIcon('Logging', false);
   });
 
   it('Show deprecated apps filter works properly', () => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This disables the generic icon check for the Logging chart. It's currently generic in `2.10-head` and will need to fixed at a later date:

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Disable generic icon check for the Logging chart

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- The icon is currently generic in `2.10-head`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- `Charts have expected icons` e2e test passes

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/user-attachments/assets/b889271d-f112-4072-a0d4-7e44cd809180)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
