### PR TITLE
Fix workload list header text

### DIFF
--- a/shell/list/workload.vue
+++ b/shell/list/workload.vue
@@ -160,6 +160,7 @@ export default {
   },
 
   typeDisplay() {
+    // Used by shell/components/ResourceList/index.vue to override list title (usually found via schema, which doesn't exist for this virtual type)
     return this.$store.getters['type-map/labelFor'](this.schema || workloadSchema, 99);
   },
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13197
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- this normally comes from the schema
  - `shell/components/ResourceList/index.vue` schema --> shell/components/ResourceList/Masthead.vue --> _typeDisplay?
- there's an override in the resource list though that looks at the custom list's object typeDisplay param
  - `shell/components/ResourceList/index.vue` `this.customTypeDisplay = component.typeDisplay.apply(this);`
- typeDisplay is a method outside of the vue method param and was removed in one of the pagination PRs
- fix is to add it back in again

Note - Given https://github.com/rancher/dashboard/pull/13219 this PR now only includes the comment

### Areas or cases that should be tested
- Workload list title 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
