### PR TITLE
Adding the Registries accordion to the imported clusters edit pages

### DIFF
--- a/cypress/e2e/po/extensions/imported/cluster-edit.po.ts
+++ b/cypress/e2e/po/extensions/imported/cluster-edit.po.ts
@@ -2,6 +2,8 @@ import PagePo from '@/cypress/e2e/po/pages/page.po';
 import ACE from '@/cypress/e2e/po/components/ace.po';
 import ResourceDetailPo from '@/cypress/e2e/po/edit/resource-detail.po';
 import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
+import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
+import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
 
 /**
  * Edit page for imported cluster
@@ -29,6 +31,22 @@ export default class ClusterManagerEditImportedPagePo extends PagePo {
 
   enableNetworkAccordion() {
     return this.self().find('[data-testid="network-accordion"]').click();
+  }
+
+  enableRepositoriesAccordion() {
+    return this.self().find('[data-testid="repositories-accordion"]').click();
+  }
+
+  privateRegistryCheckbox() {
+    return new CheckboxInputPo('[data-testid="private-registry-enable-checkbox"]');
+  }
+
+  enablePrivateRegistryCheckbox() {
+    return this.privateRegistryCheckbox().set();
+  }
+
+  privateRegistry() {
+    return LabeledInputPo.byLabel(this.self(), 'Container Registry');
   }
 
   resourceDetail() {

--- a/cypress/e2e/po/extensions/imported/cluster-import-generic.po.ts
+++ b/cypress/e2e/po/extensions/imported/cluster-import-generic.po.ts
@@ -4,5 +4,7 @@ import ClusterManagerImportPagePo from '@/cypress/e2e/po/edit/provisioning.cattl
  * Import page for generic cluster
  */
 export default class ClusterManagerImportGenericPagePo extends ClusterManagerImportPagePo {
-
+  repositoriesAccordion() {
+    return this.self().find('[data-testid="repositories-accordion"]');
+  }
 }

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -592,6 +592,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     const importClusterPage = new ClusterManagerImportGenericPagePo();
     const fqdn = 'fqdn';
     const cacert = 'cacert';
