### PR TITLE
Enhance KeyValue and Labels shell components to set custom descriptions

### DIFF
--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -240,6 +240,10 @@ export default {
       default: false,
       type:    Boolean
     },
+    description: {
+      default: '',
+      type:    String,
+    },
   },
   data() {
     const rows = this.getRows(this.value);
@@ -600,6 +604,11 @@ export default {
           />
         </h3>
       </slot>
+    </div>
+    <div v-if="description">
+      <p class="mt-10 mb-10">
+        {{ description }}
+      </p>
     </div>
     <div
       class="kv-container"

--- a/shell/components/form/Labels.vue
+++ b/shell/components/form/Labels.vue
@@ -52,7 +52,18 @@ export default {
     showLabelTitle: {
       type:    Boolean,
       default: true,
-    }
+    },
+
+    showLabelDescription: {
+      type:    Boolean,
+      default: true,
+    },
+
+    // A custom label description. Defaults to `labels.labels.description` if empty.
+    labelDescription: {
+      type:    String,
+      default: '',
+    },
   },
 
   data() {
@@ -89,8 +100,15 @@ export default {
             :on-label="t('labels.labels.show')"
           />
         </div>
-        <p class="mt-10 mb-10">
-          <t k="labels.labels.description" />
+        <p
+          v-if="showLabelDescription"
+          class="mt-10 mb-10"
+        >
+          <span v-if="labelDescription">{{ labelDescription }}</span>
+          <t
+            v-if="!labelDescription"
+            k="labels.labels.description"
+          />
         </p>
         <div :class="columnsClass">
           <slot


### PR DESCRIPTION
### Summary
Allow to set a custom description for the `KeyValue` and `Labels` shell components. Additional add the ability to hide the label description for `Labels`.

Fixes: https://github.com/rancher/dashboard/issues/13397

### Occurred changes and/or fixed issues
Add the following new properties:
- Labels: `showLabelDescription` and `labelDescription`
- KeyValue: `description`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
