### PR TITLE
Add support for creation of registry secret using RKE auth config type

### DIFF
--- a/cypress/e2e/blueprints/manager/registries-rke2-payload.ts
+++ b/cypress/e2e/blueprints/manager/registries-rke2-payload.ts
@@ -9,12 +9,12 @@ export function machineSelectorConfigPayload(registryHost: string):Array<object>
   ];
 }
 
-export function registriesWithSecretPayload(registryAuthHost: string, registrySecret: string):object {
+export function registriesWithSecretPayload(registryAuthHost: string, registrySecret: string, caBundleNull = false):object {
   return {
     configs: {
       [registryAuthHost]: {
         authConfigSecretName: registrySecret,
-        caBundle:             '',
+        caBundle:             caBundleNull ? null : '',
         insecureSkipVerify:   false,
         tlsSecretName:        null
       },

--- a/cypress/e2e/po/components/registries-tab.po.ts
+++ b/cypress/e2e/po/components/registries-tab.po.ts
@@ -2,6 +2,7 @@ import ComponentPo from '@/cypress/e2e/po/components/component.po';
 import RegistyConfigsPo from '@/cypress/e2e/po/components/registry-configs.po';
 import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
 import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
+import SelectOrCreateAuthPo from '@/cypress/e2e/po/components/select-or-create-auth.po';
 
 export default class RegistriesTabPo extends ComponentPo {
   constructor(selector = '.dashboard-root') {
@@ -16,6 +17,10 @@ export default class RegistriesTabPo extends ComponentPo {
     this.self().find('[data-testid="registries-advanced-section"]').click();
   }
 
+  advancedToggle() {
+    return this.self().find('[data-testid="registries-advanced-section"]');
+  }
+
   registryHostInput(): LabeledInputPo {
     return new LabeledInputPo('[data-testid="registry-host-input"]');
   }
@@ -26,5 +31,9 @@ export default class RegistriesTabPo extends ComponentPo {
 
   registryConfigs(): RegistyConfigsPo {
     return new RegistyConfigsPo(this.self());
+  }
+
+  registryAuthSelector(): SelectOrCreateAuthPo {
+    return new SelectOrCreateAuthPo('.select-or-create-auth-secret');
   }
 }

--- a/cypress/e2e/po/components/select-or-create-auth.po.ts
+++ b/cypress/e2e/po/components/select-or-create-auth.po.ts
@@ -29,13 +29,20 @@ export default class SelectOrCreateAuthPo extends ComponentPo {
 
   createBasicAuth(username = 'auth-test-user', password = 'auth-test-password') {
     this.authSelect().toggle();
-    this.authSelect().clickOptionWithLabel('Create a HTTP Basic Auth Secret');
+    this.authSelect().clickOptionWithLabel('Create an HTTP Basic Auth Secret');
     this.setBasicAuthSecret(username, password);
   }
 
   createSSHAuth(privateKey: string, publicKey: string) {
     this.authSelect().toggle();
-    this.authSelect().clickOptionWithLabel('Create a SSH Key Secret');
+    this.authSelect().clickOptionWithLabel('Create an SSH Key Secret');
     this.setSSHSecret(privateKey, publicKey);
+  }
+
+  createRKEAuth(username = 'auth-test-user', password = 'auth-test-password') {
+    this.authSelect().toggle();
+    this.authSelect().clickOptionWithLabel('Create an RKE Auth Config Secret');
+    this.authSelect().self().scrollIntoView();
+    this.setBasicAuthSecret(username, password);
   }
 }

--- a/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
@@ -147,9 +147,9 @@ describe('Apps', () => {
         appRepoCreate.ociMaxRetries().should('be.empty');
         // check auth dropdown not to have SSH key option when oci is selected
         appRepoCreate.authSelectOrCreate().authSelect().toggle();
-        appRepoCreate.authSelectOrCreate().authSelect().getOptions().contains('Create a HTTP Basic Auth Secret')
+        appRepoCreate.authSelectOrCreate().authSelect().getOptions().contains('Create an HTTP Basic Auth Secret')
           .should('exist');
-        appRepoCreate.authSelectOrCreate().authSelect().getOptions().contains('Create a SSH Key Secret')
+        appRepoCreate.authSelectOrCreate().authSelect().getOptions().contains('Create an SSH Key Secret')
           .should('not.exist');
       });
     });

--- a/cypress/e2e/tests/pages/manager/registries.spec.ts
+++ b/cypress/e2e/tests/pages/manager/registries.spec.ts
@@ -5,13 +5,27 @@ import { machineSelectorConfigPayload, registriesWithSecretPayload } from '@/cyp
 const registryHost = 'docker.io';
 const registryAuthHost = 'a.registry.com';
 
+const clusters = [];
+const secrets = [];
+
 describe('Registries for RKE2', { tags: ['@manager', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
     cy.createE2EResourceName('cluster').as('clusterName');
+    cy.createE2EResourceName('cluster2').as('clusterName2');
   });
 
-  it('Should send the correct payload to the server', function() {
+  after(() => {
+    clusters.forEach((name) => {
+      cy.deleteRancherResource('v1', `provisioning.cattle.io.clusters/fleet-default`, `${ name }`);
+    });
+
+    secrets.forEach((name) => {
+      cy.deleteRancherResource('v1', `secrets/fleet-default`, `${ name }`);
+    });
+  });
+
+  it('HTTP Basic Auth: Should send the correct payload to the server', function() {
     const clusterList = new ClusterManagerListPagePo();
     const createCustomClusterPage = new ClusterManagerCreateRke2CustomPagePo();
 
@@ -59,9 +73,14 @@ describe('Registries for RKE2', { tags: ['@manager', '@adminUser'] }, () => {
     cy.wait('@registrySecretCreation', { requestTimeout: 10000 }).then((req) => {
       expect(req.response?.statusCode).to.equal(201);
       registrySecret = req.response?.body?.metadata?.name;
+
+      secrets.push(registrySecret);
     });
     cy.wait('@customRKE2ClusterCreation', { requestTimeout: 10000 }).then((req) => {
       expect(req.response?.statusCode).to.equal(201);
+
+      clusters.push(req.response?.body?.metadata.name);
+
       expect(req.request?.body?.spec.rkeConfig.machineSelectorConfig).to.deep.equal(machineSelectorConfigPayload(registryHost));
       expect(req.request?.body?.spec.rkeConfig.registries).to.deep.equal(
         registriesWithSecretPayload(
@@ -69,6 +88,72 @@ describe('Registries for RKE2', { tags: ['@manager', '@adminUser'] }, () => {
           registrySecret
         ));
       expect(req.request?.body?.spec.rkeConfig.registries.configs[registryHost]).to.equal(undefined);
+    });
+  });
+
+  it('RKE Auth: Should send the correct payload to the server', function() {
+    const clusterList = new ClusterManagerListPagePo();
+    const createCustomClusterPage = new ClusterManagerCreateRke2CustomPagePo();
+
+    clusterList.goTo();
+
+    clusterList.checkIsCurrentPage();
+    clusterList.createCluster();
+
+    createCustomClusterPage.waitForPage();
+    createCustomClusterPage.rkeToggle().set('RKE2/K3s');
+
+    createCustomClusterPage.selectCustom(0);
+
+    // intercepts
+    cy.intercept('POST', 'v1/provisioning.cattle.io.clusters').as('customRKE2ClusterCreation');
+    cy.intercept('POST', 'v1/secrets/fleet-default').as('registrySecretCreation');
+
+    // cluster name
+    createCustomClusterPage.nameNsDescription().name().set(this.clusterName2);
+    // navigate to Registries tab
+    createCustomClusterPage.clusterConfigurationTabs().clickTabWithSelector('#registry');
+    // enable registry
+    createCustomClusterPage.registries().enableRegistryCheckbox().set();
+    // add host
+    createCustomClusterPage.registries().addRegistryHost(registryHost);
+
+    createCustomClusterPage.registries().advancedToggle().scrollIntoView();
+
+    createCustomClusterPage.registries().registryAuthSelector().createRKEAuth('testuser', 'testpassword');
+
+    // save
+    createCustomClusterPage.create();
+
+    let registrySecret;
+
+    // need to do a wait to make sure intercept doesn't fail on cy.wait for request
+    // ci/cd pipelines are notoriously slow... let's wait longer than usual
+    cy.wait('@registrySecretCreation', { requestTimeout: 10000 }).then((req) => {
+      expect(req.response?.statusCode).to.equal(201);
+      registrySecret = req.response?.body?.metadata?.name;
+
+      // Check registrySecret fields
+      expect(req.request.body?.type).to.equal('rke.cattle.io/auth-config');
+      expect(req.request.body?.data?.auth).to.equal('dGVzdHVzZXI6dGVzdHBhc3N3b3Jk');
+      expect(req.request.body?.data?.username).to.equal(undefined);
+      expect(req.request.body?.data?.password).to.equal(undefined);
+
+      secrets.push(registrySecret);
+    });
+
+    cy.wait('@customRKE2ClusterCreation', { requestTimeout: 10000 }).then((req) => {
+      expect(req.response?.statusCode).to.equal(201);
+
+      clusters.push(req.response?.body?.metadata.name);
+
+      expect(req.request?.body?.spec.rkeConfig.machineSelectorConfig).to.deep.equal(machineSelectorConfigPayload(registryHost));
+      expect(req.request?.body?.spec.rkeConfig.registries).to.deep.equal(
+        registriesWithSecretPayload(
+          registryHost,
+          registrySecret,
+          true
+        ));
     });
   });
 });

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5187,11 +5187,14 @@ selectOrCreateAuthSecret:
   basic:
     username: Username
     password: Password
+  rke:
+    info: "An RKE Auth Config secret contains the username and password concatenated and base64 encoded into the secret's 'auth' key"
   namespaceGroup: "Namespace: {name}"
   chooseExisting: "Choose an existing secret:"
-  createSsh: Create a SSH Key Secret
-  createBasic: Create a HTTP Basic Auth Secret
-  createS3: Create a S3-Compatible Auth Secret
+  createSsh: Create an SSH Key Secret
+  createBasic: Create an HTTP Basic Auth Secret
+  createS3: Create an S3-Compatible Auth Secret
+  createRKE: Create an RKE Auth Config Secret
 
 serviceAccount:
   automount: Automount Service Account Token

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -333,7 +333,8 @@ export const AUTH_TYPE = {
   _NONE:  '_none',
   _BASIC: '_basic',
   _SSH:   '_ssh',
-  _S3:    '_S3'
+  _S3:    '_S3',
+  _RKE:   '_RKE',
 };
 
 export const LOCAL_CLUSTER = 'local';


### PR DESCRIPTION
### Summary
Fixes #13116

### Technical notes summary

This PR adds support for creation of the `rke.cattle.io/auth-config` (RKE Auth Config) when setting a secret for the registry configuration on cluster creation.

Note we already showed RKE Auth config secrets in the drop-down, but we did not offer the user the ability to create them from the cluster creation screen - this has now been addded.

The changes are all in the `SelectOrCreateAuthSecret` component. The remaining code is to add a new E2E test for these changes.

Note the relevant e2e tests are also updated to delete the secrets and clusters that they create.

I also create the grammar on the create labels - I believe it should be 'an' and not 'a' for the options we have.

### Areas or cases that should be tested

Cluster creation with registry configuration and RKE auth config secret auth.

### Screenshot/Video

New option is added to the drop-down - see below:

![image](https://github.com/user-attachments/assets/6e4389aa-d433-4728-b9c8-e933f42207f3)

### Checklist
- [x ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
