### PR TITLE
[backport 2.9.5] unpin chrome version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,14 +91,14 @@ jobs:
 
       # Installing fixed version of Chrome since latest version does not work (128 didn't work)
       # Leaving this here again in case we need to pin to a specific Chrome version in the future
-      - name: Install Chrome 127
-        run: |
-          sudo apt-get install -y wget libu2f-udev
-          cd /tmp
-          wget -q http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_127.0.6533.72-1_amd64.deb
-          sudo dpkg -i google-chrome-stable_127.0.6533.72-1_amd64.deb
-          sudo apt-get install -y --allow-downgrades ./google-chrome-stable_127.0.6533.72-1_amd64.deb
-          google-chrome --version
+      # - name: Install Chrome 127
+      #   run: |
+      #     sudo apt-get install -y wget libu2f-udev
+      #     cd /tmp
+      #     wget -q http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_127.0.6533.72-1_amd64.deb
+      #     sudo dpkg -i google-chrome-stable_127.0.6533.72-1_amd64.deb
+      #     sudo apt-get install -y --allow-downgrades ./google-chrome-stable_127.0.6533.72-1_amd64.deb
+      #     google-chrome --version
 
       - name: Download e2e build
         uses:  actions/download-artifact@v4

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -28,100 +28,6 @@ describe('Home Page', () => {
     cy.get('@settingsReq.all').should('have.length', 1);
   });
 
