### PR TITLE
automation: harvester tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,7 +79,7 @@ jobs:
           ['@charts'],
           ['@explorer'],
           ['@explorer2'],
-          ['@fleet'],
+          ['@virtualizationMgmt', '@fleet']
           ['@generic', '@globalSettings'],
           ['@manager'],
           ['@userMenu', '@usersAndAuths'],

--- a/cypress/e2e/po/pages/virtualization-mgmt/harvester-clusters.po.ts
+++ b/cypress/e2e/po/pages/virtualization-mgmt/harvester-clusters.po.ts
@@ -1,0 +1,122 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
+import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
+import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
+import ResourceDetailPo from '@/cypress/e2e/po/edit/resource-detail.po';
+import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
+
+export class HarvesterClusterPagePo extends PagePo {
+  private static createPath(clusterId: string) {
+    return `/c/${ clusterId }/harvesterManager/harvesterhci.io.management.cluster`;
+  }
+
+  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(HarvesterClusterPagePo.createPath(clusterId));
+  }
+
+  constructor(private clusterId = '_') {
+    super(HarvesterClusterPagePo.createPath(clusterId));
+  }
+
+  static navTo() {
+    BurgerMenuPo.burgerMenuNavToMenubyLabel('Virtualization Management');
+  }
+
+  masthead() {
+    return new BaseResourceList(this.self()).masthead();
+  }
+
+  title() {
+    return this.masthead().title();
+  }
+
+  importHarvesterClusterButton() {
+    return this.masthead().actions();
+  }
+
+  list(): BaseResourceList {
+    return new BaseResourceList('[data-testid="sortable-table-list-container"]');
+  }
+
+  extensionWarning() {
+    return this.self().get('.extension-warning');
+  }
+
+  harvesterLogo() {
+    return this.self().get('div.logo');
+  }
+
+  harvesterTagline() {
+    return this.self().get('div.tagline');
+  }
+
+  updateOrInstallButton(): AsyncButtonPo {
+    return new AsyncButtonPo('[data-testid="action-button-async-button"]', this.self());
+  }
+
+  createHarvesterClusterForm(namespace?: string, id?: string): HarvesterClusterCreateEditPo {
+    return new HarvesterClusterCreateEditPo(this.clusterId, namespace, id);
+  }
+}
+export class HarvesterClusterCreateEditPo extends PagePo {
+  private static createPath(clusterId: string, namespace?: string, id?: string ) {
+    const root = `/c/${ clusterId }/harvesterManager/harvesterhci.io.management.cluster`;
+
+    return id ? `${ root }/${ namespace }/${ id }` : `${ root }/create`;
+  }
+
+  static goTo(path: string): Cypress.Chainable<Cypress.AUTWindow> {
+    throw new Error('invalid');
+  }
+
+  constructor(clusterId = '_', namespace?: string, id?: string) {
+    super(HarvesterClusterCreateEditPo.createPath(clusterId, namespace, id));
+  }
+
+  resourceDetail() {
+    return new ResourceDetailPo(this.self());
+  }
+
+  masthead() {
+    return new BaseResourceList(this.self()).masthead();
+  }
+
+  title() {
+    return this.masthead().title();
+  }
+
+  nameNsDescription() {
+    return new NameNsDescription(this.self());
+  }
+
+  tabs() {
+    return new TabbedPo('[data-testid="tabbed"]');
+  }
+
+  memberRolesTab() {
+    return this.tabs().clickTabWithSelector('[data-testid="memberRoles"]');
+  }
+}
+
+export class HarvesterClusterDetailsPo extends PagePo {
+  private static createPath(clusterId: string, namespace: string, id: string ) {
+    return `/c/${ clusterId }/harvesterManager/harvesterhci.io.management.cluster/${ namespace }/${ id }`;
+  }
+
+  static goTo(path: string): Cypress.Chainable<Cypress.AUTWindow> {
+    throw new Error('invalid');
+  }
+
+  constructor(clusterId = '_', namespace = 'fleet-default', id: string) {
+    super(HarvesterClusterDetailsPo.createPath(clusterId, namespace, id));
+  }
+
+  masthead() {
+    return new BaseResourceList(this.self()).masthead();
+  }
+
+  title() {
+    return this.masthead().title();
+  }
+}

