### PR TITLE
update gke networking to select the default network by default

### DIFF
--- a/pkg/gke/components/Networking.vue
+++ b/pkg/gke/components/Networking.vue
@@ -203,9 +203,15 @@ export default defineComponent({
 
     networkOptions(neu) {
       if (neu && neu.length && !this.network) {
-        const firstnetwork = neu.find((network: GKENetwork) => network.kind !== 'group');
+        const defaultNetwork = neu.find((network: GKENetwork) => network?.name === 'default');
 
-        this.$emit('update:network', firstnetwork?.name);
+        if (defaultNetwork) {
+          this.$emit('update:network', defaultNetwork.name);
+        } else {
+          const firstnetwork = neu.find((network: GKENetwork) => network.kind !== 'group');
+
+          this.$emit('update:network', firstnetwork?.name);
+        }
       }
     },
 

--- a/pkg/gke/components/__tests__/Networking.test.ts
+++ b/pkg/gke/components/__tests__/Networking.test.ts
@@ -67,7 +67,7 @@ describe('gke Networking', () => {
     expect(spy).toHaveBeenCalledTimes(4);
   });
 
-  it('should populate network dropdown and select the first option after loading gcp data', async() => {
+  it('should populate network dropdown and select the default network after loading gcp data', async() => {
     const setup = requiredSetup();
 
     const wrapper = shallowMount(Networking, {
@@ -85,8 +85,8 @@ describe('gke Networking', () => {
 
     const networksDropdown = wrapper.getComponent('[data-testid="gke-networks-dropdown"]');
 
-    expect(networksDropdown.props().options).toHaveLength(4);
-    expect(wrapper.emitted('update:network')?.[0]?.[0]).toBe('host-shared-vpc');
+    expect(networksDropdown.props().options).toHaveLength(5);
+    expect(wrapper.emitted('update:network')?.[0]?.[0]).toBe('default');
   });
 
   it('should populate subnetworks dropdown dependent on network selection', async() => {

--- a/pkg/gke/util/__mocks__/gcp.ts
+++ b/pkg/gke/util/__mocks__/gcp.ts
@@ -247,6 +247,64 @@ const mockedGKENetworksResponse = {
       'https://www.googleapis.com/compute/v1/projects/test-project/regions/me-central1/subnetworks/test-network',
       'https://www.googleapis.com/compute/v1/projects/test-project/regions/asia-east2/subnetworks/test-network',
       'https://www.googleapis.com/compute/v1/projects/test-project/regions/me-central2/subnetworks/test-network']
+  },
+  {
+    autoCreateSubnetworks:                 true,
+    creationTimestamp:                     '2022-10-26T14:50:30.702-07:00',
+    id:                                    '11111111',
+    kind:                                  'compute#network',
+    mtu:                                   1460,
+    name:                                  'default',
+    networkFirewallPolicyEnforcementOrder: 'AFTER_CLASSIC_FIREWALL',
+    routingConfig:                         { routingMode: 'REGIONAL' },
+    selfLink:                              'https://www.googleapis.com/compute/v1/projects/test-data-project/global/networks/default',
+    selfLinkWithId:                        'https://www.googleapis.com/compute/v1/projects/test-data-project/global/networks/11111111',
+    subnetworks:                           [
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/africa-south1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-west8/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/asia-northeast3/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/asia-northeast2/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/asia-south2/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/europe-west3/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-west3/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-west2/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/asia-northeast1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/europe-west12/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/asia-southeast1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-south1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/southamerica-west1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/asia-southeast2/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/me-west1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-east7/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-central1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/southamerica-east1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/europe-west9/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/europe-north1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-east4/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/asia-east1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/europe-west10/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/europe-central2/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/europe-north2/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/asia-south1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/northamerica-south1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-east5/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-east1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/europe-west4/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/europe-west2/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/europe-west8/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/northamerica-northeast1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/australia-southeast2/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-west4/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/europe-west6/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/northamerica-northeast2/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/europe-southwest1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-west1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/australia-southeast1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/europe-west1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/me-central1/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/asia-east2/subnetworks/default',
+      'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/me-central2/subnetworks/default'
+    ]
   }]
 };
 
@@ -267,7 +325,30 @@ const mockedGKESubnetworksResponse = {
     secondaryIpRanges:       [{ ipCidrRange: '10.0.1.0/24', rangeName: 'range-1' }],
     selfLink:                'https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/subnetworks/test-network',
     stackType:               'IPV4_ONLY',
-  }]
+  },
+  {
+    creationTimestamp:       '2022-10-26T14:50:38.688-07:00',
+    fingerprint:             '3456',
+    gatewayAddress:          '10.128.0.1',
+    id:                      '1234',
+    ipCidrRange:             '10.128.0.0/20',
+    kind:                    'compute#subnetwork',
+    name:                    'default',
+    network:                 'https://www.googleapis.com/compute/v1/projects/test-data-project/global/networks/default',
+    privateIpGoogleAccess:   true,
+    privateIpv6GoogleAccess: 'DISABLE_GOOGLE_ACCESS',
+    purpose:                 'PRIVATE',
+    region:                  'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-central1',
+    secondaryIpRanges:       [
+      {
+        ipCidrRange: '10.0.1.0/24',
+        rangeName:   'range-1'
+      }
+    ],
+    selfLink:  'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-central1/subnetworks/default',
+    stackType: 'IPV4_ONLY'
+  },
+  ]
 };
 
 const mockedGKESharedSubnetworksResponse = {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11895
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
GKE networking should auto-select the network named 'default' if it exists. If not, it should fall back on the first network in the list.

### Technical notes summary
The old UI determines which network is the default network by looking for one named 'default'  https://github.com/rancher/ui/blob/master/lib/shared/addon/components/cluster-driver/driver-gke/component.js#L236


### Areas or cases that should be tested
Our GCP project doesn't appear to have a 'default' network (Google docs confirm that projects may be configured without one). I suggest using the spoofed network and subnetwork I added to the gcp test mock file (I verified the shape of this data by borrowing a QA instance that _did_ have a default network). Add it to the getNetworks and getSubnetworks methods like so:

```
  async getNetworks() {
      try {
        const res = await getGKENetworks(this.$store, this.cloudCredentialId, this.projectId, { zone: this.zone, region: this.region });
        // TODO nb rm
        const spoofedDefault = {
          creationTimestamp:       '2022-10-26T14:50:38.688-07:00',
          fingerprint:             '3456',
          gatewayAddress:          '10.128.0.1',
          id:                      '1234',
          ipCidrRange:             '10.128.0.0/20',
          kind:                    'compute#subnetwork',
          name:                    'default',
          network:                 'https://www.googleapis.com/compute/v1/projects/test-data-project/global/networks/default',
          privateIpGoogleAccess:   true,
          privateIpv6GoogleAccess: 'DISABLE_GOOGLE_ACCESS',
          purpose:                 'PRIVATE',
          region:                  'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-central1',
          secondaryIpRanges:       [
            {
              ipCidrRange: '10.0.1.0/24',
              rangeName:   'range-1'
            }
          ],
          selfLink:  'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-central1/subnetworks/default',
          stackType: 'IPV4_ONLY'
        };

        res.items.push(spoofedDefault);
        this.networksResponse = res;
      } catch (err:any) {
        this.$emit('error', err);
      }
    },

    async getSubnetworks() {
      let { region, zone } = this;

      if (!region && !!zone) {
        region = `${ zone.split('-')[0] }-${ zone.split('-')[1] }`;
      }

      try {
        const res = await getGKESubnetworks(this.$store, this.cloudCredentialId, this.projectId, { region });
        // TODO nb rm
        const spoofedDefaultSub = {
          creationTimestamp:       '2022-10-26T14:50:38.688-07:00',
          fingerprint:             '3456',
          gatewayAddress:          '10.128.0.1',
          id:                      '1234',
          ipCidrRange:             '10.128.0.0/20',
          kind:                    'compute#subnetwork',
          name:                    'default',
          network:                 'https://www.googleapis.com/compute/v1/projects/test-data-project/global/networks/default',
          privateIpGoogleAccess:   true,
          privateIpv6GoogleAccess: 'DISABLE_GOOGLE_ACCESS',
          purpose:                 'PRIVATE',
          region:                  'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-central1',
          secondaryIpRanges:       [
            {
              ipCidrRange: '10.0.1.0/24',
              rangeName:   'range-1'
            }
          ],
          selfLink:  'https://www.googleapis.com/compute/v1/projects/test-data-project/regions/us-central1/subnetworks/default',
          stackType: 'IPV4_ONLY'
        };

        res.items.push(spoofedDefaultSub);
        this.subnetworksResponse = res;
      } catch (err:any) {
        this.$emit('error', err);
      }
    },
```

Then, to verify the fix:
1. Go to GKE cluster creation
2. Open the networking tab and verify that the network selected is 'default'
3. verify that the subnetwork selected is also 'default'
4. Hit save and check the POST request - gkeConfig.network should be 'default' and gkeConfig.subnetwork should also be 'default'

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
