### PR TITLE
Fix AKS nodegroup upgrade validation

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -160,7 +160,7 @@ export default defineComponent({
       }
 
       // track original version on edit to ensure we don't offer k8s downgrades
-      const kubernetesVersion = semver.coerce(this.normanCluster?.aksConfig?.kubernetesVersion);
+      const kubernetesVersion = semver.coerce(this.normanCluster?.aksConfig?.kubernetesVersion)?.version;
 
       this.originalVersion = kubernetesVersion;
     } else {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12862
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
This is a follow on from https://github.com/rancher/dashboard/pull/12532 We started using `semver.coerce` on the AKS cluster version because it may not specify a patch version (eg if provisioned outside rancher, `"1.30"` would be a valid cluster k8s version). Consequently the `originalVersion` prop went from being a string to a semver object. This appears to be _mostly_ fine, as we are mostly using semver to compare versions and semver doesn't care; however, [in nodegroups](https://github.com/rancher/dashboard/blob/master/pkg/aks/components/AksNodePool.vue#L126) we are merely checking if versions are equal and use a simple equality comparison.

I think the simplest fix is to make sure that `originalVersion` is a string again. I verified that this change wont re-introduce https://github.com/rancher/dashboard/issues/12525 by double-checking that `semver.coerce("1.30").version === "1.30.0"`

### Areas or cases that should be tested
1. Create a new AKS cluster with some version less than the latest available version
2. wait for provisioning to complete
3. edit the cluster and select a new kubernetes version. Check for version comparison regressions:
    - the cluster version dropdown should not list any versions older than your current version
    - when a new cluster version is selected an info box should appear in node group tabs
4. Edit the cluster again, and verify a couple things:
   - node groups now have a checkbox to upgrade their version
   - if a new cluster version is selected(again), node groups no longer have the upgrade option and show a checkbox instead
5. Keep the cluster version unchanged, and select the node group upgrade checkbox, save the cluster
6. Edit the cluster again and verify that the nodegroup now has the same version as the cluster.

### Areas which could experience regressions
anything to do with version comparison in the aks form - I believe I've covered all cases in the above section.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
