### PR TITLE
Handle empty registryUrls

### DIFF
--- a/shell/utils/validators/formRules/__tests__/index.test.ts
+++ b/shell/utils/validators/formRules/__tests__/index.test.ts
@@ -248,7 +248,7 @@ describe('formRules', () => {
     const expectedTranslation = JSON.stringify({ message: 'cluster.privateRegistry.privateRegistryUrlError' });
     const testCases = [
       // Empty
-      [undefined, expectedTranslation],
+      [undefined, undefined],
 
       // Word
       ['registry', expectedTranslation],

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -177,6 +177,10 @@ export default function(t: Translation, { key = 'Value' }: ValidationOptions): {
   };
 
   const registryUrl = (privateRegistryURL: string) => {
+    if (!privateRegistryURL) {
+      return;
+    }
+
     const pattern = new RegExp('^([a-z\\-0-9]+:\\/\\/?)?' + // scheme (optional, https://, http://, file:/, admin:/)
         '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
         '((\\d{1,3}\\.){3}\\d{1,3}))' + // ip address


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Handle empty registryUrls

Fixes https://github.com/rancher/dashboard/issues/13559

### Occurred changes and/or fixed issues
Fixing an issue where our validation didn't accept empty urls even though the field isn't required.

### Technical notes summary
Don't return an error on empty string.

### Areas or cases that should be tested
Imported generic clusters should be able to edit and save without entering a registryUrl.


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