--- a/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
+++ b/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
@@ -1,0 +1,223 @@
+import ExtensionsPagePo from '@/cypress/e2e/po/pages/extensions.po';
+import { HarvesterClusterDetailsPo, HarvesterClusterPagePo } from '@/cypress/e2e/po/pages/virtualization-mgmt/harvester-clusters.po';
+import RepositoriesPagePo from '@/cypress/e2e/po/pages/chart-repositories.po';
+import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+
+const extensionsPo = new ExtensionsPagePo();
+const harvesterPo = new HarvesterClusterPagePo();
+let harvesterClusterName = '';
+const harvesterGitRepoName = 'harvester';
+const branchName = 'gh-pages';
+const harvesterGitRepoUrl = 'https://github.com/harvester/harvester-ui-extension.git';
+
+describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
+  beforeEach(() => {
+    cy.login();
+    cy.createE2EResourceName('harvesterclustername').then((name) => {
+      harvesterClusterName = name;
+    });
+  });
+
+  it('can auto install harvester and begin process of importing a harvester cluster', () => {
+    cy.intercept('POST', '/v1/catalog.cattle.io.clusterrepos').as('createHarvesterChart');
+    cy.intercept('PUT', `/v1/catalog.cattle.io.clusterrepos/${ harvesterGitRepoName }`).as('updateHarvesterChart');
+    cy.intercept('POST', `/v1/catalog.cattle.io.clusterrepos/${ harvesterGitRepoName }?action=install`).as('installHarvesterExtension');
+    cy.intercept('POST', '/v1/provisioning.cattle.io.clusters').as('createHarvesterCluster');
+
+    // verify install button and message displays
+    harvesterPo.goTo();
+    harvesterPo.waitForPage();
+    harvesterPo.updateOrInstallButton().checkVisible();
+    harvesterPo.extensionWarning().should('have.text', 'The Harvester UI Extension is not installed');
+
+    // install harvester extension
+    harvesterPo.updateOrInstallButton().click();
+    cy.wait('@createHarvesterChart').its('response.statusCode').should('eq', 201);
+    cy.wait('@updateHarvesterChart').its('response.statusCode').should('eq', 200);
+    cy.wait('@installHarvesterExtension', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 201);
+    harvesterPo.waitForPage();
+    cy.wait('@updateHarvesterChart', LONG_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
+    harvesterPo.extensionWarning().should('not.exist');
+
+    // verify harvester extension added to extensions page
+    extensionsPo.goTo();
+    extensionsPo.waitForPage(null, 'installed');
+    extensionsPo.loading().should('not.exist');
+    extensionsPo.extensionCard(harvesterGitRepoName).should('be.visible');
+
+    // verify harvester repo is added to repos list page
+    const appRepoList = new RepositoriesPagePo(undefined, 'manager');
+
+    appRepoList.goTo();
+    appRepoList.waitForPage();
+    appRepoList.sortableTable().rowElementWithName(harvesterGitRepoName).should('be.visible');
+
+    // begin process of importing harvester cluster
+    harvesterPo.goTo();
+    harvesterPo.waitForPage();
+    cy.wait('@updateHarvesterChart', LONG_TIMEOUT_OPT);
+    harvesterPo.importHarvesterClusterButton().click();
+    harvesterPo.createHarvesterClusterForm().waitForPage(null, 'memberRoles');
+    harvesterPo.createHarvesterClusterForm().title().should('contain', 'Harvester Cluster:');
+    harvesterPo.createHarvesterClusterForm().nameNsDescription().name().set(harvesterClusterName);
+    harvesterPo.createHarvesterClusterForm().nameNsDescription().description().set(`${ harvesterClusterName }-desc`);
+    harvesterPo.createHarvesterClusterForm().resourceDetail().createEditView().create();
+    cy.wait('@createHarvesterCluster').then(({ response }) => {
+      expect(response?.statusCode).to.eq(201);
+    });
+    const harvesterDetails = new HarvesterClusterDetailsPo(undefined, undefined, harvesterClusterName);
+
+    harvesterDetails.waitForPage(null, 'registration');
+    harvesterDetails.title().should('contain', harvesterClusterName);
+
+    // navigate to harvester list page and verify the logo and tagline do not display after cluster created
+    HarvesterClusterPagePo.navTo();
+    harvesterPo.waitForPage();
+    harvesterPo.list().resourceTable().sortableTable().rowWithName(harvesterClusterName)
+      .checkVisible();
+    harvesterPo.harvesterLogo().should('not.exist');
+    harvesterPo.harvesterTagline().should('not.exist');
+
+    // delete cluster
+    cy.deleteRancherResource('v1', 'provisioning.cattle.io.clusters', `fleet-default/${ harvesterClusterName }`);
+  });
+
+  it('missing repo message should display when repo does NOT exist', () => {
+    cy.intercept('POST', `/v1/catalog.cattle.io.clusterrepos/${ harvesterGitRepoName }?action=install`).as('installHarvesterExtension');
+    cy.intercept('PUT', `/v1/catalog.cattle.io.clusterrepos/${ harvesterGitRepoName }`).as('updateHarvesterChart');
+
+    // add harvester repo
+    cy.createRancherResource('v1', 'catalog.cattle.io.clusterrepos', {
+      type:     'catalog.cattle.io.clusterrepo',
+      metadata: { name: harvesterGitRepoName },
+      spec:     {
+        clientSecret: null, gitRepo: harvesterGitRepoUrl, gitBranch: branchName
+      }
+    });
+
+    extensionsPo.goTo();
+    extensionsPo.waitForPage(null, 'available');
+    extensionsPo.loading().should('not.exist');
+
+    // click on install button on card
+    extensionsPo.extensionCardInstallClick(harvesterGitRepoName);
+    extensionsPo.extensionInstallModal().should('be.visible');
+
+    // select latest version and click install
+    extensionsPo.installModalSelectVersionClick(1);
+    extensionsPo.installModalInstallClick();
+    cy.wait('@installHarvesterExtension').its('response.statusCode').should('eq', 201);
+    extensionsPo.waitForPage(null, 'installed');
+
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
+    extensionsPo.loading().should('not.exist');
+
+    harvesterPo.goTo();
+    harvesterPo.waitForPage();
+    cy.wait('@updateHarvesterChart', LONG_TIMEOUT_OPT);
+    harvesterPo.extensionWarning().should('not.exist');
+
+    // delete harvester repo
+    cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', harvesterGitRepoName);
+
+    harvesterPo.goTo();
+    harvesterPo.waitForPage();
+    // verify missing repo message displays
+    harvesterPo.extensionWarning().should('have.text', 'The Harvester UI Extension repository is missing');
+
+    // uninstall harvester
+    cy.createRancherResource('v1', 'catalog.cattle.io.apps/cattle-ui-plugin-system/harvester?action=uninstall', {});
+
+    // reload extensions
+    extensionsPo.goTo();
+    extensionsPo.waitForPage(null, 'available');
+    extensionsPo.loading().should('not.exist');
+    extensionsPo.extensionReloadBanner().should('be.visible');
+    extensionsPo.extensionReloadClick();
+    extensionsPo.loading().should('not.exist');
+
+    // verify install button and message displays
+    HarvesterClusterPagePo.navTo();
+    harvesterPo.waitForPage();
+    harvesterPo.updateOrInstallButton().checkVisible();
+    harvesterPo.extensionWarning().should('have.text', 'The Harvester UI Extension is not installed');
+  });
+
+  it('able to update harvester extension version', () => {
+    cy.intercept('POST', `/v1/catalog.cattle.io.clusterrepos/${ harvesterGitRepoName }?action=install`).as('installHarvesterExtension');
+    cy.intercept('POST', `/v1/catalog.cattle.io.clusterrepos/${ harvesterGitRepoName }?action=upgrade`).as('upgradeHarvesterExtension');
+    cy.intercept('PUT', `/v1/catalog.cattle.io.clusterrepos/${ harvesterGitRepoName }`).as('updateHarvesterChart');
+    cy.intercept('GET', `/v1/catalog.cattle.io.clusterrepos/${ harvesterGitRepoName }?link=index`).as('getHarvesterVersions');
+
+    // add harvester repo
+    cy.createRancherResource('v1', 'catalog.cattle.io.clusterrepos', {
+      type:     'catalog.cattle.io.clusterrepo',
+      metadata: { name: harvesterGitRepoName },
+      spec:     {
+        clientSecret: null, gitRepo: harvesterGitRepoUrl, gitBranch: branchName
+      }
+    });
+
+    extensionsPo.goTo();
+    extensionsPo.waitForPage(null, 'available');
+    extensionsPo.loading().should('not.exist');
+
+    // get harvester extension versions
+    cy.wait('@getHarvesterVersions').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+      const fetchedVersions = response?.body.entries.harvester.map((item: any) => item.version);
+
+      cy.wrap(fetchedVersions).as('harvesterVersions');
+    });
+
+    // click on install button on card
+    extensionsPo.extensionCardInstallClick(harvesterGitRepoName);
+    extensionsPo.extensionInstallModal().should('be.visible');
+
+    cy.get('@harvesterVersions').then((versions) => {
+      // select older version and click install
+      extensionsPo.installModalSelectVersionClick(2);
+      extensionsPo.installModalInstallClick();
+      cy.wait('@installHarvesterExtension').its('response.statusCode').should('eq', 201);
+      extensionsPo.waitForPage(null, 'installed');
+
+      extensionsPo.extensionReloadBanner().should('be.visible');
+      extensionsPo.extensionReloadClick();
+      extensionsPo.loading().should('not.exist');
+
+      // check harvester version on card - should not be older version
+      extensionsPo.extensionCardVersion(harvesterGitRepoName).should('contain', versions[1]);
+
+      harvesterPo.goTo();
+      harvesterPo.waitForPage();
+      cy.wait('@updateHarvesterChart', LONG_TIMEOUT_OPT);
+
+      // check for update harvester message
+      harvesterPo.extensionWarning().should('have.text', 'The Harvester UI Extension is not updated');
+      harvesterPo.updateOrInstallButton().click();
+
+      // wait for update version update
+      cy.wait('@upgradeHarvesterExtension', MEDIUM_TIMEOUT_OPT).then(({ request, response }) => {
+        expect(response?.statusCode).to.eq(201);
+        expect(request?.body?.charts[0].version).to.eq(versions[0]);
+      });
+      cy.wait('@updateHarvesterChart', LONG_TIMEOUT_OPT);
+
+      // verify update button and message not displayed
+      harvesterPo.extensionWarning().should('not.exist');
+      harvesterPo.updateOrInstallButton().checkNotExists();
+
+      extensionsPo.goTo();
+      extensionsPo.waitForPage(null, 'installed');
+      extensionsPo.loading().should('not.exist');
+      // check harvester version on card after update - should be latest
+      extensionsPo.extensionCardVersion(harvesterGitRepoName).should('contain', versions[0]);
+    });
+  });
+
+  afterEach(() => {
+    cy.createRancherResource('v1', 'catalog.cattle.io.apps/cattle-ui-plugin-system/harvester?action=uninstall', {}, false);
+    cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', harvesterGitRepoName, false);
+  });
+});

