### PR TITLE
Fix missing await async calls getting Harvester repository

### DIFF
--- a/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
@@ -239,15 +239,17 @@ export default {
       let installed = false;
 
       try {
-        if (!this.harvesterRepository) {
-          this.harvesterRepository = await createHelmRepository(this.$store, HARVESTER_REPO.metadata.name, HARVESTER_REPO.gitRepo, HARVESTER_REPO.gitBranch);
+        let harvesterRepository = this.harvesterRepository;
+
+        if (!harvesterRepository) {
+          harvesterRepository = await createHelmRepository(this.$store, HARVESTER_REPO.metadata.name, HARVESTER_REPO.gitRepo, HARVESTER_REPO.gitBranch);
         }
 
         /**
          * Server issue
          * It needs to refresh the HelmRepository because the server can have a previous one in the cache.
          */
-        await refreshHelmRepository(this.$store, this.harvesterRepository.spec.gitRepo || this.harvesterRepository.spec.url);
+        await refreshHelmRepository(this.$store, harvesterRepository.spec.gitRepo || harvesterRepository.spec.url);
 
         this.harvesterInstallVersion = await getLatestExtensionVersion(this.$store, HARVESTER_CHART.name, this.rancherVersion, this.kubeVersion);
 
@@ -258,7 +260,7 @@ export default {
         }
 
         await installHelmChart(
-          this.harvesterRepository,
+          harvesterRepository,
           {
             ...HARVESTER_CHART,
             version: this.harvesterInstallVersion

--- a/shell/utils/uiplugins.ts
+++ b/shell/utils/uiplugins.ts
@@ -165,7 +165,7 @@ export async function installHelmChart(repo: any, chart: any, values: any = {}, 
  * @returns HelmRepository
  */
 export async function getHelmRepositoryExact(store: any, url: string): Promise<HelmRepository> {
-  return getHelmRepository(store, (repository: any) => {
+  return await getHelmRepository(store, (repository: any) => {
     const target = repository.spec?.gitRepo || repository.spec?.url;
 
     return target === url;
@@ -179,7 +179,7 @@ export async function getHelmRepositoryExact(store: any, url: string): Promise<H
  * @returns HelmRepository
  */
 export async function getHelmRepositoryMatch(store: any, urlRegexes: string[]): Promise<HelmRepository> {
-  return getHelmRepository(store, (repository: any) => {
+  return await getHelmRepository(store, (repository: any) => {
     const target = repository.spec?.gitBranch ? repository.spec?.gitRepo : repository.spec?.url;
 
     return matchesSomeRegex(target, urlRegexes);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Contributes to #13199
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Add missing `await`s
- Remove this.harvesterRepository assignment from Install function to avoid multiple repo refresh

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
