### PR TITLE
[2.10.2]Hide AKS, EKS, and GKE cards when their kontainer drivers are deactivated

### DIFF
--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
@@ -42,6 +42,10 @@ export default class ClusterManagerCreatePagePo extends ClusterManagerCreateImpo
     return this.self().contains('.grid .name', name, { timeout: 10000 }).should(assertion);
   }
 
+  gridElementGroupTitles() {
+    return this.self().find('.subtypes-container > div > h4');
+  }
+
   selectKubeProvider(index: number) {
     return this.resourceDetail().cruResource().selectSubType(0, index).click();
   }

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -93,12 +93,13 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
   it('deactivating a kontainer driver should hide its card from the cluster creation page', () => {
     const driversPage = new KontainerDriversPagePo();
     const clusterCreatePage = new ClusterManagerCreatePagePo();
-    const deactivateDialog = new DeactivateDriverDialogPo();
 
     // deactivate the AKS driver
     KontainerDriversPagePo.navTo();
     driversPage.waitForPage();
     driversPage.list().actionMenu('Azure AKS').getMenuItem('Deactivate').click();
+    const deactivateDialog = new DeactivateDriverDialogPo();
+
     deactivateDialog.deactivate();
 
     // verify that the AKS card is not shown

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -25,8 +25,8 @@ import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import LoadingPo from '@/cypress/e2e/po/components/loading.po';
 import { EXTRA_LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
-import KontainerDriversPagePo from '~/cypress/e2e/po/pages/cluster-manager/kontainer-drivers.po';
-import DeactivateDriverDialogPo from '~/cypress/e2e/po/prompts/deactivateDriverDialog.po';
+import KontainerDriversPagePo from '@/cypress/e2e/po/pages/cluster-manager/kontainer-drivers.po';
+import DeactivateDriverDialogPo from '@/cypress/e2e/po/prompts/deactivateDriverDialog.po';
 
 // At some point these will come from somewhere central, then we can make tools to remove resources from this or all runs
 const runTimestamp = +new Date();

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -25,6 +25,8 @@ import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import LoadingPo from '@/cypress/e2e/po/components/loading.po';
 import { EXTRA_LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import KontainerDriversPagePo from '~/cypress/e2e/po/pages/cluster-manager/kontainer-drivers.po';
+import DeactivateDriverDialogPo from '~/cypress/e2e/po/prompts/deactivateDriverDialog.po';
 
 // At some point these will come from somewhere central, then we can make tools to remove resources from this or all runs
 const runTimestamp = +new Date();
@@ -86,6 +88,35 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
       // check that the nav group isn't visible anymore
       sideNav.navToSideMenuGroupByLabelExistence('RKE1 Configuration', 'not.exist');
     });
+  });
+
+  it('deactivating a kontainer driver should hide its card from the cluster creation page', () => {
+    const driversPage = new KontainerDriversPagePo();
+    const clusterCreatePage = new ClusterManagerCreatePagePo();
+    const deactivateDialog = new DeactivateDriverDialogPo();
+
+    // deactivate the AKS driver
+    KontainerDriversPagePo.navTo();
+    driversPage.waitForPage();
+    driversPage.list().actionMenu('Azure AKS').getMenuItem('Deactivate').click();
+    deactivateDialog.deactivate();
+
+    // verify that the AKS card is not shown
+    clusterList.goTo();
+    clusterList.checkIsCurrentPage();
+    clusterList.createCluster();
+    clusterCreatePage.gridElementExistanceByName('Azure AKS', 'not.exist');
+
+    // re-enable the AKS kontainer driver
+    KontainerDriversPagePo.navTo();
+    driversPage.waitForPage();
+    driversPage.list().actionMenu('Azure AKS').getMenuItem('Activate').click();
+
+    // verify that the AKS card is back
+    clusterList.goTo();
+    clusterList.checkIsCurrentPage();
+    clusterList.createCluster();
+    clusterCreatePage.gridElementExistanceByName('Azure AKS', 'exist');
   });
 
   describe('All providers', () => {

--- a/pkg/aks/provisioner.ts
+++ b/pkg/aks/provisioner.ts
@@ -2,6 +2,7 @@ import { IClusterProvisioner, ClusterProvisionerContext } from '@shell/core/type
 import CruAks from './components/CruAks.vue';
 import { mapDriver } from '@shell/store/plugins';
 import type { Component } from 'vue';
+import { MANAGEMENT } from '@shell/config/types';
 
 export class AKSProvisioner implements IClusterProvisioner {
   static ID = 'azureaks'
@@ -28,6 +29,12 @@ export class AKSProvisioner implements IClusterProvisioner {
 
   get component(): Component {
     return CruAks;
+  }
+
+  get disabled(): boolean {
+    const kontainerDriver = this.context.getters['management/byId'](MANAGEMENT.KONTAINER_DRIVER, 'azurekubernetesservice');
+
+    return !kontainerDriver?.spec?.active;
   }
 
   get detailTabs(): any {

--- a/pkg/aks/provisioner.ts
+++ b/pkg/aks/provisioner.ts
@@ -31,7 +31,7 @@ export class AKSProvisioner implements IClusterProvisioner {
     return CruAks;
   }
 
-  get disabled(): boolean {
+  get hidden(): boolean {
     const kontainerDriver = this.context.getters['management/byId'](MANAGEMENT.KONTAINER_DRIVER, 'azurekubernetesservice');
 
     return !kontainerDriver?.spec?.active;

--- a/pkg/eks/provisioner.ts
+++ b/pkg/eks/provisioner.ts
@@ -1,7 +1,8 @@
 import { IClusterProvisioner, ClusterProvisionerContext } from '@shell/core/types';
 import CruEKS from './components/CruEKS.vue';
 import { mapDriver } from '@shell/store/plugins';
-import { Component } from 'vue/types/umd';
+import { Component } from 'vue';
+import { MANAGEMENT } from '@shell/config/types';
 
 export class EKSProvisioner implements IClusterProvisioner {
   static ID = 'amazoneks'
@@ -28,6 +29,12 @@ export class EKSProvisioner implements IClusterProvisioner {
 
   get component(): Component {
     return CruEKS;
+  }
+
+  get disabled(): boolean {
+    const kontainerDriver = this.context.getters['management/byId'](MANAGEMENT.KONTAINER_DRIVER, 'amazonelasticcontainerservice');
+
+    return !kontainerDriver?.spec?.active;
   }
 
   get detailTabs(): any {

--- a/pkg/eks/provisioner.ts
+++ b/pkg/eks/provisioner.ts
@@ -31,7 +31,7 @@ export class EKSProvisioner implements IClusterProvisioner {
     return CruEKS;
   }
 
-  get disabled(): boolean {
+  get hidden(): boolean {
     const kontainerDriver = this.context.getters['management/byId'](MANAGEMENT.KONTAINER_DRIVER, 'amazonelasticcontainerservice');
 
     return !kontainerDriver?.spec?.active;

--- a/pkg/gke/provisioner.ts
+++ b/pkg/gke/provisioner.ts
@@ -31,7 +31,7 @@ export class GKEProvisioner implements IClusterProvisioner {
     return CruGKE;
   }
 
-  get disabled(): boolean {
+  get hidden(): boolean {
     const kontainerDriver = this.context.getters['management/byId'](MANAGEMENT.KONTAINER_DRIVER, 'googlekubernetesengine');
 
     return !kontainerDriver?.spec?.active;

--- a/pkg/gke/provisioner.ts
+++ b/pkg/gke/provisioner.ts
@@ -1,7 +1,8 @@
 import { IClusterProvisioner, ClusterProvisionerContext } from '@shell/core/types';
 import CruGKE from './components/CruGKE.vue';
 import { mapDriver } from '@shell/store/plugins';
-import { Component } from 'vue/types/umd';
+import { Component } from 'vue';
+import { MANAGEMENT } from '@shell/config/types';
 
 export class GKEProvisioner implements IClusterProvisioner {
   static ID = 'googlegke'
@@ -28,6 +29,12 @@ export class GKEProvisioner implements IClusterProvisioner {
 
   get component(): Component {
     return CruGKE;
+  }
+
+  get disabled(): boolean {
+    const kontainerDriver = this.context.getters['management/byId'](MANAGEMENT.KONTAINER_DRIVER, 'googlekubernetesengine');
+
+    return !kontainerDriver?.spec?.active;
   }
 
   get detailTabs(): any {

--- a/shell/core/types-provisioning.ts
+++ b/shell/core/types-provisioning.ts
@@ -102,9 +102,14 @@ export interface IClusterProvisioner {
   group?: string;
 
   /**
-   * Hide the cluster provider card
+   * Disable the cluster provider card
    */
   disabled?: boolean;
+
+  /**
+   * Hide the cluster provider card
+   */
+  hidden?: boolean;
 
   /**
    * Custom Dashboard route to navigate to when the cluster provider card is clicked

--- a/shell/core/types-provisioning.ts
+++ b/shell/core/types-provisioning.ts
@@ -102,7 +102,7 @@ export interface IClusterProvisioner {
   group?: string;
 
   /**
-   * Disable the cluster provider card
+   * Hide the cluster provider card
    */
   disabled?: boolean;
 

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -367,6 +367,9 @@ export default {
 
         // Add from extensions
         this.extensions.forEach((ext) => {
+          if (ext.disabled) {
+            return;
+          }
           // if the rke toggle is set to rke1, don't add extensions that specify rke2 group
           // default group is rke2
           if (!this.isRke2 && (ext.group === _RKE2 || !ext.group)) {

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -628,7 +628,7 @@ export default {
       <div
         v-for="(obj, i) in groupedSubTypes"
         :key="i"
-        class="mb-20"
+        class="mt-20"
         style="width: 100%;"
       >
         <h4>

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -628,7 +628,7 @@ export default {
       <div
         v-for="(obj, i) in groupedSubTypes"
         :key="i"
-        class="mt-20"
+        :class="{'mt-5': i === 0, 'mt-20': i !== 0, }"
         style="width: 100%;"
       >
         <h4>

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -367,9 +367,6 @@ export default {
 
         // Add from extensions
         this.extensions.forEach((ext) => {
-          if (ext.disabled) {
-            return;
-          }
           // if the rke toggle is set to rke1, don't add extensions that specify rke2 group
           // default group is rke2
           if (!this.isRke2 && (ext.group === _RKE2 || !ext.group)) {
@@ -407,7 +404,8 @@ export default {
           disabled:    ext.disabled || false,
           link:        ext.link,
           tag:         ext.tag,
-          component:   ext.component
+          component:   ext.component,
+          hidden:      ext.hidden,
         };
 
         out.push(subtype);
@@ -452,10 +450,14 @@ export default {
       }
     },
 
+    filteredSubTypes() {
+      return this.subTypes.filter((subtype) => !subtype.hidden);
+    },
+
     groupedSubTypes() {
       const out = {};
 
-      for ( const row of this.subTypes ) {
+      for ( const row of this.filteredSubTypes ) {
         const name = row.group;
         let entry = out[name];
 

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -628,7 +628,7 @@ export default {
       <div
         v-for="(obj, i) in groupedSubTypes"
         :key="i"
-        :class="{'mt-5': i === 0, 'mt-20': i !== 0, }"
+        :class="{'mt-5': i === 0, 'mt-20': i !== 0 }"
         style="width: 100%;"
       >
         <h4>


### PR DESCRIPTION
Fixes #12901

backport of https://github.com/rancher/dashboard/pull/12903