### PR TITLE
Add support for known hosts on ssh secret in Fleet Git Repo

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5144,10 +5144,22 @@ secret:
     username: Username
   ssh:
     keys: Keys
+    keysAndHosts: Keys and Known Hosts
     public: Public Key
     publicPlaceholder: "Paste in your public key"
     private: Private Key
     privatePlaceholder: "Paste in your private key"
+    knownHosts: Known Hosts
+    knownHostsPlaceholder: "Known hosts metadata, one per line"
+    editKnownHosts:
+      title: SSH Known Hosts Configuration
+      entries:  |-
+        {entries, plural,
+          =0 {No Entries}
+          =1 {1 Entry}
+          other {{entries} Entries}
+        }
+
   serviceAcct:
     ca: CA Certificate
     token: Token

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2441,6 +2441,7 @@ fleet:
       resources: Resources
       unready: Non-Ready
     auth:
+      title: Authentication
       label: Authentication
       git: Git Authentication
       helm: Helm Authentication
@@ -5155,7 +5156,7 @@ secret:
       title: SSH Known Hosts Configuration
       entries:  |-
         {entries, plural,
-          =0 {No Entries}
+          =0 {Empty}
           =1 {1 Entry}
           other {{entries} Entries}
         }

--- a/shell/components/form/SSHKnownHosts/KnownHostsEditDialog.vue
+++ b/shell/components/form/SSHKnownHosts/KnownHostsEditDialog.vue
@@ -1,0 +1,146 @@
+<script>
+import AppModal from '@shell/components/AppModal.vue';
+
+export default {
+  emits: ['closed'],
+
+  components: { AppModal },
+
+  data() {
+    return {
+      data:                   '',
+      currentVersion:         '',
+      defaultRegistrySetting: null,
+      plugin:                 undefined,
+      busy:                   false,
+      version:                '',
+      update:                 false,
+      mode:                   '',
+      showModal:              false,
+      chartVersionInfo:       null
+    };
+  },
+
+  methods: {
+    showDialog(data) {
+      this.showModal = true;
+      this.data = data;
+    },
+
+    closeDialog(result) {
+      this.showModal = false;
+
+      const value = (this.$refs.textbox)?.value;
+
+      this.$emit('closed', {
+        success: result,
+        value,
+      });
+    },
+  }
+};
+</script>
+
+<template>
+  <app-modal
+    v-if="showModal"
+    name="sshKnownHostsDialog"
+    height="auto"
+    :scrollable="true"
+    @close="closeDialog(false)"
+  >
+    <div
+      class="ssh-known-hosts-dialog"
+    >
+      <h4 class="mt-10">
+        {{ t('secret.ssh.editKnownHosts.title') }}
+      </h4>
+      <div class="custom mt-10">
+        <div class="dialog-panel">
+          <textarea
+            ref="textbox"
+            :value="data"
+            class="edit-box"
+          />
+        </div>
+        <div class="dialog-buttons">
+          <button
+            :disabled="busy"
+            class="btn role-secondary"
+            data-testid="ssh-known-hosts-dialog-cancel-btn"
+            @click="closeDialog(false)"
+          >
+            {{ t('generic.cancel') }}
+          </button>
+          <button
+            class="btn role-primary"
+            data-testid="ssh-known-hosts-dialog-save-btn"
+            @click="closeDialog(true)"
+          >
+            {{ t('generic.save') }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </app-modal>
+</template>
+
+<style lang="scss" scoped>
+  .ssh-known-hosts-dialog {
+    padding: 10px;
+
+    h4 {
+      font-weight: bold;
+    }
+
+    .dialog-panel {
+      display: flex;
+      flex-direction: column;
+      min-height: 100px;
+
+      .edit-box {
+        font-family: monospace;
+        font-size: 12px;
+        resize: none;
+        max-height: 400px;
+        height: 50vh;
+        padding: 10px;
+      }
+
+      p {
+        margin-bottom: 5px;
+      }
+
+      .dialog-info {
+        flex: 1;
+      }
+
+      .toggle-advanced {
+        display: flex;
+        align-items: center;
+        cursor: pointer;
+        margin: 10px 0;
+
+        &:hover {
+          text-decoration: none;
+          color: var(--link);
+        }
+      }
+
+      .version-selector {
+        margin: 0 10px 10px 10px;
+        width: auto;
+      }
+    }
+
+    .dialog-buttons {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: 10px;
+
+      > *:not(:last-child) {
+        margin-right: 10px;
+      }
+    }
+  }
+</style>

--- a/shell/components/form/SSHKnownHosts/KnownHostsEditDialog.vue
+++ b/shell/components/form/SSHKnownHosts/KnownHostsEditDialog.vue
@@ -79,7 +79,7 @@ export default {
 <template>
   <app-modal
     v-if="showModal"
-    name="sshKnownHostsDialog"
+    ref="sshKnownHostsDialog"
     height="auto"
     :scrollable="true"
     @close="closeDialog(false)"
@@ -93,8 +93,9 @@ export default {
       <div class="custom mt-10">
         <div class="dialog-panel">
           <CodeMirror
+            class="code-mirror"
             :value="text"
-            class="editor"
+            data-testid="ssh-known-hosts-dialog_code-mirror"
             :options="codeMirrorOptions"
             :showKeyMapBox="true"
             @onInput="onTextChange"
@@ -104,6 +105,7 @@ export default {
           <div class="action-pannel file-selector">
             <FileSelector
               class="btn role-secondary"
+              data-testid="ssh-known-hosts-dialog_file-selector"
               :label="t('generic.readFromFile')"
               @selected="onTextChange"
             />
@@ -111,14 +113,14 @@ export default {
           <div class="action-pannel form-actions">
             <button
               class="btn role-secondary"
-              data-testid="ssh-known-hosts-dialog-cancel-btn"
+              data-testid="ssh-known-hosts-dialog_cancel-btn"
               @click="closeDialog(false)"
             >
               {{ t('generic.cancel') }}
             </button>
             <button
               class="btn role-primary"
-              data-testid="ssh-known-hosts-dialog-save-btn"
+              data-testid="ssh-known-hosts-dialog_save-btn"
               @click="closeDialog(true)"
             >
               {{ t('generic.save') }}
@@ -145,7 +147,7 @@ export default {
       min-height: 100px;
       border: 1px solid var(--border);
 
-      :deep() .editor {
+      :deep() .code-mirror {
         display: flex;
         flex-direction: column;
         resize: none;

--- a/shell/components/form/SSHKnownHosts/__tests__/KnownHostsEditDialog.test.ts
+++ b/shell/components/form/SSHKnownHosts/__tests__/KnownHostsEditDialog.test.ts
@@ -1,0 +1,104 @@
+import { mount, VueWrapper } from '@vue/test-utils';
+import { _EDIT } from '@shell/config/query-params';
+import KnownHostsEditDialog from '@shell/components/form/SSHKnownHosts/KnownHostsEditDialog.vue';
+import CodeMirror from '@shell/components/CodeMirror.vue';
+import FileSelector from '@shell/components/form/FileSelector.vue';
+
+let wrapper: VueWrapper<InstanceType<typeof KnownHostsEditDialog>>;
+
+const mockedStore = () => {
+  return { getters: { 'prefs/get': () => jest.fn() } };
+};
+
+const requiredSetup = () => {
+  return { global: { mocks: { $store: mockedStore() } } };
+};
+
+describe('component: KnownHostsEditDialog', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="modals"></div>';
+    wrapper = mount(KnownHostsEditDialog, {
+      attachTo: document.body,
+      props:    {
+        mode:  _EDIT,
+        value: 'line1\nline2\n',
+      },
+      ...requiredSetup(),
+    });
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+    document.body.innerHTML = '';
+  });
+
+  it('should update text from CodeMirror', async() => {
+    await wrapper.setData({ showModal: true });
+
+    expect(wrapper.vm.text).toBe('line1\nline2\n');
+
+    const codeMirror = wrapper.getComponent(CodeMirror);
+
+    expect(codeMirror.element).toBeDefined();
+
+    await codeMirror.setData({ loaded: true });
+
+    // Emit CodeMirror value
+    codeMirror.vm.$emit('onInput', 'bar');
+    await codeMirror.vm.$nextTick();
+
+    expect(wrapper.vm.text).toBe('bar');
+  });
+
+  it('should update text from FileSelector', async() => {
+    await wrapper.setData({ showModal: true });
+
+    expect(wrapper.vm.text).toBe('line1\nline2\n');
+
+    const fileSelector = wrapper.getComponent(FileSelector);
+
+    expect(fileSelector.element).toBeDefined();
+
+    // Emit Fileselector value
+    fileSelector.vm.$emit('selected', 'foo');
+    await fileSelector.vm.$nextTick();
+
+    expect(wrapper.vm.text).toBe('foo');
+  });
+
+  it('should save changes and close dialog', async() => {
+    await wrapper.setData({
+      showModal: true,
+      text:      'foo',
+    });
+
+    expect(wrapper.vm.value).toBe('line1\nline2\n');
+    expect(wrapper.vm.text).toBe('foo');
+
+    await wrapper.vm.closeDialog(true);
+
+    expect((wrapper.emitted('closed') as any)[0][0].value).toBe('foo');
+
+    const dialog = wrapper.vm.$refs['sshKnownHostsDialog'];
+
+    expect(dialog).toBeNull();
+  });
+
+  it('should discard changes and close dialog', async() => {
+    await wrapper.setData({
+      showModal: true,
+      text:      'foo',
+    });
+
+    expect(wrapper.vm.value).toBe('line1\nline2\n');
+    expect(wrapper.vm.text).toBe('foo');
+
+    await wrapper.vm.closeDialog(false);
+
+    expect((wrapper.emitted('closed') as any)[0][0].value).toBe('line1\nline2\n');
+
+    const dialog = wrapper.vm.$refs['sshKnownHostsDialog'];
+
+    expect(dialog).toBeNull();
+  });
+});

--- a/shell/components/form/SSHKnownHosts/index.vue
+++ b/shell/components/form/SSHKnownHosts/index.vue
@@ -1,0 +1,101 @@
+<script lang="ts">
+import { defineComponent } from 'vue';
+import EditDialog from './KnownHostsEditDialog.vue';
+import { _EDIT, _VIEW } from '@shell/config/query-params';
+
+export default defineComponent({
+  name: 'SSHKnownHosts',
+
+  emits: ['update:value'],
+
+  props: {
+    value: {
+      type:     String,
+      required: true
+    },
+
+    mode: {
+      type:    String,
+      default: _EDIT
+    },
+  },
+
+  components: { EditDialog },
+
+  computed: {
+    isViewMode() {
+      return this.mode === _VIEW;
+    },
+
+    // Summarize number of entries - exclude empty lines and comments
+    summary() {
+      const lines = this.value.split('\n').filter((line: string) => !!line.length && !line.startsWith('#')).length;
+
+      return this.t('secret.ssh.editKnownHosts.entries', { entries: lines });
+    }
+  },
+
+  methods: {
+    openDialog() {
+      (this.$refs.button as HTMLInputElement)?.blur();
+      (this.$refs.editDialog as any).showDialog(this.value);
+    },
+
+    dialogClosed(result: any) {
+      if (result.success) {
+        this.$emit('update:value', result.value);
+      }
+    }
+  }
+});
+</script>
+<template>
+  <div class="input-known-ssh-hosts labeled-input">
+    <label>{{ t('secret.ssh.knownHosts') }}</label>
+    <div
+      class="hosts-input"
+    >
+      {{ summary }}
+    </div>
+    <button
+      v-if="!isViewMode"
+      ref="button"
+      class="show-dialog btn"
+      @click="openDialog"
+    >
+      ...
+    </button>
+    <EditDialog
+      v-if="!isViewMode"
+      ref="editDialog"
+      @closed="dialogClosed"
+    />
+  </div>
+</template>
+<style lang="scss" scoped>
+  .input-known-ssh-hosts {
+    $ssKnownHostsButtonHeight: 20px;
+
+    .hosts-input {
+      cursor: default;
+      line-height: calc(18px + 1px);
+      padding: 18px 0 0 0;
+    }
+
+    .show-dialog {
+      position: absolute;
+      top: 28px;
+      padding: 0 6px;
+      min-height: $ssKnownHostsButtonHeight;
+      line-height: $ssKnownHostsButtonHeight;
+      right: 4px;
+
+      &:hover, &:focus {
+        border-color: var(--primary);
+        //color: var(--primary);
+        // TODO: Don't use hard-coded color
+        color: #fff
+      }
+    }
+  }
+</style>

--- a/shell/components/form/SSHKnownHosts/index.vue
+++ b/shell/components/form/SSHKnownHosts/index.vue
@@ -27,11 +27,13 @@ export default defineComponent({
       return this.mode === _VIEW;
     },
 
-    // Summarize number of entries - exclude empty lines and comments
-    summary() {
-      const lines = this.value.split('\n').filter((line: string) => !!line.length && !line.startsWith('#')).length;
+    // The number of entries - exclude empty lines and comments
+    entries() {
+      return this.value.split('\n').filter((line: string) => !!line.trim().length && !line.startsWith('#')).length;
+    },
 
-      return this.t('secret.ssh.editKnownHosts.entries', { entries: lines });
+    summary() {
+      return this.t('secret.ssh.editKnownHosts.entries', { entries: this.entries });
     }
   },
 
@@ -50,14 +52,21 @@ export default defineComponent({
 });
 </script>
 <template>
-  <div class="input-known-ssh-hosts labeled-input">
+  <div
+    class="input-known-ssh-hosts labeled-input"
+    data-testid="input-known-ssh-hosts"
+  >
     <label>{{ t('secret.ssh.knownHosts') }}</label>
-    <div class="hosts-input">
+    <div
+      class="hosts-input"
+      data-testid="input-known-ssh-hosts_summary"
+    >
       {{ summary }}
     </div>
     <template v-if="!isViewMode">
       <button
         ref="button"
+        data-testid="input-known-ssh-hosts_open-dialog"
         class="show-dialog-btn btn"
         @click="openDialog"
       >

--- a/shell/components/form/SSHKnownHosts/index.vue
+++ b/shell/components/form/SSHKnownHosts/index.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
-import EditDialog from './KnownHostsEditDialog.vue';
+import KnownHostsEditDialog from './KnownHostsEditDialog.vue';
 import { _EDIT, _VIEW } from '@shell/config/query-params';
 
 export default defineComponent({
@@ -20,7 +20,7 @@ export default defineComponent({
     },
   },
 
-  components: { EditDialog },
+  components: { KnownHostsEditDialog },
 
   computed: {
     isViewMode() {
@@ -38,7 +38,7 @@ export default defineComponent({
   methods: {
     openDialog() {
       (this.$refs.button as HTMLInputElement)?.blur();
-      (this.$refs.editDialog as any).showDialog(this.value);
+      (this.$refs.editDialog as any).showDialog();
     },
 
     dialogClosed(result: any) {
@@ -52,29 +52,31 @@ export default defineComponent({
 <template>
   <div class="input-known-ssh-hosts labeled-input">
     <label>{{ t('secret.ssh.knownHosts') }}</label>
-    <div
-      class="hosts-input"
-    >
+    <div class="hosts-input">
       {{ summary }}
     </div>
-    <button
-      v-if="!isViewMode"
-      ref="button"
-      class="show-dialog btn"
-      @click="openDialog"
-    >
-      ...
-    </button>
-    <EditDialog
-      v-if="!isViewMode"
-      ref="editDialog"
-      @closed="dialogClosed"
-    />
+    <template v-if="!isViewMode">
+      <button
+        ref="button"
+        class="show-dialog-btn btn"
+        @click="openDialog"
+      >
+        <i class="icon icon-edit" />
+      </button>
+
+      <KnownHostsEditDialog
+        ref="editDialog"
+        :value="value"
+        :mode="mode"
+        @closed="dialogClosed"
+      />
+    </template>
   </div>
 </template>
 <style lang="scss" scoped>
   .input-known-ssh-hosts {
-    $ssKnownHostsButtonHeight: 20px;
+    display: flex;
+    justify-content: space-between;
 
     .hosts-input {
       cursor: default;
@@ -82,20 +84,9 @@ export default defineComponent({
       padding: 18px 0 0 0;
     }
 
-    .show-dialog {
-      position: absolute;
-      top: 28px;
-      padding: 0 6px;
-      min-height: $ssKnownHostsButtonHeight;
-      line-height: $ssKnownHostsButtonHeight;
-      right: 4px;
-
-      &:hover, &:focus {
-        border-color: var(--primary);
-        //color: var(--primary);
-        // TODO: Don't use hard-coded color
-        color: #fff
-      }
+    .show-dialog-btn {
+      display: contents;
+      background-color: transparent;
     }
   }
 </style>

--- a/shell/components/form/SelectOrCreateAuthSecret.vue
+++ b/shell/components/form/SelectOrCreateAuthSecret.vue
@@ -568,11 +568,11 @@ export default {
             [privateField]: base64Encode(this.privateKey),
           };
 
-        // Add ssh known hosts data key - we will add a key with an empty value if the inout field was left blank
-        // This ensures on edit of the secret, we allow the user to edit the known_hosts field
-        if ((this.selected === AUTH_TYPE._SSH) && this.showSshKnownHosts) {
-          secret.data.known_hosts = base64Encode(this.sshKnownHosts || '');
-        }
+          // Add ssh known hosts data key - we will add a key with an empty value if the inout field was left blank
+          // This ensures on edit of the secret, we allow the user to edit the known_hosts field
+          if ((this.selected === AUTH_TYPE._SSH) && this.showSshKnownHosts) {
+            secret.data.known_hosts = base64Encode(this.sshKnownHosts || '');
+          }
         }
       }
 

--- a/shell/components/form/__tests__/SSHKnownHosts.test.ts
+++ b/shell/components/form/__tests__/SSHKnownHosts.test.ts
@@ -1,0 +1,59 @@
+import { mount } from '@vue/test-utils';
+import { _EDIT, _VIEW } from '@shell/config/query-params';
+import SSHKnownHosts from '@shell/components/form/SSHKnownHosts/index.vue';
+
+describe('component: SSHKnownHosts', () => {
+  it.each([
+    ['0 entities', '', 0],
+    ['0 entities (multiple empty lines)', '\n  \n  \n', 0],
+    ['1 entity', 'line1\n', 1],
+    ['1 entity (multiple empty lines)', 'line1\n\n\n', 1],
+    ['2 entities', 'line1\nline2\n', 2],
+    ['2 entities (multiple empty lines)', 'line1\n  \n  line2\n \n', 2],
+  ])('mode view: summary should be: %p', (_, value, entities) => {
+    const wrapper = mount(SSHKnownHosts, {
+      props: {
+        mode: _VIEW,
+        value,
+      }
+    });
+
+    const knownSshHostsSummary = wrapper.find('[data-testid="input-known-ssh-hosts_summary"]');
+    const knownSshHostsOpenDialog = wrapper.findAll('[data-testid="input-known-ssh-hosts_open-dialog"]');
+
+    expect(wrapper.vm.entries).toBe(entities);
+    expect(knownSshHostsSummary.element).toBeDefined();
+    expect(knownSshHostsOpenDialog).toHaveLength(0);
+  });
+
+  it('mode edit: should display summary and edit button', () => {
+    const wrapper = mount(SSHKnownHosts, {
+      props: {
+        mode:  _EDIT,
+        value: 'line1\nline2\n',
+      }
+    });
+
+    const knownSshHostsSummary = wrapper.find('[data-testid="input-known-ssh-hosts_summary"]');
+    const knownSshHostsOpenDialog = wrapper.find('[data-testid="input-known-ssh-hosts_open-dialog"]');
+
+    expect(knownSshHostsSummary.element).toBeDefined();
+    expect(knownSshHostsOpenDialog.element).toBeDefined();
+  });
+
+  it('mode edit: should open edit dialog', async() => {
+    const wrapper = mount(SSHKnownHosts, {
+      props: {
+        mode:  _EDIT,
+        value: '',
+      }
+    });
+
+    const knownSshHostsOpenDialog = wrapper.find('[data-testid="input-known-ssh-hosts_open-dialog"]');
+    const editDialog = wrapper.vm.$refs['editDialog'] as any;
+
+    await knownSshHostsOpenDialog.trigger('click');
+
+    expect(editDialog.showModal).toBe(true);
+  });
+});

--- a/shell/detail/secret.vue
+++ b/shell/detail/secret.vue
@@ -122,6 +122,10 @@ export default {
       return this.value._type === TYPES.SSH;
     },
 
+    showKnownHosts() {
+      return this.isSsh && this.value.supportsSshKnownHosts;
+    },
+
     isBasicAuth() {
       return this.value._type === TYPES.BASIC;
     },
@@ -140,6 +144,12 @@ export default {
       });
 
       return rows;
+    },
+
+    knownHosts() {
+      const { data = {} } = this.value;
+
+      return data.known_hosts ? base64Decode(data.known_hosts) : '';
     },
 
     dataLabel() {
@@ -270,6 +280,21 @@ export default {
           <div
             v-t="'sortableTable.noRows'"
             class="m-20 text-center"
+          />
+        </div>
+      </div>
+    </Tab>
+    <Tab
+      v-if="showKnownHosts"
+      name="known_hosts"
+      label-key="secret.ssh.knownHosts"
+    >
+      <div class="row">
+        <div class="col span-12">
+          <DetailText
+            :value="knownHosts"
+            label-key="secret.ssh.knownHosts"
+            :conceal="false"
           />
         </div>
       </div>

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -586,6 +586,10 @@ export default {
           />
         </div>
       </div>
+
+      <div class="spacer" />
+      <h2 v-t="'fleet.gitRepo.auth.title'" />
+
       <SelectOrCreateAuthSecret
         :value="value.spec.clientSecretName"
         :register-before-hook="registerBeforeHook"
@@ -767,6 +771,11 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+  :deep() .select-or-create-auth-secret {
+    .row {
+      margin-top: 10px !important;
+    }
+  }
   .resource-handling {
     display: flex;
     flex-direction: column;

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -408,7 +408,12 @@ export default {
     },
 
     async doCreate(name, credentials) {
-      const { selected, publicKey, privateKey } = credentials;
+      const {
+        selected,
+        publicKey,
+        privateKey,
+        sshKnownHosts
+      } = credentials;
 
       if ( ![AUTH_TYPE._SSH, AUTH_TYPE._BASIC, AUTH_TYPE._S3].includes(selected) ) {
         return;
@@ -456,6 +461,11 @@ export default {
           [publicField]:  base64Encode(publicKey),
           [privateField]: base64Encode(privateKey),
         };
+
+        // Add ssh known hosts
+        if (selected === AUTH_TYPE._SSH && sshKnownHosts) {
+          secret.data.known_hosts = base64Encode(sshKnownHosts);
+        }
       }
 
       await secret.save();

--- a/shell/edit/secret/index.vue
+++ b/shell/edit/secret/index.vue
@@ -206,7 +206,7 @@ export default {
       case TYPES.TLS:
         return this.t('secret.certificate.certificate');
       case TYPES.SSH:
-        return this.t('secret.ssh.keys');
+        return this.value.supportsSshKnownHosts ? this.t('secret.ssh.keysAndHosts') : this.t('secret.ssh.keys');
       case TYPES.BASIC:
         return this.t('secret.authentication');
       default:

--- a/shell/edit/secret/ssh.vue
+++ b/shell/edit/secret/ssh.vue
@@ -20,16 +20,21 @@ export default {
   data() {
     const username = this.value.decodedData['ssh-publickey'] || '';
     const password = this.value.decodedData['ssh-privatekey'] || '';
+    const knownHosts = this.value.decodedData['known_hosts'] || '';
+    const showKnownHosts = this.value.supportsSshKnownHosts;
 
     return {
       username,
       password,
+      knownHosts,
+      showKnownHosts,
     };
   },
 
   watch: {
-    username: 'update',
-    password: 'update',
+    username:   'update',
+    password:   'update',
+    knownHosts: 'update'
   },
 
   methods: {
@@ -39,8 +44,9 @@ export default {
     update() {
       this.value.setData('ssh-publickey', this.username);
       this.value.setData('ssh-privatekey', this.password);
+      this.value.setData('known_hosts', this.knownHosts);
     }
-  },
+  }
 };
 </script>
 
@@ -75,6 +81,18 @@ export default {
           class="btn btn-sm bg-primary mt-10"
           :label="t('generic.readFromFile')"
           @selected="onPasswordSelected"
+        />
+      </div>
+    </div>
+    <div class="row mt-40">
+      <div class="col span-12">
+        <LabeledInput
+          v-if="showKnownHosts"
+          v-model:value="knownHosts"
+          type="multiline"
+          :label="t('secret.ssh.knownHosts')"
+          :mode="mode"
+          :placeholder="t('secret.ssh.knownHostsPlaceholder')"
         />
       </div>
     </div>

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -178,7 +178,7 @@ export default class GitRepo extends SteveModel {
   }
 
   get github() {
-    const match = this.spec.repo.match(/^https?:\/\/github\.com\/(.*?)(\.git)?\/*$/);
+    const match = (this.spec.repo || '').match(/^https?:\/\/github\.com\/(.*?)(\.git)?\/*$/);
 
     if (match) {
       return match[1];
@@ -196,7 +196,7 @@ export default class GitRepo extends SteveModel {
   }
 
   get repoDisplay() {
-    let repo = this.spec.repo;
+    let repo = this.spec.repo || '';
 
     if (!repo) {
       return null;

--- a/shell/models/secret.js
+++ b/shell/models/secret.js
@@ -49,6 +49,11 @@ export default class Secret extends SteveModel {
     return this._type === TYPES.CLOUD_CREDENTIAL || (this.metadata.namespace === 'cattle-global-data' && this.metadata.generateName === 'cc-');
   }
 
+  // For Fleet SSH secrets - does the secret have the 'known_hosts' data key?
+  get supportsSshKnownHosts() {
+    return this._type === TYPES.SSH && 'known_hosts' in this.data;
+  }
+
   get issuer() {
     const { metadata:{ annotations = {} } } = this;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11236

### Occurred changes and/or fixed issues

This PR enhances the `SelectOrCreateAuthSecret` component so that for the SSH secret type, it can also support the `known_hosts` field. Note that this is non-standard in that known hosts is not part of the standard k8s SSH secret type. This is only used by Fleet.

The Fleet GitRepo use of the above control enables the new field, so that when creating a GitRepo, you can specify the known hosts information.

Lastly, the secret view is updated, so that if an SSH secret has the `known_hosts` data key, we will show this on the detail screen and also allow the user to edit via the config screen.

### Areas or cases that should be tested

Creating a Git Repo with a secret with known hosts. Validate that the secret that is created has the known_hosts data field and validate that this can be edited in the secrets screen.

### Screenshot/Video

The updated auth secret control:
 
![Screenshot 2025-01-21 at 13 57 30](https://github.com/user-attachments/assets/77294965-328b-452e-bb86-ffe857379a12)

The edit dialog for this control when you click the three dots:

![Screenshot 2025-01-21 at 13 57 42](https://github.com/user-attachments/assets/1a378ee1-bd8b-4a5b-8c02-c6490f0d2ba9)

Secrets edit view when `known_hosts` is present in an SSH secret:

![Screenshot 2025-01-21 at 13 27 13](https://github.com/user-attachments/assets/d74cac06-c0f2-476a-974d-e0221d804be5)

EDIT @torchiaf 

[Screencast from 2025-01-30 18-09-07.webm](https://github.com/user-attachments/assets/18dd108a-5845-48c1-84c0-73f75e2b8e88)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
