### PR TITLE
Fix e2e tests - change forums.rancher.com to forums.suse.com

### DIFF
--- a/cypress/e2e/tests/pages/generic/get-support.spec.ts
+++ b/cypress/e2e/tests/pages/generic/get-support.spec.ts
@@ -62,13 +62,13 @@ describe('Support Page', () => {
     });
 
     it('can click on Forums link', () => {
-      catchTargetPageException('TenantFeatures', 'https://forums.rancher.com');
+      catchTargetPageException('TenantFeatures', 'https://forums.suse.com');
 
       // click Forums link
       supportPage.clickSupportLink(1, true);
 
-      cy.origin('https://forums.rancher.com', () => {
-        cy.url().should('include', 'forums.rancher.com/');
+      cy.origin('https://forums.suse.com', () => {
+        cy.url().should('include', 'forums.suse.com/');
       });
     });
 

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -173,13 +173,13 @@ describe('Home Page', () => {
     });
 
     it('can click on Forums link', () => {
-      catchTargetPageException('TenantFeatures', 'https://forums.rancher.com');
+      catchTargetPageException('TenantFeatures', 'https://forums.suse.com');
 
       // click Forums link
       homePage.clickSupportLink(1, true);
 
-      cy.origin('https://forums.rancher.com', () => {
-        cy.url().should('include', 'forums.rancher.com/');
+      cy.origin('https://forums.suse.com', () => {
+        cy.url().should('include', 'forums.suse.com/');
       });
     });
 

--- a/shell/config/home-links.js
+++ b/shell/config/home-links.js
@@ -13,7 +13,7 @@ const DEFAULT_LINKS = [
   },
   {
     key:     'forums',
-    value:   'https://forums.rancher.com/',
+    value:   'https://forums.suse.com/',
     enabled: true,
   },
   {


### PR DESCRIPTION

### Occurred changes and/or fixed issues
This PR updates the forum url from https://forums.rancher.com to https://forums.suse.com - the old URL is redirecting to the new, but e2e tests do consider this a failure: https://github.com/rancher/dashboard/actions/runs/13317789813/job/37196017760#step:8:195

### Areas which could experience regressions
'Forums' link on home page


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
