### PR TITLE
Add WAI-ARIA Roles, States, and Properties to ToggleSwitch

### DIFF
--- a/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.vue
+++ b/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, onMounted, onBeforeUnmount, useTemplateRef } from 'vue';
 
 type StateType = boolean | 'true' | 'false' | undefined;
 
@@ -33,6 +33,29 @@ export default defineComponent({
 
   emits: ['update:value'],
 
+  setup() {
+    const switchChrome = useTemplateRef<HTMLElement>('switchChrome');
+    const focus = () => {
+      switchChrome.value?.classList.add('focus');
+    };
+
+    const blur = () => {
+      switchChrome.value?.classList.remove('focus');
+    };
+
+    const switchInput = useTemplateRef<HTMLInputElement>('switchInput');
+
+    onMounted(() => {
+      switchInput.value?.addEventListener('focus', focus);
+      switchInput.value?.addEventListener('blur', blur);
+    });
+
+    onBeforeUnmount(() => {
+      switchInput.value?.removeEventListener('focus', focus);
+      switchInput.value?.removeEventListener('blur', blur);
+    });
+  },
+
   data() {
     return { state: false as StateType };
   },
@@ -64,6 +87,7 @@ export default defineComponent({
     >{{ offLabel }}</span>
     <label class="switch hand">
       <input
+        ref="switchInput"
         type="checkbox"
         role="switch"
         :checked="state"
@@ -71,7 +95,10 @@ export default defineComponent({
         @input="toggle(null)"
         @keydown.enter="toggle(null)"
       >
-      <span class="slider round" />
+      <span
+        ref="switchChrome"
+        class="slider round"
+      />
     </label>
     <span
       class="label no-select hand"
@@ -121,6 +148,13 @@ $toggle-height: 16px;
   background-color: var(--checkbox-disabled-bg);
   -webkit-transition: .4s;
   transition: .4s;
+
+  &.focus {
+    @include focus-outline;
+    outline-offset: 2px;
+    -webkit-transition: 0s;
+    transition: 0s;
+  }
 }
 
 .slider:before {

--- a/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.vue
+++ b/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.vue
@@ -65,8 +65,11 @@ export default defineComponent({
     <label class="switch hand">
       <input
         type="checkbox"
+        role="switch"
         :checked="state"
+        :aria-label="onLabel"
         @input="toggle(null)"
+        @keydown.enter="toggle(null)"
       >
       <span class="slider round" />
     </label>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds additional WAI-ARIA Roles, States, and Properties to ToggleSwitch. Noted missing properties and keyboard interactions:

- role
- aria-label
- @keydown.enter - defined as optional, but I opted to include it here

Fixes #12817 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

`aria-label` is set to `onLabel` because this should be the primary when working with the switch.

The following patterns specified for the switch pattern in the APG[^1] have been implemented. Patterns not implemented are not relevant to this PR.

[^1]: https://www.w3.org/WAI/ARIA/apg/patterns/switch/

#### Keyboard Interaction

- ✅ Space: When focus is on the switch, changes the state of the switch.
- ✅ Enter (Optional): When focus is on the switch, changes the state of the switch.

WAI-ARIA Roles, States, and Properties

- ✅ The switch has role switch.
- ✅ The switch has an accessible label provided by one of the following:
    - ◻️ Visible text content contained within the element with role switch.
    - ◻️ A visible label referenced by the value of [aria-labelledby](https://w3c.github.io/aria/#aria-labelledby) set on the element with role switch.
    - ✅ aria-label set on the element with role switch.
- ◻️ When on, the switch element has state [aria-checked](https://w3c.github.io/aria/#aria-checked) set to true.
- ◻️ When off, the switch element has state [aria-checked](https://w3c.github.io/aria/#aria-checked) set to false.
- ✅ If the switch element is an HTML input[type="checkbox"], it uses the HTML checked attribute instead of the aria-checked property.
- ◻️ If a set of switches is presented as a logical group with a visible label, either:
    - ◻️ The switches are included in an element with role [group](https://w3c.github.io/aria/#group) that has the property [aria-labelledby](https://w3c.github.io/aria/#aria-labelledby) set to the ID of the element containing the group label.
    - ◻️ The set is contained in an HTML fieldset and the label for the set is contained in an HTML legend element.
- ◻️ If the presentation includes additional descriptive static text relevant to a switch or switch group, the switch or switch group has the property aria-describedby set to the ID of the element containing the description.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

ToggleSwitch is used in the following components:

- shell/components/form/Labels.vue
- shell/edit/provisioning.cattle.io.cluster/index.vue
- shell/pages/c/_cluster/auth/user.retention/index.vue


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
