### PR TITLE
Allow to skip Cypress dashboard E2E tests using a label or env var

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ env:
   TEST_BASE_URL: https://127.0.0.1/dashboard
   API: https://127.0.0.1
   TEST_PROJECT_ID: rancher-dashboard
-  TEST_DISABLE_DASHBOARD_LABEL: "${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e')}}"
+  TEST_DISABLE_DASHBOARD_LABEL: "${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-dashboard')}}"
   CYPRESS_API_URL: http://139.59.134.103:1234/
   TEST_RUN_ID: ${{github.run_number}}-${{github.run_attempt}}-${{github.event.pull_request.title || github.event.head_commit.message}}
   # Build the dashboard to use in tests. When set to false it will grab `latest` from CDN (useful for running e2e tests quickly)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,7 @@ env:
   TEST_BASE_URL: https://127.0.0.1/dashboard
   API: https://127.0.0.1
   TEST_PROJECT_ID: rancher-dashboard
+  TEST_DISABLE_DASHBOARD_LABEL: "${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e')}}"
   CYPRESS_API_URL: http://139.59.134.103:1234/
   TEST_RUN_ID: ${{github.run_number}}-${{github.run_attempt}}-${{github.event.pull_request.title || github.event.head_commit.message}}
   # Build the dashboard to use in tests. When set to false it will grab `latest` from CDN (useful for running e2e tests quickly)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ env:
   TEST_BASE_URL: https://127.0.0.1/dashboard
   API: https://127.0.0.1
   TEST_PROJECT_ID: rancher-dashboard
-  TEST_DISABLE_DASHBOARD_LABEL: "${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-dashboard')}}"
+  TEST_DISABLE_DASHBOARD_LABEL: "${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-cypress-dashboard')}}"
   CYPRESS_API_URL: http://139.59.134.103:1234/
   TEST_RUN_ID: ${{github.run_number}}-${{github.run_attempt}}-${{github.event.pull_request.title || github.event.head_commit.message}}
   # Build the dashboard to use in tests. When set to false it will grab `latest` from CDN (useful for running e2e tests quickly)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,7 @@ env:
   TEST_BASE_URL: https://127.0.0.1/dashboard
   API: https://127.0.0.1
   TEST_PROJECT_ID: rancher-dashboard
+  TEST_DISABLE_DASHBOARD: ${{ vars.TEST_DISABLE_DASHBOARD }} # This is required to get it from the project configuration
   TEST_DISABLE_DASHBOARD_LABEL: "${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-cypress-dashboard')}}"
   CYPRESS_API_URL: http://139.59.134.103:1234/
   TEST_RUN_ID: ${{github.run_number}}-${{github.run_attempt}}-${{github.event.pull_request.title || github.event.head_commit.message}}

--- a/docusaurus/docs/internal/testing/e2e-test.md
+++ b/docusaurus/docs/internal/testing/e2e-test.md
@@ -109,6 +109,14 @@ These values are provided when you create a new project within Cypress dashboard
 
 It's also possible to run a workflow in GitHub Actions E2E test using these values to record on personal dashboards.
 
+### Skip dashboard or tests
+
+CI gates can be disabled in the following way:
+
+- Use label `ci/skip-e2e` to skip the E2E tests in the PR
+- Use label `ci/skip-e2e-cypress-dashboard` to run the E2E tests without Sorry Cypress dashboard in the PR (it will enable `TEST_DISABLE_DASHBOARD_LABEL` env var)
+- Use GitHub settings and define env var `TEST_DISABLE_DASHBOARD` as `true` (which is string and not boolean) to disable the Cypress dashboard entirely in every CI run
+
 ## Local and CI/prod run
 
 It is possible to start the project and run all the tests at once with a single command. There's however a difference between `dev` and `production` run. The first will not require an official certificate and will build the project in `dist`, while the production will enable all the SSL configurations to run encrypted.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "e2e:dev": "START_SERVER_AND_TEST_INSECURE=1 server-test start:dev https-get://localhost:8005 cy:run:sorry",
     "e2e:build": "mkdir dist && TEST_INSTRUMENT=false ./scripts/build-e2e",
     "e2e:docker": "yarn docker:local:stop && ./scripts/e2e-docker-start $RANCHER_VERSION_E2E",
-    "e2e:prod": "BUILD_DASHBOARD=$BUILD_DASHBOARD GREP_TAGS=$GREP_TAGS TEST_USERNAME=$TEST_USERNAME TEST_BASE_URL=https://127.0.0.1/dashboard yarn cy:run",
+    "e2e:prod": "BUILD_DASHBOARD=$BUILD_DASHBOARD GREP_TAGS=$GREP_TAGS TEST_USERNAME=$TEST_USERNAME TEST_BASE_URL=https://127.0.0.1/dashboard yarn cy:run:sorry",
     "coverage": "npx nyc merge coverage coverage/coverage.json",
     "storybook": "cd storybook && yarn storybook",
     "build-storybook": "cd storybook && yarn install --no-lockfile && NODE_OPTIONS=--max_old_space_size=4096 yarn build-storybook --quiet",

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -20,7 +20,7 @@ else
 fi
 
 # Construct the full command
