### PR TITLE
fix misc issues with codemirror and a11y

### DIFF
--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -239,6 +239,7 @@ export default {
 <template>
   <div
     ref="codeMirrorContainer"
+    :inert="isDisabled ? true : false"
     :tabindex="codeMirrorContainerTabIndex"
     class="code-mirror code-mirror-container"
     :class="{['as-text-area']: asTextArea}"
@@ -290,10 +291,6 @@ export default {
 
 <style lang="scss">
   $code-mirror-animation-time: 0.1s;
-
-  .escape-text {
-    font-size: 12px;
-  }
 
   .code-mirror {
     &.code-mirror-container:focus-visible {
@@ -395,6 +392,14 @@ export default {
 
   .code-mirror {
     position: relative;
+    margin-bottom: 20px;
+
+    .escape-text {
+      font-size: 12px;
+      position: absolute;
+      bottom: -20px;
+      left: 0;
+    }
 
     .codemirror-container {
       z-index: 0;

--- a/shell/components/ResourceYaml.vue
+++ b/shell/components/ResourceYaml.vue
@@ -298,6 +298,7 @@ export default {
     <YamlEditor
       ref="yamleditor"
       v-model:value="currentYaml"
+      :mode="mode"
       :initial-yaml-values="initialYaml"
       class="yaml-editor flex-content"
       :editor-mode="editorMode"

--- a/shell/components/YamlEditor.vue
+++ b/shell/components/YamlEditor.vue
@@ -28,6 +28,11 @@ export default {
       }
     },
 
+    mode: {
+      type:    String,
+      default: '',
+    },
+
     asObject: {
       type:    Boolean,
       default: false,
@@ -238,6 +243,7 @@ export default {
       :options="codeMirrorOptions"
       :showKeyMapBox="true"
       :data-testid="componentTestid + '-code-mirror'"
+      :mode="mode"
       @onInput="onInput"
       @onReady="onReady"
       @onChanges="onChanges"

--- a/shell/components/form/SSHKnownHosts/KnownHostsEditDialog.vue
+++ b/shell/components/form/SSHKnownHosts/KnownHostsEditDialog.vue
@@ -94,7 +94,6 @@ export default {
       <div class="custom mt-10">
         <div class="dialog-panel">
           <CodeMirror
-            class="code-mirror"
             :value="text"
             data-testid="ssh-known-hosts-dialog_code-mirror"
             :options="codeMirrorOptions"
@@ -146,13 +145,15 @@ export default {
       display: flex;
       flex-direction: column;
       min-height: 100px;
-      border: 1px solid var(--border);
 
       :deep() .code-mirror {
         display: flex;
         flex-direction: column;
         resize: none;
-        max-height: 400px;
+
+        .codemirror-container {
+          border: 1px solid var(--border);
+        }
 
         .CodeMirror,
         .CodeMirror-gutters {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13528 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Fixes issue `1` by adding the `inert` HTML attribute when in view mode (disabled) https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert so that element and it's children aren't focusable
- Fixes issue `2` by updating CSS on modal + adding padding to bottom of `CodeMirror` component so that it can fit the "escape to blur" message

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue --> 
- @torchiaf regarding the issue with `escape` closing the modal and not leaving the code mirror focus trap, it will be fixed once https://github.com/rancher/dashboard/pull/13519 get's merged.

After that you'll only need to add to AppModal component inside of that modal the following: `:trigger-focus-trap="true"`.

This will make the modal a focus trap itself while it's open.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [X] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [X] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [X] The PR template has been filled out
- [X] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [X] The PR has a reviewer assigned
- [X] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [X] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
