### PR TITLE
chore(workload): disable access to unreturned data attributes in data method

### DIFF
--- a/shell/edit/workload/mixins/workload.js
+++ b/shell/edit/workload/mixins/workload.js
@@ -250,7 +250,6 @@ export default {
       }
     }
 
-    this.selectContainer(container);
     if (this.realMode === _CLONE && this.value.type === WORKLOAD_TYPES.JOB) {
       this.cleanUpClonedJobData();
     }
@@ -280,12 +279,10 @@ export default {
       podFsGroup:                 podTemplateSpec.securityContext?.fsGroup,
       savePvcHookName:            'savePvcHook',
       tabWeightMap:               TAB_WEIGHT_MAP,
-      fvFormRuleSets:             [{
-        path: 'image', rootObject: this.container, rules: ['required'], translationKey: 'workload.container.image'
-      }],
-      fvReportedValidationPaths: ['spec'],
-      isNamespaceNew:            false,
-      idKey:                     ID_KEY
+      fvFormRuleSets:             [],
+      fvReportedValidationPaths:  ['spec'],
+      isNamespaceNew:             false,
+      idKey:                      ID_KEY
     };
   },
 
@@ -605,6 +602,15 @@ export default {
       this.value['type'] = neu;
       delete this.value.apiVersion;
     },
+
+    container: {
+      handler(c) {
+        this.fvFormRuleSets = [{
+          path: 'image', rootObject: c, rules: ['required'], translationKey: 'workload.container.image'
+        }];
+      },
+      immediate: true
+    }
   },
 
   created() {
@@ -612,6 +618,8 @@ export default {
     this.registerBeforeHook(this.getPorts, 'getPorts');
 
     this.registerAfterHook(this.saveService, 'saveService');
+
+    this.selectContainer(this.container);
   },
 
   methods: {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13001
<!-- Define findings related to the feature or bug issue. -->


### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

The data  method is expected to return a plain JavaScript object, which will be made reactive by Vue. Accessing or modifying unreturned data attributes  in the data method may result in undesired issues

ref: https://vuejs.org/api/options-state.html#data
### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

1. When the component is initialized, the method call to select the first container is placed in the created  lifecycle hooks.
2. watch the active container changes and update `fvFormRuleSets`, in order to display the image form status in real time.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

1. should manual test that the form error prompts for the container are correct when creating or editing a workload
ref: https://github.com/rancher/dashboard/issues/13001

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
