### PR TITLE
GKE - disable the 'max pods per node' field when editing node pools

### DIFF
--- a/pkg/gke/components/GKENodePool.vue
+++ b/pkg/gke/components/GKENodePool.vue
@@ -322,6 +322,7 @@ export default defineComponent({
           :value="maxPodsConstraint"
           label-key="gke.maxPodsConstraint.label"
           :disabled="!isNew"
+          data-testid="gke-max-pod-constraint-input"
           @update:value="$emit('update:maxPodsConstraint', $event)"
         />
       </div>

--- a/pkg/gke/components/GKENodePool.vue
+++ b/pkg/gke/components/GKENodePool.vue
@@ -321,6 +321,7 @@ export default defineComponent({
           :mode="mode"
           :value="maxPodsConstraint"
           label-key="gke.maxPodsConstraint.label"
+          :disabled="!isNew"
           @update:value="$emit('update:maxPodsConstraint', $event)"
         />
       </div>

--- a/pkg/gke/components/__tests__/GKENodePool.test.ts
+++ b/pkg/gke/components/__tests__/GKENodePool.test.ts
@@ -160,4 +160,27 @@ describe('gke node pool', () => {
       NO_SCHEDULE: 'NoSchedule', PREFER_NO_SCHEDULE: 'PreferNoSchedule', NO_EXECUTE: 'NoExecute'
     });
   });
+
+  it('should disable the pod constraint input when editing existing pools', async() => {
+    const setup = requiredSetup();
+    const wrapper = shallowMount(GKENodePool, {
+      propsData: { isNew: false },
+      ...setup
+    });
+
+    let maxPodInput = wrapper.findComponent('[data-testid="gke-max-pod-constraint-input"]');
+
+    expect(maxPodInput.exists()).toBe(true);
+
+    expect(maxPodInput.props().disabled).toBe(true);
+
+    wrapper.setProps({ isNew: true });
+    await wrapper.vm.$nextTick();
+
+    maxPodInput = wrapper.findComponent('[data-testid="gke-max-pod-constraint-input"]');
+
+    expect(maxPodInput.exists()).toBe(true);
+
+    expect(maxPodInput.props().disabled).toBe(false);
+  });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12508 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
1. Create a new GKE cluster - max pods per node should be editable
2. Once the cluster has provisioned, edit it - max pods should be uneditable
3. Add a new node pool to an existing cluster - the new pool's max pods should be editable

### Areas which could experience regressions
none


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
