### PR TITLE
Import GKE clusters

### DIFF
--- a/pkg/gke/components/AccountAccess.vue
+++ b/pkg/gke/components/AccountAccess.vue
@@ -112,40 +112,45 @@ export default defineComponent({
 </script>
 
 <template>
-  <div
-    :class="{'showing-form': !credential}"
-    class="credential-project"
-  >
+  <div>
     <div
-      v-show="!!credential"
-      class="project mb-10"
+      :class="{'showing-form': !credential}"
+      class="credential-project"
     >
-      <LabeledInput
-        :disabled="isAuthenticated"
-        :value="project"
-        label-key="gke.project.label"
-        required
-        @update:value="$emit('update:project', $event)"
-      />
+      <div
+        v-show="!!credential"
+        class="project mb-10"
+      >
+        <LabeledInput
+          :disabled="isAuthenticated"
+          :value="project"
+          label-key="gke.project.label"
+          required
+          @update:value="$emit('update:project', $event)"
+        />
+      </div>
+      <div
+        :class="{'view': isView}"
+        class="select-credential-container mb-10"
+      >
+        <SelectCredential
+          :value="credential"
+          data-testid="crugke-select-credential"
+          :mode="(isView|| isAuthenticated) ? VIEW : CREATE"
+          provider="gcp"
+          :default-on-cancel="true"
+          :showing-form="!credential"
+          class="select-credential"
+          :cancel="()=>$emit('cancel-credential')"
+          @update:value="$emit('update:credential', $event)"
+          @credential-created="parseNewCredential"
+        />
+      </div>
     </div>
     <div
-      :class="{'view': isView}"
-      class="select-credential-container mb-10"
+      v-if="!isView && !isAuthenticated"
+      class="row mt-10"
     >
-      <SelectCredential
-        :value="credential"
-        data-testid="crugke-select-credential"
-        :mode="(isView|| isAuthenticated) ? VIEW : CREATE"
-        provider="gcp"
-        :default-on-cancel="true"
-        :showing-form="!credential"
-        class="select-credential"
-        :cancel="()=>$emit('cancel-credential')"
-        @update:value="$emit('update:credential', $event)"
-        @credential-created="parseNewCredential"
-      />
-    </div>
-    <template v-if="!isView">
       <div
         v-show="!!credential"
         class="auth-button-container mb-10"
@@ -158,7 +163,7 @@ export default defineComponent({
           @click="testProjectId"
         />
       </div>
-    </template>
+    </div>
   </div>
 </template>
 
@@ -167,7 +172,7 @@ export default defineComponent({
     display: flex;
     min-width: 150px;
     .project {
-      flex-basis: 50%;
+      flex-basis: 49.25%;
       flex-grow: 0;
       margin: 0 1.75% 0 0;
     }
@@ -188,8 +193,8 @@ export default defineComponent({
     }
 
     &>.select-credential-container{
-      flex-basis: 50%;
-      margin: 0 1.75% 0 0;
+      flex-basis: 49.25%;
+      // margin: 0 1.75% 0 0;
 
       &.view{
         margin: 0;
@@ -204,7 +209,7 @@ export default defineComponent({
 
   .auth-button-container {
     align-content: center;
-    min-width: 150px;
+    width:100%;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/pkg/gke/components/AccountAccess.vue
+++ b/pkg/gke/components/AccountAccess.vue
@@ -188,7 +188,6 @@ export default defineComponent({
 
     &>.select-credential-container{
       flex-basis: 49.25%;
-      // margin: 0 1.75% 0 0;
 
       &.view{
         margin: 0;
@@ -203,7 +202,7 @@ export default defineComponent({
 
   .auth-button-container {
     align-content: center;
-    width:100%;
+    width: 100%;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/pkg/gke/components/AccountAccess.vue
+++ b/pkg/gke/components/AccountAccess.vue
@@ -44,6 +44,12 @@ export default defineComponent({
     if (this.mode === _VIEW) {
       this.$emit('update:isAuthenticated', true);
     }
+    // TODO nb remove
+    if (!this.project) {
+      if (process.env.VUE_APP_GCP_PROJECT) {
+        this.$emit('update:project', process.env.VUE_APP_GCP_PROJECT);
+      }
+    }
   },
 
   computed: {

--- a/pkg/gke/components/AccountAccess.vue
+++ b/pkg/gke/components/AccountAccess.vue
@@ -44,12 +44,6 @@ export default defineComponent({
     if (this.mode === _VIEW) {
       this.$emit('update:isAuthenticated', true);
     }
-    // TODO nb remove
-    if (!this.project) {
-      if (process.env.VUE_APP_GCP_PROJECT) {
-        this.$emit('update:project', process.env.VUE_APP_GCP_PROJECT);
-      }
-    }
   },
 
   computed: {

--- a/pkg/gke/components/AdvancedOptions.vue
+++ b/pkg/gke/components/AdvancedOptions.vue
@@ -1,11 +1,12 @@
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, PropType } from 'vue';
 import { mapGetters } from 'vuex';
 
 import { _CREATE } from '@shell/config/query-params';
 import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
 import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 import Banner from '@components/Banner/Banner.vue';
+import KeyValue from '@shell/components/form/KeyValue.vue';
 
 const NONE_OPTION = 'none';
 
@@ -16,12 +17,13 @@ const LOGGING_OPTION = 'logging.googleapis.com/kubernetes';
 export default defineComponent({
   name: 'GKEAdvancedOptions',
 
-  emits: ['update:loggingService', 'update:monitoringService', 'update:httpLoadBalancing', 'update:horizontalPodAutoscaling', 'update:enableKubernetesAlpha', 'update:maintenanceWindow'],
+  emits: ['update:loggingService', 'update:monitoringService', 'update:httpLoadBalancing', 'update:horizontalPodAutoscaling', 'update:enableKubernetesAlpha', 'update:maintenanceWindow', 'update:labels'],
 
   components: {
     LabeledSelect,
     Checkbox,
     Banner,
+    KeyValue
   },
 
   props: {
@@ -63,7 +65,15 @@ export default defineComponent({
     enableKubernetesAlpha: {
       type:    Boolean,
       default: false
-    }
+    },
+
+    // these are gkeconfig.labels NOT normancluster.labels (handled in another accordion)
+    labels: {
+      type:    Object as PropType<{[key:string]: string}>,
+      default: () => {
+        return {};
+      }
+    },
   },
 
   computed: {
@@ -214,6 +224,24 @@ export default defineComponent({
           label-key="gke.enableKubernetesAlpha.warning"
           icon="icon-warning"
         />
+      </div>
+    </div>
+    <div class="row mt-20 mb-10">
+      <div class="col span-12">
+        <KeyValue
+          :mode="mode"
+          :value="labels"
+          :as-map="true"
+          :title="t('gke.clusterLabels.label')"
+          :add-label="t('gke.clusterLabels.add')"
+          @update:value="$emit('update:labels', $event)"
+        >
+          <template #title>
+            <h4>
+              {{ t('gke.clusterLabels.label') }}
+            </h4>
+          </template>
+        </KeyValue>
       </div>
     </div>
   </div>

--- a/pkg/gke/components/Config.vue
+++ b/pkg/gke/components/Config.vue
@@ -99,6 +99,11 @@ export default defineComponent({
       default: ''
     },
 
+    isImport: {
+      type:    Boolean,
+      default: false
+    },
+
     rules: {
       type:    Object,
       default: () => {
@@ -328,8 +333,12 @@ export default defineComponent({
     // when credential/region/zone change, fetch dependent resources from gcp
     loadGCPData(loadZones = true) {
       if (!this.isView) {
-        this.loadingVersions = true;
-        this.getVersions();
+        // wont show a version picker when initially importing a cluster
+        if (!this.isImport) {
+          this.loadingVersions = true;
+          this.getVersions();
+        }
+
         if (loadZones) {
           this.loadingZones = true;
           this.getZones();
@@ -416,7 +425,7 @@ export default defineComponent({
 <template>
   <div>
     <div class="row mb-10">
-      <div class="col span-4">
+      <div :class="{col: true, 'span-4': !isImport, 'span-6': isImport}">
         <LabeledInput
           :value="clusterName"
           :mode="mode"
@@ -427,7 +436,7 @@ export default defineComponent({
           @update:value="$emit('update:clusterName', $event)"
         />
       </div>
-      <div class="col span-4">
+      <div :class="{col: true, 'span-4': !isImport, 'span-6': isImport}">
         <LabeledInput
           :value="clusterDescription"
           :mode="mode"
@@ -437,7 +446,10 @@ export default defineComponent({
           @update:value="$emit('update:clusterDescription', $event)"
         />
       </div>
-      <div class="col span-4">
+      <div
+        v-if="!isImport"
+        class="col span-4"
+      >
         <LabeledSelect
           :options="versionOptions"
           label-key="gke.version.label"
@@ -479,7 +491,7 @@ export default defineComponent({
       </div>
       <div
         v-if="!loadingZones"
-        class="col span-3 extra-zones"
+        class="col span-2 extra-zones"
         data-testid="gke-extra-zones-container"
       >
         <span class="text-muted">{{ t('gke.location.extraZones') }}</span>

--- a/pkg/gke/components/Config.vue
+++ b/pkg/gke/components/Config.vue
@@ -4,6 +4,8 @@ import { _CREATE, _VIEW } from '@shell/config/query-params';
 import RadioGroup from '@components/Form/Radio/RadioGroup.vue';
 import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
 import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
+import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
+
 import {
   DEFAULT_GCP_REGION, DEFAULT_GCP_ZONE, getGKEZones, getGKERegionFromZone,
   getGKEVersions, getGKEClusters,
@@ -18,18 +20,17 @@ import debounce from 'lodash/debounce';
 import { MANAGEMENT } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';
 import { mapGetters } from 'vuex';
-import KeyValue from '@shell/components/form/KeyValue.vue';
 
 export default defineComponent({
   name: 'GKEConfig',
 
-  emits: ['update:kubernetesVersion', 'update:locations', 'update:zone', 'update:region', 'update:defaultImageType', 'error', 'update:labels'],
+  emits: ['update:kubernetesVersion', 'update:locations', 'update:zone', 'update:region', 'update:defaultImageType', 'error', 'update:clusterName', 'update:clusterDescription'],
 
   components: {
     RadioGroup,
     LabeledSelect,
     Checkbox,
-    KeyValue
+    LabeledInput
   },
 
   props: {
@@ -83,6 +84,11 @@ export default defineComponent({
       default: ''
     },
 
+    clusterDescription: {
+      type:    String,
+      default: ''
+    },
+
     kubernetesVersion: {
       type:    String,
       default: ''
@@ -92,13 +98,13 @@ export default defineComponent({
       type:    String,
       default: ''
     },
-    // these are gkeconfig.labels NOT normancluster.labels (handled in another accordion)
-    labels: {
-      type:    Object as PropType<{[key:string]: string}>,
+
+    rules: {
+      type:    Object,
       default: () => {
         return {};
       }
-    },
+    }
   },
 
   created() {
@@ -411,6 +417,27 @@ export default defineComponent({
   <div>
     <div class="row mb-10">
       <div class="col span-4">
+        <LabeledInput
+          :value="clusterName"
+          :mode="mode"
+          label-key="generic.name"
+          required
+          :rules="rules.clusterName"
+          data-testid="gke-cluster-name"
+          @update:value="$emit('update:clusterName', $event)"
+        />
+      </div>
+      <div class="col span-4">
+        <LabeledInput
+          :value="clusterDescription"
+          :mode="mode"
+          label-key="nameNsDescription.description.label"
+          :placeholder="t('nameNsDescription.description.placeholder')"
+          data-testid="gke-cluster-description"
+          @update:value="$emit('update:clusterDescription', $event)"
+        />
+      </div>
+      <div class="col span-4">
         <LabeledSelect
           :options="versionOptions"
           label-key="gke.version.label"
@@ -423,6 +450,7 @@ export default defineComponent({
         />
       </div>
     </div>
+
     <div class="row location-row mb-10">
       <div class="col span-4">
         <LabeledSelect
@@ -479,25 +507,6 @@ export default defineComponent({
           :disabled="!isNewOrUnprovisioned"
           data-testid="gke-location-mode-radio"
         />
-      </div>
-    </div>
-    <div class="row mt-20 mb-10">
-      <div class="col span-12">
-        <KeyValue
-          :mode="mode"
-          :value="labels"
-          :as-map="true"
-          :title="t('gke.clusterLabels.label')"
-          :add-label="t('gke.clusterLabels.add')"
-          @update:value="$emit('update:labels', $event)"
-        >
-          <template #title>
-            <!-- keyvalue title by default is an h3 and looks bad with the accordion header also being an h3 -->
-            <h4>
-              {{ t('gke.clusterLabels.label') }}
-            </h4>
-          </template>
-        </KeyValue>
       </div>
     </div>
   </div>

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -694,12 +694,8 @@ export default defineComponent({
         class="mt-10"
         data-testid="crugke-form"
       >
-        <div
-          class="row mb-10"
-        >
-          <div
-            class="col span-6"
-          >
+        <!-- <div class="row mb-10">
+          <div class="col span-6">
             <LabeledInput
               :value="normanCluster.name"
               :mode="mode"
@@ -722,7 +718,30 @@ export default defineComponent({
               @update:value="setClusterDescription"
             />
           </div>
-        </div>
+        </div> -->
+
+        <Config
+          v-model:kubernetes-version="config.kubernetesVersion"
+          v-model:zone="config.zone"
+          v-model:region="config.region"
+          v-model:locations="config.locations"
+          v-model:default-image-type="defaultImageType"
+          v-model:labels="config.labels"
+          :mode="mode"
+          :cloud-credential-id="config.googleCredentialSecret"
+          :project-id="config.projectID"
+          :is-new-or-unprovisioned="isNewOrUnprovisioned"
+          :original-version="originalVersion"
+          :cluster-id="normanCluster.id"
+          :cluster-name="config.clusterName"
+          :cluster-description="normanCluster.description"
+          :rules="{
+            clusterName: fvGetAndReportPathRules('clusterName')
+          }"
+          @update:clusterName="setClusterName"
+          @update:clusterDescription="setClusterDescription"
+        />
+
         <div><h3>{{ t('gke.accordion.nodePools') }}</h3></div>
         <Tabbed
           ref="pools"
@@ -776,7 +795,7 @@ export default defineComponent({
             />
           </Tab>
         </Tabbed>
-        <Accordion
+        <!-- <Accordion
           class="mb-20"
           :title="t('gke.accordion.config')"
           :open-initially="true"
@@ -796,7 +815,7 @@ export default defineComponent({
             :cluster-id="normanCluster.id"
             :cluster-name="config.clusterName"
           />
-        </Accordion>
+        </Accordion> -->
         <Accordion
           class="mb-20"
           :title="t('gke.accordion.networking')"

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -12,7 +12,6 @@ import { SETTING } from '@shell/config/settings';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import FormValidation from '@shell/mixins/form-validation';
 import CruResource from '@shell/components/CruResource.vue';
-import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 import Labels from '@shell/components/form/Labels.vue';
 import Tab from '@shell/components/Tabbed/Tab.vue';
 import Tabbed from '@shell/components/Tabbed/index.vue';
@@ -27,6 +26,8 @@ import AdvancedOptions from './AdvancedOptions.vue';
 import Networking from './Networking.vue';
 import GKENodePoolComponent from './GKENodePool.vue';
 import Config from './Config.vue';
+import Import from './Import.vue';
+
 import {
   DEFAULT_GCP_ZONE, DEFAULT_GCP_SERVICE_ACCOUNT, GKEImageTypes, getGKEMachineTypes, getGKEServiceAccounts
 } from '../util/gcp';
@@ -129,6 +130,22 @@ const defaultCluster = {
   windowsPreferedCluster:  false,
 };
 
+const defaultImportedCluster = {
+  dockerRootDir:          '/var/lib/docker',
+  enableNetworkPolicy:    false,
+  windowsPreferedCluster: false,
+  name:                   '',
+  gkeConfig:              {
+    imported:               true,
+    clusterName:            '',
+    zone:                   DEFAULT_GCP_ZONE,
+    googleCredentialSecret: '',
+    projectID:              '',
+    region:                 '',
+  },
+  labels: {}
+};
+
 export default defineComponent({
   name: 'CruGKE',
 
@@ -139,14 +156,14 @@ export default defineComponent({
     Networking,
     GKENodePoolComponent,
     Config,
-    LabeledInput,
     ClusterMembershipEditor,
     Labels,
     Tabbed,
     Tab,
     Accordion,
     Banner,
-    Loading
+    Loading,
+    Import
   },
 
   mixins: [CreateEditView, FormValidation],
@@ -175,7 +192,11 @@ export default defineComponent({
       this.normanCluster = await store.dispatch(`rancher/clone`, { resource: liveNormanCluster });
       this.originalVersion = this.normanCluster?.gkeConfig?.kubernetesVersion;
     } else {
-      this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...defaultCluster }, { root: true });
+      if (this.isImport) {
+        this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...cloneDeep(defaultImportedCluster) }, { root: true });
+      } else {
+        this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...defaultCluster }, { root: true });
+      }
       if (!this.$store.getters['auth/principalId'].includes('local://')) {
         this.normanCluster.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
       }
@@ -184,21 +205,25 @@ export default defineComponent({
     if (!this.isNewOrUnprovisioned) {
       syncUpstreamConfig('gke', this.normanCluster);
     }
-    if (!this.normanCluster.gkeConfig) {
-      this.normanCluster['gkeConfig'] = cloneDeep(defaultGkeConfig);
+
+    if (!this.isImport) {
+      if (!this.normanCluster.gkeConfig) {
+        this.normanCluster['gkeConfig'] = cloneDeep(defaultGkeConfig);
+      }
+      if (!this.normanCluster.gkeConfig.nodePools) {
+        this.normanCluster.gkeConfig['nodePools'] = [{ ...cloneDeep(defaultNodePool), name: 'group-1' }];
+      }
+      if (!this.normanCluster.gkeConfig.ipAllocationPolicy) {
+        this.normanCluster.gkeConfig['ipAllocationPolicy'] = cloneDeep(defaultGkeConfig.ipAllocationPolicy);
+      }
+      if (!this.normanCluster.gkeConfig.clusterAddons) {
+        this.normanCluster.gkeConfig['clusterAddons'] = cloneDeep(defaultGkeConfig.clusterAddons);
+      }
+      if (!this.normanCluster.gkeConfig.privateClusterConfig) {
+        this.normanCluster.gkeConfig['privateClusterConfig'] = cloneDeep(defaultGkeConfig.privateClusterConfig);
+      }
     }
-    if (!this.normanCluster.gkeConfig.nodePools) {
-      this.normanCluster.gkeConfig['nodePools'] = [{ ...cloneDeep(defaultNodePool), name: 'group-1' }];
-    }
-    if (!this.normanCluster.gkeConfig.ipAllocationPolicy) {
-      this.normanCluster.gkeConfig['ipAllocationPolicy'] = cloneDeep(defaultGkeConfig.ipAllocationPolicy);
-    }
-    if (!this.normanCluster.gkeConfig.clusterAddons) {
-      this.normanCluster.gkeConfig['clusterAddons'] = cloneDeep(defaultGkeConfig.clusterAddons);
-    }
-    if (!this.normanCluster.gkeConfig.privateClusterConfig) {
-      this.normanCluster.gkeConfig['privateClusterConfig'] = cloneDeep(defaultGkeConfig.privateClusterConfig);
-    }
+
     this.config = this.normanCluster.gkeConfig;
     this.nodePools = this.normanCluster.gkeConfig.nodePools;
 
@@ -217,8 +242,10 @@ export default defineComponent({
   data() {
     const store = this.$store as Store<any>;
     const supportedVersionRange = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_SUPPORTED_K8S_VERSIONS)?.value;
+    const isImport = this.$route?.query?.mode === 'import';
 
     return {
+      isImport,
       normanCluster:    { name: '' } as any,
       nodePools:        [] as GKENodePool[],
       config:           { } as GKEConfig,
@@ -232,7 +259,10 @@ export default defineComponent({
       machineTypesResponse:    {} as getGKEMachineTypesResponse,
       serviceAccountsResponse: {} as getGKEServiceAccountsResponse,
 
-      fvFormRuleSets: [
+      fvFormRuleSets: isImport ? [{
+        path:  'clusterName',
+        rules: ['nameRequired', 'clusterNameChars', 'clusterNameStartEnd']
+      }] : [
         {
           path:  'diskSizeGb',
           rules: ['diskSizeGb']
@@ -286,17 +316,20 @@ export default defineComponent({
   },
 
   created() {
-    if (!this.nodePools.length) {
-      this.addPool();
-    }
     const registerBeforeHook = this.registerBeforeHook as Function;
     const registerAfterHook = this.registerAfterHook as Function;
 
-    registerBeforeHook(this.cleanPoolsForSave);
-    registerBeforeHook(this.removeUnchangedConfigFields);
     registerAfterHook(this.saveRoleBindings, 'save-role-bindings');
 
     this.debouncedLoadGCPData = debounce(this.loadGCPData, 500);
+
+    if (!this.isImport) {
+      if (!this.nodePools.length) {
+        this.addPool();
+      }
+      registerBeforeHook(this.cleanPoolsForSave);
+      registerBeforeHook(this.removeUnchangedConfigFields);
+    }
   },
 
   computed: {
@@ -606,7 +639,9 @@ export default defineComponent({
 
     setClusterName(name: string): void {
       this.normanCluster['name'] = name;
-      this.config['clusterName'] = name;
+      if (!this.isImport) {
+        this.config['clusterName'] = name;
+      }
     },
 
     setClusterDescription(decription: string): void {
@@ -691,35 +726,8 @@ export default defineComponent({
 
       <div
         v-if="isAuthenticated"
-        class="mt-10"
         data-testid="crugke-form"
       >
-        <!-- <div class="row mb-10">
-          <div class="col span-6">
-            <LabeledInput
-              :value="normanCluster.name"
-              :mode="mode"
-              label-key="generic.name"
-              required
-              :rules="fvGetAndReportPathRules('clusterName')"
-              data-testid="gke-cluster-name"
-              @update:value="setClusterName"
-            />
-          </div>
-          <div
-            class="col span-6"
-          >
-            <LabeledInput
-              :value="normanCluster.description"
-              :mode="mode"
-              label-key="nameNsDescription.description.label"
-              :placeholder="t('nameNsDescription.description.placeholder')"
-              data-testid="gke-cluster-description"
-              @update:value="setClusterDescription"
-            />
-          </div>
-        </div> -->
-
         <Config
           v-model:kubernetes-version="config.kubernetesVersion"
           v-model:zone="config.zone"
@@ -733,147 +741,148 @@ export default defineComponent({
           :is-new-or-unprovisioned="isNewOrUnprovisioned"
           :original-version="originalVersion"
           :cluster-id="normanCluster.id"
-          :cluster-name="config.clusterName"
+          :cluster-name="normanCluster.name"
           :cluster-description="normanCluster.description"
           :rules="{
             clusterName: fvGetAndReportPathRules('clusterName')
           }"
+          :is-import="isImport"
           @update:clusterName="setClusterName"
           @update:clusterDescription="setClusterDescription"
         />
 
-        <div><h3>{{ t('gke.accordion.nodePools') }}</h3></div>
-        <Tabbed
-          ref="pools"
-          :side-tabs="true"
-          :show-tabs-add-remove="mode !== 'view'"
+        <Accordion
+          v-if="isImport"
           class="mb-20"
-          @addTab="addPool($event)"
-          @removeTab="removePool($event)"
-        >
-          <Tab
-            v-for="(pool) in nodePools"
-            :key="pool._id"
-            :name="pool._id || pool.name"
-            :label="pool.name || t('gke.notNamed')"
-            :error="pool._minMaxValid===false || pool._nameUnique===false"
-          >
-            <GKENodePoolComponent
-              v-model:version="pool.version"
-              v-model:image-type="pool.config.imageType"
-              v-model:machine-type="pool.config.machineType"
-              v-model:service-account="pool.config.serviceAccount"
-              v-model:disk-type="pool.config.diskType"
-              v-model:disk-size-gb="pool.config.diskSizeGb"
-              v-model:local-ssd-count="pool.config.localSsdCount"
-              v-model:preemptible="pool.config.preemptible"
-              v-model:taints="pool.config.taints"
-              v-model:labels="pool.config.labels"
-              v-model:tags="pool.config.tags"
-              v-model:name="pool.name"
-              v-model:initial-node-count="pool.initialNodeCount"
-              v-model:max-pods-constraint="pool.maxPodsConstraint"
-              v-model:autoscaling="pool.autoscaling.enabled"
-              v-model:min-node-count="pool.autoscaling.minNodeCount"
-              v-model:max-node-count="pool.autoscaling.maxNodeCount"
-              v-model:auto-repair="pool.management.autoRepair"
-              v-model:auto-upgrade="pool.management.autoUpgrade"
-              v-model:oauth-scopes="pool.config.oauthScopes"
-              :rules="{
-                diskSizeGb: fvGetAndReportPathRules('diskSizeGb'),
-                initialNodeCount: fvGetAndReportPathRules('initialNodeCount'),
-                ssdCount: fvGetAndReportPathRules('ssdCount'),
-                poolName: fvGetAndReportPathRules('poolName'),
-              }"
-              :mode="mode"
-              :cluster-kubernetes-version="config.kubernetesVersion"
-              :machine-type-options="machineTypeOptions"
-              :service-account-options="serviceAccountOptions"
-              :loading-machine-types="loadingMachineTypes"
-              :loading-service-accounts="loadingServiceAccounts"
-              :is-new="pool._isNewOrUnprovisioned"
-            />
-          </Tab>
-        </Tabbed>
-        <!-- <Accordion
-          class="mb-20"
-          :title="t('gke.accordion.config')"
+          :title="t('gke.accordion.import')"
           :open-initially="true"
         >
-          <Config
-            v-model:kubernetes-version="config.kubernetesVersion"
-            v-model:zone="config.zone"
-            v-model:region="config.region"
-            v-model:locations="config.locations"
-            v-model:default-image-type="defaultImageType"
-            v-model:labels="config.labels"
-            :mode="mode"
-            :cloud-credential-id="config.googleCredentialSecret"
-            :project-id="config.projectID"
-            :is-new-or-unprovisioned="isNewOrUnprovisioned"
-            :original-version="originalVersion"
-            :cluster-id="normanCluster.id"
-            :cluster-name="config.clusterName"
-          />
-        </Accordion> -->
-        <Accordion
-          class="mb-20"
-          :title="t('gke.accordion.networking')"
-        >
-          <Networking
-            v-model:kubernetes-version="config.kubernetesVersion"
-            v-model:network="config.network"
-            v-model:subnetwork="config.subnetwork"
-            v-model:create-subnetwork="config.ipAllocationPolicy.createSubnetwork"
-            v-model:use-ip-aliases="config.ipAllocationPolicy.useIpAliases"
-            v-model:network-policy-config="config.clusterAddons.networkPolicyConfig"
+          <Import
             v-model:enable-network-policy="normanCluster.enableNetworkPolicy"
-            v-model:network-policy-enabled="config.networkPolicyEnabled"
-            v-model:cluster-ipv4-cidr="config.clusterIpv4Cidr"
-            v-model:cluster-secondary-range-name="config.ipAllocationPolicy.clusterSecondaryRangeName"
-            v-model:services-secondary-range-name="config.ipAllocationPolicy.servicesSecondaryRangeName"
-            v-model:cluster-ipv4-cidr-block="config.ipAllocationPolicy.clusterIpv4CidrBlock"
-            v-model:services-ipv4-cidr-block="config.ipAllocationPolicy.servicesIpv4CidrBlock"
-            v-model:node-ipv4-cidr-block="config.ipAllocationPolicy.nodeIpv4CidrBlock"
-            v-model:subnetwork-name="config.ipAllocationPolicy.subnetworkName"
-            v-model:enable-private-endpoint="config.privateClusterConfig.enablePrivateEndpoint"
-            v-model:enable-private-nodes="config.privateClusterConfig.enablePrivateNodes"
-            v-model:master-ipv4-cidr-block="config.privateClusterConfig.masterIpv4CidrBlock"
-            v-model:enable-master-authorized-network="config.masterAuthorizedNetworks.enabled"
-            v-model:master-authorized-network-cidr-blocks="config.masterAuthorizedNetworks.cidrBlocks"
-            :rules="{
-              masterIpv4CidrBlock: fvGetAndReportPathRules('masterIpv4CidrBlock'),
-              clusterIpv4CidrBlock: fvGetAndReportPathRules('clusterIpv4CidrBlock'),
-              nodeIpv4CidrBlock: fvGetAndReportPathRules('nodeIpv4CidrBlock'),
-              servicesIpv4CidrBlock: fvGetAndReportPathRules('servicesIpv4CidrBlock'),
-              clusterIpv4Cidr: fvGetAndReportPathRules('clusterIpv4Cidr')
-            }"
-            :mode="mode"
+            :credential="config.googleCredentialSecret"
+            :project="config.projectID"
             :zone="config.zone"
             :region="config.region"
-            :cloud-credential-id="config.googleCredentialSecret"
-            :project-id="config.projectID"
-            :original-version="originalVersion"
-            :cluster-id="normanCluster.id"
-            :cluster-name="config.clusterName"
-            :is-new-or-unprovisioned="isNewOrUnprovisioned"
-          />
-        </Accordion>
-        <Accordion
-          class="mb-20"
-          :title="t('gke.accordion.advanced')"
-        >
-          <AdvancedOptions
-            v-model:logging-service="config.loggingService"
-            v-model:monitoring-service="config.monitoringService"
-            v-model:maintenance-window="config.maintenanceWindow"
-            v-model:http-load-balancing="config.clusterAddons.httpLoadBalancing"
-            v-model:horizontal-pod-autoscaling="config.clusterAddons.horizontalPodAutoscaling"
-            v-model:enable-kubernetes-alpha="config.enableKubernetesAlpha"
             :mode="mode"
-            :is-new-or-unprovisioned="isNewOrUnprovisioned"
+            :cluster-name="config.clusterName"
+            @error="e=>errors.push(e)"
+            @update:clusterName="e=>config.clusterName=e"
           />
         </Accordion>
+
+        <template v-else>
+          <div><h3>{{ t('gke.accordion.nodePools') }}</h3></div>
+          <Tabbed
+            ref="pools"
+            :side-tabs="true"
+            :show-tabs-add-remove="mode !== 'view'"
+            class="mb-20"
+            @addTab="addPool($event)"
+            @removeTab="removePool($event)"
+          >
+            <Tab
+              v-for="(pool) in nodePools"
+              :key="pool._id"
+              :name="pool._id || pool.name"
+              :label="pool.name || t('gke.notNamed')"
+              :error="pool._minMaxValid===false || pool._nameUnique===false"
+            >
+              <GKENodePoolComponent
+                v-model:version="pool.version"
+                v-model:image-type="pool.config.imageType"
+                v-model:machine-type="pool.config.machineType"
+                v-model:service-account="pool.config.serviceAccount"
+                v-model:disk-type="pool.config.diskType"
+                v-model:disk-size-gb="pool.config.diskSizeGb"
+                v-model:local-ssd-count="pool.config.localSsdCount"
+                v-model:preemptible="pool.config.preemptible"
+                v-model:taints="pool.config.taints"
+                v-model:labels="pool.config.labels"
+                v-model:tags="pool.config.tags"
+                v-model:name="pool.name"
+                v-model:initial-node-count="pool.initialNodeCount"
+                v-model:max-pods-constraint="pool.maxPodsConstraint"
+                v-model:autoscaling="pool.autoscaling.enabled"
+                v-model:min-node-count="pool.autoscaling.minNodeCount"
+                v-model:max-node-count="pool.autoscaling.maxNodeCount"
+                v-model:auto-repair="pool.management.autoRepair"
+                v-model:auto-upgrade="pool.management.autoUpgrade"
+                v-model:oauth-scopes="pool.config.oauthScopes"
+                :rules="{
+                  diskSizeGb: fvGetAndReportPathRules('diskSizeGb'),
+                  initialNodeCount: fvGetAndReportPathRules('initialNodeCount'),
+                  ssdCount: fvGetAndReportPathRules('ssdCount'),
+                  poolName: fvGetAndReportPathRules('poolName'),
+                }"
+                :mode="mode"
+                :cluster-kubernetes-version="config.kubernetesVersion"
+                :machine-type-options="machineTypeOptions"
+                :service-account-options="serviceAccountOptions"
+                :loading-machine-types="loadingMachineTypes"
+                :loading-service-accounts="loadingServiceAccounts"
+                :is-new="pool._isNewOrUnprovisioned"
+              />
+            </Tab>
+          </Tabbed>
+          <Accordion
+            class="mb-20"
+            :title="t('gke.accordion.networking')"
+          >
+            <Networking
+              v-model:kubernetes-version="config.kubernetesVersion"
+              v-model:network="config.network"
+              v-model:subnetwork="config.subnetwork"
+              v-model:create-subnetwork="config.ipAllocationPolicy.createSubnetwork"
+              v-model:use-ip-aliases="config.ipAllocationPolicy.useIpAliases"
+              v-model:network-policy-config="config.clusterAddons.networkPolicyConfig"
+              v-model:enable-network-policy="normanCluster.enableNetworkPolicy"
+              v-model:network-policy-enabled="config.networkPolicyEnabled"
+              v-model:cluster-ipv4-cidr="config.clusterIpv4Cidr"
+              v-model:cluster-secondary-range-name="config.ipAllocationPolicy.clusterSecondaryRangeName"
+              v-model:services-secondary-range-name="config.ipAllocationPolicy.servicesSecondaryRangeName"
+              v-model:cluster-ipv4-cidr-block="config.ipAllocationPolicy.clusterIpv4CidrBlock"
+              v-model:services-ipv4-cidr-block="config.ipAllocationPolicy.servicesIpv4CidrBlock"
+              v-model:node-ipv4-cidr-block="config.ipAllocationPolicy.nodeIpv4CidrBlock"
+              v-model:subnetwork-name="config.ipAllocationPolicy.subnetworkName"
+              v-model:enable-private-endpoint="config.privateClusterConfig.enablePrivateEndpoint"
+              v-model:enable-private-nodes="config.privateClusterConfig.enablePrivateNodes"
+              v-model:master-ipv4-cidr-block="config.privateClusterConfig.masterIpv4CidrBlock"
+              v-model:enable-master-authorized-network="config.masterAuthorizedNetworks.enabled"
+              v-model:master-authorized-network-cidr-blocks="config.masterAuthorizedNetworks.cidrBlocks"
+              :rules="{
+                masterIpv4CidrBlock: fvGetAndReportPathRules('masterIpv4CidrBlock'),
+                clusterIpv4CidrBlock: fvGetAndReportPathRules('clusterIpv4CidrBlock'),
+                nodeIpv4CidrBlock: fvGetAndReportPathRules('nodeIpv4CidrBlock'),
+                servicesIpv4CidrBlock: fvGetAndReportPathRules('servicesIpv4CidrBlock'),
+                clusterIpv4Cidr: fvGetAndReportPathRules('clusterIpv4Cidr')
+              }"
+              :mode="mode"
+              :zone="config.zone"
+              :region="config.region"
+              :cloud-credential-id="config.googleCredentialSecret"
+              :project-id="config.projectID"
+              :original-version="originalVersion"
+              :cluster-id="normanCluster.id"
+              :cluster-name="config.clusterName"
+              :is-new-or-unprovisioned="isNewOrUnprovisioned"
+            />
+          </Accordion>
+          <Accordion
+            class="mb-20"
+            :title="t('gke.accordion.advanced')"
+          >
+            <AdvancedOptions
+              v-model:logging-service="config.loggingService"
+              v-model:monitoring-service="config.monitoringService"
+              v-model:maintenance-window="config.maintenanceWindow"
+              v-model:http-load-balancing="config.clusterAddons.httpLoadBalancing"
+              v-model:horizontal-pod-autoscaling="config.clusterAddons.horizontalPodAutoscaling"
+              v-model:enable-kubernetes-alpha="config.enableKubernetesAlpha"
+              :mode="mode"
+              :is-new-or-unprovisioned="isNewOrUnprovisioned"
+            />
+          </Accordion>
+        </template>
 
         <Accordion
           class="mb-20"

--- a/pkg/gke/components/Import.vue
+++ b/pkg/gke/components/Import.vue
@@ -14,7 +14,7 @@ export default defineComponent({
   name: 'GKEImport',
 
   components: {
-    LabeledSelect, Banner, Checkbox, LabeledInput
+    LabeledSelect, Checkbox, LabeledInput
   },
 
   emits: ['error', 'update:clusterName', 'update:enableNetworkPolicy'],

--- a/pkg/gke/components/Import.vue
+++ b/pkg/gke/components/Import.vue
@@ -1,0 +1,153 @@
+
+<script lang="ts">
+import { _EDIT } from '@shell/config/query-params';
+import { defineComponent } from 'vue';
+import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
+import { getGKEClusters } from '../util/gcp';
+import type { getGKEClustersResponse } from '../types/gcp.d.ts';
+import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
+import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
+
+import debounce from 'lodash/debounce';
+
+export default defineComponent({
+  name: 'GKEImport',
+
+  components: {
+    LabeledSelect, Banner, Checkbox, LabeledInput
+  },
+
+  emits: ['error', 'update:clusterName', 'update:enableNetworkPolicy'],
+
+  props: {
+    mode: {
+      type:    String,
+      default: _EDIT
+    },
+
+    // name of cluster to be imported
+    // this wont necessarily align with normanCluster.name as it would w/ provisioning
+    clusterName: {
+      type:    String,
+      default: ''
+    },
+
+    credential: {
+      type:    String,
+      default: null
+    },
+
+    project: {
+      type:    String,
+      default: ''
+    },
+
+    region: {
+      type:    String,
+      default: ''
+    },
+
+    zone: {
+      type:    String,
+      default: ''
+    },
+
+    enableNetworkPolicy: {
+      type:    Boolean,
+      default: false
+    }
+  },
+
+  created() {
+    this.debouncedloadGKEClusters = debounce(this.loadGKEClusters, 200);
+    this.debouncedloadGKEClusters();
+  },
+
+  data() {
+    return {
+      clustersResponse: {} as getGKEClustersResponse, debouncedloadGKEClusters: () => {}, loadClusterFailed: false
+    };
+  },
+
+  watch: {
+    project() {
+      this.debouncedloadGKEClusters();
+    },
+    region() {
+      this.debouncedloadGKEClusters();
+    },
+    zone() {
+      this.debouncedloadGKEClusters();
+    },
+    credential() {
+      this.debouncedloadGKEClusters();
+    }
+  },
+
+  computed: {
+    clusterOptions() {
+      return (this.clustersResponse?.clusters || []).map((c) => {
+        return c.name;
+      });
+    }
+  },
+
+  methods: {
+    // query for GKE clusters every time credentials or region change
+    async loadGKEClusters() {
+      try {
+        const res = await getGKEClusters(this.$store, this.credential, this.project, { zone: this.zone, region: this.region });
+
+        this.clustersResponse = res;
+        if (!res?.clusters) {
+          this.loadClusterFailed = true;
+        } else {
+          this.loadClusterFailed = false;
+        }
+      } catch (err:any) {
+        this.$emit('error', err);
+      }
+    },
+  },
+
+});
+</script>
+
+<template>
+  <div>
+    <div class="row mb-10 center">
+      <div class="col span-6">
+        <LabeledSelect
+          v-if="!loadClusterFailed"
+          :value="clusterName"
+          :mode="mode"
+          :label="t('gke.import.cluster.label')"
+          :options="clusterOptions"
+          @selecting="$emit('update:clusterName', $event)"
+        />
+        <LabeledInput
+          v-else
+          :value="clusterName"
+          :mode="mode"
+          :label="t('gke.import.cluster.label')"
+          @input="$emit('update:clusterName', $event)"
+        />
+      </div>
+      <div class="col span-6 ">
+        <Checkbox
+          :value="enableNetworkPolicy"
+          :mode="mode"
+          :label="t('gke.enableNetworkPolicy.label')"
+          @update:value="$emit('update:enableNetworkPolicy', $event)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .center {
+    display: flex;
+    align-items: center;
+  }
+</style>

--- a/pkg/gke/l10n/en-us.yaml
+++ b/pkg/gke/l10n/en-us.yaml
@@ -8,6 +8,7 @@ gke:
     advanced: Additional Options
     config: Config
     labels: Labels and Annotations
+    import: Choose Cluster
     members: Cluster Members
     networking: Networking
     nodePools: Node Pools
@@ -109,6 +110,9 @@ gke:
     WINDOWS_SAC: Windows Semi-Annual Channel with Docker
     WINDOWS_SAC_CONTAINERD: Windows Semi-Annual Channel with Containerd
     label: Image Type
+  import:
+    cluster:
+      label: Cluster to register
   initialNodeCount:
     label: Initial Node Count
   label: Google GKE

--- a/pkg/gke/provisioner.ts
+++ b/pkg/gke/provisioner.ts
@@ -48,4 +48,8 @@ export class GKEProvisioner implements IClusterProvisioner {
       conditions:   false,
     };
   }
+
+  get showImport(): boolean {
+    return true;
+  }
 }

--- a/pkg/gke/util/gcp.ts
+++ b/pkg/gke/util/gcp.ts
@@ -81,14 +81,13 @@ export function getGKESharedSubnetworks(store: Store<any>, cloudCredentialId: st
   return getGKEOptions('gkeSharedSubnets', store, cloudCredentialId, projectId, location);
 }
 
-export function getGKEClusters(store: Store<any>, cloudCredentialId: string, projectId: string, location: {zone?: string, region?: string}, clusterId: string): Promise<getGKEClustersResponse> {
-  return getGKEOptions('gkeClusters', store, cloudCredentialId, projectId, location, clusterId);
+export function getGKEClusters(store: Store<any>, cloudCredentialId: string, projectId: string, location: {zone?: string, region?: string}): Promise<getGKEClustersResponse> {
+  return getGKEOptions('gkeClusters', store, cloudCredentialId, projectId, location);
 }
 
 export function getGKEServiceAccounts(store: Store<any>, cloudCredentialId: string, projectId: string, location: {zone?: string, region?: string}): Promise<getGKEServiceAccountsResponse> {
   return getGKEOptions('gkeServiceAccounts', store, cloudCredentialId, projectId, location);
 }
-
 /**
  * we fetch GKE zones and etrapolate available regions from that list. Zones include a url to the region they are in.
  * @param zone

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -385,23 +385,22 @@ export default {
 
           addType(this.$plugin, 'custom', 'custom2', false);
         }
-
-        // Add from extensions
-        this.extensions.forEach((ext) => {
+      }
+      // Add from extensions
+      this.extensions.forEach((ext) => {
         // if the rke toggle is set to rke1, don't add extensions that specify rke2 group
         // default group is rke2
-          if (!this.isRke2 && (ext.group === _RKE2 || !ext.group)) {
-            return;
-          }
-          // Do not show the extension provisioner on the import cluster page unless its explicitly set to do so
-          if (isImport && !ext.showImport) {
-            return;
-          }
-          // Allow extensions to overwrite provisioners with the same id
-          out = out.filter((type) => type.id !== ext.id);
-          addExtensionType(ext, getters);
-        });
-      }
+        if (!this.isRke2 && (ext.group === _RKE2 || !ext.group)) {
+          return;
+        }
+        // Do not show the extension provisioner on the import cluster page unless its explicitly set to do so
+        if (isImport && !ext.showImport) {
+          return;
+        }
+        // Allow extensions to overwrite provisioners with the same id
+        out = out.filter((type) => type.id !== ext.id);
+        addExtensionType(ext, getters);
+      });
 
       return out;
 
@@ -682,7 +681,7 @@ export default {
     </template>
 
     <Import
-      v-if="isImport"
+      v-if="isImport && (selectedSubType && !selectedSubType.component)"
       v-model:value="localValue"
       :mode="mode"
       :provider="subType"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12408 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR adds the initial import page for GKE clusters.

### Technical notes summary
I had to re-arrange some elements of the GKE provisioning form so I could better reuse components between the import and create/edit cluster views. It may be easier to view this PR commit-by-commit for that reason. 

### Areas or cases that should be tested

First, go make a GKE cluster or two to import into Rancher.

1. Navigate to the cluster management list view and click 'import existing'
2. Select GKE
3. Enter credentials: if the rancher instance already has at least on gcp cloud credential defined, you should see a dropdown to pick it and an input for the project id. If you don't already have a gcp cloud credential you should see the form to add one
4. Click 'authenticate' - the remainder of the form should load (smaller form than GKE creation)
5. Try selecting different regions and zones: you should see requests to gkeClusters in the network tab, and the contents of the cluster dropdown should change (assuming you already have clusters in GKE)
6. Name your cluster - verify that name form validators are used
7. Add users, labels and annotations as well
8. Click save
9. Wait for the cluster to become available
10. Edit the cluster: you should see the same form used to edit GKE clusters provisioned through Rancher

### Areas which could experience regressions
1. Regular GKE cluster creation should be quickly verified. In particular there is a potential for regression around cluster name validation


### Screenshot/Video

![Screenshot 2025-02-19 at 5 44 22 AM](https://github.com/user-attachments/assets/d72cdb0f-d20e-42d0-8058-d41b332fa2df)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
