### PR TITLE
Improve feature flag restart terminology

### DIFF
--- a/cypress/e2e/tests/pages/global-settings/feature-flags.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/feature-flags.spec.ts
@@ -219,7 +219,7 @@ describe('Feature Flags', { testIsolation: 'off' }, () => {
     it('validate feature flags table header content', () => {
       FeatureFlagsPagePo.navTo();
       // check table headers are visible
-      const expectedHeaders = ['State', 'Name', 'Description', 'Restart Required'];
+      const expectedHeaders = ['State', 'Name', 'Description', 'Restart Rancher'];
 
       featureFlagsPage.list().resourceTable().sortableTable().tableHeaderRow()
         .get('.table-header-container .content')

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5836,7 +5836,7 @@ tableHeaders:
   resourcesReady: Resources Ready
   restarts: Restarts
   restart: Restart Required
-  restartSystem: Restart System
+  restartSystem: Restart { vendor }
   restore: Restore
   role: Role
   roles: Roles
@@ -7507,7 +7507,7 @@ featureFlags:
     This will result in a short outage of the API and UI, but not affect running clusters or workloads.
   promptActivate: Please confirm that you want to activate the feature flag "{flag}"
   promptDeactivate: Please confirm that you want to deactivate the feature flag "{flag}"
-  restartRequired: "Note: Updating this feature flag will restart the {vendor} server"
+  restartRequired: "Note: Updating this feature flag will restart {vendor}"
   restart:
     title: Waiting for Restart
     wait: This may take a few moments

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5836,6 +5836,7 @@ tableHeaders:
   resourcesReady: Resources Ready
   restarts: Restarts
   restart: Restart Required
+  restartSystem: Restart System
   restore: Restore
   role: Role
   roles: Roles
@@ -7498,6 +7499,7 @@ advancedSettings:
 
 featureFlags:
   label: Feature Flags
+  title: "Are you sure?"
   warning: |-
     Feature flags allow {vendor} to gate certain features behind flags.
     Features that are off by default should be considered experimental functionality.
@@ -7505,7 +7507,7 @@ featureFlags:
     This will result in a short outage of the API and UI, but not affect running clusters or workloads.
   promptActivate: Please confirm that you want to activate the feature flag "{flag}"
   promptDeactivate: Please confirm that you want to deactivate the feature flag "{flag}"
-  restartRequired: "Note: Updating this feature flag requires a restart"
+  restartRequired: "Note: Updating this feature flag will restart the {vendor} server"
   restart:
     title: Waiting for Restart
     wait: This may take a few moments

--- a/shell/config/product/settings.js
+++ b/shell/config/product/settings.js
@@ -6,6 +6,7 @@ import {
   RESTART,
   NAME_UNLINKED,
 } from '@shell/config/table-headers';
+import { getVendor } from '@shell/config/private-label';
 
 export const NAME = 'settings';
 
@@ -142,11 +143,18 @@ export function init(store) {
     canYaml:     true,
   });
 
+  // Change the restart header to 'Restart <VENDOR>' so that it is clearer what is being restarted
+  const t = store.getters['i18n/t'];
+
   headers(MANAGEMENT.FEATURE, [
     STATE,
     NAME_UNLINKED,
     FEATURE_DESCRIPTION,
-    RESTART,
+    {
+      ...RESTART,
+      labelKey: undefined,
+      label:    t('tableHeaders.restartSystem', { vendor: getVendor() })
+    }
   ]);
 
   hideBulkActions(MANAGEMENT.FEATURE, true);

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -962,7 +962,7 @@ export const EXPIRES = {
 
 export const RESTART = {
   name:      'restart',
-  labelKey:  'tableHeaders.restart',
+  labelKey:  'tableHeaders.restartSystem',
   value:     'restartRequired',
   sort:      ['restartRequired', 'nameSort'],
   formatter: 'Checked',

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -962,11 +962,11 @@ export const EXPIRES = {
 
 export const RESTART = {
   name:      'restart',
-  labelKey:  'tableHeaders.restartSystem',
+  labelKey:  'tableHeaders.restart',
   value:     'restartRequired',
   sort:      ['restartRequired', 'nameSort'],
   formatter: 'Checked',
-  width:     75,
+  width:     125,
   align:     'center'
 };
 

--- a/shell/list/management.cattle.io.feature.vue
+++ b/shell/list/management.cattle.io.feature.vue
@@ -9,6 +9,7 @@ import { LabeledInput } from '@components/Form/LabeledInput';
 import { MANAGEMENT } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';
 import ResourceFetch from '@shell/mixins/resource-fetch';
+import { getVendor } from '@shell/config/private-label';
 
 export default {
   components: {
@@ -63,6 +64,7 @@ export default {
       serverUrl:        '',
       noUrlSet:         false,
       showModal:        false,
+      vendor:           getVendor(),
     };
   },
 
@@ -214,7 +216,7 @@ export default {
       v-if="showModal"
       class="update-modal"
       name="toggleFlag"
-      :width="350"
+      :width="450"
       height="auto"
       styles="max-height: 100vh;"
       :click-to-close="!restart || !waiting"
@@ -227,7 +229,7 @@ export default {
       >
         <template #title>
           <h4 class="text-default-text">
-            Are you sure?
+            {{ t('featureFlags.title') }}
           </h4>
         </template>
         <template #body>
@@ -263,8 +265,8 @@ export default {
             </span>
             <Banner
               v-if="restart"
-              color="warning"
-              :label="t('featureFlags.restartRequired')"
+              color="error"
+              :label="t('featureFlags.restartRequired', vendor)"
             />
           </div>
           <div class="text-error mb-10">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11305

### Occurred changes and/or fixed issues

This PR renames the column name on the feature flag page and also the message in the confirmation modal.

The terminology now is 'Restart Rancher' (where 'Rancher' is the vendor name)

### Technical notes summary

Table columns only accept a label key which can not have params, so we evaluate the table header with the vendor name when we add the table headers for the feature flag table.

### Areas or cases that should be tested

1. Visually check that the column name has changed.
2. Try and activate/deactivate a feature flag that requires restart and check the message is correctly updated. 

### Screenshot/Video

List, showing new name for list column for restart:

![image](https://github.com/user-attachments/assets/f4be4d76-ca28-469c-a375-a7d54e6dc1a0)

Modal dialog for activate/de-activate:

![image](https://github.com/user-attachments/assets/8c5c3389-5ffa-4307-bc28-35c18e40e641)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
