### PR TITLE
fix focus return async btn

### DIFF
--- a/shell/components/AsyncButton.vue
+++ b/shell/components/AsyncButton.vue
@@ -117,7 +117,10 @@ export default defineComponent({
       type:    Boolean,
       default: false,
     },
-
+    returnFocusOnError: {
+      type:    Boolean,
+      default: false,
+    },
   },
 
   setup() {
@@ -231,7 +234,7 @@ export default defineComponent({
   },
 
   methods: {
-    clicked() {
+    clicked(ev: any) {
       if ( this.isDisabled ) {
         return;
       }
@@ -246,16 +249,21 @@ export default defineComponent({
       }
 
       const cb: AsyncButtonCallback = (success) => {
-        this.done(success);
+        this.done(success, ev);
       };
 
       this.$emit('click', cb);
     },
 
-    done(success: boolean | 'cancelled') {
+    done(success: boolean | 'cancelled', ev?: any) {
       if (success === 'cancelled') {
         this.phase = ASYNC_BUTTON_STATES.ACTION;
       } else {
+        // ev.detail = 0 means that the trigger was a key press
+        if (!success && this.returnFocusOnError && ev && ev.detail === 0) {
+          // set the focus back on the async button. We lose it when saving a "form" HTML element
+          setTimeout(() => this.focus(), 0);
+        }
         this.phase = (success ? ASYNC_BUTTON_STATES.SUCCESS : ASYNC_BUTTON_STATES.ERROR );
         this.timer = setTimeout(() => {
           this.timerDone();

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -643,6 +643,7 @@ export default {
                     <AsyncButton
                       v-if="!showSubtypeSelection && !isView"
                       ref="save"
+                      :return-focus-on-error="true"
                       :disabled="!activeStep.ready"
                       :mode="finishButtonMode || mode"
                       @click="$emit('finish', $event)"
@@ -718,6 +719,7 @@ export default {
                   :disabled="!canSave"
                   :mode="finishButtonMode || mode"
                   :data-testid="componentTestid + '-save'"
+                  :return-focus-on-error="true"
                   @click="clickSave($event)"
                 />
               </div>
@@ -790,6 +792,7 @@ export default {
                     </button>
                     <AsyncButton
                       v-if="!showSubtypeSelection"
+                      :return-focus-on-error="true"
                       :data-testid="componentTestid + '-yaml-save'"
                       :disabled="!canSave"
                       :action-label="isEdit ? t('generic.save') : t('generic.create')"

--- a/shell/components/form/Footer.vue
+++ b/shell/components/form/Footer.vue
@@ -80,6 +80,7 @@ export default defineComponent({
             v-if="!isView"
             :mode="mode"
             :disabled="disableSave"
+            :return-focus-on-error="true"
             @click="save"
           />
         </slot>

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -462,6 +462,7 @@ export default {
                   :waiting-label="t('login.loggingIn')"
                   :success-label="t('login.loggedIn')"
                   :error-label="t('asyncButton.default.error')"
+                  :return-focus-on-error="true"
                   @click="loginLocal"
                 />
                 <div


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12793 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix focus return async btn

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
