### PR TITLE
Fix issue with configmap description and pressing `space` shifting focus

### DIFF
--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -41,7 +41,8 @@ export default {
       removeKeyMapBox:     false,
       hasLintErrors:       false,
       currFocusedElem:     undefined,
-      isCodeMirrorFocused: false
+      isCodeMirrorFocused: false,
+      isMounted:           false
     };
   },
 
@@ -103,6 +104,13 @@ export default {
     },
 
     isCodeMirrorContainerFocused() {
+      // this is a gimmick so that vue only looks at this.$refs in this computed after it's mounted
+      // we do this because this.$refs is not reactive and is "undefined" at the time of the computed's
+      // first evaluation. Addresses https://github.com/rancher/dashboard/issues/13506
+      if (!this.isMounted) {
+        return false;
+      }
+
       return this.currFocusedElem === this.$refs?.codeMirrorContainer;
     },
 
@@ -123,6 +131,7 @@ export default {
 
   async mounted() {
     document.addEventListener('keyup', this.handleKeyPress);
+    this.isMounted = true;
   },
 
   beforeUnmount() {

--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -36,13 +36,13 @@ export default {
 
   data() {
     return {
-      codeMirrorRef:       null,
-      loaded:              false,
-      removeKeyMapBox:     false,
-      hasLintErrors:       false,
-      currFocusedElem:     undefined,
-      isCodeMirrorFocused: false,
-      isMounted:           false
+      codeMirrorRef:          null,
+      loaded:                 false,
+      removeKeyMapBox:        false,
+      hasLintErrors:          false,
+      currFocusedElem:        undefined,
+      isCodeMirrorFocused:    false,
+      codeMirrorContainerRef: undefined
     };
   },
 
@@ -104,14 +104,7 @@ export default {
     },
 
     isCodeMirrorContainerFocused() {
-      // this is a gimmick so that vue only looks at this.$refs in this computed after it's mounted
-      // we do this because this.$refs is not reactive and is "undefined" at the time of the computed's
-      // first evaluation. Addresses https://github.com/rancher/dashboard/issues/13506
-      if (!this.isMounted) {
-        return false;
-      }
-
-      return this.currFocusedElem === this.$refs?.codeMirrorContainer;
+      return this.currFocusedElem === this.codeMirrorContainerRef;
     },
 
     codeMirrorContainerTabIndex() {
@@ -131,7 +124,7 @@ export default {
 
   async mounted() {
     document.addEventListener('keyup', this.handleKeyPress);
-    this.isMounted = true;
+    this.codeMirrorContainerRef = this.$refs.codeMirrorContainer;
   },
 
   beforeUnmount() {

--- a/shell/components/nav/WindowManager/ContainerShell.vue
+++ b/shell/components/nav/WindowManager/ContainerShell.vue
@@ -74,24 +74,24 @@ export default {
 
   data() {
     return {
-      container:       this.initialContainer || this.pod?.defaultContainerName,
-      socket:          null,
-      terminal:        null,
-      fitAddon:        null,
-      searchAddon:     null,
-      webglAddon:      null,
-      canvasAddon:     null,
-      isOpen:          false,
-      isOpening:       false,
-      backlog:         [],
-      node:            null,
-      keepAliveTimer:  null,
-      errorMsg:        '',
-      backupShells:    ['linux', 'windows'],
-      os:              undefined,
-      retries:         0,
-      currFocusedElem: undefined,
-      isMounted:       false
+      container:         this.initialContainer || this.pod?.defaultContainerName,
+      socket:            null,
+      terminal:          null,
+      fitAddon:          null,
+      searchAddon:       null,
+      webglAddon:        null,
+      canvasAddon:       null,
+      isOpen:            false,
+      isOpening:         false,
+      backlog:           [],
+      node:              null,
+      keepAliveTimer:    null,
+      errorMsg:          '',
+      backupShells:      ['linux', 'windows'],
+      os:                undefined,
+      retries:           0,
+      currFocusedElem:   undefined,
+      xtermContainerRef: undefined
     };
   },
 
@@ -116,14 +116,7 @@ export default {
     },
 
     isXtermContainerFocused() {
-      // this is a gimmick so that vue only looks at this.$refs in this computed after it's mounted
-      // we do this because this.$refs is not reactive and is "undefined" at the time of the computed's
-      // first evaluation. Addresses https://github.com/rancher/dashboard/issues/13506
-      if (!this.isMounted) {
-        return false;
-      }
-
-      return this.currFocusedElem === this.$refs?.xterm;
+      return this.currFocusedElem === this.xtermContainerRef;
     },
 
     xTermContainerTabIndex() {
@@ -186,7 +179,7 @@ export default {
       this.fit();
     }, 60 * 1000);
 
-    this.isMounted = true;
+    this.xtermContainerRef = this.$refs?.xterm;
   },
 
   methods: {

--- a/shell/components/nav/WindowManager/ContainerShell.vue
+++ b/shell/components/nav/WindowManager/ContainerShell.vue
@@ -90,7 +90,8 @@ export default {
       backupShells:    ['linux', 'windows'],
       os:              undefined,
       retries:         0,
-      currFocusedElem: undefined
+      currFocusedElem: undefined,
+      isMounted:       false
     };
   },
 
@@ -115,6 +116,13 @@ export default {
     },
 
     isXtermContainerFocused() {
+      // this is a gimmick so that vue only looks at this.$refs in this computed after it's mounted
+      // we do this because this.$refs is not reactive and is "undefined" at the time of the computed's
+      // first evaluation. Addresses https://github.com/rancher/dashboard/issues/13506
+      if (!this.isMounted) {
+        return false;
+      }
+
       return this.currFocusedElem === this.$refs?.xterm;
     },
 
@@ -177,6 +185,8 @@ export default {
     this.keepAliveTimer = setInterval(() => {
       this.fit();
     }, 60 * 1000);
+
+    this.isMounted = true;
   },
 
   methods: {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13506 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- update wrongly used patterns for `computed` properties using `$refs`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- Just learned that `$refs` aren't reactive and in the first evaluation of a `computed` they are always `undefined`, which in conjunction with the condition `this.isCodeMirrorContainerFocused && (ev.code === 'Enter' || ev.code === 'Space')` triggered the focus (`this.isCodeMirrorContainerFocused` => `this.currFocusedElem === this.$refs?.codeMirrorContainer` => `undefined` === `undefined`).

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- `Import YAML` modal (triggered from header)
- configmap, as per original issue
- `ContainerShell` -> opening terminal and clicking `space`

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
