### PR TITLE
fix tab component keyboard navigation

### DIFF
--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -224,7 +224,7 @@ export default {
 
         if (nxt >= tabsLength) {
           return 0;
-        } else if (nxt <= 0) {
+        } else if (nxt < 0) {
           return tabsLength - 1;
         } else {
           return nxt;
@@ -259,11 +259,13 @@ export default {
       class="tabs"
       :class="{'clearfix':!sideTabs, 'vertical': sideTabs, 'horizontal': !sideTabs}"
       data-testid="tabbed-block"
+      tabindex="0"
       @keydown.right.prevent="selectNext(1)"
       @keydown.left.prevent="selectNext(-1)"
       @keydown.down.prevent="selectNext(1)"
       @keydown.up.prevent="selectNext(-1)"
     >
+      <!-- This is the tabs link... tabs appear here because they are injected from the "Tab" component -->
       <li
         v-for="tab in sortedTabs"
         :id="tab.name"
@@ -278,7 +280,6 @@ export default {
           :aria-selected="tab.active"
           :aria-label="tab.labelDisplay || ''"
           role="tab"
-          tabindex="0"
           @click.prevent="select(tab.name, $event)"
           @keyup.enter.space="select(tab.name, $event)"
         >
@@ -336,8 +337,9 @@ export default {
         'tab-container--flat': !!flat,
       }"
     >
+      <!-- This is where "normal" tab content goes... -->
       <slot />
-      <!-- Extension tabs -->
+      <!-- Extension tabs content goes here... -->
       <Tab
         v-for="tab, i in extensionTabs"
         :key="`${tab.name}${i}`"
@@ -380,12 +382,13 @@ export default {
     }
   }
 
-  &:focus {
-    outline: none;
+  &:focus-visible {
+    @include focus-outline;
+    outline-offset: -2px;
+  }
 
-    & .tab.active a span {
-      text-decoration: underline;
-    }
+  &:focus .tab.active a span {
+    text-decoration: underline;
   }
 
   .tab {
@@ -404,12 +407,6 @@ export default {
         span {
           text-decoration: underline;
         }
-      }
-
-      &:focus-visible {
-        @include focus-outline;
-        outline-offset: -4px;
-        text-decoration: none;
       }
     }
 

--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -367,11 +367,20 @@ export default {
   margin: 0;
   padding: 0;
 
+  &:focus-visible {
+    @include focus-outline;
+    outline-offset: -2px;
+  }
+
   &.horizontal {
     border: solid thin var(--border);
     border-bottom: 0;
     display: flex;
     flex-direction: row;
+
+    &:focus-visible {
+      outline-offset: 2px;
+    }
 
     + .tab-container {
       border: solid thin var(--border);
@@ -380,11 +389,6 @@ export default {
     .tab.active {
       border-bottom: solid 2px var(--primary);
     }
-  }
-
-  &:focus-visible {
-    @include focus-outline;
-    outline-offset: -2px;
   }
 
   &:focus .tab.active a span {

--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -368,8 +368,12 @@ export default {
   padding: 0;
 
   &:focus-visible {
-    @include focus-outline;
-    outline-offset: -2px;
+    outline: none;
+
+    .tab.active {
+      @include focus-outline;
+      outline-offset: -2px;
+    }
   }
 
   &.horizontal {
@@ -377,10 +381,6 @@ export default {
     border-bottom: 0;
     display: flex;
     flex-direction: row;
-
-    &:focus-visible {
-      outline-offset: 2px;
-    }
 
     + .tab-container {
       border: solid thin var(--border);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13260 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix tab component keyboard navigation

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- went for the [automatic](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/examples/tabs-automatic/) approach here

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
