### PR TITLE
Update pagination settings (almost) ready for production

### DIFF
--- a/cypress/e2e/po/side-bars/user-menu.po.ts
+++ b/cypress/e2e/po/side-bars/user-menu.po.ts
@@ -92,6 +92,11 @@ export default class UserMenuPo extends ComponentPo {
    * @returns
    */
   clickMenuItem(label: 'Preferences' | 'Account & API Keys' | 'Log Out') {
-    return this.getMenuItem(label).click();
+    this.getMenuItem(label).click();
+
+    if (label === 'Log Out') {
+      // This ensures that if cy.login runs again it doesn't use the stale session
+      Cypress.session.clearAllSavedSessions();
+    }
   }
 }

--- a/cypress/e2e/tests/pages/global-settings/performance.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/performance.spec.ts
@@ -175,7 +175,7 @@ describe('Performance', { testIsolation: 'off', tags: ['@globalSettings', '@admi
     performancePage.namespaceFilteringCheckbox().set();
 
     performancePage.incompatibleModal().getBody().contains('Required Namespace / Project Filtering is incompatible with Manual Refresh and Incremental Loading. Enabling this will disable them.');
-    performancePage.incompatibleModal().submit('Enable');
+    performancePage.incompatibleModal().submit('Continue');
     performancePage.namespaceFilteringCheckbox().isChecked();
     performancePage.applyAndWait('forceNsFilterV2-true').then(({ request, response }) => {
       expect(response?.statusCode).to.eq(200);

--- a/cypress/e2e/tests/priority/vai-setup.spec.ts
+++ b/cypress/e2e/tests/priority/vai-setup.spec.ts
@@ -34,7 +34,7 @@ describe('Setup Vai', { testIsolation: 'off', tags: ['@vai', '@adminUser'] }, ()
     performancePage.serverSidePaginationCheckbox().set();
 
     performancePage.incompatibleModal().checkVisible();
-    performancePage.incompatibleModal().submit('Enable');
+    performancePage.incompatibleModal().submit('Continue');
 
     performancePage.serverSidePaginationCheckbox().isChecked();
 

--- a/shell/assets/styles/themes/_light.scss
+++ b/shell/assets/styles/themes/_light.scss
@@ -91,6 +91,10 @@ BODY, .theme-light {
 
   .text-link {
     color: var(--link) !important;
+
+    &.disabled {
+      color: var(--disabled-text) !important;
+    }
   }
 
   .bg-link {

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7729,16 +7729,12 @@ performance:
     label: Server-side Pagination
     description: By default Lists will fetch all resources and paginate in the browser (create the page given sorting and filtering settings). Change this setting to enable pagination server-side. This should help the responsiveness of the UI in systems with a lot of resources.
     checkboxLabel: Enable Server-side Pagination
-    checkboxUseDefault:
-      label: Enable Custom Resources
-      placeholder: Customize the resources that server-side pagination applies to. This is an advanced feature and must be managed outside of the UI. Customized resource types are not updated on Rancher upgrade and must be manually changed.
-    applicable: "Server-side pagination applies to:"
+    applicable: "Server-side pagination applies to Resource Types"
     incompatibleDescription: "Server-side Pagination is incompatible with Manual Refresh and Incremental Loading. Enabling this will disable them."
     featureFlag: The&nbsp;<a href="{ffUrl}">Feature Flag</a>&nbsp;`ui-sql-cache` must be enabled to use this feature
     resources:
       generic: most resources in the cluster's 'More Resources' section
       all: All Resources
-    populateDefaults: Populate with latest pagination defaults
 banner:
   label: Fixed Banners
   settingName: Banners

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7729,7 +7729,10 @@ performance:
     label: Server-side Pagination
     description: By default Lists will fetch all resources and paginate in the browser (create the page given sorting and filtering settings). Change this setting to enable pagination server-side. This should help the responsiveness of the UI in systems with a lot of resources.
     checkboxLabel: Enable Server-side Pagination
-    applicable: "This applies to the following resource types"
+    checkboxUseDefault:
+      label: Apply to default resource types
+      placeholder: Default types will be updated in future versions. Check this setting to override the default with your own manually supplied settings.
+    applicable: Applies to the following resource types
     incompatibleDescription: "Server-side Pagination is incompatible with Manual Refresh and Incremental Loading. Enabling this will disable them."
     featureFlag: The&nbsp;<a href="{ffUrl}">Feature Flag</a>&nbsp;`ui-sql-cache` must be enabled to use this feature
     resources:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7664,8 +7664,7 @@ featureFlags:
 performance:
   label: UI Performance Settings
   settingName: Performance
-  experimental: This setting is experimental and may be removed or updated in future versions.
-  deprecatedForSSP: The <i class="mr-5">"{setting}"</i> setting is now deprecated and will be removed in a future release. Please use the <a href="#ssp-setting" class="ml-5 mr-5">Server-side Pagination</a> setting instead.
+  deprecatedForSSP: The <i class="mr-5">"{setting}"</i> setting is now deprecated and will be removed in a future release.
   incrementalLoad:
     label: Incremental Loading
     setting: You can configure the threshold above which incremental loading will be used.
@@ -7735,6 +7734,7 @@ performance:
     resources:
       generic: most resources in the cluster's 'More Resources' section
       all: All Resources
+    experimental: This setting is experimental and may be removed or updated in future versions. We do not recommend enabling this setting in production environments.
 banner:
   label: Fixed Banners
   settingName: Banners

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7730,9 +7730,9 @@ performance:
     description: By default Lists will fetch all resources and paginate in the browser (create the page given sorting and filtering settings). Change this setting to enable pagination server-side. This should help the responsiveness of the UI in systems with a lot of resources.
     checkboxLabel: Enable Server-side Pagination
     checkboxUseDefault:
-      label: Apply to default resource types
-      placeholder: Default types will be updated in future versions. Check this setting to override the default with your own manually supplied settings.
-    applicable: Applies to the following resource types
+      label: Override default applicable resources types
+      placeholder: This is an advanced feature configured outside of this UI. Overriding applicable resource types will ignore updates to default values in later versions
+    applicable: Applicable Resource Types
     incompatibleDescription: "Server-side Pagination is incompatible with Manual Refresh and Incremental Loading. Enabling this will disable them."
     featureFlag: The&nbsp;<a href="{ffUrl}">Feature Flag</a>&nbsp;`ui-sql-cache` must be enabled to use this feature
     resources:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7730,9 +7730,9 @@ performance:
     description: By default Lists will fetch all resources and paginate in the browser (create the page given sorting and filtering settings). Change this setting to enable pagination server-side. This should help the responsiveness of the UI in systems with a lot of resources.
     checkboxLabel: Enable Server-side Pagination
     checkboxUseDefault:
-      label: Override default applicable resources types
-      placeholder: This is an advanced feature configured outside of this UI. Overriding applicable resource types will ignore updates to default values in later versions
-    applicable: Applicable Resource Types
+      label: Enable Custom Resources
+      placeholder: Customize the resources that server-side pagination applies to. This is an advanced feature and must be managed outside of the UI. Customized resource types are not updated on Rancher upgrade and must be manually changed.
+    applicable: "Server-side pagination applies to:"
     incompatibleDescription: "Server-side Pagination is incompatible with Manual Refresh and Incremental Loading. Enabling this will disable them."
     featureFlag: The&nbsp;<a href="{ffUrl}">Feature Flag</a>&nbsp;`ui-sql-cache` must be enabled to use this feature
     resources:

--- a/shell/components/Collapse.vue
+++ b/shell/components/Collapse.vue
@@ -13,7 +13,12 @@ export default {
     title: {
       type:    String,
       default: ''
-    }
+    },
+
+    isDisabled: {
+      type:    Boolean,
+      default: false
+    },
   },
 
   methods: {
@@ -25,10 +30,15 @@ export default {
 </script>
 
 <template>
-  <div class="collapse">
+  <div
+    class="collapse"
+    :class="{ 'disabled': isDisabled }"
+  >
     <slot name="title">
       <div
         class="advanced text-link"
+        :class="{ 'disabled': isDisabled }"
+        :disabled="isDisabled"
         data-testid="collapse-div"
         @click="showAdvanced"
       >
@@ -59,11 +69,14 @@ export default {
 <style lang="scss" scoped>
 .advanced {
   user-select: none;
-  padding: 0 5px;
   cursor: pointer;
   line-height: 40px;
   font-size: 15px;
   font-weight: 500;
+
+  .disabled {
+    cursor: not-allowed;
+  }
 }
 .content {
   background: var(--nav-active);

--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -253,38 +253,8 @@ export const DEFAULT_PERF_SETTING: PerfSettings = {
     }
   },
   serverPagination: {
-    enabled: false,
-    stores:  {
-      cluster: {
-        resources: {
-          enableAll:  false,
-          enableSome: {
-            // if a resource list is shown by a custom resource list component or has specific list headers then it's not generically shown
-            // and must be included here.
-            enabled: [
-              NODE, EVENT,
-              WORKLOAD_TYPES.CRON_JOB, WORKLOAD_TYPES.DAEMON_SET, WORKLOAD_TYPES.DEPLOYMENT, WORKLOAD_TYPES.JOB, WORKLOAD_TYPES.STATEFUL_SET, POD,
-              CATALOG.APP, CATALOG.CLUSTER_REPO, CATALOG.OPERATION,
-              HPA, INGRESS, SERVICE,
-              PV, CONFIG_MAP, STORAGE_CLASS, PVC, SECRET,
-              WORKLOAD_TYPES.REPLICA_SET, WORKLOAD_TYPES.REPLICATION_CONTROLLER
-            ],
-            generic: true,
-          }
-        }
-      },
-      management: {
-        resources: {
-          enableAll:  false,
-          enableSome: {
-            enabled: [
-              { resource: CAPI.RANCHER_CLUSTER, context: ['home', 'side-bar'] },
-              { resource: MANAGEMENT.CLUSTER, context: ['side-bar'] },
-            ],
-            generic: false,
-          }
-        }
-      }
-    }
+    enabled:          false,
+    useDefaultStores: true,
+    stores:           undefined,
   }
 };

--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -1,16 +1,6 @@
 // Settings
 import { GC_DEFAULTS, GC_PREFERENCES } from '@shell/utils/gc/gc-types';
 import { PaginationSettings } from '@shell/types/resources/settings';
-import {
-  CAPI, MANAGEMENT, EVENT, CATALOG, HPA, INGRESS, SERVICE,
-  CONFIG_MAP,
-  SECRET,
-  POD, NODE,
-  STORAGE_CLASS,
-  PVC,
-  PV,
-  WORKLOAD_TYPES
-} from '@shell/config/types';
 
 interface GlobalSettingRuleset {
   name: string,

--- a/shell/pages/c/_cluster/settings/performance.vue
+++ b/shell/pages/c/_cluster/settings/performance.vue
@@ -11,6 +11,7 @@ import UnitInput from '@shell/components/form/UnitInput';
 import { STEVE_CACHE } from '@shell/store/features';
 import { NAME as SETTING_PRODUCT } from '@shell/config/product/settings';
 import paginationUtils from '@shell/utils/pagination-utils';
+import Collapse from '@shell/components/Collapse';
 
 const incompatible = {
   incrementalLoading: ['forceNsFilterV2', 'serverPagination'],
@@ -33,7 +34,8 @@ export default {
     AsyncButton,
     Banner,
     LabeledInput,
-    UnitInput
+    UnitInput,
+    Collapse,
   },
 
   async fetch() {
@@ -76,7 +78,8 @@ export default {
           resource: MANAGEMENT.FEATURE
         }
       }).href,
-      isDev: process.env.NODE_ENV === 'dev',
+      isDev:                  process.env.NODE_ENV === 'dev',
+      ssPApplicableTypesOpen: false,
     };
   },
 
@@ -239,28 +242,41 @@ export default {
             @update:value="compatibleWarning('serverPagination', $event)"
           />
 
+          <Collapse
+            :title="t('performance.serverPagination.applicable')"
+            :open="steveCacheAndSSPEnabled && ssPApplicableTypesOpen"
+            :isDisabled="!steveCacheAndSSPEnabled"
+            @update:open="ssPApplicableTypesOpen = !ssPApplicableTypesOpen"
+          >
+            <p
+              v-clean-html="sspApplicableResources"
+              :class="{ 'text-muted': !value.serverPagination.enabled }"
+            />
+          </Collapse>
+
           <div>
             <Checkbox
-              v-model:value="value.serverPagination.useDefaultStores"
+              :value="!value.serverPagination.useDefaultStores"
               :mode="mode"
               :label-key="'performance.serverPagination.checkboxUseDefault.label'"
               :tooltip-key="'performance.serverPagination.checkboxUseDefault.placeholder'"
               class="mt-10 mb-10"
               :primary="true"
               :disabled="!steveCacheAndSSPEnabled"
+              @update:value="value.serverPagination.useDefaultStores = !value.serverPagination.useDefaultStores"
             />
           </div>
 
-          <p :class="{ 'text-muted': !value.serverPagination.enabled }">
+          <!-- <p :class="{ 'text-muted': !value.serverPagination.enabled }">
             {{ t('performance.serverPagination.applicable') }}
           </p>
           <p
             v-clean-html="sspApplicableResources"
             :class="{ 'text-muted': !value.serverPagination.enabled }"
-          />
+          /> -->
           <button
             v-if="isDev"
-            class="btn btn-sm role-primary"
+            class="btn btn-sm role-primary mt-10"
             style="width: fit-content;"
             :disabled="!steveCacheAndSSPEnabled"
             @click.prevent="sspApplyDefaults(true)"

--- a/shell/pages/c/_cluster/settings/performance.vue
+++ b/shell/pages/c/_cluster/settings/performance.vue
@@ -11,7 +11,6 @@ import UnitInput from '@shell/components/form/UnitInput';
 import { STEVE_CACHE } from '@shell/store/features';
 import { NAME as SETTING_PRODUCT } from '@shell/config/product/settings';
 import paginationUtils from '@shell/utils/pagination-utils';
-import { isDevBuild } from '@shell/utils/version';
 
 const incompatible = {
   incrementalLoading: ['forceNsFilterV2', 'serverPagination'],
@@ -97,7 +96,7 @@ export default {
     },
 
     steveCacheAndSSPEnabled() {
-      return this.steveCacheEnabled && this.value.serverPagination.enabled
+      return this.steveCacheEnabled && this.value.serverPagination.enabled;
     },
 
     sspApplicableResources() {
@@ -204,7 +203,7 @@ export default {
       };
 
       if (defaultStore) {
-        this.value.serverPagination.stores = paginationUtils.getStoreDefault()
+        this.value.serverPagination.stores = paginationUtils.getStoreDefault();
       }
     }
   },
@@ -263,8 +262,8 @@ export default {
             v-if="isDev"
             class="btn btn-sm role-primary"
             style="width: fit-content;"
-            @click.prevent="sspApplyDefaults(true)"
             :disabled="!steveCacheAndSSPEnabled"
+            @click.prevent="sspApplyDefaults(true)"
           >
             {{ t('performance.serverPagination.populateDefaults') }}
           </button>

--- a/shell/pages/c/_cluster/settings/performance.vue
+++ b/shell/pages/c/_cluster/settings/performance.vue
@@ -78,7 +78,6 @@ export default {
           resource: MANAGEMENT.FEATURE
         }
       }).href,
-      isDev:                  process.env.NODE_ENV === 'dev',
       ssPApplicableTypesOpen: false,
     };
   },
@@ -198,17 +197,6 @@ export default {
         },
       });
     },
-
-    sspApplyDefaults(defaultStore) {
-      this.value = {
-        ...this.value,
-        serverPagination: { ...DEFAULT_PERF_SETTING.serverPagination }
-      };
-
-      if (defaultStore) {
-        this.value.serverPagination.stores = paginationUtils.getStoreDefault();
-      }
-    }
   },
 };
 </script>
@@ -222,7 +210,7 @@ export default {
     <div>
       <div class="ui-perf-setting">
         <!-- Server Side Pagination -->
-        <div class="mt-40">
+        <div class="mt-20">
           <h2 id="ssp-setting">
             {{ t('performance.serverPagination.label') }}
           </h2>
@@ -241,19 +229,6 @@ export default {
             :disabled="!steveCacheEnabled"
             @update:value="compatibleWarning('serverPagination', $event)"
           />
-
-          <div>
-            <Checkbox
-              :value="!value.serverPagination.useDefaultStores"
-              :mode="mode"
-              :label-key="'performance.serverPagination.checkboxUseDefault.label'"
-              :tooltip-key="'performance.serverPagination.checkboxUseDefault.placeholder'"
-              class="mt-10 mb-10"
-              :primary="true"
-              :disabled="!steveCacheAndSSPEnabled"
-              @update:value="value.serverPagination.useDefaultStores = !value.serverPagination.useDefaultStores"
-            />
-          </div>
           <Collapse
             :title="t('performance.serverPagination.applicable')"
             :open="steveCacheAndSSPEnabled && ssPApplicableTypesOpen"
@@ -265,16 +240,6 @@ export default {
               :class="{ 'text-muted': !value.serverPagination.enabled }"
             />
           </Collapse>
-          <div v-if="isDev">
-            <button
-              class="btn btn-sm role-primary mt-10"
-              style="width: fit-content;"
-              :disabled="!steveCacheAndSSPEnabled"
-              @click.prevent="sspApplyDefaults(true)"
-            >
-              {{ t('performance.serverPagination.populateDefaults') }}
-            </button>
-          </div>
         </div>
         <!-- Inactivity -->
         <div class="mt-20">
@@ -318,7 +283,7 @@ export default {
           />
         </div>
         <!-- Incremental Loading -->
-        <div class="mt-40">
+        <div class="mt-20">
           <h2>{{ t('performance.incrementalLoad.label') }}</h2>
           <Banner
             color="warning"
@@ -481,7 +446,7 @@ export default {
           />
         </div>
         <!-- Advanced Websocket Worker -->
-        <div class="mt-40">
+        <div class="mt-20">
           <h2>{{ t('performance.advancedWorker.label') }}</h2>
           <Banner
             color="warning"

--- a/shell/pages/c/_cluster/settings/performance.vue
+++ b/shell/pages/c/_cluster/settings/performance.vue
@@ -242,18 +242,6 @@ export default {
             @update:value="compatibleWarning('serverPagination', $event)"
           />
 
-          <Collapse
-            :title="t('performance.serverPagination.applicable')"
-            :open="steveCacheAndSSPEnabled && ssPApplicableTypesOpen"
-            :isDisabled="!steveCacheAndSSPEnabled"
-            @update:open="ssPApplicableTypesOpen = !ssPApplicableTypesOpen"
-          >
-            <p
-              v-clean-html="sspApplicableResources"
-              :class="{ 'text-muted': !value.serverPagination.enabled }"
-            />
-          </Collapse>
-
           <div>
             <Checkbox
               :value="!value.serverPagination.useDefaultStores"
@@ -266,23 +254,27 @@ export default {
               @update:value="value.serverPagination.useDefaultStores = !value.serverPagination.useDefaultStores"
             />
           </div>
-
-          <!-- <p :class="{ 'text-muted': !value.serverPagination.enabled }">
-            {{ t('performance.serverPagination.applicable') }}
-          </p>
-          <p
-            v-clean-html="sspApplicableResources"
-            :class="{ 'text-muted': !value.serverPagination.enabled }"
-          /> -->
-          <button
-            v-if="isDev"
-            class="btn btn-sm role-primary mt-10"
-            style="width: fit-content;"
-            :disabled="!steveCacheAndSSPEnabled"
-            @click.prevent="sspApplyDefaults(true)"
+          <Collapse
+            :title="t('performance.serverPagination.applicable')"
+            :open="steveCacheAndSSPEnabled && ssPApplicableTypesOpen"
+            :isDisabled="!steveCacheAndSSPEnabled"
+            @update:open="ssPApplicableTypesOpen = !ssPApplicableTypesOpen"
           >
-            {{ t('performance.serverPagination.populateDefaults') }}
-          </button>
+            <p
+              v-clean-html="sspApplicableResources"
+              :class="{ 'text-muted': !value.serverPagination.enabled }"
+            />
+          </Collapse>
+          <div v-if="isDev">
+            <button
+              class="btn btn-sm role-primary mt-10"
+              style="width: fit-content;"
+              :disabled="!steveCacheAndSSPEnabled"
+              @click.prevent="sspApplyDefaults(true)"
+            >
+              {{ t('performance.serverPagination.populateDefaults') }}
+            </button>
+          </div>
         </div>
         <!-- Inactivity -->
         <div class="mt-20">

--- a/shell/pages/c/_cluster/settings/performance.vue
+++ b/shell/pages/c/_cluster/settings/performance.vue
@@ -209,38 +209,6 @@ export default {
     </h1>
     <div>
       <div class="ui-perf-setting">
-        <!-- Server Side Pagination -->
-        <div class="mt-20">
-          <h2 id="ssp-setting">
-            {{ t('performance.serverPagination.label') }}
-          </h2>
-          <p>{{ t('performance.serverPagination.description') }}</p>
-          <Banner
-            v-if="!steveCacheEnabled"
-            v-clean-html="t(`performance.serverPagination.featureFlag`, { ffUrl }, true)"
-            color="warning"
-          />
-          <Checkbox
-            v-model:value="value.serverPagination.enabled"
-            :mode="mode"
-            :label="t('performance.serverPagination.checkboxLabel')"
-            class="mt-10 mb-10"
-            :primary="true"
-            :disabled="!steveCacheEnabled"
-            @update:value="compatibleWarning('serverPagination', $event)"
-          />
-          <Collapse
-            :title="t('performance.serverPagination.applicable')"
-            :open="steveCacheAndSSPEnabled && ssPApplicableTypesOpen"
-            :isDisabled="!steveCacheAndSSPEnabled"
-            @update:open="ssPApplicableTypesOpen = !ssPApplicableTypesOpen"
-          >
-            <p
-              v-clean-html="sspApplicableResources"
-              :class="{ 'text-muted': !value.serverPagination.enabled }"
-            />
-          </Collapse>
-        </div>
         <!-- Inactivity -->
         <div class="mt-20">
           <h2>{{ t('performance.inactivity.title') }}</h2>
@@ -281,6 +249,42 @@ export default {
             class="mt-10 mb-20"
             :primary="true"
           />
+        </div>
+        <!-- Server Side Pagination -->
+        <div class="mt-20">
+          <h2 id="ssp-setting">
+            {{ t('performance.serverPagination.label') }}
+          </h2>
+          <p>{{ t('performance.serverPagination.description') }}</p>
+          <Banner
+            v-if="!steveCacheEnabled"
+            v-clean-html="t(`performance.serverPagination.featureFlag`, { ffUrl }, true)"
+            color="warning"
+          />
+          <Banner
+            color="error"
+            label-key="performance.serverPagination.experimental"
+          />
+          <Checkbox
+            v-model:value="value.serverPagination.enabled"
+            :mode="mode"
+            :label="t('performance.serverPagination.checkboxLabel')"
+            class="mt-10 mb-10"
+            :primary="true"
+            :disabled="!steveCacheEnabled"
+            @update:value="compatibleWarning('serverPagination', $event)"
+          />
+          <Collapse
+            :title="t('performance.serverPagination.applicable')"
+            :open="steveCacheAndSSPEnabled && ssPApplicableTypesOpen"
+            :isDisabled="!steveCacheAndSSPEnabled"
+            @update:open="ssPApplicableTypesOpen = !ssPApplicableTypesOpen"
+          >
+            <p
+              v-clean-html="sspApplicableResources"
+              :class="{ 'text-muted': !value.serverPagination.enabled }"
+            />
+          </Collapse>
         </div>
         <!-- Incremental Loading -->
         <div class="mt-20">

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -1,7 +1,7 @@
 import { ActionFindPageArgs } from '@shell/types/store/dashboard-store.types';
 import { PaginationParam, PaginationFilterField, PaginationParamProjectOrNamespace, PaginationParamFilter } from '@shell/types/store/pagination.types';
 import { NAMESPACE_FILTER_ALL_SYSTEM, NAMESPACE_FILTER_ALL_USER, NAMESPACE_FILTER_P_FULL_PREFIX } from '@shell/utils/namespace-filter';
-import Namespace from '@shell/models/namespace';
+import ModelNamespace from '@shell/models/namespace';
 import { uniq } from '@shell/utils/array';
 import {
   CAPI,
@@ -18,6 +18,15 @@ import {
 import { CAPI as CAPI_LABELS, CATTLE_PUBLIC_ENDPOINTS } from '@shell/config/labels-annotations';
 import { Schema } from '@shell/plugins/steve/schema';
 import { PaginationSettingsStore } from '@shell/types/resources/settings';
+
+/**
+ * This is a workaround for a ts build issue found in check-plugins-build.
+ *
+ * The build would error on <ns>.name, it somehow doesn't know about the steve model's properties (they are included in typegen)
+ */
+interface Namespace extends ModelNamespace {
+  name: string;
+}
 
 class NamespaceProjectFilters {
   /**

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -12,10 +12,12 @@ import {
   SERVICE,
   INGRESS,
   WORKLOAD_TYPES,
-  HPA
+  HPA,
+  SECRET
 } from '@shell/config/types';
 import { CAPI as CAPI_LABELS, CATTLE_PUBLIC_ENDPOINTS } from '@shell/config/labels-annotations';
 import { Schema } from '@shell/plugins/steve/schema';
+import { PaginationSettingsStore } from '@shell/types/resources/settings';
 
 class NamespaceProjectFilters {
   /**
@@ -465,5 +467,38 @@ class StevePaginationUtils extends NamespaceProjectFilters {
     return res;
   }
 }
+
+export const PAGINATION_SETTINGS_STORE_DEFAULTS: PaginationSettingsStore = {
+  cluster: {
+    resources: {
+      enableAll:  false,
+      enableSome: {
+        // if a resource list is shown by a custom resource list component or has specific list headers then it's not generically shown
+        // and must be included here.
+        enabled: [
+          NODE, EVENT,
+          WORKLOAD_TYPES.CRON_JOB, WORKLOAD_TYPES.DAEMON_SET, WORKLOAD_TYPES.DEPLOYMENT, WORKLOAD_TYPES.JOB, WORKLOAD_TYPES.STATEFUL_SET, POD,
+          CATALOG.APP, CATALOG.CLUSTER_REPO, CATALOG.OPERATION,
+          HPA, INGRESS, SERVICE,
+          PV, CONFIG_MAP, STORAGE_CLASS, PVC, SECRET,
+          WORKLOAD_TYPES.REPLICA_SET, WORKLOAD_TYPES.REPLICATION_CONTROLLER
+        ],
+        generic: true,
+      }
+    }
+  },
+  management: {
+    resources: {
+      enableAll:  false,
+      enableSome: {
+        enabled: [
+          { resource: CAPI.RANCHER_CLUSTER, context: ['home', 'side-bar'] },
+          { resource: MANAGEMENT.CLUSTER, context: ['side-bar'] },
+        ],
+        generic: false,
+      }
+    }
+  }
+};
 
 export default new StevePaginationUtils();

--- a/shell/scripts/typegen.sh
+++ b/shell/scripts/typegen.sh
@@ -34,6 +34,7 @@ ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/plugins/dashboard-store/resource-
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/plugins/dashboard-store/classify.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/plugins/dashboard-store/ > /dev/null
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/plugins/dashboard-store/actions.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/plugins/dashboard-store/ > /dev/null
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/plugins/steve/steve-class.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/plugins/steve/ > /dev/null
+${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/plugins/steve/hybrid-class.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/plugins/steve/ > /dev/null
 
 # # mixins
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/mixins/create-edit-view/index.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/mixins/create-edit-view > /dev/null

--- a/shell/types/resources/settings.d.ts
+++ b/shell/types/resources/settings.d.ts
@@ -1,3 +1,25 @@
+
+export interface PaginationSettingsStore {
+  [name: string]: {
+    resources: {
+      /**
+       * Enable for all resources in this store
+       */
+      enableAll: boolean,
+      enableSome: {
+        /**
+         * Specific resource type to enable
+         */
+        enabled: (string | { resource: string, context: string[]})[],
+        /**
+         * There's no hardcoded headers or custom list for the resource type, headers will be generated from schema attributes.columns
+         */
+        generic: boolean,
+      },
+    }
+  }
+}
+
 /**
  * Settings to handle server side pagination
  */
@@ -7,28 +29,13 @@ export interface PaginationSettings {
    */
   enabled: boolean,
   /**
+   * Override `stores` and apply pagination to a set of default resource types that can change between versions
+   */
+  useDefaultStores: boolean,
+  /**
    * Should pagination be enabled for resources in a store
    */
-  stores: {
-    [name: string]: {
-      resources: {
-        /**
-         * Enable for all resources in this store
-         */
-        enableAll: boolean,
-        enableSome: {
-          /**
-           * Specific resource type to enable
-           */
-          enabled: (string | { resource: string, context: string[]})[],
-          /**
-           * There's no hardcoded headers or custom list for the resource type, headers will be generated from schema attributes.columns
-           */
-          generic: boolean,
-        },
-      }
-    }
-  }
+  stores: PaginationSettingsStore | undefined
 }
 
 type Links = {

--- a/shell/utils/pagination-utils.ts
+++ b/shell/utils/pagination-utils.ts
@@ -1,4 +1,4 @@
-import { PaginationSettings } from '@shell/types/resources/settings';
+import { PaginationSettings, PaginationSettingsStore } from '@shell/types/resources/settings';
 import {
   NAMESPACE_FILTER_ALL_USER as ALL_USER,
   NAMESPACE_FILTER_ALL as ALL,
@@ -14,6 +14,7 @@ import { sameArrayObjects } from '@shell/utils/array';
 import { isEqual } from '@shell/utils/object';
 import { STEVE_CACHE } from '@shell/store/features';
 import { getPerformanceSetting } from '@shell/utils/settings';
+import { PAGINATION_SETTINGS_STORE_DEFAULTS } from '@shell/plugins/steve/steve-pagination-utils';
 
 /**
  * Helper functions for server side pagination
@@ -30,6 +31,18 @@ class PaginationUtils {
     const perf = getPerformanceSetting(rootGetters);
 
     return perf.serverPagination;
+  }
+
+  public getStoreSettings(ctx: any): PaginationSettingsStore
+  public getStoreSettings(serverPagination: PaginationSettings): PaginationSettingsStore
+  public getStoreSettings(arg: any | PaginationSettings): PaginationSettingsStore {
+    const serverPagination: PaginationSettings = arg?.rootGetters !== undefined ? this.getSettings(arg) : arg;
+
+    return serverPagination?.useDefaultStores ? this.getStoreDefault() : serverPagination?.stores || this.getStoreDefault();
+  }
+
+  public getStoreDefault(): PaginationSettingsStore {
+    return PAGINATION_SETTINGS_STORE_DEFAULTS;
   }
 
   isSteveCacheEnabled({ rootGetters }: any): boolean {
@@ -58,7 +71,7 @@ class PaginationUtils {
       return false;
     }
 
-    const storeSettings = settings.stores?.[enabledFor.store];
+    const storeSettings = this.getStoreSettings(settings)?.[enabledFor.store];
 
     // No pagination setting for target store, not enabled
     if (!storeSettings) {


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13089
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Previously the ui-performance object ssp object contained a required set of resources to apply ssp to
- This isn't workable going forward where the available resources will be updated between versions
  - i.e upgraded clusters won't get the new settings
- Now the default is to use a the inbuilt default resources which can change between versions
- Users can override if they wish (for preference OR in case of bugs)

### Areas or cases that should be tested
- Fresh system (or with `/v3/settings/ui-performance` value set to an empty string). No pagination anywhere 
- Check SSP on, no other changes. Pagination on for places like the home page
- When running in dev, in performance page, use the `defaults` button and enable SSP to populate the `resources with default`. Pagination on for places like the home page. Tweak the resources (`store` object) like changing the `context` of the prov cluster to not include `home` (`like `homeaaa`). Pagination on home page should not be on


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
