### PR TITLE
fix aks region being overwritten when editing unprovisioned aks clusters

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -804,8 +804,6 @@ export default defineComponent({
         return;
       }
       this.loadingLocations = true;
-      // this will force the resourceLocation watcher to re-run every time new locations are fetched even if the default one selected hasn't changed
-      this.config['resourceLocation'] = '';
 
       const { azureCredentialSecret } = this.config;
 
@@ -839,6 +837,11 @@ export default defineComponent({
 
         errors.push(this.t('aks.errors.regions', { e: parsedError || err }));
       }
+
+      // once regions are loaded and a default selected, fetch resources that are region-scoped
+      this.getAksVersions();
+      this.getVmSizes();
+      this.getVirtualNetworks();
     },
 
     async getAksVersions(): Promise<void> {

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -645,7 +645,7 @@ export default defineComponent({
 
     virtualNetwork: {
       get() {
-        return this.virtualNetworkOptions.find((opt) => opt.value === this.config.subnet) || this.t('generic.none');
+        return this.virtualNetworkOptions.find((opt) => opt.value === this.config.subnet) || { label: this.t('generic.none') };
       },
       set(neu: {label: string, kind?: string, disabled?: boolean, value?: string, virtualNetwork?: any}) {
         if (neu.label === this.t('generic.none')) {

--- a/pkg/aks/components/__tests__/CruAks.test.ts
+++ b/pkg/aks/components/__tests__/CruAks.test.ts
@@ -240,7 +240,7 @@ describe('aks provisioning form', () => {
   it('should display subnets grouped by network in the virtual network dropdown', async() => {
     const noneOption = { label: 'generic.none' };
     const config = {
-      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc'
+      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc', resourceLocation: 'eastus'
     };
     const wrapper = shallowMount(CruAks, {
       propsData: {
@@ -254,7 +254,6 @@ describe('aks provisioning form', () => {
     const networkOpts = virtualNetworkSelect.props().options;
 
     expect(virtualNetworkSelect.props().value).toStrictEqual(noneOption);
-
     expect(networkOpts).toStrictEqual([{ label: 'generic.none' }, {
       disabled: true, kind: 'group', label: 'network2'
     }, {
@@ -299,7 +298,7 @@ describe('aks provisioning form', () => {
 
   it('should prevent saving if a node pool has taints missing keys or values', async() => {
     const config = {
-      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc'
+      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc', resourceLocation: 'eastus'
     };
     const wrapper = shallowMount(CruAks, {
       propsData: {
@@ -343,7 +342,7 @@ describe('aks provisioning form', () => {
     }],
   ])('should set virtualNetwork, virtualNetworkResourceGroup, and subnet when a virtual network is selected', async(optionIndex, { virtualNetwork, virtualNetworkResourceGroup, subnet }) => {
     const config = {
-      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc'
+      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc', resourceLocation: 'eastus'
     };
     const wrapper = shallowMount(CruAks, {
       propsData: {
@@ -366,7 +365,7 @@ describe('aks provisioning form', () => {
 
   it('should set config.monitoring to \'true\' and show log anaytics workspace name and log analytics workspace group inputs when the monitoring checkbox is checked', async() => {
     const config = {
-      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc'
+      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc', resourceLocation: 'eastus'
     };
     const wrapper = shallowMount(CruAks, {
       propsData: {
@@ -397,7 +396,7 @@ describe('aks provisioning form', () => {
 
   it('should clear virtualNetwork, virtualNetworkResourceGroup, and subnet when the \'none\' virtual network option is selected', async() => {
     const config = {
-      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc'
+      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc', resourceLocation: 'eastus'
     };
     const wrapper = shallowMount(CruAks, {
       propsData: {
@@ -430,7 +429,7 @@ describe('aks provisioning form', () => {
       name: 'abc', _validation: {}, _isNewOrUnprovisioned: false, orchestratorVersion: originalVersion
     }];
     const config = {
-      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc', kubernetesVersion: originalVersion, nodePools
+      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc', kubernetesVersion: originalVersion, nodePools, resourceLocation: 'eastus'
     };
     const wrapper = shallowMount(CruAks, {
       propsData: {
@@ -451,7 +450,7 @@ describe('aks provisioning form', () => {
 
   it('should clear config.logAnalyticsWorkspaceName and config.logAnalyticsWorkspaceGroup when the monitoring checkbox is unchecked', async() => {
     const config = {
-      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc', monitoring: true, logAnalyticsWorkspaceGroup: 'abc', logAnalyticsWorkspaceName: 'def'
+      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc', monitoring: true, logAnalyticsWorkspaceGroup: 'abc', logAnalyticsWorkspaceName: 'def', resourceLocation: 'eastus'
     };
     const wrapper = shallowMount(CruAks, {
       propsData: {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11841 

This bug is specific to AKS clusters that have been created in Rancher, but not yet created in AKS. To repro, you can use the default AKS configuration options (except region) but you need to edit the cluster immediately after creating it to see the bug. This PR tweaks some login in the location-fetching method that failed to account for this inbetweeny edit mode.

### Areas or cases that should be tested
1. Create a new AKS cluster - after entering in credentials, regions should be loaded and east us selected by default.
2. Change the region to something else
3. Set other required fields and save
4. immediately edit the cluster. The region dropdown should show whatever region you picked in step 2. If you open the dropdown, you should see a list of regions to select.



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
