### PR TITLE
Disable editing and detail view for kev1 clusters

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1996,11 +1996,12 @@ cluster:
     aliyun:  Alibaba ACK
     amazonec2: Amazon EC2
     amazoneks: Amazon EKS
+    amazonelasticcontainerservice: Amazon EKS (Unsupported Kev1)
     aws: Amazon
     azure: Azure
     azureaks: Azure AKS
     aks: Azure AKS
-    azurekubernetesservice: Azure AKS
+    azurekubernetesservice: Azure AKS (Unsupported Kev1)
     baiducloudcontainerengine: Baidu CCE
     baidu: Baidu CCE
     cloudca: Cloud.ca
@@ -2014,6 +2015,7 @@ cluster:
     google: Google GCE
     googlegke: Google GKE
     gke: Google GKE
+    googlekubernetesengine: Google GKE (Unsupported Kev1)
     harvester: Harvester
     huaweicce: Huawei CCE
     import: Generic

--- a/shell/models/management.cattle.io.kontainerdriver.js
+++ b/shell/models/management.cattle.io.kontainerdriver.js
@@ -29,6 +29,13 @@ export const KONTAINER_TO_DRIVER = {
   opentelekomcloudcontainerengine:  'otccce',
 };
 
+// Legacy KEV1 Hosted cluster drivers
+export const KEV1 = [
+  'amazonelasticcontainerservice',
+  'azurekubernetesservice',
+  'googlekubernetesengine',
+];
+
 // And the Import page has even shorter ones that don't match kontainer or create...
 export const DRIVER_TO_IMPORT = {
   googlegke: 'gke',

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -10,6 +10,7 @@ import { compare } from '@shell/utils/version';
 import { AS, MODE, _VIEW, _YAML } from '@shell/config/query-params';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import { CAPI as CAPI_ANNOTATIONS, NODE_ARCHITECTURE } from '@shell/config/labels-annotations';
+import { KEV1 } from '@shell/models/management.cattle.io.kontainerdriver';
 
 /**
  * Class representing Cluster resource.
@@ -180,6 +181,15 @@ export default class ProvCluster extends SteveModel {
 
     const all = actions.concat(out);
 
+    // If the cluster is a KEV1 cluster then prevent edit
+    if (this.isKev1) {
+      const edit = all.find((action) => action.action === 'goToEdit');
+
+      if (edit) {
+        edit.enabled = false;
+      }
+    }
+
     // If we have a helper that wants to modify the available actions, let it do it
     if (this.customProvisionerHelper?.availableActions) {
       // Provider can either modify the provided list or return one of its own
@@ -187,6 +197,15 @@ export default class ProvCluster extends SteveModel {
     }
 
     return all;
+  }
+
+  get detailLocation() {
+    // Prevent going to detail page for a KEV1 cluster
+    if (this.isKev1) {
+      return undefined;
+    }
+
+    return super.detailLocation;
   }
 
   get normanCluster() {
@@ -287,6 +306,11 @@ export default class ProvCluster extends SteveModel {
 
   get isLocal() {
     return this.mgmt?.isLocal;
+  }
+
+  // Is the cluster a legacy (unsupported) KEV1 cluster?
+  get isKev1() {
+    return KEV1.includes(this.mgmt?.spec?.genericEngineConfig?.driverName);
   }
 
   get isImported() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13331

### Occurred changes and/or fixed issues

This PR removes editing of Kev1 clusters and the ability to dive into the details. It also puts back in the strings for Kev1 clusters with `(Unsupported Kev1)`.

### Areas or cases that should be tested

Manually create a kev1 cluster using an old version of the UI (e.g. 2.9) and going to `g/clusters/add/launch/amazoneks` (for AWS) and creating a KEV1 cluster.

It does not matter if the cluster finishes provisioning to verify this PR.

### Screenshot/Video

![image](https://github.com/user-attachments/assets/00b3966a-baa5-42f3-96e6-6b083727a00a)

Expected is as above - the `Edit Config` is removed from the action menu, the cluster name is not a link so you can not go to details and the Provider shows that it is unsupported kev1.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
