### PR TITLE
Don't show built-in extensions by default

### DIFF
--- a/cypress/e2e/po/components/tabbed.po.ts
+++ b/cypress/e2e/po/components/tabbed.po.ts
@@ -13,12 +13,20 @@ export default class TabbedPo extends ComponentPo {
     return this.self().find(`${ selector }`).click();
   }
 
+  clickTabWithName(name: string) {
+    return this.self().get(`[data-testid="btn-${ name }"]`).click();
+  }
+
   allTabs() {
     return this.self().get('[data-testid="tabbed-block"] > li');
   }
 
   assertTabIsActive(selector: string) {
     return this.self().find(`${ selector }`).should('have.class', 'active');
+  }
+
+  getTab(name: string) {
+   return new ComponentPo(`[data-testid="${ name }"]`, this.self());
   }
 
   /**

--- a/cypress/e2e/po/components/tabbed.po.ts
+++ b/cypress/e2e/po/components/tabbed.po.ts
@@ -26,7 +26,7 @@ export default class TabbedPo extends ComponentPo {
   }
 
   getTab(name: string) {
-   return new ComponentPo(`[data-testid="${ name }"]`, this.self());
+    return new ComponentPo(`[data-testid="${ name }"]`, this.self());
   }
 
   /**

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -8,7 +8,6 @@ import BannersPo from '@/cypress/e2e/po/components/banners.po';
 import ChartRepositoriesCreateEditPo from '@/cypress/e2e/po/edit/chart-repositories.po';
 import AppClusterRepoEditPo from '@/cypress/e2e/po/edit/catalog.cattle.io.clusterrepo.po';
 import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
-import ComponentPo from '~/cypress/e2e/po/components/component.po';
 
 export default class ExtensionsPagePo extends PagePo {
   static url = '/c/local/uiplugins'
@@ -230,11 +229,11 @@ export default class ExtensionsPagePo extends PagePo {
   }
 
   extensionTabBuiltinClick(): Cypress.Chainable {
-    return this.self().get('[data-testid="btn-builtin"]').click();
+    return this.extensionTabs.clickTabWithName('builtin');
   }
 
   extensionTabBuiltin() {
-    return new ComponentPo('[data-testid="builtin"]', this.self());
+    return this.extensionTabs.getTab('builtin');
   }
 
   // ------------------ extension reload banner ------------------

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -8,6 +8,7 @@ import BannersPo from '@/cypress/e2e/po/components/banners.po';
 import ChartRepositoriesCreateEditPo from '@/cypress/e2e/po/edit/chart-repositories.po';
 import AppClusterRepoEditPo from '@/cypress/e2e/po/edit/catalog.cattle.io.clusterrepo.po';
 import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import ComponentPo from '~/cypress/e2e/po/components/component.po';
 
 export default class ExtensionsPagePo extends PagePo {
   static url = '/c/local/uiplugins'
@@ -226,6 +227,14 @@ export default class ExtensionsPagePo extends PagePo {
 
   extensionTabAllClick(): Cypress.Chainable {
     return this.extensionTabs.clickNthTab(4);
+  }
+
+  extensionTabBuiltinClick(): Cypress.Chainable {
+    return this.self().get('[data-testid="btn-builtin"]').click();
+  }
+
+  extensionTabBuiltin() {
+    return new ComponentPo('[data-testid="builtin"]', this.self());
   }
 
   // ------------------ extension reload banner ------------------

--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -24,14 +24,34 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     cy.login();
   });
 
-  it('versions for built-in extensions should display as expected', () => {
-    const pluginVersion = '1.0.0';
+  it('should go to the available tab by default', () => {
     const extensionsPo = new ExtensionsPagePo();
 
     extensionsPo.goTo();
     extensionsPo.waitForPage(null, 'available');
-    extensionsPo.extensionTabInstalledClick();
-    extensionsPo.waitForPage(null, 'installed');
+  });
+
+  it('should show built-in extensions only when configured', () => {
+    const extensionsPo = new ExtensionsPagePo();
+    const pluginVersion = '1.0.0';
+
+    cy.setUserPreference({ 'plugin-developer': false });
+    extensionsPo.goTo();
+    extensionsPo.waitForPage(null, 'available');
+
+    // Should not be able to see the built-in tab
+    extensionsPo.extensionTabBuiltin().checkNotExists();
+
+    // Set the preference
+    cy.setUserPreference({ 'plugin-developer': true });
+    extensionsPo.goTo();
+    extensionsPo.waitForPage(null, 'available');
+
+    // Reload
+    extensionsPo.extensionTabBuiltin().checkExists();
+    extensionsPo.waitForPage(null, 'available');
+    extensionsPo.extensionTabBuiltinClick();
+    extensionsPo.waitForPage(null, 'builtin');
 
     // AKS Provisioning
     extensionsPo.extensionCardVersion('aks').should('contain', pluginVersion);
@@ -60,6 +80,8 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     extensionsPo.extensionDetailsTitle().should('contain', 'Virtualization Manager');
     extensionsPo.extensionDetailsVersion().should('contain', pluginVersion);
     extensionsPo.extensionDetailsCloseClick();
+
+    cy.setUserPreference({ 'plugin-developer': false });
   });
 
   it('add repository', () => {

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -1092,15 +1092,17 @@ Cypress.Commands.add('tableRowsPerPageAndNamespaceFilter', (rows: number, cluste
   });
 });
 
-// Update the user preferences by over-writing the given prefrence
+// Update the user preferences by over-writing the given preference
 Cypress.Commands.add('setUserPreference', (prefs: any) => {
-  return cy.getRancherResource('v3', 'users?me=true').then((resp: Cypress.Response<any>) => {
+  return cy.getRancherResource('v1', 'userpreferences').then((resp: Cypress.Response<any>) => {
     const update = resp.body.data[0];
 
     update.data = {
       ...update.data,
       ...prefs
     };
+
+    delete update.links;
 
     return cy.setRancherResource('v1', 'userpreferences', update.id, update);
   });

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4544,6 +4544,7 @@ plugins:
   tabs:
     all: All
     available: Available
+    builtin: Built-in
     images: Images
     installed: Installed
     updates: Updates

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -211,11 +211,12 @@ export default {
     },
 
     list() {
-      const all = this.available;
+      // If not an extension developer, then don't include built-in extensions
+      const all = this.pluginDeveloper ? this.available : this.available.filter((p) => !p.builtin);
 
       switch (this.view) {
       case TABS_VALUES.INSTALLED:
-        return all.filter((p) => !p.builtin && (!!p.installed || !!p.installing));
+        return all.filter((p) => !!p.installed || !!p.installing);
       case TABS_VALUES.UPDATES:
         return this.updates;
       case TABS_VALUES.AVAILABLE:

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -45,7 +45,8 @@ const TABS_VALUES = {
   INSTALLED: 'installed',
   UPDATES:   'updates',
   AVAILABLE: 'available',
-  ALL:       'all'
+  BUILTIN:   'builtin',
+  ALL:       'all',
 };
 
 export default {
@@ -214,11 +215,13 @@ export default {
 
       switch (this.view) {
       case TABS_VALUES.INSTALLED:
-        return all.filter((p) => !!p.installed || !!p.installing);
+        return all.filter((p) => !p.builtin && (!!p.installed || !!p.installing));
       case TABS_VALUES.UPDATES:
         return this.updates;
       case TABS_VALUES.AVAILABLE:
         return all.filter((p) => !p.installed);
+      case TABS_VALUES.BUILTIN:
+        return all.filter((p) => p.builtin);
       default:
         return all;
       }
@@ -791,9 +794,15 @@ export default {
             :badge="updates.length"
           />
           <Tab
+            v-if="pluginDeveloper"
+            :name="TABS_VALUES.BUILTIN"
+            label-key="plugins.tabs.builtin"
+            :weight="17"
+          />
+          <Tab
             :name="TABS_VALUES.ALL"
             label-key="plugins.tabs.all"
-            :weight="17"
+            :weight="16"
           />
         </Tabbed>
         <div


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13468
Fixed #8134

### Occurred changes and/or fixed issues

Only shows built-in extensions on the new 'built-in' tab, which is now only shown when the user has enabled the extension developer preference.

### Testing

Validate that when you go to 'Extensions' that no built-in extensions show up.

Go to preferences and enable the preference 'Enable Extension developer features'.

Go back to extensions and you should see a new `Built-in` tab:

![image](https://github.com/user-attachments/assets/032af659-af88-4be5-ba78-833de0a5d29c)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
