### PR TITLE
Fix gitrepo bundle list and bundle list when there's a gitrepo that does not contain a summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "e2e:dev": "START_SERVER_AND_TEST_INSECURE=1 server-test start:dev https-get://localhost:8005 cy:run:sorry",
     "e2e:build": "mkdir dist && TEST_INSTRUMENT=false ./scripts/build-e2e",
     "e2e:docker": "yarn docker:local:stop && ./scripts/e2e-docker-start $RANCHER_VERSION_E2E",
-    "e2e:prod": "BUILD_DASHBOARD=$BUILD_DASHBOARD GREP_TAGS=$GREP_TAGS TEST_USERNAME=$TEST_USERNAME TEST_BASE_URL=https://127.0.0.1/dashboard yarn cy:run:sorry",
+    "e2e:prod": "BUILD_DASHBOARD=$BUILD_DASHBOARD GREP_TAGS=$GREP_TAGS TEST_USERNAME=$TEST_USERNAME TEST_BASE_URL=https://127.0.0.1/dashboard yarn cy:run",
     "coverage": "npx nyc merge coverage coverage/coverage.json",
     "storybook": "cd storybook && yarn storybook",
     "build-storybook": "cd storybook && yarn install --no-lockfile && NODE_OPTIONS=--max_old_space_size=4096 yarn build-storybook --quiet",

--- a/shell/components/fleet/FleetBundles.vue
+++ b/shell/components/fleet/FleetBundles.vue
@@ -127,7 +127,8 @@ export default {
             class="text-warning"
           >
             {{ row.status.summary.ready }}/{{ row.status.summary.desiredReady }}</span>
-          <span v-else-if="row.status">{{ row.status.summary.desiredReady }}</span>
+          <span v-else-if="row.status && row.status.summary">{{ row.status.summary.desiredReady }}</span>
+          <span v-else>-</span>
         </template>
       </ResourceTable>
     </div>

--- a/shell/list/fleet.cattle.io.bundle.vue
+++ b/shell/list/fleet.cattle.io.bundle.vue
@@ -115,11 +115,11 @@ export default {
     >
       <template #cell:deploymentsReady="{row}">
         <span
-          v-if="row.status && (row.status.summary.desiredReady !== row.status.summary.ready)"
+          v-if="row.status && row.status.summary && (row.status.summary.desiredReady !== row.status.summary.ready)"
           class="text-warning"
         >
           {{ row.status.summary.ready }}/{{ row.status.summary.desiredReady }}</span>
-        <span v-else-if="row.status">{{ row.status.summary.desiredReady }}</span>
+        <span v-else-if="row.status && row.status.summary">{{ row.status.summary.desiredReady }}</span>
         <span v-else>-</span>
       </template>
     </ResourceTable>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13136
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Forward port of https://github.com/rancher/dashboard/pull/13135
- Note test was not disabled on master. I'm guessing this is because we've pinned the `head` image the e2e tests use so does not contain the fleet regression

> Note - i've muddled branch names up. local branch as 2.10, but correctly from master merging to master


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
