### PR TITLE
Move env var to only be available to publish step

### DIFF
--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -1,6 +1,4 @@
 name: storybook
-env:
-    STORYBOOK_TOKEN: ${{ secrets.STORYBOOK_TOKEN }}
 on:
   push:
     branches:
@@ -24,4 +22,6 @@ jobs:
         yarn build-storybook
     - name: Publish Storybook
       if: ${{ github.event_name == 'push' && github.repository_owner == 'rancher'}}
+      env:
+        STORYBOOK_TOKEN: ${{ secrets.STORYBOOK_TOKEN }}
       run: .github/workflows/scripts/publish-storybook


### PR DESCRIPTION
Minor update to github workflow

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
