### PR TITLE
Change the way we size the ns-glass element responsible for closing the dropdown if you click outside of the element

### DIFF
--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -894,12 +894,13 @@ export default {
     display: inline-block;
 
     .ns-glass {
-      height: 100vh;
-      left: 0;
-      opacity: 0;
-      position: absolute;
       top: 0;
-      width: 100vw;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      opacity: 0;
+      position: fixed;
+
       z-index: z-index('overContent');
     }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Change the way we size the ns-glass element responsible for closing the dropdown if you click outside of the element

Fixes https://github.com/rancher/dashboard/issues/6748
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Updated the styling to make sure the element covers the entire screen while ensuring we never overflow the boundaries of the screen.

### Technical notes summary
I deciding to switch the position from absolute to fixed. Previously we covered the entire screen (except the banner) with the element anyway
![image](https://github.com/user-attachments/assets/e94d62ba-4581-4fba-a7c9-29d212e12236)

We now just make it fixed and use right, bottom instead of width and height to guarantee we never exceed the bounds of the window so we won't scroll. We also include the banner because I don't think we intended on omitting it anyway.

### Areas or cases that should be tested
Namespace filter on a couple pages.

### Areas which could experience regressions
Nothing known. It's possibly but unlikely that we may have another element we didn't want to cover but it's difficult to anticipate.

### Screenshot/Video
https://github.com/user-attachments/assets/cd7175df-04bd-4d3a-a8db-ede340e61ca3

Note: I don't think this is a good candidate for our current automated testing, in general I like to avoid negative tests. If we make headway with visual testing I think exercising the namespace filter with the banner open would be sufficient to ensure this issue doesn't crop up again.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
