### PR TITLE
fix issue with clone of global role with inheritedClusterRoles

### DIFF
--- a/cypress/e2e/po/lists/role-list.po.ts
+++ b/cypress/e2e/po/lists/role-list.po.ts
@@ -5,6 +5,11 @@ export default class RoleListPo extends BaseResourceList {
     return this.resourceTable().downloadYamlButton().first();
   }
 
+  rowCloneYamlClick(name: string) {
+    return this.resourceTable().sortableTable().rowActionMenuOpen(name).getMenuItem('Clone')
+      .click();
+  }
+
   delete() {
     return this.resourceTable().sortableTable().deleteButton().first();
   }

--- a/shell/models/management.cattle.io.globalrole.js
+++ b/shell/models/management.cattle.io.globalrole.js
@@ -117,6 +117,7 @@ export default class GlobalRole extends SteveDescriptionModel {
       norman.id = this.id;
       norman.name = this.displayName;
       norman.description = this.description;
+      norman.inheritedClusterRoles = this.inheritedClusterRoles;
 
       return norman;
     })();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12146
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix issue with clone of global role with `inheritedClusterRoles`
- add e2e test

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Go to `local` cluster -> header -> and import the YAML on the issue body https://github.com/rancher/dashboard/issues/12146
- Go to `Users & Authentication` -> `Role Templates` -> `Global Role` and find the imported role on the list. Afterwards click on the row action menu `clone` and fill out the `name` field and press save
- check the network request or the YAML for the newly created role from the clone and make sure `inheritedClusterRoles` exists 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
https://github.com/user-attachments/assets/74457e71-4444-47a3-8b4e-11cac3645c51

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
