### PR TITLE
validate that AKS node pool count is no more than 1000

### DIFF
--- a/pkg/aks/l10n/en-us.yaml
+++ b/pkg/aks/l10n/en-us.yaml
@@ -163,8 +163,8 @@ aks:
     availabilityZones: Availability zones are not available in the selected region.
     privateDnsZone: Private DNS Zone Resource ID must be in the format /subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCEGROUP_NAME/providers/Microsoft.Network/privateDnsZones/PRIVATE_DNS_ZONE_NAME. The Private DNS Zone Resource Name must be in the format privatelink.REGION.azmk8s.io, SUBZONE.privatelink.REGION.azmk8s.io, private.REGION.azmk8s.io, or SUBZONE.private.REGION.azmk8s.io
     poolName: Node pool names must be 1-12 characters long, consist only of lowercase letters and numbers, and start with a letter.
-    poolCount: Node count must be at least one in System pools.
-    poolUserCount: Node count cannot be less than zero.
+    poolCount: Node count must be at least one and at most 1000 in System pools.
+    poolUserCount: Node count cannot be less than zero or greater than 1000 in User pools.
     poolMinMax: The minimum number of nodes must be less than or equal to the maximum number of nodes, and the node count must be between or equal to the minimum and maximum.
     poolMin: The minimum number of nodes must be greater than 0 and at most 1000.
     poolMax: The maximum number of nodes must be greater than 0 and at most 1000.

--- a/pkg/aks/l10n/en-us.yaml
+++ b/pkg/aks/l10n/en-us.yaml
@@ -163,8 +163,8 @@ aks:
     availabilityZones: Availability zones are not available in the selected region.
     privateDnsZone: Private DNS Zone Resource ID must be in the format /subscriptions/SUBSCRIPTION_ID/resourceGroups/RESOURCEGROUP_NAME/providers/Microsoft.Network/privateDnsZones/PRIVATE_DNS_ZONE_NAME. The Private DNS Zone Resource Name must be in the format privatelink.REGION.azmk8s.io, SUBZONE.privatelink.REGION.azmk8s.io, private.REGION.azmk8s.io, or SUBZONE.private.REGION.azmk8s.io
     poolName: Node pool names must be 1-12 characters long, consist only of lowercase letters and numbers, and start with a letter.
-    poolCount: Node count must be at least one and at most 1000 in System pools.
-    poolUserCount: Node count cannot be less than zero or greater than 1000 in User pools.
+    poolCount: Node count must be at least 1 and at most 1000 in System pools.
+    poolUserCount: Node count cannot be less than 0 or greater than 1000 in User pools.
     poolMinMax: The minimum number of nodes must be less than or equal to the maximum number of nodes, and the node count must be between or equal to the minimum and maximum.
     poolMin: The minimum number of nodes must be greater than 0 and at most 1000.
     poolMax: The maximum number of nodes must be greater than 0 and at most 1000.

--- a/pkg/aks/util/__tests__/validators.test.ts
+++ b/pkg/aks/util/__tests__/validators.test.ts
@@ -140,19 +140,24 @@ describe('fx: nodePoolNames', () => {
 
 describe('fx: nodePoolCount', () => {
   // AksNodePool unit tests check that the second arg is passed in as expected
-  it('validates that count is at least 1 when second arg is false', () => {
+  it('validates that count is at least 1 and at most 1000 when second arg is false', () => {
     const validator = validators.nodePoolCount(mockCtx);
 
     expect(validator(1, false)).toBeUndefined();
     expect(validator(0, false)).toStrictEqual(MOCK_TRANSLATION);
+    expect(validator(1000, false)).toBeUndefined();
+    expect(validator(1001, false)).toStrictEqual(MOCK_TRANSLATION);
   });
 
-  it('validates that count is at least 0 when second arg is true', () => {
+  it('validates that count is at least 0 and at most 1000 when second arg is true', () => {
     const validator = validators.nodePoolCount(mockCtx);
 
     expect(validator(1, true)).toBeUndefined();
     expect(validator(0, true)).toBeUndefined();
+    expect(validator(1000, true)).toBeUndefined();
+
     expect(validator(-1, true)).toStrictEqual(MOCK_TRANSLATION);
+    expect(validator(1001, true)).toStrictEqual(MOCK_TRANSLATION);
   });
 
   it('validates each node pool in the provided context when not passed a count value', () => {
@@ -170,6 +175,12 @@ describe('fx: nodePoolCount', () => {
         },
         {
           name: 'klm', _validation: {}, mode: 'User', count: -1
+        },
+        {
+          name: 'nop', _validation: {}, mode: 'User', count: 1001
+        },
+        {
+          name: 'qrs', _validation: {}, mode: 'System', count: 1001
         }
       ] as unknown as AKSNodePool[]
     };
@@ -180,5 +191,7 @@ describe('fx: nodePoolCount', () => {
     expect(ctx.nodePools[1]?._validation?._validCount).toStrictEqual(true);
     expect(ctx.nodePools[2]?._validation?._validCount).toStrictEqual(true);
     expect(ctx.nodePools[3]?._validation?._validCount).toStrictEqual(false);
+    expect(ctx.nodePools[4]?._validation?._validCount).toStrictEqual(false);
+    expect(ctx.nodePools[5]?._validation?._validCount).toStrictEqual(false);
   });
 });

--- a/pkg/aks/util/validators.ts
+++ b/pkg/aks/util/validators.ts
@@ -181,6 +181,7 @@ export const nodePoolNamesUnique = (ctx: any) => {
 export const nodePoolCount = (ctx:any) => {
   return (count?: number, canBeZero = false) => {
     let min = 1;
+    const max = 1000;
     let errMsg = ctx.t('aks.errors.poolCount');
 
     if (canBeZero) {
@@ -188,7 +189,7 @@ export const nodePoolCount = (ctx:any) => {
       errMsg = ctx.t('aks.errors.poolUserCount');
     }
     if (count || count === 0) {
-      return count >= min ? undefined : errMsg;
+      return count >= min && count <= max ? undefined : errMsg;
     } else {
       let allValid = true;
 
@@ -201,7 +202,7 @@ export const nodePoolCount = (ctx:any) => {
           min = 1;
         }
 
-        if (count < min) {
+        if (count < min || count > max) {
           pool._validation['_validCount'] = false;
           allValid = false;
         } else {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11843 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the AKS node pool count validator to include a maximum value.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
1. open the AKS cluster creation form and fill in required fields
2. set the aks pool's node count to something >1000
3. verify that an error icon is shown and save button disabled
4. add another node pool and switch to its tab
5. verify that the first node pool's tab has an error icon
6. nav back to the first pool and reduce the node count to <1000
7. verify that the create button is re-enabled and error message gone

### Areas which could experience regressions
None; changes are very narrow in scope

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
