### PR TITLE
fix workload health accessibility

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6198,6 +6198,11 @@ wm:
     title: "Kubectl: {name}"
 
 workload:
+  scaleWorkloads: Scale workloads
+  healthWorkloads: Jobs/Pods health status
+  healthScaleToggle: Toggle/Expand workloads scaling/health
+  plus: Scale up workload
+  minus: Scale down workload
   container:
     command:
       addEnvVar: Add Variable

--- a/shell/components/ProgressBarMulti.vue
+++ b/shell/components/ProgressBarMulti.vue
@@ -90,6 +90,19 @@ export default {
 
       return out.filter((obj) => obj.percent);
     },
+    ariaLabelText() {
+      if (Array.isArray(this.values) && this.values.length) {
+        let ariaLabel = '';
+
+        this.values.forEach((val) => {
+          ariaLabel += `${ val.value } ${ val.value === 1 ? 'item' : 'items' } ${ val.label }`;
+        });
+
+        return ariaLabel;
+      }
+
+      return '';
+    }
   }
 };
 
@@ -108,6 +121,7 @@ function toPercent(value, min, max) {
   <div
     v-trim-whitespace
     :class="{progress: true, multi: pieces.length > 1}"
+    :aria-label="ariaLabelText"
   >
     <div
       v-for="(piece, idx) of pieces"

--- a/shell/components/form/PlusMinus.vue
+++ b/shell/components/form/PlusMinus.vue
@@ -54,11 +54,17 @@ export default {
     <button
       v-clean-tooltip="minusTooltip"
       :disabled="disabled || !canMinus"
+      :aria-disabled="disabled || !canMinus"
       type="button"
+      role="button"
+      :aria-label="t('workload.plus')"
       class="btn btn-sm role-secondary"
       @click="$emit('minus')"
     >
-      <i class="icon icon-sm icon-minus" />
+      <i
+        class="icon icon-sm icon-minus"
+        :alt="t('workload.plus')"
+      />
     </button>
     <div class="value">
       {{ value }}
@@ -66,11 +72,17 @@ export default {
     <button
       v-clean-tooltip="plusTooltip"
       :disabled="disabled || !canPlus"
+      :aria-disabled="disabled || !canPlus"
       type="button"
+      role="button"
+      :aria-label="t('workload.minus')"
       class="btn btn-sm role-secondary"
       @click="$emit('plus')"
     >
-      <i class="icon icon-sm icon-plus" />
+      <i
+        class="icon icon-sm icon-plus"
+        :alt="t('workload.minus')"
+      />
     </button>
   </div>
 </template>

--- a/shell/components/formatter/WorkloadHealthScale.vue
+++ b/shell/components/formatter/WorkloadHealthScale.vue
@@ -182,14 +182,21 @@ export default {
     <div
       id="trigger"
       class="hs-popover__trigger"
+      aria-role="button"
+      tabindex="0"
       :class="{expanded}"
+      :aria-roledescription="t('workload.scaleWorkloads')"
+      :aria-label="t('workload.healthScaleToggle')"
+      :aria-expanded="expanded"
       @click="expanded = !expanded"
+      @keyup.enter.space="expanded = !expanded"
     >
       <ProgressBarMulti
         v-if="parts"
         class="health"
         :values="parts"
         :show-zeros="true"
+        :aria-describedby="t('workload.healthWorkloads')"
       />
       <i :class="{icon: true, 'icon-chevron-up': expanded, 'icon-chevron-down': !expanded}" />
     </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12782 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Fix workload health keyboard navigation and accessibility

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
