### PR TITLE
[2.9] Align gitlab reusable workflow with release-2.9

### DIFF
--- a/creators/extension/app/files/.gitlab-ci.yml
+++ b/creators/extension/app/files/.gitlab-ci.yml
@@ -11,4 +11,4 @@ variables:
   IMAGE_NAMESPACE: $CI_PROJECT_NAMESPACE/$CI_PROJECT_NAME
 
 include:
-  - remote: 'https://raw.githubusercontent.com/rancher/dashboard/master/shell/scripts/.gitlab/workflows/build-extension-catalog.gitlab-ci.yml'
+  - remote: 'https://raw.githubusercontent.com/rancher/dashboard/release-2.9/shell/scripts/.gitlab/workflows/build-extension-catalog.gitlab-ci.yml'

--- a/creators/extension/package.json
+++ b/creators/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rancher/create-extension",
   "description": "Rancher UI Extension generator",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "license": "Apache-2.0",
   "author": "SUSE",
   "packageManager": "yarn@4.5.0",

--- a/shell/scripts/.gitlab/workflows/build-extension-catalog.gitlab-ci.yml
+++ b/shell/scripts/.gitlab/workflows/build-extension-catalog.gitlab-ci.yml
@@ -1,7 +1,7 @@
 variables:
   NODE_VERSION: "v16.20.2"
   NODE_DISTRO: "node-${NODE_VERSION}-linux-x64"
-  YQ_VERSION: "v4.44.1"
+  YQ_VERSION: "v4.44.6"
   YQ_URL: "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
 
 .podman-setup: &podman-setup


### PR DESCRIPTION
### Summary
This updates the target branch of the reusable workflow within the `.gitlab-ci.yml` file that is imported into an extension through the creator and ensures we are targeting the correct branch of the workflow file.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Bumped yq version `v4.4.6`
- Bumped extension creator version `2.0.8`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
