### PR TITLE
test e2e retries

### DIFF
--- a/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
@@ -107,7 +107,7 @@ describe('Users', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
     const mgmtUserEditPo = new MgmtUserEditPo();
 
     mgmtUserEditPo.globalRoleBindings().globalOptions().then((list) => {
-      expect(list.length).to.eq(3);
+      expect(list.length).to.eq(4); // mock error
       expect(list[0]).to.eq('Administrator');
       expect(list[1]).to.eq('Standard User');
       expect(list[2]).to.eq('User-Base');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
test e2e retries
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
