### PR TITLE
Add focus ring to tertiary buttons

### DIFF
--- a/shell/assets/styles/base/_basic.scss
+++ b/shell/assets/styles/base/_basic.scss
@@ -89,14 +89,6 @@ TEXTAREA,
   }
 }
 
-BUTTON,
-.btn {
-   &:focus, &.focused {
-    outline: none;
-    box-shadow: 0 0 0 var(--outline-width) var(--outline);
-    background: var(--primary-hover-bg);
-   }
-}
 A {
   @include link-color(var(--link), var(--body-text));
 

--- a/shell/assets/styles/global/_button.scss
+++ b/shell/assets/styles/global/_button.scss
@@ -126,6 +126,11 @@ button,
   &.btn:not(.btn-sm) {
     line-height: $btn-height - 2px;
   }
+
+  &:focus-visible {
+    @include focus-outline;
+    outline-offset: 2px;
+  }
 }
 
 .role-link {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates tertiary button to include the same focus ring used for other button styles. 

This also removes some focus styles that were applied to all buttons by default; these no longer appear to be relevant.

<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Tertiary buttons are on display for provisioning Amazon EKS clusters (see screenshots).

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Button styles across the board. It's good to review existing button styles to assert that the removed styles do not regress.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before

![image](https://github.com/user-attachments/assets/4b501241-e66c-41f1-bd2b-7ca95c94a957)

#### After

![image](https://github.com/user-attachments/assets/1d6fe98b-62cf-4752-8e05-39832fb10ba2)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
