### PR TITLE
automation: add coverage for labeledinput using v-model.value.number

### DIFF
--- a/cypress/e2e/po/components/component.po.ts
+++ b/cypress/e2e/po/components/component.po.ts
@@ -82,4 +82,8 @@ export default class ComponentPo {
   checkNotExists(options?: GetOptions): Cypress.Chainable<boolean> {
     return this.self(options).should('not.exist');
   }
+
+  shouldHaveValue(value: string, options?: GetOptions): Cypress.Chainable<boolean> {
+    return this.self(options).should('have.value', value);
+  }
 }

--- a/cypress/e2e/po/edit/policy/network-policy.po.ts
+++ b/cypress/e2e/po/edit/policy/network-policy.po.ts
@@ -1,13 +1,25 @@
-import CreateEditViewPo from '@/cypress/e2e/po/components/create-edit-view.po';
+import PagePo from '@/cypress/e2e/po/pages/page.po';
 import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import BannersPo from '@/cypress/e2e/po/components/banners.po';
 import CodeMirrorPo from '@/cypress/e2e/po/components/code-mirror.po';
-export default class NetworkPolicyPo extends CreateEditViewPo {
-  constructor(selector = '.dashboard-root') {
-    super(selector);
+import ArrayListPo from '@/cypress/e2e/po/components/array-list.po';
+
+export default class CreateEditNetworkPolicyPagePo extends PagePo {
+  private static createPath(clusterId: string, namespace?: string, id?: string ) {
+    const root = `/c/${ clusterId }/explorer/networking.k8s.io.networkpolicy`;
+
+    return id ? `${ root }/${ namespace }/${ id }` : `${ root }/create`;
+  }
+
+  static goTo(path: string): Cypress.Chainable<Cypress.AUTWindow> {
+    throw new Error('invalid');
+  }
+
+  constructor(clusterId = 'local', namespace?: string, id?: string) {
+    super(CreateEditNetworkPolicyPagePo.createPath(clusterId, namespace, id));
   }
 
   nameInput() {
@@ -28,6 +40,14 @@ export default class NetworkPolicyPo extends CreateEditViewPo {
 
   addAllowedTrafficSourceButton() {
     return cy.get('[data-testid="array-list-button"]').contains('Add allowed traffic source');
+  }
+
+  addAllowedPortButton() {
+    return cy.get('[data-testid="array-list-button"]').contains('Add allowed port');
+  }
+
+  ingressRuleItem(index: number) {
+    return new ArrayListPo('section #rule-ingress0', this.self()).arrayListItem(index);
   }
 
   policyRuleTargetSelect(index: number) {

--- a/cypress/e2e/po/pages/explorer/network-policy.po.ts
+++ b/cypress/e2e/po/pages/explorer/network-policy.po.ts
@@ -2,6 +2,7 @@ import PagePo from '@/cypress/e2e/po/pages/page.po';
 import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+import CreateEditNetworkPolicyPagePo from '@/cypress/e2e/po/edit/policy/network-policy.po';
 
 export class NetworkPolicyPagePo extends PagePo {
   private static createPath(clusterId: string) {
@@ -21,7 +22,7 @@ export class NetworkPolicyPagePo extends PagePo {
     sideNav.navToSideMenuEntryByLabel('Network Policies');
   }
 
-  constructor(clusterId = 'local') {
+  constructor(private clusterId = 'local') {
     super(NetworkPolicyPagePo.createPath(clusterId));
   }
 
@@ -39,5 +40,9 @@ export class NetworkPolicyPagePo extends PagePo {
 
   searchForNetworkPolicy(name: string) {
     return this.list().resourceTable().sortableTable().filter(name);
+  }
+
+  createEditNetworkPolicyForm(namespace?: string, id?: string): CreateEditNetworkPolicyPagePo {
+    return new CreateEditNetworkPolicyPagePo(this.clusterId, namespace, id);
   }
 }

--- a/cypress/e2e/po/pages/global-settings/performance.po.ts
+++ b/cypress/e2e/po/pages/global-settings/performance.po.ts
@@ -60,6 +60,10 @@ export class PerformancePagePo extends RootClusterPage {
     return CheckboxInputPo.byLabel(this.self(), 'Enable Garbage Collection');
   }
 
+  garbageCollectionResourceCount() {
+    return LabeledInputPo.byLabel(this.self(), 'Resource Count');
+  }
+
   namespaceFilteringCheckbox(): CheckboxInputPo {
     return CheckboxInputPo.byLabel(this.self(), 'Enable Required Namespace / Project Filtering');
   }

--- a/cypress/e2e/tests/pages/explorer/policy/network-policy.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/policy/network-policy.spec.ts
@@ -1,80 +1,126 @@
 import { NetworkPolicyPagePo } from '@/cypress/e2e/po/pages/explorer/network-policy.po';
-import NetworkPolicyPo from '@/cypress/e2e/po/components/policy/network-policy.po';
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 
 const networkPolicyPage = new NetworkPolicyPagePo('local');
-const networkPolicyName = 'custom-network-policy';
+const customNetworkPolicyName = 'custom-network-policy';
 const networkPolicyDescription = 'Custom Network Policy Description';
+const namespace = 'default';
+let networkPolicyName = '';
+let removeNetworkPolicy = false;
+const networkPolicyToDelete = [];
 
 describe('NetworkPolicies', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, () => {
   before(() => {
     cy.login();
+    cy.createE2EResourceName('networkpolicy').then((name) => {
+      networkPolicyName = name;
+    });
   });
 
   it('creates a network policy and displays it in the list', () => {
     // Visit the main menu and select the 'local' cluster
     // Navigate to Policy => Network Policies
     NetworkPolicyPagePo.navTo();
+    networkPolicyPage.waitForPage();
     // Go to Create Page
     networkPolicyPage.clickCreate();
-    const networkPolicyPo = new NetworkPolicyPo();
 
     // Enter name & description
-    networkPolicyPo.nameInput().set(networkPolicyName);
-    networkPolicyPo.descriptionInput().set(networkPolicyDescription);
+    networkPolicyPage.createEditNetworkPolicyForm().nameInput().set(customNetworkPolicyName);
+    networkPolicyPage.createEditNetworkPolicyForm().descriptionInput().set(networkPolicyDescription);
     // Enable ingress checkbox
-    networkPolicyPo.enableIngressCheckbox().set();
+    networkPolicyPage.createEditNetworkPolicyForm().enableIngressCheckbox().set();
     // Add a new rule without a key to match all the namespaces
-    networkPolicyPo.newNetworkPolicyRuleAddBtn().click();
-    networkPolicyPo.addAllowedTrafficSourceButton().click();
-    networkPolicyPo.policyRuleTargetSelect(0).toggle();
-    networkPolicyPo.policyRuleTargetSelect(0).clickOptionWithLabel('Namespace Selector');
+    networkPolicyPage.createEditNetworkPolicyForm().newNetworkPolicyRuleAddBtn().click();
+    networkPolicyPage.createEditNetworkPolicyForm().addAllowedTrafficSourceButton().click();
+    networkPolicyPage.createEditNetworkPolicyForm().policyRuleTargetSelect(0).toggle();
+    networkPolicyPage.createEditNetworkPolicyForm().policyRuleTargetSelect(0).clickOptionWithLabel('Namespace Selector');
 
     cy.getRancherResource('v1', 'namespaces').then((resp: Cypress.Response<any>) => {
       cy.wrap(resp.body.count).as('namespaceCount');
     });
 
     cy.get('@namespaceCount').then((count) => {
-      networkPolicyPo.matchingNamespacesMessage(0).should('contain.text', `Matches ${ count } of ${ count }`);
+      networkPolicyPage.createEditNetworkPolicyForm().matchingNamespacesMessage(0).should('contain.text', `Matches ${ count } of ${ count }`);
       // Add a second rule a key to match none of the namespaces
-      networkPolicyPo.addAllowedTrafficSourceButton().click();
-      networkPolicyPo.policyRuleTargetSelect(1).toggle();
-      networkPolicyPo.policyRuleTargetSelect(1).clickOptionWithLabel('Namespace Selector');
-      networkPolicyPo.policyRuleKeyInput(1).focus().type('something-with-no-matching-namespaces');
-      networkPolicyPo.matchingNamespacesMessage(1).should('contain.text', `Matches 0 of ${ count }`);
+      networkPolicyPage.createEditNetworkPolicyForm().addAllowedTrafficSourceButton().click();
+      networkPolicyPage.createEditNetworkPolicyForm().policyRuleTargetSelect(1).toggle();
+      networkPolicyPage.createEditNetworkPolicyForm().policyRuleTargetSelect(1).clickOptionWithLabel('Namespace Selector');
+      networkPolicyPage.createEditNetworkPolicyForm().policyRuleKeyInput(1).focus().type('something-with-no-matching-namespaces');
+      networkPolicyPage.createEditNetworkPolicyForm().matchingNamespacesMessage(1).should('contain.text', `Matches 0 of ${ count }`);
       // Click on Create
-      networkPolicyPo.saveCreateForm().click();
+      networkPolicyPage.createEditNetworkPolicyForm().saveCreateForm().click();
       // Check if the NetworkPolicy is created successfully
       networkPolicyPage.waitForPage();
-      networkPolicyPage.searchForNetworkPolicy(networkPolicyName);
-      networkPolicyPage.waitForPage(`q=${ networkPolicyName }`);
-      networkPolicyPage.listElementWithName(networkPolicyName).should('exist').and('be.visible');
+      networkPolicyPage.searchForNetworkPolicy(customNetworkPolicyName);
+      networkPolicyPage.waitForPage(`q=${ customNetworkPolicyName }`);
+      networkPolicyPage.listElementWithName(customNetworkPolicyName).should('exist').and('be.visible');
       // Navigate back to the edit page and check if the matching message is still correct
-      networkPolicyPage.list().actionMenu(networkPolicyName).getMenuItem('Edit Config').click();
-      networkPolicyPo.matchingNamespacesMessage(0).should('contain.text', `Matches ${ count } of ${ count }`);
-      networkPolicyPo.matchingNamespacesMessage(1).should('contain.text', `Matches 0 of ${ count }`);
+      networkPolicyPage.list().actionMenu(customNetworkPolicyName).getMenuItem('Edit Config').click();
+      networkPolicyPage.createEditNetworkPolicyForm().matchingNamespacesMessage(0).should('contain.text', `Matches ${ count } of ${ count }`);
+      networkPolicyPage.createEditNetworkPolicyForm().matchingNamespacesMessage(1).should('contain.text', `Matches 0 of ${ count }`);
     });
   });
 
   it('can open "Edit as YAML"', () => {
     NetworkPolicyPagePo.navTo();
+    networkPolicyPage.waitForPage();
     networkPolicyPage.clickCreate();
-    const networkPolicyPo = new NetworkPolicyPo();
 
-    networkPolicyPo.editAsYaml().click();
-    networkPolicyPo.yamlEditor().checkExists();
+    networkPolicyPage.createEditNetworkPolicyForm().editAsYaml().click();
+    networkPolicyPage.createEditNetworkPolicyForm().yamlEditor().checkExists();
+  });
+
+  // testing https://github.com/rancher/dashboard/issues/11856
+  it('port value is sent correctly in request payload', () => {
+    cy.intercept('POST', 'v1/networking.k8s.io.networkpolicies').as('createNetworkPolicy');
+
+    NetworkPolicyPagePo.navTo();
+    networkPolicyPage.waitForPage();
+    networkPolicyPage.clickCreate();
+    networkPolicyPage.createEditNetworkPolicyForm().waitForPage(null, 'ingress');
+
+    networkPolicyPage.createEditNetworkPolicyForm().nameInput().set(networkPolicyName);
+    networkPolicyPage.createEditNetworkPolicyForm().descriptionInput().set(networkPolicyDescription);
+    networkPolicyPage.createEditNetworkPolicyForm().enableIngressCheckbox().set();
+    networkPolicyPage.createEditNetworkPolicyForm().newNetworkPolicyRuleAddBtn().click();
+    networkPolicyPage.createEditNetworkPolicyForm().addAllowedPortButton().click();
+    networkPolicyPage.createEditNetworkPolicyForm().ingressRuleItem(0).find('.col:nth-of-type(1) input').type('8080');
+    networkPolicyPage.createEditNetworkPolicyForm().saveCreateForm().click();
+
+    // check request payload
+    cy.wait('@createNetworkPolicy').then(({ request, response }) => {
+      expect(response?.statusCode).to.eq(201);
+      removeNetworkPolicy = true;
+      networkPolicyToDelete.push(`${ namespace }/${ networkPolicyName }`);
+      expect(request?.body.spec.ingress).to.deep.include({ ports: [{ port: 8080 }] });
+    });
+    networkPolicyPage.waitForPage();
+    networkPolicyPage.searchForNetworkPolicy(networkPolicyName);
+    networkPolicyPage.waitForPage(`q=${ networkPolicyName }`);
+    networkPolicyPage.list().actionMenu(networkPolicyName).getMenuItem('Edit Config').click();
+    networkPolicyPage.createEditNetworkPolicyForm(namespace, networkPolicyName).waitForPage(`mode=edit#rule-ingress0`);
+    // check elements value property
+    networkPolicyPage.createEditNetworkPolicyForm().ingressRuleItem(0).find('.col:nth-of-type(1) input').should('have.value', '8080');
   });
 
   it('can delete a network policy', () => {
     NetworkPolicyPagePo.navTo();
     networkPolicyPage.waitForPage();
-    networkPolicyPage.list().actionMenu(networkPolicyName).getMenuItem('Delete').click();
+    networkPolicyPage.list().actionMenu(customNetworkPolicyName).getMenuItem('Delete').click();
     const promptRemove = new PromptRemove();
 
     cy.intercept('DELETE', 'v1/networking.k8s.io.networkpolicies/**').as('deleteNetworkPolicy');
     promptRemove.remove();
     cy.wait('@deleteNetworkPolicy');
     networkPolicyPage.waitForPage();
-    cy.contains(networkPolicyName).should('not.exist');
+    cy.contains(customNetworkPolicyName).should('not.exist');
+  });
+
+  after(() => {
+    if (removeNetworkPolicy) {
+      // delete gitrepo
+      networkPolicyToDelete.forEach((r) => cy.deleteRancherResource('v1', 'networking.k8s.io.networkpolicies', r, false));
+    }
   });
 });

--- a/cypress/e2e/tests/pages/global-settings/performance.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/performance.spec.ts
@@ -144,11 +144,17 @@ describe('Performance', { testIsolation: 'off', tags: ['@globalSettings', '@admi
     performancePage.garbageCollectionCheckbox().isUnchecked();
     performancePage.garbageCollectionCheckbox().set();
     performancePage.garbageCollectionCheckbox().isChecked();
+    // testing https://github.com/rancher/dashboard/issues/11856
+    performancePage.garbageCollectionResourceCount().set('600');
     performancePage.applyAndWait('garbageCollection-true').then(({ request, response }) => {
       expect(response?.statusCode).to.eq(200);
       expect(request.body).to.have.property('value').contains('\"garbageCollection\":{\"enabled\":true');
       expect(response?.body).to.have.property('value').contains('\"garbageCollection\":{\"enabled\":true');
+      expect(response?.body).to.have.property('value').contains('\"countThreshold\":600');
     });
+
+    // check elements value property
+    performancePage.garbageCollectionResourceCount().shouldHaveValue('600');
 
     // Disable garbage collection
     performancePage.garbageCollectionCheckbox().isChecked();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1589
- Updated name of performance spec (peformance->performance)
- Moved location of policy/network-policy folder
- Updated network-policy po file to be able to construct the page URL dynamically 
- Added test and updated existing network-policy tests based on PO file changes
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