-E2E_COMMAND="CYPRESS_coverage=true CYPRESS_API_URL='http://139.59.134.103:1234' ${CYPRESS_COMMAND} run ${SPEC_ARG} --ci-build-id \"$ID\" --record --key rancher-dashboard --group \"$GREP_TAGS\" --browser chrome --record --key rancher-dashboard --parallel"
+E2E_COMMAND="CYPRESS_API_URL='http://139.59.134.103:1234' ${CYPRESS_COMMAND} run ${SPEC_ARG} --ci-build-id \"$ID\" --record --key rancher-dashboard --group \"$GREP_TAGS\" --browser chrome --record --key rancher-dashboard --parallel"
 
 # Execute the command
 eval $E2E_COMMAND

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -10,4 +10,17 @@ if [ $# -eq 1 ]; then
   SPEC_ARG="--spec ${1}"
 fi
 
-CYPRESS_coverage=true CYPRESS_API_URL='http://139.59.134.103:1234' cy2 run ${SPEC_ARG} --group "$GREP_TAGS" --browser chrome --record --key rancher-dashboard --parallel --ci-build-id "$ID"
+# Define the command to use (cy2 or cypress)
+if [ "${TEST_DISABLE_DASHBOARD}" = "true" ]; then
+  echo "Running Cypress without dashboard"
+  CYPRESS_COMMAND="cypress"
+else
+  echo "Running Cypress with Sorry Cypress on dashboard"
+  CYPRESS_COMMAND="cy2"
+fi
+
+# Construct the full command
+E2E_COMMAND="CYPRESS_coverage=true CYPRESS_API_URL='http://139.59.134.103:1234' ${CYPRESS_COMMAND} run ${SPEC_ARG} --ci-build-id \"$ID\" --record --key rancher-dashboard --group \"$GREP_TAGS\" --browser chrome --record --key rancher-dashboard --parallel"
+
+# Execute the command
+eval $E2E_COMMAND

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -11,7 +11,7 @@ if [ $# -eq 1 ]; then
 fi
 
 # Define the command to use (cy2 or cypress)
-if [ "${TEST_DISABLE_DASHBOARD}" = "true" ]; then
+if [ "${TEST_DISABLE_DASHBOARD}" = "true" ] || [ "${TEST_DISABLE_DASHBOARD_LABEL}" = "true" ]; then
   echo "Running Cypress without dashboard"
   CYPRESS_COMMAND="cypress"
 else

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -11,6 +11,10 @@ if [ $# -eq 1 ]; then
 fi
 
 # Define the command to use (cy2 or cypress)
+# TEST_DISABLE_DASHBOARD: Disable Cypress dashboard using GH repository settings
+# TEST_DISABLE_DASHBOARD_LABEL: Disable Cypress dashboard using PR label `ci/skip-e2e-cypress-dashboard`
+echo "TEST_DISABLE_DASHBOARD: ${TEST_DISABLE_DASHBOARD}"
+echo "TEST_DISABLE_DASHBOARD_LABEL: ${TEST_DISABLE_DASHBOARD_LABEL}"
 if [ "${TEST_DISABLE_DASHBOARD}" = "true" ] || [ "${TEST_DISABLE_DASHBOARD_LABEL}" = "true" ]; then
   echo "Running Cypress without dashboard"
   CYPRESS_COMMAND="cypress run ${SPEC_ARG}"

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -13,14 +13,14 @@ fi
 # Define the command to use (cy2 or cypress)
 if [ "${TEST_DISABLE_DASHBOARD}" = "true" ] || [ "${TEST_DISABLE_DASHBOARD_LABEL}" = "true" ]; then
   echo "Running Cypress without dashboard"
-  CYPRESS_COMMAND="cypress"
+  CYPRESS_COMMAND="cypress run ${SPEC_ARG}"
 else
   echo "Running Cypress with Sorry Cypress on dashboard"
-  CYPRESS_COMMAND="cy2"
+  CYPRESS_COMMAND="cy2 run ${SPEC_ARG} --ci-build-id \"$ID\" --record --key rancher-dashboard --parallel --group \"$GREP_TAGS\""
 fi
 
 # Construct the full command
-E2E_COMMAND="CYPRESS_API_URL='http://139.59.134.103:1234' ${CYPRESS_COMMAND} run ${SPEC_ARG} --ci-build-id \"$ID\" --record --key rancher-dashboard --group \"$GREP_TAGS\" --browser chrome --record --key rancher-dashboard --parallel"
+E2E_COMMAND="CYPRESS_API_URL='http://139.59.134.103:1234' ${CYPRESS_COMMAND} --browser chrome"
 
 # Execute the command
 eval $E2E_COMMAND


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13138
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

[Added ability to skip Sorry Cypress dashboard](https://github.com/rancher/dashboard/pull/13146/files#diff-8cb4f24c0ba5f6c40b682ffa5d952615082882a11904f3f0faa54ccc942827bc) outside the code and keep E2E tests.
[Added documentation](https://github.com/rancher/dashboard/pull/13146/files#diff-47048a370a6d29aece29830f830c85eff2ff74ef809999d08055f0fbcd3ff4de) to the new skip methodologies.

### Technical notes summary

E2E script will now have the options to run:
- Using Sorry Cypress dashboard as we always did ([CI example](https://github.com/rancher/dashboard/actions/runs/12831157113/job/35781037294?pr=13146#step:7:26))
- Using just E2E and no dashboard, skipping via label ([CI example](https://github.com/cnotv/dashboard/actions/runs/12830898058/job/35780227768#step:7:11))
- Using just E2E and no dashboard, skipping via GitHub settings ([CI example](https://github.com/cnotv/dashboard/actions/runs/12857248432/job/35844927212#step:7:29))

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
