### PR TITLE
add missing types for extensions

### DIFF
--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -243,6 +243,11 @@ export interface ProductOptions {
   svg?: Function;
 
   /**
+   * Product name
+   */
+  name?: string;
+
+  /**
    * Leaving these here for completeness but I don't think these should be advertised as useable to plugin creators.
    */
   // ifHaveVerb: string | RegExp;

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -238,6 +238,11 @@ export interface ProductOptions {
   to?: PluginRouteRecordRaw;
 
   /**
+   * Alternative to the icon property. Uses require
+   */
+  svg?: Function;
+
+  /**
    * Leaving these here for completeness but I don't think these should be advertised as useable to plugin creators.
    */
   // ifHaveVerb: string | RegExp;
@@ -384,9 +389,14 @@ export interface ConfigureVirtualTypeOptions extends ConfigureTypeOptions {
   ifHaveType?: string | RegExp | Object;
 
   /**
+   * The label that this type should display
+   */
+  label?: string;
+
+  /**
    * The translation key displayed anywhere this type is referenced
    */
-  labelKey: string;
+  labelKey?: string;
 
   /**
    * An identifier that should be unique across all types


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12945
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Adds missing types used in extensions. Cross-checked with extension docs to see what was missing in product/pages configuration

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- clone repo [https://github.com/masap/supportability-review-app-210](https://github.com/masap/supportability-review-app-210)
- yarn link this PR's `shell` to that repo
- confirm that there are no more TS errors from the extension registration functions


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
