### PR TITLE
Add missing alert roles to User Retention, Create User, & Health Scale

### DIFF
--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -400,6 +400,8 @@ export default defineComponent({
     >
       <div
         v-if="cronHint"
+        role="alert"
+        :aria-label="cronHint"
       >
         {{ cronHint }}
       </div>

--- a/shell/components/GrowlManager.vue
+++ b/shell/components/GrowlManager.vue
@@ -87,7 +87,10 @@ export default {
     <div class="growl-list">
       <div
         v-for="(growl, idx) in stack"
-        :key="idx"
+        :key="growl.id"
+        role="alert"
+        :aria-labelledby="`growl-title-${ growl.id }`"
+        :aria-describedby="`growl-message-${ growl.id }`"
         :data-testid="`growl-list-item-${idx}`"
         :class="{'growl': true, ['bg-'+growl.color]: true}"
       >
@@ -103,11 +106,15 @@ export default {
               class="close hand icon icon-close"
               @click="close(growl)"
             />
-            <div class="growl-text-title">
+            <div
+              :id="`growl-title-${ growl.id }`"
+              class="growl-text-title"
+            >
               {{ growl.title }}
             </div>
             <p
               v-if="growl.message"
+              :id="`growl-message-${ growl.id }`"
               :class="{ 'has-title': !!growl.title }"
             >
               {{ growl.message }}

--- a/shell/components/form/ChangePassword.vue
+++ b/shell/components/form/ChangePassword.vue
@@ -407,6 +407,8 @@ export default {
         <Banner
           v-for="(err, i) in errorMessages"
           :key="i"
+          role="alert"
+          :aria-label="err"
           color="error"
           :label="err"
           class="mb-0"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds alert roles to the sections that are called out in #12812:

- Users Retention Settings: Cron Schedule
- Create User: Password mismatch
- Health Scale Component: Growl messages

Fixes #12812 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This adds the alert role to the base components so that the issue will be resolved in as many instances as possible.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Users Retention Settings: Cron Schedule
- Create User: Password mismatch
- Health Scale Component: Growl messages

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Users Retention Settings: Cron Schedule
- Create User: Password mismatch
- Health Scale Component: Growl messages

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
