### PR TITLE
[2.9.5] Fix AKS nodegroup upgrade validation

### DIFF
--- a/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
@@ -179,6 +179,7 @@ describe('Apps', () => {
         // Note we're intercepting a more precise url here to avoid any icon requests made from the charts list
         cy.intercept('GET', '/v1/catalog.cattle.io.clusterrepos/rancher-charts?link=info&chartName=rancher-backup&version=*', cy.spy().as('rancherCharts2'));
         ChartPage.navTo(clusterId, 'Rancher Backups');
+        cy.wait(1000);// eslint-disable-line cypress/no-unnecessary-waiting
         chartPage.waitForPage('repo-type=cluster&repo=rancher-charts&chart=rancher-backup');
         // The specific version of the chart (and any other) should NOT be fetched
         cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -156,7 +156,7 @@ export default defineComponent({
       }
 
       // track original version on edit to ensure we don't offer k8s downgrades
-      const kubernetesVersion = semver.coerce(this.normanCluster?.aksConfig?.kubernetesVersion);
+      const kubernetesVersion = semver.coerce(this.normanCluster?.aksConfig?.kubernetesVersion)?.version;
 
       this.originalVersion = kubernetesVersion;
     } else {


### PR DESCRIPTION
Fixes #12860 

Backport of https://github.com/rancher/dashboard/pull/12865