### PR TITLE
 [2.10.3] GKE - disable the 'max pods per node' field when editing node pools

### DIFF
--- a/pkg/gke/components/GKENodePool.vue
+++ b/pkg/gke/components/GKENodePool.vue
@@ -322,6 +322,7 @@ export default defineComponent({
           :value="maxPodsConstraint"
           label-key="gke.maxPodsConstraint.label"
           :disabled="!isNew"
+          data-testid="gke-max-pod-constraint-input"
           @update:value="$emit('update:maxPodsConstraint', $event)"
         />
       </div>

--- a/pkg/gke/components/GKENodePool.vue
+++ b/pkg/gke/components/GKENodePool.vue
@@ -321,6 +321,7 @@ export default defineComponent({
           :mode="mode"
           :value="maxPodsConstraint"
           label-key="gke.maxPodsConstraint.label"
+          :disabled="!isNew"
           @update:value="$emit('update:maxPodsConstraint', $event)"
         />
       </div>

--- a/pkg/gke/components/__tests__/GKENodePool.test.ts
+++ b/pkg/gke/components/__tests__/GKENodePool.test.ts
@@ -160,4 +160,27 @@ describe('gke node pool', () => {
       NO_SCHEDULE: 'NoSchedule', PREFER_NO_SCHEDULE: 'PreferNoSchedule', NO_EXECUTE: 'NoExecute'
     });
   });
+
+  it('should disable the pod constraint input when editing existing pools', async() => {
+    const setup = requiredSetup();
+    const wrapper = shallowMount(GKENodePool, {
+      propsData: { isNew: false },
+      ...setup
+    });
+
+    let maxPodInput = wrapper.findComponent('[data-testid="gke-max-pod-constraint-input"]');
+
+    expect(maxPodInput.exists()).toBe(true);
+
+    expect(maxPodInput.props().disabled).toBe(true);
+
+    wrapper.setProps({ isNew: true });
+    await wrapper.vm.$nextTick();
+
+    maxPodInput = wrapper.findComponent('[data-testid="gke-max-pod-constraint-input"]');
+
+    expect(maxPodInput.exists()).toBe(true);
+
+    expect(maxPodInput.props().disabled).toBe(false);
+  });
 });


### PR DESCRIPTION

Fixes #12674 

Backport of https://github.com/rancher/dashboard/pull/13310