### PR TITLE
Wire in sorting/filtering clusters on new cluster human name label

### DIFF
--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -56,6 +56,12 @@ export const CAPI = {
   MACHINE_NAME:         'cluster.x-k8s.io/machine',
   DELETE_MACHINE:       'cluster.x-k8s.io/delete-machine',
   PROVIDER:             'provider.cattle.io',
+  /**
+   * RKE2 - metadata.name is human name
+   * RKE1 and some others - metadata.name is v1 mgmt id --> v1mgmt cluster contains human name
+   * This label ensures something is in the v1 prov cluster that can be sorted/filtered on
+   */
+  HUMAN_NAME:           'provisioning.cattle.io/management-cluster-display-name',
   SECRET_AUTH:          'v2prov-secret-authorized-for-cluster',
   SECRET_WILL_DELETE:   'v2prov-authorized-secret-deletes-on-cluster-removal',
   /**

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -58,7 +58,7 @@ export const CAPI = {
   PROVIDER:             'provider.cattle.io',
   /**
    * RKE2 - metadata.name is human name
-   * RKE1 and some others - metadata.name is v1 mgmt id --> v1mgmt cluster contains human name
+   * RKE1 and some others - metadata.name is v1 mgmt id and it's the v1 mgmt cluster that contains human name
    * This label ensures something is in the v1 prov cluster that can be sorted/filtered on
    */
   HUMAN_NAME:           'provisioning.cattle.io/management-cluster-display-name',

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -30,6 +30,7 @@ import ProvCluster from '@shell/models/provisioning.cattle.io.cluster';
 import { sameContents } from '@shell/utils/array';
 import { PagTableFetchPageSecondaryResourcesOpts, PagTableFetchSecondaryResourcesOpts, PagTableFetchSecondaryResourcesReturns } from '@shell/types/components/paginatedResourceTable';
 import { CURRENT_RANCHER_VERSION } from '@shell/config/version';
+import { CAPI as CAPI_LABELS } from '@shell/config/labels-annotations';
 
 export default defineComponent({
   name:       'Home',
@@ -156,11 +157,12 @@ export default defineComponent({
 
       paginationHeaders: [
         STEVE_STATE_COL,
-        // https://github.com/rancher/dashboard/issues/12890 BUG - rke1 cluster's prov cluster metadata.name is the mgmt cluster id rather than true name
         {
           ...STEVE_NAME_COL,
           canBeVariable: true,
-          getValue:      (row: ProvCluster) => row.metadata?.name
+          value:         `metadata.labels."${ CAPI_LABELS.HUMAN_NAME }"`,
+          sort:          [`metadata.labels."${ CAPI_LABELS.HUMAN_NAME }"`],
+          search:        `metadata.labels."${ CAPI_LABELS.HUMAN_NAME }"`,
         },
         {
           label:     this.t('landing.clusters.provider'),

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -30,7 +30,7 @@ import ProvCluster from '@shell/models/provisioning.cattle.io.cluster';
 import { sameContents } from '@shell/utils/array';
 import { PagTableFetchPageSecondaryResourcesOpts, PagTableFetchSecondaryResourcesOpts, PagTableFetchSecondaryResourcesReturns } from '@shell/types/components/paginatedResourceTable';
 import { CURRENT_RANCHER_VERSION } from '@shell/config/version';
-import { CAPI as CAPI_LABELS } from '@shell/config/labels-annotations';
+import { CAPI as CAPI_LAB_AND_ANO } from '@shell/config/labels-annotations';
 
 export default defineComponent({
   name:       'Home',
@@ -160,9 +160,9 @@ export default defineComponent({
         {
           ...STEVE_NAME_COL,
           canBeVariable: true,
-          value:         `metadata.labels."${ CAPI_LABELS.HUMAN_NAME }"`,
-          sort:          [`metadata.labels."${ CAPI_LABELS.HUMAN_NAME }"`],
-          search:        `metadata.labels."${ CAPI_LABELS.HUMAN_NAME }"`,
+          value:         `metadata.annotations[${ CAPI_LAB_AND_ANO.HUMAN_NAME }]`,
+          sort:          [`metadata.annotations[${ CAPI_LAB_AND_ANO.HUMAN_NAME }]`],
+          search:        `metadata.annotations[${ CAPI_LAB_AND_ANO.HUMAN_NAME }]`,
         },
         {
           label:     this.t('landing.clusters.provider'),

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -15,7 +15,7 @@ import {
   HPA,
   SECRET
 } from '@shell/config/types';
-import { CAPI as CAPI_LABELS, CATTLE_PUBLIC_ENDPOINTS } from '@shell/config/labels-annotations';
+import { CAPI as CAPI_LAB_AND_ANO, CATTLE_PUBLIC_ENDPOINTS } from '@shell/config/labels-annotations';
 import { Schema } from '@shell/plugins/steve/schema';
 import { PaginationSettingsStore } from '@shell/types/resources/settings';
 
@@ -152,7 +152,7 @@ class StevePaginationUtils extends NamespaceProjectFilters {
       { field: 'spec.internal' },
       { field: 'spec.displayName' },
       { field: `status.provider` },
-      { field: `metadata.labels."${ CAPI_LABELS.PROVIDER }"` },
+      { field: `metadata.labels["${ CAPI_LAB_AND_ANO.PROVIDER }]` },
       { field: `status.connected` },
     ],
     [CONFIG_MAP]: [
@@ -182,10 +182,10 @@ class StevePaginationUtils extends NamespaceProjectFilters {
       { field: 'status.releaseName' },
     ],
     [CAPI.RANCHER_CLUSTER]: [
-      { field: `metadata.labels."${ CAPI_LABELS.PROVIDER }"` },
+      { field: `metadata.labels[${ CAPI_LAB_AND_ANO.PROVIDER }]` },
       { field: `status.provider` },
       { field: 'status.clusterName' },
-      { field: `metadata.labels."${ CAPI_LABELS.HUMAN_NAME }"` }
+      { field: `metadata.annotations[${ CAPI_LAB_AND_ANO.HUMAN_NAME }]` }
     ],
     [SERVICE]: [
       { field: 'spec.type' },

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -185,6 +185,7 @@ class StevePaginationUtils extends NamespaceProjectFilters {
       { field: `metadata.labels."${ CAPI_LABELS.PROVIDER }"` },
       { field: `status.provider` },
       { field: 'status.clusterName' },
+      { field: `metadata.labels."${ CAPI_LABELS.HUMAN_NAME }"` }
     ],
     [SERVICE]: [
       { field: 'spec.type' },

--- a/shell/utils/cluster.js
+++ b/shell/utils/cluster.js
@@ -81,7 +81,7 @@ export function paginationFilterOnlyKubernetesClusters(store) {
 
   return PaginationParamFilter.createMultipleFields([
     new PaginationFilterField({
-      field:  `metadata.labels."${ CAPI.PROVIDER }"`,
+      field:  `metadata.labels[${ CAPI.PROVIDER }]`,
       equals: false,
       value:  VIRTUAL_HARVESTER_PROVIDER,
       exact:  true


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12890
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- There is now an annotation on the v1 prov cluster that displays the name of the cluster regardless of provisioner
- Wire this in to the home page list sorting by name


### Areas or cases that should be tested
> There needs to be a combination of both rke1 and rke2 cluters - they can be of type imported

- order of home page clusters when sorting by name

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
