### PR TITLE
Update `notificationBlockList` to support new API warning messages format

### DIFF
--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -249,7 +249,7 @@ export const DEFAULT_PERF_SETTING: PerfSettings = {
       /**
        * Show warnings in a notification if they're not in this block list
        */
-      notificationBlockList: ['299 - unknown field']
+      notificationBlockList: ['299 - unknown field', '299 - "unknown field']
     }
   },
   serverPagination: {

--- a/shell/plugins/steve/__tests__/header-warnings.test.ts
+++ b/shell/plugins/steve/__tests__/header-warnings.test.ts
@@ -6,7 +6,7 @@ describe('steve: header-warnings', () => {
 
   function setupMocks(settings = {
     separator:             '299 - ',
-    notificationBlockList: ['299 - unknown field']
+    notificationBlockList: DEFAULT_PERF_SETTING.kubeAPI.warningHeader.notificationBlockList,
   }) {
     return {
       dispatch:     jest.fn(),
@@ -53,7 +53,7 @@ describe('steve: header-warnings', () => {
   const createKey = 'growl.kubeApiHeaderWarning.titleCreate';
   const podSecurity = '299 - would violate PodSecurity "restricted:latest": unrestricted capabilities (container "container-0" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (container "container-0" must not set securityContext.runAsNonRoot=false), seccompProfile (pod or container "container-0" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")';
   const deprecated = "299 - i'm deprecated";
-  const validation = '299 - unknown field "spec.containers[0].__active"';
+  const validation = '299 - "unknown field "spec.containers[0].__active"';
 
   describe('no warnings', () => {
     it('put, no header warning', () => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Rancher `head` recently introduced API changes, previous version is `v2.11-2053ce644a31cd8053d1f58e2487154b0b8513b6-head` see https://github.com/rancher/dashboard/pull/13111

1. The format of warning messages in PUT response headers has changed:
  `299 - unknown field "id"` has become `299 - "unknown field "\id\""`

2. The PUT requests now send the warnings for fields we are sending in the PUT requests that are not expected.
3. Some fields are missing from the response: `id`, `links`, `type` .
4. Warnings are notified by growl dialogs. We should consider if this is the right approach or switch to console warnings

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Fixing point 1 in description. 
We need to investigate whether the other points have an impact on the UI

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
