### PR TITLE
Add error handling to extension load

### DIFF
--- a/shell/core/plugins.js
+++ b/shell/core/plugins.js
@@ -92,7 +92,7 @@ export default function(context, inject, vueApp) {
           element.dataset.purpose = 'extension';
 
           element.onload = () => {
-            if (!window[id]) {
+              if (!window[id] || (typeof window[id].default !== 'function')) {
               return reject(new Error('Could not load plugin code'));
             }
 
@@ -106,7 +106,13 @@ export default function(context, inject, vueApp) {
             plugins[id] = plugin;
 
             // Initialize the plugin
-            window[id].default(plugin, this.internal());
+              try {
+                window[id].default(plugin, this.internal());
+              } catch (e) {
+                delete plugins[id];
+
+                return reject(new Error('Could not initialize plugin'));
+              }
 
             // Load all of the types etc from the plugin
             this.applyPlugin(plugin);

--- a/shell/core/plugins.js
+++ b/shell/core/plugins.js
@@ -92,7 +92,7 @@ export default function(context, inject, vueApp) {
           element.dataset.purpose = 'extension';
 
           element.onload = () => {
-              if (!window[id] || (typeof window[id].default !== 'function')) {
+            if (!window[id] || (typeof window[id].default !== 'function')) {
               return reject(new Error('Could not load plugin code'));
             }
 
@@ -106,13 +106,13 @@ export default function(context, inject, vueApp) {
             plugins[id] = plugin;
 
             // Initialize the plugin
-              try {
-                window[id].default(plugin, this.internal());
-              } catch (e) {
-                delete plugins[id];
+            try {
+              window[id].default(plugin, this.internal());
+            } catch (e) {
+              delete plugins[id];
 
-                return reject(new Error('Could not initialize plugin'));
-              }
+              return reject(new Error('Could not initialize plugin'));
+            }
 
             // Load all of the types etc from the plugin
             this.applyPlugin(plugin);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13205

### Technical notes summary

This PR improves the error handling when we load extensions.

I checked out the elemental-ui extension with the 2.9 branch, built it and served it up locally and developer loaded it into a 2.11 UI running locally - to reproduce trying to load a Vue 2 extension into Vue 3.

We don't have any exception handling in the load - the script for the extension loads, so our onloadhandler gets called. The script has an exception when it is evaluated at load time (error reading 'extend'), but this does not affect our code path - we check window[id]`  is set, but because the injected script errored, it is an empty object and does not have the default function, so the real error for us is when we call that method here - https://github.com/rancher/dashboard/blob/master/shell/core/plugins.js#L116 - this throws an unhandled exception.

In the PR, I have added a check for the default function and added a try/catch around the call of it.

With this, the UI handles the load error. Note when running in dev, you will get the red overlay saying there is an unhandled exception (this is due to the error with the script load), but if you close it, our UI is working fine - before, you'd be stuck with the loading spinner. In production you wont' get the red overlay.

### Areas or cases that should be tested

Extension loading

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
