### PR TITLE
Use correct container registry for latest 2.9 `head` builds

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,20 +111,6 @@ jobs:
          name: ${{ env.E2E_BUILD_DIST_EMBER_NAME }}
          path: ${{ env.E2E_BUILD_DIST_EMBER_DIR }}
 
-      - name: "Read Vault Secrets"
-        uses: rancher-eio/read-vault-secrets@main
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials username | READ_STAGE_REGISTRY_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials password | READ_STAGE_REGISTRY_PASSWORD ;
-
-      - name: Log into Staging registry
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.READ_STAGE_REGISTRY_USERNAME }}
-          password: ${{ env.READ_STAGE_REGISTRY_PASSWORD }}
-          registry: stgregistry.suse.com
-      
       - name: Run Rancher
         run: yarn e2e:docker
       

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -110,6 +110,20 @@ jobs:
         with:
          name: ${{ env.E2E_BUILD_DIST_EMBER_NAME }}
          path: ${{ env.E2E_BUILD_DIST_EMBER_DIR }}
+
+      - name: "Read Vault Secrets"
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials username | READ_STAGE_REGISTRY_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials password | READ_STAGE_REGISTRY_PASSWORD ;
+
+      - name: Log into Staging registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.READ_STAGE_REGISTRY_USERNAME }}
+          password: ${{ env.READ_STAGE_REGISTRY_PASSWORD }}
+          registry: stgregistry.suse.com
       
       - name: Run Rancher
         run: yarn e2e:docker

--- a/scripts/e2e-docker-start
+++ b/scripts/e2e-docker-start
@@ -7,7 +7,7 @@ DASHBOARD_DIST=${DIR}/dist
 EMBER_DIST=${DIR}/dist_ember
 
 # Image Repo
-RANCHER_IMG_REGISTRY=stgregistry.suse.com
+RANCHER_IMG_REGISTRY=stgregistry.suse.com/rancher/rancher
 
 # Image version
 RANCHER_IMG_VERSION=v2.9-head

--- a/scripts/e2e-docker-start
+++ b/scripts/e2e-docker-start
@@ -6,6 +6,9 @@ DIR=$(cd $(dirname $0)/..; pwd)
 DASHBOARD_DIST=${DIR}/dist
 EMBER_DIST=${DIR}/dist_ember
 
+# Image Repo
+RANCHER_IMG_REGISTRY=stgregistry.suse.com
+
 # Image version
 RANCHER_IMG_VERSION=v2.9-head
 
@@ -17,7 +20,7 @@ docker run -d --restart=unless-stopped -p 80:80 -p 443:443 \
   -e CATTLE_PASSWORD_MIN_LENGTH=3 \
   --name cypress \
   --privileged \
-  rancher/rancher:${RANCHER_IMG_VERSION}
+  ${RANCHER_IMG_REGISTRY}:${RANCHER_IMG_VERSION}
 
 docker ps
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes: #12936

### Occurred changes and/or fixed issues
- without this it doesn't look like rancher serves up the correct CNi charts related to the version of kube (1.28 and below are fine, 1.29 and above will fail to fetch charts)  

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
