### PR TITLE
Fix select behavior for ResourceTable when the enter key is pressed

### DIFF
--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -190,20 +190,6 @@ export default {
     },
   },
 
-  mounted() {
-    /**
-     * v-shortkey prevents the event's propagation:
-     * https://github.com/fgr-araujo/vue-shortkey/blob/55d802ea305cadcc2ea970b55a3b8b86c7b44c05/src/index.js#L156-L157
-     *
-     * 'Enter' key press is handled via event listener in order to allow the event propagation
-     */
-    window.addEventListener('keyup', this.handleEnterKeyPress);
-  },
-
-  beforeUnmount() {
-    window.removeEventListener('keyup', this.handleEnterKeyPress);
-  },
-
   data() {
     // Confirm which store we're in, if schema isn't available we're probably showing a list with different types
     const inStore = this.schema?.id ? this.$store.getters['currentStore'](this.schema.id) : undefined;
@@ -602,6 +588,7 @@ export default {
     :mandatory-sort="_mandatorySort"
     @clickedActionButton="handleActionButtonClick"
     @group-value-change="group = $event"
+    @enter="handleEnterKeyPress"
   >
     <template
       v-if="showGrouping"

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1080,6 +1080,7 @@ export default {
                 :disabled="!act.enabled"
                 :data-testid="componentTestid + '-' + act.action"
                 @click="applyTableAction(act, null, $event)"
+                @keydown.enter.stop
                 @mouseover="setBulkActionOfInterest(act)"
                 @mouseleave="setBulkActionOfInterest(null)"
               >


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This refactors the event listener that was attached to the window so that it is now attached the sortable table. The table needs to listen to the keyup event and the row needs to receive focus in order for this to work; the row's tabindex is set to -1 so that it is not navigable via keyboard.

Fixes #13239
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Refactor event listener for the enter key so that it is no longer attached to the window object, but the sortable table instead
- Prevent event propagation when the action menu button is activated via the enter key

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The design of the Checkbox component is quite interesting in that it customizes how events are emitted, rendering common strategies to stop event propagation via `keydown.enter.stop` useless. Rather than attempt a refactor of the Checkbox implementation at this time, I thought it to be easier to resolve the problem within the listener.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Keyboard interactions with the ResourceTable
  - Pressing enter on the selection checkbox will no longer route to the selected line item
  - Pressing enter on the actions menu will no longer route to the selected line item
- Mouse & Keyboard interactions for selecting a line item
  - Clicking on a row to select it should still work
  - Pressing enter should route to the selected row

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

It was technically possible to select a row with the mouse, remove focus from the table, and press enter to route to the selected item. I don't think that this use case makes sense.. I think that the table should minimally be the current active element in order to register the enter key action.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
