### PR TITLE
Prevent activating shortkeys when modals are active

### DIFF
--- a/shell/initialize/install-plugins.js
+++ b/shell/initialize/install-plugins.js
@@ -35,7 +35,12 @@ export async function installPlugins(vueApp) {
   vueApp.use(PortalVue);
   vueApp.use(Vue3Resize);
   vueApp.use(FloatingVue, floatingVueOptions);
-  vueApp.use(ShortKey, { prevent: ['input', 'textarea', 'select'] });
+  vueApp.use(
+    ShortKey,
+    {
+      prevent:          ['input', 'textarea', 'select'],
+      preventContainer: ['#modal-container-element']
+    });
   vueApp.use(InstallCodeMirror);
   vueApp.component('v-select', vSelect);
 }

--- a/shell/plugins/shortkey.js
+++ b/shell/plugins/shortkey.js
@@ -10,6 +10,7 @@ const ShortKey = {};
 const mapFunctions = {};
 let objAvoided = [];
 let elementAvoided = [];
+let containerAvoided = [];
 let keyPressed = false;
 
 const parseValue = (value) => {
@@ -55,6 +56,7 @@ const unbindValue = (value, el) => {
 
 ShortKey.install = (Vue, options) => {
   elementAvoided = [...(options && options.prevent ? options.prevent : [])];
+  containerAvoided = [...(options && options.preventContainer ? options.preventContainer : [])];
   Vue.directive('shortkey', {
     beforeMount: (el, binding, vnode) => {
       // Mapping the commands
@@ -266,8 +268,15 @@ const mappingFunctions = ({
 const availableElement = (decodedKey) => {
   const objectIsAvoided = !!objAvoided.find((r) => r === document.activeElement);
   const filterAvoided = !!(elementAvoided.find((selector) => document.activeElement && document.activeElement.matches(selector)));
+  const filterAvoidedContainer = !!(containerAvoided.find((selector) => isActiveElementChildOf(selector)));
 
-  return !!mapFunctions[decodedKey] && !(objectIsAvoided || filterAvoided);
+  return !!mapFunctions[decodedKey] && !(objectIsAvoided || filterAvoided) && !filterAvoidedContainer;
+};
+
+const isActiveElementChildOf = (container) => {
+  const activeElement = document.activeElement;
+
+  return activeElement && activeElement.closest(container) !== null;
 };
 
 export default ShortKey;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This disables vue-shortkey when modals are active by creating a new option when registering vue-shortkey, `containerAvoided`, that will prevent triggering if active elements are a child of the modal container.

Fixes #13237 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- add new method to vue-shortkey to prevent triggering when the active element is a child of a given container
- register the modal as a container that should disable vue-shortkey

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

We might need to consider if any modals rely on keyboard shortcuts registered via vue-shortkey; they would no longer work with this change.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Example: https://github.com/rancher/dashboard/issues/13237#issuecomment-2659782111

- Raise modals on pages that contain keyboard shortcuts
- Ensure that keyboard shortcuts do not trigger when modal is active

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- If vue-shortkey registers shortcuts for use inside of a modal, they will no longer work

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

- NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
