### PR TITLE
fix keyboard nav on settings page

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7428,6 +7428,8 @@ registryConfig:
 ##############################
 
 advancedSettings:
+  setEnv: Set by Environment Variable
+  hideShow: Hide/show setting
   label: Settings
   subtext: Typical users will not need to change these. Proceed with caution, incorrect values can break your {appName} installation. Settings which have been customized from default settings are tagged 'Modified'.
   show: Show

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -443,6 +443,9 @@ export default {
             <router-link
               v-if="location"
               :to="location"
+              role="link"
+              class="masthead-resource-list-link"
+              :aria-label="parent.displayName"
             >
               {{ parent.displayName }}:
             </router-link>
@@ -584,10 +587,10 @@ export default {
   }
 
   HEADER {
-    margin: 0;
+    margin: 0 0 0 -5px;
 
     .title {
-      overflow: hidden;
+      overflow-x: hidden;
     }
   }
 
@@ -598,7 +601,7 @@ export default {
 
     h1 {
       margin: 0;
-      overflow: hidden;
+      overflow-x: hidden;
       display: flex;
       flex-direction: row;
       align-items: center;
@@ -606,8 +609,12 @@ export default {
       .masthead-resource-title {
         padding: 0 8px;
         text-overflow: ellipsis;
-        overflow: hidden;
+        overflow-x: hidden;
         white-space: nowrap;
+      }
+
+      .masthead-resource-list-link {
+        margin: 5px;
       }
     }
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12787 
<!-- Define findings related to the feature or bug issue. -->


### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix keyboard nav on settings list page 
- settings edit page

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
**NOTE: `edit setting` action menu on each setting will be fixed by https://github.com/rancher/dashboard/pull/13019**

- improved show/hide settings list template because it was reliant on a v-if and rendered 2 different buttons that essentially worked as toggle
- needed to tweak the masthead component so that the `focus-visible` CSS state for the title link is actually visible for the user
- also verified that https://github.com/rancher/dashboard/issues/9790 did not regress

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
