### PR TITLE
Allow HMR in Rancher Components and Harvester

### DIFF
--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -456,7 +456,7 @@ const printLogs = (dev, dashboardVersion, resourceBase, routerBasePath, pl, ranc
  * - as list: [/.shell/, /dist-pkg/, /scripts\/standalone/, /\/pkg.test-pkg/, /\/pkg.harvester/]
  * - as chained regex rule: /.shell|dist-pkg|scripts\/standalone|\/pkg.test-pkg|\/pkg.harvester/
  */
-const getWatcherIgnored = (excludes) => {
+const getWatcherIgnored = (excludes = []) => {
   const paths = [
     /node_modules/,
     /dist-pkg/,
@@ -557,7 +557,7 @@ module.exports = function(dir, _appConfig) {
       config.resolve.extensions.push(...['.tsx', '.ts', '.js', '.vue', '.scss']);
       config.watchOptions = {
         ...(config.watchOptions || {}),
-        ignored: getWatcherIgnored(excludes)
+        ignored: getWatcherIgnored()
       };
 
       if (dev) {

--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -474,12 +474,11 @@ const getWatcherIgnored = (excludes = []) => {
  * This takes the directory of the application as the first argument so that we can derive folder locations
  * from it, rather than from the location of this file
  */
-module.exports = function(dir, _appConfig) {
+module.exports = function(dir, appConfig = {}) {
   require('events').EventEmitter.defaultMaxListeners = 20;
   require('dotenv').config();
 
   const { SHELL_ABS, COMPONENTS_DIR } = getShellPaths(dir);
-  const appConfig = _appConfig || {};
   const excludes = appConfig.excludes || [];
 
   const includePkg = (name) => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This allows HMR to trigger when changes are made to Rancher Components and Harvester by omitting the `excludes` argument from `getWatcherIgnored()`. Watch and WatchOptions work to allow Webpack to watch files and recompile whenever they change - I don't see any benefit in excluding Rancher Components and Harvester from this process by default.

As I understand, the `excludes` variable exists to control production builds; this change will only affect development.

This also includes a change to clean up the `appConfig` param in `shell/vue.config`.

The prefix `_` is a convention to indicate that a parameter is expected, but unused within a function. We make use of `appConfig` in the default export, so we can remove the `_` and supply a default value for `appConfig` if nothing is passed.

<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- HMR triggers when running development builds and modifying Rancher Components/Harvester

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Perhaps, we were intentionally excluding these from HMR for a reason that I'm not aware of.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
