### PR TITLE
Fleet: expose Polling Interval for GitRepos

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@aws-sdk/client-kms": "3.8.1",
     "@novnc/novnc": "1.2.0",
     "@popperjs/core": "2.11.8",
-    "@rancher/icons": "2.0.29",
+    "@rancher/icons": "2.0.32",
     "ansi_up": "5.0.0",
     "axios": "0.21.4",
     "axios-retry": "3.1.9",

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2475,7 +2475,7 @@ fleet:
       pollingInterval:
         label: Polling Interval
         tooltip: Polling Interval is the time between a push to the Repository and Fleet's reaction to it.
-        webhookWarning: Warning, a webhhok is configured in Rancher to reconcile Git updates and GitRepo resources. The Polling Interval will be automatically adjusted to 1 hour.
+        webhookWarning: Warning, a webhook is configured in Rancher to reconcile Git updates and GitRepo resources. The Polling Interval will automatically be adjusted to 1 hour.
         minimumValuewarning: Warning, the recommended minimum value for Polling Interval is 15 seconds. Please consider to increase the interval value if the GitRepo has a large amount of resources, to avoid performance issues.
     add:
       steps:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2469,8 +2469,8 @@ fleet:
       keepResourcesTooltip: When enabled, resources will be kept when deleting a GitRepo or Bundle - only Helm release secrets will be deleted.
       correctDrift: Enable Self-Healing
       correctDriftTooltip: When enabled, Fleet will ensure that the cluster resources are kept in sync with the git repository. All resource changes made on the cluster will be lost.
-    syncronization:
-      label: Syncronization
+    polling:
+      label: Polling
       pollingInterval:
         label: Polling Interval
         tooltip: Polling Interval is the time between a push to the Repository and Fleet reacting to it.

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2474,7 +2474,7 @@ fleet:
       pollingInterval:
         label: Polling Interval
         tooltip: Polling Interval is the time between a push to the Repository and Fleet reacting to it.
-        warning: Warning, the recommended value for Polling Interval is 15 seconds. Please consider to increase the interval value if the GitRepo has a large amount of resources, to avoid performance issues.
+        warning: Warning, the recommended minimum value for Polling Interval is 15 seconds. Please consider to increase the interval value if the GitRepo has a large amount of resources, to avoid performance issues.
     add:
       steps:
         repoInfo:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2475,7 +2475,8 @@ fleet:
       pollingInterval:
         label: Polling Interval
         tooltip: Polling Interval is the time between a push to the Repository and Fleet reacting to it.
-        warning: Warning, the recommended minimum value for Polling Interval is 15 seconds. Please consider to increase the interval value if the GitRepo has a large amount of resources, to avoid performance issues.
+        webhookWarning: Warning, a webhhok is configured in Rancher to reconcile Git updates and GitRepo resources. The Polling Interval will be automatically adjusted to 1 hour.
+        minimumValuewarning: Warning, the recommended minimum value for Polling Interval is 15 seconds. Please consider to increase the interval value if the GitRepo has a large amount of resources, to avoid performance issues.
     add:
       steps:
         repoInfo:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2469,6 +2469,12 @@ fleet:
       keepResourcesTooltip: When enabled, resources will be kept when deleting a GitRepo or Bundle - only Helm release secrets will be deleted.
       correctDrift: Enable Self-Healing
       correctDriftTooltip: When enabled, Fleet will ensure that the cluster resources are kept in sync with the git repository. All resource changes made on the cluster will be lost.
+    syncronization:
+      label: Syncronization
+      pollingInterval:
+        label: Polling Interval
+        tooltip: Polling Interval is the time between a push to the Repository and Fleet reacting to it.
+        warning: Warning, the recommended value for Polling Interval is 15 seconds. Please consider to increase the interval value if the GitRepo has a large amount of resources, to avoid performance issues.
     add:
       steps:
         repoInfo:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2471,6 +2471,7 @@ fleet:
       correctDriftTooltip: When enabled, Fleet will ensure that the cluster resources are kept in sync with the git repository. All resource changes made on the cluster will be lost.
     polling:
       label: Polling
+      enable: Enable Polling
       pollingInterval:
         label: Polling Interval
         tooltip: Polling Interval is the time between a push to the Repository and Fleet reacting to it.

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2476,7 +2476,7 @@ fleet:
         label: Polling Interval
         tooltip: Polling Interval is the time between a push to the Repository and Fleet's reaction to it.
         webhookWarning: Warning, a webhook is configured in Rancher to reconcile Git updates and GitRepo resources. The Polling Interval will automatically be adjusted to 1 hour.
-        minimumValuewarning: Warning, the recommended minimum value for Polling Interval is 15 seconds. Please consider to increase the interval value if the GitRepo has a large amount of resources, to avoid performance issues.
+        minimumValuewarning: Warning, the recommended minimum Polling Interval is 15 seconds. To avoid performance issues with GitRepos that contain a large amount of resources please consider increasing this value.
     add:
       steps:
         repoInfo:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2474,7 +2474,7 @@ fleet:
       enable: Enable Polling
       pollingInterval:
         label: Polling Interval
