### PR TITLE
Fix issue loading cluster provisioning ui from extensions on edit; fix provisioning cluster table grouping label

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -268,8 +268,6 @@ export default {
             return this.selectedSubType.emberLink;
           }
 
-          // this.selectType(this.subType, false);
-
           return '';
         }
 
@@ -385,24 +383,23 @@ export default {
 
           addType(this.$plugin, 'custom', 'custom2', false);
         }
-      }
 
-      // TODO nb should this be outside the above else block??
-      // Add from extensions
-      this.extensions.forEach((ext) => {
+        // Add from extensions
+        this.extensions.forEach((ext) => {
         // if the rke toggle is set to rke1, don't add extensions that specify rke2 group
         // default group is rke2
-        if (!this.isRke2 && (ext.group === _RKE2 || !ext.group)) {
-          return;
-        }
-        // Do not show the extension provisioner on the import cluster page unless its explicitly set to do so
-        if (isImport && !ext.showImport) {
-          return;
-        }
-        // Allow extensions to overwrite provisioners with the same id
-        out = out.filter((type) => type.id !== ext.id);
-        addExtensionType(ext, getters);
-      });
+          if (!this.isRke2 && (ext.group === _RKE2 || !ext.group)) {
+            return;
+          }
+          // Do not show the extension provisioner on the import cluster page unless its explicitly set to do so
+          if (isImport && !ext.showImport) {
+            return;
+          }
+          // Allow extensions to overwrite provisioners with the same id
+          out = out.filter((type) => type.id !== ext.id);
+          addExtensionType(ext, getters);
+        });
+      }
 
       return out;
 

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -170,17 +170,6 @@ export default {
     }
   },
 
-  methods: {
-    groupDetails(clusterId) {
-    // find capi cluster?
-      const cluster = this.$store.getters['management/byId'](CAPI.RANCHER_CLUSTER, clusterId);
-
-      console.log('*** cluster from id', cluster);
-
-      return cluster ? { to: cluster.detailLocation, label: cluster.nameDisplay } : {};
-    }
-  },
-
   $loadingResources() {
     // results are filtered so we wouldn't get the correct count on indicator...
     return { loadIndeterminate: true };
@@ -241,15 +230,6 @@ export default {
       :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
       :sub-rows="true"
     >
-      <template #group-by="{group}">
-        <div class="group-bar">
-          <div class="group-tab">
-            <span v-if="group.key"> Host Cluster: <router-link :to="groupDetails(group.key).to">{{ groupDetails(group.key).label }}</router-link> </span>
-            <span v-else>Hosts</span>
-          </div>
-        </div>
-      </template>
-
       <!-- Why are state column and subrow overwritten here? -->
       <!-- for rke1 clusters, where they try to use the mgmt cluster stateObj instead of prov cluster stateObj,  -->
       <!-- updates were getting lost. This isn't performant as normal columns, but the list shouldn't grow -->

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -170,10 +170,22 @@ export default {
     }
   },
 
+  methods: {
+    groupDetails(clusterId) {
+    // find capi cluster?
+      const cluster = this.$store.getters['management/byId'](CAPI.RANCHER_CLUSTER, clusterId);
+
+      console.log('*** cluster from id', cluster);
+
+      return cluster ? { to: cluster.detailLocation, label: cluster.nameDisplay } : {};
+    }
+  },
+
   $loadingResources() {
     // results are filtered so we wouldn't get the correct count on indicator...
     return { loadIndeterminate: true };
-  }
+  },
+
 };
 </script>
 
@@ -229,6 +241,15 @@ export default {
       :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
       :sub-rows="true"
     >
+      <template #group-by="{group}">
+        <div class="group-bar">
+          <div class="group-tab">
+            <span v-if="group.key"> Host Cluster: <router-link :to="groupDetails(group.key).to">{{ groupDetails(group.key).label }}</router-link> </span>
+            <span v-else>Hosts</span>
+          </div>
+        </div>
+      </template>
+
       <!-- Why are state column and subrow overwritten here? -->
       <!-- for rke1 clusters, where they try to use the mgmt cluster stateObj instead of prov cluster stateObj,  -->
       <!-- updates were getting lost. This isn't performant as normal columns, but the list shouldn't grow -->

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -173,7 +173,7 @@ export default {
   $loadingResources() {
     // results are filtered so we wouldn't get the correct count on indicator...
     return { loadIndeterminate: true };
-  },
+  }
 
 };
 </script>

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -988,17 +988,7 @@ export default class ProvCluster extends SteveModel {
 
   get groupByParent() {
     // Customer helper can report if the cluster has a parent cluster
-    return this.customProvisionerHelper?.parentCluster?.(this);
-  }
-
-  get groupByLabel() {
-    const name = this.groupByParent;
-
-    if (name) {
-      return this.$rootGetters['i18n/t']('resourceTable.groupLabel.cluster', { name: escapeHtml(name) });
-    } else {
-      return this.$rootGetters['i18n/t']('resourceTable.groupLabel.notInACluster');
-    }
+    return this.customProvisionerHelper?.parentCluster?.(this) || this.t('resourceTable.groupLabel.NotInACluster');
   }
 
   get hasError() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Needed for #13106

### Occurred changes and/or fixed issues
This PR tweaks some logic in the provisioning cluster edit page to prioritize loading custom UI from extensions when a cluster has an annotation indicated that it was created by a particular UI component. 

This PR also removes the `groupByLabel` property from provisioning clusters and tweaks the groupByParent property so that it may be used to label groups. `groupByLabel` is a generic property used when grouping by namespace - overwriting it here caused the cluster list to show 'not in a cluster' instead of 'not in a namespace' when namespace grouping was enabled.

### Technical notes summary


### Areas or cases that should be tested
Create/edit the following cluster types and ensure the right ui still loads:
1. imported k3s or rke2 clusters
2. imported non-k3s/rke2 clusters
3. import aks/eks/gke - these should load an ember page when initially importing, then vue page on edit
4. rancher-provisioned aks/eks/gke
5. rancher-provisioned k3s/rke2
6. rancher-provisioned rke1 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
