### PR TITLE
Update typescript configs for better in-editor support

### DIFF
--- a/docusaurus/docs/extensions/changelog.md
+++ b/docusaurus/docs/extensions/changelog.md
@@ -8,6 +8,7 @@
 
 | Date | Version | Description |
 |---|---|---|
+| TBD | [**3.1.0**](https://github.com/rancher/dashboard/releases) | [BREAKING] Bump TypeScript from 4.5.5 to 5.6.3: Extension developers need to bump TypeScript to version 5.6.3 in their projects. |
 | 01&#160;November&#160;2024 | [**2.0.2**](https://github.com/rancher/dashboard/releases/tag/shell-pkg-v2.0.2) | Remove upper limit on kube version for default annotations on extensions. Update creators package. Minor bug fixes |
 | 09&#160;July&#160;2024 | 1.2.3 | Minor bug fixes |
 | 09&#160;July&#160;2024 | [**2.0.1**](https://github.com/rancher/dashboard/releases/tag/shell-pkg-v2.0.1) | Minor bug fixes |

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "start-server-and-test": "1.13.1",
     "style-loader": "3.3.2",
     "ts-jest": "27.1.4",
-    "typescript": "4.5.5",
+    "typescript": "5.6.3",
     "vue": "3.2.47",
     "webpack-bundle-analyzer": "4.5.0",
     "webpack-virtual-modules": "0.4.3",

--- a/pkg/aks/tsconfig.json
+++ b/pkg/aks/tsconfig.json
@@ -46,7 +46,8 @@
     "**/*.ts",
     "**/*.d.ts",
     "**/*.tsx",
-    "**/*.vue"
+    "**/*.vue",
+    "../../shell/types/vue-shim.d.ts"
   ],
   "exclude": [
     "../../node_modules"

--- a/pkg/aks/tsconfig.json
+++ b/pkg/aks/tsconfig.json
@@ -38,7 +38,10 @@
         "../../shell/*"
       ],
       "@components/*": [
-        "@rancher/components/*"
+        "../../pkg/rancher-components/src/components/*"
+      ],
+      "@pkg/*": [
+        "../../pkg/*"
       ]
     }
   },

--- a/pkg/eks/tsconfig.json
+++ b/pkg/eks/tsconfig.json
@@ -46,7 +46,8 @@
     "**/*.ts",
     "**/*.d.ts",
     "**/*.tsx",
-    "**/*.vue"
+    "**/*.vue",
+    "../../shell/types/vue-shim.d.ts"
   ],
   "exclude": [
     "../../node_modules"

--- a/pkg/eks/tsconfig.json
+++ b/pkg/eks/tsconfig.json
@@ -38,7 +38,7 @@
         "../../shell/*"
       ],
       "@components/*": [
-        "@rancher/components/*"
+        "../../pkg/rancher-components/src/components/*"
       ]
     }
   },

--- a/pkg/gke/tsconfig.json
+++ b/pkg/gke/tsconfig.json
@@ -46,7 +46,8 @@
     "**/*.ts",
     "**/*.d.ts",
     "**/*.tsx",
-    "**/*.vue"
+    "**/*.vue",
+    "../../shell/types/vue-shim.d.ts"
   ],
   "exclude": [
     "../../node_modules"

--- a/pkg/gke/tsconfig.json
+++ b/pkg/gke/tsconfig.json
@@ -38,7 +38,7 @@
         "../../shell/*"
       ],
       "@components/*": [
-        "@rancher/components/*"
+        "../../pkg/rancher-components/src/components/*"
       ]
     }
   },

--- a/pkg/harvester-manager/tsconfig.json
+++ b/pkg/harvester-manager/tsconfig.json
@@ -44,7 +44,8 @@
     "**/*.ts",
     "**/*.tsx",
     "**/*.vue",
-    "../../shell/core/types.ts"
+    "../../shell/core/types.ts",
+    "../../shell/types/vue-shim.d.ts"
   ],
   "exclude": [
     "node_modules"

--- a/pkg/kubectl-explain/tsconfig.json
+++ b/pkg/kubectl-explain/tsconfig.json
@@ -45,7 +45,8 @@
     "**/*.ts",
     "**/*.d.ts",
     "**/*.tsx",
-    "**/*.vue"
+    "**/*.vue",
+    "../../shell/types/vue-shim.d.ts"
   ],
   "exclude": [
     "../../node_modules"

--- a/pkg/kubectl-explain/tsconfig.json
+++ b/pkg/kubectl-explain/tsconfig.json
@@ -37,7 +37,7 @@
         "../../shell/*"
       ],
       "@components/*": [
-        "@rancher/components/*"
+        "../../pkg/rancher-components/src/components/*"
       ]
     }
   },

--- a/pkg/rancher-components/package.json
+++ b/pkg/rancher-components/package.json
@@ -46,7 +46,7 @@
     "jsonpath-plus": "10.0.7",
     "sass": "1.55.0",
     "sass-loader": "~12.0.0",
-    "typescript": "4.5.5",
+    "typescript": "5.6.3",
     "vue": "~3.2.13",
     "eslint-plugin-local-rules": "link:../../eslint-plugin-local-rules"
   },

--- a/shell/package.json
+++ b/shell/package.json
@@ -123,7 +123,7 @@
     "start-server-and-test": "1.13.1",
     "style-loader": "1.2.1",
     "ts-node": "8.10.2",
