### PR TITLE
Adding a custom lint rule to ensure we use v-clean-tooltip instead of v-tooltip directives.

### DIFF
--- a/.eslintrc.default.js
+++ b/.eslintrc.default.js
@@ -190,7 +190,10 @@ module.exports = {
     'vue/one-component-per-file':       'off',
     'vue/no-deprecated-slot-attribute': 'off',
     'vue/require-explicit-emits':       'error',
-    'vue/v-on-event-hyphenation':       'off'
+    'vue/v-on-event-hyphenation':       'off',
+
+    // Locally defined rules, you can find these defined in the `eslint-local-rules` directory.
+    'v-clean-tooltip': 'error',
   },
   overrides: [
     {

--- a/eslint-local-rules/v-clean-tooltip.js
+++ b/eslint-local-rules/v-clean-tooltip.js
@@ -1,0 +1,33 @@
+// Currently loading these rules with the --rulesdir argument. In the future we could make use of `eslint-plugin-local-rules`.
+const vueUtils = require('eslint-plugin-vue/lib/utils');
+
+module.exports = {
+  meta: {
+    type:   'problem',
+    docs:   { description: 'We want to use `v-clean-tooltip` instead of `v-tooltip` in most all areas to avoid XSS exploits.' },
+    schema: [],
+  },
+  create(context) {
+    return vueUtils.defineTemplateBodyVisitor(context, {
+      VAttribute(node) {
+        // v-tooltip is a VDirectiveKey
+        if (node?.key?.type !== 'VDirectiveKey') {
+          return;
+        }
+
+        // v-tooltip is also a VIdentifier
+        if (node.key.name.type !== 'VIdentifier') {
+          return;
+        }
+
+        if (node.key.name.name === 'tooltip') {
+          context.report({
+            node:    node.key,
+            loc:     node.loc,
+            message: 'We want to use `v-clean-tooltip` instead of `v-tooltip` in most all areas to avoid XSS exploits.'
+          });
+        }
+      }
+    });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "serve-pkgs": "./shell/scripts/serve-pkgs",
     "publish-shell-reset-reg": "cd shell && npm publish",
     "clean": "./shell/scripts/clean",
-    "lint": "./node_modules/.bin/eslint --max-warnings 0 --ext .js,.ts,.vue .",
+    "lint": "./node_modules/.bin/eslint --rulesdir ./eslint-local-rules --max-warnings 0 --ext .js,.ts,.vue .",
     "lint:lib": "cd pkg/rancher-components && yarn lint",
     "lint-l10n": "./node_modules/.bin/yamllint ./shell/assets/translations",
     "test": "NODE_OPTIONS=--max_old_space_size=8192 jest --watch",

--- a/pkg/rancher-components/package.json
+++ b/pkg/rancher-components/package.json
@@ -14,8 +14,8 @@
   ],
   "types": "./types/index.d.ts",
   "scripts": {
-    "build:lib": "vue-cli-service build --target lib --name @rancher/components src/main.ts",
-    "lint": "vue-cli-service lint"
+    "build:lib": "vue-cli-service build --skip-plugins eslint --target lib --name @rancher/components src/main.ts",
+    "lint": "vue-cli-service lint --rulesdir ../../eslint-local-rules"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Wanted to automate the ability to detect an issue with using v-tooltip over v-clean-tooltip. I wrote a custom linter rule so we can catch this in CI.

### Technical notes summary
I noticed that we currently exclude linting rancher-components from our root directory. I'd think we'd just want to include everything but I'm not sure.

### Areas or cases that should be tested
None, it's in a way an additional test.

### Areas which could experience regressions
None

### Screenshot/Video
**Example:**
![image](https://github.com/user-attachments/assets/48fb6295-36e8-45bd-8df1-65ee6b9db7fe)

**You can disable the rule in the template using:**
![image](https://github.com/user-attachments/assets/f7b8094f-7656-4af2-b431-4d686b01ec0f)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
