### PR TITLE
Fix offer to uninstall crd app on cluster tools app uninstall

### DIFF
--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -167,7 +167,7 @@ export default {
       if (show) {
         const selected = this.toRemove[0];
 
-        if (this.currentRouter?.currentRoute?.name === 'c-cluster-explorer-tools' &&
+        if (this.currentRouter?.currentRoute?.value?.name === 'c-cluster-explorer-tools' &&
             selected.type === CATALOG.APP &&
             selected.spec?.chart?.metadata?.annotations[CATALOG_ANNOTATIONS.AUTO_INSTALL]) {
           this.chartsToRemoveIsApp = true;
@@ -407,22 +407,28 @@ export default {
           >
             {{ protip }}
           </div>
-          <Checkbox
-            v-if="chartsToRemoveIsApp"
-            v-model:value="chartsDeleteCrd"
-            label-key="promptRemoveApp.removeCrd"
-            class="mt-10 type"
-            @update:value="chartAddCrdToRemove"
-          />
         </LabeledInput>
         <div v-else-if="!hasCustomRemove">
-          <div class="text-warning mb-10 mt-10">
+          <div
+            v-if="warning"
+            class="text-warning mb-10 mt-10"
+          >
             {{ warning }}
           </div>
-          <div class="text-error mb-10 mt-10">
+          <div
+            v-if="error"
+            class="text-error mb-10 mt-10"
+          >
             {{ error }}
           </div>
         </div>
+        <Checkbox
+          v-if="chartsToRemoveIsApp"
+          v-model:value="chartsDeleteCrd"
+          label-key="promptRemoveApp.removeCrd"
+          class="mt-10 type"
+          @update:value="chartAddCrdToRemove"
+        />
       </template>
       <template #actions>
         <button


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #4849
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Ensure when uninstalling a cluster tool to offer user the option to also uninstall (if exists) the accompanying crd app.
- This was an existing mechanism broken in two places
  - the option is only offered in the cluster tool screen and checked it was there by currentRouter.currentRoute.name. this was no longer correct
  - the checkbox was grouped with the confirm delete mechanism
- also fixed some spacing issues

### Areas or cases that should be tested
- delete an app from cluster tools page with/without deleting the crd. deleting an app without deleting it's crd should mean any resource nav sections remain (good one to test with is CIS Benchmarch

### Areas which could experience regressions
- deleting an app from the apps list should remain unchanged
- deleting any resource that requires confirmation should remain unchanged

### Screenshot/Video
![image](https://github.com/user-attachments/assets/77af849c-a70f-4e6d-a661-34298bc73097)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
