### PR TITLE
Better handling of rendering the etcd page when a no longer supported k8s version is used

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/tabs/etcd/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/etcd/index.vue
@@ -48,7 +48,7 @@ export default {
       return this.value.spec.rkeConfig.etcd;
     },
     argsEtcdExposeMetrics() {
-      return !!this.selectedVersion?.serverArgs['etcd-expose-metrics'];
+      return !!this.selectedVersion?.serverArgs?.['etcd-expose-metrics'];
     },
     configEtcdExposeMetrics() {
       return !!this.value.spec.rkeConfig.machineGlobalConfig['etcd-expose-metrics'];


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes: https://github.com/rancher/dashboard/issues/13497

https://jira.suse.com/browse/SURE-9817

### Technical notes summary
Properly handle missing object data

### Areas or cases that should be tested
Message me if you'd like creds to an instance that's already done the upgrade cycle.
1. Create a rancher v2.9-head instance
2. Create a cluster with a k8s version `v1.27.16+rke2r2` (DO, EC2 providers work)
3. Upgrade the rancher instance to head
4. Edit the cluster and then click on the etcd tab (it should now render)
   i. Without my changes I had to click between tabs a few times and wait before the etcd tab would stop rendering. 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
