### PR TITLE
[2.10] Storage class selector not working

### DIFF
--- a/shell/chart/monitoring/StorageClassSelector.vue
+++ b/shell/chart/monitoring/StorageClassSelector.vue
@@ -44,6 +44,6 @@ export default {
     :options="options"
     :push-tags="true"
     :taggable="true"
-    @input="updateName"
+    @update:value="updateName"
   />
 </template>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12972 
As part of Vue 3 migration, we needed to remove @input from compponents that use LabeledSelect

Occurred changes and/or fixed issues
Fixed event listener in StorageClassSelector.

Technical notes summary
Areas or cases that should be tested
Create a new StorageClass
Apps -> Charts -> Monitoring -> Install/Update -> Prometheus -> Persistent Storage for Prometheus -> Storage Class name -> You should be able to select a storage class
Apps -> Charts -> Monitoring -> Install/Update -> Grafana -> "Enable with PVC Template" Grafana storage -> Storage Class name -> You should be able to select a storage class
Areas which could experience regressions
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
