### PR TITLE
Fix icon alignment in the growl component

### DIFF
--- a/shell/components/GrowlManager.vue
+++ b/shell/components/GrowlManager.vue
@@ -106,7 +106,10 @@ export default {
             <div class="growl-text-title">
               {{ growl.title }}
             </div>
-            <p v-if="growl.message">
+            <p
+              v-if="growl.message"
+              :class="{ 'has-title': !!growl.title }"
+            >
               {{ growl.message }}
             </p>
           </div>
@@ -153,12 +156,16 @@ export default {
     word-break: break-all;
     box-shadow: 0 3px 5px 0px var(--shadow);
 
+    $growl-icon-size: 20px;
+
     .icon-container {
       align-self: center;
       flex-basis: 10%;
       padding: 10px 20px 10px 10px;
       i {
-        font-size: 24px;
+        font-size: $growl-icon-size;
+        width: $growl-icon-size;
+        height: $growl-icon-size;
       }
     }
 
@@ -183,11 +190,14 @@ export default {
         }
         .growl-text-title {
           font-size: 16px;
-          margin-bottom: 20px;
         }
 
         > P {
-          margin-top: 5px;
+          padding-top: 2px;
+
+          &.has-title {
+            margin-top: 5px;
+          }
         }
       }
     }


### PR DESCRIPTION
### Summary
Fixes #10247

### Occurred changes and/or fixed issues

This PR fixes the alignment issues on the growl component.

### Technical notes summary

Removed margin which caused the issue, reduced the size of the icon slightly for better presentation and tweaked the padding to accommodate the case where a message is used without a title.

### Areas or cases that should be tested

See original issue - use the kubeconfig operation from the action menu.
 

### Screenshot/Video

Before:

![image](https://github.com/user-attachments/assets/9194f67a-0e46-44cc-8b59-ed1cd5081af7)

After: (with this PR's fixes)

![image](https://github.com/user-attachments/assets/82e5b980-656b-49b0-9ce9-c61f748455a5)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
