### PR TITLE
LabeledSelect: Show tag prompts only if select is searchable

### DIFF
--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -147,7 +147,7 @@ export default {
 
     // update placeholder text to inform user they can add their own opts when none are found
     showTagPrompts() {
-      return !this.options.length && this.$attrs.taggable;
+      return !this.options.length && this.$attrs.taggable && this.isSearchable;
     }
   },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes [#6946](https://github.com/harvester/harvester/issues/6946)
<!-- Define findings related to the feature or bug issue. -->
when there were no options, the prompt text `start typing to delete an item` would appear even if the select was not searchable.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Modified the logic to ensure the prompt only shows if the select is searchable

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The `showTagPrompts` was introduced in [PR#12350](https://github.com/rancher/dashboard/pull/12350)
Ref: https://github.com/rancher/dashboard/pull/12350/files#diff-5316c4da698262a356a5f70f02f4d94b95c66b780cedf9cb04515deb011017d8R148-R151

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Verify the prompt text only appears when:
- There are no options available and select is both taggable and searchable

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Prompt display behavior in `LabeledSelect` component when there are no options

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
Show `No options` if the select was not searchable
![Screenshot 2025-01-13 at 2 50 25 PM (2)](https://github.com/user-attachments/assets/472b5668-0bd6-48f4-a9e2-1a3a29c8d734)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
