### PR TITLE
Never show built-in extensions on the 'installed' tab

### DIFF
--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -216,7 +216,8 @@ export default {
 
       switch (this.view) {
       case TABS_VALUES.INSTALLED:
-        return all.filter((p) => !!p.installed || !!p.installing);
+        // We never show built-in extensions as installed - installed are just the ones the user has installed
+        return all.filter((p) => !p.builtin && (!!p.installed || !!p.installing));
       case TABS_VALUES.UPDATES:
         return this.updates;
       case TABS_VALUES.AVAILABLE:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13541

### Occurred changes and/or fixed issues

This PR makes a minor update so that built-in extensions never show on the `installed` tab, even when the extension developer preference is set.

The `Installed` tab is only for extensions that have been manually installed by the user.

The `Updates` tab will never show built-in extensions, as they are not installed so won't have updates.

Built-in extensions will appear on the `Built-in` and `All` tabs when the preference is set.

### Areas or cases that should be tested

Validate that with the developer preference set, the `Installed` tab does NOT show built-in extensions.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
