### PR TITLE
CloudCredential Model: Fix CC expiry display

### DIFF
--- a/shell/models/cloudcredential.js
+++ b/shell/models/cloudcredential.js
@@ -277,7 +277,10 @@ export default class CloudCredential extends NormanModel {
       };
     }
 
-    return null;
+    return {
+      expired:  false,
+      expiring: false,
+    };
   }
 
   get expiresString() {


### PR DESCRIPTION
Fix CloudCredential expiry date not being displayed if it's more than a week in the future.
In this case, the behavior was the same as if there wasn't an expiry date at all. This was confusing to users.
Fix it by always displaying the expiry date for CloudCredentials if it's set.

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/13186
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This fix changes the model such that if an expiration-timestamp is set, `expireData` will always return an object. It will only return `null`, if there is no expiration-timestamp set at all, which can be the case for CloudCredential objects for infrastructure providers other than Harvester.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Cloud Credential List

Case 1)
Cloud Credentials for non-Harvester infrastructure providers should be correctly displayed without an expiration date, if they don't have an expiration date

Case 2)
Cloud Credentials for Harvester should be correctly displayed with their expiration date clearly visible regardless of when the expiration date is

Case 3)
Cloud Credentials for Harvester should be displayed with a info/highlighting if the expiration date is within the next 7 days

Case 4)
Cloud Credentials for Harvester should be displayed with an warning/highlighting if the expiration date is in the past

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Cloud Credential List

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![Screenshot at 2025-01-23 13-08-50](https://github.com/user-attachments/assets/4af36182-a417-4fed-b070-45f0c47e6b88)
### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