-  describe('Home Page', { testIsolation: 'off' }, () => {
-    before(() => {
-      cy.login();
-    });
-
-    it('Can navigate to release notes page for latest Rancher version', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
-    /**
-     * Verify changelog banner is hidden after clicking link
-     * Verify release notes link is valid github page
-     * Verify correct Rancher version is displayed
-     */
-      HomePagePo.navTo();
-      homePage.waitForPage();
-      homePage.restoreAndWait();
-
-      cy.getRancherResource('v1', 'management.cattle.io.settings', 'server-version').then((resp: Cypress.Response<any>) => {
-        const rancherVersion = resp.body['value'].split('-', 1)[0].slice(1);
-
-        homePage.changelog().self().contains('Learn more about the improvements and new capabilities in this version.');
-        homePage.whatsNewBannerLink().contains(`What's new in ${ rancherVersion }`);
-
-        homePage.whatsNewBannerLink().invoke('attr', 'href').then((releaseNotesUrl) => {
-          cy.request(releaseNotesUrl).then((res) => {
-            expect(res.status).equals(200);
-          });
-        });
-
-        homePage.whatsNewBannerLink().click();
-        homePage.changelog().self().should('not.exist');
-      });
-    });
-
-    it('Can navigate to Preferences page', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
-    /**
-     * Click link and verify user lands on preferences page
-     */
-
-      HomePagePo.navTo();
-      homePage.waitForPage();
-      const prefPage = new PreferencesPagePo();
-
-      homePage.prefPageLink().click();
-      prefPage.waitForPage();
-      prefPage.checkIsCurrentPage();
-      prefPage.title();
-    });
-
-    it('Can restore hidden cards', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
-    /**
-     * Hide home page banners
-     * Click the restore link
-     * Verify banners display on home page
-     */
-      HomePagePo.navTo();
-      homePage.waitForPage();
-      homePage.restoreAndWait();
-
-      homePage.bannerGraphic().graphicBanner().should('be.visible');
-      homePage.bannerGraphic().graphicBannerCloseButton();
-      homePage.bannerGraphic().graphicBanner().should('not.exist');
-
-      homePage.getLoginPageBanner().checkVisible();
-      homePage.getLoginPageBanner().closeButton();
-      homePage.getLoginPageBanner().checkNotExists();
-
-      homePage.restoreAndWait();
-
-      homePage.bannerGraphic().graphicBanner().should('be.visible');
-      homePage.getLoginPageBanner().checkVisible();
-    });
-
-    it('Can use the Manage, Import Existing, and Create buttons', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
-    /**
-     * Click 'Manage' button and verify user lands on the Cluster Management page
-     * Click on the Import Existing button and verify user lands on the cluster creation page in import mode
-     * Click on the Create button and verify user lands on the cluster creation page
-     */
-      const clusterManagerPage = new ClusterManagerListPagePo('_');
-      const genericCreateClusterPage = new ClusterManagerImportGenericPagePo('_');
-
-      HomePagePo.navTo();
-      homePage.manageButton().click();
-      clusterManagerPage.waitForPage();
-
-      HomePagePo.goToAndWaitForGet();
-      homePage.importExistingButton().click();
-      genericCreateClusterPage.waitForPage('mode=import');
-
-      HomePagePo.goToAndWaitForGet();
-      homePage.createButton().click();
-      genericCreateClusterPage.waitForPage();
-    });
-  });
-
   describe('List', { testIsolation: 'off' }, () => {
     before(() => {
       cy.login();
@@ -301,6 +207,102 @@ describe('Home Page', () => {
       homePage.clickSupportLink(5);
 
       cy.url().should('include', '/support');
+    });
+  });
+
+  describe('Home Page', { testIsolation: 'off' }, () => {
+    before(() => {
+      cy.login();
+    });
+
+    it('Can navigate to Preferences page', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+    /**
+     * Click link and verify user lands on preferences page
+     */
+
+      HomePagePo.navTo();
+      homePage.waitForPage();
+      const prefPage = new PreferencesPagePo();
+
+      homePage.prefPageLink().click();
+      prefPage.waitForPage();
+      prefPage.checkIsCurrentPage();
+      prefPage.title();
+    });
+
+    it('Can restore hidden cards', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+    /**
+     * Hide home page banners
+     * Click the restore link
+     * Verify banners display on home page
+     */
+      HomePagePo.navTo();
+      homePage.waitForPage();
+      homePage.restoreAndWait();
+
+      homePage.bannerGraphic().graphicBanner().should('be.visible');
+      homePage.bannerGraphic().graphicBannerCloseButton();
+      homePage.bannerGraphic().graphicBanner().should('not.exist');
+
+      homePage.getLoginPageBanner().checkVisible();
+      homePage.getLoginPageBanner().closeButton();
+      homePage.getLoginPageBanner().checkNotExists();
+
+      homePage.restoreAndWait();
+
+      homePage.bannerGraphic().graphicBanner().should('be.visible');
+      homePage.getLoginPageBanner().checkVisible();
+    });
+
+    it('Can use the Manage, Import Existing, and Create buttons', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+    /**
+     * Click 'Manage' button and verify user lands on the Cluster Management page
+     * Click on the Import Existing button and verify user lands on the cluster creation page in import mode
+     * Click on the Create button and verify user lands on the cluster creation page
+     */
+      const clusterManagerPage = new ClusterManagerListPagePo('_');
+      const genericCreateClusterPage = new ClusterManagerImportGenericPagePo('_');
+
+      HomePagePo.navTo();
+      homePage.manageButton().click();
+      clusterManagerPage.waitForPage();
+
+      HomePagePo.goToAndWaitForGet();
+      homePage.importExistingButton().click();
+      genericCreateClusterPage.waitForPage('mode=import');
+
+      HomePagePo.goToAndWaitForGet();
+      homePage.createButton().click();
+      genericCreateClusterPage.waitForPage();
+    });
+
+    // Note: This must be the last test to run in this test suite.
+    // When the test clicks on a link that opens a new tab it causes failures in tests that run after it.
+    it('Can navigate to release notes page for latest Rancher version', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+      /**
+       * Verify changelog banner is hidden after clicking link
+       * Verify release notes link is valid github page
+       * Verify correct Rancher version is displayed
+       */
+      HomePagePo.navTo();
+      homePage.waitForPage();
+      homePage.restoreAndWait();
+
+      cy.getRancherResource('v1', 'management.cattle.io.settings', 'server-version').then((resp: Cypress.Response<any>) => {
+        const rancherVersion = resp.body['value'].split('-', 1)[0].slice(1);
+
+        homePage.changelog().self().contains('Learn more about the improvements and new capabilities in this version.');
+        homePage.whatsNewBannerLink().contains(`What's new in ${ rancherVersion }`);
+
+        homePage.whatsNewBannerLink().invoke('attr', 'href').then((releaseNotesUrl) => {
+          cy.request(releaseNotesUrl).then((res) => {
+            expect(res.status).equals(200);
+          });
+        });
+
+        homePage.whatsNewBannerLink().click();
+        homePage.changelog().self().should('not.exist');
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/dashboard/issues/11836

- Unpinned Chrome version
- Moved Can navigate to release notes page for latest Rancher version to run last; The test clicks on a link that opens a new tab which is causing issues with subsequent tests (once we are able to upgrade our Cypress version, test order will not matter).

<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
