### PR TITLE
fix misc issues for a11y

### DIFF
--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -111,7 +111,7 @@ export default defineComponent({
      * Optionally use this to comply with a11y IF there's no label
      * associated with the input
      */
-    accessibilityLabel: {
+    ariaLabel: {
       type:    String,
       default: ''
     }
@@ -373,7 +373,7 @@ export default defineComponent({
         :id="inputId"
         ref="value"
         v-bind="$attrs"
-        v-stripped-aria-label="!hasLabel && accessibilityLabel ? accessibilityLabel : undefined"
+        v-stripped-aria-label="!hasLabel && ariaLabel ? ariaLabel : undefined"
         :maxlength="_maxlength"
         :disabled="isDisabled"
         :value="value || ''"
@@ -388,7 +388,7 @@ export default defineComponent({
         v-else
         :id="inputId"
         ref="value"
-        v-stripped-aria-label="!hasLabel && accessibilityLabel ? accessibilityLabel : undefined"
+        v-stripped-aria-label="!hasLabel && ariaLabel ? ariaLabel : undefined"
         role="textbox"
         :class="{ 'no-label': !hasLabel }"
         v-bind="$attrs"

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -105,6 +105,15 @@ export default defineComponent({
     class: {
       type:    String,
       default: ''
+    },
+
+    /**
+     * Optionally use this to comply with a11y IF there's no label
+     * associated with the input
+     */
+    accessibilityLabel: {
+      type:    String,
+      default: ''
     }
   },
 
@@ -364,6 +373,7 @@ export default defineComponent({
         :id="inputId"
         ref="value"
         v-bind="$attrs"
+        v-stripped-aria-label="!hasLabel && accessibilityLabel ? accessibilityLabel : undefined"
         :maxlength="_maxlength"
         :disabled="isDisabled"
         :value="value || ''"
@@ -378,6 +388,7 @@ export default defineComponent({
         v-else
         :id="inputId"
         ref="value"
+        v-stripped-aria-label="!hasLabel && accessibilityLabel ? accessibilityLabel : undefined"
         role="textbox"
         :class="{ 'no-label': !hasLabel }"
         v-bind="$attrs"

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -968,6 +968,10 @@ catalog:
     experimentalWarning: '{chartName} has been marked as experimental. Use caution when installing this helm chart as it might not function as expected.'
     deprecatedAndExperimentalWarning: '{chartName} has been marked as deprecated and experimental. Use caution when installing this helm chart as it might be removed in the future and might not function as expected.'
   charts:
+    browseBtn: Browse
+    featuredBtn: Featured
+    featuredAriaLabel: Show Featured Charts Carousel and charts grid
+    browseAriaLabel: Show only charts grid
     iconAlt: Icon for {app} card/grid item
     refresh: refresh charts
     all: All

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6315,7 +6315,7 @@ wm:
     timestamps: Show Timestamps
     wrap: Wrap Lines
   containerShell:
-    resizeShellWindow: Resize Shell window
+    resizeShellWindow: Resize Shell window - use arrow keys {arrow1} and {arrow2} to resize with keyboard
     tabIcon: Shell tab icon
     closeShellTab: Close Shell tab - {tab}
     escapeText: Press Escape key to blur from terminal

--- a/shell/components/AppModal.vue
+++ b/shell/components/AppModal.vue
@@ -61,15 +61,6 @@ export default defineComponent({
       default: '',
     },
     /**
-     * pass codemirror yaml editor reference (optional)
-     * will be used to prevent "escape" from triggering modal closing
-     * IF there's an instance of codemirror focused on this modal
-     */
-    yamlEditor: {
-      type:    Object,
-      default: () => {},
-    },
-    /**
      * trigger focus trap
      */
     triggerFocusTrap: {
@@ -160,9 +151,7 @@ export default defineComponent({
       }
     },
     handleEscapeKey(event: KeyboardEvent) {
-      if (this.clickToClose &&
-        (!this.yamlEditor || !Object.keys(this.yamlEditor).length || (Object.keys(this.yamlEditor).length && !this.yamlEditor.hasFocus())) &&
-        event.key === 'Escape') {
+      if (this.clickToClose && event.key === 'Escape') {
         this.$emit('close');
       }
     },

--- a/shell/components/ButtonGroup.vue
+++ b/shell/components/ButtonGroup.vue
@@ -70,6 +70,13 @@ export default {
       const label = opt.labelKey ? this.t(opt.labelKey) : opt.label;
 
       return tooltip || label || '';
+    },
+    actionAriaLabel(opt) {
+      const ariaLabel = opt.ariaLabel;
+      const label = opt.labelKey ? this.t(opt.labelKey) : opt.label;
+      const tooltip = opt.tooltipKey ? this.t(opt.tooltipKey) : opt.tooltip;
+
+      return ariaLabel || tooltip || label || undefined;
     }
   }
 };
@@ -89,7 +96,7 @@ export default {
       :class="opt.class"
       :disabled="disabled || opt.disabled"
       role="button"
-      :aria-label="actionDescription(opt)"
+      :aria-label="actionAriaLabel(opt)"
       @click="change(opt.value)"
     >
       <slot
@@ -100,7 +107,7 @@ export default {
         <i
           v-if="opt.icon"
           :class="{icon: true, [opt.icon]: true, [`icon-${iconSize}`]: !!iconSize }"
-          :alt="actionDescription(opt)"
+          :alt="actionAriaLabel(opt)"
         />
         <t
           v-if="opt.labelKey"

--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -123,12 +123,16 @@ export default {
   },
 
   async mounted() {
-    document.addEventListener('keyup', this.handleKeyPress);
+    const el = this.$refs.codeMirrorContainer;
+
+    el.addEventListener('keydown', this.handleKeyPress);
     this.codeMirrorContainerRef = this.$refs.codeMirrorContainer;
   },
 
   beforeUnmount() {
-    document.removeEventListener('keyup', this.handleKeyPress);
+    const el = this.$refs.codeMirrorContainer;
+
+    el.removeEventListener('keydown', this.handleKeyPress);
   },
 
   watch: {
@@ -158,11 +162,10 @@ export default {
     },
 
     handleKeyPress(ev) {
-      ev.preventDefault();
-      ev.stopPropagation();
-
       // make focus leave the editor for it's parent container so that we can tab
       if (this.isCodeMirrorFocused && ev.code === 'Escape') {
+        ev.preventDefault();
+        ev.stopPropagation();
         this.$refs?.codeMirrorContainer?.focus();
       }
 

--- a/shell/components/PodSecurityAdmission.vue
+++ b/shell/components/PodSecurityAdmission.vue
@@ -256,6 +256,7 @@ export default defineComponent({
           :options="options"
           :placeholder="t('podSecurityAdmission.version.placeholder', { psaControl: mode })"
           :mode="mode"
+          :accessibility-label="`${t(`podSecurityAdmission.labels.${level}`)} - ${t('podSecurityAdmission.version.placeholder', { psaControl: mode })}`"
           @update:value="updateLabels()"
         />
       </span>
@@ -295,6 +296,7 @@ export default defineComponent({
             :options="options"
             :placeholder="t('podSecurityAdmission.exemptions.placeholder', { psaExemptionsControl: dimension })"
             :mode="mode"
+            :accessibility-label="`${t(`podSecurityAdmission.labels.${ dimension }`)} - ${t('podSecurityAdmission.exemptions.placeholder', { psaExemptionsControl: dimension })}`"
             @update:value="updateExemptions()"
           />
         </span>

--- a/shell/components/PodSecurityAdmission.vue
+++ b/shell/components/PodSecurityAdmission.vue
@@ -256,7 +256,7 @@ export default defineComponent({
           :options="options"
           :placeholder="t('podSecurityAdmission.version.placeholder', { psaControl: mode })"
           :mode="mode"
-          :accessibility-label="`${t(`podSecurityAdmission.labels.${level}`)} - ${t('podSecurityAdmission.version.placeholder', { psaControl: mode })}`"
+          :aria-label="`${t(`podSecurityAdmission.labels.${level}`)} - ${t('podSecurityAdmission.version.placeholder', { psaControl: mode })}`"
           @update:value="updateLabels()"
         />
       </span>
@@ -296,7 +296,7 @@ export default defineComponent({
             :options="options"
             :placeholder="t('podSecurityAdmission.exemptions.placeholder', { psaExemptionsControl: dimension })"
             :mode="mode"
-            :accessibility-label="`${t(`podSecurityAdmission.labels.${ dimension }`)} - ${t('podSecurityAdmission.exemptions.placeholder', { psaExemptionsControl: dimension })}`"
+            :aria-label="`${t(`podSecurityAdmission.labels.${ dimension }`)} - ${t('podSecurityAdmission.exemptions.placeholder', { psaExemptionsControl: dimension })}`"
             @update:value="updateExemptions()"
           />
         </span>

--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -389,7 +389,7 @@ export default {
           v-focus
           :data-testid="componentTestid + '-input'"
           type="text"
-          :accessibility-label="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) })"
+          :aria-label="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) })"
         >
           <div class="text-warning mb-10 mt-10">
             {{ warning }}

--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -389,6 +389,7 @@ export default {
           v-focus
           :data-testid="componentTestid + '-input'"
           type="text"
+          :accessibility-label="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) })"
         >
           <div class="text-warning mb-10 mt-10">
             {{ warning }}

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -81,8 +81,7 @@ export default {
       extensionHeaderActions: getApplicableExtensionEnhancements(this, ExtensionPoint.ACTION, ActionLocation.HEADER, this.$route),
       ctx:                    this,
       showImportModal:        false,
-      showSearchModal:        false,
-      currYamlEditor:         undefined
+      showSearchModal:        false
     };
   },
 
@@ -391,10 +390,6 @@ export default {
       }
 
       return null;
-    },
-
-    onReadyYamlEditor(yamlEditor) {
-      this.currYamlEditor = yamlEditor;
     }
   }
 };
@@ -567,12 +562,10 @@ export default {
             width="75%"
             height="auto"
             styles="max-height: 90vh;"
-            :yaml-editor="currYamlEditor"
             @close="closeImport"
           >
             <Import
               :cluster="currentCluster"
-              @onReadyYamlEditor="onReadyYamlEditor"
               @close="closeImport"
             />
           </app-modal>

--- a/shell/components/nav/WindowManager/index.vue
+++ b/shell/components/nav/WindowManager/index.vue
@@ -302,6 +302,7 @@ export default {
       this.height = height;
 
       this.setWmDimensions(height);
+      this.setReportedHeight(height);
     },
 
     resizeHorizontal(arrowLeft) {
@@ -317,6 +318,7 @@ export default {
       this.width = width;
 
       this.setWmDimensions(width);
+      this.setReportedWidth(width);
     }
   }
 };

--- a/shell/components/nav/WindowManager/index.vue
+++ b/shell/components/nav/WindowManager/index.vue
@@ -261,15 +261,15 @@ export default {
       this.reportedWidth = this.width;
     },
 
-    setWmDimensions() {
+    setWmDimensions(forceValue) {
       switch (this.userPin) {
       case RIGHT:
       case LEFT:
         document.documentElement.style.setProperty('--wm-height', `${ window.innerHeight - 55 }px`);
-        document.documentElement.style.setProperty('--wm-width', `${ this.width }px`);
+        document.documentElement.style.setProperty('--wm-width', `${ forceValue || this.width }px`);
         break;
       case BOTTOM:
-        document.documentElement.style.setProperty('--wm-height', `${ this.height }px`);
+        document.documentElement.style.setProperty('--wm-height', `${ forceValue || this.height }px`);
         break;
       }
     },
@@ -293,6 +293,30 @@ export default {
 
     emitDraggable(event) {
       this.$emit('draggable', event);
+    },
+
+    resizeVertical(arrowUp) {
+      const resizeStep = 20;
+      const height = arrowUp ? this.height + resizeStep : this.height - resizeStep;
+
+      this.height = height;
+
+      this.setWmDimensions(height);
+    },
+
+    resizeHorizontal(arrowLeft) {
+      const resizeStep = 20;
+      let width;
+
+      if (this.userPin === 'left') {
+        width = arrowLeft ? this.width - resizeStep : this.width + resizeStep;
+      } else {
+        width = arrowLeft ? this.width + resizeStep : this.width - resizeStep;
+      }
+
+      this.width = width;
+
+      this.setWmDimensions(width);
     }
   }
 };
@@ -320,8 +344,14 @@ export default {
       <div
         v-if="userPin == 'right'"
         class="resizer resizer-x"
+        role="button"
+        tabindex="0"
+        :aria-label="t('wm.containerShell.resizeShellWindow')"
+        aria-expanded="true"
         @mousedown.prevent.stop="dragXStart($event)"
         @touchstart.prevent.stop="dragXStart($event)"
+        @keyup.left.prevent.stop="resizeHorizontal(true)"
+        @keyup.right.prevent.stop="resizeHorizontal(false)"
       >
         <i
           class="icon icon-code"
@@ -361,9 +391,15 @@ export default {
       <div
         v-if="userPin == 'bottom'"
         class="resizer resizer-y"
+        role="button"
+        tabindex="0"
+        :aria-label="t('wm.containerShell.resizeShellWindow')"
+        aria-expanded="true"
         @mousedown.prevent.stop="dragYStart($event)"
         @touchstart.prevent.stop="dragYStart($event)"
         @click="toggle"
+        @keyup.up.prevent.stop="resizeVertical(true)"
+        @keyup.down.prevent.stop="resizeVertical(false)"
       >
         <i
           class="icon icon-sort"
@@ -373,8 +409,14 @@ export default {
       <div
         v-if="userPin == 'left'"
         class="resizer resizer-x resizer-align-right"
+        role="button"
+        tabindex="0"
+        :aria-label="t('wm.containerShell.resizeShellWindow')"
+        aria-expanded="true"
         @mousedown.prevent.stop="dragXStart($event)"
         @touchstart.prevent.stop="dragXStart($event)"
+        @keyup.left.prevent.stop="resizeHorizontal(true)"
+        @keyup.right.prevent.stop="resizeHorizontal(false)"
       >
         <i
           class="icon icon-code"

--- a/shell/components/nav/WindowManager/index.vue
+++ b/shell/components/nav/WindowManager/index.vue
@@ -348,7 +348,7 @@ export default {
         class="resizer resizer-x"
         role="button"
         tabindex="0"
-        :aria-label="t('wm.containerShell.resizeShellWindow')"
+        :aria-label="t('wm.containerShell.resizeShellWindow', {arrow1: 'left', arrow2: 'right'})"
         aria-expanded="true"
         @mousedown.prevent.stop="dragXStart($event)"
         @touchstart.prevent.stop="dragXStart($event)"
@@ -357,7 +357,7 @@ export default {
       >
         <i
           class="icon icon-code"
-          :alt="t('wm.containerShell.resizeShellWindow')"
+          :alt="t('wm.containerShell.resizeShellWindow', {arrow1: 'left', arrow2: 'right'})"
         />
       </div>
       <div
@@ -395,7 +395,7 @@ export default {
         class="resizer resizer-y"
         role="button"
         tabindex="0"
-        :aria-label="t('wm.containerShell.resizeShellWindow')"
+        :aria-label="t('wm.containerShell.resizeShellWindow', {arrow1: 'up', arrow2: 'down'})"
         aria-expanded="true"
         @mousedown.prevent.stop="dragYStart($event)"
         @touchstart.prevent.stop="dragYStart($event)"
@@ -405,7 +405,7 @@ export default {
       >
         <i
           class="icon icon-sort"
-          :alt="t('wm.containerShell.resizeShellWindow')"
+          :alt="t('wm.containerShell.resizeShellWindow', {arrow1: 'up', arrow2: 'down'})"
         />
       </div>
       <div
@@ -413,7 +413,7 @@ export default {
         class="resizer resizer-x resizer-align-right"
         role="button"
         tabindex="0"
-        :aria-label="t('wm.containerShell.resizeShellWindow')"
+        :aria-label="t('wm.containerShell.resizeShellWindow', {arrow1: 'left', arrow2: 'right'})"
         aria-expanded="true"
         @mousedown.prevent.stop="dragXStart($event)"
         @touchstart.prevent.stop="dragXStart($event)"
@@ -422,7 +422,7 @@ export default {
       >
         <i
           class="icon icon-code"
-          :alt="t('wm.containerShell.resizeShellWindow')"
+          :alt="t('wm.containerShell.resizeShellWindow', {arrow1: 'left', arrow2: 'right'})"
         />
       </div>
     </div>

--- a/shell/mixins/vue-select-overrides.js
+++ b/shell/mixins/vue-select-overrides.js
@@ -20,6 +20,9 @@ export default {
 
       // escape
       (out[27] = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+
         vm.open = false;
         vm.search = '';
 

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -58,12 +58,14 @@ export default {
       showHidden:      null,
       chartOptions:    [
         {
-          label: 'Browse',
-          value: 'browse',
+          label:     this.t('catalog.charts.browseBtn'),
+          value:     'browse',
+          ariaLabel: this.t('catalog.charts.browseAriaLabel')
         },
         {
-          label: 'Featured',
-          value: 'featured'
+          label:     this.t('catalog.charts.featuredBtn'),
+          value:     'featured',
+          ariaLabel: this.t('catalog.charts.featuredAriaLabel')
         }
       ]
     };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12811 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Fixes a11y issue `223`, focus trap on `LabeledSelect` inside `Import Extension Catalog` modal by refactoring the mechanism to prevent `escape` key handler on modals based on other UI elements like `CodeMirror` and `LabeledSelect`. Architecture is now only based on preventing propagation of events 🪄 

Should be tested also the `Import YAML` modal since it features both `LabeledSelect` and `CodeMirror` as UI elements that have the need to prevent that `escape` key handler on `AppModal`

- a11y issue `177` fixed on a previous PR
- Fixes a11y issue `166` by improving aria-label's for the `ButtonGroup`
- Fixes a11y issue `155` and `179`  by allowing `LabeledInput` to pass an `aria-label` as a prop of `LabeledInput`. This covers the cases where `LabeledInput` is used without a label
- Fixes a11y issue `145` by adding the necessary a11y attributes and allowing keyboard interaction with arrow keys to resize the shell console window


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
