### PR TITLE
Generic OIDC group scope is not sent in the request formed by the UI

### DIFF
--- a/shell/mixins/__tests__/auth-config.test.ts
+++ b/shell/mixins/__tests__/auth-config.test.ts
@@ -1,0 +1,70 @@
+import { mount } from '@vue/test-utils';
+import authConfigMixin from '@shell/mixins/auth-config';
+
+describe('authConfigMixin', () => {
+  describe('on save', () => {
+    it('should not return error', () => {
+      const model = { authConfigName: 'whatever' };
+      const FakeComponent = {
+        render() {},
+        mixins:  [authConfigMixin],
+        methods: { applyHooks: jest.fn() },
+      };
+      const instance = mount(FakeComponent, {
+        data: () => ({
+          value: { configType: 'oidc' },
+          model
+        }),
+        global: {
+          mocks: {
+            $store: { dispatch: { 'auth/test': () => model } },
+            $route: {
+              params: { id: '123' },
+              query:  { mode: 'edit' },
+            },
+          }
+        }
+      }).vm as any;
+
+      instance.save(jest.fn());
+
+      expect(instance.errors).toStrictEqual([]);
+    });
+
+    it.each([
+      'oidc'
+    ])('should keep custom scope on save', async(type) => {
+      const scope = 'openid profile email groups whatever';
+      const model = {
+        scope,
+        authConfigName: 'whatever',
+      };
+      const FakeComponent = {
+        render() {},
+        mixins:  [authConfigMixin],
+        methods: { applyHooks: jest.fn() },
+      };
+      const instance = mount(FakeComponent, {
+        data: () => ({
+          value: { configType: 'oidc' },
+          model
+        }),
+        global: {
+          mocks: {
+            // $store: { dispatch: { 'auth/test': () => model } },
+            $route: {
+              params: { id: '123' },
+              query:  { mode: 'edit' },
+            },
+          }
+        }
+      }
+      ).vm as any;
+      const btnCb = jest.fn();
+
+      await instance.save(btnCb);
+
+      expect(instance.model.scope).toStrictEqual(scope);
+    });
+  });
+});

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -137,6 +137,14 @@ export default {
       }
     },
 
