### PR TITLE
Fix legacy projects redirect

### DIFF
--- a/shell/pages/c/_cluster/legacy/project/index.vue
+++ b/shell/pages/c/_cluster/legacy/project/index.vue
@@ -17,7 +17,7 @@ export default {
     project(nue, old) {
       if (nue && !old) {
         // User selected a project while on this page, so redirect to the projects view now that we have a project
-        this.$router.replace({ name: 'c-cluster-legacy-project-page', params: { page: 'apps' } });
+        this.$router.replace({ name: 'c-cluster-legacy-project-page', params: { page: 'config-maps' } });
       }
     }
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12622

### Occurred changes and/or fixed issues

Fixes the above issue.

The `apps` page that was being used as the initial redirect when selecting a project has been removed.

This PR updates this to now go to the legach project-scoped Config Maps page.

### Testing

Follow the steps in the linked issue and validate that you now go the Config Maps page and do not see the previous schema error message.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
