### PR TITLE
fix keyboard nav for home page

### DIFF
--- a/pkg/rancher-components/src/components/Banner/Banner.vue
+++ b/pkg/rancher-components/src/components/Banner/Banner.vue
@@ -67,6 +67,7 @@ export default defineComponent({
     :class="{
       [color]: true,
     }"
+    role="banner"
   >
     <div
       v-if="icon"
@@ -102,7 +103,12 @@ export default defineComponent({
       <div
         v-if="closable"
         class="banner__content__closer"
+        tabindex="0"
+        role="button"
+        aria-label="close"
         @click="$emit('close')"
+        @keyup.enter="$emit('close')"
+        @keyup.space="$emit('close')"
       >
         <i
           data-testid="banner-close"
@@ -226,6 +232,7 @@ $icon-size: 24px;
       width: $icon-size;
       line-height: $icon-size;
       text-align: center;
+      outline: none;
 
       .closer-icon {
         opacity: 0.7;
@@ -234,6 +241,11 @@ $icon-size: 24px;
           opacity: 1;
           color: var(--link);
         }
+      }
+
+      &:focus-visible i {
+        @include focus-outline;
+        outline-offset: 2px;
       }
     }
 

--- a/pkg/rancher-components/src/components/Banner/Banner.vue
+++ b/pkg/rancher-components/src/components/Banner/Banner.vue
@@ -105,7 +105,7 @@ export default defineComponent({
         class="banner__content__closer"
         tabindex="0"
         role="button"
-        aria-label="close"
+        :aria-label="t('generic.close')"
         @click="$emit('close')"
         @keyup.enter="$emit('close')"
         @keyup.space="$emit('close')"

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -227,7 +227,7 @@ export default defineComponent({
         :checked="isChecked"
         :value="valueWhenTrue"
         type="checkbox"
-        :tabindex="isDisabled ? -1 : 0"
+        tabindex="-1"
         :name="id"
         @click.stop.prevent
         @keyup.enter.stop.prevent
@@ -235,7 +235,7 @@ export default defineComponent({
       <span
         class="checkbox-custom"
         :class="{indeterminate: indeterminate}"
-        :tabindex="-1"
+        :tabindex="isDisabled ? -1 : 0"
         :aria-label="label"
         :aria-checked="!!value"
         role="checkbox"

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -230,11 +230,12 @@ export default defineComponent({
         tabindex="-1"
         :name="id"
         @click.stop.prevent
+        @keyup.enter.stop.prevent
       >
       <span
         class="checkbox-custom"
         :class="{indeterminate: indeterminate}"
-        :tabindex="isDisabled ? -1 : 0"
+        :tabindex="-1"
         :aria-label="label"
         :aria-checked="!!value"
         role="checkbox"
@@ -340,6 +341,12 @@ $fontColor: var(--input-label);
     opacity: 0;
     position: absolute;
     z-index: -1;
+  }
+
+  input:focus-visible ~ .checkbox-custom {
+    @include focus-outline;
+    outline-offset: 2px;
+    border-radius: 0;
   }
 
   input:checked ~ .checkbox-custom {

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -227,7 +227,7 @@ export default defineComponent({
         :checked="isChecked"
         :value="valueWhenTrue"
         type="checkbox"
-        tabindex="-1"
+        :tabindex="isDisabled ? -1 : 0"
         :name="id"
         @click.stop.prevent
         @keyup.enter.stop.prevent

--- a/shell/assets/styles/global/_button.scss
+++ b/shell/assets/styles/global/_button.scss
@@ -108,8 +108,8 @@ button,
   }
 
   &:focus-visible {
-    @include focus-outline-primary;
-    outline-offset: -2px;
+    @include focus-outline;
+    outline-offset: 2px;
   }
 }
 

--- a/shell/assets/styles/global/_button.scss
+++ b/shell/assets/styles/global/_button.scss
@@ -106,6 +106,11 @@ button,
       border: 0;
     }
   }
+
+  &:focus-visible {
+    @include focus-outline-primary;
+    outline-offset: -2px;
+  }
 }
 
 .role-tertiary {

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4,6 +4,7 @@
 generic:
   add: Add
   all: All
+  ascending: ascending
   and: ' and '
   back: Back
   cancel: Cancel
@@ -19,6 +20,7 @@ generic:
   customize: Customize
   dashboard: Dashboard
   default: Default
+  descending: descending
   disabled: Disabled
   done: Done
   enabled: Enabled

--- a/shell/components/ActionMenu.vue
+++ b/shell/components/ActionMenu.vue
@@ -264,7 +264,10 @@ export default {
         :disabled="opt.disabled ? true : null"
         :class="{divider: opt.divider}"
         :data-testid="componentTestid + '-' + i + '-item'"
+        :tabindex="opt.divider ? -1 : 0"
         @click="execute(opt, $event)"
+        @keyup.enter="execute(opt, $event)"
+        @keyup.space="execute(opt, $event)"
       >
         <IconOrSvg
           v-if="opt.icon || opt.svg"
@@ -310,6 +313,11 @@ export default {
       display: flex;
       padding: 8px 10px;
       margin: 0;
+
+      &:focus-visible {
+        @include focus-outline;
+        outline-offset: -2px;
+      }
 
       &[disabled] {
         cursor: not-allowed  !important;

--- a/shell/components/BannerGraphic.vue
+++ b/shell/components/BannerGraphic.vue
@@ -55,7 +55,11 @@ export default {
       v-if="pref"
       class="close-button"
       data-testid="graphic-banner-close"
+      tabindex="0"
+      aria-label="close"
       @click="hide()"
+      @keyup.enter="hide()"
+      @keyup.space="hide()"
     >
       <i class="icon icon-close" />
     </div>
@@ -72,6 +76,11 @@ export default {
     .close-button {
       position: absolute;
       visibility: hidden;
+
+      &:focus-visible {
+        @include focus-outline;
+        outline-offset: 2px;
+      }
     }
 
     &:hover .close-button {

--- a/shell/components/BannerGraphic.vue
+++ b/shell/components/BannerGraphic.vue
@@ -57,6 +57,7 @@ export default {
       data-testid="graphic-banner-close"
       tabindex="0"
       :aria-label="t('generic.close')"
+      role="button"
       @click="hide()"
       @keyup.enter="hide()"
       @keyup.space="hide()"

--- a/shell/components/BannerGraphic.vue
+++ b/shell/components/BannerGraphic.vue
@@ -56,7 +56,7 @@ export default {
       class="close-button"
       data-testid="graphic-banner-close"
       tabindex="0"
-      aria-label="close"
+      :aria-label="t('generic.close')"
       @click="hide()"
       @keyup.enter="hide()"
       @keyup.space="hide()"

--- a/shell/components/ButtonMultiAction.vue
+++ b/shell/components/ButtonMultiAction.vue
@@ -33,6 +33,12 @@ const buttonClass = computed(() => {
 .borderless {
   background-color: transparent;
   border: none;
+
+  &:focus-visible {
+    @include focus-outline;
+    outline-offset: -2px;
+  }
+
   &:hover, &:focus {
     background-color: var(--accent-btn);
     box-shadow: none;

--- a/shell/components/CommunityLinks.vue
+++ b/shell/components/CommunityLinks.vue
@@ -112,7 +112,6 @@ export default {
           :to="link.value"
           role="link"
           :aria-label="link.label"
-          @keyup.space="$router.push(link.value)"
         >
           {{ link.label }}
         </router-link>
@@ -134,9 +133,9 @@ export default {
           class="link"
           tabindex="0"
           :aria-label="t('footer.wechat.title')"
+          role="link"
           @click="show"
           @keyup.enter="show"
-          @keyup.space="show"
         >
           {{ t('footer.wechat.title') }}
         </a>
@@ -158,6 +157,7 @@ export default {
             class="btn role-primary"
             tabindex="0"
             :aria-label="t('generic.close')"
+            role="button"
             @click="close"
             @keyup.enter="close"
             @keyup.space="close"

--- a/shell/components/CommunityLinks.vue
+++ b/shell/components/CommunityLinks.vue
@@ -110,6 +110,8 @@ export default {
         <router-link
           v-if="link.value.startsWith('/') "
           :to="link.value"
+          role="link"
+          @keyup.space="$router.push(link.value)"
         >
           {{ link.label }}
         </router-link>
@@ -118,6 +120,7 @@ export default {
           :href="link.value"
           rel="noopener noreferrer nofollow"
           target="_blank"
+          role="link"
         > {{ link.label }} </a>
       </div>
       <slot />
@@ -127,7 +130,10 @@ export default {
       >
         <a
           class="link"
+          tabindex="0"
           @click="show"
+          @keyup.enter="show"
+          @keyup.space="show"
         >
           {{ t('footer.wechat.title') }}
         </a>
@@ -147,7 +153,10 @@ export default {
         <div>
           <button
             class="btn role-primary"
+            tabindex="0"
             @click="close"
+            @keyup.enter="close"
+            @keyup.space="close"
           >
             {{ t('generic.close') }}
           </button>

--- a/shell/components/CommunityLinks.vue
+++ b/shell/components/CommunityLinks.vue
@@ -111,6 +111,7 @@ export default {
           v-if="link.value.startsWith('/') "
           :to="link.value"
           role="link"
+          :aria-label="link.label"
           @keyup.space="$router.push(link.value)"
         >
           {{ link.label }}
@@ -121,6 +122,7 @@ export default {
           rel="noopener noreferrer nofollow"
           target="_blank"
           role="link"
+          :aria-label="link.label"
         > {{ link.label }} </a>
       </div>
       <slot />
@@ -131,6 +133,7 @@ export default {
         <a
           class="link"
           tabindex="0"
+          :aria-label="t('footer.wechat.title')"
           @click="show"
           @keyup.enter="show"
           @keyup.space="show"
@@ -154,6 +157,7 @@ export default {
           <button
             class="btn role-primary"
             tabindex="0"
+            :aria-label="t('generic.close')"
             @click="close"
             @keyup.enter="close"
             @keyup.space="close"

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -235,7 +235,11 @@ export default {
         :align="col.align || 'left'"
         :width="col.width"
         :class="{ sortable: col.sort, [col.breakpoint]: !!col.breakpoint}"
+        :tabindex="col.sort ? 0 : -1"
+        class="sortable-table-head-element"
         @click.prevent="changeSort($event, col)"
+        @keyup.enter="changeSort($event, col)"
+        @keyup.space="changeSort($event, col)"
       >
         <div
           class="table-header-container"
@@ -427,6 +431,11 @@ export default {
       font-weight: normal;
       border: 0;
       color: var(--body-text);
+
+      &.sortable-table-head-element:focus-visible {
+        @include focus-outline;
+        outline-offset: -4px;
+      }
 
       .table-header-container {
         display: inline-flex;

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -162,6 +162,14 @@ export default {
       return col.name === this.sortBy;
     },
 
+    ariaSort(col) {
+      if (this.isCurrent(col)) {
+        return this.descending ? this.t('generic.descending') : this.t('generic.ascending');
+      }
+
+      return this.t('generic.none');
+    },
+
     tableColsOptionsClick(ev) {
       // set menu position
       const menu = document.querySelector('.table-options-container');
@@ -237,6 +245,7 @@ export default {
         :class="{ sortable: col.sort, [col.breakpoint]: !!col.breakpoint}"
         :tabindex="col.sort ? 0 : -1"
         class="sortable-table-head-element"
+        :aria-sort="ariaSort(col)"
         @click.prevent="changeSort($event, col)"
         @keyup.enter="changeSort($event, col)"
         @keyup.space="changeSort($event, col)"

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1222,6 +1222,7 @@ export default {
       class="sortable-table"
       :class="classObject"
       width="100%"
+      role="table"
     >
       <THead
         v-if="showHeaders"
@@ -1451,6 +1452,8 @@ export default {
                       :data-testid="componentTestid + '-' + i + '-action-button'"
                       :borderless="true"
                       @click="handleActionButtonClick(i, $event)"
+                      @keyup.enter="handleActionButtonClick(i, $event)"
+                      @keyup.space="handleActionButtonClick(i, $event)"
                     />
                   </slot>
                 </td>

--- a/shell/components/SortableTable/selection.js
+++ b/shell/components/SortableTable/selection.js
@@ -1,3 +1,4 @@
+import { mapGetters } from 'vuex';
 import { isMore, isRange, suppressContextMenu, isAlternate } from '@shell/utils/platform';
 import { get } from '@shell/utils/object';
 import { filterBy } from '@shell/utils/array';
@@ -29,6 +30,13 @@ export default {
   },
 
   computed: {
+    ...mapGetters({
+      // Use either these Vuex getters
+      // OR the props to set the action menu state,
+      // but don't use both.
+      targetElem: 'action-menu/elem',
+      shouldShow: 'action-menu/showing',
+    }),
     // Used for the table-level selection check-box to show checked (all selected)/intermediate (some selected)/unchecked (none selected)
     howMuchSelected() {
       const total = this.pagedRows.length;
@@ -270,11 +278,17 @@ export default {
           }
         }
 
-        this.$store.commit(`action-menu/show`, {
-          resources,
-          event: e,
-          elem:  actionElement
-        });
+        if (!this.targetElem && !this.shouldShow) {
+          this.$store.commit(`action-menu/show`, {
+            resources,
+            event: e,
+            elem:  actionElement
+          });
+        } else if (this.targetElem === actionElement && this.shouldShow) {
+          // this condition is needed so that we can "toggle" the action menu with
+          // the keyboard for accessibility (row action menu)
+          this.$store.commit('action-menu/hide');
+        }
 
         return;
       }

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -504,16 +504,18 @@ export default defineComponent({
               {{ t('landing.seeWhatsNew') }}
             </div>
             <a
-              class="hand"
+              class="hand banner-link"
               :href="releaseNotesUrl"
+              role="link"
               target="_blank"
               rel="noopener noreferrer nofollow"
               @click.stop="showWhatsNew"
+              @keyup.stop.enter="showWhatsNew"
+              @keyup.stop.space="showWhatsNew"
             ><span v-clean-html="t('landing.whatsNewLink')" /></a>
           </Banner>
         </div>
       </div>
-
       <div class="row home-panels">
         <div class="col main-panel">
           <div
@@ -532,7 +534,10 @@ export default defineComponent({
                 </div>
                 <a
                   class="hand mr-20"
+                  tabindex="0"
                   @click.prevent.stop="showUserPrefs"
+                  @keyup.prevent.stop.enter="showUserPrefs"
+                  @keyup.prevent.stop.space="showUserPrefs"
                 ><span v-clean-html="t('landing.landingPrefs.userPrefs')" /></a>
               </Banner>
             </div>
@@ -583,6 +588,8 @@ export default defineComponent({
                       :to="manageLocation"
                       class="btn btn-sm role-secondary"
                       data-testid="cluster-management-manage-button"
+                      role="link"
+                      @keyup.space="$router.push(manageLocation)"
                     >
                       {{ t('cluster.manageAction') }}
                     </router-link>
@@ -591,6 +598,8 @@ export default defineComponent({
                       :to="importLocation"
                       class="btn btn-sm role-primary"
                       data-testid="cluster-create-import-button"
+                      role="link"
+                      @keyup.space="$router.push(importLocation)"
                     >
                       {{ t('cluster.importAction') }}
                     </router-link>
@@ -599,6 +608,8 @@ export default defineComponent({
                       :to="createLocation"
                       class="btn btn-sm role-primary"
                       data-testid="cluster-create-button"
+                      role="link"
+                      @keyup.space="$router.push(createLocation)"
                     >
                       {{ t('generic.create') }}
                     </router-link>
@@ -614,6 +625,8 @@ export default defineComponent({
                         <router-link
                           v-if="row.mgmt.isReady && !row.hasError"
                           :to="{ name: 'c-cluster-explorer', params: { cluster: row.mgmt.id }}"
+                          role="link"
+                          @keyup.space="$router.push({ name: 'c-cluster-explorer', params: { cluster: row.mgmt.id }})"
                         >
                           {{ row.nameDisplay }}
                         </router-link>
@@ -687,6 +700,10 @@ export default defineComponent({
 </template>
 
 <style lang='scss' scoped>
+  .banner-link:focus-visible {
+    @include focus-outline;
+  }
+
   .home-panels {
     display: flex;
     align-items: stretch;

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -509,6 +509,7 @@ export default defineComponent({
               role="link"
               target="_blank"
               rel="noopener noreferrer nofollow"
+              :aria-label="t('landing.whatsNewLink')"
               @click.stop="showWhatsNew"
               @keyup.stop.enter="showWhatsNew"
               @keyup.stop.space="showWhatsNew"
@@ -535,6 +536,7 @@ export default defineComponent({
                 <a
                   class="hand mr-20"
                   tabindex="0"
+                  :aria-label="t('landing.landingPrefs.userPrefs')"
                   @click.prevent.stop="showUserPrefs"
                   @keyup.prevent.stop.enter="showUserPrefs"
                   @keyup.prevent.stop.space="showUserPrefs"
@@ -589,6 +591,7 @@ export default defineComponent({
                       class="btn btn-sm role-secondary"
                       data-testid="cluster-management-manage-button"
                       role="link"
+                      :aria-label="t('cluster.manageAction')"
                       @keyup.space="$router.push(manageLocation)"
                     >
                       {{ t('cluster.manageAction') }}
@@ -599,6 +602,7 @@ export default defineComponent({
                       class="btn btn-sm role-primary"
                       data-testid="cluster-create-import-button"
                       role="link"
+                      :aria-label="t('cluster.importAction')"
                       @keyup.space="$router.push(importLocation)"
                     >
                       {{ t('cluster.importAction') }}
@@ -609,6 +613,7 @@ export default defineComponent({
                       class="btn btn-sm role-primary"
                       data-testid="cluster-create-button"
                       role="link"
+                      :aria-label="t('generic.create')"
                       @keyup.space="$router.push(createLocation)"
                     >
                       {{ t('generic.create') }}
@@ -626,6 +631,7 @@ export default defineComponent({
                           v-if="row.mgmt.isReady && !row.hasError"
                           :to="{ name: 'c-cluster-explorer', params: { cluster: row.mgmt.id }}"
                           role="link"
+                          :aria-label="row.nameDisplay"
                           @keyup.space="$router.push({ name: 'c-cluster-explorer', params: { cluster: row.mgmt.id }})"
                         >
                           {{ row.nameDisplay }}

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -589,8 +589,9 @@ export default defineComponent({
                       :to="manageLocation"
                       class="btn btn-sm role-secondary"
                       data-testid="cluster-management-manage-button"
-                      role="link"
+                      role="button"
                       :aria-label="t('cluster.manageAction')"
+                      @keyup.space="$router.push(manageLocation)"
                     >
                       {{ t('cluster.manageAction') }}
                     </router-link>
@@ -599,8 +600,9 @@ export default defineComponent({
                       :to="importLocation"
                       class="btn btn-sm role-primary"
                       data-testid="cluster-create-import-button"
-                      role="link"
+                      role="button"
                       :aria-label="t('cluster.importAction')"
+                      @keyup.space="$router.push(importLocation)"
                     >
                       {{ t('cluster.importAction') }}
                     </router-link>
@@ -609,8 +611,9 @@ export default defineComponent({
                       :to="createLocation"
                       class="btn btn-sm role-primary"
                       data-testid="cluster-create-button"
-                      role="link"
+                      role="button"
                       :aria-label="t('generic.create')"
+                      @keyup.space="$router.push(createLocation)"
                     >
                       {{ t('generic.create') }}
                     </router-link>

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -591,7 +591,6 @@ export default defineComponent({
                       data-testid="cluster-management-manage-button"
                       role="link"
                       :aria-label="t('cluster.manageAction')"
-                      @keyup.space="$router.push(manageLocation)"
                     >
                       {{ t('cluster.manageAction') }}
                     </router-link>
@@ -602,7 +601,6 @@ export default defineComponent({
                       data-testid="cluster-create-import-button"
                       role="link"
                       :aria-label="t('cluster.importAction')"
-                      @keyup.space="$router.push(importLocation)"
                     >
                       {{ t('cluster.importAction') }}
                     </router-link>
@@ -613,7 +611,6 @@ export default defineComponent({
                       data-testid="cluster-create-button"
                       role="link"
                       :aria-label="t('generic.create')"
-                      @keyup.space="$router.push(createLocation)"
                     >
                       {{ t('generic.create') }}
                     </router-link>
@@ -631,7 +628,6 @@ export default defineComponent({
                           :to="{ name: 'c-cluster-explorer', params: { cluster: row.mgmt.id }}"
                           role="link"
                           :aria-label="row.nameDisplay"
-                          @keyup.space="$router.push({ name: 'c-cluster-explorer', params: { cluster: row.mgmt.id }})"
                         >
                           {{ row.nameDisplay }}
                         </router-link>

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -512,7 +512,6 @@ export default defineComponent({
               :aria-label="t('landing.whatsNewLink')"
               @click.stop="showWhatsNew"
               @keyup.stop.enter="showWhatsNew"
-              @keyup.stop.space="showWhatsNew"
             ><span v-clean-html="t('landing.whatsNewLink')" /></a>
           </Banner>
         </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12776 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Fix keyboard navigation on `home` page
- checkbox is now visibly focusable
- `Banner` component has correct roles, labels and is focusable
- `SortableTable` component has been fixed for basic keyboard nav (sorting, checkboxes, links, open/close row action menu)


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Go to the `home` page and browse the page with the tab key
- use `enter` or `space` key to trigger UI elements on the page

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


https://github.com/user-attachments/assets/47ee2472-9fb8-445d-b808-a4330f7ad9d2




### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
