### PR TITLE
RcDropdown: Only focus first element with keyboard input

### DIFF
--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdown.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdown.vue
@@ -35,6 +35,7 @@ const {
   setFocus,
   provideDropdownContext,
   registerDropdownCollection,
+  handleKeydown,
 } = useDropdownContext();
 
 provideDropdownContext();
@@ -68,10 +69,14 @@ const applyShow = () => {
     <template #popper>
       <div
         ref="dropdownTarget"
+        class="dropdownTarget"
+        tabindex="-1"
         role="menu"
         aria-orientation="vertical"
         dropdown-menu-collection
         :aria-label="ariaLabel || 'Dropdown Menu'"
+        @keydown="handleKeydown"
+        @keydown.down="setFocus()"
       >
         <slot name="dropdownCollection">
           <!--Empty slot content-->
@@ -106,6 +111,12 @@ const applyShow = () => {
           padding: 10px 0 10px 0;
         }
       }
+    }
+  }
+
+  .dropdownTarget {
+    &:focus-visible, &:focus {
+      outline: none;
     }
   }
 </style>

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownTrigger.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownTrigger.vue
@@ -9,7 +9,6 @@ import { DropdownContext, defaultContext } from './types';
 const {
   showMenu,
   registerTrigger,
-  focusFirstElement,
   isMenuOpen,
   handleKeydown,
 } = inject<DropdownContext>('dropdownContext') || defaultContext;
@@ -34,8 +33,6 @@ defineExpose({ focus });
     aria-haspopup="menu"
     :aria-expanded="isMenuOpen"
     @keydown.enter.space="handleKeydown"
-    @keydown.down="focusFirstElement"
-    @keydown.escape="showMenu(false)"
     @click="showMenu(true)"
   >
     <slot name="default">

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownTrigger.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownTrigger.vue
@@ -11,6 +11,7 @@ const {
   registerTrigger,
   focusFirstElement,
   isMenuOpen,
+  handleKeydown,
 } = inject<DropdownContext>('dropdownContext') || defaultContext;
 
 const dropdownTrigger = useTemplateRef<RcButtonType>('dropdownTrigger');
@@ -32,6 +33,7 @@ defineExpose({ focus });
     role="button"
     aria-haspopup="menu"
     :aria-expanded="isMenuOpen"
+    @keydown.enter.space="handleKeydown"
     @keydown.down="focusFirstElement"
     @keydown.escape="showMenu(false)"
     @click="showMenu(true)"

--- a/pkg/rancher-components/src/components/RcDropdown/useDropdownCollection.ts
+++ b/pkg/rancher-components/src/components/RcDropdown/useDropdownCollection.ts
@@ -40,6 +40,7 @@ export const useDropdownCollection = () => {
   return {
     dropdownItems,
     firstDropdownItem,
+    dropdownContainer,
     registerDropdownCollection,
   };
 };

--- a/pkg/rancher-components/src/components/RcDropdown/useDropdownContext.ts
+++ b/pkg/rancher-components/src/components/RcDropdown/useDropdownContext.ts
@@ -12,7 +12,12 @@ import { RcButtonType } from '@components/RcButton';
  * interactions and setting focus.
  */
 export const useDropdownContext = () => {
-  const { dropdownItems, firstDropdownItem, registerDropdownCollection } = useDropdownCollection();
+  const {
+    dropdownItems,
+    firstDropdownItem,
+    dropdownContainer,
+    registerDropdownCollection,
+  } = useDropdownCollection();
 
   const isMenuOpen = ref(false);
 
@@ -21,6 +26,9 @@ export const useDropdownContext = () => {
    * @param show - Whether to show or hide the dropdown menu.
    */
   const showMenu = (show: boolean) => {
+    if (!show) {
+      didKeydown.value = false;
+    }
     isMenuOpen.value = show;
   };
 
@@ -47,11 +55,28 @@ export const useDropdownContext = () => {
   };
 
   /**
+     * Tracks if a keydown event has occurred. Important for distinguishing keyboard
+     * events from mouse events.
+     */
+  const didKeydown = ref(false);
+
+  const handleKeydown = () => {
+    didKeydown.value = true;
+  };
+
+  /**
    * Sets focus to the first dropdown item if a keydown event has occurred.
    */
   const setFocus = () => {
     nextTick(() => {
+      if (!didKeydown.value) {
+        dropdownContainer.value?.focus();
+
+        return;
+      }
+
       firstDropdownItem.value?.focus();
+      didKeydown.value = false;
     });
   };
 
@@ -69,6 +94,7 @@ export const useDropdownContext = () => {
       focusFirstElement: () => {
         setFocus();
       },
+      handleKeydown,
     });
   };
 
@@ -79,5 +105,6 @@ export const useDropdownContext = () => {
     setFocus,
     provideDropdownContext,
     registerDropdownCollection,
+    handleKeydown,
   };
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This ensures that the first item in a dropdown menu only receives focus if the menu is triggered via keyboard interaction. 

Fixes #13358
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Prevents focus of the first dropdown menu item when triggering the dropdown with a mouse

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

When the dropdown is triggered with the mouse, the focus is sent to the dropdown container. This allows for:

- enabling keyboard interactions to properly set the focus after the dropdown has been triggered via the mouse
- tab behavior of closing the menu and navigating the next tabbable element to remain consistent with keyboard navigation

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Page actions menu
- User Menu

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Page actions menu
- User Menu

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/5f0b8e4e-089d-4f93-84bc-f5a7f978cd3e

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