-    "typescript": "4.5.5",
+    "typescript": "5.6.3",
     "ufo": "0.7.11",
     "unfetch": "4.2.0",
     "url-parse": "1.5.10",

--- a/shell/tsconfig.json
+++ b/shell/tsconfig.json
@@ -25,6 +25,12 @@
       "../node_modules/@types"
     ],
   },
+  "include": [
+    "./**/*.ts",
+    "./**/*.d.ts",
+    "./**/*.tsx",
+    "./**/*.vue"
+  ],
   "exclude": [
     "node_modules",
     "dist",

--- a/shell/types/vue-shim.d.ts
+++ b/shell/types/vue-shim.d.ts
@@ -1,36 +1,13 @@
-// eslint-disable-next-line no-unused-vars
-import Vue, { ComponentCustomProperties } from 'vue';
-declare module '*.vue' {
-  export default Vue;
-}
+/* eslint-disable */
+import type { DefineComponent } from 'vue'
+import { ComponentCustomProperties } from 'vue';
 
-// This is required to keep typescript from complaining. It is required for
-// our i18n plugin. For more info see:
-// https://v2.vuejs.org/v2/guide/typescript.html?redirect=true#Augmenting-Types-for-Use-with-Plugins
-declare module 'vue/types/vue' {
-  // eslint-disable-next-line no-unused-vars
-  interface Vue {
-      /**
-       * Lookup a given string with the given arguments
-       * @param raw if set, do not do HTML escaping.
-       */
-      t: {
-        (key: string, args?: Record<string, any>, raw?: boolean): string;
-        (options: { k: string; raw?: boolean; tag?: string | Record<string, any>; escapehtml?: boolean }): string;
-      };
-  }
+declare module '*.vue' {
+  const component: DefineComponent<{}, {}, any>
+  export default component
 }
 
 declare module '@vue/runtime-core' {
-  // eslint-disable-next-line no-unused-vars
-  interface Vue {
-    t: {
-      (key: string, args?: Record<string, any>, raw?: boolean): string;
-      (options: { k: string; raw?: boolean; tag?: string | Record<string, any>; escapehtml?: boolean }): string;
-    }
-  }
-
-  // eslint-disable-next-line no-unused-vars
   interface ComponentCustomProperties {
     t: {
       (key: string, args?: Record<string, any>, raw?: boolean): string;
@@ -47,5 +24,3 @@ declare module '@vue/runtime-core' {
     }
   }
 }
-
-declare module 'js-yaml';

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -13283,10 +13283,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@5.6.3:
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
+  integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
 
 ua-parser-js@^1.0.38:
   version "1.0.38"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9328,18 +9328,7 @@ html-tags@^3.3.1:
     tapable "^1.1.3"
     util.promisify "1.0.0"
 
-"html-webpack-plugin-5@npm:html-webpack-plugin@^5":
-  version "5.6.0"
-  resolved "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz#50a8fa6709245608cb00e811eacecb8e0d7b7ea0"
-  integrity sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==
-  dependencies:
-    "@types/html-minifier-terser" "^6.0.0"
-    html-minifier-terser "^6.0.2"
-    lodash "^4.17.21"
-    pretty-error "^4.0.0"
-    tapable "^2.0.0"
-
-html-webpack-plugin@^5.0.0, html-webpack-plugin@^5.1.0:
+"html-webpack-plugin-5@npm:html-webpack-plugin@^5", html-webpack-plugin@^5.0.0, html-webpack-plugin@^5.1.0:
   version "5.6.0"
   resolved "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz#50a8fa6709245608cb00e811eacecb8e0d7b7ea0"
   integrity sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==
@@ -13943,7 +13932,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13959,15 +13948,6 @@ string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -14020,7 +14000,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -14040,13 +14020,6 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -14594,10 +14567,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.5.5:
-  version "4.5.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@5.6.3:
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
+  integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
 
 ua-parser-js@^1.0.38:
   version "1.0.38"
@@ -15318,7 +15291,7 @@ worker-loader@3.0.8:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -15339,15 +15312,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This enhances in-editor typescript support by

- ensuring that `shell/types/vue-shim.d.ts` is included in the typescript config
- removing vue2 type augments from `shell/types/vue-shim.d.ts`
- updating typescript to 5.6.3 

Fixes #12893
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I tested this change in Zed, Webstorm, and VS Code - typescript support appears to be improved across the board with regards to properly detecting aliased imports and detecting Vue augments. 

VS Code allows for selecting the typescript version; developers can choose to use VS Code's version or the workspace version. Later versions of Typescript appear to better handle multiple tsconfigs, so updating typescript to 5.6.3 resolves the import issue nicely. This is also the default version that is currently used in VS Code as of writing.  

> NOTE: Make sure to run the `Vue: restart Vue and TS servers` VS Code action after checking out this change

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

In-editor typescript support. We want to ensure that aliased imports of components work across the board. We also want to ensure that `this.$t()` and `this.$store()` are properly detected in component scripts.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This should enhance in-editor typescript support, but keep an eye out for new invalid typescript warnings that might not have been present before. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Component imports no longer display errors

![image](https://github.com/user-attachments/assets/96b6be2a-870c-4109-a5cb-664a9a755be4)

#### Store getters no longer display errors

![image](https://github.com/user-attachments/assets/02f69f52-d17e-4927-856b-d22697ce94a6)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
