### PR TITLE
[2.9.7] GKE - disable the 'max pods per node' field when editing node pools

### DIFF
--- a/pkg/gke/components/GKENodePool.vue
+++ b/pkg/gke/components/GKENodePool.vue
@@ -320,6 +320,7 @@ export default defineComponent({
           :value="maxPodsConstraint"
           label-key="gke.maxPodsConstraint.label"
           :disabled="!isNew"
+          data-testid="gke-max-pod-constraint-input"
           @input="$emit('update:maxPodsConstraint', $event)"
         />
       </div>

--- a/pkg/gke/components/GKENodePool.vue
+++ b/pkg/gke/components/GKENodePool.vue
@@ -319,6 +319,7 @@ export default defineComponent({
           :mode="mode"
           :value="maxPodsConstraint"
           label-key="gke.maxPodsConstraint.label"
+          :disabled="!isNew"
           @input="$emit('update:maxPodsConstraint', $event)"
         />
       </div>

--- a/pkg/gke/components/__tests__/GKENodePool.test.ts
+++ b/pkg/gke/components/__tests__/GKENodePool.test.ts
@@ -158,4 +158,27 @@ describe('gke node pool', () => {
       NO_SCHEDULE: 'NoSchedule', PREFER_NO_SCHEDULE: 'PreferNoSchedule', NO_EXECUTE: 'NoExecute'
     });
   });
+
+  it('should disable the pod constraint input when editing existing pools', async() => {
+    const setup = requiredSetup();
+    const wrapper = shallowMount(GKENodePool, {
+      propsData: { isNew: false },
+      ...setup
+    });
+
+    let maxPodInput = wrapper.findComponent('[data-testid="gke-max-pod-constraint-input"]');
+
+    expect(maxPodInput.exists()).toBe(true);
+
+    expect(maxPodInput.props().disabled).toBe(true);
+
+    wrapper.setProps({ isNew: true });
+    await wrapper.vm.$nextTick();
+
+    maxPodInput = wrapper.findComponent('[data-testid="gke-max-pod-constraint-input"]');
+
+    expect(maxPodInput.exists()).toBe(true);
+
+    expect(maxPodInput.props().disabled).toBe(false);
+  });
 });

--- a/pkg/gke/components/__tests__/GKENodePool.test.ts
+++ b/pkg/gke/components/__tests__/GKENodePool.test.ts
@@ -166,7 +166,7 @@ describe('gke node pool', () => {
       ...setup
     });
 
-    let maxPodInput = wrapper.findComponent('[data-testid="gke-max-pod-constraint-input"]');
+    let maxPodInput = wrapper.find('[data-testid="gke-max-pod-constraint-input"]');
 
     expect(maxPodInput.exists()).toBe(true);
 
@@ -175,7 +175,7 @@ describe('gke node pool', () => {
     wrapper.setProps({ isNew: true });
     await wrapper.vm.$nextTick();
 
-    maxPodInput = wrapper.findComponent('[data-testid="gke-max-pod-constraint-input"]');
+    maxPodInput = wrapper.find('[data-testid="gke-max-pod-constraint-input"]');
 
     expect(maxPodInput.exists()).toBe(true);
 


### PR DESCRIPTION
Fixes #12721 

Backport of https://github.com/rancher/dashboard/pull/13310/