### PR TITLE
Resolving some issues around rendering pagination loading on resource list pages

### DIFF
--- a/shell/components/PaginatedResourceTable.vue
+++ b/shell/components/PaginatedResourceTable.vue
@@ -109,7 +109,7 @@ export default defineComponent({
       v-bind="$attrs"
       :schema="schema"
       :rows="rows"
-      :alt-loading="canPaginate"
+      :alt-loading="canPaginate && !isFirstLoad"
       :loading="loading"
       :groupable="groupable"
 

--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -271,7 +271,7 @@ export default {
       v-else
       :schema="schema"
       :rows="rows"
-      :alt-loading="canPaginate"
+      :alt-loading="canPaginate && !isFirstLoad"
       :loading="loading"
       :headers="headers"
       :group-by="groupBy"

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -428,10 +428,7 @@ export default {
         background-color: var(--sortable-table-header-bg);
         color: var(--body-text);
         text-align: left;
-
-        &:not(.loading) {
-          border-bottom: 1px solid var(--sortable-table-top-divider);
-        }
+        border-bottom: 1px solid var(--sortable-table-top-divider);
       }
     }
 

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -380,8 +380,10 @@ export default {
       eventualSearchQuery = this.$route.query?.q;
     }
 
+    const isLoading = this.loading || false;
+
     return {
-      refreshButtonPhase:         ASYNC_BUTTON_STATES.WAITING,
+      refreshButtonPhase:         isLoading ? ASYNC_BUTTON_STATES.WAITING : ASYNC_BUTTON_STATES.ACTION,
       expanded:                   {},
       searchQuery,
       eventualSearchQuery,
@@ -392,7 +394,7 @@ export default {
       /**
        * The is the bool the DOM uses to show loading state. it's proxied from `loading` to avoid blipping the indicator (see usages)
        */
-      isLoading:                  false,
+      isLoading
     };
   },
 
@@ -535,9 +537,6 @@ export default {
 
     manualRefreshLoadingFinished() {
       const res = !!(!this.isLoading && this._didinit && this.rows?.length && !this.isManualRefreshLoading);
-
-      // Always ensure the Refresh button phase aligns with loading state (regardless of if manualRefreshLoadingFinished has changed or not)
-      this.refreshButtonPhase = !res || this.loading ? ASYNC_BUTTON_STATES.WAITING : ASYNC_BUTTON_STATES.ACTION;
 
       return res;
     },

--- a/shell/mixins/resource-fetch.js
+++ b/shell/mixins/resource-fetch.js
@@ -52,6 +52,7 @@ export default {
       incremental:                false,
       fetchedResourceType:        [],
       paginating:                 null,
+      isFirstLoad:                true,
     };
   },
 
@@ -110,7 +111,7 @@ export default {
 
     loading() {
       if (this.canPaginate) {
-        return this.paginating;
+        return this.paginating === null ? true : this.paginating;
       }
 
       return this.rows.length ? false : this.$fetchState.pending;
@@ -127,6 +128,12 @@ export default {
             canPaginate: this.canPaginate, force: true, page: this.rows, pagResult: this.paginationResult
           });
         }
+      }
+    },
+
+    loading(newValue, oldValue) {
+      if (oldValue && !newValue) {
+        this.isFirstLoad = false;
       }
     }
   },


### PR DESCRIPTION
### Summary
It wasn't readily apparent what the expected behavior was around things like alt-loading and the manual refresh so I did what made sense to me. See the video to see if it's what we want or if adjustments need to be made.

fixes https://github.com/rancher/dashboard/issues/12748

### Occurred changes and/or fixed issues
We no longer flicker the no-rows messaging when first loading one of the server-side pagination pages.

### Areas or cases that should be tested
SSP and non-SSP resource list pages.

I think that this should be manually tested, it seems a little difficult to test given the nature of network latency and debouncing we have.


### Screenshot/Video
The behavior seen in this video has changed some since the latest rebase. https://github.com/rancher/dashboard/pull/12884/files#diff-16199a1483a9651b7f40bfcb61ed890469ea35d889aee82b0f50b95d2ed2057eR506-R510 Causes the refresh button to no longer trigger the altLoading overlay/opacity. This appears to be intended but maybe we'll want to update it because the lack of feedback makes me think nothing is happening.


https://github.com/user-attachments/assets/ccaef498-ed43-4b8e-bfb4-82c8953d417c


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
