### PR TITLE
Delete dialogs, fix list of items message and Vue warnings

### DIFF
--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -47,7 +47,7 @@ export default {
   },
   computed: {
     names() {
-      return this.toRemove.map((obj) => obj.nameDisplay).slice(0, 5);
+      return this.toRemove.map((obj) => obj.nameDisplay);
     },
 
     nameToMatchPosition() {
@@ -91,12 +91,6 @@ export default {
       const first = this.toRemove[0];
 
       return first?.confirmRemove;
-    },
-
-    plusMore() {
-      const remaining = this.toRemove.length - this.names.length;
-
-      return this.t('promptRemove.andOthers', { count: remaining });
     },
 
     // if the current route ends with the ID of the resource being deleted, whatever page this is wont be valid after successful deletion: navigate away
@@ -360,7 +354,7 @@ export default {
         <div class="mb-10">
           <template v-if="!hasCustomRemove">
             {{ t('promptRemove.attemptingToRemove', { type }) }} <span
-              v-clean-html="resourceNames(names, plusMore, t)"
+              v-clean-html="resourceNames(names, t)"
             />
           </template>
 
@@ -369,7 +363,7 @@ export default {
             v-if="hasCustomRemove"
             ref="customPrompt"
             v-model:value="toRemove"
-                        :close="close"
+            :close="close"
             :needs-confirm="needsConfirm"
             :value="toRemove"
             :names="names"

--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -363,6 +363,7 @@ export default {
             v-if="hasCustomRemove"
             ref="customPrompt"
             v-model:value="toRemove"
+            v-bind="$data"
             :close="close"
             :needs-confirm="needsConfirm"
             :value="toRemove"

--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -1,4 +1,5 @@
 <script>
+import { shallowRef } from 'vue';
 import { mapState, mapGetters } from 'vuex';
 import { get, isEmpty } from '@shell/utils/object';
 import { escapeHtml, resourceNames } from '@shell/utils/string';
@@ -38,7 +39,7 @@ export default {
       error:               '',
       warning:             '',
       preventDelete:       false,
-      removeComponent:     this.$store.getters['type-map/importCustomPromptRemove'](resource),
+      removeComponent:     shallowRef(this.$store.getters['type-map/importCustomPromptRemove'](resource)),
       chartsToRemoveIsApp: false,
       chartsDeleteCrd:     false,
       showModal:           false,
@@ -183,7 +184,7 @@ export default {
 
         this.hasCustomRemove = this.$store.getters['type-map/hasCustomPromptRemove'](resource);
 
-        this.removeComponent = this.$store.getters['type-map/importCustomPromptRemove'](resource);
+        this.removeComponent = shallowRef(this.$store.getters['type-map/importCustomPromptRemove'](resource));
       } else {
         this.showModal = false;
       }
@@ -368,8 +369,7 @@ export default {
             v-if="hasCustomRemove"
             ref="customPrompt"
             v-model:value="toRemove"
-            v-bind="_data"
-            :close="close"
+                        :close="close"
             :needs-confirm="needsConfirm"
             :value="toRemove"
             :names="names"

--- a/shell/dialog/DeactivateDriverDialog.vue
+++ b/shell/dialog/DeactivateDriverDialog.vue
@@ -31,15 +31,15 @@ export default {
   },
   computed: {
     formattedText() {
-      const namesSliced = this.drivers.map((obj) => obj.nameDisplay).slice(0, 5);
-      const remaining = this.drivers.length - namesSliced.length;
+      const namesSliced = this.drivers.map((obj) => obj.nameDisplay);
+      const count = namesSliced.length;
+      const remaining = namesSliced.length > 5 ? namesSliced.length - 5 : 0;
 
       const plusMore = this.t('drivers.deactivate.andOthers', { count: remaining });
-      const names = resourceNames(namesSliced, plusMore, this.t);
-      const count = remaining || namesSliced.length;
+      const names = resourceNames(namesSliced, this.t, { plusMore, endString: false });
       const warningDrivers = this.t('drivers.deactivate.warningDrivers', { names, count });
 
-      return this.t('drivers.deactivate.warning', { warningDrivers, count: namesSliced.length });
+      return this.t('drivers.deactivate.warning', { warningDrivers, count });
     },
     ...mapGetters({ t: 'i18n/t' }),
   },

--- a/shell/promptRemove/management.cattle.io.globalrole.vue
+++ b/shell/promptRemove/management.cattle.io.globalrole.vue
@@ -21,7 +21,7 @@ export default {
 
 <template>
   <div>
-    {{ t('promptRemove.attemptingToRemove', { type }) }} <span v-clean-html="resourceNames(names, plusMore, t)" />
+    {{ t('promptRemove.attemptingToRemove', { type }) }} <span v-clean-html="resourceNames(names, t)" />
     <div
       v-if="info"
       class="text info mb-10 mt-20"

--- a/shell/promptRemove/management.cattle.io.project.vue
+++ b/shell/promptRemove/management.cattle.io.project.vue
@@ -58,12 +58,6 @@ export default {
       return [];
     },
 
-    plusMore() {
-      const remaining = this.filteredNamespaces.length > 5 ? this.filteredNamespaces.length - 5 : 0;
-
-      return this.t('promptRemove.andOthers', { count: remaining });
-    },
-
     displayName() {
       return this.currentProject?.spec?.displayName;
     },
@@ -100,7 +94,7 @@ export default {
         <template v-if="!canSeeProjectlessNamespaces">
           <span class="delete-warning"> {{ t('promptRemove.willDeleteAssociatedNamespaces') }}</span> <br>
           <div
-            v-clean-html="resourceNames(names, plusMore, t)"
+            v-clean-html="resourceNames(names, t)"
             class="mt-10"
           />
         </template>
@@ -114,7 +108,7 @@ export default {
           :label="t('promptRemove.deleteAssociatedNamespaces')"
         />
         <div class="mt-10 ml-20">
-          <span v-clean-html="resourceNames(names, plusMore, t)" />
+          <span v-clean-html="resourceNames(names, t)" />
         </div>
       </div>
     </div>

--- a/shell/promptRemove/management.cattle.io.roletemplate.vue
+++ b/shell/promptRemove/management.cattle.io.roletemplate.vue
@@ -22,7 +22,7 @@ export default {
 <template>
   <div>
     {{ t('promptRemove.attemptingToRemove', { type }) }} <span
-      v-clean-html="resourceNames(names, plusMore, t)"
+      v-clean-html="resourceNames(names, t)"
     />
     <div
       v-if="info"

--- a/shell/promptRemove/mixin/roleDeletionCheck.js
+++ b/shell/promptRemove/mixin/roleDeletionCheck.js
@@ -17,13 +17,7 @@ export default {
     ...mapGetters({ t: 'i18n/t' }),
 
     names() {
-      return this.toRemove.map((obj) => obj.nameDisplay).slice(0, 5);
-    },
-
-    plusMore() {
-      const remaining = this.toRemove.length - this.names.length;
-
-      return this.t('promptRemove.andOthers', { count: remaining });
+      return this.toRemove.map((obj) => obj.nameDisplay);
     },
   },
   watch: {

--- a/shell/promptRemove/pod.vue
+++ b/shell/promptRemove/pod.vue
@@ -1,4 +1,5 @@
 <script>
+import { resourceNames } from '@shell/utils/string';
 import { Banner } from '@components/Banner';
 import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 import { mapGetters, mapState } from 'vuex';
@@ -55,31 +56,10 @@ export default {
   computed: {
     ...mapState('action-menu', ['toRemove']),
     ...mapGetters({ t: 'i18n/t' }),
-
-    plusMore() {
-      const count = this.names.length - this.names.length;
-
-      return this.t('promptRemove.andOthers', { count });
-    },
-
-    podNames() {
-      return this.names.reduce((res, name, i) => {
-        if (i >= 5) {
-          return res;
-        }
-        res += `<b>${ name }</b>`;
-        if (i === this.names.length - 1) {
-          res += this.plusMore;
-        } else {
-          res += i === this.toRemove.length - 2 ? ' and ' : ', ';
-        }
-
-        return res;
-      }, '');
-    },
   },
 
   methods: {
+    resourceNames,
     async remove(confirm) {
       let goTo;
 
@@ -118,8 +98,8 @@ export default {
   <div class="mt-10">
     <div class="mb-30">
       {{ t('promptRemove.attemptingToRemove', { type }) }} <span
-        v-clean-html="podNames"
-        class="machine-name"
+        v-clean-html="resourceNames(names, t)"
+        class="body"
       />
     </div>
     <div class="mb-30">
@@ -143,11 +123,10 @@ export default {
 </template>
 
 <style lang='scss' scoped>
+  .body {
+    font-weight: 600;
+  }
   .actions {
     text-align: right;
-  }
-
-  .machine-name {
-    font-weight: 600;
   }
 </style>

--- a/shell/utils/__tests__/string.test.ts
+++ b/shell/utils/__tests__/string.test.ts
@@ -1,4 +1,4 @@
-import { decodeHtml } from '@shell/utils/string';
+import { decodeHtml, resourceNames } from '@shell/utils/string';
 
 describe('fx: decodeHtml', () => {
   it('should decode HTML values from escaped string into valid markup', () => {
@@ -8,5 +8,84 @@ describe('fx: decodeHtml', () => {
     const result = decodeHtml(text);
 
     expect(result).toStrictEqual(expectation);
+  });
+});
+
+describe('fx: resourceNames', () => {
+  // default plusMore function
+  const t = (key: string, options: { count: number }) => {
+    switch (key) {
+    case 'generic.and':
+      return ' and ';
+    case 'generic.comma':
+      return ', ';
+    case 'promptRemove.andOthers': {
+      if (options.count === 0) {
+        return '.';
+      }
+      if (options.count === 1) {
+        return 'and <b>one other</b>.';
+      }
+
+      return `and <b>${ options.count } others</b>.`;
+    }
+    }
+  };
+
+  describe.each([
+    ['no options',
+      [
+        [[], '', {}],
+        [['item1'], '<b>item1</b>.', {}],
+        [['item1', 'item2'], '<b>item1</b> and <b>item2</b>.', {}],
+        [['item1', 'item2', 'item3'], '<b>item1</b>, <b>item2</b> and <b>item3</b>.', {}],
+        [['item1', 'item2', 'item3', 'item4', 'item5'], '<b>item1</b>, <b>item2</b>, <b>item3</b>, <b>item4</b> and <b>item5</b>.', {}],
+        [['item1', 'item2', 'item3', 'item4', 'item5', 'item6'], '<b>item1</b>, <b>item2</b>, <b>item3</b>, <b>item4</b>, <b>item5</b>and <b>one other</b>.', {}],
+        [['item1', 'item2', 'item3', 'item4', 'item5', 'item6', 'item7'], '<b>item1</b>, <b>item2</b>, <b>item3</b>, <b>item4</b>, <b>item5</b>and <b>2 others</b>.', {}],
+      ]
+    ],
+    ['plusMore option',
+      [
+        [[], '', { plusMore: 'foo' }],
+        [['item1'], '<b>item1</b>.', { plusMore: 'foo' }],
+        [['item1', 'item2'], '<b>item1</b> and <b>item2</b>.', { plusMore: 'foo' }],
+        [['item1', 'item2', 'item3'], '<b>item1</b>, <b>item2</b> and <b>item3</b>.', { plusMore: 'foo' }],
+        [['item1', 'item2', 'item3', 'item4', 'item5'], '<b>item1</b>, <b>item2</b>, <b>item3</b>, <b>item4</b> and <b>item5</b>.', { plusMore: 'foo' }],
+        [['item1', 'item2', 'item3', 'item4', 'item5', 'item6'], '<b>item1</b>, <b>item2</b>, <b>item3</b>, <b>item4</b>, <b>item5</b>foo', { plusMore: 'foo' }],
+        [['item1', 'item2', 'item3', 'item4', 'item5', 'item6', 'item7'], '<b>item1</b>, <b>item2</b>, <b>item3</b>, <b>item4</b>, <b>item5</b>foo', { plusMore: 'foo' }],
+      ]
+    ],
+    ['endString option',
+      [
+        [[], '', { endString: false }],
+        [['item1'], '<b>item1</b> ', { endString: false }],
+        [['item1', 'item2'], '<b>item1</b> and <b>item2</b> ', { endString: false }],
+        [['item1', 'item2'], '<b>item1</b> and <b>item2</b>.', { endString: '' }],
+        [['item1', 'item2'], '<b>item1</b> and <b>item2</b>foo', { endString: 'foo' }],
+      ]
+    ],
+    [
+      'plusMore & endString options', [
+        [[], '', { plusMore: '', endString: false }],
+        [[], '', { plusMore: 'foo', endString: 'foo' }],
+        [['item1'], '<b>item1</b>foo', { plusMore: 'foo', endString: 'foo' }],
+        [['item1', 'item2'], '<b>item1</b> and <b>item2</b>foo', { plusMore: 'foo', endString: 'foo' }],
+        [['item1', 'item2'], '<b>item1</b> and <b>item2</b> ', { plusMore: 'foo', endString: false }],
+        [['item1', 'item2', 'item3', 'item4', 'item5', 'item6'], '<b>item1</b>, <b>item2</b>, <b>item3</b>, <b>item4</b>, <b>item5</b>foo', { plusMore: 'foo', endString: 'foo' }],
+        [['item1', 'item2', 'item3', 'item4', 'item5', 'item6', 'item7'], '<b>item1</b>, <b>item2</b>, <b>item3</b>, <b>item4</b>, <b>item5</b>foo', { plusMore: 'foo', endString: 'foo' }],
+        [['item1', 'item2', 'item3', 'item4', 'item5', 'item6'], '<b>item1</b>, <b>item2</b>, <b>item3</b>, <b>item4</b>, <b>item5</b>foo', { plusMore: 'foo', endString: false }],
+        [['item1', 'item2', 'item3', 'item4', 'item5', 'item6', 'item7'], '<b>item1</b>, <b>item2</b>, <b>item3</b>, <b>item4</b>, <b>item5</b>foo', { plusMore: 'foo', endString: false }],
+      ]
+    ]
+  ])('should build a single message from a list of names, with: %p', (_, args) => {
+    it.each(args)(`having: %p`, (
+      names,
+      expectation,
+      options,
+    ) => {
+      const result = resourceNames(names, t, options);
+
+      expect(result).toStrictEqual(expectation);
+    });
   });
 });

--- a/shell/utils/string.js
+++ b/shell/utils/string.js
@@ -151,16 +151,36 @@ export function pluralize(str) {
   }
 }
 
-export function resourceNames(names, plusMore, t) {
+export function resourceNames(names, t, options = {}) {
+  const MAX_NAMES_COUNT = 5;
+
+  let { plusMore, endString } = options;
+
+  // plusMore default value
+  if (!plusMore) {
+    plusMore = t('promptRemove.andOthers', { count: names.length > MAX_NAMES_COUNT ? names.length - MAX_NAMES_COUNT : 0 });
+  }
+
+  // endString default value
+  if (!endString) {
+    endString = endString === false ? ' ' : '.';
+  }
+
   return names.reduce((res, name, i) => {
-    if (i >= 5) {
-      return res;
+    if (i < MAX_NAMES_COUNT) {
+      res += `<b>${ escapeHtml( name ) }</b>`;
+
+      if (i === names.length - 1) {
+        res += endString;
+      } else if (i === names.length - 2) {
+        res += names.length <= 5 ? t('generic.and') : '';
+      } else {
+        res += i < MAX_NAMES_COUNT - 1 ? t('generic.comma') : '';
+      }
     }
-    res += `<b>${ escapeHtml( name ) }</b>`;
-    if (i === names.length - 1) {
+
+    if (i === MAX_NAMES_COUNT) {
       res += plusMore;
-    } else {
-      res += i === names.length - 2 ? t('generic.and') : t('generic.comma');
     }
 
     return res;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13455
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Any of Remove dialogs using the default `shell/components/PromptRemove.vue` component.

  - Go to Fleet -> Advanced -> Workspaces
  - Create some new workspaces, even empty
  - Select N workspaces and click on Delete action

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- DeactivateDriverDialog: `shell/dialog/DeactivateDriverDialog.vue`

  - Go to Cluster Management -> Drivers -> Node Drivers
  - Select N active drivers
  - Click on Delete action

- Each dialogs defined in `shell/promptRemove`

  - Go to Projects/Namespaces _or_ Users-> RoleTemplate _or_ Workspaces -> Pods
  - Select N items
  - Click on Delete action

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
