### PR TITLE
Fix: Prevent dropdown width from shrinking in container picker (#12642)

### DIFF
--- a/shell/components/nav/WindowManager/ContainerLogs.vue
+++ b/shell/components/nav/WindowManager/ContainerLogs.vue
@@ -747,9 +747,9 @@ export default {
     :deep() &.unlabeled-select {
       display: inline-block;
       min-width: 200px;
+      max-width: 300px; /* Adjust max width to fit the design */
       height: 30px;
       min-height: 30px;
-      width: initial;
     }
   }
 


### PR DESCRIPTION
### Summary
Fixes #12642
This PR resolves an issue in the log viewer where the width of the container dropdown fluctuates during expand/collapse, causing misalignment with adjacent buttons.

### Occurred changes and/or fixed issues
Modified the .containerPicker CSS class to:
- Set a min-width of 200px and max-width of 300px to stabilize the dropdown width.
- Maintain consistent height (height: 30px) with adjacent buttons.
- Ensured the dropdown no longer resizes or misaligns the buttons when expanded or collapsed

### Technical notes summary
- The CSS update applies only to the containerPicker class within the log viewer context.
- The fix ensures consistent behaviour across all states (expanded, collapsed) of the dropdown.

### Areas or cases that should be tested
1. Deploy a pod with multiple containers
2. Open View Logs: Expand and collapse the dropdown multiple times. Verify that the dropdown width does not fluctuate.
3. Check alignment and responsiveness of buttons next to the dropdown
4. Test in different browsers (e.g., Chrome, Firefox, Safari) - It was tested in Chrome & Safari

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Ensure no regressions in other components using containerPicker

### Screenshots
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
**Before Fix:**
<img width="663" alt="before1" src="https://github.com/user-attachments/assets/329b2fa3-eb1c-46e5-b42f-0e06d621b240">

<img width="576" alt="before2" src="https://github.com/user-attachments/assets/79225d25-fe9a-4c14-bb3d-f9fc7c20219c">

**After Fix:**
<img width="678" alt="Screenshot 2024-12-02 at 5 32 45 PM" src="https://github.com/user-attachments/assets/10ead461-ade2-4f34-a943-e02dcafb8e54">
<img width="672" alt="Screenshot 2024-12-02 at 5 32 55 PM" src="https://github.com/user-attachments/assets/4c144642-e4f7-4a9d-b714-0fb18a00d04b">

**NOTE:** there was a max-width set, this can be changed or based on your design requirement.  Here is what a long container name would look like with the width requirement in place:
<img width="656" alt="Screenshot 2024-12-02 at 5 33 02 PM" src="https://github.com/user-attachments/assets/192c2d1d-f7b1-4515-8950-dbc89dfec83b">
<img width="593" alt="Screenshot 2024-12-02 at 5 33 08 PM" src="https://github.com/user-attachments/assets/d78b4a9b-75f3-4869-bcbe-d52c39b2268d">


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
