### PR TITLE
Fix empty GitRepos list on Cluster details

### DIFF
--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -338,6 +338,11 @@ export default class GitRepo extends SteveModel {
     for (const bd of bundleDeployments) {
       const clusterId = FleetUtils.clusterIdFromBundleDeploymentLabels(bd.metadata?.labels);
       const c = clusters[clusterId];
+
+      if (!c) {
+        continue;
+      }
+
       const resources = FleetUtils.resourcesFromBundleDeploymentStatus(bd.status);
 
       resources.forEach((r) => {


### PR DESCRIPTION
### Summary
Follow up of #12521

### Occurred changes and/or fixed issues
Fixes the GitRepos list being empty in the Cluster details view.

### Technical notes summary
The cluster lists used to get the `Cluster` object data is based on `targetClusters` spec, which may vary depending on the context. Since `resourcesStatuses` now iterates on `BundleDeployments` resources directly, it should skip those deployed in a cluster that is not present in the `targetClusters`.