### PR TITLE
Simplify handling of GitRepo status resources

### DIFF
--- a/shell/components/fleet/FleetBundles.vue
+++ b/shell/components/fleet/FleetBundles.vue
@@ -126,7 +126,7 @@ export default {
             v-if="displayWarning(row)"
             class="text-warning"
           >
-            {{ row.status.summary.ready }}/{{ row.status.summary.desiredReady }}</span>
+            {{ row.status.summary.ready || 0 }}/{{ row.status.summary.desiredReady }}</span>
           <span v-else-if="row.status && row.status.summary">{{ row.status.summary.desiredReady }}</span>
           <span v-else>-</span>
         </template>

--- a/shell/components/fleet/FleetResources.vue
+++ b/shell/components/fleet/FleetResources.vue
@@ -1,6 +1,5 @@
 <script>
 import SortableTable from '@shell/components/SortableTable';
-import { AGE } from '@shell/config/table-headers';
 
 export default {
   name: 'FleetResources',
@@ -65,7 +64,6 @@ export default {
           sort:  'namespace',
           label: 'Namespace',
         },
-        { ...AGE }
       ];
     },
   }

--- a/shell/components/fleet/FleetSummary.vue
+++ b/shell/components/fleet/FleetSummary.vue
@@ -2,57 +2,47 @@
 import { STATES, STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 import FleetStatus from '@shell/components/fleet/FleetStatus';
 
-const getResourceDefaultState = (labelGetter, stateKey) => {
-  return {
-    ready: {
+const getResourcesDefaultState = (labelGetter, stateKey) => {
+  return [
+    STATES_ENUM.READY,
+    STATES_ENUM.NOT_READY,
+    STATES_ENUM.WAIT_APPLIED,
+    STATES_ENUM.MODIFIED,
+    STATES_ENUM.MISSING,
+    STATES_ENUM.ORPHANED,
+    STATES_ENUM.UNKNOWN,
+  ].reduce((acc, state) => {
+    acc[state] = {
       count:  0,
-      color:  STATES[STATES_ENUM.READY].color,
-      label:  labelGetter(`${ stateKey }.${ STATES_ENUM.READY }`, null, STATES[STATES_ENUM.READY].label ),
-      status: STATES_ENUM.READY
-    },
-    info: {
+      color:  STATES[state].color,
+      label:  labelGetter(`${ stateKey }.${ state }`, null, STATES[state].label ),
+      status: state
+    };
+
+    return acc;
+  }, {});
+};
+
+const getBundlesDefaultState = (labelGetter, stateKey) => {
+  return [
+    STATES_ENUM.READY,
+    STATES_ENUM.INFO,
+    STATES_ENUM.WARNING,
+    STATES_ENUM.NOT_READY,
+    STATES_ENUM.ERROR,
+    STATES_ENUM.ERR_APPLIED,
+    STATES_ENUM.WAIT_APPLIED,
+    STATES_ENUM.UNKNOWN,
+  ].reduce((acc, state) => {
+    acc[state] = {
       count:  0,
-      color:  STATES[STATES_ENUM.INFO].color,
-      label:  labelGetter(`${ stateKey }.${ STATES_ENUM.INFO }`, null, STATES[STATES_ENUM.INFO].label ),
-      status: STATES_ENUM.INFO
-    },
-    warning: {
-      count:  0,
-      color:  STATES[STATES_ENUM.WARNING].color,
-      label:  labelGetter(`${ stateKey }.${ STATES_ENUM.WARNING }`, null, STATES[STATES_ENUM.WARNING].label ),
-      status: STATES_ENUM.WARNING
-    },
-    notready: {
-      count:  0,
-      color:  STATES[STATES_ENUM.NOT_READY].color,
-      label:  labelGetter(`${ stateKey }.${ STATES_ENUM.NOT_READY }`, null, STATES[STATES_ENUM.NOT_READY].label ),
-      status: STATES_ENUM.NOT_READY
-    },
-    error: {
-      count:  0,
-      color:  STATES[STATES_ENUM.ERROR].color,
-      label:  labelGetter(`${ stateKey }.${ STATES_ENUM.ERROR }`, null, STATES[STATES_ENUM.ERROR].label ),
-      status: STATES_ENUM.ERROR
-    },
-    errapplied: {
-      count:  0,
-      color:  STATES[STATES_ENUM.ERR_APPLIED].color,
-      label:  labelGetter(`${ stateKey }.${ STATES_ENUM.ERR_APPLIED }`, null, STATES[STATES_ENUM.ERR_APPLIED].label ),
-      status: STATES_ENUM.ERR_APPLIED,
-    },
-    waitapplied: {
-      count:  0,
-      color:  STATES[STATES_ENUM.WAIT_APPLIED].color,
-      label:  labelGetter(`${ stateKey }.${ STATES_ENUM.WAIT_APPLIED }`, null, STATES[STATES_ENUM.WAIT_APPLIED].label ),
-      status: STATES_ENUM.WAIT_APPLIED
-    },
-    unknown: {
-      count:  0,
-      color:  STATES[STATES_ENUM.UNKNOWN].color,
-      label:  labelGetter(`${ stateKey }.${ STATES_ENUM.UNKNOWN }`, null, STATES[STATES_ENUM.UNKNOWN].label ),
-      status: STATES_ENUM.UNKNOWN
-    }
-  };
+      color:  STATES[state].color,
+      label:  labelGetter(`${ stateKey }.${ state }`, null, STATES[state].label ),
+      status: state
+    };
+
+    return acc;
+  }, {});
 };
 
 export default {
@@ -90,7 +80,7 @@ export default {
         return [];
       }
 
-      const out = { ...getResourceDefaultState(this.$store.getters['i18n/withFallback'], this.stateKey) };
+      const out = { ...getBundlesDefaultState(this.$store.getters['i18n/withFallback'], this.stateKey) };
 
       resources.forEach(({ status, metadata }) => {
         if (!status) {
@@ -155,19 +145,20 @@ export default {
     },
 
     resourceCounts() {
-      const resources = this.value.status.resources || [];
-      const out = { ...getResourceDefaultState(this.$store.getters['i18n/withFallback'], this.stateKey) };
+      const out = { ...getResourcesDefaultState(this.$store.getters['i18n/withFallback'], this.stateKey) };
+      const resourceStatuses = this.value.allResourceStatuses;
 
-      resources.forEach(({ state }) => {
-        const k = state?.toLowerCase();
+      Object.entries(resourceStatuses.states)
+        .filter(([_, count]) => count > 0)
+        .forEach(([state, count]) => {
+          const k = state?.toLowerCase();
 
-        if (out[k]) {
-          out[k].count += 1;
-
-          return;
-        }
-        out.unknown.count += 1;
-      });
+          if (out[k]) {
+            out[k].count += count;
+          } else {
+            out.unknown.count += count;
+          }
+        });
 
       return Object.values(out).map((item) => {
         item.value = item.count;

--- a/shell/components/fleet/__tests__/FleetSummary.test.ts
+++ b/shell/components/fleet/__tests__/FleetSummary.test.ts
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils';
+import GitRepo from '@shell/models/fleet.cattle.io.gitrepo';
 import FleetSummary from '@shell/components/fleet/FleetSummary.vue';
 
 const REPO_NAME = 'testrepo';
@@ -296,7 +297,7 @@ describe('component: FleetSummary', () => {
     [mockedBundlesInRepo, '2'],
   ])('displays the number of bundles associated with the current gitrepo', (bundles: any[], bundleCount: string) => {
     const wrapper = mount(FleetSummary, {
-      props:  { bundles, value: mockRepo },
+      props:  { bundles, value: new GitRepo(mockRepo) },
       global: { mocks: { $store: mockStore } }
     });
 
@@ -311,7 +312,7 @@ describe('component: FleetSummary', () => {
 
   ])('displays the number of deployments associated with the current gitrepo', (bundles: any[], bundleCount: string) => {
     const wrapper = mount(FleetSummary, {
-      props:  { bundles, value: mockRepo },
+      props:  { bundles, value: new GitRepo(mockRepo) },
       global: { mocks: { $store: mockStore } }
     });
 

--- a/shell/detail/fleet.cattle.io.cluster.vue
+++ b/shell/detail/fleet.cattle.io.cluster.vue
@@ -49,9 +49,6 @@ export default {
   },
 
   computed: {
-    allBundleDeployments() {
-      return this.value.bundleDeployments;
-    },
     clusterId() {
       return this.value.id;
     },

--- a/shell/detail/fleet.cattle.io.gitrepo.vue
+++ b/shell/detail/fleet.cattle.io.gitrepo.vue
@@ -35,9 +35,8 @@ export default {
 
   data() {
     return {
-      allFleetClusters:     [],
-      allBundles:           [],
-      allBundleDeployments: [],
+      allFleetClusters: [],
+      allBundles:       [],
     };
   },
   computed: {
@@ -86,11 +85,6 @@ export default {
         opt:         { excludeFields: ['metadata.managedFields', 'spec.resources'] },
       },
 
-      allBundleDeployments: {
-        inStoreType: 'management',
-        type:        FLEET.BUNDLE_DEPLOYMENT
-      },
-
       allFleetClusters: {
         inStoreType: 'management',
         type:        FLEET.CLUSTER
@@ -101,7 +95,6 @@ export default {
       }
     }, this.$store);
 
-    this.allBundleDeployments = allDispatches.allBundleDeployments || [];
     this.allBundles = allDispatches.allBundles || [];
     this.allFleetClusters = allDispatches.allFleetClusters || [];
   },

--- a/shell/detail/fleet.cattle.io.gitrepo.vue
+++ b/shell/detail/fleet.cattle.io.gitrepo.vue
@@ -8,7 +8,6 @@ import Tab from '@shell/components/Tabbed/Tab';
 import { FLEET } from '@shell/config/types';
 import { isHarvesterCluster } from '@shell/utils/cluster';
 import FleetBundles from '@shell/components/fleet/FleetBundles.vue';
-import { resourceCounts } from '@shell/components/ResourceSummary.vue';
 import { checkSchemasForFindAllHash } from '@shell/utils/auth';
 
 export default {
@@ -56,9 +55,6 @@ export default {
       });
 
       return harvester;
-    },
-    bundleCounts() {
-      return resourceCounts(this.$store, FLEET.BUNDLE);
     },
     bundles() {
       const harvester = this.harvesterClusters;

--- a/shell/list/fleet.cattle.io.bundle.vue
+++ b/shell/list/fleet.cattle.io.bundle.vue
@@ -118,7 +118,7 @@ export default {
           v-if="row.status && row.status.summary && (row.status.summary.desiredReady !== row.status.summary.ready)"
           class="text-warning"
         >
-          {{ row.status.summary.ready }}/{{ row.status.summary.desiredReady }}</span>
+          {{ row.status.summary.ready || 0 }}/{{ row.status.summary.desiredReady }}</span>
         <span v-else-if="row.status && row.status.summary">{{ row.status.summary.desiredReady }}</span>
         <span v-else>-</span>
       </template>

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -330,9 +330,7 @@ export default class GitRepo extends SteveModel {
   }
 
   get bundleDeployments() {
-    const bds = this.$getters['all'](FLEET.BUNDLE_DEPLOYMENT);
-
-    return bds.filter((bd) => bd.metadata?.labels?.['fleet.cattle.io/repo-name'] === this.name);
+    return this.$getters['matching'](FLEET.BUNDLE_DEPLOYMENT, { 'fleet.cattle.io/repo-name': this.name });
   }
 
   get allBundlesStatuses() {

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -450,13 +450,12 @@ export default class GitRepo extends SteveModel {
         clusterId,
 
         // columns, see FleetResources.vue
-        state:             mapStateToEnum(state),
-        clusterName:       c.nameDisplay,
-        apiVersion:        r.apiVersion,
-        kind:              r.kind,
-        name:              r.name,
-        namespace:         r.namespace,
-        creationTimestamp: r.createdAt,
+        state:       mapStateToEnum(state),
+        clusterName: c.nameDisplay,
+        apiVersion:  r.apiVersion,
+        kind:        r.kind,
+        name:        r.name,
+        namespace:   r.namespace,
 
         // other properties
         stateBackground: color,

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -358,20 +358,7 @@ export default class GitRepo extends SteveModel {
       return {};
     }
 
-    return this.bundleDeployments
-      .filter((bd) => FleetUtils.clusterIdFromBundleDeploymentLabels(bd.metadata?.labels) === clusterId)
-      .map((bd) => FleetUtils.resourcesFromBundleDeploymentStatus(bd.status))
-      .flat()
-      .map((r) => r.state)
-      .reduce((prev, state) => {
-        if (!prev[state]) {
-          prev[state] = 0;
-        }
-        prev[state]++;
-        prev.desiredReady++;
-
-        return prev;
-      }, { desiredReady: 0 });
+    return this.status?.perClusterResourceCounts[clusterId] || { desiredReady: 0 };
   }
 
   get resourcesStatuses() {

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -395,74 +395,76 @@ export default class GitRepo extends SteveModel {
   }
 
   get resourcesStatuses() {
-    const bundleDeployments = this.bundleDeployments || [];
+    if (isEmpty(this.status?.resources)) {
+      return [];
+    }
+
     const clusters = (this.targetClusters || []).reduce((res, c) => {
       res[c.id] = c;
 
       return res;
     }, {});
+    const resources = this.status?.resources?.reduce((acc, resourceInfo) => {
+      const { perClusterState, ...resource } = resourceInfo;
 
-    const out = [];
-
-    for (const bd of bundleDeployments) {
-      const clusterId = FleetUtils.clusterIdFromBundleDeploymentLabels(bd.metadata?.labels);
-      const c = clusters[clusterId];
-
-      if (!c) {
-        continue;
-      }
-
-      const resources = FleetUtils.resourcesFromBundleDeploymentStatus(bd.status);
-
-      resources.forEach((r) => {
-        const id = FleetUtils.resourceId(r);
-        const type = FleetUtils.resourceType(r);
-        const state = r.state;
-
-        const color = colorForState(state).replace('text-', 'bg-');
-        const display = stateDisplay(state);
-
-        const detailLocation = {
-          name:   `c-cluster-product-resource${ r.namespace ? '-namespace' : '' }-id`,
-          params: {
-            product:   NAME,
-            cluster:   c.metadata.labels[FLEET_ANNOTATIONS.CLUSTER_NAME], // explorer uses the "management" Cluster name, which differs from the Fleet Cluster name
-            resource:  type,
-            namespace: r.namespace,
-            id:        r.name,
-          }
-        };
-
-        const key = `${ c.id }-${ type }-${ r.namespace }-${ r.name }`;
-
-        out.push({
-          key,
-          tableKey: key,
-
-          // Needed?
-          id,
-          type,
-          clusterId: c.id,
-
-          // columns, see FleetResources.vue
-          state:             mapStateToEnum(state),
-          clusterName:       c.nameDisplay,
-          apiVersion:        r.apiVersion,
-          kind:              r.kind,
-          name:              r.name,
-          namespace:         r.namespace,
-          creationTimestamp: r.createdAt,
-
-          // other properties
-          stateBackground: color,
-          stateDisplay:    display,
-          stateSort:       stateSort(color, display),
-          detailLocation,
+      Object.entries(perClusterState).forEach(([state, clusterIds]) => {
+        clusterIds.filter((id) => !!clusters[id]).forEach((clusterId) => {
+          acc.push(Object.assign({ clusterId, state }, resource));
         });
       });
-    }
 
-    return out;
+      return acc;
+    }, []);
+
+    return resources.map((r) => {
+      const {
+        namespace, name, clusterId, state
+      } = r;
+      const id = FleetUtils.resourceId(r);
+      const type = FleetUtils.resourceType(r);
+      const c = clusters[clusterId];
+
+      const color = colorForState(state).replace('text-', 'bg-');
+      const display = stateDisplay(state);
+
+      const detailLocation = {
+        name:   `c-cluster-product-resource${ r.namespace ? '-namespace' : '' }-id`,
+        params: {
+          product:  NAME,
+          cluster:  c.metadata.labels[FLEET_ANNOTATIONS.CLUSTER_NAME], // explorer uses the "management" Cluster name, which differs from the Fleet Cluster name
+          resource: type,
+          namespace,
+          id:       name,
+        }
+      };
+
+      const key = `${ clusterId }-${ type }-${ namespace }-${ name }`;
+
+      return {
+        key,
+        tableKey: key,
+
+        // Needed?
+        id,
+        type,
+        clusterId,
+
+        // columns, see FleetResources.vue
+        state:             mapStateToEnum(state),
+        clusterName:       c.nameDisplay,
+        apiVersion:        r.apiVersion,
+        kind:              r.kind,
+        name:              r.name,
+        namespace:         r.namespace,
+        creationTimestamp: r.createdAt,
+
+        // other properties
+        stateBackground: color,
+        stateDisplay:    display,
+        stateSort:       stateSort(color, display),
+        detailLocation,
+      };
+    });
   }
 
   get clusterInfo() {

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -376,7 +376,7 @@ export default class GitRepo extends SteveModel {
 
       Object.entries(perClusterState).forEach(([state, clusterIds]) => {
         clusterIds.filter((id) => !!clusters[id]).forEach((clusterId) => {
-          acc.push(Object.assign({ clusterId, state }, resource));
+          acc.push(Object.assign({}, resource, { clusterId, state }));
         });
       });
 

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -336,37 +336,19 @@ export default class GitRepo extends SteveModel {
   }
 
   get allBundlesStatuses() {
-    const bundleDeploymentCountsPerBundle = this.bundleDeployments.reduce((acc, bd) => {
-      const bundleId = FleetUtils.bundleIdFromBundleDeploymentLabels(bd.metadata?.labels);
-      const state = mapStateToEnum(FleetUtils.bundleDeploymentState(bd));
-
-      if (!acc[bundleId]) {
-        acc[bundleId] = {
-          total:  0,
-          states: { [STATES_ENUM.READY]: 0 },
-        };
-      }
-      acc[bundleId].total++;
-
-      if (!acc[bundleId].states[state]) {
-        acc[bundleId].states[state] = 0;
-      }
-      acc[bundleId].states[state]++;
-
-      return acc;
-    }, {});
-    const bundleIds = Object.keys(bundleDeploymentCountsPerBundle);
-
-    return bundleIds.reduce((acc, bundleId) => {
-      const state = primaryDisplayStatusFromCount(bundleDeploymentCountsPerBundle[bundleId].states);
+    return this.bundles.reduce((acc, bundle) => {
+      const { nonReadyResources, ...summary } = bundle.status?.summary;
+      const bdCounts = normalizeStateCounts(summary);
+      const state = primaryDisplayStatusFromCount(bdCounts.states);
 
       if (!acc.states[state]) {
         acc.states[state] = 0;
       }
       acc.states[state]++;
+      acc.total++;
 
       return acc;
-    }, { total: bundleIds.length, states: { [STATES_ENUM.READY]: 0 } } );
+    }, { total: 0, states: { [STATES_ENUM.READY]: 0 } } );
   }
 
   get allResourceStatuses() {

--- a/shell/pages/c/_cluster/fleet/index.vue
+++ b/shell/pages/c/_cluster/fleet/index.vue
@@ -50,7 +50,6 @@ export default {
         inStoreType: 'management',
         type:        FLEET.BUNDLE,
         opt:         { excludeFields: ['metadata.managedFields', 'spec.resources'] },
-        skipWait:    true,
       },
       gitRepos: {
         inStoreType: 'management',

--- a/shell/pages/c/_cluster/fleet/index.vue
+++ b/shell/pages/c/_cluster/fleet/index.vue
@@ -42,10 +42,6 @@ export default {
         inStoreType: 'management',
         type:        FLEET.CLUSTER_GROUP
       },
-      allBundleDeployments: {
-        inStoreType: 'management',
-        type:        FLEET.BUNDLE_DEPLOYMENT,
-      },
       allBundles: {
         inStoreType: 'management',
         type:        FLEET.BUNDLE,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Change how the GitRepo status info is obtained and processed, by consuming the new fields exposed by Fleet.

### Occurred changes and/or fixed issues
Fixes #13243
 - [x] Depends on https://github.com/rancher/fleet/pull/3287

### Technical notes summary
This PR changes (again, see #12896) the way that bundles state is processed, by iterating over the list of bundles, for simplicity.
Also:
 - It uses the new `PerClusterResourceCounts` status field
 - Uses the new format for `Resources.perClusterState` in order to build the GitRepo's resource table, getting rid of BundleDeployments altogether.
 - Fixes the resource counts in the summary of GitRepo detail pages.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
There is a small regression in the Resources table for GitRepos, since the info backing the `Age` column is no longer available. However, this field was often blank as it's not always available.

### Screenshot/Video
![Screenshot 2025-02-05 at 16 55 24](https://github.com/user-attachments/assets/ba8d2415-137c-49df-93f9-2de86fd9e432)

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [X] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [X] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [X] The PR template has been filled out
- [X] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [X] The PR has a reviewer assigned
- [X] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
