### PR TITLE
[2.10.1]Fix AKS nodegroup upgrade validation

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -160,7 +160,7 @@ export default defineComponent({
       }
 
       // track original version on edit to ensure we don't offer k8s downgrades
-      const kubernetesVersion = semver.coerce(this.normanCluster?.aksConfig?.kubernetesVersion);
+      const kubernetesVersion = semver.coerce(this.normanCluster?.aksConfig?.kubernetesVersion)?.version;
 
       this.originalVersion = kubernetesVersion;
     } else {


### PR DESCRIPTION
Fixes #12861 

Backport of https://github.com/rancher/dashboard/pull/12865