### PR TITLE
Fleet: Created By label

### DIFF
--- a/cypress/e2e/blueprints/fleet/gitrepos.ts
+++ b/cypress/e2e/blueprints/fleet/gitrepos.ts
@@ -2,7 +2,8 @@ export const gitRepoCreateRequest = {
   type:     'fleet.cattle.io.gitrepo',
   metadata: {
     namespace: 'fleet-default',
-    name:      'fleet-e2e-test-gitrepo'
+    name:      'fleet-e2e-test-gitrepo',
+    labels:    {},
   },
   spec: {
     repo:         'https://github.com/rancher/fleet-test-data.git',

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5066,6 +5066,7 @@ resourceDetail:
     view: "{subtype} {name}"
   masthead:
     age: Age
+    createdBy: Created By
     restartCount: Pod Restarts
     defaultBannerMessage:
       error: This resource is currently in an error state, but there isn't a detailed message available.

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5066,7 +5066,7 @@ resourceDetail:
     view: "{subtype} {name}"
   masthead:
     age: Age
-    createdBy: Created By
+    createdBy: Created by
     restartCount: Pod Restarts
     defaultBannerMessage:
       error: This resource is currently in an error state, but there isn't a detailed message available.

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -519,7 +519,7 @@ export default {
             <router-link
               v-if="value.createdBy.location"
               :to="value.createdBy.location"
-              data-testid="masthead-subheader-createdBy_link"
+              data-testid="masthead-subheader-createdBy-link"
             >
               {{ value.createdBy.displayName }}
             </router-link>

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -511,16 +511,22 @@ export default {
               :value="value.creationTimestamp"
             />
           </span>
-          <span v-if="value.showCreatedBy">
+          <span
+            v-if="value.showCreatedBy"
+            data-testid="masthead-subheader-createdBy"
+          >
             {{ t("resourceDetail.masthead.createdBy") }}:
             <router-link
               v-if="value.createdBy.location"
               :to="value.createdBy.location"
-              data-testid="masthead-subheader-createdBy"
+              data-testid="masthead-subheader-createdBy_link"
             >
               {{ value.createdBy.displayName }}
             </router-link>
-            <span v-else>
+            <span
+              v-else
+              data-testid="masthead-subheader-createdBy_plain-text"
+            >
               {{ value.createdBy.displayName }}
             </span>
           </span>

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -504,10 +504,26 @@ export default {
               {{ namespace }}
             </span>
           </span>
-          <span v-if="parent.showAge">{{ t("resourceDetail.masthead.age") }}: <LiveDate
-            class="live-date"
-            :value="value.creationTimestamp"
-          /></span>
+          <span v-if="parent.showAge">
+            {{ t("resourceDetail.masthead.age") }}:
+            <LiveDate
+              class="live-date"
+              :value="value.creationTimestamp"
+            />
+          </span>
+          <span v-if="value.showCreatedBy">
+            {{ t("resourceDetail.masthead.createdBy") }}:
+            <router-link
+              v-if="value.createdBy.location"
+              :to="value.createdBy.location"
+              data-testid="masthead-subheader-createdBy"
+            >
+              {{ value.createdBy.displayName }}
+            </router-link>
+            <span v-else>
+              {{ value.createdBy.displayName }}
+            </span>
+          </span>
           <span v-if="value.showPodRestarts">{{ t("resourceDetail.masthead.restartCount") }}:<span class="live-data"> {{ value.restartCount }}</span></span>
         </div>
       </div>

--- a/shell/components/ResourceDetail/__tests__/Masthead.test.ts
+++ b/shell/components/ResourceDetail/__tests__/Masthead.test.ts
@@ -51,7 +51,7 @@ describe('component: Masthead', () => {
     });
 
     const container = wrapper.find('[data-testid="masthead-subheader-createdBy"]');
-    const link = wrapper.find('[data-testid="masthead-subheader-createdBy_link"]');
+    const link = wrapper.find('[data-testid="masthead-subheader-createdBy-link"]');
     const plainText = wrapper.find('[data-testid="masthead-subheader-createdBy_plain-text"]');
 
     expect(link.exists()).toBe(showLink);

--- a/shell/components/ResourceDetail/__tests__/Masthead.test.ts
+++ b/shell/components/ResourceDetail/__tests__/Masthead.test.ts
@@ -1,0 +1,61 @@
+import { mount, RouterLinkStub } from '@vue/test-utils';
+import { _VIEW } from '@shell/config/query-params';
+import Masthead from '@shell/components/ResourceDetail/Masthead.vue';
+
+const mockedStore = () => {
+  return {
+    getters: {
+      currentStore:              () => 'current_store',
+      currentProduct:            { inStore: 'cluster' },
+      isExplorer:                false,
+      currentCluster:            {},
+      'type-map/labelFor':       jest.fn(),
+      'type-map/optionsFor':     jest.fn(),
+      'current_store/schemaFor': jest.fn(),
+    },
+  };
+};
+
+const requiredSetup = () => {
+  return {
+    stubs: {
+      'router-link': RouterLinkStub,
+      LiveDate:      true
+    },
+    mocks: { $store: mockedStore() }
+  };
+};
+
+describe('component: Masthead', () => {
+  it.each([
+    ['hidden', '', false, { displayName: 'admin', location: { id: 'resource-id' } }, false, false],
+    ['plain-text', 'admin', true, { displayName: 'admin', location: null }, false, true],
+    ['link', 'foo', true, { displayName: 'foo', location: { id: 'resource-id' } }, true, false],
+  ])('"Created By" should be %p, with text: %p', (
+    _,
+    text,
+    showCreatedBy,
+    createdBy,
+    showLink,
+    showPlainText,
+  ) => {
+    const wrapper = mount(Masthead, {
+      props: {
+        mode:  _VIEW,
+        value: {
+          showCreatedBy,
+          createdBy,
+        },
+      },
+      global: { ...requiredSetup() }
+    });
+
+    const container = wrapper.find('[data-testid="masthead-subheader-createdBy"]');
+    const link = wrapper.find('[data-testid="masthead-subheader-createdBy_link"]');
+    const plainText = wrapper.find('[data-testid="masthead-subheader-createdBy_plain-text"]');
+
+    expect(link.exists()).toBe(showLink);
+    expect(plainText.exists()).toBe(showPlainText);
+    expect(showLink || showPlainText ? container.element.textContent : '').toContain(text);
+  });
+});

--- a/shell/components/fleet/FleetSummary.vue
+++ b/shell/components/fleet/FleetSummary.vue
@@ -73,8 +73,12 @@ export default {
       return this.value.metadata.name;
     },
 
+    repoNamespace() {
+      return this.value.metadata.namespace;
+    },
+
     bundleCounts() {
-      const resources = this.bundles.filter((item) => item.repoName === this.repoName);
+      const resources = this.bundles.filter((item) => item.namespace === this.repoNamespace && item.repoName === this.repoName);
 
       if (!resources.length) {
         return [];
@@ -89,7 +93,7 @@ export default {
           return;
         }
 
-        const k = status?.summary.ready > 0 && status?.summary.desiredReady === status.summary.ready;
+        const k = status?.summary?.ready > 0 && status?.summary.desiredReady === status?.summary?.ready;
 
         if (k) {
           out.ready.count += 1;

--- a/shell/components/fleet/__tests__/FleetSummary.test.ts
+++ b/shell/components/fleet/__tests__/FleetSummary.test.ts
@@ -14,12 +14,12 @@ const mockedBundlesInRepo = [{
   apiVersion: 'fleet.cattle.io/v1alpha1',
   kind:       'Bundle',
   repoName:   REPO_NAME,
+  namespace:  'fleet-default',
   metadata:   {
     labels: {
       'fleet.cattle.io/commit':    '3640888439d1b7b6a53dbeee291a533eea2632ab',
       'fleet.cattle.io/repo-name': REPO_NAME
     },
-
     name:      `${ REPO_NAME }-${ CLUSTER_NAME }-1234`,
     namespace: 'fleet-default',
     state:     {
@@ -54,12 +54,12 @@ const mockedBundlesInRepo = [{
   apiVersion: 'fleet.cattle.io/v1alpha1',
   kind:       'Bundle',
   repoName:   REPO_NAME,
+  namespace:  'fleet-default',
   metadata:   {
     labels: {
       'fleet.cattle.io/commit':    '3640888439d1b7b6a53dbeee291a533eea2632ab',
       'fleet.cattle.io/repo-name': REPO_NAME
     },
-
     name:      `${ REPO_NAME }-${ CLUSTER_NAME }-5678`,
     namespace: 'fleet-default',
     state:     {
@@ -95,14 +95,54 @@ const mockedBundlesOutOfRepo = [{
   apiVersion: 'fleet.cattle.io/v1alpha1',
   kind:       'Bundle',
   repoName:   REPO_NAME_VARIANT,
+  namespace:  'custom-namespace',
   metadata:   {
     labels: {
       'fleet.cattle.io/commit':    '3640888439d1b7b6a53dbeee291a533eea2632ab',
       'fleet.cattle.io/repo-name': REPO_NAME_VARIANT
     },
-
     name:      `${ REPO_NAME_VARIANT }-${ CLUSTER_NAME }-1234`,
-    namespace: 'fleet-default',
+    namespace: 'custom-namespace',
+    state:     {
+      error:         false,
+      message:       'Resource is Ready',
+      name:          'active',
+      transitioning: false
+    },
+  },
+  spec: {
+    correctDrift:        { },
+    forceSyncGeneration: 2,
+    ignore:              { },
+    namespace:           'custom-namespace-name',
+    resources:           [
+      {
+        content: 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: configmap-test\n  annotations:\n    {}\n#    key: string\n  labels:\n    {}\n#    key: string\ndata:\n  key1: val1\n  key2: val2\n  key3: val3',
+        name:    'test-configmap.yaml'
+      }
+    ],
+    targets: [
+      {
+        clusterName: 'nb-cluster0-28',
+        namespace:   'custom-namespace-name'
+      }
+    ]
+  }
+},
+{
+  id:         `fleet-default/${ REPO_NAME }-${ CLUSTER_NAME }-1234`,
+  type:       'fleet.cattle.io.bundle',
+  apiVersion: 'fleet.cattle.io/v1alpha1',
+  kind:       'Bundle',
+  repoName:   REPO_NAME,
+  namespace:  'custom-namespace',
+  metadata:   {
+    labels: {
+      'fleet.cattle.io/commit':    '3640888439d1b7b6a53dbeee291a533eea2632ab',
+      'fleet.cattle.io/repo-name': REPO_NAME
+    },
+    name:      `${ REPO_NAME }-${ CLUSTER_NAME }-1234`,
+    namespace: 'custom-namespace',
     state:     {
       error:         false,
       message:       'Resource is Ready',
@@ -135,14 +175,14 @@ const mockedBundlesOutOfRepo = [{
   apiVersion: 'fleet.cattle.io/v1alpha1',
   kind:       'Bundle',
   repoName:   REPO_NAME_VARIANT,
+  namespace:  'custom-namespace',
   metadata:   {
     labels: {
       'fleet.cattle.io/commit':    '3640888439d1b7b6a53dbeee291a533eea2632ab',
       'fleet.cattle.io/repo-name': REPO_NAME_VARIANT
     },
-
     name:      `${ REPO_NAME_VARIANT }-${ CLUSTER_NAME }-5678`,
-    namespace: 'fleet-default',
+    namespace: 'custom-namespace',
     state:     {
       error:         false,
       message:       'Resource is Ready',
@@ -176,7 +216,6 @@ const mockRepo = {
   apiVersion: 'fleet.cattle.io/v1alpha1',
   kind:       'GitRepo',
   metadata:   {
-
     name:      `${ REPO_NAME }`,
     namespace: 'fleet-default',
     state:     {

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -109,6 +109,7 @@ export const CATALOG = {
 };
 
 export const FLEET = {
+  REPO_NAME:            'fleet.cattle.io/repo-name',
   CLUSTER_DISPLAY_NAME: 'management.cattle.io/cluster-display-name',
   CLUSTER_NAME:         'management.cattle.io/cluster-name',
   BUNDLE_ID:            'fleet.cattle.io/bundle-id',
@@ -116,7 +117,9 @@ export const FLEET = {
   BUNDLE_NAMESPACE:     'fleet.cattle.io/bundle-namespace',
   MANAGED:              'fleet.cattle.io/managed',
   CLUSTER_NAMESPACE:    'fleet.cattle.io/cluster-namespace',
-  CLUSTER:              'fleet.cattle.io/cluster'
+  CLUSTER:              'fleet.cattle.io/cluster',
+  CREATED_BY_USER_ID:   'fleet.cattle.io/created-by-user-id',
+  CREATED_BY_USER_NAME: 'fleet.cattle.io/created-by-display-name',
 };
 
 export const RBAC = { PRODUCT: 'management.cattle.io/ui-product' };

--- a/shell/detail/fleet.cattle.io.bundle.vue
+++ b/shell/detail/fleet.cattle.io.bundle.vue
@@ -1,4 +1,5 @@
 <script>
+import { MANAGEMENT } from '@shell/config/types';
 import FleetBundleResources from '@shell/components/fleet/FleetBundleResources.vue';
 import FleetUtils from '@shell/utils/fleet';
 
@@ -10,6 +11,15 @@ export default {
     value: {
       type:     Object,
       required: true,
+    }
+  },
+
+  async fetch() {
+    if (this.value.authorId && this.$store.getters['management/schemaFor'](MANAGEMENT.USER)) {
+      this.$store.dispatch(`management/find`, {
+        type: MANAGEMENT.USER,
+        id:   this.value.authorId,
+      }, { root: true });
     }
   },
 

--- a/shell/detail/fleet.cattle.io.bundle.vue
+++ b/shell/detail/fleet.cattle.io.bundle.vue
@@ -16,10 +16,7 @@ export default {
 
   async fetch() {
     if (this.value.authorId && this.$store.getters['management/schemaFor'](MANAGEMENT.USER)) {
-      this.$store.dispatch(`management/find`, {
-        type: MANAGEMENT.USER,
-        id:   this.value.authorId,
-      }, { root: true });
+      await this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.USER }, { root: true });
     }
   },
 

--- a/shell/detail/fleet.cattle.io.gitrepo.vue
+++ b/shell/detail/fleet.cattle.io.gitrepo.vue
@@ -5,7 +5,7 @@ import FleetSummary from '@shell/components/fleet/FleetSummary';
 import { Banner } from '@components/Banner';
 import FleetResources from '@shell/components/fleet/FleetResources';
 import Tab from '@shell/components/Tabbed/Tab';
-import { FLEET } from '@shell/config/types';
+import { FLEET, MANAGEMENT } from '@shell/config/types';
 import { isHarvesterCluster } from '@shell/utils/cluster';
 import FleetBundles from '@shell/components/fleet/FleetBundles.vue';
 import { checkSchemasForFindAllHash } from '@shell/utils/auth';
@@ -90,6 +90,13 @@ export default {
         type:        FLEET.CLUSTER_GROUP
       }
     }, this.$store);
+
+    if (this.value.authorId && this.$store.getters['management/schemaFor'](MANAGEMENT.USER)) {
+      this.$store.dispatch(`management/find`, {
+        type: MANAGEMENT.USER,
+        id:   this.value.authorId,
+      }, { root: true });
+    }
 
     this.allBundles = allDispatches.allBundles || [];
     this.allFleetClusters = allDispatches.allFleetClusters || [];

--- a/shell/detail/fleet.cattle.io.gitrepo.vue
+++ b/shell/detail/fleet.cattle.io.gitrepo.vue
@@ -92,10 +92,7 @@ export default {
     }, this.$store);
 
     if (this.value.authorId && this.$store.getters['management/schemaFor'](MANAGEMENT.USER)) {
-      this.$store.dispatch(`management/find`, {
-        type: MANAGEMENT.USER,
-        id:   this.value.authorId,
-      }, { root: true });
+      await this.$store.dispatch(`management/findAll`, { type: MANAGEMENT.USER }, { root: true });
     }
 
     this.allBundles = allDispatches.allBundles || [];

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -570,12 +570,12 @@ export default {
       });
     },
 
-    updateBeforeSave(value) {
-      value.spec['correctDrift'] = { enabled: this.correctDriftEnabled };
+    updateBeforeSave() {
+      this.value.spec['correctDrift'] = { enabled: this.correctDriftEnabled };
 
-      if (this.realMode === _CREATE) {
-        value.metadata.labels[FLEET_LABELS.CREATED_BY_USER_ID] = value.currentUser.id;
-        value.metadata.labels[FLEET_LABELS.CREATED_BY_USER_NAME] = value.currentUser.username;
+      if (this.mode === _CREATE) {
+        this.value.metadata.labels[FLEET_LABELS.CREATED_BY_USER_ID] = this.value.currentUser.id;
+        this.value.metadata.labels[FLEET_LABELS.CREATED_BY_USER_NAME] = this.value.currentUser.username;
       }
     },
   }

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -569,10 +569,19 @@ export default {
       });
     },
 
-    onSave() {
+    async saveOverride(btnCb) {
       this.value.spec['correctDrift'] = { enabled: this.correctDriftEnabled };
 
-      this.save();
+      try {
+        await this.value.save(this.mode);
+
+        btnCb(true);
+
+        this.$router.replace(this.value.listLocation);
+      } catch (err) {
+        this.errors = exceptionToErrorsArray(err);
+        btnCb(false);
+      }
     }
   }
 };
@@ -594,7 +603,7 @@ export default {
     class="wizard"
     @cancel="done"
     @error="e=>errors = e"
-    @finish="onSave"
+    @finish="saveOverride"
   >
     <template #noticeBanner>
       <Banner

--- a/shell/models/fleet.cattle.io.bundle.js
+++ b/shell/models/fleet.cattle.io.bundle.js
@@ -3,6 +3,7 @@ import SteveModel from '@shell/plugins/steve/steve-class';
 import typeHelper from '@shell/utils/type-helpers';
 import { addObject, addObjects, findBy } from '@shell/utils/array';
 import { FLEET, MANAGEMENT } from '@shell/config/types';
+import { FLEET as FLEET_ANNOTATIONS } from '@shell/config/labels-annotations';
 import { convertSelectorObj, matching } from '@shell/utils/selector';
 
 export default class FleetBundle extends SteveModel {
@@ -21,7 +22,7 @@ export default class FleetBundle extends SteveModel {
   get repoName() {
     const labels = this.metadata?.labels || {};
 
-    return labels['fleet.cattle.io/repo-name'];
+    return labels[FLEET_ANNOTATIONS.REPO_NAME];
   }
 
   get targetClusters() {
@@ -129,7 +130,7 @@ export default class FleetBundle extends SteveModel {
   }
 
   get authorId() {
-    return this.metadata.labels['fleet.cattle.io/created-by-user-id'];
+    return this.metadata.labels[FLEET_ANNOTATIONS.CREATED_BY_USER_ID];
   }
 
   get author() {
@@ -141,7 +142,7 @@ export default class FleetBundle extends SteveModel {
   }
 
   get createdBy() {
-    const displayName = this.metadata.labels['fleet.cattle.io/created-by-display-name'];
+    const displayName = this.metadata.labels[FLEET_ANNOTATIONS.CREATED_BY_USER_NAME];
 
     if (!displayName) {
       return null;

--- a/shell/models/fleet.cattle.io.bundle.js
+++ b/shell/models/fleet.cattle.io.bundle.js
@@ -142,7 +142,7 @@ export default class FleetBundle extends SteveModel {
   }
 
   get createdBy() {
-    const displayName = this.metadata.labels[FLEET_ANNOTATIONS.CREATED_BY_USER_NAME];
+    const displayName = this.metadata?.labels?.[FLEET_ANNOTATIONS.CREATED_BY_USER_NAME];
 
     if (!displayName) {
       return null;

--- a/shell/models/fleet.cattle.io.bundle.js
+++ b/shell/models/fleet.cattle.io.bundle.js
@@ -153,7 +153,7 @@ export default class FleetBundle extends SteveModel {
       location: !this.author ? null : {
         name:   'c-cluster-product-resource-id',
         params: {
-          cluster:  'local',
+          cluster:  '_',
           product:  'auth',
           resource: MANAGEMENT.USER,
           id:       this.author.id,

--- a/shell/models/fleet.cattle.io.bundle.js
+++ b/shell/models/fleet.cattle.io.bundle.js
@@ -130,7 +130,7 @@ export default class FleetBundle extends SteveModel {
   }
 
   get authorId() {
-    return this.metadata.labels[FLEET_ANNOTATIONS.CREATED_BY_USER_ID];
+    return this.metadata?.labels?.[FLEET_ANNOTATIONS.CREATED_BY_USER_ID];
   }
 
   get author() {

--- a/shell/models/fleet.cattle.io.bundle.js
+++ b/shell/models/fleet.cattle.io.bundle.js
@@ -2,7 +2,7 @@ import { escapeHtml, ucFirst } from '@shell/utils/string';
 import SteveModel from '@shell/plugins/steve/steve-class';
 import typeHelper from '@shell/utils/type-helpers';
 import { addObject, addObjects, findBy } from '@shell/utils/array';
-import { FLEET } from '@shell/config/types';
+import { FLEET, MANAGEMENT } from '@shell/config/types';
 import { convertSelectorObj, matching } from '@shell/utils/selector';
 
 export default class FleetBundle extends SteveModel {
@@ -126,5 +126,42 @@ export default class FleetBundle extends SteveModel {
         'resourceTable.groupLabel.notInAWorkspace'
       );
     }
+  }
+
+  get authorId() {
+    return this.metadata.labels['fleet.cattle.io/created-by-user-id'];
+  }
+
+  get author() {
+    if (this.authorId) {
+      return this.$rootGetters['management/byId'](MANAGEMENT.USER, this.authorId);
+    }
+
+    return null;
+  }
+
+  get createdBy() {
+    const displayName = this.metadata.labels['fleet.cattle.io/created-by-display-name'];
+
+    if (!displayName) {
+      return null;
+    }
+
+    return {
+      displayName,
+      location: !this.author ? null : {
+        name:   'c-cluster-product-resource-id',
+        params: {
+          cluster:  'local',
+          product:  'auth',
+          resource: MANAGEMENT.USER,
+          id:       this.author.id,
+        }
+      }
+    };
+  }
+
+  get showCreatedBy() {
+    return !!this.createdBy;
   }
 }

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -136,8 +136,13 @@ export default class GitRepo extends SteveModel {
   }
 
   goToClone() {
-    delete this.metadata.labels[FLEET_ANNOTATIONS.CREATED_BY_USER_ID];
-    delete this.metadata.labels[FLEET_ANNOTATIONS.CREATED_BY_USER_NAME];
+    if (this.metadata?.labels?.[FLEET_ANNOTATIONS.CREATED_BY_USER_ID]) {
+      delete this.metadata.labels[FLEET_ANNOTATIONS.CREATED_BY_USER_ID];
+    }
+
+    if (this.metadata?.labels?.[FLEET_ANNOTATIONS.CREATED_BY_USER_NAME]) {
+      delete this.metadata.labels[FLEET_ANNOTATIONS.CREATED_BY_USER_NAME];
+    }
 
     super.goToClone();
   }
@@ -492,7 +497,7 @@ export default class GitRepo extends SteveModel {
   }
 
   get authorId() {
-    return this.metadata.labels[FLEET_ANNOTATIONS.CREATED_BY_USER_ID];
+    return this.metadata?.labels?.[FLEET_ANNOTATIONS.CREATED_BY_USER_ID];
   }
 
   get author() {

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -352,11 +352,11 @@ export default class GitRepo extends SteveModel {
   }
 
   get bundles() {
-    return this.$getters['matching'](FLEET.BUNDLE, { 'fleet.cattle.io/repo-name': this.name }, this.namespace);
+    return this.$getters['matching'](FLEET.BUNDLE, { [FLEET_ANNOTATIONS.REPO_NAME]: this.name }, this.namespace);
   }
 
   get bundleDeployments() {
-    return this.$getters['matching'](FLEET.BUNDLE_DEPLOYMENT, { 'fleet.cattle.io/repo-name': this.name });
+    return this.$getters['matching'](FLEET.BUNDLE_DEPLOYMENT, { [FLEET_ANNOTATIONS.REPO_NAME]: this.name });
   }
 
   get allBundlesStatuses() {
@@ -481,7 +481,7 @@ export default class GitRepo extends SteveModel {
   }
 
   get authorId() {
-    return this.metadata.labels['fleet.cattle.io/created-by-user-id'];
+    return this.metadata.labels[FLEET_ANNOTATIONS.CREATED_BY_USER_ID];
   }
 
   get author() {
@@ -493,7 +493,7 @@ export default class GitRepo extends SteveModel {
   }
 
   get createdBy() {
-    const displayName = this.metadata.labels['fleet.cattle.io/created-by-display-name'];
+    const displayName = this.metadata.labels[FLEET_ANNOTATIONS.CREATED_BY_USER_NAME];
 
     if (!displayName) {
       return null;

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -1,4 +1,3 @@
-import { _CREATE } from '@shell/config/query-params';
 import { convert, matching, convertSelectorObj } from '@shell/utils/selector';
 import jsyaml from 'js-yaml';
 import isEmpty from 'lodash/isEmpty';
@@ -45,15 +44,6 @@ function normalizeStateCounts(data) {
 export default class GitRepo extends SteveModel {
   get currentUser() {
     return this.$rootGetters['auth/v3User'] || {};
-  }
-
-  async save(mode) {
-    if (mode === _CREATE) {
-      this.metadata.labels[FLEET_ANNOTATIONS.CREATED_BY_USER_ID] = this.currentUser.id;
-      this.metadata.labels[FLEET_ANNOTATIONS.CREATED_BY_USER_NAME] = this.currentUser.username;
-    }
-
-    await super.save();
   }
 
   applyDefaults() {
@@ -514,7 +504,7 @@ export default class GitRepo extends SteveModel {
   }
 
   get createdBy() {
-    const displayName = this.metadata.labels[FLEET_ANNOTATIONS.CREATED_BY_USER_NAME];
+    const displayName = this.metadata?.labels?.[FLEET_ANNOTATIONS.CREATED_BY_USER_NAME];
 
     if (!displayName) {
       return null;

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -377,7 +377,12 @@ export default class GitRepo extends SteveModel {
 
   get allBundlesStatuses() {
     return this.bundles.reduce((acc, bundle) => {
+      if (isEmpty(bundle.status?.summary)) {
+        return acc;
+      }
+
       const { nonReadyResources, ...summary } = bundle.status?.summary;
+
       const bdCounts = normalizeStateCounts(summary);
       const state = primaryDisplayStatusFromCount(bdCounts.states);
 
@@ -520,7 +525,7 @@ export default class GitRepo extends SteveModel {
       location: !this.author ? null : {
         name:   'c-cluster-product-resource-id',
         params: {
-          cluster:  'local',
+          cluster:  '_',
           product:  'auth',
           resource: MANAGEMENT.USER,
           id:       this.author.id,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13189
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

![image](https://github.com/user-attachments/assets/7ed75cfd-6b64-4ca5-bef7-2421976eee26)


Adding `createdBy` labels to save the author of Fleet GitRepos @edenhernandez-suse 

```
fleet.cattle.io/created-by-user-id
fleet.cattle.io/created-by-display-name
```
- The UI assigns the labels on GitRepo creation.
- The users cannot change or delete the labels.
- The 'clone' action automatically removes the labels inherited from source GitRepo.
- The new  'Created By' label is visible in the Resource header of the GitRepo and Bundle details pages.
- 'Created By' contains the name of the user that created the Repo with the link to the user's details, if logged user has permissions, otherwise just a plain text.
- In case of missing labels (previous versions), the label is simply hidden.

cc @manno 
- It's still possible to manually edit the YAML files and remove or change the new labels. IMO Fleet should protect the labels and discard edit/delete actions.
- Fleet should probably drop those labels when creating new Bundles and BundleDeployments and keep the labels only when those resources come from a GitRepo creation (?)
- BundleDeployments inherit the labels but we don't show them anywhere because the details page doesn't exist: TBD if we want to implement view/edit pages for BundleDeployments.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