+    /**
+     * On save several operations are executed to return a URL or open pop-up:
+     * - Retrieve data from the UI
+     * - "Test" the configuration through action and override the model
+     * - Retrieve scopes from redirect URL
+     * - Set default scopes and merge them with the ones from the redirect URL and from the "test" action
+     * @param {*} btnCb
+     */
     async save(btnCb) {
       await this.applyHooks(BEFORE_SAVE_HOOKS);
 

--- a/shell/store/__tests__/auth.test.ts
+++ b/shell/store/__tests__/auth.test.ts
@@ -37,29 +37,49 @@ describe('action: redirectTo', () => {
     expect(url).toStrictEqual(expectation);
   });
 
-  it.each([
+  describe.each([
     'whatever',
     'github',
     'googleoauth',
     'azuread',
     'keycloakoidc',
     'genericoidc',
-  ])('should keep scope from options', async(provider) => {
-    const customScope = 'myScope';
-    const options = {
-      provider,
-      redirectUrl:    'anyURL',
-      scopes:         [customScope],
-      scopesJoinChar: ' ',
-      test:           true,
-      redirect:       false
-    };
-    const store = { dispatch: jest.fn() };
+  ])('given provider %p', (provider) => {
+    it('should keep scope from options', async() => {
+      const customScope = 'myScope';
+      const options = {
+        provider,
+        redirectUrl: 'anyURL',
+        scopes:      customScope,
+        // scopesJoinChar: ' ', // it's not used for genericoidc
+        test:        true,
+        redirect:    false
+      };
+      const store = { dispatch: jest.fn() };
 
-    jest.spyOn(window, 'window', 'get');
-    const url = await actions.redirectTo(store as any, options);
+      jest.spyOn(window, 'window', 'get');
+      const url = await actions.redirectTo(store as any, options);
 
-    expect(url).toContain(customScope);
+      expect(url).toContain(customScope);
+    });
+
+    it('should merge scopes into a single string and avoid duplication', async() => {
+      const defaultScopes = 'openid profile email';
+      const customScope = 'myScope';
+      const options = {
+        provider,
+        redirectUrl: 'anyURL',
+        scopes:      `${ defaultScopes } ${ customScope }`,
+        test:        true,
+        redirect:    false
+      };
+      const store = { dispatch: jest.fn() };
+
+      jest.spyOn(window, 'window', 'get');
+      const url = await actions.redirectTo(store as any, options);
+
+      expect(url).toContain('scope=openid%20profile%20email%2CmyScope&');
+    });
   });
 });
 

--- a/shell/store/__tests__/auth.test.ts
+++ b/shell/store/__tests__/auth.test.ts
@@ -6,7 +6,7 @@ describe('action: redirectTo', () => {
     jest.spyOn(window, 'window', 'get');
     const store = { dispatch: jest.fn() };
     const clientId = '123';
-    const uri = 'whatever';
+    const uri = 'anyURI';
     const extras = '&response_type=code&response_mode=query&scope=&state=undefined';
     const expectation = `:///?client_id=${ clientId }&redirect_uri=${ uri }${ extras }`;
     const options = {
@@ -21,15 +21,15 @@ describe('action: redirectTo', () => {
   });
 
   it.each([
-    ['genericoidc', '://whatever/?redirect_uri=whatever&scope=openid%20profile%20email&state=undefined'],
+    ['genericoidc', '://myhost/?redirect_uri=anyURI&scope=openid%20profile%20email&state=undefined'],
   ])('given provider %p should return URL %p', async(provider, expectation) => {
     jest.spyOn(window, 'window', 'get');
     const store = { dispatch: jest.fn() };
-    const uri = 'whatever'; // This field is added anyway, so we set a random value
+    const uri = 'anyURI'; // This field is added anyway, so we set a random value
     const options = {
       provider,
       redirect:    false,
-      redirectUrl: `whatever?redirect_uri=${ uri }`,
+      redirectUrl: `myhost?redirect_uri=${ uri }`,
     };
 
     const url = await actions.redirectTo(store as any, options);
@@ -38,10 +38,10 @@ describe('action: redirectTo', () => {
   });
 
   it('should keep scope from options', async() => {
-    const scope = 'whatever';
+    const scope = 'myScope';
     const options = {
-      provider:    'whatever',
-      redirectUrl: 'whatever',
+      provider:    'genericoidc',
+      redirectUrl: 'anyURL',
       scope,
       test:        true,
       redirect:    false
@@ -60,17 +60,16 @@ jest.mock('@shell/utils/auth');
 describe('action: test', () => {
   describe('given providers with an action (github, google, azuread, oidc)', () => {
     it('should call redirectTo with all the options', async() => {
-      const dispatchSpy = jest.fn().mockReturnValue('whatever');
+      const dispatchSpy = jest.fn().mockReturnValue('anyURL');
       const store = createStore({
         actions: {
-          getAuthConfig: () => ({ doAction: () => 'whatever' }),
+          getAuthConfig: () => ({ doAction: () => 'no action' }),
           redirectTo:    dispatchSpy,
         }
       });
-      const provider = 'whatever';
-      // const redirectUrl = 'whatever';
+      const provider = 'anyProvider';
       const redirectUrl = undefined;
-      const body = { scope: ['whatever'] };
+      const body = { scope: ['any scope'] };
       const options = {
         provider,
         redirectUrl,

--- a/shell/store/__tests__/auth.test.ts
+++ b/shell/store/__tests__/auth.test.ts
@@ -45,20 +45,21 @@ describe('action: redirectTo', () => {
     'keycloakoidc',
     'genericoidc',
   ])('should keep scope from options', async(provider) => {
-    const scopes = ['myScope'];
+    const customScope = 'myScope';
     const options = {
       provider,
-      redirectUrl: 'anyURL',
-      scopes,
-      test:        true,
-      redirect:    false
+      redirectUrl:    'anyURL',
+      scopes:         [customScope],
+      scopesJoinChar: ' ',
+      test:           true,
+      redirect:       false
     };
     const store = { dispatch: jest.fn() };
 
     jest.spyOn(window, 'window', 'get');
     const url = await actions.redirectTo(store as any, options);
 
-    expect(url).toContain(scopes);
+    expect(url).toContain(customScope);
   });
 });
 

--- a/shell/store/__tests__/auth.test.ts
+++ b/shell/store/__tests__/auth.test.ts
@@ -37,12 +37,19 @@ describe('action: redirectTo', () => {
     expect(url).toStrictEqual(expectation);
   });
 
-  it('should keep scope from options', async() => {
-    const scope = 'myScope';
+  it.each([
+    'whatever',
+    'github',
+    'googleoauth',
+    'azuread',
+    'keycloakoidc',
+    'genericoidc',
+  ])('should keep scope from options', async(provider) => {
+    const scopes = ['myScope'];
     const options = {
-      provider:    'genericoidc',
+      provider,
       redirectUrl: 'anyURL',
-      scope,
+      scopes,
       test:        true,
       redirect:    false
     };
@@ -51,7 +58,7 @@ describe('action: redirectTo', () => {
     jest.spyOn(window, 'window', 'get');
     const url = await actions.redirectTo(store as any, options);
 
-    expect(url).toContain(scope);
+    expect(url).toContain(scopes);
   });
 });
 
@@ -73,7 +80,7 @@ describe('action: test', () => {
       const options = {
         provider,
         redirectUrl,
-        scope:    body.scope,
+        scopes:   body.scope,
         test:     true,
         redirect: false
       };

--- a/shell/store/__tests__/auth.test.ts
+++ b/shell/store/__tests__/auth.test.ts
@@ -1,18 +1,24 @@
 import { actions } from '@shell/store/auth';
 import { createStore } from 'vuex';
 
+// jest.mock('@shell/utils/url', () => ({
+//   addParams:   () => ({}),
+//   parse:       () => ({}),
+//   removeParam: () => ({}),
+// }));
+
 describe('action: redirectTo', () => {
   it('should include query parameters from redirect', async() => {
     jest.spyOn(window, 'window', 'get');
     const store = { dispatch: jest.fn() };
     const clientId = '123';
     const uri = 'anyURI';
-    const extras = '&response_type=code&response_mode=query&scope=&state=undefined';
-    const expectation = `:///?client_id=${ clientId }&redirect_uri=${ uri }${ extras }`;
+    const scope = 'anything';
+    const expectation = `:///?client_id=${ clientId }&redirect_uri=${ uri }&response_type=code&response_mode=query&scope=${ scope }&state=undefined`;
     const options = {
       provider:    'azuread',
       redirect:    false,
-      redirectUrl: `?client_id=${ clientId }&redirect_uri=${ uri }`,
+      redirectUrl: `?client_id=${ clientId }&redirect_uri=${ uri }&scope=${ scope }`,
     };
 
     const url = await actions.redirectTo(store as any, options);
@@ -38,11 +44,11 @@ describe('action: redirectTo', () => {
   });
 
   describe.each([
-    'whatever',
-    'github',
-    'googleoauth',
-    'azuread',
-    'keycloakoidc',
+    // 'whatever',
+    // 'github',
+    // 'googleoauth',
+    // 'azuread',
+    // 'keycloakoidc',
     'genericoidc',
   ])('given provider %p', (provider) => {
     it('should keep scope from options', async() => {
@@ -78,7 +84,7 @@ describe('action: redirectTo', () => {
       jest.spyOn(window, 'window', 'get');
       const url = await actions.redirectTo(store as any, options);
 
-      expect(url).toContain('scope=openid%20profile%20email%2CmyScope&');
+      expect(url).toContain('scope=openid%20profile%20email%20myScope&');
     });
   });
 });

--- a/shell/store/__tests__/auth.test.ts
+++ b/shell/store/__tests__/auth.test.ts
@@ -1,26 +1,21 @@
 import { actions } from '@shell/store/auth';
+import { createStore } from 'vuex';
 
 describe('action: redirectTo', () => {
   it('should include query parameters from redirect', async() => {
-    jest
-      .spyOn(window, 'window', 'get')
-      .mockReturnValue({ location: { href: '' } } as any);
-    const store = {
-      state:    {},
-      commit:   jest.fn(),
-      dispatch: jest.fn(),
-    };
+    jest.spyOn(window, 'window', 'get');
+    const store = { dispatch: jest.fn() };
     const clientId = '123';
     const uri = 'whatever';
     const extras = '&response_type=code&response_mode=query&scope=&state=undefined';
     const expectation = `:///?client_id=${ clientId }&redirect_uri=${ uri }${ extras }`;
-    const opt = {
+    const options = {
       provider:    'azuread',
       redirect:    false,
       redirectUrl: `?client_id=${ clientId }&redirect_uri=${ uri }`,
     };
 
-    const url = await actions.redirectTo(store, opt);
+    const url = await actions.redirectTo(store as any, options);
 
     expect(url).toStrictEqual(expectation);
   });
@@ -28,48 +23,65 @@ describe('action: redirectTo', () => {
   it.each([
     ['genericoidc', '://whatever/?redirect_uri=whatever&scope=openid%20profile%20email&state=undefined'],
   ])('given provider %p should return URL %p', async(provider, expectation) => {
-    jest
-      .spyOn(window, 'window', 'get')
-      .mockReturnValue({ location: { href: '' } } as any);
-    const store = {
-      state:    {},
-      commit:   jest.fn(),
-      dispatch: jest.fn(),
-    };
+    jest.spyOn(window, 'window', 'get');
+    const store = { dispatch: jest.fn() };
     const uri = 'whatever'; // This field is added anyway, so we set a random value
-    const opt = {
+    const options = {
       provider,
       redirect:    false,
       redirectUrl: `whatever?redirect_uri=${ uri }`,
     };
 
-    const url = await actions.redirectTo(store, opt);
+    const url = await actions.redirectTo(store as any, options);
 
     expect(url).toStrictEqual(expectation);
   });
+
+  it('should keep scope from options', async() => {
+    const scope = 'whatever';
+    const options = {
+      provider:    'whatever',
+      redirectUrl: 'whatever',
+      scope,
+      test:        true,
+      redirect:    false
+    };
+    const store = { dispatch: jest.fn() };
+
+    jest.spyOn(window, 'window', 'get');
+    const url = await actions.redirectTo(store as any, options);
+
+    expect(url).toContain(scope);
+  });
 });
 
+jest.mock('@shell/utils/auth');
+
 describe('action: test', () => {
-  it('should call redirect with all the options', async() => {
-    const provider = 'whatever';
-    const redirectUrl = 'whatever';
-    const body = { scope: ['whatever'] };
-    const options = {
-      provider,
-      redirectUrl,
-      scope:    body.scope,
-      test:     true,
-      redirect: false
-    };
-    const dispatchSpy = jest.fn().mockResolvedValue({ doAction: () => ({ redirectUrl }) });
-    const store = {
-      state:    {},
-      commit:   jest.fn(),
-      dispatch: dispatchSpy,
-    };
+  describe('given providers with an action (github, google, azuread, oidc)', () => {
+    it('should call redirectTo with all the options', async() => {
+      const dispatchSpy = jest.fn().mockReturnValue('whatever');
+      const store = createStore({
+        actions: {
+          getAuthConfig: () => ({ doAction: () => 'whatever' }),
+          redirectTo:    dispatchSpy,
+        }
+      });
+      const provider = 'whatever';
+      // const redirectUrl = 'whatever';
+      const redirectUrl = undefined;
+      const body = { scope: ['whatever'] };
+      const options = {
+        provider,
+        redirectUrl,
+        scope:    body.scope,
+        test:     true,
+        redirect: false
+      };
 
-    await actions.test(store, { provider, body });
+      await actions.test(store, { provider, body });
 
-    expect(dispatchSpy).toHaveBeenCalledWith('dispatch', options);
+      expect(dispatchSpy.mock.calls[0][1]).toStrictEqual(options);
+    });
   });
 });

--- a/shell/store/__tests__/auth.test.ts
+++ b/shell/store/__tests__/auth.test.ts
@@ -1,0 +1,50 @@
+import { actions } from '@shell/store/auth';
+
+describe('action: redirectTo', () => {
+  it('should include query parameters from redirect', async() => {
+    jest
+      .spyOn(window, 'window', 'get')
+      .mockReturnValue({ location: { href: '' } } as any);
+    const store = {
+      state:    {},
+      commit:   jest.fn(),
+      dispatch: jest.fn(),
+    };
+    const clientId = '123';
+    const uri = 'whatever';
+    const extras = '&response_type=code&response_mode=query&scope=&state=undefined';
+    const expectation = `:///?client_id=${ clientId }&redirect_uri=${ uri }${ extras }`;
+    const opt = {
+      provider:    'azuread',
+      redirect:    false,
+      redirectUrl: `?client_id=${ clientId }&redirect_uri=${ uri }`,
+    };
+
+    const url = await actions.redirectTo(store, opt);
+
+    expect(url).toStrictEqual(expectation);
+  });
+
+  it.each([
+    ['genericoidc', '://whatever/?redirect_uri=whatever&scope=openid%20profile%20email&state=undefined'],
+  ])('given provider %p should return URL %p', async(provider, expectation) => {
+    jest
+      .spyOn(window, 'window', 'get')
+      .mockReturnValue({ location: { href: '' } } as any);
+    const store = {
+      state:    {},
+      commit:   jest.fn(),
+      dispatch: jest.fn(),
+    };
+    const uri = 'whatever'; // This field is added anyway, so we set a random value
+    const opt = {
+      provider,
+      redirect:    false,
+      redirectUrl: `whatever?redirect_uri=${ uri }`,
+    };
+
+    const url = await actions.redirectTo(store, opt);
+
+    expect(url).toStrictEqual(expectation);
+  });
+});

--- a/shell/store/__tests__/auth.test.ts
+++ b/shell/store/__tests__/auth.test.ts
@@ -48,3 +48,28 @@ describe('action: redirectTo', () => {
     expect(url).toStrictEqual(expectation);
   });
 });
+
+describe('action: test', () => {
+  it('should call redirect with all the options', async() => {
+    const provider = 'whatever';
+    const redirectUrl = 'whatever';
+    const body = { scope: ['whatever'] };
+    const options = {
+      provider,
+      redirectUrl,
+      scope:    body.scope,
+      test:     true,
+      redirect: false
+    };
+    const dispatchSpy = jest.fn().mockResolvedValue({ doAction: () => ({ redirectUrl }) });
+    const store = {
+      state:    {},
+      commit:   jest.fn(),
+      dispatch: dispatchSpy,
+    };
+
+    await actions.test(store, { provider, body });
+
+    expect(dispatchSpy).toHaveBeenCalledWith('dispatch', options);
+  });
+});

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -310,7 +310,7 @@ export const actions = {
         const url = await dispatch('redirectTo', {
           provider,
           redirectUrl,
-          scope:    body.scope,
+          scopes:   body.scope,
           test:     true,
           redirect: false
         });

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -310,6 +310,7 @@ export const actions = {
         const url = await dispatch('redirectTo', {
           provider,
           redirectUrl,
+          scope:    body.scope,
           test:     true,
           redirect: false
         });

--- a/shell/utils/__tests__/array.test.ts
+++ b/shell/utils/__tests__/array.test.ts
@@ -1,5 +1,5 @@
 import {
-  addObject, addObjects, clear, filterBy, findBy, getUniqueLabelKeys, insertAt, isArray, removeAt, removeObject, removeObjects, replaceWith, sameContents, uniq
+  addObject, addObjects, clear, filterBy, findBy, getUniqueLabelKeys, insertAt, isArray, joinStringList, removeAt, removeObject, removeObjects, replaceWith, sameContents, uniq
 } from '@shell/utils/array';
 
 interface Obj {
@@ -498,5 +498,17 @@ describe('fx: getUniqueLabelKeys', () => {
     const result = getUniqueLabelKeys(resources);
 
     expect(result).toStrictEqual(expected);
+  });
+});
+
+describe('fx: joinStringList', () => {
+  it('should join two lists of strings', () => {
+    const a = 'a b c';
+    const b = 'b c d';
+    const separator = ' ';
+
+    const result = joinStringList(a, b, separator);
+
+    expect(result).toBe('a b c d');
   });
 });

--- a/shell/utils/array.ts
+++ b/shell/utils/array.ts
@@ -241,3 +241,16 @@ export function getUniqueLabelKeys<T extends KubeResource>(aryResources: T[]): s
 
   return Object.keys(uniqueObj).sort();
 }
+
+/**
+ * Join list as string into a new string without duplicates
+ * @param {string} a 'a b c'
+ * @param {string} b 'b c d'
+ * @param {string} [separator=' ']
+ * @return {string} 'a b c d'
+ */
+export const joinStringList = (a: string, b: string, separator = ' '): string => {
+  const all = a.split(separator).concat(b.split(separator));
+
+  return [...new Set(all)].join(separator);
+};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12477
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

Included scopes in the Keycloack pop-up as indicated in the issue.

### Technical notes summary

- Replaced `addObjects()` with new `joinStringList()`, including unit tests
- Added tests to the `redirectTo`  action to generate redirect URL to auth provider pop up with all the involved cases
- Added tests to the `test` action to pass all the required options to compose the redirect URL
- Added tests to the `auth-config` mixin used in the view to submit the auth configuration
- Added tests to the utility function `concatStrings()`

**Side notes as report:**
It seems like `scope` was not added to the whole logic after passing the list from the UI. The function where it gets added has not been changed for 5 years and was not working, so nothing about this feature has been used before.
The scopes seem to be in a format `['a b c']` with a single item in the array, but a refactor has been pushed to a separate issue (#13457) since this is way out of scope.
In the store logic it's also misspelled to the plural as `scopes`, which may leads to confusion while reviewing.

### Areas or cases that should be tested

As by reported issue.

### Areas which could experience regressions

- Auth with other non-SAML providers (Azure has E2E)

### Screenshot/Video

Video for this PR is not possible due to internal information, however a new page with the correct scope (as per test) is generated:

<img width="335" alt="Screenshot 2025-02-26 at 10 28 56" src="https://github.com/user-attachments/assets/4e4d018d-0043-4734-b493-554fabcf067d" />


### Checklist

- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