-        tooltip: Polling Interval is the time between a push to the Repository and Fleet reacting to it.
+        tooltip: Polling Interval is the time between a push to the Repository and Fleet's reaction to it.
         webhookWarning: Warning, a webhhok is configured in Rancher to reconcile Git updates and GitRepo resources. The Polling Interval will be automatically adjusted to 1 hour.
         minimumValuewarning: Warning, the recommended minimum value for Polling Interval is 15 seconds. Please consider to increase the interval value if the GitRepo has a large amount of resources, to avoid performance issues.
     add:

--- a/shell/detail/fleet.cattle.io.gitrepo.vue
+++ b/shell/detail/fleet.cattle.io.gitrepo.vue
@@ -40,7 +40,7 @@ export default {
   },
   computed: {
     gitRepoHasClusters() {
-      return this.value.status.desiredReadyClusters;
+      return this.value.status?.desiredReadyClusters;
     },
     clusterSchema() {
       return this.$store.getters['management/schemaFor'](FLEET.CLUSTER);

--- a/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
+++ b/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
@@ -14,7 +14,7 @@ const values = {
 describe.each([
   _CREATE,
   _EDIT
-])('view: fleet.cattle.io.gitrepo should, mode: %p', (mode) => {
+])('view: fleet.cattle.io.gitrepo, mode: %p - should', (mode) => {
   const mockStore = {
     dispatch: jest.fn(),
     getters:  {
@@ -75,12 +75,12 @@ describe.each([
   });
 
   it.each([
-    ['show Polling Interval', 'enabled', undefined, true],
-    ['show Polling Interval', 'enabled', false, true],
-    ['hide Polling Interval', 'disabled', true, false],
+    ['show Polling Interval and warnings', 'enabled', undefined, true],
+    ['show Polling Interval and warnings', 'enabled', false, true],
+    ['hide Polling Interval and warnings', 'disabled', true, false],
   ])('show Enable Polling checkbox and %p if %p, with spec.disablePolling: %p', (
-    showPollingIntervalMessage,
-    enabledMessage,
+    descr1,
+    descr2,
     disablePolling,
     enabled
   ) => {
@@ -90,8 +90,9 @@ describe.each([
           ...values,
           spec: {
             disablePolling,
-            pollingInterval: 60
-          }
+            pollingInterval: 10
+          },
+          status: { webhookCommit: 'sha' },
         },
         realMode: mode
       },
@@ -100,7 +101,11 @@ describe.each([
 
     const pollingCheckbox = wrapper.findComponent('[data-testid="GitRepo-enablePolling-checkbox"]') as any;
     const pollingIntervalInput = wrapper.find('[data-testid="GitRepo-pollingInterval-input"]');
+    const pollingIntervalMinimumValueWarning = wrapper.find('[data-testid="GitRepo-pollingInterval-minimumValueWarning"]');
+    const pollingIntervalWebhookWarning = wrapper.find('[data-testid="GitRepo-pollingInterval-webhookWarning"]');
 
+    expect(pollingIntervalMinimumValueWarning.exists()).toBe(enabled);
+    expect(pollingIntervalWebhookWarning.exists()).toBe(enabled);
     expect(pollingCheckbox.exists()).toBeTruthy();
     expect(pollingCheckbox.vm.value).toBe(enabled);
     expect(pollingIntervalInput.exists()).toBe(enabled);
@@ -115,8 +120,8 @@ describe.each([
     ['60', 'custom 60 seconds', 60, '60'],
     ['15', 'custom 15 seconds', 15, '15'],
   ])('show Polling Interval input with source: %p, value: %p', async(
-    source,
-    actual,
+    descr1,
+    descr2,
     pollingInterval,
     unitValue,
   ) => {
@@ -145,8 +150,8 @@ describe.each([
     ['hide', 'source: 16, value: higher than 15', 16, false],
     ['show', 'source: 1, value: lower than 15', 1, true],
   ])('%p Polling Interval warning if %p', async(
-    status,
-    condition,
+    descr1,
+    descr2,
     pollingInterval,
     visible,
   ) => {
@@ -161,8 +166,36 @@ describe.each([
       global: { mocks },
     });
 
-    const pollingIntervalWarning = wrapper.find('[data-testid="GitRepo-pollingInterval-warning"]');
+    const pollingIntervalMinimumValueWarning = wrapper.find('[data-testid="GitRepo-pollingInterval-minimumValueWarning"]');
 
-    expect(pollingIntervalWarning.exists()).toBe(visible);
+    expect(pollingIntervalMinimumValueWarning.exists()).toBe(visible);
+  });
+
+  it.each([
+    ['hide', 'disabled', null, false],
+    ['hide', 'disabled', false, false],
+    ['hide', 'disabled', '', false],
+    ['show', 'enabled', 'sha', true],
+  ])('%p Webhook configured warning if webhook is %p', (
+    descr1,
+    descr2,
+    webhookCommit,
+    visible
+  ) => {
+    const wrapper = mount(GitRepo, {
+      props: {
+        value: {
+          ...values,
+          spec:   { pollingInterval: 60 },
+          status: { webhookCommit },
+        },
+        realMode: mode
+      },
+      global: { mocks },
+    });
+
+    const pollingIntervalWebhookWarning = wrapper.find('[data-testid="GitRepo-pollingInterval-webhookWarning"]');
+
+    expect(pollingIntervalWebhookWarning.exists()).toBe(visible);
   });
 });

--- a/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
+++ b/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
@@ -72,11 +72,11 @@ describe('view: fleet.cattle.io.gitrepo should', () => {
   });
 
   it.each([
-    ['null', 'default 15 seconds', null, '15'],
-    ['0', 'default 15 seconds', 0, '15'],
-    ['1', 'min 15 seconds', 1, '1'],
-    ['15', 'custom 15 seconds', 15, '15'],
-    ['20', 'custom 20 seconds', 20, '20'],
+    ['null', 'default 60 seconds', null, '60'],
+    ['0', 'default 60 seconds', 0, '60'],
+    ['1', 'custom 1 second', 1, '1'],
+    ['60', 'custom 60 seconds', 60, '60'],
+    ['20', 'custom 15 seconds', 15, '15'],
   ])('show Polling Interval input with source: %p, value: %p', async(
     source,
     actual,
@@ -101,9 +101,10 @@ describe('view: fleet.cattle.io.gitrepo should', () => {
   });
 
   it.each([
-    ['hide', 'source: null, value: equal to 15', null, false],
-    ['hide', 'source: 0, value: equal to 15', 0, false],
+    ['hide', 'source: null, value: equal to 60', null, false],
+    ['hide', 'source: 0, value: equal to 60', 0, false],
     ['hide', 'source: 15, value: equal to 15', 15, false],
+    ['hide', 'source: 60, value: equal to 60', 60, false],
     ['hide', 'source: 16, value: higher than 15', 16, false],
     ['show', 'source: 1, value: lower than 15', 1, true],
   ])('%p Polling Interval warning if %p', async(

--- a/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
+++ b/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils';
-import { _EDIT } from '@shell/config/query-params';
+import { _CREATE, _EDIT } from '@shell/config/query-params';
 import GitRepo from '@shell/edit/fleet.cattle.io.gitrepo.vue';
 
 const values = {
@@ -11,7 +11,10 @@ const values = {
   targetInfo: { mode: 'all' },
 };
 
-describe('view: fleet.cattle.io.gitrepo should', () => {
+describe.each([
+  _CREATE,
+  _EDIT
+])('view: fleet.cattle.io.gitrepo should, mode: %p', (mode) => {
   const mockStore = {
     dispatch: jest.fn(),
     getters:  {
@@ -36,7 +39,7 @@ describe('view: fleet.cattle.io.gitrepo should', () => {
     },
   };
   const wrapper = mount(GitRepo, {
-    props:  { value: values, mode: _EDIT },
+    props:  { value: values, mode },
     global: { mocks }
   });
 
@@ -90,7 +93,7 @@ describe('view: fleet.cattle.io.gitrepo should', () => {
             pollingInterval: 60
           }
         },
-        mode: _EDIT
+        realMode: mode
       },
       global: { mocks },
     });
@@ -103,12 +106,14 @@ describe('view: fleet.cattle.io.gitrepo should', () => {
     expect(pollingIntervalInput.exists()).toBe(enabled);
   });
 
+  const defaultPollingInterval = mode === _CREATE ? '60' : '15';
+
   it.each([
-    ['null', 'default 60 seconds', null, '60'],
-    ['0', 'default 60 seconds', 0, '60'],
+    ['null', `default ${ defaultPollingInterval } seconds`, null, defaultPollingInterval],
+    ['0', `default ${ defaultPollingInterval } seconds`, 0, defaultPollingInterval],
     ['1', 'custom 1 second', 1, '1'],
     ['60', 'custom 60 seconds', 60, '60'],
-    ['20', 'custom 15 seconds', 15, '15'],
+    ['15', 'custom 15 seconds', 15, '15'],
   ])('show Polling Interval input with source: %p, value: %p', async(
     source,
     actual,
@@ -121,7 +126,7 @@ describe('view: fleet.cattle.io.gitrepo should', () => {
           ...values,
           spec: { pollingInterval }
         },
-        mode: _EDIT
+        realMode: mode
       },
       global: { mocks },
     });
@@ -151,7 +156,7 @@ describe('view: fleet.cattle.io.gitrepo should', () => {
           ...values,
           spec: { pollingInterval }
         },
-        mode: _EDIT
+        realMode: mode
       },
       global: { mocks },
     });

--- a/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
+++ b/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
@@ -44,8 +44,8 @@ describe.each([
   });
 
   it('have self-healing checkbox and tooltip', () => {
-    const correctDriftCheckbox = wrapper.find('[data-testid="GitRepo-correctDrift-checkbox"]');
-    const tooltip = wrapper.find('[data-testid="GitRepo-correctDrift-checkbox"]');
+    const correctDriftCheckbox = wrapper.find('[data-testid="gitRepo-correctDrift-checkbox"]');
+    const tooltip = wrapper.find('[data-testid="gitRepo-correctDrift-checkbox"]');
 
     expect(tooltip.element.classList).toContain('v-popper--has-tooltip');
     expect(correctDriftCheckbox.exists()).toBeTruthy();
@@ -53,8 +53,8 @@ describe.each([
   });
 
   it('have keep-resources checkbox and tooltip', () => {
-    const correctDriftCheckbox = wrapper.find('[data-testid="GitRepo-keepResources-checkbox"]');
-    const tooltip = wrapper.find('[data-testid="GitRepo-keepResources-checkbox"]');
+    const correctDriftCheckbox = wrapper.find('[data-testid="gitRepo-keepResources-checkbox"]');
+    const tooltip = wrapper.find('[data-testid="gitRepo-keepResources-checkbox"]');
 
     expect(tooltip.element.classList).toContain('v-popper--has-tooltip');
     expect(correctDriftCheckbox.exists()).toBeTruthy();
@@ -62,8 +62,8 @@ describe.each([
   });
 
   it('enable drift if self-healing is checked', async() => {
-    const correctDriftCheckbox = wrapper.findComponent('[data-testid="GitRepo-correctDrift-checkbox"]');
-    const correctDriftContainer = wrapper.find('[data-testid="GitRepo-correctDrift-checkbox"] .checkbox-container');
+    const correctDriftCheckbox = wrapper.findComponent('[data-testid="gitRepo-correctDrift-checkbox"]');
+    const correctDriftContainer = wrapper.find('[data-testid="gitRepo-correctDrift-checkbox"] .checkbox-container');
 
     expect(correctDriftContainer.exists()).toBeTruthy();
 
@@ -99,10 +99,10 @@ describe.each([
       global: { mocks },
     });
 
-    const pollingCheckbox = wrapper.findComponent('[data-testid="GitRepo-enablePolling-checkbox"]') as any;
-    const pollingIntervalInput = wrapper.find('[data-testid="GitRepo-pollingInterval-input"]');
-    const pollingIntervalMinimumValueWarning = wrapper.find('[data-testid="GitRepo-pollingInterval-minimumValueWarning"]');
-    const pollingIntervalWebhookWarning = wrapper.find('[data-testid="GitRepo-pollingInterval-webhookWarning"]');
+    const pollingCheckbox = wrapper.findComponent('[data-testid="gitRepo-enablePolling-checkbox"]') as any;
+    const pollingIntervalInput = wrapper.find('[data-testid="gitRepo-pollingInterval-input"]');
+    const pollingIntervalMinimumValueWarning = wrapper.find('[data-testid="gitRepo-pollingInterval-minimumValueWarning"]');
+    const pollingIntervalWebhookWarning = wrapper.find('[data-testid="gitRepo-pollingInterval-webhookWarning"]');
 
     expect(pollingIntervalMinimumValueWarning.exists()).toBe(enabled);
     expect(pollingIntervalWebhookWarning.exists()).toBe(enabled);
@@ -136,7 +136,7 @@ describe.each([
       global: { mocks },
     });
 
-    const pollingIntervalInput = wrapper.find('[data-testid="GitRepo-pollingInterval-input"]').element as any;
+    const pollingIntervalInput = wrapper.find('[data-testid="gitRepo-pollingInterval-input"]').element as any;
 
     expect(pollingIntervalInput).toBeDefined();
     expect(pollingIntervalInput.value).toBe(unitValue);
@@ -166,7 +166,7 @@ describe.each([
       global: { mocks },
     });
 
-    const pollingIntervalMinimumValueWarning = wrapper.find('[data-testid="GitRepo-pollingInterval-minimumValueWarning"]');
+    const pollingIntervalMinimumValueWarning = wrapper.find('[data-testid="gitRepo-pollingInterval-minimumValueWarning"]');
 
     expect(pollingIntervalMinimumValueWarning.exists()).toBe(visible);
   });
@@ -194,7 +194,7 @@ describe.each([
       global: { mocks },
     });
 
-    const pollingIntervalWebhookWarning = wrapper.find('[data-testid="GitRepo-pollingInterval-webhookWarning"]');
+    const pollingIntervalWebhookWarning = wrapper.find('[data-testid="gitRepo-pollingInterval-webhookWarning"]');
 
     expect(pollingIntervalWebhookWarning.exists()).toBe(visible);
   });

--- a/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
+++ b/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
@@ -72,6 +72,38 @@ describe('view: fleet.cattle.io.gitrepo should', () => {
   });
 
   it.each([
+    ['show Polling Interval', 'enabled', undefined, true],
+    ['show Polling Interval', 'enabled', false, true],
+    ['hide Polling Interval', 'disabled', true, false],
+  ])('show Enable Polling checkbox and %p if %p, with spec.disablePolling: %p', (
+    showPollingIntervalMessage,
+    enabledMessage,
+    disablePolling,
+    enabled
+  ) => {
+    const wrapper = mount(GitRepo, {
+      props: {
+        value: {
+          ...values,
+          spec: {
+            disablePolling,
+            pollingInterval: 60
+          }
+        },
+        mode: _EDIT
+      },
+      global: { mocks },
+    });
+
+    const pollingCheckbox = wrapper.findComponent('[data-testid="GitRepo-enablePolling-checkbox"]') as any;
+    const pollingIntervalInput = wrapper.find('[data-testid="GitRepo-pollingInterval-input"]');
+
+    expect(pollingCheckbox.exists()).toBeTruthy();
+    expect(pollingCheckbox.vm.value).toBe(enabled);
+    expect(pollingIntervalInput.exists()).toBe(enabled);
+  });
+
+  it.each([
     ['null', 'default 60 seconds', null, '60'],
     ['0', 'default 60 seconds', 0, '60'],
     ['1', 'custom 1 second', 1, '1'],

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -729,7 +729,7 @@ export default {
         <Checkbox
           v-model:value="correctDriftEnabled"
           :tooltip="t('fleet.gitRepo.resources.correctDriftTooltip')"
-          data-testid="GitRepo-correctDrift-checkbox"
+          data-testid="gitRepo-correctDrift-checkbox"
           class="check"
           type="checkbox"
           label-key="fleet.gitRepo.resources.correctDrift"
@@ -738,7 +738,7 @@ export default {
         <Checkbox
           v-model:value="value.spec.keepResources"
           :tooltip="t('fleet.gitRepo.resources.keepResourcesTooltip')"
-          data-testid="GitRepo-keepResources-checkbox"
+          data-testid="gitRepo-keepResources-checkbox"
           class="check"
           type="checkbox"
           label-key="fleet.gitRepo.resources.keepResources"
@@ -763,7 +763,7 @@ export default {
         <div class="col span-6">
           <Checkbox
             v-model:value="isPollingEnabled"
-            data-testid="GitRepo-enablePolling-checkbox"
+            data-testid="gitRepo-enablePolling-checkbox"
             class="check"
             type="checkbox"
             label-key="fleet.gitRepo.polling.enable"
@@ -777,19 +777,19 @@ export default {
               v-if="showPollingIntervalWarning"
               color="warning"
               label-key="fleet.gitRepo.polling.pollingInterval.minimumValuewarning"
-              data-testid="GitRepo-pollingInterval-minimumValueWarning"
+              data-testid="gitRepo-pollingInterval-minimumValueWarning"
             />
             <Banner
               v-if="isWebhookConfigured"
               color="warning"
               label-key="fleet.gitRepo.polling.pollingInterval.webhookWarning"
-              data-testid="GitRepo-pollingInterval-webhookWarning"
+              data-testid="gitRepo-pollingInterval-webhookWarning"
             />
           </div>
           <div class="col span-6">
             <UnitInput
               v-model:value="pollingInterval"
-              data-testid="GitRepo-pollingInterval-input"
+              data-testid="gitRepo-pollingInterval-input"
               min="1"
               :suffix="t('suffix.seconds', { count: pollingInterval })"
               :label="t('fleet.gitRepo.polling.pollingInterval.label')"

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -797,7 +797,7 @@ export default {
               v-model:value="pollingInterval"
               data-testid="GitRepo-pollingInterval-input"
               min="1"
-              :suffix="pollingInterval == 1 ? 'Second' : 'Seconds'"
+              :suffix="t('suffix.seconds', { count: pollingInterval })"
               :label="t('fleet.gitRepo.polling.pollingInterval.label')"
               :mode="mode"
               tooltip-key="fleet.gitRepo.polling.pollingInterval.tooltip"

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -97,6 +97,7 @@ export default {
   },
 
   data() {
+    const isPollingEnabled = !this.value.spec.disablePolling;
     const pollingInterval = this.value.spec.pollingInterval || DEFAULT_POLLING_INTERVAL;
     const targetInfo = this.value.targetInfo;
     const targetCluster = targetInfo.cluster;
@@ -150,6 +151,7 @@ export default {
       correctDriftEnabled:     false,
       targetAdvancedErrors:    null,
       matchingClusters:        null,
+      isPollingEnabled,
       pollingInterval,
       ref,
       refValue,
@@ -529,6 +531,14 @@ export default {
       }
     },
 
+    enablePolling(value) {
+      if (value) {
+        delete this.value.spec.disablePolling;
+      } else {
+        this.value.spec.disablePolling = true;
+      }
+    },
+
     updatePollingInterval(value) {
       let interval = (value || DEFAULT_POLLING_INTERVAL).toString();
 
@@ -740,8 +750,22 @@ export default {
 
       <div class="spacer" />
       <h2 v-t="'fleet.gitRepo.polling.label'" />
-      <div class="row">
+      <div class="row polling">
         <div class="col span-6">
+          <Checkbox
+            v-model:value="isPollingEnabled"
+            data-testid="GitRepo-enablePolling-checkbox"
+            class="check"
+            type="checkbox"
+            label-key="fleet.gitRepo.polling.enable"
+            :mode="mode"
+            @update:value="enablePolling"
+          />
+        </div>
+        <div
+          v-if="isPollingEnabled"
+          class="col span-6"
+        >
           <Banner
             v-if="showPollingIntervalWarning"
             color="warning"
@@ -845,6 +869,11 @@ export default {
   .resource-handling {
     display: flex;
     flex-direction: column;
-    gap: 5px
+    gap: 5px;
+  }
+  .polling {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
   }
 </style>

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -204,6 +204,10 @@ export default {
       return !(this.value?.spec?.repo || '').startsWith('http://');
     },
 
+    isWebhookConfigured() {
+      return !!this.value.status?.webhookCommit;
+    },
+
     targetOptions() {
       const out = [
         {
@@ -772,27 +776,34 @@ export default {
             @update:value="enablePolling"
           />
         </div>
-        <div
-          v-if="isPollingEnabled"
-          class="col span-6"
-        >
-          <Banner
-            v-if="showPollingIntervalWarning"
-            color="warning"
-            label-key="fleet.gitRepo.polling.pollingInterval.warning"
-            data-testid="GitRepo-pollingInterval-warning"
-          />
-          <UnitInput
-            v-model:value="pollingInterval"
-            data-testid="GitRepo-pollingInterval-input"
-            min="1"
-            :suffix="pollingInterval == 1 ? 'Second' : 'Seconds'"
-            :label="t('fleet.gitRepo.polling.pollingInterval.label')"
-            :mode="mode"
-            tooltip-key="fleet.gitRepo.polling.pollingInterval.tooltip"
-            @update:value="updatePollingInterval"
-          />
-        </div>
+        <template v-if="isPollingEnabled">
+          <div class="col">
+            <Banner
+              v-if="showPollingIntervalWarning"
+              color="warning"
+              label-key="fleet.gitRepo.polling.pollingInterval.minimumValuewarning"
+              data-testid="GitRepo-pollingInterval-minimumValueWarning"
+            />
+            <Banner
+              v-if="isWebhookConfigured"
+              color="warning"
+              label-key="fleet.gitRepo.polling.pollingInterval.webhookWarning"
+              data-testid="GitRepo-pollingInterval-webhookWarning"
+            />
+          </div>
+          <div class="col span-6">
+            <UnitInput
+              v-model:value="pollingInterval"
+              data-testid="GitRepo-pollingInterval-input"
+              min="1"
+              :suffix="pollingInterval == 1 ? 'Second' : 'Seconds'"
+              :label="t('fleet.gitRepo.polling.pollingInterval.label')"
+              :mode="mode"
+              tooltip-key="fleet.gitRepo.polling.pollingInterval.tooltip"
+              @update:value="updatePollingInterval"
+            />
+          </div>
+        </template>
       </div>
     </template>
     <template #stepTargetInfo>

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -28,7 +28,8 @@ import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 import FormValidation from '@shell/mixins/form-validation';
 import UnitInput from '@shell/components/form/UnitInput';
 
-const DEFAULT_POLLING_INTERVAL = 15;
+const MINIMUM_POLLING_INTERVAL = 15;
+const DEFAULT_POLLING_INTERVAL = 60;
 
 const _VERIFY = 'verify';
 const _SKIP = 'skip';
@@ -272,7 +273,7 @@ export default {
     },
 
     showPollingIntervalWarning() {
-      const isVisible = !this.isView && this.pollingInterval < DEFAULT_POLLING_INTERVAL;
+      const isVisible = !this.isView && this.pollingInterval < MINIMUM_POLLING_INTERVAL;
 
       if (isVisible) {
         this.scrollToBottom();
@@ -529,12 +530,18 @@ export default {
     },
 
     updatePollingInterval(value) {
-      if (!value || value === DEFAULT_POLLING_INTERVAL) {
+      let interval = (value || DEFAULT_POLLING_INTERVAL).toString();
+
+      if (!value) {
+        this.pollingInterval = DEFAULT_POLLING_INTERVAL;
+      }
+
+      if (value === MINIMUM_POLLING_INTERVAL) {
         delete this.value.spec.pollingInterval;
 
-        this.pollingInterval = DEFAULT_POLLING_INTERVAL;
+        interval = MINIMUM_POLLING_INTERVAL.toString();
       } else {
-        this.value.spec.pollingInterval = value.toString();
+        this.value.spec.pollingInterval = interval;
       }
     },
 

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -732,13 +732,13 @@ export default {
       />
 
       <div class="spacer" />
-      <h2 v-t="'fleet.gitRepo.syncronization.label'" />
+      <h2 v-t="'fleet.gitRepo.polling.label'" />
       <div class="row">
         <div class="col span-6">
           <Banner
             v-if="showPollingIntervalWarning"
             color="warning"
-            label-key="fleet.gitRepo.syncronization.pollingInterval.warning"
+            label-key="fleet.gitRepo.polling.pollingInterval.warning"
             data-testid="GitRepo-pollingInterval-warning"
           />
           <UnitInput
@@ -746,9 +746,9 @@ export default {
             data-testid="GitRepo-pollingInterval-input"
             min="1"
             :suffix="pollingInterval == 1 ? 'Second' : 'Seconds'"
-            :label="t('fleet.gitRepo.syncronization.pollingInterval.label')"
+            :label="t('fleet.gitRepo.polling.pollingInterval.label')"
             :mode="mode"
-            tooltip-key="fleet.gitRepo.syncronization.pollingInterval.tooltip"
+            tooltip-key="fleet.gitRepo.polling.pollingInterval.tooltip"
             @update:value="updatePollingInterval"
           />
         </div>

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -549,18 +549,13 @@ export default {
     },
 
     updatePollingInterval(value) {
-      let interval = (value || DEFAULT_POLLING_INTERVAL).toString();
-
       if (!value) {
         this.pollingInterval = DEFAULT_POLLING_INTERVAL;
-      }
-
-      if (value === MINIMUM_POLLING_INTERVAL) {
+        this.value.spec.pollingInterval = DEFAULT_POLLING_INTERVAL.toString();
+      } else if (value === MINIMUM_POLLING_INTERVAL) {
         delete this.value.spec.pollingInterval;
-
-        interval = MINIMUM_POLLING_INTERVAL.toString();
       } else {
-        this.value.spec.pollingInterval = interval;
+        this.value.spec.pollingInterval = value.toString();
       }
     },
 

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -97,8 +97,6 @@ export default {
   },
 
   data() {
-    const isPollingEnabled = !this.value.spec.disablePolling;
-
     let pollingInterval = this.value.spec.pollingInterval;
 
     if (!pollingInterval) {
@@ -161,7 +159,6 @@ export default {
       correctDriftEnabled:     false,
       targetAdvancedErrors:    null,
       matchingClusters:        null,
-      isPollingEnabled,
       pollingInterval,
       ref,
       refValue,
@@ -202,6 +199,10 @@ export default {
 
     isTls() {
       return !(this.value?.spec?.repo || '').startsWith('http://');
+    },
+
+    isPollingEnabled() {
+      return !this.value.spec.disablePolling;
     },
 
     isWebhookConfigured() {

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -19,7 +19,7 @@ import NameNsDescription from '@shell/components/form/NameNsDescription';
 import YamlEditor from '@shell/components/YamlEditor';
 import { base64Decode, base64Encode } from '@shell/utils/crypto';
 import SelectOrCreateAuthSecret from '@shell/components/form/SelectOrCreateAuthSecret';
-import { _CREATE } from '@shell/config/query-params';
+import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
 import { isHarvesterCluster } from '@shell/utils/cluster';
 import { CAPI, CATALOG, FLEET as FLEET_LABELS } from '@shell/config/labels-annotations';
 import { SECRET_TYPES } from '@shell/config/secret';
@@ -98,7 +98,17 @@ export default {
 
   data() {
     const isPollingEnabled = !this.value.spec.disablePolling;
-    const pollingInterval = this.value.spec.pollingInterval || DEFAULT_POLLING_INTERVAL;
+
+    let pollingInterval = this.value.spec.pollingInterval;
+
+    if (!pollingInterval) {
+      if (this.realMode === _CREATE) {
+        pollingInterval = DEFAULT_POLLING_INTERVAL;
+      } else if (this.realMode === _EDIT || this.realMode === _VIEW) {
+        pollingInterval = MINIMUM_POLLING_INTERVAL;
+      }
+    }
+
     const targetInfo = this.value.targetInfo;
     const targetCluster = targetInfo.cluster;
     const targetClusterGroup = targetInfo.clusterGroup;

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -290,13 +290,7 @@ export default {
     },
 
     showPollingIntervalWarning() {
-      const isVisible = !this.isView && this.pollingInterval < MINIMUM_POLLING_INTERVAL;
-
-      if (isVisible) {
-        this.scrollToBottom();
-      }
-
-      return isVisible;
+      return !this.isView && this.isPollingEnabled && this.pollingInterval < MINIMUM_POLLING_INTERVAL;
     },
 
     stepOneRequires() {

--- a/shell/edit/workload/Job.vue
+++ b/shell/edit/workload/Job.vue
@@ -254,7 +254,7 @@ export default {
         >
           <UnitInput
             v-model:value="terminationGracePeriodSeconds"
-            :suffix="terminationGracePeriodSeconds == 1 ? 'Second' : 'Seconds'"
+            :suffix="t('suffix.seconds', { count: terminationGracePeriodSeconds })"
             :label="t('workload.upgrading.activeDeadlineSeconds.label')"
             :mode="mode"
             @input="update"
@@ -316,7 +316,7 @@ export default {
       >
         <UnitInput
           v-model:value="terminationGracePeriodSeconds"
-          :suffix="terminationGracePeriodSeconds == 1 ? 'Second' : 'Seconds'"
+          :suffix="t('suffix.seconds', { count: terminationGracePeriodSeconds })"
           :label="t('workload.upgrading.activeDeadlineSeconds.label')"
           :mode="mode"
         >

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -83,6 +83,22 @@ export default class GitRepo extends SteveModel {
     });
 
     insertAt(out, 2, {
+      action:   'enablePolling',
+      label:    'Enable Polling',
+      icon:     'icon icon-gear',
+      bulkable: true,
+      enabled:  !!this.links.update && !!this.spec?.disablePolling
+    });
+
+    insertAt(out, 3, {
+      action:   'disablePolling',
+      label:    'Disable Polling',
+      icon:     'icon icon-gear',
+      bulkable: true,
+      enabled:  !!this.links.update && !this.spec?.disablePolling
+    });
+
+    insertAt(out, 4, {
       action:   'forceUpdate',
       label:    'Force Update',
       icon:     'icon icon-refresh',
@@ -90,7 +106,7 @@ export default class GitRepo extends SteveModel {
       enabled:  !!this.links.update
     });
 
-    insertAt(out, 3, { divider: true });
+    insertAt(out, 5, { divider: true });
 
     return out;
   }
@@ -102,6 +118,16 @@ export default class GitRepo extends SteveModel {
 
   unpause() {
     this.spec.paused = false;
+    this.save();
+  }
+
+  enablePolling() {
+    this.spec.disablePolling = false;
+    this.save();
+  }
+
+  disablePolling() {
+    this.spec.disablePolling = true;
     this.save();
   }
 

--- a/shell/models/fleet.cattle.io.gitrepo.js
+++ b/shell/models/fleet.cattle.io.gitrepo.js
@@ -85,7 +85,7 @@ export default class GitRepo extends SteveModel {
     insertAt(out, 2, {
       action:   'enablePolling',
       label:    'Enable Polling',
-      icon:     'icon icon-gear',
+      icon:     'icon icon-endpoints_connected',
       bulkable: true,
       enabled:  !!this.links.update && !!this.spec?.disablePolling
     });
@@ -93,7 +93,7 @@ export default class GitRepo extends SteveModel {
     insertAt(out, 3, {
       action:   'disablePolling',
       label:    'Disable Polling',
-      icon:     'icon icon-gear',
+      icon:     'icon icon-endpoints_disconnected',
       bulkable: true,
       enabled:  !!this.links.update && !this.spec?.disablePolling
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3320,10 +3320,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
-"@rancher/icons@2.0.29":
-  version "2.0.29"
-  resolved "https://registry.npmjs.org/@rancher/icons/-/icons-2.0.29.tgz#6546d69768c706bebd66bfa73b36aef3d105987a"
-  integrity sha512-qBBqfazS9y5VjV7fJDPNXmxd9AP/2uiE05mKFWP41kpbO+tEb62RnUBXCm14XLeScDZQcOuiAKVHMmvCFzF0BA==
+"@rancher/icons@2.0.32":
+  version "2.0.32"
+  resolved "https://registry.yarnpkg.com/@rancher/icons/-/icons-2.0.32.tgz#c6b18c81b87bc9439b1e449b2f6bd859d76c0bbe"
+  integrity sha512-afZlIHPboVgQIwnMuaQT7LTPoWuCIgyqD2Ch277lEAoFIzuU+NwHzpEAvX5xcOpVXYAFlvDE/VlJ6FmYaQBBig==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7824
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

We are adding the possibility to:
- enable/disable polling.
- set up the `pollingInterval` value when creating/editing GitRepos.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- It should be possible to enable/disable polling
- It should be possible to assign the polling interval in edit mode and display the value in view mode
- Default Polling Interval should be 60 seconds when creating new GitRepo
- The value in the input field should be 15 seconds when editing a GitRepo and `spec.pollingInterval` is `undefined`
- A warning should be displayed in case of the polling interval is lower than 15 seconds
- A warning should be displayed in case of a webhook is configured https://fleet.rancher.io/webhook

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

GitRepo, edit page

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

Create/Edit

[Screencast from 2025-02-13 17-48-28.webm](https://github.com/user-attachments/assets/c4b8e32a-01ed-4a02-ba0a-3b6fde77bdeb)

View

![image](https://github.com/user-attachments/assets/20476ff7-680c-4c24-83d4-a17ef678bc77)

Tooltip

![image](https://github.com/user-attachments/assets/d8227e68-b8fc-4b25-9d73-82e70945557d)

Warning, the interval is lower than the recommended value

![image](https://github.com/user-attachments/assets/1ca52b24-c161-4013-9634-8d2e9a040d0d)

Warning, a webhook is configured

![image](https://github.com/user-attachments/assets/8be365bc-4e7c-410a-8094-81903393bce0)

Enable/Disable Polling action

![image](https://github.com/user-attachments/assets/71b3b001-69e1-4941-94ec-255e1b0f02bf)

![image](https://github.com/user-attachments/assets/deddce99-61e4-4be8-9c76-6390d4b02c97)



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes