### PR TITLE
Updating the wording used for etcd snapshots

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2063,7 +2063,7 @@ cluster:
         title: Save Machine Configurations
         body: Machine Configurations define how machines in Pools are deployed.<br><br> They will be saved upfront to ensure valid Cluster YAML can be saved.
     snapshots:
-      suffix: Snapshots per node
+      suffix: Snapshots
     systemService:
       rke2-coredns: 'CoreDNS'
       rke2-ingress-nginx: 'NGINX Ingress'
@@ -2155,15 +2155,18 @@ cluster:
         enable: Enable IPv6 support
     etcd:
       disableSnapshots:
-        label: Automatic Snapshots
+        label: Automatic Backups
       snapshotScheduleCron:
         label: Cron Schedule
       snapshotRetention:
-        label: Keep the last
+        label: Snapshot retention count 
+        tooltip: Each backup records 1 snapshot per etcd node. If you specify 3 snapshots and you have 3 etcd nodes you will only retain 1 full backup.
       exportMetric:
         label: Metrics
         false: Only available inside the cluster
         true: Exposed to the public interface
+      s3backups:
+        label: Save Backups to S3
   k3s:
     systemService:
       coredns: 'CoreDNS'

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/etcd/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/etcd/index.vue
@@ -91,6 +91,7 @@ export default {
           :mode="mode"
           :label="t('cluster.rke2.etcd.snapshotRetention.label')"
           :suffix="t('cluster.rke2.snapshots.suffix')"
+          :tooltip="t('cluster.rke2.etcd.snapshotRetention.tooltip')"
         />
       </div>
     </div>
@@ -102,8 +103,8 @@ export default {
         :value="s3Backup"
         name="etcd-s3"
         :options="[false, true]"
-        label="Backup Snapshots to S3"
-        :labels="['Disable','Enable']"
+        :label="t('cluster.rke2.etcd.s3backups.label')"
+        :labels="[t('generic.disable'),t('generic.enable')]"
         :mode="mode"
         @update:value="$emit('s3-backup-changed', $event)"
       />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Updating the wording used for etcd snapshots

Fixes https://github.com/rancher/dashboard/issues/12487
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
Before:
![image](https://github.com/user-attachments/assets/bfefac61-b374-4dd9-bb83-e79f19b8e3f0)

After:
![image](https://github.com/user-attachments/assets/f8fed679-1018-4360-865b-6bb3b726edd1)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
