### PR TITLE
add missing alt attribute for informative images

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -950,6 +950,7 @@ catalog:
     experimentalWarning: '{chartName} has been marked as experimental. Use caution when installing this helm chart as it might not function as expected.'
     deprecatedAndExperimentalWarning: '{chartName} has been marked as deprecated and experimental. Use caution when installing this helm chart as it might be removed in the future and might not function as expected.'
   charts:
+    iconAlt: Icon for {app} card/grid item
     refresh: refresh charts
     all: All
     categories:
@@ -1133,6 +1134,7 @@ catalog:
       label: Refresh Interval
       placeholder: 'default: {hours}'
   tools:
+    iconAlt: Icon for {app} Cluster Tool
     header: Cluster Tools
     noTools: "No Cluster Tools found"
     action:
@@ -4376,6 +4378,7 @@ inactivity:
 
 # Rancher Extensions
 plugins:
+  altIcon: Icon for {extension} extension card
   incompatibleRancherVersion: "The latest version of this extension ({ version }) is not compatible with the current Rancher version ({ required })."
   incompatibleKubeVersion: "The latest version of this extension ({ version }) is not compatible with the current Kube version ({ required })."
   incompatibleUiExtensionsApiVersionMissing: 'The latest version of this extension ({ version }) is missing the mandatory annotation catalog.cattle.io/ui-extensions-version from Rancher 2.10 and onwards.'

--- a/shell/components/SelectIconGrid.vue
+++ b/shell/components/SelectIconGrid.vue
@@ -148,10 +148,12 @@ export default {
         <i
           v-if="r.iconClass"
           :class="r.iconClass"
+          :alt="t('catalog.charts.iconAlt', { app: get(r, nameField) })"
         />
         <LazyImage
           v-else
           :src="get(r, iconField)"
+          :alt="t('catalog.charts.iconAlt', { app: get(r, nameField) })"
         />
       </div>
       <h4 class="name">

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -169,6 +169,7 @@ export default {
             <LazyImage
               :src="chart.icon"
               class="logo"
+              :alt="t('catalog.charts.iconAlt', { app: chart.chartNameDisplay })"
             />
           </div>
           <h1>

--- a/shell/pages/c/_cluster/explorer/tools/index.vue
+++ b/shell/pages/c/_cluster/explorer/tools/index.vue
@@ -309,9 +309,11 @@ export default {
             v-if="opt.chart.iconName"
             class="icon"
             :class="opt.chart.iconName"
+            :alt="t('catalog.tools.iconAlt', { app: opt.chart.chartNameDisplay })"
           />
           <LazyImage
             v-else
+            :alt="t('catalog.tools.iconAlt', { app: opt.chart.chartNameDisplay })"
             :src="opt.chart.icon"
           />
         </div>
@@ -347,6 +349,8 @@ export default {
           <template v-if="opt.blocked">
             <button
               v-clean-html="t('catalog.tools.action.install')"
+              role="button"
+              :aria-label="t('catalog.tools.action.install')"
               disabled="true"
               class="btn btn-sm role-primary"
             />
@@ -354,12 +358,19 @@ export default {
           <template v-else-if="opt.app">
             <button
               class="btn btn-sm role-secondary"
+              role="button"
+              :aria-label="t('catalog.tools.action.remove')"
               @click="remove(opt.app, $event)"
             >
-              <i class="icon icon-delete icon-lg" />
+              <i
+                class="icon icon-delete icon-lg"
+                :alt="t('catalog.tools.action.remove')"
+              />
             </button>
             <button
               v-clean-html="t('catalog.tools.action.edit')"
+              role="button"
+              :aria-label="t('catalog.tools.action.edit')"
               class="btn btn-sm role-secondary"
               @click="edit(opt.app)"
             />
@@ -367,6 +378,8 @@ export default {
           <template v-else>
             <button
               v-clean-html="t('catalog.tools.action.install')"
+              role="button"
+              :aria-label="t('catalog.tools.action.install')"
               class="btn btn-sm role-primary"
               @click="install(opt.chart)"
             />

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -843,11 +843,13 @@ export default {
                   :error-src="defaultIcon"
                   :src="plugin.icon"
                   class="icon plugin-icon-img"
+                  :alt="t('plugins.altIcon', { extension: plugin.name })"
                 />
                 <img
                   v-else
                   :src="defaultIcon"
                   class="icon plugin-icon-img"
+                  :alt="t('plugins.altIcon', { extension: plugin.name })"
                 >
               </div>
               <!-- extension card -->


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12810 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add missing alt attribute for informative images
- the `alt` added to the `SelectIconGrid` tackles grid card areas such as cluster provisioning, charts main screen, navlinks groups and auth providers

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
