### PR TITLE
Fix project members not showing up when switching projects

### DIFF
--- a/shell/components/form/Members/MembershipEditor.vue
+++ b/shell/components/form/Members/MembershipEditor.vue
@@ -61,7 +61,7 @@ export default {
     const roleBindingRequestParams = { type: this.type, opt: { force: true } };
 
     if (this.type === NORMAN.PROJECT_ROLE_TEMPLATE_BINDING && this.parentId) {
-      Object.assign(roleBindingRequestParams, { opt: { filter: { projectId: this.parentId.split('/').join(':') } } });
+      Object.assign(roleBindingRequestParams, { opt: { filter: { projectId: this.parentId.split('/').join(':') }, force: true } });
     }
     const userHydration = [
       this.schema ? this.$store.dispatch(`rancher/findAll`, roleBindingRequestParams) : [],

--- a/shell/edit/management.cattle.io.project.vue
+++ b/shell/edit/management.cattle.io.project.vue
@@ -132,7 +132,7 @@ export default {
             });
           }
 
-          // // we allow users with permissions for projectroletemplatebindings to be able to manage members on projects
+          // We allow users with permissions for projectroletemplatebindings to be able to manage members on projects
           if (this.membershipUpdate.save) {
             const norman = await this.value.norman;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12885 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
In `MembershipEditor.vue` where we request to fetch the members, the `force: true` flag was needed to be added to `roleBindingRequestParams` in order to get the members.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Please watch the recorded video for a manual test.
### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/c40e8ecf-c5c2-4cc6-a81c-3b0cec35c32a


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