--- a/cypress/e2e/tests/setup/rancher-setup.spec.ts
+++ b/cypress/e2e/tests/setup/rancher-setup.spec.ts
@@ -6,7 +6,7 @@ import { serverUrlLocalhostCases, urlWithTrailingForwardSlash, httpUrl, nonUrlCa
 
 // Cypress or the GrepTags avoid to run multiples times the same test for each tag used.
 // This is a temporary solution till initialization is not handled as a test
-describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@setup', '@components', '@navigation', '@charts', '@explorer', '@explorer2', '@extensions', '@fleet', '@generic', '@globalSettings', '@manager', '@userMenu', '@usersAndAuths', '@elemental', '@vai'] }, () => {
+describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@setup', '@components', '@navigation', '@charts', '@explorer', '@explorer2', '@extensions', '@fleet', '@virtualizationMgmt', '@generic', '@globalSettings', '@manager', '@userMenu', '@usersAndAuths', '@elemental', '@vai'] }, () => {
   const rancherSetupLoginPage = new RancherSetupLoginPagePo();
   const rancherSetupConfigurePage = new RancherSetupConfigurePage();
   const homePage = new HomePagePo();

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -97,7 +97,7 @@ declare global {
 
       getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode?: number): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: any): Chainable;
-      createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any): Chainable;
+      createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any, failOnStatusCode?: boolean): Chainable;
       waitForRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, testFn: (resp: any) => boolean, retries?: number): Chainable;
       waitForRancherResources(prefix: 'v3' | 'v1', resourceType: string, expectedResourcesTotal: number, greaterThan: boolean): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1' | 'k8s', resourceType: string, resourceId: string, failOnStatusCode?: boolean): Chainable;

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -486,7 +486,7 @@ Cypress.Commands.add('deleteRancherResource', (prefix, resourceType, resourceId,
 /**
  * create a v3 / v1 resource
  */
-Cypress.Commands.add('createRancherResource', (prefix, resourceType, body) => {
+Cypress.Commands.add('createRancherResource', (prefix, resourceType, body, failOnStatusCode = true) => {
   return cy.request({
     method:  'POST',
     url:     `${ Cypress.env('api') }/${ prefix }/${ resourceType }`,
@@ -494,11 +494,14 @@ Cypress.Commands.add('createRancherResource', (prefix, resourceType, body) => {
       'x-api-csrf': token.value,
       Accept:       'application/json'
     },
-    body
+    body,
+    failOnStatusCode
   })
     .then((resp) => {
+      if (failOnStatusCode) {
       // Expect 200 or 201, Created HTTP status code
-      expect(resp.status).to.be.oneOf([200, 201]);
+        expect(resp.status).to.be.oneOf([200, 201]);
+      }
     });
 });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
