### PR TITLE
Fix editing rke2/k3s clusters in 'pending' state

### DIFF
--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -89,30 +89,6 @@ export default class MgmtCluster extends SteveModel {
     return pools.filter((x) => x.spec?.clusterName === this.id);
   }
 
-  get isImported() {
-    if (this.isLocal) {
-      return false;
-    }
-    // imported rke2 and k3s have status.driver === rke2 and k3s respectively
-    // Provisioned rke2 and k3s have status.driver === imported
-    if (this.status?.provider === 'k3s' || this.status?.provider === 'rke2') {
-      return this.status?.driver === this.status?.provider;
-    }
-
-    // imported KEv2
-    const kontainerConfigs = ['aksConfig', 'eksConfig', 'gkeConfig'];
-
-    const isImportedKontainer = kontainerConfigs.filter((key) => {
-      return this.spec?.[key]?.imported === true;
-    }).length;
-
-    if (isImportedKontainer) {
-      return true;
-    }
-
-    return this.provisioner === 'imported';
-  }
-
   get provisioner() {
     // For imported K3s clusters, this.status.driver is 'k3s.'
     return this.status?.driver ? this.status.driver : 'imported';

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -282,7 +282,29 @@ export default class ProvCluster extends SteveModel {
   }
 
   get isImported() {
-    return this.mgmt?.isImported;
+    if (this.isLocal) {
+      return false;
+    }
+
+    // imported rke2 and k3s have status.driver === rke2 and k3s respectively
+    // Provisioned rke2 and k3s have status.driver === imported
+    if (this.mgmt?.status?.provider === 'k3s' || this.mgmt?.status?.provider === 'rke2') {
+      return this.mgmt?.status?.driver === this.mgmt?.status?.provider;
+    }
+
+    // imported KEv2
+    // we can't rely on this.provisioner to determine imported-ness for these clusters, as it will return 'aks' 'eks' 'gke' for both provisioned and imported clusters
+    const kontainerConfigs = ['aksConfig', 'eksConfig', 'gkeConfig'];
+
+    const isImportedKontainer = kontainerConfigs.filter((key) => {
+      return this.mgmt?.spec?.[key]?.imported === true;
+    }).length;
+
+    if (isImportedKontainer) {
+      return true;
+    }
+
+    return this.provisioner === 'imported';
   }
 
   get isCustom() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12662 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This is a follow on from last PR, which moved `isImported` to the mgmt cluster. I was incorrect in thinking it could be calculated solely from the mgmt cluster spec; `status.driver` and `status.provider` are not available until a cluster finishes provisioning. The provisioning cluster has enough information to determine a cluster is not imported before the mgmt cluster `status.provider` and `status.driver` are available.

### Areas or cases that should be tested
rke2/k3s clusters in 'pending' state 

### Areas which could experience regressions
In addition to the clusters in #12662, we need to verify that the issues with editing local kontainer and local rke1 clusters have not been reintroduced.


### Screenshot/Video

<details>
  <summary>Pending imported kontainer (aks)</summary>

https://github.com/user-attachments/assets/881c4593-62ae-45bf-92af-3c40bcc20011

</details>


<details>
  <summary>Active provisioned kontainer (aks)</summary>

https://github.com/user-attachments/assets/bcb4c067-2a48-462b-a22c-81d304c1d75f

</details>

<details>
  <summary>Pending provisioned kontainer (aks)</summary>

https://github.com/user-attachments/assets/9c3e77d2-b19e-469d-aff6-80e86275c704

</details>

<details>
  <summary>Active imported rke1 </summary>

https://github.com/user-attachments/assets/90209532-91d3-4b20-a3c4-b832daade7b4

</details>

<details>
  <summary>Pending imported rke1</summary>

https://github.com/user-attachments/assets/7ecf6412-b79a-4578-b83d-ac20cdbe6bd2

</details>

<details>
  <summary>Active provisioned rke1 </summary>

https://github.com/user-attachments/assets/27cd030f-6999-4f58-88d2-e63303a80dd1

</details>

<details>
  <summary>Pending provisioned rke1</summary>

https://github.com/user-attachments/assets/c842548d-c3bc-4a88-8fb0-b7e4160b2b35

</details>

<details>
  <summary>Active k3s imported </summary>

https://github.com/user-attachments/assets/97f592be-87c6-4629-a63e-bec3e711e290

</details>

<details>
  <summary>Pending k3s imported</summary>

https://github.com/user-attachments/assets/a478aa83-6906-4b2d-980d-c8942c697292

</details>


<details>
  <summary>Active k3s provisioned</summary>

https://github.com/user-attachments/assets/36c39871-8e2a-430a-b743-3326b5063fca

</details>


<details>
  <summary>Pending k3s provisioned</summary>

https://github.com/user-attachments/assets/8574275a-7ca6-4b72-b372-bec565c19bb0

</details>


<details>
  <summary>Active rke2 provisioned</summary>

https://github.com/user-attachments/assets/d7dc5844-b475-41ef-a46b-59bb60658815

</details>


<details>
  <summary>Pending rke2 provisioned</summary>

https://github.com/user-attachments/assets/42b968ac-7edd-473a-a604-d197fc29e608

</details>


<details>
  <summary>Active rke2 imported</summary>

https://github.com/user-attachments/assets/3e6c70c4-61a3-4c09-b7c6-fdd284fe6007

</details>


<details>
  <summary>Pending rke2 imported</summary>

https://github.com/user-attachments/assets/7141cbc0-c1e4-4472-a7d2-41469c7f2987

</details>



<details>
  <summary>Local k3s</summary>

https://github.com/user-attachments/assets/cc747e41-73cc-481a-93f7-2d0fe6b2dfe9

</details>

<details>
  <summary>Local EKS</summary>

https://github.com/user-attachments/assets/aba999df-9c1a-424d-b4ed-50f4463eaa6d

</details>

<details>
  <summary>Local rke1</summary>

https://github.com/user-attachments/assets/1891b578-cb21-4ffc-a73f-ada74d65705d

</details>


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
