### PR TITLE
proposal: Refactor build-extension-charts workflow in master to use scripts from upstream (dashboard)

### DIFF
--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -83,13 +83,35 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          yarn parse-tag-name ${{ inputs.tagged_release }} ${{ github.run_id }} "charts"
+          #!/usr/bin/env bash
+
+          set -eo pipefail
+
+          SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+          BASE_DIR="$(
+            cd $SCRIPT_DIR && cd ../.. &
+            pwd
+          )"
+
+          git clone -b master https://github.com/rancher/dashboard.git dashboard-repo
+
+          ${BASE_DIR}/dashboard-repo/shell/scripts/extension/parse-tag-name ${{ inputs.tagged_release }} ${{ github.run_id }} "charts"
 
       - name: Run build script
         shell: bash
         id: build_script
         run: |
-          publish="yarn publish-pkgs -s ${{ github.repository }} -b ${{ inputs.target_branch }}"
+          #!/usr/bin/env bash
+
+          set -eo pipefail
+
+          SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+          BASE_DIR="$(
+            cd $SCRIPT_DIR && cd ../.. &
+            pwd
+          )"
+
+          publish="publish -s ${{ github.repository }} -b ${{ inputs.target_branch }}"
 
           if [[ -n "${{ inputs.tagged_release }}" ]]; then
             publish="$publish -t ${{ inputs.tagged_release }}"
@@ -98,8 +120,8 @@ jobs:
           if [[ "${{ inputs.is_test }}" == "true" ]]; then
             publish="$publish -f"
           fi
-
-          $publish
+          
+          ${BASE_DIR}/dashboard-repo/shell/scripts/extension/${publish}
 
       - name: Upload charts artifact
         if: github.ref_type == 'tag' || (github.ref == 'refs/heads/main' && github.event_name != 'pull_request') || inputs.is_test == 'true'


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12824 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Refactor `build-extension-charts` workflow in `master` to use scripts from upstream (dashboard) instead of shell package

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The reusable workflows `build-extension-charts` and  `build-extension-catalog` make use of a couple of scripts, as per https://github.com/rancher/dashboard/blob/master/.github/workflows/build-extension-charts.yml#L80-L102, that are being pulled from the client's `shell` package.

The goal here is to update these workflows to that we use the versions of those scripts in each branch (for `latest` would be `master` branch) so that we can apply fixes without the need for the client to update shell

Testing should be already covered in https://github.com/rancher/dashboard/blob/master/.github/workflows/test-extension-workflows-master.yml + https://github.com/rancher/dashboard/blob/master/.github/workflows/test-extension-workflows-release-2.9.yml + https://github.com/rancher/dashboard/blob/master/.github/workflows/test-extension-workflows-release-2.8.yml

**This is a working proposal, tested on Elemental repo**

Workflow that ran: https://github.com/rancher/elemental-ui/blob/0cfbc152983d6f8631cac1c022a6f216570e7796/.github/workflows/build-extension-charts.yml

pipeline success: https://github.com/rancher/elemental-ui/actions/runs/12483392216/job/34839112211

Extension installed:
<img width="2284" alt="Screenshot 2024-12-24 at 15 27 01" src="https://github.com/user-attachments/assets/2857b7ee-7fdc-41ca-bc9b-5fccecb9a92b" />
<img width="2284" alt="Screenshot 2024-12-24 at 15 27 05" src="https://github.com/user-attachments/assets/da9ad315-75d6-4a26-98d4-5df320daf6e7" />

The goal is, if there are no impediments by analysing this PR, to apply these changes to the `release-2.8` and `release-2.9` branches, so that we can, afterwards, attack with full force some small issues that we've identified with the scripts.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
