### PR TITLE
Add ability to modify `GroupSearchEnabled` for OIDC/Keycloak auth providers

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -661,6 +661,9 @@ authConfig:
     key:
       label: Private Key
       placeholder: Paste in the private key, typically starting with -----BEGIN RSA PRIVATE KEY-----
+    groupSearch:
+      label: Enable group search
+      tooltip: Allows users with appropriate permissions to search and view all groups within the OIDC provider's realm. This can be useful for administrators who need to assign global roles to groups that they are not currently a member of.
   stateBanner:
     disabled: 'The {provider} authentication provider is currently disabled.'
     enabled: 'The {provider} authentication provider is currently enabled.'

--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -19,15 +19,16 @@ const validAuthEndpoint = 'http://localhost:8080/realms/rancherrealm/protocol/op
 const validScope = 'openid profile email';
 
 const mockModel = {
-  enabled:      false,
-  id:           'genericoidc',
-  rancherUrl:   validRancherUrl,
-  issuer:       validIssuer,
-  authEndpoint: validAuthEndpoint,
-  scope:        validScope,
-  clientId:     validClientId,
-  clientSecret: validClientSecret,
-  type:         'genericOIDCConfig',
+  enabled:            false,
+  id:                 'genericoidc',
+  rancherUrl:         validRancherUrl,
+  issuer:             validIssuer,
+  authEndpoint:       validAuthEndpoint,
+  scope:              validScope,
+  clientId:           validClientId,
+  clientSecret:       validClientSecret,
+  type:               'genericOIDCConfig',
+  groupSearchEnabled: false,
 };
 
 describe('oidc.vue', () => {
@@ -130,5 +131,21 @@ describe('oidc.vue', () => {
     await nextTick();
 
     expect(wrapper.vm.model.issuer).toBe(`${ validUrl }/realms/${ validRealm }`);
+  });
+
+  it('`groupSearchEnabled` defaults to false', async() => {
+    const groupSearchCheckbox = wrapper.getComponent('[data-testid="input-group-search"]');
+
+    expect(groupSearchCheckbox.isVisible()).toBe(true);
+    expect(wrapper.vm.model.groupSearchEnabled).toBe(false);
+  });
+
+  it('`groupSearchEnabled` updates when checkbox is clicked', async() => {
+    const groupSearchCheckbox = wrapper.getComponent('[data-testid="input-group-search"]');
+
+    await groupSearchCheckbox.find('[role="checkbox"]').trigger('click');
+
+    expect(groupSearchCheckbox.isVisible()).toBe(true);
+    expect(wrapper.vm.model.groupSearchEnabled).toBe(true);
   });
 });

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -259,6 +259,7 @@ export default {
           <div class="col span-6">
             <Checkbox
               v-model:value="model.groupSearchEnabled"
+              data-testid="input-group-search"
               :label="t('authConfig.oidc.groupSearch.label')"
               :tooltip="t('authConfig.oidc.groupSearch.tooltip')"
               :mode="mode"

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -11,6 +11,7 @@ import AdvancedSection from '@shell/components/AdvancedSection.vue';
 import ArrayList from '@shell/components/form/ArrayList';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import { RadioGroup } from '@components/Form/Radio';
+import { Checkbox } from '@components/Form/Checkbox';
 
 export default {
   components: {
@@ -23,7 +24,8 @@ export default {
     AdvancedSection,
     ArrayList,
     LabeledInput,
-    RadioGroup
+    RadioGroup,
+    Checkbox,
   },
 
   mixins: [CreateEditView, AuthConfig],
@@ -249,6 +251,17 @@ export default {
               :label="t('generic.readFromFile')"
               :mode="mode"
               @selected="model.certificate = $event"
+            />
+          </div>
+        </div>
+
+        <div class="row mb-20">
+          <div class="col span-6">
+            <Checkbox
+              v-model:value="model.groupSearchEnabled"
+              :label="t('authConfig.oidc.groupSearch.label')"
+              :tooltip="t('authConfig.oidc.groupSearch.tooltip')"
+              :mode="mode"
             />
           </div>
         </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This Add ability to modify `groupSearchEnabled` for Generic OIDC/Keycloak

Fixes #12853 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add a new checkbox to modify `groupSearchEnabled`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Configuring OIDC is a hassle, DM me and we can work on configuring an environment

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- OIDC/Keycloak auth providers

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- NA

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/user-attachments/assets/32a01385-d881-4ff8-86de-dc23cfd36fb1)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
