### PR TITLE
The page `Cluster: Create Harvester` crashes when the vgpudevice request fails

### DIFF
--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -744,11 +744,12 @@ export default {
       if (clusterId) {
         const url = `/k8s/clusters/${ clusterId }/v1`;
 
-        const vGpus = await this.$store.dispatch('cluster/request', { url: `${ url }/${ HCI.VGPU_DEVICE }` });
-
         let deviceCapacity = null;
+        let vGpus = null ;
 
         try {
+          vGpus = await this.$store.dispatch('cluster/request', { url: `${ url }/${ HCI.VGPU_DEVICE }` });
+
           const harvesterCluster = await this.$store.dispatch('cluster/request', { url: `${ url }/harvester/cluster/local` });
 
           if (harvesterCluster?.links?.deviceCapacity) {


### PR DESCRIPTION
### Summary
Fixes https://github.com/rancher/dashboard/issues/13119

### Occurred changes and/or fixed issues
n/a

### Technical notes summary
Relocate the request in the already existing try-catch block.

### Areas or cases that should be tested
Create a Harvester guest cluster.

### Areas which could experience regressions
n/a

### Screenshot/Video
n/a

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
