### PR TITLE
[FIX] Fixed app icon aligntment for extensions with image icon

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -1122,7 +1122,6 @@ export default {
           &:not(.pin){
             width: 42px;
           }
-
         }
 
         .rancher-provider-icon,

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -1119,9 +1119,10 @@ export default {
           display: block;
           font-size: $icon-size;
           margin-right: 14px;
-          &.group-icon {
+          &:not(.pin){
             width: 42px;
           }
+
         }
 
         .rancher-provider-icon,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12758 
<!-- Define findings related to the feature or bug issue. -->
Changed css to exclude pins instead of specifying which element to apply to include more cases.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Install an extension from https://nwmac.github.io/rancher-dev-portal/
2. All items on app bar (top level menu) should be positioned the same
3. Create a new imported cluster without actually importing it.
4. Pin the new cluster and local cluster. Pin positioning should be the same.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Top level menu application bar

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="309" alt="Screenshot 2024-12-05 at 10 41 06 AM" src="https://github.com/user-attachments/assets/e1438e5f-e7e4-43ab-b187-981a27645895">
<img width="112" alt="Screenshot 2024-12-05 at 10 40 57 AM" src="https://github.com/user-attachments/assets/f531e10f-fcb4-4b9c-a25b-59524838c69c">


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
