### PR TITLE
Fix errors propagation in Settings edit page

### DIFF
--- a/shell/edit/__tests__/management.cattle.io.setting.test.ts
+++ b/shell/edit/__tests__/management.cattle.io.setting.test.ts
@@ -2,27 +2,27 @@ import { mount } from '@vue/test-utils';
 import Settings from '@shell/edit/management.cattle.io.setting.vue';
 import { SETTING } from '@shell/config/settings';
 
-describe('view: management.cattle.io.setting should', () => {
-  const requiredSetup = () => ({
-    // Remove all these mocks after migration to Vue 2.7/3 due mixin logic
-    global: {
-      mocks: {
-        $store: {
-          getters: {
-            currentStore:              () => 'current_store',
-            'current_store/schemaFor': jest.fn(),
-            'current_store/all':       jest.fn(),
-            'i18n/t':                  jest.fn(),
-            'i18n/exists':             jest.fn(),
-          },
-          dispatch: jest.fn(),
+const requiredSetup = () => ({
+  // Remove all these mocks after migration to Vue 2.7/3 due mixin logic
+  global: {
+    mocks: {
+      $store: {
+        getters: {
+          currentStore:              () => 'current_store',
+          'current_store/schemaFor': jest.fn(),
+          'current_store/all':       jest.fn(),
+          'i18n/t':                  jest.fn(),
+          'i18n/exists':             jest.fn(),
         },
-        $route:  { query: { AS: '' } },
-        $router: { applyQuery: jest.fn() },
-      }
+        dispatch: jest.fn(),
+      },
+      $route:  { query: { AS: '' } },
+      $router: { applyQuery: jest.fn() },
     }
-  });
+  }
+});
 
+describe('view: management.cattle.io.setting should', () => {
   it('allowing to save if no rules in settings', () => {
     const wrapper = mount(Settings, {
       props: { value: { value: 'anything' } },
@@ -86,5 +86,24 @@ describe('view: management.cattle.io.setting should', () => {
 
       expect(rules).toStrictEqual(expectation);
     });
+  });
+});
+
+describe('edit: management.cattle.io.setting should', () => {
+  it('display form errors', () => {
+    const wrapper = mount(Settings, {
+      props: {
+        value: { value: 'anything' },
+        mode:  'edit',
+      },
+      data: () => ({
+        setting: { },
+        errors:  ['generic'] as any,
+      }),
+      ...requiredSetup()
+    });
+    const errorBanner = wrapper.find('[data-testid="banner-content"]');
+
+    expect(errorBanner.element.textContent).toBe('generic');
   });
 });

--- a/shell/edit/management.cattle.io.setting.vue
+++ b/shell/edit/management.cattle.io.setting.vue
@@ -24,6 +24,8 @@ export default {
     Banner
   },
 
+  inheritAttrs: false,
+
   mixins: [CreateEditView, FormValidation],
 
   data() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13163
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- The errors variable in `management.cattle.io.setting.vue` is being overwritten by the errors variable in `@shell/mixins/create-edit-view` mixin.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- We generated a javascript error to test the error's banner. Alternatively, a webhook or a proxy server can be used to generate an API error. See issue's description.


![image](https://github.com/user-attachments/assets/a494e66e-38b6-4e9b-add4-8e3357819589)


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Edit settings, UI validations

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
