### PR TITLE
adding data-testid to mandatory GKE elements for e2e tests locators

### DIFF
--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -704,8 +704,8 @@ export default defineComponent({
               label-key="generic.name"
               required
               :rules="fvGetAndReportPathRules('clusterName')"
-              @update:value="setClusterName"
               data-testid="gke-cluster-name"
+              @update:value="setClusterName"
             />
           </div>
           <div class="col span-6">
@@ -714,8 +714,8 @@ export default defineComponent({
               :mode="mode"
               label-key="nameNsDescription.description.label"
               :placeholder="t('nameNsDescription.description.placeholder')"
-              @update:value="setClusterDescription"
               data-testid="gke-cluster-description"
+              @update:value="setClusterDescription"
             />
           </div>
         </div>

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -705,6 +705,7 @@ export default defineComponent({
               required
               :rules="fvGetAndReportPathRules('clusterName')"
               @update:value="setClusterName"
+              data-testid="gke-cluster-name"
             />
           </div>
           <div class="col span-6">
@@ -714,6 +715,7 @@ export default defineComponent({
               label-key="nameNsDescription.description.label"
               :placeholder="t('nameNsDescription.description.placeholder')"
               @update:value="setClusterDescription"
+              data-testid="gke-cluster-description"
             />
           </div>
         </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

### Occurred changes and/or fixed issues
Added `data-testid` to GKE elements for e2e tests - cluster name and cluster description - to be validated in an e2e test that provisions a GKE cluster with default settings and verifies that the cluster was successfully created with the correct settings. Unblocks the test development tracked by issue https://github.com/rancher/qa-tasks/issues/1571

### Areas which could experience regressions
<!-- Test cases that utilize Labeled Input locators -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
