### PR TITLE
Temporarily stop failing settings-p2 system registry setting e2e test

### DIFF
--- a/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
@@ -1,9 +1,9 @@
 import { SettingsPagePo } from '@/cypress/e2e/po/pages/global-settings/settings.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
-import ClusterManagerCreateRke2CustomPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-custom.po';
+// import ClusterManagerCreateRke2CustomPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-custom.po';
 import AccountPagePo from '@/cypress/e2e/po/pages/account-api-keys.po';
-import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
+// import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import {
   settings, serverUrlLocalhostCases, urlWithTrailingForwardSlash, httpUrl, nonUrlCases
 } from '@/cypress/e2e/blueprints/global_settings/settings-data';
@@ -11,7 +11,7 @@ import {
 const settingsPage = new SettingsPagePo('local');
 const homePage = new HomePagePo();
 const accountPage = new AccountPagePo();
-const clusterList = new ClusterManagerListPagePo();
+// const clusterList = new ClusterManagerListPagePo();
 const burgerMenu = new BurgerMenuPo();
 const settingsOrginal = [];
 let removeServerUrl = false;

--- a/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
@@ -398,50 +398,51 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('hide-local-cluster').contains(settings['hide-local-cluster'].original);
   });
 
-  it('can update system-default-registry', { tags: ['@globalSettings', '@adminUser'] }, () => {
-    // Update setting
-    SettingsPagePo.navTo();
-    settingsPage.editSettingsByLabel('system-default-registry');
+  // Blocked on https://github.com/rancher/dashboard/issues/12936 / https://github.com/rancher/dashboard/pull/12935
+  // it('can update system-default-registry', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  //   // Update setting
+  //   SettingsPagePo.navTo();
+  //   settingsPage.editSettingsByLabel('system-default-registry');
 
-    const settingsEdit = settingsPage.editSettings('local', 'system-default-registry');
+  //   const settingsEdit = settingsPage.editSettings('local', 'system-default-registry');
 
-    settingsEdit.waitForPage();
-    settingsEdit.title().contains('Setting: system-default-registry').should('be.visible');
-    settingsEdit.settingsInput().set(settings['system-default-registry'].new);
-    settingsEdit.saveAndWait('system-default-registry');
-    settingsPage.waitForPage();
-    settingsPage.settingsValue('system-default-registry').contains(settings['system-default-registry'].new);
+  //   settingsEdit.waitForPage();
+  //   settingsEdit.title().contains('Setting: system-default-registry').should('be.visible');
+  //   settingsEdit.settingsInput().set(settings['system-default-registry'].new);
+  //   settingsEdit.saveAndWait('system-default-registry');
+  //   settingsPage.waitForPage();
+  //   settingsPage.settingsValue('system-default-registry').contains(settings['system-default-registry'].new);
 
-    // Check cluster manager > create
-    const createRKE2ClusterPage = new ClusterManagerCreateRke2CustomPagePo();
+  //   // Check cluster manager > create
+  //   const createRKE2ClusterPage = new ClusterManagerCreateRke2CustomPagePo();
 
-    clusterList.goTo();
-    clusterList.checkIsCurrentPage();
-    clusterList.createCluster();
+  //   clusterList.goTo();
+  //   clusterList.checkIsCurrentPage();
+  //   clusterList.createCluster();
 
-    createRKE2ClusterPage.waitForPage();
-    createRKE2ClusterPage.rkeToggle().set('RKE2/K3s');
+  //   createRKE2ClusterPage.waitForPage();
+  //   createRKE2ClusterPage.rkeToggle().set('RKE2/K3s');
 
-    createRKE2ClusterPage.selectCustom(0);
-    createRKE2ClusterPage.clusterConfigurationTabs().clickTabWithSelector('[data-testid="btn-rke2-calico"]');
-    cy.contains(settings['system-default-registry'].new).should('exist'); // Note - this doesn't test anything. docker.io exists in the chart in all worlds, system-default-registry value does not
+  //   createRKE2ClusterPage.selectCustom(0);
+  //   createRKE2ClusterPage.clusterConfigurationTabs().clickTabWithSelector('[data-testid="btn-rke2-calico"]');
+  //   cy.contains(settings['system-default-registry'].new).should('exist'); // Note - this doesn't test anything. docker.io exists in the chart in all worlds, system-default-registry value does not
 
-    const settingsPageBlank = new SettingsPagePo();
-    const settingsEditBlank = settingsPageBlank.editSettings(undefined, 'system-default-registry');
+  //   const settingsPageBlank = new SettingsPagePo();
+  //   const settingsEditBlank = settingsPageBlank.editSettings(undefined, 'system-default-registry');
 
-    // Reset
-    SettingsPagePo.navTo();
-    settingsPageBlank.waitForPage();
-    settingsPageBlank.editSettingsByLabel('system-default-registry');
+  //   // Reset
+  //   SettingsPagePo.navTo();
+  //   settingsPageBlank.waitForPage();
+  //   settingsPageBlank.editSettingsByLabel('system-default-registry');
 
-    settingsEditBlank.waitForPage();
-    settingsEditBlank.title().contains('Setting: system-default-registry').should('be.visible');
-    settingsEditBlank.settingsInput().clear();
-    settingsEditBlank.saveAndWait('system-default-registry');
+  //   settingsEditBlank.waitForPage();
+  //   settingsEditBlank.title().contains('Setting: system-default-registry').should('be.visible');
+  //   settingsEditBlank.settingsInput().clear();
+  //   settingsEditBlank.saveAndWait('system-default-registry');
 
-    settingsPageBlank.waitForPage();
-    settingsPageBlank.settingsValue('system-default-registry').contains(settings['system-default-registry'].original);
-  });
+  //   settingsPageBlank.waitForPage();
+  //   settingsPageBlank.settingsValue('system-default-registry').contains(settings['system-default-registry'].original);
+  // });
 
   it('standard user has only read access to Settings page', { tags: ['@globalSettings', '@standardUser'] }, () => {
     // verify action buttons are hidden for standard user


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Temporarily stop failing settings-p2 system registry setting e2e test

### Occurred changes and/or fixed issues
- See https://github.com/rancher/dashboard/issues/12936 for details
  - This PR should be reverted once that issue is resolved  
- (requires calico tab in rke create page, which isn't there because 2.9 dockerhub head doesn't serve the related addon chart)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
