### PR TITLE
fix issue with display of fleet and cattle agent status on cluster dashboard view with very limited user permissions

### DIFF
--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -188,7 +188,11 @@ export default {
     },
 
     fleetAgentNamespace() {
-      return this.$store.getters['cluster/byId'](NAMESPACE, 'cattle-fleet-system');
+      if (this.currentCluster.isLocal) {
+        return this.$store.getters['cluster/canList'](WORKLOAD_TYPES.DEPLOYMENT) && this.$store.getters['cluster/canList'](WORKLOAD_TYPES.STATEFUL_SET) && this.$store.getters['cluster/byId'](NAMESPACE, 'cattle-fleet-system');
+      }
+
+      return this.$store.getters['cluster/canList'](WORKLOAD_TYPES.STATEFUL_SET) && this.$store.getters['cluster/byId'](NAMESPACE, 'cattle-fleet-system');
     },
 
     cattleAgentNamespace() {
@@ -196,7 +200,7 @@ export default {
         return;
       }
 
-      return this.$store.getters['cluster/byId'](NAMESPACE, 'cattle-system');
+      return this.$store.getters['cluster/canList'](WORKLOAD_TYPES.DEPLOYMENT) && this.$store.getters['cluster/byId'](NAMESPACE, 'cattle-system');
     },
 
     canViewAgents() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12685
<!-- Define findings related to the feature or bug issue. -->

**NOTE:** started with the 2.10 issue repro. Will do a forward port to 2.11

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix issue with display of fleet and cattle agent status on cluster dashboard view with very limited user permissions (as per https://github.com/rancher/dashboard/issues/12680#issuecomment-2506489417)

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- The `View Monitoring` custom role allows for the user to have access to the namespaces that were the condition to display the boxes, but the user didn't have permissions to view `Deployments` and `Statefulsets` which are the resources that hold the status information

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Repro steps as per https://github.com/rancher/dashboard/issues/12680#issuecomment-2506489417

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
