### PR TITLE
Fix e2e tests given new machine based resource finalizer

### DIFF
--- a/cypress/e2e/po/pages/cluster-manager/machine-deployments.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/machine-deployments.po.ts
@@ -4,12 +4,14 @@ import MachineDeploymentsCreateEditPo from '@/cypress/e2e/po/edit/machine-deploy
 import MachineDeploymentsListPo from '@/cypress/e2e/po/lists/machine-deployments-list.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+import { BLANK_CLUSTER } from '@shell/store/store-types.js';
+
 export default class MachineDeploymentsPagePo extends PagePo {
-  private static createPath(clusterId: string) {
+  private static createPath(clusterId: string = BLANK_CLUSTER) {
     return `/c/${ clusterId }/manager/cluster.x-k8s.io.machinedeployment`;
   }
 
-  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+  static goTo(clusterId: string = BLANK_CLUSTER): Cypress.Chainable<Cypress.AUTWindow> {
     return super.goTo(MachineDeploymentsPagePo.createPath(clusterId));
   }
 

--- a/cypress/e2e/po/pages/cluster-manager/machine-sets.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/machine-sets.po.ts
@@ -4,13 +4,14 @@ import MachineSetsCreateEditPo from '@/cypress/e2e/po/edit/machine-sets.po';
 import MachineSetsListPo from '@/cypress/e2e/po/lists/machine-set-list.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+import { BLANK_CLUSTER } from '@shell/store/store-types.js';
 
 export default class MachineSetsPagePo extends PagePo {
-  private static createPath(clusterId: string) {
+  private static createPath(clusterId: string = BLANK_CLUSTER) {
     return `/c/${ clusterId }/manager/cluster.x-k8s.io.machineset`;
   }
 
-  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+  static goTo(clusterId: string = BLANK_CLUSTER): Cypress.Chainable<Cypress.AUTWindow> {
     return super.goTo(MachineSetsPagePo.createPath(clusterId));
   }
 

--- a/cypress/e2e/po/pages/cluster-manager/machines.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/machines.po.ts
@@ -4,13 +4,14 @@ import MachinesListPo from '@/cypress/e2e/po/lists/machines-list.po';
 import CodeMirrorPo from '@/cypress/e2e/po/components/code-mirror.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+import { BLANK_CLUSTER } from '@shell/store/store-types.js';
 
 export default class MachinesPagePo extends PagePo {
-  private static createPath(clusterId: string) {
+  private static createPath(clusterId: string = BLANK_CLUSTER) {
     return `/c/${ clusterId }/manager/cluster.x-k8s.io.machine`;
   }
 
-  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+  static goTo(clusterId: string = BLANK_CLUSTER): Cypress.Chainable<Cypress.AUTWindow> {
     return super.goTo(MachinesPagePo.createPath(clusterId));
   }
 

--- a/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
@@ -22,7 +22,7 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
   });
 
   it('can create a MachineDeployments', function() {
-    MachineDeploymentsPagePo.navTo();
+    MachineDeploymentsPagePo.goTo();
     machineDeploymentsPage.waitForPage();
 
     machineDeploymentsPage.create();
@@ -34,6 +34,7 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
       const json: any = jsyaml.load(machineDeploymentDoc);
 
       json.metadata.name = this.machineDeploymentsName;
+      json.metadata.namespace = nsName;
       machineDeploymentsPage.yamlEditor().set(jsyaml.dump(json));
     });
 
@@ -41,7 +42,6 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
     machineDeploymentsPage.createEditMachineDeployment().saveCreateForm().resourceYaml().saveOrCreate()
       .click();
     cy.wait('@createMachineDeployment').then((req) => {
-      resourceVersion = req.response?.body.metadata.resourceVersion;
       creationTimestamp = req.response?.body.metadata.creationTimestamp;
       time = req.response?.body.metadata.managedFields[0].time;
       uid = req.response?.body.metadata.uid;
@@ -55,6 +55,11 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
     machineDeploymentsPage.waitForPage();
     machineDeploymentsPage.list().actionMenu(this.machineDeploymentsName).getMenuItem('Edit YAML').click();
     machineDeploymentsPage.createEditMachineDeployment(nsName, this.machineDeploymentsName).waitForPage('mode=edit&as=yaml');
+
+    cy.getRancherResource('v1', 'cluster.x-k8s.io.machinedeployments', `${ nsName }/${ this.machineDeploymentsName }`, 200).then((resp) => {
+      // Resource gets updated post create (finalizer added). So refetch it to get the correct resourceVersion
+      resourceVersion = resp.body.metadata.resourceVersion;
+    });
 
     cy.readFile('cypress/e2e/blueprints/cluster_management/machine-deployments-edit.yml').then((machineSetDoc) => {
       // convert yaml into json to update values
@@ -85,12 +90,14 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
     machineDeploymentsPage.waitForPage();
     machineDeploymentsPage.list().actionMenu(this.machineDeploymentsName).getMenuItem('Clone').click();
     machineDeploymentsPage.createEditMachineDeployment(nsName, this.machineDeploymentsName).waitForPage('mode=clone&as=yaml');
+    const cloneName = `${ this.machineDeploymentsName }-clone`;
 
     cy.readFile('cypress/e2e/blueprints/cluster_management/machine-deployments.yml').then((machineSetDoc) => {
       // convert yaml into json to update name value
       const json: any = jsyaml.load(machineSetDoc);
 
-      json.metadata.name = `${ this.machineDeploymentsName }-clone`;
+      json.metadata.name = cloneName;
+      json.metadata.namespace = nsName;
       machineDeploymentsPage.yamlEditor().set(jsyaml.dump(json));
     });
 
@@ -101,7 +108,7 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
     machineDeploymentsPage.waitForPage();
 
     // check list details
-    machineDeploymentsPage.list().details(`${ this.machineDeploymentsName }-clone`, 2).should('be.visible');
+    machineDeploymentsPage.list().details(cloneName, 2).should('be.visible');
   });
 
   it('can download YAML', function() {
@@ -125,8 +132,10 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
     MachineDeploymentsPagePo.navTo();
     machineDeploymentsPage.waitForPage();
 
+    const cloneName = `${ this.machineDeploymentsName }-clone`;
+
     // delete original cloned MachineSet
-    machineDeploymentsPage.list().actionMenu(`${ this.machineDeploymentsName }-clone`).getMenuItem('Delete').click();
+    machineDeploymentsPage.list().actionMenu(cloneName).getMenuItem('Delete').click();
 
     const promptRemove = new PromptRemove();
 
@@ -136,8 +145,16 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
     cy.wait('@deleteMachineSet');
     machineDeploymentsPage.waitForPage();
 
+    cy.getRancherResource('v1', 'cluster.x-k8s.io.machinedeployments', `${ nsName }/${ cloneName }`, 200).then((resp) => {
+      // Resource gets updated post create (finalizer added). So refetch it to get the correct resourceVersion
+      const resource = resp.body;
+
+      delete resource.metadata.finalizers;
+      cy.setRancherResource('v1', 'cluster.x-k8s.io.machinedeployments', `${ nsName }/${ cloneName }`, resource);
+    });
+
     // check list details
-    cy.contains(`${ this.machineDeploymentsName }-clone`).should('not.exist');
+    cy.contains(cloneName).should('not.exist');
   });
 
   it('can delete MachineDeployments via bulk actions', function() {
@@ -149,7 +166,9 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
       .set();
     machineDeploymentsPage.list().openBulkActionDropdown();
 
-    cy.intercept('DELETE', `v1/cluster.x-k8s.io.machinedeployments/${ nsName }/${ this.machineDeploymentsName }`).as('deleteMachineSet');
+    const machineName = `${ nsName }/${ this.machineDeploymentsName }`;
+
+    cy.intercept('DELETE', `v1/cluster.x-k8s.io.machinedeployments/${ machineName }`).as('deleteMachineSet');
     machineDeploymentsPage.list().bulkActionButton('Delete').click();
 
     const promptRemove = new PromptRemove();
@@ -157,6 +176,14 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
     promptRemove.remove();
     cy.wait('@deleteMachineSet');
     machineDeploymentsPage.waitForPage();
+
+    cy.getRancherResource('v1', 'cluster.x-k8s.io.machinedeployments', `${ machineName }`, 200).then((resp) => {
+      // Resource gets updated post create (finalizer added). So refetch it to get the correct resourceVersion
+      const resource = resp.body;
+
+      delete resource.metadata.finalizers;
+      cy.setRancherResource('v1', 'cluster.x-k8s.io.machinedeployments', `${ machineName }`, resource);
+    });
 
     // check list details
     cy.contains(this.machineDeploymentsName).should('not.exist');


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fix e2e tests given new machine based resource finalizer

### Occurred changes and/or fixed issues
- Looks like on create of the resource a finalizer is added
- The new resourceVersion given change broke edit tests
- The new finalizer broke delete tests
- We now update resourceVersion before editing, and remove finalizer (needs to be done after edit, or it gets added again)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
