### PR TITLE
Wire in new status.connected property

### DIFF
--- a/shell/components/nav/TopLevelMenu.helper.ts
+++ b/shell/components/nav/TopLevelMenu.helper.ts
@@ -37,7 +37,7 @@ type ProvCluster = {
 }
 
 /**
- * Order
+ * Order of v1 mgmt clusters
  * 1. local cluster - https://github.com/rancher/dashboard/issues/10975
  * 2. working clusters
  * 3. name
@@ -47,10 +47,10 @@ const DEFAULT_SORT: Array<PaginationSort> = [
     asc:   false,
     field: 'spec.internal',
   },
-  // {
-  //   asc:   true,
-  //   field: 'status.conditions[0].status' // Pending API changes https://github.com/rancher/rancher/issues/48092
-  // },
+  {
+    asc:   false,
+    field: 'status.connected'
+  },
   {
     asc:   true,
     field: 'spec.displayName',

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -142,7 +142,7 @@ class StevePaginationUtils extends NamespaceProjectFilters {
       { field: 'spec.displayName' },
       { field: `status.provider` },
       { field: `metadata.labels."${ CAPI_LABELS.PROVIDER }"` },
-
+      { field: `status.connected` },
     ],
     [CONFIG_MAP]: [
       { field: 'metadata.labels[harvesterhci.io/cloud-init-template]' }

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -433,9 +433,15 @@ class StevePaginationUtils extends NamespaceProjectFilters {
               this.validateField(validateFields, schema, field.field);
 
               const value = encodeURIComponent(field.value);
-              const exactPartial = field.exact ? `'${ value }'` : value;
 
-              return `${ this.convertArrayPath(field.field) }${ field.equals ? '=' : '!=' }${ exactPartial }`;
+              // = exact match
+              // ~ partial match
+              // != not exact match
+              // !~ not partial match
+
+              const operator = `${ field.equals ? '' : '!' }${ field.exact ? '=' : '~' }`;
+
+              return `${ this.convertArrayPath(field.field) }${ operator }${ value }`;
             }
 
             return field.value;


### PR DESCRIPTION
- blocker on steve bump to rancher/rancher (to get fix for BE filter bug)

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13268
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- as per title, now that the v1 mgmt cluster status.connected property is supported wire it in

### Areas or cases that should be tested
- side nav cluster list should order clusters in
  - local cluster
  - running
  - name

### Areas which could experience regressions
- side nav

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
