### PR TITLE
Resolve Vue compiler warnings after upgrade to 3.5

### DIFF
--- a/pkg/aks/components/AksNodePool.vue
+++ b/pkg/aks/components/AksNodePool.vue
@@ -387,26 +387,28 @@ export default defineComponent({
           v-if="(taints && taints.length) || isView"
           class="taints"
         >
-          <tr>
-            <th>
-              <label class="text-label">
-                {{ t('aks.nodePools.taints.key') }}
-                <span class="text-error">*</span>
-              </label>
-            </th>
-            <th>
-              <label class="text-label">
-                {{ t('aks.nodePools.taints.value') }}
-                <span class="text-error">*</span>
-              </label>
-            </th>
-            <th>
-              <label class="text-label">
-                {{ t('aks.nodePools.taints.effect') }}
-              </label>
-            </th>
-            <th />
-          </tr>
+          <thead>
+            <tr>
+              <th>
+                <label class="text-label">
+                  {{ t('aks.nodePools.taints.key') }}
+                  <span class="text-error">*</span>
+                </label>
+              </th>
+              <th>
+                <label class="text-label">
+                  {{ t('aks.nodePools.taints.value') }}
+                  <span class="text-error">*</span>
+                </label>
+              </th>
+              <th>
+                <label class="text-label">
+                  {{ t('aks.nodePools.taints.effect') }}
+                </label>
+              </th>
+              <th />
+            </tr>
+          </thead>
           <template v-if="taints && taints.length">
             <Taint
               v-for="(keyedTaint, i) in taints"

--- a/shell/components/ButtonMultiAction.vue
+++ b/shell/components/ButtonMultiAction.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, defineEmits } from 'vue';
+import { computed } from 'vue';
 
 defineEmits(['click']);
 

--- a/shell/components/auth/Principal.vue
+++ b/shell/components/auth/Principal.vue
@@ -85,9 +85,11 @@ export default {
         class="name"
       >
         <table>
-          <tr><td>{{ t('principal.name') }}: </td><td>{{ principal.name || principal.loginName }}</td></tr>
-          <tr><td>{{ t('principal.loginName') }}: </td><td>{{ principal.loginName }}</td></tr>
-          <tr><td>{{ t('principal.type') }}: </td><td>{{ principal.displayType }}</td></tr>
+          <tbody>
+            <tr><td>{{ t('principal.name') }}: </td><td>{{ principal.name || principal.loginName }}</td></tr>
+            <tr><td>{{ t('principal.loginName') }}: </td><td>{{ principal.loginName }}</td></tr>
+            <tr><td>{{ t('principal.type') }}: </td><td>{{ principal.displayType }}</td></tr>
+          </tbody>
         </table>
       </div>
       <template v-else>

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -211,12 +211,14 @@ export default {
             </Banner>
 
             <table v-if="showLdapDetails && model.openLdapConfig">
-              <tr><td>{{ t('authConfig.ldap.hostname.label') }}:</td><td>{{ ldapHosts }}</td></tr>
-              <tr><td>{{ t('authConfig.ldap.port') }}:</td><td>{{ model.openLdapConfig.port }}</td></tr>
-              <tr><td>{{ t('authConfig.ldap.protocol') }}:</td><td>{{ ldapProtocol }}</td></tr>
-              <tr><td>{{ t('authConfig.ldap.serviceAccountDN') }}:</td><td>{{ model.openLdapConfig.serviceAccountDistinguishedName }}</td></tr>
-              <tr><td>{{ t('authConfig.ldap.userSearchBase.label') }}:</td><td>{{ model.openLdapConfig.userSearchBase }}</td></tr>
-              <tr><td>{{ t('authConfig.ldap.groupSearchBase.label') }}:</td><td>{{ model.openLdapConfig.groupSearchBase }}</td></tr>
+              <tbody>
+                <tr><td>{{ t('authConfig.ldap.hostname.label') }}:</td><td>{{ ldapHosts }}</td></tr>
+                <tr><td>{{ t('authConfig.ldap.port') }}:</td><td>{{ model.openLdapConfig.port }}</td></tr>
+                <tr><td>{{ t('authConfig.ldap.protocol') }}:</td><td>{{ ldapProtocol }}</td></tr>
+                <tr><td>{{ t('authConfig.ldap.serviceAccountDN') }}:</td><td>{{ model.openLdapConfig.serviceAccountDistinguishedName }}</td></tr>
+                <tr><td>{{ t('authConfig.ldap.userSearchBase.label') }}:</td><td>{{ model.openLdapConfig.userSearchBase }}</td></tr>
+                <tr><td>{{ t('authConfig.ldap.groupSearchBase.label') }}:</td><td>{{ model.openLdapConfig.groupSearchBase }}</td></tr>
+              </tbody>
             </table>
           </template>
         </AuthBanner>

--- a/shell/pages/diagnostic.vue
+++ b/shell/pages/diagnostic.vue
@@ -346,21 +346,23 @@ export default {
           class="full-width"
         >
           <thead @click="toggleTable(cluster.id)">
-            <th colspan="4">
-              <div class="cluster-row">
-                <span>Cluster: <b>{{ cluster.name }}</b></span>
-                <span>Namespace: <b>{{ cluster.namespace }}</b></span>
-                <span>Total Resources: <b>{{ sumResourceCount(cluster.counts) }}</b></span>
-                <span>Nodes: <b>{{ nodeCount(cluster.counts) }}</b></span>
-                <i
-                  class="icon"
-                  :class="{
-                    'icon-chevron-down': !cluster.isTableVisible,
-                    'icon-chevron-up': cluster.isTableVisible
-                  }"
-                />
-              </div>
-            </th>
+            <tr>
+              <th colspan="4">
+                <div class="cluster-row">
+                  <span>Cluster: <b>{{ cluster.name }}</b></span>
+                  <span>Namespace: <b>{{ cluster.namespace }}</b></span>
+                  <span>Total Resources: <b>{{ sumResourceCount(cluster.counts) }}</b></span>
+                  <span>Nodes: <b>{{ nodeCount(cluster.counts) }}</b></span>
+                  <i
+                    class="icon"
+                    :class="{
+                      'icon-chevron-down': !cluster.isTableVisible,
+                      'icon-chevron-up': cluster.isTableVisible
+                    }"
+                  />
+                </div>
+              </th>
+            </tr>
           </thead>
           <tbody v-show="cluster.isTableVisible">
             <tr>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves Vue compiler warnings that started appearing after the upgrade to Vue 3.5.

Fixes #13124
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Fix warnings about table structure
- Fix warnings about defineEmits

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

It appears that this is a behavior that was introduced in to vuejs/core#12088. There's some debate as to whether or not the message is always valid, but it appeared simple enough for us to update our table usage to resolve the warning and clean up the console output.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

The affected tables should be reviewed for regressions:

- Diagnostics
- AksNodePool
- Saml
- Principal

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

The affected tables should be reviewed for regressions:

- Diagnostics
- AksNodePool
- Saml
- Principal

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
