### PR TITLE
Remove close button from banner and move to a page action

### DIFF
--- a/cypress/e2e/po/pages/home.po.ts
+++ b/cypress/e2e/po/pages/home.po.ts
@@ -58,7 +58,7 @@ export default class HomePagePo extends PagePo {
 
     cy.intercept('PUT', 'v1/userpreferences/*').as('restoreBanners');
     pageActionsPo.restoreLink().click();
-    cy.wait('@restoreBanners');
+    cy.wait(['@restoreBanners', '@restoreBanners']);
   }
 
   toggleBanner() {

--- a/cypress/e2e/po/pages/home.po.ts
+++ b/cypress/e2e/po/pages/home.po.ts
@@ -58,7 +58,15 @@ export default class HomePagePo extends PagePo {
 
     cy.intercept('PUT', 'v1/userpreferences/*').as('restoreBanners');
     pageActionsPo.restoreLink().click();
-    cy.wait(['@restoreBanners', '@restoreBanners']);
+    cy.wait('@restoreBanners');
+  }
+
+  toggleBanner() {
+    const pageActionsPo = new PageActions();
+
+    cy.intercept('PUT', 'v1/userpreferences/*').as('toggleBanner');
+    pageActionsPo.toggleBanner().click();
+    cy.wait('@toggleBanner');
   }
 
   list(): HomeClusterListPo {

--- a/cypress/e2e/po/side-bars/page-actions.po.ts
+++ b/cypress/e2e/po/side-bars/page-actions.po.ts
@@ -52,4 +52,12 @@ export default class PageActionsPo extends ComponentPo {
   restoreLink(): Cypress.Chainable {
     return this.links().last();
   }
+
+  /**
+   * Get restore button link
+   * @returns {Cypress.Chainable}
+   */
+  toggleBanner(): Cypress.Chainable {
+    return this.links().contains('Show/Hide Banner');
+  }
 }

--- a/cypress/e2e/po/side-bars/page-actions.po.ts
+++ b/cypress/e2e/po/side-bars/page-actions.po.ts
@@ -54,7 +54,7 @@ export default class PageActionsPo extends ComponentPo {
   }
 
   /**
-   * Get restore button link
+   * Get show/hide banner button link
    * @returns {Cypress.Chainable}
    */
   toggleBanner(): Cypress.Chainable {

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -218,7 +218,7 @@ describe('Home Page', () => {
       cy.setUserPreference({ 'home-page-cards': '{}' });
 
       // Go to the home page
-      HomePagePo.navTo();
+      HomePagePo.goToAndWaitForGet();
       homePage.waitForPage();
 
       // Banner graphic and the login banner should be visible
@@ -235,6 +235,23 @@ describe('Home Page', () => {
 
       // Check login banner is visible
       homePage.getLoginPageBanner().checkVisible();
+    });
+
+    it('Can toggle banner graphic', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+      // Reset the home page cards pref so that everything is shown
+      cy.setUserPreference({ 'home-page-cards': '{}' });
+
+      // Go to the home page
+      HomePagePo.goToAndWaitForGet();
+      homePage.waitForPage();
+
+      // Wait for the page to settle and the table loading indicator to go away
+      homePage.self().get('.data-loading').should('exist');
+      homePage.self().get('.data-loading').should('not.exist');
+
+      // Banner graphic and the login banner should be visible
+      homePage.bannerGraphic().graphicBanner().should('exist');
+      homePage.bannerGraphic().graphicBanner().should('be.visible');
 
       // Hide the main banner graphic
       homePage.toggleBanner();
@@ -245,7 +262,7 @@ describe('Home Page', () => {
       // Show the banner graphic
       homePage.toggleBanner();
       homePage.bannerGraphic().graphicBanner().should('exist');
-    });
+    });    
 
     it('Can use the Manage, Import Existing, and Create buttons', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
     /**

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -30,8 +30,10 @@ function goToHomePageAndSettle() {
 
   // Wait for the page to settle - filter the cluster list ensures table is ready and page is ready
   cy.wait('@fetchClustersHomePage');
-  homeClusterList.resourceTable().sortableTable().filter('local');
-  homeClusterList.name('local').should((el) => expect(el).to.contain.text('local'));
+
+  // Wait for the cluster table to load and filter so there are no rows
+  homeClusterList.resourceTable().sortableTable().filter('random text');
+  homeClusterList.resourceTable().sortableTable().rowElements().should((el) => expect(el).to.contain.text('There are no rows which match your search query.'));
 }
 
 describe('Home Page', () => {

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -214,26 +214,40 @@ describe('Home Page', () => {
     });
 
     it('Can restore hidden cards', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
-    /**
-     * Hide home page banners
-     * Click the restore link
-     * Verify banners display on home page
-     */
+      // Reset the home page cars pref so that everything is shown
+      cy.setUserPreference({ 'home-page-cards': '{}' });
+
+      /**
+       * Hide home page banners
+       * Click the restore link
+       * Verify banners display on home page
+       */
       HomePagePo.navTo();
       homePage.waitForPage();
-      homePage.restoreAndWait();
 
+      // Banner graphic and the login banner should be visible
+      homePage.bannerGraphic().graphicBanner().should('exist');
       homePage.bannerGraphic().graphicBanner().should('be.visible');
-      homePage.bannerGraphic().graphicBannerCloseButton();
+      homePage.getLoginPageBanner().checkVisible();
+
+      // Hide the banner graphic
+      homePage.toggleBanner();
+
+      // Banner graphic and the login banner should be visible
       homePage.bannerGraphic().graphicBanner().should('not.exist');
 
+      // Show the banner graphic
+      homePage.toggleBanner();
+      homePage.bannerGraphic().graphicBanner().should('exist');
+
+      // Close the banner for changing login view
       homePage.getLoginPageBanner().checkVisible();
       homePage.getLoginPageBanner().closeButton();
       homePage.getLoginPageBanner().checkNotExists();
 
+      // Restore the cards should bring back the login banner
       homePage.restoreAndWait();
 
-      homePage.bannerGraphic().graphicBanner().should('be.visible');
       homePage.getLoginPageBanner().checkVisible();
     });
 

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -226,18 +226,7 @@ describe('Home Page', () => {
       homePage.bannerGraphic().graphicBanner().should('be.visible');
       homePage.getLoginPageBanner().checkVisible();
 
-      // Hide the banner graphic
-      homePage.toggleBanner();
-
-      // Banner graphic and the login banner should be visible
-      homePage.bannerGraphic().graphicBanner().should('not.exist');
-
-      // Show the banner graphic
-      homePage.toggleBanner();
-      homePage.bannerGraphic().graphicBanner().should('exist');
-
       // Close the banner for changing login view
-      homePage.getLoginPageBanner().checkVisible();
       homePage.getLoginPageBanner().closeButton();
       homePage.getLoginPageBanner().checkNotExists();
 
@@ -246,6 +235,16 @@ describe('Home Page', () => {
 
       // Check login banner is visible
       homePage.getLoginPageBanner().checkVisible();
+
+      // Hide the main banner graphic
+      homePage.toggleBanner();
+
+      // Banner graphic and the login banner should be visible
+      homePage.bannerGraphic().graphicBanner().should('not.exist');
+
+      // Show the banner graphic
+      homePage.toggleBanner();
+      homePage.bannerGraphic().graphicBanner().should('exist');
     });
 
     it('Can use the Manage, Import Existing, and Create buttons', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -245,7 +245,7 @@ describe('Home Page', () => {
       HomePagePo.goToAndWaitForGet();
       homePage.waitForPage();
 
-      // Wait for the page to settle and the table loading indicator to go away
+      // Wait for the page to settle
       homePage.self().get('.data-loading').should('exist');
       homePage.self().get('.data-loading').should('not.exist');
 
@@ -262,7 +262,7 @@ describe('Home Page', () => {
       // Show the banner graphic
       homePage.toggleBanner();
       homePage.bannerGraphic().graphicBanner().should('exist');
-    });    
+    });
 
     it('Can use the Manage, Import Existing, and Create buttons', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
     /**

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -257,7 +257,7 @@ describe('Home Page', () => {
 
     it('Can toggle banner graphic', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
       goToHomePageAndSettle();
-      
+
       // Banner graphic and the login banner should be visible
       homePage.bannerGraphic().graphicBanner().should('exist');
       homePage.bannerGraphic().graphicBanner().should('be.visible');

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -214,14 +214,10 @@ describe('Home Page', () => {
     });
 
     it('Can restore hidden cards', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
-      // Reset the home page cars pref so that everything is shown
+      // Reset the home page cards pref so that everything is shown
       cy.setUserPreference({ 'home-page-cards': '{}' });
 
-      /**
-       * Hide home page banners
-       * Click the restore link
-       * Verify banners display on home page
-       */
+      // Go to the home page
       HomePagePo.navTo();
       homePage.waitForPage();
 
@@ -248,6 +244,7 @@ describe('Home Page', () => {
       // Restore the cards should bring back the login banner
       homePage.restoreAndWait();
 
+      // Check login banner is visible
       homePage.getLoginPageBanner().checkVisible();
     });
 

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -106,6 +106,8 @@ declare global {
       tableRowsPerPageAndNamespaceFilter(rows: number, clusterName: string, groupBy: string, namespaceFilter: string)
       tableRowsPerPageAndPreferences(rows: number, preferences: { clusterName: string, groupBy: string, namespaceFilter: string, allNamespaces: string}, iteration?: number)
 
+      setUserPreference(prefs: any);
+
       /**
        * update namespace filter
        * @param clusterName

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -1085,3 +1085,17 @@ Cypress.Commands.add('tableRowsPerPageAndNamespaceFilter', (rows: number, cluste
     clusterName, groupBy, namespaceFilter
   });
 });
+
+// Update the user preferences by over-writing the given prefrence
+Cypress.Commands.add('setUserPreference', (prefs: any) => {
+  return cy.getRancherResource('v3', 'users?me=true').then((resp: Cypress.Response<any>) => {
+    const update = resp.body.data[0];
+
+    update.data = {
+      ...update.data,
+      ...prefs
+    };
+
+    return cy.setRancherResource('v1', 'userpreferences', update.id, update);
+  });
+});

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -224,6 +224,7 @@ nav:
   header:
     setLoginPage: Set as login page
     restoreCards: Restore hidden cards
+    showHideBanner: Show/Hide Banner
   userMenu:
     preferences: Preferences
     accountAndKeys: Account & API Keys

--- a/shell/components/BannerGraphic.vue
+++ b/shell/components/BannerGraphic.vue
@@ -51,19 +51,6 @@ export default {
       data-testid="banner-title"
       class="title"
     />
-    <div
-      v-if="pref"
-      class="close-button"
-      data-testid="graphic-banner-close"
-      tabindex="0"
-      :aria-label="t('generic.close')"
-      role="button"
-      @click="hide()"
-      @keyup.enter="hide()"
-      @keyup.space="hide()"
-    >
-      <i class="icon icon-close" />
-    </div>
   </div>
 </template>
 
@@ -73,35 +60,6 @@ export default {
 
   .banner-graphic {
     position: relative;
-
-    .close-button {
-      position: absolute;
-      visibility: hidden;
-
-      &:focus-visible {
-        @include focus-outline;
-        outline-offset: 2px;
-      }
-    }
-
-    &:hover .close-button {
-      visibility: visible;
-      position: absolute;
-      right: 4px;
-      top: 4px;
-      font-size: 16px;
-      padding: 4px;
-      display: flex;
-      align-items: center;
-      cursor: pointer;
-      opacity: 0.4;
-
-      &:hover {
-        background-color: var(--accent-btn-hover);
-        color: var(--accent-btn-hover-text);
-        opacity: 1;
-      }
-    }
 
     .graphic {
       display: flex;

--- a/shell/config/page-actions.js
+++ b/shell/config/page-actions.js
@@ -1,3 +1,4 @@
 export const RESET_CARDS_ACTION = 'reset-homepage-cards';
 export const SET_LOGIN_ACTION = 'set-as-login';
 export const ADD_CUSTOM_NAV_LINK = 'add-custom-nav-link';
+export const SHOW_HIDE_BANNER_ACTION = 'toggle-homepage-banner';

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -376,7 +376,7 @@ export default defineComponent({
         this.toggleBanner();
         break;
 
-        case SET_LOGIN_ACTION:
+      case SET_LOGIN_ACTION:
         this.afterLoginRoute = 'home';
         break;
 

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -23,7 +23,7 @@ import { filterHiddenLocalCluster, filterOnlyKubernetesClusters, paginationFilte
 import TabTitle from '@shell/components/TabTitle.vue';
 import { ActionFindPageArgs } from '@shell/types/store/dashboard-store.types';
 
-import { RESET_CARDS_ACTION, SET_LOGIN_ACTION } from '@shell/config/page-actions';
+import { RESET_CARDS_ACTION, SET_LOGIN_ACTION, SHOW_HIDE_BANNER_ACTION } from '@shell/config/page-actions';
 import { STEVE_NAME_COL, STEVE_STATE_COL } from '@shell/config/pagination-table-headers';
 import { PaginationParamFilter, FilterArgs, PaginationFilterField, PaginationArgs } from '@shell/types/store/pagination.types';
 import ProvCluster from '@shell/models/provisioning.cattle.io.cluster';
@@ -57,6 +57,10 @@ export default defineComponent({
           action:   SET_LOGIN_ACTION
         },
         { separator: true },
+        {
+          labelKey: 'nav.header.showHideBanner',
+          action:   SHOW_HIDE_BANNER_ACTION
+        },
         {
           labelKey: 'nav.header.restoreCards',
           action:   RESET_CARDS_ACTION
@@ -368,7 +372,11 @@ export default defineComponent({
         this.resetCards();
         break;
 
-      case SET_LOGIN_ACTION:
+      case SHOW_HIDE_BANNER_ACTION:
+        this.toggleBanner();
+        break;
+
+        case SET_LOGIN_ACTION:
         this.afterLoginRoute = 'home';
         break;
 
@@ -407,8 +415,25 @@ export default defineComponent({
     },
 
     async resetCards() {
-      await this.$store.dispatch('prefs/set', { key: HIDE_HOME_PAGE_CARDS, value: {} });
+      const value = this.$store.getters['prefs/get'](HIDE_HOME_PAGE_CARDS) || {};
+
+      delete value.setLoginPage;
+
+      await this.$store.dispatch('prefs/set', { key: HIDE_HOME_PAGE_CARDS, value });
+
       await this.$store.dispatch('prefs/set', { key: READ_WHATS_NEW, value: '' });
+    },
+
+    async toggleBanner() {
+      const value = this.$store.getters['prefs/get'](HIDE_HOME_PAGE_CARDS) || {};
+
+      if (value.welcomeBanner) {
+        delete value.welcomeBanner;
+      } else {
+        value.welcomeBanner = true;
+      }
+
+      await this.$store.dispatch('prefs/set', { key: HIDE_HOME_PAGE_CARDS, value });
     },
 
     async closeSetLoginBanner(retry = 0) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13251

### Occurred changes and/or fixed issues

This PR modifies the UI slightly to avoid the issue with keyboard navigation on the banner close icon.

The banner can now be shown/hidden by the page action menu - this feels like a better fit.

PR adds an e2e test to cover the change.

Restore hidden cards now only restores the what's new and login preference banner visibility.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/user-attachments/assets/2608003d-a6e2-4f73-8492-108eb85f62ec)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
