### PR TITLE
Remove `onChanges()` method in `ResourceYaml.vue`

### DIFF
--- a/shell/components/ResourceYaml.vue
+++ b/shell/components/ResourceYaml.vue
@@ -205,58 +205,6 @@ export default {
       cm.getMode().fold = saved;
     },
 
-    onChanges(cm, changes) {
-      if ( changes.length !== 1 ) {
-        return;
-      }
-
-      const change = changes[0];
-
-      if ( change.from.line !== change.to.line ) {
-        return;
-      }
-
-      let line = change.from.line;
-      let str = cm.getLine(line);
-      let maxIndent = indentChars(str);
-
-      if ( maxIndent === null ) {
-        return;
-      }
-
-      cm.replaceRange('', { line, ch: 0 }, { line, ch: 1 }, '+input');
-
-      while ( line > 0 ) {
-        line--;
-        str = cm.getLine(line);
-        const indent = indentChars(str);
-
-        if ( indent === null ) {
-          break;
-        }
-
-        if ( indent < maxIndent ) {
-          cm.replaceRange('', { line, ch: 0 }, { line, ch: 1 }, '+input');
-
-          if ( indent === 0 ) {
-            break;
-          }
-
-          maxIndent = indent;
-        }
-      }
-
-      function indentChars(str) {
-        const match = str.match(/^#(\s+)/);
-
-        if ( match ) {
-          return match[1].length;
-        }
-
-        return null;
-      }
-    },
-
     updateValue(value) {
       this.$refs.yamleditor.updateValue(value);
     },
@@ -354,7 +302,6 @@ export default {
       class="yaml-editor flex-content"
       :editor-mode="editorMode"
       @onReady="onReady"
-      @onChanges="onChanges"
     />
     <slot
       name="yamlFooter"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This removes the `onChanges()` method from `ResourceYaml.vue` because the intent of the code is not clear and appears to provide no benefit in testing. This is a source of frustration for some users, making it impossible to add comments to YAML. 

It appears that this function exists to automatically adjust the indentation of comment lines; it has failed to accomplish this task during testing. If users wish to format yaml, we should support this with an explicit action in the YAML editor, not something that is performed on every keypress.

Fixes #11226 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- remove the `onChanges()` method from `ResourceYaml.vue`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- this method doesn't appear to function
- it is the root cause of clobbering user input

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

YAML editors throughout Dashboard: we want to make sure that we can edit, delete, and create lines. Ensure that Copy/Paste works. Make sure that no regressions arise as a result of this change, especially in scenarios related to indenting and comments.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

YAML Editor

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before

https://github.com/user-attachments/assets/7f610754-8a9e-492e-80c9-c9b82d4dc280

#### After

https://github.com/user-attachments/assets/e48c0d28-eb0d-4b11-85f2-837e2dfd2399

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