+    const privateRegistry = 'registry.io';
 
     describe('Generic', () => {
       it('can create new cluster', () => {
@@ -603,6 +604,8 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
         importClusterPage.waitForPage('mode=import');
         importClusterPage.selectGeneric(0);
+        // Verify that we only show when editing
+        importClusterPage.repositoriesAccordion().should('not.be.visible');
         importClusterPage.nameNsDescription().name().set(importGenericName);
         importClusterPage.create();
 
@@ -663,6 +666,10 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         editImportedClusterPage.ace().enterFdqn(fqdn);
         editImportedClusterPage.ace().enterCaCerts(cacert);
 
+        editImportedClusterPage.enableRepositoriesAccordion();
+        editImportedClusterPage.enablePrivateRegistryCheckbox();
+        editImportedClusterPage.privateRegistry().set(privateRegistry);
+
         editImportedClusterPage.save();
 
         // We should be taken back to the list page if the save was successful
@@ -673,6 +680,10 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         editImportedClusterPage.waitForPage('mode=edit');
         editImportedClusterPage.ace().fqdn().value().should('eq', fqdn );
         editImportedClusterPage.ace().caCerts().value().should('eq', cacert );
+
+        // Verify the private registry values
+        editImportedClusterPage.privateRegistryCheckbox().isChecked();
+        editImportedClusterPage.privateRegistry().value().should('eq', privateRegistry);
       });
 
       it('can delete cluster by bulk actions', () => {

--- a/pkg/imported/l10n/en-us.yaml
+++ b/pkg/imported/l10n/en-us.yaml
@@ -15,6 +15,7 @@ imported:
     basics: Basics
     upgrade: Upgrade Strategy
     networking: Networking
+    registries: Registries
     labels: Labels and Annotations
     k3sOptions: K3S Options
     rke2Options: RKE2 Options

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1985,8 +1985,10 @@ cluster:
     header: Registry for Rancher System Container Images
     label: Enable cluster scoped container registry for Rancher system container images
     description: "If enabled, Rancher will pull container images from this registry during cluster provisioning. By default, Rancher will also use this registry when installing Rancher's official Helm chart apps. If the cluster scoped registry is disabled, system images are pulled from the System Default Registry in the global settings."
+    importedDescription: "By default, Rancher will also use this registry when installing Rancher's official Helm chart apps. If the cluster scoped registry is disabled, system images are pulled from the System Default Registry in the global settings."
     docsLinkRke2: "For help configuring private registry mirrors, see the RKE2 <a href=\"https://docs.rke2.io/install/private_registry\" target=\"_blank\">documentation.</a>"
     docsLinkK3s: "For help configuring private registry mirrors, see the K3s <a href=\"https://docs.k3s.io/installation/private-registry\" target=\"_blank\">documentation.</a>"
+    privateRegistryUrlError: A registry must be a valid url. Scheme is optional.
   provider:
     aliyunecs: Aliyun ECS
     aliyunkubernetescontainerservice: Alibaba ACK

--- a/shell/utils/validators/formRules/__tests__/index.test.ts
+++ b/shell/utils/validators/formRules/__tests__/index.test.ts
@@ -244,6 +244,33 @@ describe('formRules', () => {
     expect(formRuleResult).toStrictEqual(expectedResult);
   });
 
+  describe('"registryUrl": has the expected output for each input', () => {
+    const expectedTranslation = JSON.stringify({ message: 'cluster.privateRegistry.privateRegistryUrlError' });
+    const testCases = [
+      // Empty
+      [undefined, expectedTranslation],
+
+      // Word
+      ['registry', expectedTranslation],
+
+      // Without schema
+      ['registry.io', undefined],
+
+      // With schemas
+      ['http://registry.io', undefined],
+      ['https://registry.io', undefined],
+    ];
+
+    it.each(testCases)(
+      'should return undefined or correct message based on the provided url',
+      (url, expected) => {
+        const formRuleResult = formRules.registryUrl(url);
+
+        expect(formRuleResult).toStrictEqual(expected);
+      }
+    );
+  });
+
   it('"ruleGroups" : returns undefined when rulegroups are supplied', () => {
     const testValue = { groups: ['group1'] };
     const formRuleResult = formRules.ruleGroups(testValue);

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -176,6 +176,17 @@ export default function(t: Translation, { key = 'Value' }: ValidationOptions): {
     return containers.map((container: any) => containerImage(container)).find((containerError: string) => containerError);
   };
 
+  const registryUrl = (privateRegistryURL: string) => {
+    const pattern = new RegExp('^([a-z\\-0-9]+:\\/\\/?)?' + // scheme (optional, https://, http://, file:/, admin:/)
+        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
+        '((\\d{1,3}\\.){3}\\d{1,3}))' + // ip address
+        '(\\:\\d+)?'); // port
+
+    const isValid = pattern.test(privateRegistryURL);
+
+    return isValid ? undefined : t('cluster.privateRegistry.privateRegistryUrlError');
+  };
+
   const dnsLabel: Validator = (val: string) => {
     const validators = [
       dnsChars,
@@ -504,6 +515,7 @@ export default function(t: Translation, { key = 'Value' }: ValidationOptions): {
     minValue,
     noUpperCase,
     portNumber,
+    registryUrl,
     required,
     requiredInt,
     isInteger,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Adding the Registries accordion to the imported clusters edit pages

Fixes https://github.com/rancher/dashboard/issues/13063
<!-- Define findings related to the feature or bug issue. -->

Just a port from ember to vue.

### Technical notes summary
Nothing of note, just followed the existing patterns.

### Areas or cases that should be tested
The registries tab within the generic import provisioning page.

### Areas which could experience regressions
This is new and unlikely to affect other areas.

### Screenshot/Video
![image](https://github.com/user-attachments/assets/f6b55dc9-7955-48ad-9963-9073ac73ab5f)
![image](https://github.com/user-attachments/assets/5839c3de-dfae-4e41-82fb-8788caaf14c8)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
