### PR TITLE
Update focus styles for inputs

### DIFF
--- a/shell/assets/styles/base/_basic.scss
+++ b/shell/assets/styles/base/_basic.scss
@@ -73,6 +73,7 @@ INPUT,
 .unlabeled-select {
   &:focus-visible, &.focused {
     @include focus-outline;
+    outline-offset: -1px;
   }
 }
 

--- a/shell/assets/styles/global/_labeled-input.scss
+++ b/shell/assets/styles/global/_labeled-input.scss
@@ -1,6 +1,6 @@
 .labeled-input {
   position: relative;
-  display: table;
+  display: flex;
   border-collapse: separate;
   min-height: $input-height;
   z-index: 0; // Prevent label from cover other elements outside of the input
@@ -97,9 +97,9 @@
 
     .addon,
     .addon.btn {
-      display: table-cell;
-      vertical-align: middle;
-      width: 1%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       white-space: nowrap;
       vertical-align: middle;
       color: #{$secondary};
@@ -117,14 +117,6 @@
 
   &.suffix INPUT {
     padding-right: 8px;
-  }
-
-  &.suffix.v-popper--has-tooltip INPUT {
-    width: calc(100% - 30px);
-  }
-
-  &.suffix.v-popper--has-tooltip INPUT {
-    width: calc(100% - 30px);
   }
 
   .cron-label,

--- a/shell/assets/styles/global/_select.scss
+++ b/shell/assets/styles/global/_select.scss
@@ -34,6 +34,11 @@
     float: right;
   }
 
+  &:focus-visible, &.focused {
+    @include focus-outline;
+    outline-offset: -1px;
+  }
+
   &.focused {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;

--- a/shell/assets/styles/themes/_dark.scss
+++ b/shell/assets/styles/themes/_dark.scss
@@ -21,7 +21,6 @@
 
   // dark main text
   $lightest: #ffffff;
-  $keyboard-focus: #00ddff;
 
   // menu cluster description active+hover
   $desc-light: #EEEFF4;
@@ -50,7 +49,6 @@
   --default-light-bg           : #{rgba($dark, 0.05)};
   --slider-light-bg            : #{rgba($darker, 1)};
   --slider-light-bg-right      : #{rgba($darker, 0)};
-  --primary-keyboard-focus     : #{$keyboard-focus};
 
   --muted                      : #{$disabled};
 

--- a/shell/assets/styles/themes/_light.scss
+++ b/shell/assets/styles/themes/_light.scss
@@ -26,7 +26,7 @@ $disabled  : $medium;
 $primary         : #3D98D3;
 $secondary       : $darker;
 $link            : #3D98D3;
-$keyboard-focus  : #3300ff;
+$keyboard-focus  : #{darken($primary, 10%)};
 
 // Status colors
 $success         : #5D995D;

--- a/shell/components/form/Password.vue
+++ b/shell/components/form/Password.vue
@@ -164,6 +164,9 @@ export default {
 
     .labeled-input {
       .addon {
+        display: flex;
+        align-items: center;
+        justify-content: center;
         padding-left: 12px;
         min-width: 65px;
 

--- a/shell/components/form/UnitInput.vue
+++ b/shell/components/form/UnitInput.vue
@@ -252,7 +252,6 @@ export default {
 
 <style lang="scss" scoped>
   .addon.with-tooltip {
-    position: relative;
-    right: 30px;
+    padding-right: 42px;
   }
 </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates focus styles for inputs to match the updated design and colors.

Fixes #13522 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add new colors, `waterhole` & `waterhole-60`
- Change display of inputs from `display: table` to `display: flex`
- Update focus ring offset
- Add focus ring to select component

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

In order to resolve an issue with displaying the focus ring in Firefox, we had to update the display of the labeled input from `table` to `flex`. This change requires some additional style updates. For example, the password input needed some additional changes to properly display the show/hide toggle.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Inputs & Selects
- Forms

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Labeled Input

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before

![image](https://github.com/user-attachments/assets/a4a7e771-3784-4853-9a61-0b8ac81cb0b2)

#### After

![image](https://github.com/user-attachments/assets/54e84b9f-c924-417b-863f-b2a89b188bbf)

![image](https://github.com/user-attachments/assets/7767cbe4-10e4-451c-8d4a-083e4a213cc0)

![image](https://github.com/user-attachments/assets/ee5443ae-da30-45ff-ab35-e56ae4e12012)

![image](https://github.com/user-attachments/assets/8fba08a0-6e97-47f3-9ba6-a4b378218e63)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
