### PR TITLE
Allow Longhorn CSI storage driver to be selected

### DIFF
--- a/cypress/e2e/po/components/workloads/pod-storage.po.ts
+++ b/cypress/e2e/po/components/workloads/pod-storage.po.ts
@@ -1,5 +1,7 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 import CodeMirrorPo from '@/cypress/e2e/po/components/code-mirror.po';
+import ButtonDropdownPo from '@/cypress/e2e/po/components/button-dropdown.po';
+import SelectPo from '@/cypress/e2e/po/components/select.po';
 
 class WorkloadVolumePo extends ComponentPo {
   yamlEditor(): CodeMirrorPo {
@@ -14,5 +16,13 @@ export default class WorkloadPodStoragePo extends ComponentPo {
 
   nthVolumeComponent(n: number) {
     return new WorkloadVolumePo(`[data-testid="volume-component-${ n }"]`);
+  }
+
+  addVolumeButton() : ButtonDropdownPo {
+    return new ButtonDropdownPo('[data-testid="dropdown-button-storage-volume"]');
+  }
+
+  driverInput(): SelectPo {
+    return new SelectPo('[data-testid="workload-storage-driver"]');
   }
 }

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -90,7 +90,7 @@ describe('Cluster Explorer', () => {
         deploymentEditConfigPage.horizontalTabs().clickTabWithSelector('li#pod');
 
         // open the pod storage tab
-        deploymentEditConfigPage.podTabs().clickTabWithSelector('li#storage');
+        deploymentEditConfigPage.podTabs().clickTabWithSelector('li#storage-pod');
 
         // check that there is a component rendered for each workload volume and that that component has rendered some information about the volume
         deploymentEditConfigPage.podStorage().nthVolumeComponent(0).yamlEditor().value()

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -151,6 +151,29 @@ describe('Cluster Explorer', () => {
           expect(response.body.spec.template.spec.containers[0].volumeMounts).to.eq(undefined);
         });
       });
+
+      it('should be able to select Pod CSI storage option', () => {
+        deploymentsCreatePage.goTo();
+        deploymentsCreatePage.waitForPage();
+
+        // open the pod tab
+        deploymentsCreatePage.horizontalTabs().clickTabWithSelector('li#pod');
+
+        // open the pod storage tab
+        deploymentsCreatePage.podTabs().clickTabWithSelector('li#storage-pod');
+
+        deploymentsCreatePage.podStorage().addVolumeButton().toggle();
+        deploymentsCreatePage.podStorage().addVolumeButton().getOptions().should('contain', 'CSI');
+
+        deploymentsCreatePage.podStorage().addVolumeButton().clickOptionWithLabel('CSI');
+
+        // open the driver input
+        deploymentsCreatePage.podStorage().driverInput().toggle();
+        deploymentsCreatePage.podStorage().driverInput().getOptions().should('contain', 'Longhorn');
+
+        // select the Longhorn option from the driver input
+        deploymentsCreatePage.podStorage().driverInput().clickOptionWithLabel('Longhorn');
+      });
     });
 
     describe('List: Deployments', () => {

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6544,7 +6544,7 @@ workload:
           managed: Managed
           shared: Shared
       drivers:
-        driver.longhorn.io: Longhorn
+        driver-longhorn-io: Longhorn
       fsType: Filesystem Type
       shareName: Share Name
       secretName: Secret Name

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -415,7 +415,7 @@ export default {
           >
             <Tab
               :label="t('workload.storage.title')"
-              name="storage"
+              name="storage-pod"
               :weight="tabWeightMap['storage']"
               @active="$refs.storage.refresh()"
             >

--- a/shell/edit/workload/storage/csi/index.vue
+++ b/shell/edit/workload/storage/csi/index.vue
@@ -44,6 +44,33 @@ export default {
 
     ...mapGetters({ t: 'i18n/t' })
   },
+
+  methods: {
+    /**
+    * Retrieves the label for a given option
+    * @param option The option for which to retrieve the label. option can be
+    * either a string or an object. If it is an object, is should have a `label`
+    * property associated with it.
+    */
+    getOptionLabel(option) {
+      if (typeof option === 'string') {
+        return this.getOptionLabelString(option);
+      }
+
+      const { label } = option;
+
+      return this.getOptionLabelString(label);
+    },
+    /**
+    * Translates a given key into a localized string.
+    * @param key The key to be translated.
+    */
+    getOptionLabelString(key) {
+      // Periods are replaced with `-` to prevent conflict with the default key
+      // separator.
+      return this.t(`workload.storage.csi.drivers.'${ key.replaceAll('.', '-') }'`);
+    }
+  }
 };
 </script>
 
@@ -74,7 +101,7 @@ export default {
             :mode="mode"
             :label="t('workload.storage.driver')"
             :options="driverOpts"
-            :get-option-label="opt=>t(`workload.storage.csi.drivers.'${opt}'`)"
+            :get-option-label="getOptionLabel"
             :required="true"
           />
         </div>

--- a/shell/edit/workload/storage/csi/index.vue
+++ b/shell/edit/workload/storage/csi/index.vue
@@ -98,6 +98,7 @@ export default {
         <div class="col span-6">
           <LabeledSelect
             v-model:value="value.csi.driver"
+            data-testid="workload-storage-driver"
             :mode="mode"
             :label="t('workload.storage.driver')"
             :options="driverOpts"

--- a/shell/edit/workload/storage/index.vue
+++ b/shell/edit/workload/storage/index.vue
@@ -301,6 +301,7 @@ export default {
           :button-label="t('workload.storage.addVolume')"
           :dropdown-options="volumeTypeOptions"
           size="sm"
+          data-testid="dropdown-button-storage-volume"
           @click-action="e=>addVolume(e.value)"
         />
       </template>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves an issue with selecting options for Pod Storage: CSI. It appears that there are two different ways that an option can be represented, by either being a string or an object with a label key. It also appears that periods are exclusively used for i18n selectors, so the key for Longhorn has been updated to use `-` instead. 

Fixes #11899 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Create methods for getting CSI option labels
- Replace periods with `-` in keys like `driver.longhorn.io` so that the i18n implementation will properly match a translation.
- Add e2e test for selecting Longhorn CSI Pod storage

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Options for CSI can be either a string or an object; objects contain a label property

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

See associated issue for more instructions.

- Adding CSI storage driver in pod storage
- Editing CSI storage driver in pod storage

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Adding CSI storage driver in pod storage
- Editing CSI storage driver in pod storage

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
