### PR TITLE
Improve accessibility of `KeyValue.vue`

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -117,6 +117,10 @@ generic:
         }
   basic: Basic
 
+  ariaLabel:
+    key: Key {index}
+    value: Value {index}
+
 locale:
   menu: Locale selector menu
   en-us: English

--- a/shell/components/form/FileSelector.vue
+++ b/shell/components/form/FileSelector.vue
@@ -148,6 +148,7 @@ export default {
   <button
     v-if="!isView"
     :disabled="disabled"
+    :aria-label="label"
     type="button"
     role="button"
     class="file-selector btn"

--- a/shell/components/form/FileSelector.vue
+++ b/shell/components/form/FileSelector.vue
@@ -149,6 +149,7 @@ export default {
     v-if="!isView"
     :disabled="disabled"
     type="button"
+    role="button"
     class="file-selector btn"
     data-testid="file-selector__uploader-button"
     @click="selectFile"

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -666,6 +666,7 @@ export default {
               :taggable="keyTaggable"
               :options="calculateOptions(row[keyName])"
               :data-testid="`select-kv-item-key-${i}`"
+              :aria-label="t('generic.ariaLabel.key', {index: i})"
               @update:value="queueUpdate"
             />
             <input
@@ -675,6 +676,7 @@ export default {
               :disabled="isView || disabled || !keyEditable || isProtected(row.key)"
               :placeholder="_keyPlaceholder"
               :data-testid="`input-kv-item-key-${i}`"
+              :aria-label="t('generic.ariaLabel.key', {index: i})"
               @input="queueUpdate"
               @paste="onPaste(i, $event)"
             >
@@ -713,6 +715,9 @@ export default {
                 :value="row[valueName]"
                 :as-text-area="true"
                 :mode="mode"
+                :options="{
+                  screenReaderLabel: t('generic.ariaLabel.value', { index: i })
+                }"
                 @onInput="onInputMarkdownMultiline(i, $event)"
                 @onFocus="onFocusMarkdownMultiline(i, $event)"
               />
@@ -726,6 +731,7 @@ export default {
                 :placeholder="_valuePlaceholder"
                 :min-height="40"
                 :spellcheck="false"
+                :aria-label="t('generic.ariaLabel.value', {index: i})"
                 @update:value="queueUpdate"
               />
               <input
@@ -738,6 +744,7 @@ export default {
                 autocapitalize="off"
                 spellcheck="false"
                 :data-testid="`input-kv-item-value-${i}`"
+                :aria-label="t('generic.ariaLabel.value', {index: i})"
                 @input="queueUpdate"
               >
               <FileSelector
@@ -745,6 +752,7 @@ export default {
                 class="btn btn-sm role-secondary file-selector"
                 :label="t('generic.upload')"
                 :include-file-name="true"
+                :aria-label="t('generic.ariaLabel.value', {index: i})"
                 @selected="onValueFileSelected(i, $event)"
               />
             </div>

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -609,49 +609,57 @@ export default {
       :style="containerStyle"
     >
       <template v-if="rows.length || isView">
-        <label
-          class="text-label"
-          role="columnheader"
-        >
-          {{ _keyLabel }}
-          <i
-            v-if="_protip && !isView && addAllowed"
-            v-clean-tooltip="_protip"
-            class="icon icon-info"
-          />
-        </label>
-        <label
-          class="text-label"
-          role="columnheader"
-        >
-          {{ _valueLabel }}
-        </label>
-        <label
-          v-for="(c, i) in extraColumns"
-          :key="i"
-          role="columnheader"
-        >
-          <slot :name="'label:'+c">{{ c }}</slot>
-        </label>
-        <slot
-          v-if="canRemove"
-          name="remove"
-        >
-          <span />
-        </slot>
+        <div class="rowgroup">
+          <div class="row">
+            <label
+              class="text-label"
+              role="columnheader"
+            >
+              {{ _keyLabel }}
+              <i
+                v-if="_protip && !isView && addAllowed"
+                v-clean-tooltip="_protip"
+                class="icon icon-info"
+              />
+            </label>
+            <label
+              class="text-label"
+              role="columnheader"
+            >
+              {{ _valueLabel }}
+            </label>
+            <label
+              v-for="(c, i) in extraColumns"
+              :key="i"
+              role="columnheader"
+            >
+              <slot :name="'label:'+c">{{ c }}</slot>
+            </label>
+            <slot
+              v-if="canRemove"
+              name="remove"
+            >
+              <span />
+            </slot>
+          </div>
+        </div>
       </template>
       <template v-if="!rows.length && isView">
-        <div
-          class="kv-item key text-muted"
-          role="gridcell"
-        >
-          &mdash;
-        </div>
-        <div
-          class="kv-item key text-muted"
-          role="gridcell"
-        >
-          &mdash;
+        <div class="rowgroup">
+          <div class="row">
+            <div
+              class="kv-item key text-muted"
+              role="gridcell"
+            >
+              &mdash;
+            </div>
+            <div
+              class="kv-item key text-muted"
+              role="gridcell"
+            >
+              &mdash;
+            </div>
+          </div>
         </div>
       </template>
       <template
@@ -659,166 +667,171 @@ export default {
         v-else
         :key="i"
       >
-        <!-- Key -->
-        <div
-          class="kv-item key"
-          role="gridcell"
-          :aria-rowindex="i+1"
-          :aria-colindex="1"
-        >
-          <slot
-            name="key"
-            :row="row"
-            :mode="mode"
-            :keyName="keyName"
-            :valueName="valueName"
-            :queueUpdate="queueUpdate"
-            :disabled="disabled"
-          >
-            <Select
-              v-if="keyOptions"
-              ref="key"
-              v-model:value="row[keyName]"
-              :searchable="true"
-              :disabled="disabled || isProtected(row.key)"
-              :clearable="false"
-              :taggable="keyTaggable"
-              :options="calculateOptions(row[keyName])"
-              :data-testid="`select-kv-item-key-${i}`"
-              :aria-label="t('generic.ariaLabel.key', {index: i})"
-              @update:value="queueUpdate"
-            />
-            <input
-              v-else
-              ref="key"
-              v-model="row[keyName]"
-              :disabled="isView || disabled || !keyEditable || isProtected(row.key)"
-              :placeholder="_keyPlaceholder"
-              :data-testid="`input-kv-item-key-${i}`"
-              :aria-label="t('generic.ariaLabel.key', {index: i})"
-              @input="queueUpdate"
-              @paste="onPaste(i, $event)"
+        <div class="rowgroup">
+          <div class="row">
+            <!-- Key -->
+            <div
+              class="kv-item key"
+              role="gridcell"
+              :aria-rowindex="i+1"
+              :aria-colindex="1"
             >
-          </slot>
-        </div>
-
-        <!-- Value -->
-        <div
-          :data-testid="`kv-item-value-${i}`"
-          class="kv-item value"
-          role="gridcell"
-          :aria-rowindex="i+1"
-          :aria-colindex="2"
-        >
-          <slot
-            name="value"
-            :row="row"
-            :mode="mode"
-            :keyName="keyName"
-            :valueName="valueName"
-            :queueUpdate="queueUpdate"
-          >
-            <div v-if="!row.supported">
-              {{ t('detailText.unsupported', null, true) }}
+              <slot
+                name="key"
+                :row="row"
+                :mode="mode"
+                :keyName="keyName"
+                :valueName="valueName"
+                :queueUpdate="queueUpdate"
+                :disabled="disabled"
+              >
+                <Select
+                  v-if="keyOptions"
+                  ref="key"
+                  v-model:value="row[keyName]"
+                  :searchable="true"
+                  :disabled="disabled || isProtected(row.key)"
+                  :clearable="false"
+                  :taggable="keyTaggable"
+                  :options="calculateOptions(row[keyName])"
+                  :data-testid="`select-kv-item-key-${i}`"
+                  :aria-label="t('generic.ariaLabel.key', {index: i})"
+                  @update:value="queueUpdate"
+                />
+                <input
+                  v-else
+                  ref="key"
+                  v-model="row[keyName]"
+                  :disabled="isView || disabled || !keyEditable || isProtected(row.key)"
+                  :placeholder="_keyPlaceholder"
+                  :data-testid="`input-kv-item-key-${i}`"
+                  :aria-label="t('generic.ariaLabel.key', {index: i})"
+                  @input="queueUpdate"
+                  @paste="onPaste(i, $event)"
+                >
+              </slot>
             </div>
-            <div v-else-if="row.binary">
-              {{ binaryTextSize(row.value) }}
+
+            <!-- Value -->
+            <div
+              :data-testid="`kv-item-value-${i}`"
+              class="kv-item value"
+              role="gridcell"
+              :aria-rowindex="i+1"
+              :aria-colindex="2"
+            >
+              <slot
+                name="value"
+                :row="row"
+                :mode="mode"
+                :keyName="keyName"
+                :valueName="valueName"
+                :queueUpdate="queueUpdate"
+              >
+                <div v-if="!row.supported">
+                  {{ t('detailText.unsupported', null, true) }}
+                </div>
+                <div v-else-if="row.binary">
+                  {{ binaryTextSize(row.value) }}
+                </div>
+                <div
+                  v-else
+                  class="value-container"
+                  :class="{ 'upload-button': parseValueFromFile }"
+                >
+                  <CodeMirror
+                    v-if="valueMarkdownMultiline"
+                    ref="cm"
+                    data-testid="code-mirror-multiline-field"
+                    :class="{['focus']: codeMirrorFocus[i]}"
+                    :value="row[valueName]"
+                    :as-text-area="true"
+                    :mode="mode"
+                    :options="{
+                      screenReaderLabel: t('generic.ariaLabel.value', { index: i })
+                    }"
+                    @onInput="onInputMarkdownMultiline(i, $event)"
+                    @onFocus="onFocusMarkdownMultiline(i, $event)"
+                  />
+                  <TextAreaAutoGrow
+                    v-else-if="valueMultiline && row[valueName] !== undefined"
+                    v-model:value="row[valueName]"
+                    data-testid="value-multiline"
+                    :class="{'conceal': valueConcealed}"
+                    :disabled="disabled || isProtected(row.key)"
+                    :mode="mode"
+                    :placeholder="_valuePlaceholder"
+                    :min-height="40"
+                    :spellcheck="false"
+                    :aria-label="t('generic.ariaLabel.value', {index: i})"
+                    @update:value="queueUpdate"
+                  />
+                  <input
+                    v-else
+                    v-model="row[valueName]"
+                    :disabled="isView || disabled || isProtected(row.key)"
+                    :type="valueConcealed ? 'password' : 'text'"
+                    :placeholder="_valuePlaceholder"
+                    autocorrect="off"
+                    autocapitalize="off"
+                    spellcheck="false"
+                    :data-testid="`input-kv-item-value-${i}`"
+                    :aria-label="t('generic.ariaLabel.value', {index: i})"
+                    @input="queueUpdate"
+                  >
+                  <FileSelector
+                    v-if="parseValueFromFile && readAllowed && !isView && isValueFieldEmpty(row[valueName])"
+                    class="btn btn-sm role-secondary file-selector"
+                    :label="t('generic.upload')"
+                    :include-file-name="true"
+                    :aria-label="t('generic.ariaLabel.value', {index: i})"
+                    @selected="onValueFileSelected(i, $event)"
+                  />
+                </div>
+              </slot>
             </div>
             <div
-              v-else
-              class="value-container"
-              :class="{ 'upload-button': parseValueFromFile }"
+              v-for="(c, j) in extraColumns"
+              :key="`${i}-${j}`"
+              class="kv-item extra"
+              role="gridcell"
+              :aria-rowindex="i+1"
+              :aria-colindex="j+3"
             >
-              <CodeMirror
-                v-if="valueMarkdownMultiline"
-                ref="cm"
-                data-testid="code-mirror-multiline-field"
-                :class="{['focus']: codeMirrorFocus[i]}"
-                :value="row[valueName]"
-                :as-text-area="true"
-                :mode="mode"
-                :options="{
-                  screenReaderLabel: t('generic.ariaLabel.value', { index: i })
-                }"
-                @onInput="onInputMarkdownMultiline(i, $event)"
-                @onFocus="onFocusMarkdownMultiline(i, $event)"
-              />
-              <TextAreaAutoGrow
-                v-else-if="valueMultiline && row[valueName] !== undefined"
-                v-model:value="row[valueName]"
-                data-testid="value-multiline"
-                :class="{'conceal': valueConcealed}"
-                :disabled="disabled || isProtected(row.key)"
-                :mode="mode"
-                :placeholder="_valuePlaceholder"
-                :min-height="40"
-                :spellcheck="false"
-                :aria-label="t('generic.ariaLabel.value', {index: i})"
-                @update:value="queueUpdate"
-              />
-              <input
-                v-else
-                v-model="row[valueName]"
-                :disabled="isView || disabled || isProtected(row.key)"
-                :type="valueConcealed ? 'password' : 'text'"
-                :placeholder="_valuePlaceholder"
-                autocorrect="off"
-                autocapitalize="off"
-                spellcheck="false"
-                :data-testid="`input-kv-item-value-${i}`"
-                :aria-label="t('generic.ariaLabel.value', {index: i})"
-                @input="queueUpdate"
-              >
-              <FileSelector
-                v-if="parseValueFromFile && readAllowed && !isView && isValueFieldEmpty(row[valueName])"
-                class="btn btn-sm role-secondary file-selector"
-                :label="t('generic.upload')"
-                :include-file-name="true"
-                :aria-label="t('generic.ariaLabel.value', {index: i})"
-                @selected="onValueFileSelected(i, $event)"
+              <slot
+                :name="'col:' + c"
+                :row="row"
+                :queue-update="queueUpdate"
+                :i="i"
               />
             </div>
-          </slot>
-        </div>
-        <div
-          v-for="(c, j) in extraColumns"
-          :key="`${i}-${j}`"
-          class="kv-item extra"
-          role="gridcell"
-          :aria-rowindex="i+1"
-          :aria-colindex="j+3"
-        >
-          <slot
-            :name="'col:' + c"
-            :row="row"
-            :queue-update="queueUpdate"
-            :i="i"
-          />
-        </div>
-        <div
-          v-if="canRemove"
-          :key="i"
-          class="kv-item remove"
-          role="gridcell"
-          :aria-rowindex="i+1"
-          :aria-colindex="extraColumns.length+3"
-        >
-          <slot
-            name="removeButton"
-            :remove="remove"
-            :row="row"
-            :i="i"
-          >
-            <button
-              type="button"
-              role="button"
-              :disabled="isView || isProtected(row.key) || disabled"
-              class="btn role-link"
-              @click="remove(i)"
+            <div
+              v-if="canRemove"
+              :key="i"
+              class="kv-item remove"
+              role="gridcell"
+              :aria-rowindex="i+1"
+              :aria-colindex="extraColumns.length+3"
+              :data-testid="`remove-column-${i}`"
             >
-              {{ removeLabel || t('generic.remove') }}
-            </button>
-          </slot>
+              <slot
+                name="removeButton"
+                :remove="remove"
+                :row="row"
+                :i="i"
+              >
+                <button
+                  type="button"
+                  role="button"
+                  :disabled="isView || isProtected(row.key) || disabled"
+                  class="btn role-link"
+                  @click="remove(i)"
+                >
+                  {{ removeLabel || t('generic.remove') }}
+                </button>
+              </slot>
+            </div>
+          </div>
         </div>
       </template>
     </div>
@@ -898,6 +911,24 @@ export default {
       }
     }
   }
+
+  .rowgroup {
+    display: grid;
+    grid-column-start: 1;
+    grid-column-end: span end;
+    grid-template-columns: subgrid;
+  }
+
+  .row {
+    &::before {
+      display: none;
+    }
+    display: grid;
+    grid-column-start: 1;
+    grid-column-end: span end;
+    grid-template-columns: subgrid;
+  }
+
   .remove {
     text-align: center;
     BUTTON {

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -784,6 +784,7 @@ export default {
           >
             <button
               type="button"
+              role="button"
               :disabled="isView || isProtected(row.key) || disabled"
               class="btn role-link"
               @click="remove(i)"
@@ -805,6 +806,7 @@ export default {
         <button
           v-if="addAllowed"
           type="button"
+          role="button"
           class="btn role-tertiary add"
           data-testid="add_row_item_button"
           :disabled="loading || disabled || (keyOptions && filteredKeyOptions.length === 0)"

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -824,6 +824,7 @@ export default {
                   type="button"
                   role="button"
                   :disabled="isView || isProtected(row.key) || disabled"
+                  :aria-label="removeLabel || t('generic.remove')"
                   class="btn role-link"
                   @click="remove(i)"
                 >
@@ -850,6 +851,7 @@ export default {
           class="btn role-tertiary add"
           data-testid="add_row_item_button"
           :disabled="loading || disabled || (keyOptions && filteredKeyOptions.length === 0)"
+          :aria-label="_addLabel"
           @click="add()"
         >
           <i

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -603,10 +603,16 @@ export default {
     </div>
     <div
       class="kv-container"
+      role="grid"
+      :aria-rowcount="rows.length"
+      :aria-colcount="extraColumns.length + 2"
       :style="containerStyle"
     >
       <template v-if="rows.length || isView">
-        <label class="text-label">
+        <label
+          class="text-label"
+          role="columnheader"
+        >
           {{ _keyLabel }}
           <i
             v-if="_protip && !isView && addAllowed"
@@ -614,12 +620,16 @@ export default {
             class="icon icon-info"
           />
         </label>
-        <label class="text-label">
+        <label
+          class="text-label"
+          role="columnheader"
+        >
           {{ _valueLabel }}
         </label>
         <label
           v-for="(c, i) in extraColumns"
           :key="i"
+          role="columnheader"
         >
           <slot :name="'label:'+c">{{ c }}</slot>
         </label>
@@ -631,10 +641,16 @@ export default {
         </slot>
       </template>
       <template v-if="!rows.length && isView">
-        <div class="kv-item key text-muted">
+        <div
+          class="kv-item key text-muted"
+          role="gridcell"
+        >
           &mdash;
         </div>
-        <div class="kv-item key text-muted">
+        <div
+          class="kv-item key text-muted"
+          role="gridcell"
+        >
           &mdash;
         </div>
       </template>
@@ -646,6 +662,9 @@ export default {
         <!-- Key -->
         <div
           class="kv-item key"
+          role="gridcell"
+          :aria-rowindex="i+1"
+          :aria-colindex="1"
         >
           <slot
             name="key"
@@ -687,6 +706,9 @@ export default {
         <div
           :data-testid="`kv-item-value-${i}`"
           class="kv-item value"
+          role="gridcell"
+          :aria-rowindex="i+1"
+          :aria-colindex="2"
         >
           <slot
             name="value"
@@ -762,6 +784,9 @@ export default {
           v-for="(c, j) in extraColumns"
           :key="`${i}-${j}`"
           class="kv-item extra"
+          role="gridcell"
+          :aria-rowindex="i+1"
+          :aria-colindex="j+3"
         >
           <slot
             :name="'col:' + c"
@@ -774,7 +799,9 @@ export default {
           v-if="canRemove"
           :key="i"
           class="kv-item remove"
-          :data-testid="`remove-column-${i}`"
+          role="gridcell"
+          :aria-rowindex="i+1"
+          :aria-colindex="extraColumns.length+3"
         >
           <slot
             name="removeButton"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This improves accessibility of `KeyValue.vue` by:

- adding missing aria labels to `KeyValue.vue` 
- adding missing button roles to buttons used throughout the `KeyValue.vue`
- adding table-style grouping with grid roles[^1]

I recommend reviewing this PR commit-by-commit due to the large restructuring of the template with the introduction of row/rowgroup roles.

[^1]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/gridcell_role#rowheader

Fixes #12813 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

🗒️ NOTE: The code mirror component requires a special option, `screenReaderLabel`, to assign the `aria-label` to the correct element.

🗒️ NOTE: This makes use of CSS Subgrids, which should have widespread browser support as of 2023[^2]

[^2]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Subgrid

ℹ️ INFO: This change should improve compatibility with assistive technologies, but it is always recommended to use native table markup whenever possible[^3]. Migrating to table markup will be a considerable change that would undo previous efforts to migrate to CSS grid (#928).

[^3]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/gridcell_role#accessibility_concerns

ℹ️ INFO: Grid keyboard interactions[^4] are out of scope for this change.

[^4]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/grid_role#keyboard_interactions

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Repository: Create
- Git Repo - Add Repository
- Home Links

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

There's a high level of variability with rendering elements in this component. We will want to ensure that the layout has not regressed in these scenarios.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
