### PR TITLE
Adding the ability to configure resource sets to `resources.cattle.io.backup`

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -849,7 +849,17 @@ asyncButton:
     success: Generated
     waiting: Generating&hellip;
 
-backupRestoreOperator:
+backupRestoreOperator: 
+  backup:
+    label: Resource Set
+    description: The Resource Set determines which resources the backup-restore-operator collects in a backup
+    enableEncryptionWarning: 'Enabling encryption is highly recommended when using <b><i>Full Rancher backup resource set</i></b>, otherwise sensitive information will be backed up as plain-text. <a target="_blank" rel="noopener noreferrer nofollow" href="https://ranchermanager.docs.rancher.com/reference-guides/backup-restore-configuration/backup-configuration#resourcesets">Read more</a>.'
+    missingResourceSetWarning: The <b><i>{resourceSet}</i></b> resource set doesn't exist, it's possible it has been deleted. Please select a different option.
+    resourceSetOptions: 
+      'rancher-resource-set-basic': 'Basic Rancher backup restore set'
+      'rancher-resource-set-full': 'Full Rancher backup resource set'
+      custom: Custom
+      customResourceSetLabel: Custom Resource Set
   backupFilename: Backup Filename
   deleteTimeout:
     label: Delete Timeout


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Adding the ability to configure resource sets to `resources.cattle.io.backup`

Fixes: https://github.com/rancher/dashboard/issues/12997
<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
_You'll need to install the `Rancher Backup` app first._

- The `resources.cattle.io.backup` edit/detail page.
- You should test the backup page while creating and deleting the `resources.cattle.io.resourceset`. To create I just cloned the existing and changed the name field in the yaml.




### Areas which could experience regressions
- Same as above

### Screenshot/Video


https://github.com/user-attachments/assets/fab0e9d9-8a9c-4d34-b1ab-3712e2d97506

Forgot to include deleting the selected resource in the video:
![image](https://github.com/user-attachments/assets/7327668d-530b-4c13-9a16-c09d95c32b49)



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
