### PR TITLE
Sort EKS versions

### DIFF
--- a/pkg/eks/components/Config.vue
+++ b/pkg/eks/components/Config.vue
@@ -4,6 +4,8 @@ import { EKSConfig, AWS } from '../types';
 import { _EDIT, _VIEW, _CREATE } from '@shell/config/query-params';
 import semver from 'semver';
 import { Store, mapGetters } from 'vuex';
+import { sortable } from '@shell/utils/version';
+import { sortBy } from '@shell/utils/sort';
 
 import { MANAGEMENT } from '@shell/config/types';
 import { SETTING } from '@shell/config/settings';
@@ -180,7 +182,7 @@ export default defineComponent({
       return this.versionOptions.filter((opt) => !opt.disabled).length > 1;
     },
 
-    versionOptions(): {value: string, label: string, disabled?:boolean}[] {
+    versionOptions(): {value: string, label: string, sort?: string, disabled?:boolean}[] {
       return this.allKubernetesVersions.reduce((versions, v: string) => {
         const coerced = semver.coerce(v);
 
@@ -201,8 +203,13 @@ export default defineComponent({
           }
         }
 
-        return versions;
-      }, [] as {value: string, label: string, disabled?:boolean}[]);
+        // Generate sort field for each version
+        versions.forEach((v) => {
+          v.sort = sortable(v.value);
+        });
+
+        return sortBy(versions, 'sort', true);
+      }, [] as {value: string, label: string, sort?: string, disabled?:boolean}[]);
     },
 
     kmsOptions(): string[] {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12509

### Occurred changes and/or fixed issues

This PR uses the same sorting code as with the AKS provider to fix the version sorting bug in the EKS versions list.

### Areas or cases that should be tested

See issue - go to create an EKS cluster and verify that the Kubernetes Version list in the drop-down is now sorted, as per the screen shot below.

### Screenshot/Video

![image](https://github.com/user-attachments/assets/2fbcf639-a928-4799-9efc-cf290aa11435)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
