### PR TITLE
Fix users e2e tests 2

### DIFF
--- a/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
@@ -124,14 +124,23 @@ describe('Users', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
 
   describe('Action Menu', () => {
     it('can Deactivate and Activate user', () => {
-      // Deactivate user and check state is Inactive
       usersPo.goTo();
 
-      usersPo.list().actionMenu(standardUsername).getMenuItem('Disable').click();
+      let menu = usersPo.list().actionMenu(standardUsername);
+
+      // Deactivate user and check state is Inactive
+      menu.checkVisible();
+      menu.getMenuItem('Disable').click();
+      menu.checkNotExists();
+
       usersPo.list().details(standardUsername, 1).find('i').should('have.class', 'icon-user-xmark');
 
       // Activate user and check state is Active
-      usersPo.list().actionMenu(standardUsername).getMenuItem('Enable').click();
+      menu = usersPo.list().actionMenu(standardUsername);
+      menu.checkVisible();
+      menu.getMenuItem('Enable').click();
+      menu.checkNotExists();
+
       usersPo.list().details(standardUsername, 1).find('i').should('have.class', 'icon-user-check');
     });
 

--- a/shell/components/__tests__/Collapse.test.ts
+++ b/shell/components/__tests__/Collapse.test.ts
@@ -21,13 +21,13 @@ describe('component: Collapse.vue', () => {
   describe('collapsed', () => {
     const wrapper = mount(Collapse, { props: { open: true } });
 
-    it('is collapse', () => {
+    it('is collapsed', () => {
       const content = wrapper.find(`[data-testid="collapse-content"]`);
 
       expect(content.element).toBeDefined();
     });
 
-    it('icon should is chevron down', () => {
+    it('icon is chevron down', () => {
       const icon = wrapper.find(`[data-testid="collapse-icon-down"]`);
 
       expect(icon.element).toBeDefined();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
