### PR TITLE
Hide local selector for harvester in login and SideNav

### DIFF
--- a/shell/components/SideNav.vue
+++ b/shell/components/SideNav.vue
@@ -111,8 +111,10 @@ export default {
 
   computed: {
     ...mapState(['managementReady', 'clusterReady']),
-    ...mapGetters(['productId', 'clusterId', 'currentProduct', 'rootProduct', 'isSingleProduct', 'namespaceMode', 'isExplorer', 'isVirtualCluster']),
-    ...mapGetters({ locale: 'i18n/selectedLocaleLabel', availableLocales: 'i18n/availableLocales' }),
+    ...mapGetters(['isStandaloneHarvester', 'productId', 'clusterId', 'currentProduct', 'rootProduct', 'isSingleProduct', 'namespaceMode', 'isExplorer', 'isVirtualCluster']),
+    ...mapGetters({
+      locale: 'i18n/selectedLocaleLabel', availableLocales: 'i18n/availableLocales', hasMultipleLocales: 'i18n/hasMultipleLocales'
+    }),
     ...mapGetters('type-map', ['activeProducts']),
 
     favoriteTypes: mapPref(FAVORITE_TYPES),
@@ -437,7 +439,7 @@ export default {
       </span>
 
       <!-- locale selector -->
-      <span v-if="isSingleProduct">
+      <span v-if="isSingleProduct && hasMultipleLocales && !isStandaloneHarvester">
         <v-dropdown
           popperClass="localeSelector"
           placement="top"

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -31,6 +31,7 @@ import {
 import loadPlugins from '@shell/plugins/plugin';
 import Loading from '@shell/components/Loading';
 import { getGlobalBannerFontSizes } from '@shell/utils/banners';
+import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 
 export default {
   name:       'Login',
@@ -64,7 +65,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['isStandaloneHarvester']),
+    ...mapGetters(['isSingleProduct']),
     ...mapGetters({ t: 'i18n/t', hasMultipleLocales: 'i18n/hasMultipleLocales' }),
 
     loggedOutSuccessMsg() {
@@ -75,6 +76,10 @@ export default {
       }
 
       return this.t('login.loggedOut');
+    },
+
+    isHarvester() {
+      return this.isSingleProduct?.productName === HARVESTER;
     },
 
     singleProvider() {
@@ -498,7 +503,7 @@ export default {
           </div>
         </template>
         <div
-          v-if="showLocaleSelector && hasMultipleLocales && !isStandaloneHarvester"
+          v-if="showLocaleSelector && hasMultipleLocales && !isHarvester"
           class="locale-selector"
         >
           <LocaleSelector


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Previous [PR change](https://github.com/rancher/dashboard/pull/12352) miss to hide locale selector in SideNav for harvester, the locale selector still appears in login and SideNav within harvester-ui-extension standalone mode.


We need to have @rancher/shell : `3.0.1-rc2` release after this PR merge.

<img width="1495" alt="Screenshot 2024-11-25 at 4 23 17 PM" src="https://github.com/user-attachments/assets/f14057f0-261c-49df-94a6-eb6dd72dd86f">

Fixes #
https://github.com/rancher/dashboard/issues/12347
https://github.com/harvester/harvester/issues/6928


### Screenshot/Video
After fix (I test this PR change under harvester-ui-extension/node_modules/@rancher/shell)

Login page
<img width="1496" alt="Screenshot 2024-11-25 at 5 30 55 PM" src="https://github.com/user-attachments/assets/8aabda89-8bb8-4ea1-8cd8-009f2eb804e5">

SideNav

<img width="1486" alt="Screenshot 2024-11-25 at 4 30 29 PM" src="https://github.com/user-attachments/assets/f00a6429-487e-4d62-a0e6-460668df6e77">


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes

