### PR TITLE
fix wf catalog build on creators + creators version bump

### DIFF
--- a/creators/extension/app/files/.github/workflows/build-extension-catalog.yml
+++ b/creators/extension/app/files/.github/workflows/build-extension-catalog.yml
@@ -20,5 +20,6 @@ jobs:
     with:
       registry_target: ghcr.io
       registry_user: ${{ github.actor }}
+      tagged_release: ${{ github.ref_name }}
     secrets: 
       registry_token: ${{ secrets.GITHUB_TOKEN }}

--- a/creators/extension/package.json
+++ b/creators/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rancher/create-extension",
   "description": "Rancher UI Extension generator",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "license": "Apache-2.0",
   "author": "SUSE",
   "packageManager": "yarn@4.5.0",

--- a/docusaurus/docs/extensions/known-issues.md
+++ b/docusaurus/docs/extensions/known-issues.md
@@ -19,3 +19,23 @@ To resolve this add the following `resolution` to the root application's `packag
   ...
 }
 ```
+
+- Running `yarn install` might throw the following errors:
+```
+error @aws-sdk/types@3.723.0: The engine "node" is incompatible with this module. Expected version ">=18.0.0". Got "16.20.2"
+error @aws-sdk/util-locate-window@3.723.0: The engine "node" is incompatible with this module. Expected version ">=18.0.0". Got "16.20.2"
+```
+
+To resolve this add the following `resolutions` to the root application's `package.json`:
+```
+{
+  "name": "app-name",
+  "version": "0.1.0",
+  ...
+  resolutions": {
+    "@aws-sdk/types": "3.714.0",
+    "@aws-sdk/util-locate-window": "3.693.0"
+  },
+  ...
+}
+```


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12993 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix workflow for `catalog` build on `creators` package by adding missing `tagged_release` input
- bump `creators` version
- adds documentation for issues  #12988 and #12995 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
