### PR TITLE
[2.10.2] Fix Node Scheduling / Node Name option in Workloads page

### DIFF
--- a/shell/components/form/NodeScheduling.vue
+++ b/shell/components/form/NodeScheduling.vue
@@ -32,6 +32,7 @@ export default {
       type:    String,
       default: 'create'
     },
+
     loading: {
       default: false,
       type:    Boolean
@@ -169,6 +170,7 @@ export default {
         name="selectNode"
         :options="selectNodeOptions"
         :mode="mode"
+        :data-testid="'node-scheduling-selectNode'"
         @input="update"
       />
     </div>
@@ -182,7 +184,8 @@ export default {
             :mode="mode"
             :multiple="false"
             :loading="loading"
-            @input="update"
+            :data-testid="'node-scheduling-nodeSelector'"
+            @update:value="update"
           />
         </div>
       </div>
@@ -191,6 +194,7 @@ export default {
       <NodeAffinity
         v-model:value="nodeAffinity"
         :mode="mode"
+        :data-testid="'node-scheduling-nodeAffinity'"
         @input="update"
       />
     </template>

--- a/shell/components/form/__tests__/NodeScheduling.test.ts
+++ b/shell/components/form/__tests__/NodeScheduling.test.ts
@@ -1,0 +1,44 @@
+import { mount } from '@vue/test-utils';
+import NodeScheduling from '@shell/components/form/NodeScheduling.vue';
+import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
+
+const requiredSetup = () => {
+  return {
+    global: {
+      mocks: {
+        $store: {
+          getters: {
+            currentProduct: { inStore: 'cluster' },
+            'i18n/t':       (text: string) => text,
+            t:              (text: string) => text,
+          }
+        }
+      },
+    }
+  };
+};
+
+describe('component: NodeScheduling', () => {
+  const value = { nodeName: 'node-1' };
+
+  const nodes = ['node-0', 'node-1'];
+
+  it.each([
+    _VIEW,
+    _CREATE,
+    _EDIT
+  ])('should show NodeName option', (mode) => {
+    const wrapper = mount(
+      NodeScheduling,
+      {
+        props: {
+          mode, loading: false, value, nodes
+        },
+        ...requiredSetup(),
+      }
+    );
+
+    expect(wrapper.find('[data-testid="node-scheduling-selectNode"]').exists()).toBeTruthy();
+    expect(wrapper.find('[data-testid="node-scheduling-nodeSelector"]').element.textContent).toContain(value.nodeName);
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12963
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
