### PR TITLE
small sortable table a11y fixes

### DIFF
--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -160,6 +160,10 @@ export default defineComponent({
       }
 
       return undefined;
+    },
+
+    idForLabel():string {
+      return `${ this.id }-label`;
     }
   },
 
@@ -251,6 +255,7 @@ export default defineComponent({
       @click="clicked($event)"
     >
       <input
+        :id="id"
         :checked="isChecked"
         :value="valueWhenTrue"
         type="checkbox"
@@ -264,7 +269,7 @@ export default defineComponent({
         :tabindex="isDisabled ? -1 : 0"
         :aria-label="replacementLabel"
         :aria-checked="!!value"
-        :aria-labelledby="labelKey || label ? id : undefined"
+        :aria-labelledby="labelKey || label ? idForLabel : undefined"
         role="checkbox"
       />
       <span
@@ -275,13 +280,13 @@ export default defineComponent({
         <slot name="label">
           <t
             v-if="labelKey"
-            :id="id"
+            :id="idForLabel"
             :k="labelKey"
             :raw="true"
           />
           <span
             v-else-if="label"
-            :id="id"
+            :id="idForLabel"
           >{{ label }}</span>
           <i
             v-if="tooltipKey"

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -34,6 +34,14 @@ export default defineComponent({
     },
 
     /**
+     * Random ID generated for binding label to input.
+     */
+    id: {
+      type:    String,
+      default: generateRandomAlphaString(12)
+    },
+
+    /**
      * Disable the checkbox.
      */
     disabled: {
@@ -119,10 +127,6 @@ export default defineComponent({
   },
 
   emits: ['update:value'],
-
-  data() {
-    return { id: generateRandomAlphaString(12) };
-  },
 
   computed: {
     /**
@@ -242,7 +246,6 @@ export default defineComponent({
     <label
       class="checkbox-container"
       :class="{ 'disabled': isDisabled}"
-      :for="id"
       @keydown.enter.prevent="clicked($event)"
       @keydown.space.prevent="clicked($event)"
       @click="clicked($event)"

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5391,6 +5391,8 @@ setup:
   welcome: Welcome to {vendor}!
 
 sortableTable:
+  genericGroupCheckbox: Table group selection checkbox
+  genericRowCheckbox: Table row selection checkbox for item {item}
   tableActionsLabel: More actions - { resource }
   tableActionsImgAlt: More actions icon
   bulkActions:

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -230,6 +230,7 @@ export default {
           data-testid="sortable-table_check_select_all"
           :indeterminate="isIndeterminate"
           :disabled="noRows || noResults"
+          :alternate-label="t('sortableTable.genericGroupCheckbox')"
         />
       </th>
       <th

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -270,6 +270,7 @@ export default {
           <div
             v-if="col.sort"
             class="sort"
+            aria-hidden="true"
           >
             <i
               v-show="hasAdvancedFiltering && !col.isFilter"

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1383,6 +1383,7 @@ export default {
                     :data-node-id="row.key"
                     :data-testid="componentTestid + '-' + i + '-checkbox'"
                     :value="selectedRows.includes(row.row)"
+                    :alternate-label="t('sortableTable.genericRowCheckbox', { item: row && row.row ? row.row.id : '' })"
                   />
                 </td>
                 <td

--- a/shell/utils/string.js
+++ b/shell/utils/string.js
@@ -336,3 +336,7 @@ export function isBase64(value) {
 
   return base64regex.test(value);
 }
+
+export function generateRandomAlphaString(length) {
+  return Array.from({ length }, () => String.fromCharCode(97 + Math.random() * 26 | 0)).join('');
+}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12794
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add sortable table a11y fixes according to issue #12794 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
