### PR TITLE
Add GKE credential to jenkinsfile 

### DIFF
--- a/cypress/jenkins/Jenkinsfile
+++ b/cypress/jenkins/Jenkinsfile
@@ -27,7 +27,9 @@ node {
                         string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
                         string(credentialsId: 'AZURE_AKS_SUBSCRIPTION_ID', variable: 'AZURE_AKS_SUBSCRIPTION_ID'),
                         string(credentialsId: 'AZURE_CLIENT_ID', variable: 'AZURE_CLIENT_ID'),
-                        string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'AZURE_CLIENT_SECRET')]) {
+                        string(credentialsId: 'AZURE_CLIENT_SECRET', variable: 'AZURE_CLIENT_SECRET'),
+                        string(credentialsId: 'GKE_SERVICE_ACCOUNT', variable: 'GKE_SERVICE_ACCOUNT')
+                        ]) {
         withEnv(paramsMap) {
             stage('Checkout') {
             deleteDir()

--- a/cypress/jenkins/cypress.config.jenkins.ts
+++ b/cypress/jenkins/cypress.config.jenkins.ts
@@ -86,7 +86,8 @@ export default defineConfig({
     azureClientId:       process.env.AZURE_CLIENT_ID,
     azureClientSecret:   process.env.AZURE_CLIENT_SECRET,
     customNodeIp:        process.env.CUSTOM_NODE_IP,
-    customNodeKey:       process.env.CUSTOM_NODE_KEY
+    customNodeKey:       process.env.CUSTOM_NODE_KEY,
+    gkeServiceAccount:   process.env.GKE_SERVICE_ACCOUNT
   },
   // Jenkins reporters configuration jUnit and HTML
   reporter:        'cypress-multi-reporters',

--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -93,6 +93,7 @@ corral config vars set azure_subscription_id "${AZURE_AKS_SUBSCRIPTION_ID}"
 corral config vars set azure_client_id "${AZURE_CLIENT_ID}"
 corral config vars set azure_client_secret "${AZURE_CLIENT_SECRET}"
 corral config vars set create_initial_clusters "${CREATE_INITIAL_CLUSTERS}"
+corral config vars set gke_service_account "${GKE_SERVICE_ACCOUNT}"
 
 create_initial_clusters() {
   shopt -u nocasematch


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

ATTENTION!! 
Depends on https://github.com/rancherlabs/corral-packages/pull/71 to be merged in the corral-packages repo

Fixes #https://github.com/rancher/qa-tasks/issues/1641
Supports e2e tests in https://github.com/rancher/dashboard/pull/12934 by Adding the GKE credentials to the jenkins file

### Occurred changes and/or fixed issues

GKE cred was stored in the secrets manager with the jenkins identifier tag for the e2e tests that validate GKE cluster provisioning to be executed in the pipeline that stores cloud credentials

### Areas or cases that should be tested
Run all e2e tests via the jenkins pipeline

### Areas which could experience regressions
Cluster provisioning tests
Cloud credentials creation tests
Any other tests that rely on authentication with cloud credentials

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
