### PR TITLE
Hide filtered items in KeyValue

### DIFF
--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -295,12 +295,6 @@ export default {
      */
     canRemove() {
       return !this.isView && this.removeAllowed;
-    },
-    /**
-     * Filter rows based on toggler, keeping to still emit all the values
-     */
-    filteredRows() {
-      return this.rows.filter((row) => !(this.isProtected(row.key) && !this.toggleFilter));
     }
   },
   created() {
@@ -665,11 +659,14 @@ export default {
         </div>
       </template>
       <template
-        v-for="(row,i) in filteredRows"
+        v-for="(row,i) in rows"
         v-else
         :key="i"
       >
-        <div class="rowgroup">
+        <div
+          class="rowgroup"
+          :class="{'hidden': isProtected(row.key) && !toggleFilter}"
+        >
           <div class="row">
             <!-- Key -->
             <div
@@ -921,6 +918,10 @@ export default {
     grid-column-start: 1;
     grid-column-end: span end;
     grid-template-columns: subgrid;
+
+    &.hidden {
+      display: none;
+    }
   }
 
   .row {

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -665,7 +665,7 @@ export default {
       >
         <div
           class="rowgroup"
-          :class="{'hidden': isProtected(row.key) && !toggleFilter}"
+          :class="{'hide': isProtected(row.key) && !toggleFilter}"
         >
           <div class="row">
             <!-- Key -->
@@ -918,10 +918,6 @@ export default {
     grid-column-start: 1;
     grid-column-end: span end;
     grid-template-columns: subgrid;
-
-    &.hidden {
-      display: none;
-    }
   }
 
   .row {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13470 , #13471 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The filtering toggle in `KeyValue.vue` has never worked properly. There were two sources of truth in there, first `filteredRows` which was filtering items that are a system label, passed as `protectedKeys` prop, and the second was `this.rows` which includes the whole items. When rendering, the component was using `filteredRows` but when adding or removing items, `this.rows` was being mutated by using the index of items in `filteredRows`.

You can see this issue by going to Explorer => Projects/Namespaces => Edit Config => Check Pod Security Admission Tab => enable any of the items there => Check Labels & Annotations Tab => Add a label using "Z" for its key and label => Try to Remove

Because there's no unique property in a label to rely on, you need to either create a temporary local id/index to track, or hide the filtered items without removing them from the list. I implemented the hiding approach since this component has many functionalities relied on the index which makes it tricky to update all the places, specially when it supports both arrays and objects, and also it's been vastly used throughout the app that makes it hard to test for the possible regressions. I've tested the performance of the component with 1000 items and didn't notice any slowness, though it's not the most accurate testing.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
What's been mentioned on the issues, and also the case mentioned above
### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/14dae5b7-3458-4485-a442-5314f1707d97


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
