### PR TITLE
Make a windows workers role warning more prominent

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1312,8 +1312,9 @@ cluster:
     registrationCommand:
       label: Registration Command
       linuxDetail: Run this command on each of the existing Linux machines you want to register.
-      windowsDetail: Run this command in PowerShell on each of the existing Windows machines you want to register. Windows nodes can only be workers.
-      windowsNotReady: The cluster must be up and running with Linux etcd, control plane, and worker nodes before the registration command for adding Windows workers will display.
+      windowsDetail: Run this command in PowerShell on each of the existing Windows machines you want to register. 
+      windowsWorkersOnly: <b>Windows nodes can only be workers.</b>
+      windowsNotReady: The cluster must be up and running with Linux etcd, control plane, and worker nodes before the registration command for adding Windows workers will display.<br /> <br /><b>Windows nodes can only be workers.</b>
       windowsWarning: Workload pods, including some deployed by Rancher charts, will be scheduled on both Linux and Windows nodes by default. Edit NodeSelector in the chart to direct them to be placed onto a compatible node.
       windowsDeprecatedForRKE1: Windows support is being deprecated for RKE1. We suggest migrating to RKE2.
       insecure: "Insecure: Select this to skip TLS verification if your server has a self-signed certificate."

--- a/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -263,6 +263,12 @@ export default {
         <hr class="mt-20 mb-20">
         <h4 v-t="'cluster.custom.registrationCommand.windowsDetail'" />
         <Banner
+          v-if="readyForWindows"
+          color="info"
+          label-key="cluster.custom.registrationCommand.windowsWorkersOnly"
+          data-testid="ready-for-windows"
+        />
+        <Banner
           v-if="cluster.isRke1"
           color="warning"
           :label="t('cluster.custom.registrationCommand.windowsDeprecatedForRKE1')"
@@ -288,7 +294,8 @@ export default {
         <Banner
           v-else
           color="info"
-          :label="t('cluster.custom.registrationCommand.windowsNotReady')"
+          label-key="cluster.custom.registrationCommand.windowsNotReady"
+          data-testid="windows-not-ready"
         />
       </template>
     </InfoBox>


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/7250

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Making the windows messaging more prominent while trying to prevent multiple adjacent banners.

### Technical notes summary
I also added some unit tests to avoid further manual verification.

### Areas or cases that should be tested
Custom rke2 clusters on the registration tab.

### Areas which could experience regressions
Custom rke2 clusters on the registration tab.

### Screenshot/Video
![with-nodes](https://github.com/user-attachments/assets/075603cf-4597-4a66-9a96-02ffc48edc76)

![without-nodes](https://github.com/user-attachments/assets/01a76a83-13be-40c5-b647-21a034ad42e5)



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
