### PR TITLE
[FIX] Fixed drain worker form being uneditable

### DIFF
--- a/shell/dialog/DrainNode.vue
+++ b/shell/dialog/DrainNode.vue
@@ -146,7 +146,7 @@ export default {
       <div class="pl-10 pr-10">
         <div>
           <RadioGroup
-            v-model="body.deleteLocalData"
+            v-model:value="body.deleteLocalData"
             name="deleteLocalData"
             :options="radioOptions"
             :row="true"
@@ -157,7 +157,7 @@ export default {
             </template>
           </RadioGroup>
           <RadioGroup
-            v-model="body.force"
+            v-model:value="body.force"
             name="force"
             :options="radioOptions"
             :row="true"
@@ -168,7 +168,7 @@ export default {
             </template>
           </RadioGroup>
           <RadioGroup
-            v-model="gracePeriod"
+            v-model:value="gracePeriod"
             name="gracePeriod"
             :options="gracePeriodOptions"
             class="mb-15"
@@ -178,7 +178,7 @@ export default {
             </template>
           </RadioGroup>
           <UnitInput
-            v-model="body.gracePeriod"
+            v-model:value="body.gracePeriod"
             :mode="gracePeriod ? EDIT : VIEW"
             type="number"
             min="1"
@@ -187,7 +187,7 @@ export default {
             class="mb-10"
           />
           <RadioGroup
-            v-model="timeout"
+            v-model:value="timeout"
             name="timeout"
             :options="timeoutOptions"
             class="mb-15"
@@ -197,7 +197,7 @@ export default {
             </template>
           </RadioGroup>
           <UnitInput
-            v-model="body.timeout"
+            v-model:value="body.timeout"
             :mode="timeout ? EDIT : VIEW"
             type="number"
             min="1"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12632 
<!-- Define findings related to the feature or bug issue. -->
DrainNode dialog didn't get updated correctly as part of Vue 3 migration

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Nodes -> Drain dialog. 
Input elements should be editable. 
After saving, request should contain correct data that matches edited configuration

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
N/A

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/cc0938b4-02fc-4968-8cfb-08d97745d550



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
