### PR TITLE
Improve color used for primary active nav section

### DIFF
--- a/shell/assets/styles/themes/_dark.scss
+++ b/shell/assets/styles/themes/_dark.scss
@@ -72,7 +72,7 @@
   --banner-text-color          : #{$lightest};
 
   --nav-bg                     : #{$darkest};
-  --nav-active                 : var(--primary-active-bg);
+  --nav-active                 : #333;
   --nav-border                 : #{$medium};
   --nav-hover                  : var(--primary);
   --nav-expander-hover         : var(--primary-banner-bg);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9799

### Occurred changes and/or fixed issues

Simple color change for the active nav section for dark mode.

Use a dark grey rather than a color determined off of the primary color.

### Areas or cases that should be tested

Set to dark mode.

Go to cluster explorer for a cluster, open one of the nav sections and verify the background color is now grey (see image below).

Go to global settings and change `ui-brand` to `suse` and `csp` and verify that the above again.

### Screenshot/Video
![image](https://github.com/user-attachments/assets/2b6784e4-e35b-4f6d-8f28-aa4424bb8a6b)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
