### PR TITLE
partially revert 13347

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -173,7 +173,16 @@ export default {
   },
 
   data() {
-    const subType = this.$route.query[SUB_TYPE] || null;
+    let subType = null;
+
+    subType = this.$route.query[SUB_TYPE] || null;
+    if ( this.$route.query[SUB_TYPE]) {
+      subType = this.$route.query[SUB_TYPE];
+    } else if (this.value.isImported) {
+      subType = IMPORTED;
+    } else if (this.value.isLocal) {
+      subType = LOCAL;
+    }
     const rkeType = this.$route.query[RKE_TYPE] || null;
     const chart = this.$route.query[CHART] || null;
     const isImport = this.realMode === _IMPORT;
@@ -213,14 +222,6 @@ export default {
 
     emberLink() {
       if (this.value) {
-        // for imported and local clusters, set subtype using properties from prov cluster model
-        //
-        if (this.value.isImported) {
-          this.selectType(IMPORTED, false);
-        } else if (this.value.isLocal) {
-          this.selectType(LOCAL, false);
-        }
-
         // set subtype if editing EKS/GKE/AKS cluster -- this ensures that the component provided by extension is loaded instead of iframing old ember ui
         if (this.value.provisioner) {
           const matchingSubtype = this.subTypes.find((st) => DRIVER_TO_IMPORT[st.id.toLowerCase()] === this.value.provisioner.toLowerCase());
@@ -239,6 +240,7 @@ export default {
 
           return '';
         }
+
         // For custom RKE2 clusters, don't load an Ember page.
         // It should be the dashboard.
         if ( this.value.isRke2 && ((this.value.isCustom && this.mode === _EDIT) || (this.value.isCustom && this.as === _CONFIG && this.mode === _VIEW) || (this.subType || '').toLowerCase() === 'custom')) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Partially revert https://github.com/rancher/dashboard/pull/13347/

Needed for #13106 


### Technical notes summary
In #13347 I moved subType computations into one function for readability. Ultimately this causes `emberLink` to recursively call itself when editing virtual clusters as they are technically imported, but also have an annotation specifying a different subType (ie different UI to use). 

### Areas or cases that should be tested
This PR primarily effects virtual clusters (or any cluster with custom UI that may be recognized as imported). To test, you will need to run the [virtual clusters ui extension](https://github.com/rancher/virtual-clusters-ui) locally, using [yarn link](https://extensions.rancher.io/extensions/next/advanced/yarn-link) to use code from this PR.

1. create a virtual cluster with default options
2. attempt to edit the cluster

result: page breaks with error about infinite recursion

desired result: edit succeeds, user is redirected back to the cluster list view


### Areas which could experience regressions
1. Create/edit local clusters
4. Create/edit imported clusters

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
