### PR TITLE
Crontab @daily marked as invalid in Rancher Cronjobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "cookie": "0.7.0",
     "cookie-universal": "2.2.2",
     "cron-validator": "1.2.0",
-    "cronstrue": "1.95.0",
+    "cronstrue": "2.53.0",
     "cross-env": "7.0.3",
     "custom-event-polyfill": "1.0.7",
     "d3": "7.3.0",

--- a/pkg/rancher-components/package.json
+++ b/pkg/rancher-components/package.json
@@ -36,7 +36,7 @@
     "babel-eslint": "10.1.0",
     "core-js": "3.40.0",
     "cron-validator": "1.3.1",
-    "cronstrue": "2.50.0",
+    "cronstrue": "2.53.0",
     "eslint-plugin-import": "2.31.0",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "5.2.0",

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
@@ -20,7 +20,7 @@ describe('component: LabeledInput', () => {
     expect(wrapper.emitted('update:value')![0][0]).toBe(value);
   });
 
-  it('using mode "multiline" should emit input value correctly', () => {
+  it('using type "multiline" should emit input value correctly', () => {
     const value = 'any-string';
     const delay = 1;
     const wrapper = mount(LabeledInput, {
@@ -36,5 +36,20 @@ describe('component: LabeledInput', () => {
 
     expect(wrapper.emitted('update:value')).toHaveLength(1);
     expect(wrapper.emitted('update:value')![0][0]).toBe(value);
+  });
+
+  describe('using type "chron"', () => {
+    it.each([
+      ['0 * * * *', 'Every hour, every day'],
+      ['@daily', 'Every day at midnight'],
+      ['You must fail! Go!', 'Invalid cron schedule'],
+    ])('passing value %p should display hint %p', (value, hint) => {
+      const wrapper = mount(LabeledInput, {
+        mocks: { $store: { getters: { 'i18n/t': jest.fn() } } }
+      });
+
+      const subLabel = wrapper.find('[data-testid="sub-label"]').element as HTMLElement;
+      expect(subLabel.innerText).toBe(hint);
+    });
   });
 });

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
@@ -41,15 +41,17 @@ describe('component: LabeledInput', () => {
   describe('using type "chron"', () => {
     it.each([
       ['0 * * * *', 'Every hour, every day'],
-      ['@daily', 'Every day at midnight'],
-      ['You must fail! Go!', 'Invalid cron schedule'],
+      ['@daily', 'At 12:00 AM, every day'],
+      ['You must fail! Go!', '%generic.invalidCron%'],
     ])('passing value %p should display hint %p', (value, hint) => {
       const wrapper = mount(LabeledInput, {
-        mocks: { $store: { getters: { 'i18n/t': jest.fn() } } }
+        propsData: { value, type: 'cron' },
+        mocks:     { $store: { getters: { 'i18n/t': jest.fn() } } }
       });
 
-      const subLabel = wrapper.find('[data-testid="sub-label"]').element as HTMLElement;
-      expect(subLabel.innerText).toBe(hint);
+      const subLabel = wrapper.find('[data-testid="sub-label"]');
+
+      expect(subLabel.text()).toBe(hint);
     });
   });
 });

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -179,14 +179,28 @@ export default defineComponent({
       if (this.type !== 'cron' || !this.value) {
         return;
       }
+
+      // TODO - #13202: This is required due use of 2 libraries and 3 different libraries through the code.
+      const predefined = [
+        '@yearly',
+        '@annually',
+        '@monthly',
+        '@weekly',
+        '@daily',
+        '@midnight',
+        '@hourly'
+      ];
+      const isPredefined = predefined.includes(this.value as string);
+
       // refer https://github.com/GuillaumeRochat/cron-validator#readme
-      if (!isValidCron(this.value as string, {
+      if (!isPredefined && !isValidCron(this.value as string, {
         alias:              true,
         allowBlankDay:      true,
         allowSevenAsSunday: true,
       })) {
         return this.t('generic.invalidCron');
       }
+
       try {
         const hint = cronstrue.toString(this.value as string || '', { verbose: true });
 

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -382,6 +382,7 @@ export default defineComponent({
     <div
       v-if="cronHint || subLabel"
       class="sub-label"
+      data-testid="sub-label"
     >
       <div
         v-if="cronHint"

--- a/shell/package.json
+++ b/shell/package.json
@@ -64,7 +64,7 @@
     "cookie": "0.7.0",
     "core-js": "3.40.0",
     "cron-validator": "1.3.1",
-    "cronstrue": "2.50.0",
+    "cronstrue": "2.53.0",
     "cross-env": "7.0.3",
     "css-loader": "6.7.3",
     "csv-loader": "3.0.3",

--- a/shell/utils/validators/cron-schedule.js
+++ b/shell/utils/validators/cron-schedule.js
@@ -10,5 +10,5 @@ export function cronSchedule(schedule = '', getters, errors) {
 
 export const cronScheduleRule = {
   validation: (text) => cronstrue.toString(text, { verbose: true }),
-  message: 'validation.invalidCron'
+  message:    'validation.invalidCron'
 };

--- a/shell/utils/validators/cron-schedule.js
+++ b/shell/utils/validators/cron-schedule.js
@@ -2,8 +2,13 @@ import cronstrue from 'cronstrue';
 
 export function cronSchedule(schedule = '', getters, errors) {
   try {
-    cronstrue.toString(schedule, { verbose: true });
+    cronScheduleRule.validation(schedule);
   } catch (e) {
-    errors.push(getters['i18n/t']('validation.invalidCron'));
+    errors.push(getters['i18n/t'](cronScheduleRule.message));
   }
 }
+
+export const cronScheduleRule = {
+  validation: (text) => cronstrue.toString(text, { verbose: true }),
+  message: 'validation.invalidCron'
+};

--- a/shell/utils/validators/formRules/__tests__/index.test.ts
+++ b/shell/utils/validators/formRules/__tests__/index.test.ts
@@ -27,22 +27,6 @@ describe('formRules', () => {
     expect(formRuleResult).toStrictEqual(expectedResult);
   });
 
-  it('"cronSchedule" : returns undefined when valid cron string value supplied', () => {
-    const testValue = '0 * * * *';
-    const formRuleResult = formRules.cronSchedule(testValue);
-
-    expect(formRuleResult).toBeUndefined();
-  });
-
-  it('"cronSchedule" : returns the correct message when invalid cron string value supplied', () => {
-    // specific logic of what constitutes a cron string is in the "cronstrue" function in an external library and not tested here
-    const testValue = '0 * * **';
-    const formRuleResult = formRules.cronSchedule(testValue);
-    const expectedResult = JSON.stringify({ message: 'validation.invalidCron' });
-
-    expect(formRuleResult).toStrictEqual(expectedResult);
-  });
-
   it('"https" : returns undefined when valid https url value is supplied', () => {
     const testValue = 'https://url.com';
     const formRuleResult = formRules.https(testValue);
@@ -1112,6 +1096,14 @@ describe('formRules', () => {
     expect(formRuleResult).toStrictEqual(expectedResult);
   });
 
+
+  /**
+   * Test all factory validators
+   * @param rule - the name of the factory validator
+   * @param argument - the value to validate
+   * @param correctValues - an array of values that should pass the validation
+   * @param wrongValues - an array of values that should fail the validation
+   */
   describe.each([
     ['minValue', 2, [3], [1]],
     ['maxValue', 256, [1], [300]],
@@ -1133,12 +1125,18 @@ describe('formRules', () => {
     });
   });
 
+  /**
+   * Test all standard validators
+   * @param rule - the name of the standard validator
+   * @param correctValues - an array of values that should pass the validation
+   * @param wrongValues - an array of values that should fail the validation
+   */
   describe.each([
     ['requiredInt', [2, 2.2], ['e']],
     ['isInteger', ['2', 2, 0], [2.2, 'e', '1.0']],
     ['isPositive', ['0', 1], [-1]],
     ['isOctal', ['0', 0, 10], ['01']],
-
+    ['cronSchedule', ['0 * * * *', '@daily'], ['0 * * **']],
   ])('given validator %p', (rule, correctValues, wrongValues) => {
     it.each(wrongValues as [])('should return error for value %p', (wrong) => {
       const formRuleResult = (formRules as any)[rule](wrong);

--- a/shell/utils/validators/formRules/__tests__/index.test.ts
+++ b/shell/utils/validators/formRules/__tests__/index.test.ts
@@ -1096,7 +1096,6 @@ describe('formRules', () => {
     expect(formRuleResult).toStrictEqual(expectedResult);
   });
 
-
   /**
    * Test all factory validators
    * @param rule - the name of the factory validator

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -10,9 +10,21 @@ import { isHttps, isLocalhost, hasTrailingForwardSlash } from '@shell/utils/vali
 import { cronScheduleRule } from '@shell/utils/validators/cron-schedule';
 
 // import uniq from 'lodash/uniq';
-export type Validator<T = undefined | string> = (val: any, arg?: any) => T;
 
-export type ValidatorFactory = (arg1: any, arg2?: any) => Validator
+/**
+ * Fixed validation rule which require only the value to be evaluated
+ * @param value
+ * @returns { string | undefined }
+ */
+export type Validator<T = undefined | string> = (value: any, arg?: any) => T;
+
+/**
+ * Factory function which returns a validation rule
+ * @param arg Argument used as part of the validation rule process, not necessarily as parameter of the validation rule
+ * @param value Value to be evaluated
+ * @returns { Validator }
+ */
+export type ValidatorFactory = (arg: any, value?: any) => Validator
 
 type ServicePort = {
   name?: string,

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -4,7 +4,6 @@ import isEmpty from 'lodash/isEmpty';
 import has from 'lodash/has';
 import isUrl from 'is-url';
 // import uniq from 'lodash/uniq';
-import cronstrue from 'cronstrue';
 import { Translation } from '@shell/types/t';
 import { isHttps, isLocalhost, hasTrailingForwardSlash } from '@shell/utils/validators/setting';
 import { cronScheduleRule } from '@shell/utils/validators/cron-schedule';

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -7,6 +7,7 @@ import isUrl from 'is-url';
 import cronstrue from 'cronstrue';
 import { Translation } from '@shell/types/t';
 import { isHttps, isLocalhost, hasTrailingForwardSlash } from '@shell/utils/validators/setting';
+import { cronScheduleRule } from '@shell/utils/validators/cron-schedule';
 
 // import uniq from 'lodash/uniq';
 export type Validator<T = undefined | string> = (val: any, arg?: any) => T;
@@ -131,9 +132,9 @@ export default function(t: Translation, { key = 'Value' }: ValidationOptions): {
 
   const cronSchedule: Validator = (val: string) => {
     try {
-      cronstrue.toString(val, { verbose: true });
+      cronScheduleRule.validation(val);
     } catch (e) {
-      return t('validation.invalidCron');
+      return t(cronScheduleRule.message);
     }
   };
 

--- a/storybook/src/stories/Form/Input.mdx
+++ b/storybook/src/stories/Form/Input.mdx
@@ -46,3 +46,5 @@ Addition information can be added to the input field using the `subLabel` prop.
 The `chron` prop can be used to add [Chron language](https://en.wikipedia.org/wiki/Cron) hints.
 
 <Canvas of={LabeledInput.ChronType} />
+
+<Canvas of={LabeledInput.ChronTypeDaily} />

--- a/storybook/src/stories/Form/Input.mdx
+++ b/storybook/src/stories/Form/Input.mdx
@@ -41,13 +41,15 @@ Addition information can be added to the input field using the `subLabel` prop.
 
 <Canvas of={LabeledInput.SubLabel} />
 
-#### Chron Type
+#### Cron Type
 
-The `chron` prop can be used to add [Chron language](https://en.wikipedia.org/wiki/Cron) hints.
+The `cron` prop can be used to add [Cron language](https://en.wikipedia.org/wiki/Cron) hints.
 
-<Canvas of={LabeledInput.ChronType} />
+<Canvas of={LabeledInput.CronType} />
 
-<Canvas of={LabeledInput.ChronTypeDaily} />
+<Canvas of={LabeledInput.CronTypeDaily} />
+
+<Canvas of={LabeledInput.CronTypeError} />
 
 #### Multiline Type
 

--- a/storybook/src/stories/Form/Input.mdx
+++ b/storybook/src/stories/Form/Input.mdx
@@ -48,3 +48,7 @@ The `chron` prop can be used to add [Chron language](https://en.wikipedia.org/wi
 <Canvas of={LabeledInput.ChronType} />
 
 <Canvas of={LabeledInput.ChronTypeDaily} />
+
+#### Multiline Type
+
+<Canvas of={LabeledInput.MultilineType} />

--- a/storybook/src/stories/Form/Input.mdx
+++ b/storybook/src/stories/Form/Input.mdx
@@ -34,3 +34,15 @@ Input elements with type ‘text’ allow users to enter any combination of lett
 #### Error
 
 <Canvas of={LabeledInput.Error} />
+
+#### SubLabel
+
+Addition information can be added to the input field using the `subLabel` prop.
+
+<Canvas of={LabeledInput.SubLabel} />
+
+#### Chron Type
+
+The `chron` prop can be used to add [Chron language](https://en.wikipedia.org/wiki/Cron) hints.
+
+<Canvas of={LabeledInput.ChronType} />

--- a/storybook/src/stories/Form/Input.stories.ts
+++ b/storybook/src/stories/Form/Input.stories.ts
@@ -78,8 +78,17 @@ export const SubLabel: Story = {
 export const ChronType: Story = {
   ...Default,
   args: {
-    label:      'Name',
+    label:      'Period',
     type:       'cron',
     value:      '0 * * * *',
+  },
+};
+
+export const ChronTypeDaily: Story = {
+  ...Default,
+  args: {
+    label:      'Period',
+    type:       'cron',
+    value:      '@daily',
   },
 };

--- a/storybook/src/stories/Form/Input.stories.ts
+++ b/storybook/src/stories/Form/Input.stories.ts
@@ -92,3 +92,16 @@ export const ChronTypeDaily: Story = {
     value:      '@daily',
   },
 };
+
+export const MultilineType: Story = {
+  ...Default,
+  args: {
+    label: 'Period',
+    type:  'multiline',
+    value: `this
+is
+a
+multiline
+text`,
+  },
+};

--- a/storybook/src/stories/Form/Input.stories.ts
+++ b/storybook/src/stories/Form/Input.stories.ts
@@ -75,7 +75,7 @@ export const SubLabel: Story = {
   },
 };
 
-export const ChronType: Story = {
+export const CronType: Story = {
   ...Default,
   args: {
     label:      'Period',
@@ -84,12 +84,21 @@ export const ChronType: Story = {
   },
 };
 
-export const ChronTypeDaily: Story = {
+export const CronTypeDaily: Story = {
   ...Default,
   args: {
     label:      'Period',
     type:       'cron',
     value:      '@daily',
+  },
+};
+
+export const CronTypeError: Story = {
+  ...Default,
+  args: {
+    label:      'Period',
+    type:       'cron',
+    value:      'not a cron expression',
   },
 };
 

--- a/storybook/src/stories/Form/Input.stories.ts
+++ b/storybook/src/stories/Form/Input.stories.ts
@@ -68,37 +68,37 @@ export const Error: Story = {
 export const SubLabel: Story = {
   ...Default,
   args: {
-    label:      'Name',
-    subLabel:   'Additional information',
-    type:       'text',
-    value:      'Simon',
+    label:    'Name',
+    subLabel: 'Additional information',
+    type:     'text',
+    value:    'Simon',
   },
 };
 
 export const CronType: Story = {
   ...Default,
   args: {
-    label:      'Period',
-    type:       'cron',
-    value:      '0 * * * *',
+    label: 'Period',
+    type:  'cron',
+    value: '0 * * * *',
   },
 };
 
 export const CronTypeDaily: Story = {
   ...Default,
   args: {
-    label:      'Period',
-    type:       'cron',
-    value:      '@daily',
+    label: 'Period',
+    type:  'cron',
+    value: '@daily',
   },
 };
 
 export const CronTypeError: Story = {
   ...Default,
   args: {
-    label:      'Period',
-    type:       'cron',
-    value:      'not a cron expression',
+    label: 'Period',
+    type:  'cron',
+    value: 'not a cron expression',
   },
 };
 

--- a/storybook/src/stories/Form/Input.stories.ts
+++ b/storybook/src/stories/Form/Input.stories.ts
@@ -64,3 +64,22 @@ export const Error: Story = {
     tooltipKey: 'Error message'
   },
 };
+
+export const SubLabel: Story = {
+  ...Default,
+  args: {
+    label:      'Name',
+    subLabel:   'Additional information',
+    type:       'text',
+    value:      'Simon',
+  },
+};
+
+export const ChronType: Story = {
+  ...Default,
+  args: {
+    label:      'Name',
+    type:       'cron',
+    value:      '0 * * * *',
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6386,15 +6386,10 @@ cron-validator@1.3.1:
   resolved "https://registry.yarnpkg.com/cron-validator/-/cron-validator-1.3.1.tgz#8f2fe430f92140df77f91178ae31fc1e3a48a20e"
   integrity sha512-C1HsxuPCY/5opR55G5/WNzyEGDWFVG+6GLrA+fW/sCTcP6A6NTjUP2AK7B8n2PyFs90kDG2qzwm8LMheADku6A==
 
-cronstrue@1.95.0:
-  version "1.95.0"
-  resolved "https://registry.npmjs.org/cronstrue/-/cronstrue-1.95.0.tgz#171df1fad8b0f0cb636354dd1d7842161c15478f"
-  integrity sha512-CdbQ17Z8Na2IdrK1SiD3zmXfE66KerQZ8/iApkGsxjmUVGJPS9M9oK4FZC3LM6ohUjjq3UeaSk+90Cf3QbXDfw==
-
-cronstrue@2.50.0:
-  version "2.50.0"
-  resolved "https://registry.yarnpkg.com/cronstrue/-/cronstrue-2.50.0.tgz#eabba0f915f186765258b707b7a3950c663b5573"
-  integrity sha512-ULYhWIonJzlScCCQrPUG5uMXzXxSixty4djud9SS37DoNxDdkeRocxzHuAo4ImRBUK+mAuU5X9TSwEDccnnuPg==
+cronstrue@2.53.0:
+  version "2.53.0"
+  resolved "https://registry.npmjs.org/cronstrue/-/cronstrue-2.53.0.tgz#5bbcd7483636b99379480f624faef5056f3efbd8"
+  integrity sha512-CkAcaI94xL8h6N7cGxgXfR5D7oV2yVtDzB9vMZP8tIgPyEv/oc/7nq9rlk7LMxvc3N+q6LKZmNLCVxJRpyEg8A==
 
 cross-env@7.0.3:
   version "7.0.3"
@@ -7862,6 +7857,7 @@ eslint-plugin-jest@24.4.0:
 
 "eslint-plugin-local-rules@link:./eslint-plugin-local-rules":
   version "0.0.0"
+  uid ""
 
 "eslint-plugin-local-rules@link:eslint-plugin-local-rules":
   version "0.0.0"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12229
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

- Updated library to match new cronjob language terms
- Updated LabelInput logic to accept periodical values as validation of hints with another library which does not support them

### Technical notes summary
- Bumped all 3 packages containing `cronstrue` lib
- Replaced form validation code duplication with exported util, to avoid refactoring in https://github.com/rancher/dashboard/issues/13202
- Extended test to
  - Form validation
  - Label input with
    - Normal
    - Periodical
    - Invalid
- Added Storybook stories for
  - SubLabel
  - Cron type
    - Normal
    - Periodical
    - Error
  - Multiline
- Added Form rules JSDocs to validation types, to explain how do they work

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

**Rancher Manager**

![Screenshot 2025-01-27 at 18 36 54](https://github.com/user-attachments/assets/85b89113-55bb-4370-acd2-6b163423e9a8)

**Storybook**

<img width="716" alt="Screenshot 2025-01-27 at 18 33 51" src="https://github.com/user-attachments/assets/536d07af-c899-4c6f-b309-adc847f2fc12" />



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
