### PR TITLE
Early return in `focusSearch` method when `LabeledSelect` is disabled

### DIFF
--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -154,6 +154,10 @@ export default {
   methods: {
     // resizeHandler = in mixin
     focusSearch() {
+      if (this.isView || this.disabled || this.loading) {
+        return;
+      }
+
       // we need this override as in a "closeOnSelect" type of component
       // if we don't have this override, it would open again
       if (this.overridesMixinPreventDoubleTriggerKeysOpen) {

--- a/shell/components/form/__tests__/LabeledSelect.test.ts
+++ b/shell/components/form/__tests__/LabeledSelect.test.ts
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils';
+import { _VIEW, _EDIT, _CREATE } from '@shell/config/query-params';
 import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
 import { defineComponent } from 'vue';
 
@@ -134,6 +135,42 @@ describe('component: LabeledSelect', () => {
         // Component is from a library and class is not going to be changed
         expect(wrapper.find('.vs__selected').text()).toBe(translation);
       });
+    });
+  });
+
+  describe(`given {'disabled', 'mode', 'loading'} options`, () => {
+    it.each([
+      ['open', false, _EDIT, false, true],
+      ['open', false, _CREATE, false, true],
+      ['not open', false, _VIEW, false, false],
+      ['not open', false, _EDIT, true, false],
+      ['not open', true, _EDIT, false, false],
+    ])('should %p dropdown element if options are { disabled: %p, mode: %p, loading: %p }', async(
+      _,
+      disabled,
+      mode,
+      loading,
+      isOpen
+    ) => {
+      const label = 'Foo';
+      const value = 'foo';
+      const wrapper = mount(LabeledSelect, {
+        props: {
+          value,
+          options: [
+            { label, value },
+          ],
+          disabled,
+          mode,
+          loading
+        }
+      });
+
+      await wrapper.trigger('click');
+
+      const dropdownOpen = wrapper.find('.vs--open');
+
+      expect(dropdownOpen.exists()).toBe(isOpen);
     });
   });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Adding an early return in focusSearch() method:

- Executing the focus logic it's not necessary if the component is `disabled`.
- The early return will skip the open=true assignment 
  `this.$refs['select-input'].open = true;`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
