### PR TITLE
Fix failure to fetch workload resources in monitoring chart install

### DIFF
--- a/shell/chart/monitoring/index.vue
+++ b/shell/chart/monitoring/index.vue
@@ -55,7 +55,7 @@ export default {
   async fetch() {
     const { $store } = this;
 
-    // Fetch all the resources required for all the tabs asyncronously up front
+    // Fetch all the resources required for all the tabs asynchronously up front
     const hashPromises = {
       namespaces:        $store.getters['namespaces'](),
       pvcs:              $store.dispatch('cluster/findAll', { type: PVC }),

--- a/shell/components/form/ResourceTabs/index.vue
+++ b/shell/components/form/ResourceTabs/index.vue
@@ -195,7 +195,7 @@ export default {
         pagination.filters = [];
       }
 
-      const field = `involvedObject.uid`; // TODO: RC TEST
+      const field = `involvedObject.uid`;
 
       // of type PaginationParamFilter
       let existing = null;

--- a/shell/components/form/ResourceTabs/index.vue
+++ b/shell/components/form/ResourceTabs/index.vue
@@ -195,7 +195,7 @@ export default {
         pagination.filters = [];
       }
 
-      const field = `involvedObject.uid`; // Pending API Support - https://github.com/rancher/rancher/issues/48603
+      const field = `involvedObject.uid`; // TODO: RC TEST
 
       // of type PaginationParamFilter
       let existing = null;

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -32,7 +32,7 @@ import {
 import { COLUMN_BREAKPOINTS } from '@shell/types/store/type-map';
 import { STEVE_CACHE } from '@shell/store/features';
 import { configureConditionalDepaginate } from '@shell/store/type-map.utils';
-import { CATTLE_PUBLIC_ENDPOINTS } from '@shell/config/labels-annotations';
+import { CATTLE_PUBLIC_ENDPOINTS, STORAGE } from '@shell/config/labels-annotations';
 
 export const NAME = 'explorer';
 
@@ -283,7 +283,7 @@ export function init(store) {
       STEVE_NAMESPACE_COL,
       {
         ...INGRESS_TARGET,
-        sort:   'spec.rules[0].host', // TODO: RC TEST
+        sort:   'spec.rules[0].host', // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
         search: false, // This is broken in normal world, so disable here
       },
       {
@@ -294,7 +294,7 @@ export function init(store) {
       {
         ...INGRESS_CLASS,
         sort:   'spec.ingressClassName',
-        search: 'spec.ingressClassName', // TODO: RC TEST
+        search: 'spec.ingressClassName',
       },
       STEVE_AGE_COL
     ]
@@ -305,8 +305,11 @@ export function init(store) {
     [
       STEVE_STATE_COL,
       STEVE_NAME_COL,
-      STEVE_NAMESPACE_COL,
-      TARGET_PORT,
+      STEVE_NAMESPACE_COL, {
+        ...TARGET_PORT,
+        sort:   false,
+        search: false,
+      },
       {
         // Selector is an object. This is broken in non-SSP world anyway (won't sort on object, filtering on `$[x][y]` paths are broken )
         ...SELECTOR,
@@ -315,8 +318,8 @@ export function init(store) {
       },
       {
         ...SPEC_TYPE,
-        sort:   ['spec.type', 'spec.clusterIP'], // TODO: RC TEST
-        search: 'spec.type', // TODO: RC add search on clusterIp?
+        sort:   ['spec.type'],
+        search: 'spec.type'
       },
       STEVE_AGE_COL
     ]
@@ -345,10 +348,10 @@ export function init(store) {
       STEVE_STATE_COL,
       STEVE_NAME_COL,
       STEVE_NAMESPACE_COL,
-      HPA_REFERENCE, // Pending API support https://github.com/rancher/rancher/issues/48479 (hpa filtering)
-      MIN_REPLICA, // Pending API support https://github.com/rancher/rancher/issues/48479 (hpa filtering)
-      MAX_REPLICA, // Pending API support https://github.com/rancher/rancher/issues/48479 (hpa filtering)
-      CURRENT_REPLICA, // Pending API support https://github.com/rancher/rancher/issues/48479 (hpa filtering)
+      HPA_REFERENCE, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
+      MIN_REPLICA, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
+      MAX_REPLICA, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
+      CURRENT_REPLICA, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
       STEVE_AGE_COL
     ]
   );
@@ -496,8 +499,8 @@ export function init(store) {
       },
       {
         ...STORAGE_CLASS_DEFAULT,
-        sort:   false, // [`metadata.annotations[${ STORAGE.DEFAULT_STORAGE_CLASS }]`], // Pending API Support - https://github.com/rancher/rancher/issues/48453
-        search: false, // [`metadata.annotations[${ STORAGE.DEFAULT_STORAGE_CLASS }]`], // Pending API Support - https://github.com/rancher/rancher/issues/48453
+        sort:   [`metadata.annotations[${ STORAGE.DEFAULT_STORAGE_CLASS }]`],
+        search: [`metadata.annotations[${ STORAGE.DEFAULT_STORAGE_CLASS }]`],
       },
       STEVE_AGE_COL
     ]

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -283,7 +283,7 @@ export function init(store) {
       STEVE_NAMESPACE_COL,
       {
         ...INGRESS_TARGET,
-        sort:   'spec.rules[0].host', // Pending API support https://github.com/rancher/rancher/issues/48473 (index fields)
+        sort:   'spec.rules[0].host', // TODO: RC TEST
         search: false, // This is broken in normal world, so disable here
       },
       {
@@ -294,7 +294,7 @@ export function init(store) {
       {
         ...INGRESS_CLASS,
         sort:   'spec.ingressClassName',
-        search: 'spec.ingressClassName', // Pending API support  (blocked https://github.com/rancher/rancher/issues/48473 (index fields)
+        search: 'spec.ingressClassName', // TODO: RC TEST
       },
       STEVE_AGE_COL
     ]
@@ -315,8 +315,8 @@ export function init(store) {
       },
       {
         ...SPEC_TYPE,
-        sort:   false, // ['spec.type', 'spec.clusterIP'] Pending API support  (blocked https://github.com/rancher/rancher/issues/48473 (index fields)
-        search: 'spec.type',
+        sort:   ['spec.type', 'spec.clusterIP'], // TODO: RC TEST
+        search: 'spec.type', // TODO: RC add search on clusterIp?
       },
       STEVE_AGE_COL
     ]

--- a/shell/models/service.js
+++ b/shell/models/service.js
@@ -138,6 +138,11 @@ export default class Service extends SteveModel {
   }
 
   async fetchPods() {
+    if (!this.podRelationship) {
+      // If empty or not present, the service is assumed to have an external process managing its endpoints
+      return [];
+    }
+
     return await this.$dispatch('findLabelSelector', {
       type:     POD,
       matching: {

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -194,7 +194,7 @@ class StevePaginationUtils extends NamespaceProjectFilters {
       { field: '_type' },
       { field: 'reason' },
       { field: 'involvedObject.kind' },
-      // { field: 'involvedObject.uid' }, // Pending API Support - https://github.com/rancher/rancher/issues/48603
+      { field: 'involvedObject.uid' }, // TODO: RC TEST
       { field: 'message' },
     ],
     [CATALOG.CLUSTER_REPO]: [
@@ -215,17 +215,17 @@ class StevePaginationUtils extends NamespaceProjectFilters {
     ],
     [SERVICE]: [
       { field: 'spec.type' },
-      // { field: 'spec.clusterIP' }, // Pending API support  (blocked https://github.com/rancher/rancher/issues/48473 (index fields)
+      { field: 'spec.clusterIP' }, // TODO: RC TEST
     ],
     [INGRESS]: [
-      // { field: 'spec.rules.host' }, // Pending API support  (blocked https://github.com/rancher/rancher/issues/48473 (index fields)
-      // { field: 'spec.ingressClassName' }, // Pending API support  (blocked https://github.com/rancher/rancher/issues/48473 (index fields)
+      { field: 'spec.rules.host' }, // TODO: RC TEST
+      { field: 'spec.ingressClassName' }, // TODO: RC TEST
     ],
     [HPA]: [
-      // { field: 'spec.scaleTargetRef.name' }, // Pending API support https://github.com/rancher/rancher/issues/48473 (hpa filtering fix)
-      // { field: 'spec.minReplicas' }, // Pending API support https://github.com/rancher/rancher/issues/48473 (hpa filtering fix)
-      // { field: 'spec.maxReplicas' }, // Pending API support https://github.com/rancher/rancher/issues/48473 (hpa filtering fix)
-      // { field: 'spec.currentReplicas' }, // Pending API support https://github.com/rancher/rancher/issues/48473 (hpa filtering fix)
+      { field: 'spec.scaleTargetRef.name' }, // TODO: RC TEST
+      { field: 'spec.minReplicas' }, // TODO: RC TEST
+      { field: 'spec.maxReplicas' }, // TODO: RC TEST
+      { field: 'spec.currentReplicas' }, // TODO: RC TEST
     ],
     [PVC]: [
       { field: 'spec.volumeName' },
@@ -236,36 +236,36 @@ class StevePaginationUtils extends NamespaceProjectFilters {
     ],
     [STORAGE_CLASS]: [
       { field: 'provisioner' },
-      // { field: `metadata.annotations[STORAGE.DEFAULT_STORAGE_CLASS]` }, // Pending API Support - https://github.com/rancher/rancher/issues/48453
+      { field: `metadata.annotations[STORAGE.DEFAULT_STORAGE_CLASS]` }, // TODO: RC TEST
     ],
     [CATALOG.APP]: [
       { field: 'spec.chart.metadata.name' }
     ],
     [WORKLOAD_TYPES.CRON_JOB]: [
       { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
-      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/48603
+      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/49116
     ],
     [WORKLOAD_TYPES.DAEMON_SET]: [
       { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
-      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/48603
+      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/49116
     ],
     [WORKLOAD_TYPES.DEPLOYMENT]: [
       { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
-      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/48603
+      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/49116
     ],
     [WORKLOAD_TYPES.JOB]: [
       { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
-      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/48603
+      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/49116
     ],
     [WORKLOAD_TYPES.STATEFUL_SET]: [
       { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
-      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/48603
+      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/49116
     ],
     [WORKLOAD_TYPES.REPLICA_SET]: [
-      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/48603
+      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/49116
     ],
     [WORKLOAD_TYPES.REPLICATION_CONTROLLER]: [
-      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/48603
+      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/49116
     ],
   }
 

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -15,7 +15,7 @@ import {
   HPA,
   SECRET
 } from '@shell/config/types';
-import { CAPI as CAPI_LAB_AND_ANO, CATTLE_PUBLIC_ENDPOINTS } from '@shell/config/labels-annotations';
+import { CAPI as CAPI_LAB_AND_ANO, CATTLE_PUBLIC_ENDPOINTS, STORAGE } from '@shell/config/labels-annotations';
 import { Schema } from '@shell/plugins/steve/schema';
 import { PaginationSettingsStore } from '@shell/types/resources/settings';
 import paginationUtils from '@shell/utils/pagination-utils';
@@ -194,7 +194,7 @@ class StevePaginationUtils extends NamespaceProjectFilters {
       { field: '_type' },
       { field: 'reason' },
       { field: 'involvedObject.kind' },
-      { field: 'involvedObject.uid' }, // TODO: RC TEST
+      { field: 'involvedObject.uid' },
       { field: 'message' },
     ],
     [CATALOG.CLUSTER_REPO]: [
@@ -215,17 +215,17 @@ class StevePaginationUtils extends NamespaceProjectFilters {
     ],
     [SERVICE]: [
       { field: 'spec.type' },
-      { field: 'spec.clusterIP' }, // TODO: RC TEST
+      { field: 'spec.clusterIP' },
     ],
     [INGRESS]: [
-      { field: 'spec.rules.host' }, // TODO: RC TEST
-      { field: 'spec.ingressClassName' }, // TODO: RC TEST
+      { field: 'spec.rules.host' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
+      { field: 'spec.ingressClassName' },
     ],
     [HPA]: [
-      { field: 'spec.scaleTargetRef.name' }, // TODO: RC TEST
-      { field: 'spec.minReplicas' }, // TODO: RC TEST
-      { field: 'spec.maxReplicas' }, // TODO: RC TEST
-      { field: 'spec.currentReplicas' }, // TODO: RC TEST
+      { field: 'spec.scaleTargetRef.name' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
+      { field: 'spec.minReplicas' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
+      { field: 'spec.maxReplicas' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
+      { field: 'spec.currentReplicas' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
     ],
     [PVC]: [
       { field: 'spec.volumeName' },
@@ -236,36 +236,36 @@ class StevePaginationUtils extends NamespaceProjectFilters {
     ],
     [STORAGE_CLASS]: [
       { field: 'provisioner' },
-      { field: `metadata.annotations[STORAGE.DEFAULT_STORAGE_CLASS]` }, // TODO: RC TEST
+      { field: `metadata.annotations[${ STORAGE.DEFAULT_STORAGE_CLASS }]` },
     ],
     [CATALOG.APP]: [
       { field: 'spec.chart.metadata.name' }
     ],
     [WORKLOAD_TYPES.CRON_JOB]: [
       { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
-      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/49116
+      { field: 'spec.template.spec.containers.image' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
     ],
     [WORKLOAD_TYPES.DAEMON_SET]: [
       { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
-      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/49116
+      { field: 'spec.template.spec.containers.image' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
     ],
     [WORKLOAD_TYPES.DEPLOYMENT]: [
       { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
-      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/49116
+      { field: 'spec.template.spec.containers.image' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
     ],
     [WORKLOAD_TYPES.JOB]: [
       { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
-      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/49116
+      { field: 'spec.template.spec.containers.image' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
     ],
     [WORKLOAD_TYPES.STATEFUL_SET]: [
       { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
-      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/49116
+      { field: 'spec.template.spec.containers.image' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
     ],
     [WORKLOAD_TYPES.REPLICA_SET]: [
-      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/49116
+      { field: 'spec.template.spec.containers.image' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
     ],
     [WORKLOAD_TYPES.REPLICATION_CONTROLLER]: [
-      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/49116
+      { field: 'spec.template.spec.containers.image' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
     ],
   }
 

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -242,21 +242,31 @@ class StevePaginationUtils extends NamespaceProjectFilters {
       { field: 'spec.chart.metadata.name' }
     ],
     [WORKLOAD_TYPES.CRON_JOB]: [
-      { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` }
+      { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
+      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/48603
     ],
     [WORKLOAD_TYPES.DAEMON_SET]: [
-      { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` }
+      { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
+      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/48603
     ],
     [WORKLOAD_TYPES.DEPLOYMENT]: [
-      { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` }
+      { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
+      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/48603
     ],
     [WORKLOAD_TYPES.JOB]: [
-      { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` }
+      { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
+      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/48603
     ],
     [WORKLOAD_TYPES.STATEFUL_SET]: [
-      { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` }
-    ]
-
+      { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
+      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/48603
+    ],
+    [WORKLOAD_TYPES.REPLICA_SET]: [
+      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/48603
+    ],
+    [WORKLOAD_TYPES.REPLICATION_CONTROLLER]: [
+      // { field: 'spec.template.spec.containers.image' }, // Pending API Support - https://github.com/rancher/rancher/issues/48603
+    ],
   }
 
   private convertArrayPath(path: string): string {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11536
Fixes #11539
Fixes #11540

Also
Fixes #14446
Fixes #14445

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Fields in install monitoring wizard were empty (#11536, #11539, #11540)
  - exception caused by missing backend indexed fields
  - exception meant a number of input options were not populated
  - these fields have now been indexed, so no code changes required to fix (just comments tidied up)
- Review sorting/filtering on other fields that depended on backend indexing or bug fixes 
  - some are fine (removed comments associated with them)
  - some are still not (created new issues and updated comments)
- Fix sorting storage classes by `default` column
- Fixed issue when searching `services`, ensure column using local property targetPort are not used when searching server side (#14446)
- Can now sort on service type
- Can now view service detail page for services without selectors without seeing error in console (#14445)

### Areas or cases that should be tested
All with vai on

- Install monitoring chart (should be fine)
- Services list - search by any text should result in the correct rows displayed (no errors)
- Services list - sorting by type should work
- Service detail page for `kubernetes` service - no error in console
- Storage Class - sorting on default class should work


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
