### PR TITLE
fix e2e test following removal of restricted admin role

### DIFF
--- a/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
@@ -41,21 +41,6 @@ describe('Users', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
     userCreate.saveAndWaitForRequests('POST', '/v3/globalrolebindings');
   });
 
-  it('can create Restricted Admin', () => {
-    const restrictedAdminUsername = `${ runPrefix }-restrictedAdmin-user`;
-    const restrictedAdminPassword = 'restrictedAdmin-password';
-
-    usersPo.goTo();
-    usersPo.list().create();
-
-    userCreate.waitForPage();
-    userCreate.username().set(restrictedAdminUsername);
-    userCreate.newPass().set(restrictedAdminPassword);
-    userCreate.confirmNewPass().set(restrictedAdminPassword);
-    userCreate.selectCheckbox('Restricted Administrator').set();
-    userCreate.saveAndWaitForRequests('POST', '/v3/globalrolebindings');
-  });
-
   it('can create User-Base', () => {
     const userBasePassword = 'userBase-password';
 
@@ -122,9 +107,8 @@ describe('Users', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
     const mgmtUserEditPo = new MgmtUserEditPo();
 
     mgmtUserEditPo.globalRoleBindings().globalOptions().then((list) => {
-      expect(list.length).to.eq(4);
+      expect(list.length).to.eq(3);
       expect(list[0]).to.eq('Administrator');
-      expect(list[1]).to.eq('Restricted Administrator');
       expect(list[2]).to.eq('Standard User');
       expect(list[3]).to.eq('User-Base');
     });

--- a/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
@@ -109,8 +109,8 @@ describe('Users', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
     mgmtUserEditPo.globalRoleBindings().globalOptions().then((list) => {
       expect(list.length).to.eq(3);
       expect(list[0]).to.eq('Administrator');
-      expect(list[2]).to.eq('Standard User');
-      expect(list[3]).to.eq('User-Base');
+      expect(list[1]).to.eq('Standard User');
+      expect(list[2]).to.eq('User-Base');
     });
   });
 

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4878,10 +4878,6 @@ rbac:
       admin:
         label: Administrator
         description: Administrators have full control over the entire installation and all resources in all clusters.
-      restricted-admin:
-        label: Restricted Administrator
-        description: Restricted Admins have full control over all resources in all downstream clusters but no access to the local cluster.
-        deprecation: 'Warning: The Restricted Administrator role has been deprecated as of Rancher 2.8.0 and will be removed in a future release - Check out the <a href="{releaseNotesUrl}" target="_blank" rel="noopener noreferrer nofollow">Release Notes</a>'
       user:
         label: Standard User
         description: Standard Users can create new clusters and manage clusters and projects they have been granted access to.


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12689 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix e2e test following removal of restricted admin role

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
