### PR TITLE
Removing extension router logic that's no longer necessary with the bump of vue-router

### DIFF
--- a/shell/config/router/routes.js
+++ b/shell/config/router/routes.js
@@ -23,6 +23,7 @@ const interopDefault = (promise) => promise.then((page) => page.default || page)
  */
 export default [
   {
+    name:      'root',
     path:      '/',
     component: () => interopDefault(import('@shell/pages/index.vue')),
     meta:      { requiresAuthentication: true },

--- a/shell/core/plugin-routes.ts
+++ b/shell/core/plugin-routes.ts
@@ -22,123 +22,13 @@ export class PluginRoutes {
     });
   }
 
-  public addRoutes(plugin: any, newRouteInfos: RouteInfo[]) {
-    const allRoutes = [
-      ...(this.router.options.routes || [])
-    ];
-
-    // Need to take into account if routes are being replaced
-    // Despite what the docs say, routes are not replaced, so we use a workaround
-    // Remove all routes that are being replaced
-    const newRoutes = newRouteInfos.map((ri) => ri.route);
-
-    this.forEachNestedRoutes(newRoutes, (route: RouteRecordRaw) => {
-      // Patch colliding legacy routes that start /:product
-      if (route.path?.startsWith('/:product')) {
-        // Legacy pattern used by extensions - routes may collide, so modify them not to
-        let productName;
-
-        // If the route has a name (which is always the case for the extensions we have written), use it to get the product name
-        if (route.name && typeof route.name === 'string') {
-          const nameParts = route.name.split('-');
-
-          // First part of the route name is the product name
-          productName = nameParts[0];
-        }
-
-        // Use the plugin name as the product, if the route does not have a name
-        productName = productName || plugin.name;
-
-        // Replace the path - removing :product and using the actual product name instead - this avoids route collisions
-        route.path = `/${ productName }${ route.path.substr(9) }`;
-        route.meta = route.meta || {};
-
-        route.meta.product = route.meta.product || productName;
-      }
-    });
-
-    this.updateMatcher(newRouteInfos, allRoutes);
-  }
-
-  private updateMatcher(newRoutes: RouteInfo[], allRoutes: RouteRecordRaw[]) {
-    // Note - Always use a new router and replace the existing router's matching
-    // Using the existing router and adding routes to it will force nuxt middleware to
-    // execute many times (nuxt middleware boils down to route.beforeEach). This issue was seen refreshing in a harvester cluster with a
-    // dynamically loaded cluster
-
-    if (newRoutes.length === 0) {
-      return;
-    }
-
-    const orderedPluginRoutes: RouteRecordRaw[] = [];
-
-    // separate plugin routes that have parent and not, you want to push the new routes in REVERSE order to the front of the existing list so that the order of routes specified by the extension is preserved
-    newRoutes.reverse().forEach((routeInfo: RouteInfo) => {
-      let foundParentRoute;
-
+  public addRoutes(newRouteInfos: RouteInfo[]) {
+    newRouteInfos.forEach((routeInfo) => {
       if (routeInfo.parent) {
-        foundParentRoute = this.findInNestedRoutes(allRoutes, (route: RouteRecordRaw) => route.name === routeInfo.parent);
-
-        if (foundParentRoute) {
-          foundParentRoute.children = foundParentRoute?.children || [];
-          foundParentRoute.children.unshift(routeInfo.route);
-        }
-      }
-
-      if (!foundParentRoute) {
-        orderedPluginRoutes.unshift(routeInfo.route);
+        this.router.addRoute(routeInfo.parent, routeInfo.route);
+      } else {
+        this.router.addRoute(routeInfo.route);
       }
     });
-
-    this.router.clearRoutes();
-
-    const allRoutesToAdd = [...orderedPluginRoutes, ...allRoutes];
-
-    allRoutesToAdd.forEach((route) => this.router.addRoute(route));
-  }
-
-  /**
-   * Traverse the entire tree of nested routes
-   *
-   * @param routes The routes we wish to traverse through
-   * @param fn -> Return true if you'd like to break the loop early (small)
-   * @returns {@boolean} -> Returns true if breaking early
-   */
-  private forEachNestedRoutes(
-    routes: RouteRecordRaw[] = [],
-    fn: (route: RouteRecordRaw) => boolean | undefined | void
-  ) {
-    for (let i = 0; i < routes.length; ++i) {
-      const route = routes[i];
-      const result = fn(route);
-
-      if (result || this.forEachNestedRoutes(route.children, fn)) {
-        return true;
-      }
-    }
-  }
-
-  /**
-   * Find a route that matches the criteria defined by fn.
-   *
-   * @param routes The routes we wish to search through
-   * @param fn -> Returns true if the passed in route matches the expected criteria
-   * @returns The found route or undefined
-   */
-  private findInNestedRoutes(
-    routes: RouteRecordRaw[] = [],
-    fn: (route: RouteRecordRaw) => boolean
-  ): RouteRecordRaw | undefined {
-    let found: RouteRecordRaw | undefined;
-
-    this.forEachNestedRoutes(routes, (route) => {
-      if (fn(route)) {
-        found = route;
-
-        return true;
-      }
-    });
-
-    return found;
   }
 }

--- a/shell/core/plugins.js
+++ b/shell/core/plugins.js
@@ -344,7 +344,7 @@ export default function(context, inject, vueApp) {
         });
 
         // Routes
-        pluginRoutes.addRoutes(plugin, plugin.routes);
+        pluginRoutes.addRoutes(plugin.routes);
 
         // Validators
         Object.keys(plugin.validators).forEach((key) => {


### PR DESCRIPTION
### Summary
Removing extension router logic that's no longer necessary with the bump of vue-router

Fixes #11876
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
There shouldn't be any logical changes.

### Technical notes summary
It's now possible to use the vue-router addRoute instead of replacing the matcher to add/override routes. This simplifies the routing logic that happens extensions add routes.

### Areas or cases that should be tested
Global extensions, cluster extensions and Harvester

### Areas which could experience regressions
Global extensions, cluster extensions and Harvester



https://github.com/user-attachments/assets/e8e3dd56-dda3-4038-8945-66aaefaf8b3c


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
