### PR TITLE
Fix Unable to add extension tab to Edit Storage Class page

### DIFF
--- a/pkg/harvester-manager/index.ts
+++ b/pkg/harvester-manager/index.ts
@@ -1,5 +1,5 @@
 import { importTypes } from '@rancher/auto-import';
-import { IPlugin, TabLocation } from '@shell/core/types';
+import { IPlugin } from '@shell/core/types';
 
 // Init the package
 export default function(plugin: IPlugin) {
@@ -13,18 +13,4 @@ export default function(plugin: IPlugin) {
   plugin.metadata.icon = require('./icon.svg');
 
   plugin.addProduct(require('./config/harvester-manager'));
-
-  plugin.addTab(
-    TabLocation.RESOURCE_DETAIL,
-    { resource: ['persistentvolumeclaim', 'storage.k8s.io.storageclass', 'configmap'] },
-    {
-      name:       'some-name',
-      labelKey:   'generic.comingSoon',
-      label:      'some-label',
-      weight:     -5,
-      showHeader: true,
-      tooltip:    'this is a tooltip message',
-      component:  () => import('./../../shell/components/BackLink.vue')
-    }
-  );
 }

--- a/pkg/harvester-manager/index.ts
+++ b/pkg/harvester-manager/index.ts
@@ -1,5 +1,5 @@
 import { importTypes } from '@rancher/auto-import';
-import { IPlugin } from '@shell/core/types';
+import { IPlugin, TabLocation } from '@shell/core/types';
 
 // Init the package
 export default function(plugin: IPlugin) {
@@ -13,4 +13,18 @@ export default function(plugin: IPlugin) {
   plugin.metadata.icon = require('./icon.svg');
 
   plugin.addProduct(require('./config/harvester-manager'));
+
+  plugin.addTab(
+    TabLocation.RESOURCE_DETAIL,
+    { resource: ['persistentvolumeclaim', 'storage.k8s.io.storageclass', 'configmap'] },
+    {
+      name:       'some-name',
+      labelKey:   'generic.comingSoon',
+      label:      'some-label',
+      weight:     -5,
+      showHeader: true,
+      tooltip:    'this is a tooltip message',
+      component:  () => import('./../../shell/components/BackLink.vue')
+    }
+  );
 }

--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -4,9 +4,14 @@ import isEmpty from 'lodash/isEmpty';
 import { addObject, removeObject, findBy } from '@shell/utils/array';
 import { sortBy } from '@shell/utils/sort';
 import findIndex from 'lodash/findIndex';
+import { ExtensionPoint, TabLocation } from '@shell/core/types';
+import { getApplicableExtensionEnhancements } from '@shell/core/plugin-helpers';
+import Tab from '@shell/components/Tabbed/Tab';
 
 export default {
   name: 'Tabbed',
+
+  components: { Tab },
 
   emits: ['changed', 'addTab', 'removeTab'],
 
@@ -82,9 +87,19 @@ export default {
   },
 
   data() {
+    const extensionTabs = getApplicableExtensionEnhancements(this, ExtensionPoint.TAB, TabLocation.RESOURCE_DETAIL, this.$route, this, this.extensionParams) || [];
+
+    const parsedExtTabs = extensionTabs.map((item) => {
+      return {
+        ...item,
+        active: false
+      };
+    });
+
     return {
-      tabs:          [],
-      activeTabName: null,
+      tabs:          [...parsedExtTabs],
+      extensionTabs: parsedExtTabs,
+      activeTabName: null
     };
   },
 
@@ -320,6 +335,24 @@ export default {
       }"
     >
       <slot />
+      <!-- Extension tabs -->
+      <Tab
+        v-for="tab, i in extensionTabs"
+        :key="`${tab.name}${i}`"
+        :name="tab.name"
+        :label="tab.label"
+        :label-key="tab.labelKey"
+        :weight="tab.weight"
+        :tooltip="tab.tooltip"
+        :show-header="tab.showHeader"
+        :display-alert-icon="tab.displayAlertIcon"
+        :error="tab.error"
+        :badge="tab.badge"
+      >
+        <component
+          :is="tab.component"
+        />
+      </Tab>
     </div>
   </div>
 </template>

--- a/shell/components/form/ResourceTabs/index.vue
+++ b/shell/components/form/ResourceTabs/index.vue
@@ -11,8 +11,6 @@ import { EVENT } from '@shell/config/types';
 import SortableTable from '@shell/components/SortableTable';
 import { _VIEW } from '@shell/config/query-params';
 import RelatedResources from '@shell/components/RelatedResources';
-import { ExtensionPoint, TabLocation } from '@shell/core/types';
-import { getApplicableExtensionEnhancements } from '@shell/core/plugin-helpers';
 import { isConditionReadyAndWaiting } from '@shell/plugins/dashboard-store/resource-class';
 
 export default {
@@ -77,7 +75,6 @@ export default {
       allEvents:      [],
       selectedTab:    this.defaultTab,
       didLoadEvents:  false,
-      extensionTabs:  getApplicableExtensionEnhancements(this, ExtensionPoint.TAB, TabLocation.RESOURCE_DETAIL, this.$route, this, this.extensionParams),
       inStore,
       showConditions: false,
     };
@@ -244,26 +241,6 @@ export default {
         :ignore-types="[value.type]"
         :value="value"
         direction="to"
-      />
-    </Tab>
-
-    <!-- Extension tabs -->
-    <Tab
-      v-for="tab, i in extensionTabs"
-      :key="`${tab.name}${i}`"
-      :name="tab.name"
-      :label="tab.label"
-      :label-key="tab.labelKey"
-      :weight="tab.weight"
-      :tooltip="tab.tooltip"
-      :show-header="tab.showHeader"
-      :display-alert-icon="tab.displayAlertIcon"
-      :error="tab.error"
-      :badge="tab.badge"
-    >
-      <component
-        :is="tab.component"
-        :resource="value"
       />
     </Tab>
   </Tabbed>

--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import { RouteRecordRaw } from 'vue-router';
 import { DSL as STORE_DSL } from '@shell/store/type-map';
+import { _DETAIL } from '@shell/config/query-params';
 import {
   CoreStoreInit,
   Action,
@@ -11,7 +12,7 @@ import {
   IPlugin,
   LocationConfig,
   ExtensionPoint,
-
+  TabLocation,
   PluginRouteRecordRaw, RegisterStore, UnregisterStore, CoreStoreSpecifics, CoreStoreConfig, OnNavToPackage, OnNavAwayFromPackage, OnLogOut
 } from './types';
 import coreStore, { coreStoreModule, coreStoreState } from '@shell/plugins/dashboard-store';
@@ -162,6 +163,12 @@ export class Plugin implements IPlugin {
    * Adds a tab to the UI
    */
   addTab(where: string, when: LocationConfig | string, tab: Tab): void {
+    // tackling https://github.com/rancher/dashboard/issues/11122, we don't want the tab to added in _EDIT view, unless overriden
+    // on extensions side we won't document the mode param for this extension point
+    if (where === TabLocation.RESOURCE_DETAIL && (typeof when === 'object' && !when.mode)) {
+      when.mode = [_DETAIL];
+    }
+
     this._addUIConfig(ExtensionPoint.TAB, where, when, this._createAsyncComponent(tab));
   }
 


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11122 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Improve extension point for `tabs` to allow more use cases (also implement a "default" for locationConfig IF there's no `mode` specified)

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Add the following code to https://github.com/rancher/dashboard/blob/master/pkg/harvester-manager/index.ts:
```
plugin.addTab(
    TabLocation.RESOURCE_DETAIL,
    { resource: ['persistentvolumeclaim', 'storage.k8s.io.storageclass', 'configmap'] },
    {
      name:       'some-name',
      labelKey:   'generic.comingSoon',
      label:      'some-label',
      weight:     -5,
      showHeader: true,
      tooltip:    'this is a tooltip message',
      component:  () => import('./../../shell/components/BackLink.vue')
    }
  );
```
- Check that tabs are added ONLY in `detail` view mode and that it cover the scenario specified on the issue
- Check other general uses of the TAB extension point and make sure it works

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
