### PR TITLE
[FEAT] Added grouping my namespace to CAPI.MACHINE_SET and CAPI.MACHINE_DEPLOYMENT

### DIFF
--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -9,6 +9,7 @@ import {
   NORMAN,
   SNAPSHOT,
   VIRTUAL_TYPES,
+  CAPI
 } from '@shell/config/types';
 
 import {
@@ -194,6 +195,34 @@ export function init(store) {
         hideColumn:    NODE_COL.name,
         groupLabelKey: 'groupByNode',
         tooltipKey:    'resourceTable.groupBy.node'
+      }
+    ],
+    listGroupsWillOverride: true,
+  });
+  configureType(CAPI.MACHINE_SET, {
+    listGroups: [
+      ...STEVE_LIST_GROUPS,
+      {
+        icon:          'icon-cluster',
+        value:         'cluster',
+        field:         'groupByCluster',
+        tooltipKey:    'resourceTable.groupBy.cluster',
+        groupLabelKey: 'groupByCluster',
+        hideColumn:    'cluster',
+      }
+    ],
+    listGroupsWillOverride: true,
+  });
+  configureType(CAPI.MACHINE_DEPLOYMENT, {
+    listGroups: [
+      ...STEVE_LIST_GROUPS,
+      {
+        icon:          'icon-cluster',
+        value:         'cluster',
+        field:         'groupByCluster',
+        tooltipKey:    'resourceTable.groupBy.cluster',
+        groupLabelKey: 'groupByCluster',
+        hideColumn:    'cluster',
       }
     ],
     listGroupsWillOverride: true,

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -1,4 +1,4 @@
-import { AGE, NAME as NAME_COL, STATE } from '@shell/config/table-headers';
+import { AGE, NAME as NAME_COL, NAMESPACE, STATE } from '@shell/config/table-headers';
 import {
   CAPI,
   CATALOG,
@@ -211,6 +211,7 @@ export function init(store) {
   headers(CAPI.MACHINE_DEPLOYMENT, [
     STATE,
     NAME_COL,
+    NAMESPACE,
     MACHINE_SUMMARY,
     AGE
   ]);

--- a/shell/models/cluster.x-k8s.io.machinedeployment.js
+++ b/shell/models/cluster.x-k8s.io.machinedeployment.js
@@ -22,7 +22,7 @@ export default class CapiMachineDeployment extends SteveModel {
     return cluster;
   }
 
-  get groupByLabel() {
+  get groupByCluster() {
     const name = this.cluster?.nameDisplay || this.spec.clusterName;
 
     return this.$rootGetters['i18n/t']('resourceTable.groupLabel.cluster', { name: escapeHtml(name) });

--- a/shell/models/cluster.x-k8s.io.machineset.js
+++ b/shell/models/cluster.x-k8s.io.machineset.js
@@ -15,7 +15,7 @@ export default class CapiMachineSet extends SteveModel {
     return cluster;
   }
 
-  get groupByLabel() {
+  get groupByCluster() {
     const name = this.cluster?.nameDisplay || this.spec.clusterName;
 
     return this.$rootGetters['i18n/t']('resourceTable.groupLabel.cluster', { name: escapeHtml(name) });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12844
This change was requested for CAPI, but cluster.x-k8s.io.machinedeployment and cluster.x-k8s.io.machineset are used in both Dashboard and CAPI  UI and it is better to fix it here for consistency between two.

<!-- Define findings related to the feature or bug issue. -->
- Added grouping by namespace to CAPI.MACHINE_DEPLOYMENT and CAPI.MACHINE_SET
- Added a Namespace column to CAPI.MACHINE_DEPLOYMENT

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Fixed grouping by cluster being called "Group by Namespace"

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Go to Cluster management -> Advanced -> MachineDeployments
- Namespace column should be present
- Grouping  buttons should have three options: Flat list, Group by Namespace, Group by Cluster
- Switching between them should change the grouping list accordingly.

Go to Cluster management -> Advanced -> MachineSets and repeat
To test you need to create resources in different namespaces and associated with different clusters.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Cluster detail page and provisioning may be impacted because CAPI.MACHINE_DEPLOYMENT is referenced there

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1458" alt="Screenshot 2024-12-09 at 1 46 47 PM" src="https://github.com/user-attachments/assets/9c06db39-5ba0-4dd4-b8f0-7a16d98a6d22">
<img width="1457" alt="Screenshot 2024-12-09 at 1 46 42 PM" src="https://github.com/user-attachments/assets/6ba2b022-7dc4-4fe5-b481-b7bcf38ec5e7">
<img width="1457" alt="Screenshot 2024-12-09 at 1 46 32 PM" src="https://github.com/user-attachments/assets/5d62563f-4213-4097-ab0b-93c96614ea75">
<img width="1455" alt="Screenshot 2024-12-09 at 1 46 26 PM" src="https://github.com/user-attachments/assets/33ec9d2e-c0c7-4497-84b8-33336cf8ec77">
<img width="1451" alt="Screenshot 2024-12-09 at 1 46 19 PM" src="https://github.com/user-attachments/assets/139972fd-96e8-4c98-acb1-344525c40ac5">

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
