### PR TITLE
fix eks sshkey dropdown and add unit test

### DIFF
--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -557,15 +557,14 @@ export default defineComponent({
 
         const keyPairRes: {KeyPairs: {KeyName: string}[]} = await ec2Client.describeKeyPairs({ DryRun: false });
 
-        this['sshKeyPairs'] = (keyPairRes.KeyPairs || [].map((key) => {
+        this.sshKeyPairs = (keyPairRes.KeyPairs || []).map((key) => {
           return key.KeyName;
-        }).sort());
+        }).sort();
       } catch (err: any) {
         const errors = this.errors as any[];
 
         errors.push(err);
       }
-
       this.loadingSshKeyPairs = false;
     },
   }

--- a/pkg/eks/components/__mocks__/describeKeyPairs.js
+++ b/pkg/eks/components/__mocks__/describeKeyPairs.js
@@ -1,0 +1,31 @@
+export default {
+  KeyPairs: [
+    {
+      CreateTime: 'Date Mon Jul 24 2023 14:53:22 GMT-0700 (Pacific Daylight Time)',
+
+      KeyFingerprint: 'a1:b2:c3:12345678987654321',
+
+      KeyName: 'test-key1',
+
+      KeyPairId: 'key-123456789',
+
+      KeyType: 'rsa',
+
+      Tags: []
+    },
+
+    {
+      CreateTime: 'Date Mon Jul 24 2023 14:53:22 GMT-0700 (Pacific Daylight Time)',
+
+      KeyFingerprint: 'a1:b2:c3:12345678987654321',
+
+      KeyName: 'test-key2',
+
+      KeyPairId: 'key-123456789',
+
+      KeyType: 'rsa',
+
+      Tags: []
+    }
+  ]
+};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12877 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR fixes the formatting of ssh keys in EKS node groups. Going off git history it looks like this bug was caused by the vue3 migration script mishandling a `$set` conversion.



### Areas or cases that should be tested
1. Navigate to the EKS cluster creation form
2. verify that (when a credential has been selected and the form loaded) the node group ssh key dropdown contains a list of names, not objects
3. select an ssh key and save the cluster, while watching network requests
4. verify that the POST request includes the sshkey name you selected under `nodeGroups[0].ec2SshKey`
5. edit the cluster and verify that the key you selected is still shown in the ssh key dropdown, and formatted correctly

### Areas which could experience regressions
This code change should only impact the ssh key dropdown described above.

### Screenshot/Video
![Screenshot 2024-12-12 at 9 30 01 AM](https://github.com/user-attachments/assets/09bbefdf-ce73-43ec-8a88-990fe57fd6db)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
