### PR TITLE
Add "User Login Filter" input to the LDAP auth provider config

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -548,6 +548,7 @@ authConfig:
     tls: TLS
     userEnabledAttribute: User Enabled Attribute
     userMemberAttribute: User Member Attribute
+    userLoginFilter: User Login Filter
     userSearchBase:
       label: User Search Base
       placeholder: 'e.g. ou=users,dc=mycompany,dc=com'

--- a/shell/edit/auth/ldap/__tests__/config.test.ts
+++ b/shell/edit/auth/ldap/__tests__/config.test.ts
@@ -15,4 +15,44 @@ describe('lDAP config', () => {
 
     expect(checkbox).toBeDefined();
   });
+
+  it('updates user login filter when value is entered', async() => {
+    const wrapper = mount(
+      LDAPConfig,
+      {
+        props: {
+          value: {},
+          type:  'openldap',
+        }
+      });
+
+    const userLoginFilter = wrapper.find('[data-testid="user-login-filter"]');
+
+    await userLoginFilter.setValue('Test Filter');
+
+    const expectedValue = 'Test Filter';
+
+    expect(userLoginFilter.exists()).toBe(true);
+    expect(userLoginFilter.element.value).toBe(expectedValue);
+    expect(wrapper.vm.model.userLoginFilter).toBe(expectedValue);
+  });
+
+  it('defaults to undefined for user login filter', () => {
+    const wrapper = mount(
+      LDAPConfig,
+      {
+        props: {
+          value: {},
+          type:  'openldap',
+        }
+      });
+
+    const userLoginFilter = wrapper.find('[data-testid="user-login-filter"]');
+
+    const expectedValue = '';
+
+    expect(userLoginFilter.exists()).toBe(true);
+    expect(userLoginFilter.element.value).toBe(expectedValue);
+    expect(wrapper.vm.model.userLoginFilter).toBeUndefined();
+  });
 });

--- a/shell/edit/auth/ldap/config.vue
+++ b/shell/edit/auth/ldap/config.vue
@@ -360,8 +360,6 @@ export default {
           :label="t('authConfig.ldap.userLoginFilter')"
         />
       </div>
-    </div>
-    <div class="row mb-20">
       <div class="col span-6">
         <LabeledInput
           v-model:value="model.userSearchAttribute"
@@ -369,6 +367,8 @@ export default {
           :label="t('authConfig.ldap.searchAttribute')"
         />
       </div>
+    </div>
+    <div class="row mb-20">
       <div class="col span-6">
         <LabeledInput
           v-model:value="model.groupSearchFilter"
@@ -376,8 +376,6 @@ export default {
           :label="t('authConfig.ldap.searchFilter')"
         />
       </div>
-    </div>
-    <div class="row mb-20">
       <div class="col span-6">
         <LabeledInput
           v-model:value="model.userSearchFilter"
@@ -385,6 +383,8 @@ export default {
           :label="t('authConfig.ldap.searchFilter')"
         />
       </div>
+    </div>
+    <div class="row mb-20">
       <div class="col span-6">
         <LabeledInput
           v-model:value="model.groupMemberMappingAttribute"
@@ -392,8 +392,6 @@ export default {
           :label="t('authConfig.ldap.groupMemberMappingAttribute')"
         />
       </div>
-    </div>
-    <div class="row mb-20">
       <div class="col span-6">
         <LabeledInput
           v-model:value="model.userEnabledAttribute"
@@ -401,6 +399,8 @@ export default {
           :label="t('authConfig.ldap.userEnabledAttribute')"
         />
       </div>
+    </div>
+    <div class="row mb-20">
       <div class="col span-6">
         <LabeledInput
           v-model:value="model.groupDNAttribute"
@@ -408,8 +408,6 @@ export default {
           :label="t('authConfig.ldap.groupDNAttribute')"
         />
       </div>
-    </div>
-    <div class="row mb-20">
       <div class="col span-6">
         <LabeledInput
           v-model:value="model.disabledStatusBitmask"
@@ -417,6 +415,8 @@ export default {
           :label="t('authConfig.ldap.disabledStatusBitmask')"
         />
       </div>
+    </div>
+    <div class="row mb-20">
       <div
         v-if="!isSamlProvider"
         class=" col span-6"

--- a/shell/edit/auth/ldap/config.vue
+++ b/shell/edit/auth/ldap/config.vue
@@ -354,6 +354,16 @@ export default {
     <div class="row mb-20">
       <div class="col span-6">
         <LabeledInput
+          v-model:value="model.userLoginFilter"
+          data-testid="user-login-filter"
+          :mode="mode"
+          :label="t('authConfig.ldap.userLoginFilter')"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
           v-model:value="model.userSearchAttribute"
           :mode="mode"
           :label="t('authConfig.ldap.searchAttribute')"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds the "User Login Filter" input to the LDAP config form.

Fixes #13419
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add "User Login Filter" input to the LDAP config form
- Re-flow form contents (requires manually shifting each input by one)

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Because this change include moving form elements around, I recommend reviewing each commit one at a time.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Active Directory
- OpenLDAP 
- FreeIPA

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- NA

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/user-attachments/assets/ce10c3ea-e3e8-44ea-810f-827435c35046)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
