### PR TITLE
Show badge color for local cluster

### DIFF
--- a/shell/components/ClusterIconMenu.vue
+++ b/shell/components/ClusterIconMenu.vue
@@ -25,7 +25,7 @@ export default {
     },
 
     customColor() {
-      return !this.cluster.removePreviewColor && this.cluster.badge?.iconText ? this.cluster.badge?.color : '';
+      return this.cluster.iconColor || '';
     },
   },
 

--- a/shell/components/nav/TopLevelMenu.helper.ts
+++ b/shell/components/nav/TopLevelMenu.helper.ts
@@ -13,6 +13,7 @@ interface TopLevelMenuCluster {
   ready: boolean
   providerNavLogo: string,
   badge: string,
+  iconColor: string,
   isLocal: boolean,
   pinned: boolean,
   description: string,
@@ -143,6 +144,7 @@ export abstract class BaseTopLevelMenuHelper {
       ready:           mgmtCluster.isReady, // && !provCluster?.hasError,
       providerNavLogo: mgmtCluster.providerMenuLogo,
       badge:           mgmtCluster.badge,
+      iconColor:       mgmtCluster.iconColor,
       isLocal:         mgmtCluster.isLocal,
       pinned:          mgmtCluster.pinned,
       description:     provCluster?.description || mgmtCluster.description,

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -296,6 +296,11 @@ export default class MgmtCluster extends SteveModel {
     return this.providerLogo;
   }
 
+  // Color to use as the underline for the icon in the app bar
+  get iconColor() {
+    return this.metadata?.annotations[CLUSTER_BADGE.COLOR];
+  }
+
   // Custom badge to show for the Cluster (if the appropriate annotations are set)
   get badge() {
     const icon = this.metadata?.annotations?.[CLUSTER_BADGE.ICON_TEXT];
@@ -305,7 +310,7 @@ export default class MgmtCluster extends SteveModel {
       return undefined;
     }
 
-    let color = this.metadata?.annotations[CLUSTER_BADGE.COLOR] || DEFAULT_BADGE_COLOR;
+    let color = this.iconColor || DEFAULT_BADGE_COLOR;
     const iconText = this.metadata?.annotations[CLUSTER_BADGE.ICON_TEXT] || '';
     let foregroundColor;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12582

### Occurred changes and/or fixed issues

Ensures we show the cluster icon badge color for the local cluster.

### Technical notes summary

Add a new getter to the cluster model to return the `iconColor` independently of the badge.

### Areas or cases that should be tested

Follow test case in the issue above - add a background color to the local cluster and check that this is now shown on the cluster icon in the app bar.

### Screenshot/Video

Before: (rancher icon for the local cluster shows no color)

![image](https://github.com/user-attachments/assets/39dc74d3-ee93-49d3-8f6b-4d0b34da8986)

After: (rancher icon for the local cluster now shows the color)

![image](https://github.com/user-attachments/assets/d5a2db8e-0607-45c4-964d-679f8b917437)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
