### PR TITLE
fix key nav on preferences page

### DIFF
--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
@@ -243,14 +243,8 @@ $fontColor: var(--input-label);
     min-width: 14px;
     background-color: var(--input-bg);
     border-radius: 50%;
-    transition: all 0.3s ease-out;
     border: 1.5px solid var(--border);
     margin-top: 5px;
-
-    &:focus {
-      outline: none;
-      border-radius: 50%;
-    }
   }
 
   input {

--- a/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
@@ -145,6 +145,9 @@ export default defineComponent({
      */
     isDisabled(): boolean {
       return (this.disabled || this.isView);
+    },
+    radioGroupLabel(): string {
+      return this.labelKey ? this.t(this.labelKey) : this.label ? this.label : '';
     }
   },
 
@@ -202,9 +205,10 @@ export default defineComponent({
 
     <!-- Group -->
     <div
+      role="radiogroup"
+      :aria-label="radioGroupLabel"
       class="radio-group"
       :class="{'row':row}"
-      tabindex="0"
       @keyup.down.stop="clickNext(1)"
       @keyup.up.stop="clickNext(-1)"
     >

--- a/shell/assets/styles/base/_basic.scss
+++ b/shell/assets/styles/base/_basic.scss
@@ -62,12 +62,17 @@ INPUT,
 SELECT,
 TEXTAREA,
 .labeled-input,
-.labeled-select,
-.unlabeled-select,
-.checkbox-custom,
-.radio-custom {
+.checkbox-custom {
   &:focus, &.focused {
-    @include form-focus
+    @include form-focus;
+  }
+}
+
+.radio-custom,
+.labeled-select,
+.unlabeled-select {
+  &:focus-visible, &.focused {
+    @include focus-outline;
   }
 }
 

--- a/shell/assets/styles/base/_basic.scss
+++ b/shell/assets/styles/base/_basic.scss
@@ -76,6 +76,13 @@ TEXTAREA,
   }
 }
 
+.labeled-select,
+.unlabeled-select {
+  &.focused {
+    border-color: var(--outline);
+  }
+}
+
 BUTTON,
 .btn {
    &:focus, &.focused {

--- a/shell/assets/styles/base/_mixins.scss
+++ b/shell/assets/styles/base/_mixins.scss
@@ -159,5 +159,5 @@
 @mixin focus-outline {
   // Focus for form like elements (not to be confused with basic :focus style)
   // we need to use !important because it needs to superseed other classes that might impact outlines
-  outline: 2px solid var(--primary-keyboard-focus) !important;
+  outline: 2px solid var(--primary-keyboard-focus);
 }

--- a/shell/assets/styles/base/_mixins.scss
+++ b/shell/assets/styles/base/_mixins.scss
@@ -158,5 +158,6 @@
 
 @mixin focus-outline {
   // Focus for form like elements (not to be confused with basic :focus style)
-  outline: 2px solid var(--primary-keyboard-focus);
+  // we need to use !important because it needs to superseed other classes that might impact outlines
+  outline: 2px solid var(--primary-keyboard-focus) !important;
 }

--- a/shell/assets/styles/global/_button.scss
+++ b/shell/assets/styles/global/_button.scss
@@ -185,6 +185,11 @@ fieldset[disabled] .btn {
       z-index: 1;
     }
 
+    &:focus-visible {
+      z-index: 1;
+      @include focus-outline;
+    }
+    
     &.active {
       @extend .bg-primary;
     }

--- a/shell/assets/styles/global/_form.scss
+++ b/shell/assets/styles/global/_form.scss
@@ -27,8 +27,8 @@ TEXTAREA,
 
   @include input-status-color;
 
-  &:focus, &.focused {
-    @include form-focus
+  &:focus:not(.unlabeled-select):not(.labeled-select), &.focused:not(.unlabeled-select):not(.labeled-select) {
+    @include form-focus;
   }
 
   LABEL {

--- a/shell/components/ButtonGroup.vue
+++ b/shell/components/ButtonGroup.vue
@@ -82,6 +82,8 @@ export default {
       type="button"
       :class="opt.class"
       :disabled="disabled || opt.disabled"
+      role="button"
+      :aria-label="opt.labelKey ? t(opt.labelKey) : opt.label"
       @click="change(opt.value)"
     >
       <slot

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -154,11 +154,22 @@ export default {
   methods: {
     // resizeHandler = in mixin
     focusSearch() {
-      const blurredAgo = Date.now() - this.blurred;
+      // we need this override as in a "closeOnSelect" type of component
+      // if we don't have this override, it would open again
+      if (this.overridesMixinPreventDoubleTriggerKeysOpen) {
+        this.$nextTick(() => {
+          const el = this.$refs['select'];
 
-      if (!this.focused && blurredAgo < 250) {
+          if ( el ) {
+            el.focus();
+          }
+
+          this.overridesMixinPreventDoubleTriggerKeysOpen = false;
+        });
+
         return;
       }
+      this.$refs['select-input'].open = true;
 
       this.$nextTick(() => {
         const el = this.$refs['select-input']?.searchEl;
@@ -278,8 +289,9 @@ export default {
         'no-label': !hasLabel
       }
     ]"
+    :tabindex="isView || disabled ? -1 : 0"
     @click="focusSearch"
-    @focus="focusSearch"
+    @keyup.enter.space.down="focusSearch"
   >
     <div
       :class="{ 'labeled-container': true, raised, empty, [mode]: true }"
@@ -319,7 +331,7 @@ export default {
       :selectable="selectable"
       :modelValue="value != null && !loading ? value : ''"
       :dropdown-should-open="dropdownShouldOpen"
-
+      :tabindex="-1"
       @update:modelValue="$emit('selecting', $event); $emit('update:value', $event)"
       @search:blur="onBlur"
       @search:focus="onFocus"

--- a/shell/components/form/Select.vue
+++ b/shell/components/form/Select.vue
@@ -114,11 +114,24 @@ export default {
       calculatePosition(dropdownList, component, width, this.placement);
     },
 
-    focus() {
-      this.focusSearch();
-    },
-
     focusSearch() {
+      // we need this override as in a "closeOnSelect" type of component
+      // if we don't have this override, it would open again
+      if (this.overridesMixinPreventDoubleTriggerKeysOpen) {
+        this.$nextTick(() => {
+          const el = this.$refs['select'];
+
+          if ( el ) {
+            el.focus();
+          }
+
+          this.overridesMixinPreventDoubleTriggerKeysOpen = false;
+        });
+
+        return;
+      }
+      this.$refs['select-input'].open = true;
+
       this.$nextTick(() => {
         const el = this.$refs['select-input']?.searchEl;
 
@@ -176,6 +189,11 @@ export default {
     },
     report(e) {
       alert(e);
+    },
+    handleDropdownOpen(args) {
+      // function that prevents the "opening dropdown on focus"
+      // default behaviour of v-select
+      return args.noDrop || args.disabled ? false : args.open;
     }
   },
   computed: {
@@ -227,7 +245,7 @@ export default {
     ref="select"
     class="unlabeled-select"
     :class="{
-      disabled: disabled && !isView,
+      disabled: disabled || isView,
       focused,
       [mode]: true,
       [status]: status,
@@ -236,7 +254,9 @@ export default {
       'compact-input': compact,
       [$attrs.class]: $attrs.class
     }"
-    @focus="focusSearch"
+    :tabindex="disabled || isView ? -1 : 0"
+    @click="focusSearch"
+    @keyup.enter.space.down="focusSearch"
   >
     <v-select
       ref="select-input"
@@ -258,6 +278,8 @@ export default {
       :searchable="isSearchable"
       :selectable="selectable"
       :modelValue="value != null ? value : ''"
+      :dropdownShouldOpen="handleDropdownOpen"
+      :tabindex="-1"
 
       @update:modelValue="$emit('update:value', $event)"
       @search:blur="onBlur"

--- a/shell/mixins/vue-select-overrides.js
+++ b/shell/mixins/vue-select-overrides.js
@@ -1,5 +1,8 @@
 
 export default {
+  data() {
+    return { overridesMixinPreventDoubleTriggerKeysOpen: false };
+  },
   methods: {
     mappedKeys(map, vm) {
       // Defaults found at - https://github.com/sagalbot/vue-select/blob/master/src/components/Select.vue#L947
@@ -13,31 +16,19 @@ export default {
         }
 
         e.preventDefault();
-
-        const optsLen = vm.filteredOptions.length;
-        const typeAheadPointer = vm.typeAheadPointer;
-
-        if (e.shiftKey) {
-          if (typeAheadPointer === 0) {
-            return vm.onEscape();
-          }
-
-          return vm.typeAheadUp();
-        }
-        if (typeAheadPointer + 1 === optsLen) {
-          return vm.onEscape();
-        }
-
-        return vm.typeAheadDown();
       });
 
+      // escape
       (out[27] = (e) => {
         vm.open = false;
         vm.search = '';
 
+        this.$refs.select.focus();
+
         return false;
       });
 
+      // enter
       (out[13] = (e, opt) => {
         if (!vm.open) {
           vm.open = true;
@@ -60,6 +51,9 @@ export default {
           vm.$emit('option:selected', option);
 
           if (vm.closeOnSelect) {
+            // this ties in to the Select component implementation
+            // so that the enter key handler doesn't open the dropdown again
+            this.overridesMixinPreventDoubleTriggerKeysOpen = true;
             vm.open = false;
             vm.typeAheadPointer = -1;
           }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12791 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- Fixes keyboard navigation on the user `preferences` page
- Fixes `Select` component implementation so that it opens on enter/space and not open just on focus
- Fixes `LabeledSelect` component implementation so that it opens on enter/space and not open just on focus
- Fixes `ButtonGroup` so that is keyboard navigable
- Fixes `RadioGroup` and `RadioButton` so that is keyboard navigable

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Test `LabeledSelect`'s and `Select`'s thoroughly throughout the UI, especially more "exotic" implementations. Basic use case should be covered.


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/324306c6-e4ad-4214-b1d0-f1da2ee647f7


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
