### PR TITLE
Return the old path when `next` is missing from the url

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -77,10 +77,13 @@ const config = {
       '@docusaurus/plugin-client-redirects',
       {
         createRedirects(existingPath) {
-          if (existingPath.includes('/extensions') && !existingPath.includes('/next') && !existingPath.includes('/v2')) {
-            return [
-              existingPath.replace('/extensions', '/extensions/next')
-            ];
+          // This function is invoked once per existing doc page, and we
+          // must return the “old” routes that we want to map to that doc’s path
+          if (existingPath.startsWith('/extensions/next')) {
+            // Generate the "old" route we want to redirect from
+            const oldPath = existingPath.replace('/extensions/next', '/extensions');
+
+            return [oldPath];
           }
 
           return undefined; // Return a falsy value: no redirect created


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12542 
<!-- Define findings related to the feature or bug issue. -->
This PR resolves the issue with old links (e.g., `/extensions/extensions-getting-started`) not properly redirecting to the latest version (`/extensions/next/extensions-getting-started`) for versioned extensions documentation.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Fixed the `createRedirects` function to handle unversioned routes (`/extensions/...`) and redirect them to the latest version (`/extensions/next/...`).
- Scoped the redirect logic to only affect unversioned routes (`/extensions/...`) and not interfere with existing versioned routes such as `/extensions/v2/....`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The `createRedirects` logic checks for routes under `/extensions/next/` and generates redirects for their unversioned counterparts (`/extensions/...`). This ensures that unversioned links point to the latest version (`v3`) without impacting `v2` or other explicitly versioned routes.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Test unversioned links (e.g. `/extensions/extensions-getting-started`) and confirm they redirect to `/extensions/next/extensions-getting-started`.
- Test versioned links (`/extensions/v2/extensions-getting-started`) and confirm they load directly without being redirected.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Existing routes under `/extensions/v2/...` should be verified to ensure they are not unintentionally redirected.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
