### PR TITLE
Use nicer error message for login nonce error

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3392,6 +3392,7 @@ login:
     invalidSamlAttrs: "Invalid saml attributes"
     noResponse: "No response received"
   error: An error occurred logging in. Please try again.
+  invalidResponseError: Invalid response received to login request. Please try again.
   clientError: Invalid username or password. Please try again.
   specificError: 'An error occurred logging in: {msg}'
   useLocal: Use a local user

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -105,6 +105,8 @@ export default {
         return this.t('login.clientError');
       } else if (this.err === LOGIN_ERRORS.CLIENT || this.err === LOGIN_ERRORS.SERVER) {
         return this.t('login.error');
+      } else if (this.err === LOGIN_ERRORS.NONCE) {
+        return this.t('login.invalidResponseError');
       }
 
       return this.err?.length ? this.t('login.specificError', { msg: this.err }) : '';

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -18,12 +18,11 @@ export const BASE_SCOPES = {
 
 const KEY = 'rc_nonce';
 
-const ERR_NONCE = 'nonce';
-
 export const LOGIN_ERRORS = {
   CLIENT:              'client',
   CLIENT_UNAUTHORIZED: 'client_unauthorized',
-  SERVER:              'server'
+  SERVER:              'server',
+  NONCE:               'nonce',
 };
 
 export const state = function() {
@@ -267,13 +266,13 @@ export const actions = {
     try {
       parsed = JSON.parse(expectJSON);
     } catch {
-      return ERR_NONCE;
+      return LOGIN_ERRORS.NONCE;
     }
 
     const expect = parsed.nonce;
 
     if ( !expect || expect !== nonce ) {
-      return ERR_NONCE;
+      return LOGIN_ERRORS.NONCE;
     }
 
     const body = { code };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13256

### Occurred changes and/or fixed issues

This PR adds handling of the nonce error and displays a non-offensive error in this case.

Testing is difficult, since its hard to generate this error case, however, this has been implemented such that the handling is done in the login page, so you can test by going to:

https://<RANCER_URL/auth/login?err=nonce

You should now see the friendly error message instead of the previous error message.

### Screenshot/Video

After this PR:

![image](https://github.com/user-attachments/assets/8e8be8f7-1aba-4924-b800-20db5e524282)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
