### PR TITLE
[FEAT] Option to disable version management for imported cluster

### DIFF
--- a/pkg/imported/components/Basics.vue
+++ b/pkg/imported/components/Basics.vue
@@ -8,11 +8,21 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 import { Checkbox } from '@components/Form/Checkbox';
 import { getAllOptionsAfterCurrentVersion, filterOutDeprecatedPatchVersions } from '@shell/utils/cluster';
+import { mapGetters } from 'vuex';
+import VersionManagement from '@pkg/imported/components/VersionManagement.vue';
+import Banner from '@components/Banner/Banner.vue';
+import { compare } from '@shell/utils/version';
+
+const VERSION_MANAGEMENT_DEFAULT = 'system-default';
 
 export default defineComponent({
   name:       'Basics',
   components: {
-    LabeledSelect, Checkbox, LabeledInput
+    LabeledSelect,
+    Checkbox,
+    LabeledInput,
+    VersionManagement,
+    Banner
   },
   props: {
     mode: {
@@ -40,7 +50,7 @@ export default defineComponent({
     config: {
       type:    Object,
       default: () => {
-        return {};
+        return null;
       }
     },
     upgradeStrategy: {
@@ -53,6 +63,18 @@ export default defineComponent({
       type:    Boolean,
       default: false
     },
+    versionManagementGlobalSetting: {
+      type:     Boolean,
+      required: true,
+    },
+    versionManagement: {
+      type:     String,
+      required: true
+    },
+    versionManagementOld: {
+      type:     String,
+      required: true
+    },
     rules: {
       default: () => ({
         workerConcurrency:       [],
@@ -63,17 +85,21 @@ export default defineComponent({
 
   },
   emits: ['kubernetes-version-changed', 'drain-server-nodes-changed', 'server-concurrency-changed',
-    'drain-worker-nodes-changed', 'worker-concurrency-changed', 'enable-authorized-endpoint', 'input'],
+    'drain-worker-nodes-changed', 'worker-concurrency-changed', 'enable-authorized-endpoint', 'version-management-changed', 'input'],
   data() {
     const store = this.$store;
     const supportedVersionRange = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_SUPPORTED_K8S_VERSIONS)?.value;
-    const originalVersion = this.config.kubernetesVersion;
+    const originalVersion = this.config?.kubernetesVersion || '';
 
     return {
       supportedVersionRange, originalVersion, showDeprecatedPatchVersions: false
     };
   },
   computed: {
+    ...mapGetters({ t: 'i18n/t' }),
+    showVersionInformation() {
+      return !!this.config && this.versionManagement !== 'false';
+    },
     versionOptions() {
       const cur = this.originalVersion;
       let out = getAllOptionsAfterCurrentVersion(this.$store, this.versions, cur, this.defaultVersion);
@@ -91,13 +117,26 @@ export default defineComponent({
       }
 
       return out;
+    },
+    versionInformationDisabled() {
+      return this.versionManagement === VERSION_MANAGEMENT_DEFAULT && !this.versionManagementGlobalSetting;
+    },
+    versionMismatch() {
+      return compare(this.config.kubernetesVersion, this.value.version.gitVersion) < 0;
     }
   },
 });
 
 </script>
 <template>
-  <div>
+  <div
+    v-if="showVersionInformation"
+  >
+    <Banner
+      v-if="versionMismatch"
+      label-key="imported.basics.versionMismatch"
+      color="warning"
+    />
     <div class="row row-basics mb-20">
       <div class="col-basics mr-10 span-6">
         <LabeledSelect
@@ -108,6 +147,7 @@ export default defineComponent({
           label-key="cluster.kubernetesVersion.label"
           option-key="value"
           option-label="label"
+          :disabled="versionInformationDisabled"
           :loading="loadingVersions"
           @update:value="$emit('kubernetes-version-changed', $event)"
         />
@@ -117,10 +157,23 @@ export default defineComponent({
           v-model:value="showDeprecatedPatchVersions"
           :label="t('cluster.kubernetesVersion.deprecatedPatches')"
           :tooltip="t('cluster.kubernetesVersion.deprecatedPatchWarning')"
+          :disabled="versionInformationDisabled"
           class="patch-version"
         />
       </div>
     </div>
+  </div>
+  <VersionManagement
+    :value="versionManagement"
+    :global-setting="versionManagementGlobalSetting"
+    :mode="mode"
+    :old-value="versionManagementOld"
+    @version-management-changed="$emit('version-management-changed', $event)"
+  />
+  <div
+    v-if="showVersionInformation"
+    class="mt-10"
+  >
     <h3 v-t="'imported.upgradeStrategy.header'" />
     <div class="col mt-10 mb-10">
       <div class="col mt-5">
@@ -128,6 +181,7 @@ export default defineComponent({
           :value="upgradeStrategy.drainServerNodes"
           :mode="mode"
           :label="t('imported.drainControlPlaneNodes.label')"
+          :disabled="versionInformationDisabled"
           @update:value="$emit('drain-server-nodes-changed', $event)"
         />
       </div>
@@ -136,6 +190,7 @@ export default defineComponent({
           :value="upgradeStrategy.drainWorkerNodes"
           :mode="mode"
           :label="t('imported.drainWorkerNodes.label')"
+          :disabled="versionInformationDisabled"
           @update:value="$emit('drain-worker-nodes-changed', $event)"
         />
       </div>
@@ -147,6 +202,7 @@ export default defineComponent({
           :mode="mode"
           :label="t('cluster.rke2.controlPlaneConcurrency.label')"
           :rules="rules.concurrency"
+          :disabled="versionInformationDisabled"
           required
           class="mb-10"
           @update:value="$emit('server-concurrency-changed', $event)"
@@ -158,6 +214,7 @@ export default defineComponent({
           :mode="mode"
           :label="t('cluster.rke2.workerConcurrency.label')"
           :rules="rules.concurrency"
+          :disabled="versionInformationDisabled"
           required
           class="mb-10"
           @update:value="$emit('worker-concurrency-changed', $event)"

--- a/pkg/imported/components/Basics.vue
+++ b/pkg/imported/components/Basics.vue
@@ -12,8 +12,7 @@ import { mapGetters } from 'vuex';
 import VersionManagement from '@pkg/imported/components/VersionManagement.vue';
 import Banner from '@components/Banner/Banner.vue';
 import { compare } from '@shell/utils/version';
-
-const VERSION_MANAGEMENT_DEFAULT = 'system-default';
+import { VERSION_MANAGEMENT_DEFAULT } from '@pkg/imported/util/shared.ts';
 
 export default defineComponent({
   name:       'Basics',

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -25,7 +25,11 @@ import { addObject } from '@shell/utils/array';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
 import genericImportedClusterValidators from '../util/validators';
 import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
+import { SETTING } from '@shell/config/settings';
+import { IMPORTED_CLUSTER_VERSION_MANAGEMENT } from '@shell/config/labels-annotations';
+import cloneDeep from 'lodash/cloneDeep';
 
+const VERSION_MANAGEMENT_DEFAULT = 'system-default';
 const HARVESTER_HIDE_KEY = 'cm-harvester-import';
 const defaultCluster = {
   agentEnvVars:   [],
@@ -80,20 +84,23 @@ export default defineComponent({
       this.showPrivateRegistryInput = !!this.normanCluster?.importedConfig?.privateRegistryURL;
       this.getVersions();
     } else {
-      this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...defaultCluster }, { root: true });
+      this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...cloneDeep(defaultCluster) }, { root: true });
     }
+    await this.initVersionManagement();
   },
 
   data() {
     return {
-      showPrivateRegistryInput: false,
-      normanCluster:            { name: '', importedConfig: { privateRegistryURL: null } },
-      loadingVersions:          false,
-      membershipUpdate:         {},
-      config:                   null,
-      allVersions:              [],
-      defaultVer:               '',
-      fvFormRuleSets:           [{
+      showPrivateRegistryInput:       false,
+      normanCluster:                  { name: '', importedConfig: { privateRegistryURL: null } },
+      loadingVersions:                false,
+      membershipUpdate:               {},
+      config:                         null,
+      allVersions:                    [],
+      defaultVersion:                 '',
+      versionManagementGlobalSetting: false,
+      versionManagementOld:           VERSION_MANAGEMENT_DEFAULT,
+      fvFormRuleSets:                 [{
         path:  'name',
         rules: ['clusterNameRequired', 'clusterNameChars', 'clusterNameStartEnd', 'clusterNameLength'],
       }, {
@@ -144,6 +151,15 @@ export default defineComponent({
       }
 
     },
+    versionManagement: {
+      get() {
+        return this.normanCluster.annotations[IMPORTED_CLUSTER_VERSION_MANAGEMENT];
+      },
+      set(newValue) {
+        this.normanCluster.annotations[IMPORTED_CLUSTER_VERSION_MANAGEMENT] = newValue;
+      }
+
+    },
 
     isEdit() {
       return this.mode === _EDIT;
@@ -171,12 +187,18 @@ export default defineComponent({
     },
 
     providerTabKey() {
-      return this.isK3s ? this.t('imported.accordions.k3sOptions') : this.t('imported.accordions.rke2Options');
+      if (this.isK3s) {
+        return this.t('imported.accordions.k3sOptions');
+      } else if (this.isRke2) {
+        return this.t('imported.accordions.rke2Options');
+      } else {
+        return this.t('imported.accordions.basics');
+      }
     },
     // If the cluster hasn't been fully imported yet, we won't have this information yet
     // and Basics should be hidden
     showBasics() {
-      return !!this.config;
+      return !this.isEdit || !!this.config ;
     },
     showInstanceDescription() {
       return this.isLocal || !this.isEdit;
@@ -310,6 +332,13 @@ export default defineComponent({
 
       this.hideDescriptions = neu;
     },
+    async initVersionManagement() {
+      this.versionManagementGlobalSetting = (await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.IMPORTED_CLUSTER_VERSION_MANAGEMENT })).value === 'true' || false;
+      if (!this.normanCluster.annotations[IMPORTED_CLUSTER_VERSION_MANAGEMENT]) {
+        this.normanCluster.annotations[IMPORTED_CLUSTER_VERSION_MANAGEMENT] = VERSION_MANAGEMENT_DEFAULT;
+      }
+      this.versionManagementOld = this.normanCluster.annotations[IMPORTED_CLUSTER_VERSION_MANAGEMENT];
+    }
   },
 
   watch: {
@@ -382,12 +411,16 @@ export default defineComponent({
           :versions="allVersions"
           :default-version="defaultVersion"
           :loading-versions="loadingVersions"
+          :version-management-global-setting="versionManagementGlobalSetting"
+          :version-management="versionManagement"
+          :version-management-old="versionManagementOld"
           :rules="{workerConcurrency: fvGetAndReportPathRules('workerConcurrency'), controlPlaneConcurrency: fvGetAndReportPathRules('controlPlaneConcurrency') }"
           @kubernetes-version-changed="kubernetesVersionChanged"
           @drain-server-nodes-changed="(val)=>upgradeStrategy.drainServerNodes = val"
           @drain-worker-nodes-changed="(val)=>upgradeStrategy.drainWorkerNodes = val"
           @server-concurrency-changed="(val)=>upgradeStrategy.serverConcurrency = val"
           @worker-concurrency-changed="(val)=>upgradeStrategy.workerConcurrency = val"
+          @version-management-changed="(val)=>versionManagement=val"
         />
       </Accordion>
       <Accordion

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -28,8 +28,8 @@ import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 import { SETTING } from '@shell/config/settings';
 import { IMPORTED_CLUSTER_VERSION_MANAGEMENT } from '@shell/config/labels-annotations';
 import cloneDeep from 'lodash/cloneDeep';
+import { VERSION_MANAGEMENT_DEFAULT } from '@pkg/imported/util/shared.ts';
 
-const VERSION_MANAGEMENT_DEFAULT = 'system-default';
 const HARVESTER_HIDE_KEY = 'cm-harvester-import';
 const defaultCluster = {
   agentEnvVars:   [],

--- a/pkg/imported/components/VersionManagement.vue
+++ b/pkg/imported/components/VersionManagement.vue
@@ -1,0 +1,118 @@
+<script>
+import { defineComponent } from 'vue';
+import { RadioGroup } from '@components/Form/Radio';
+import { mapGetters } from 'vuex';
+import { _EDIT } from '@shell/config/query-params';
+import Banner from '@components/Banner/Banner.vue';
+const VERSION_MANAGEMENT_DEFAULT = 'system-default';
+
+export default defineComponent({
+  emits: ['version-management-changed'],
+
+  components: { RadioGroup, Banner },
+
+  props: {
+    value: {
+      type:     String,
+      required: true
+    },
+    mode: {
+      type:     String,
+      required: true,
+    },
+    globalSetting: {
+      type:     Boolean,
+      required: true,
+    },
+    oldValue: {
+      type:     String,
+      required: true
+    },
+
+  },
+
+  computed: {
+    ...mapGetters({ t: 'i18n/t', features: 'features/get' }),
+    isEdit() {
+      return this.mode === _EDIT;
+    },
+    versionManagementOptions() {
+      const defaultLabel = this.globalSetting ? this.t('imported.basics.versionManagement.globalEnabled') : this.t('imported.basics.versionManagement.globalDisabled');
+
+      return [
+        { value: VERSION_MANAGEMENT_DEFAULT, label: defaultLabel },
+        { value: 'true', label: this.t('imported.basics.versionManagement.enabled') },
+        { value: 'false', label: this.t('imported.basics.versionManagement.disabled') },
+      ];
+    },
+    versionManagementInfo() {
+      if (!this.isEdit) {
+        if ( this.value === VERSION_MANAGEMENT_DEFAULT ) {
+          return this.t('imported.basics.versionManagement.banner.create.default');
+        } else {
+          return this.t('imported.basics.versionManagement.banner.create.nonDefault');
+        }
+      } else {
+        if (this.oldValue === VERSION_MANAGEMENT_DEFAULT) {
+          return this.value === this.globalSetting ? this.t('imported.basics.versionManagement.banner.edit.defaultToNonDefault', {}, true) : `${ this.t('imported.basics.versionManagement.banner.edit.different') } ${ this.t('imported.basics.versionManagement.banner.edit.defaultToNonDefault', {}, true ) }`;
+        } else {
+          if (this.value === VERSION_MANAGEMENT_DEFAULT) {
+            return this.oldValue === this.globalSetting ? this.t('imported.basics.versionManagement.banner.edit.nonDefaultToDefault', {}, true) : `${ this.t('imported.basics.versionManagement.banner.edit.different') } ${ this.t('imported.basics.versionManagement.banner.edit.nonDefaultToDefault', {}, true ) }`;
+          } else {
+            return this.t('imported.basics.versionManagement.banner.edit.different');
+          }
+        }
+      }
+    },
+
+    globalConfigurationText() {
+      return this.globalSetting ? this.t('imported.basics.versionManagement.summary.globallyEnabled', {}, true) : this.t('imported.basics.versionManagement.summary.globalDisabled', {}, true);
+    },
+    clusterConfigurationText() {
+      if ( this.value === 'true') {
+        return this.t('imported.basics.versionManagement.summary.willEnable', {}, true);
+      }
+      if (this.value === 'false') {
+        return this.t('imported.basics.versionManagement.summary.willDisable', {}, true);
+      }
+
+      return !this.globalSetting ? this.t('imported.basics.versionManagement.summary.canEnable', {}, true) : '';
+    }
+  }
+});
+</script>
+<template>
+  <h3 class="mb-10">
+    <t k="imported.basics.versionManagement.title" />
+  </h3>
+  <Banner
+    v-if="!(isEdit && value === oldValue)"
+    color="info"
+  >
+    {{ versionManagementInfo }}
+  </Banner>
+  <RadioGroup
+    :value="value"
+    :mode="mode"
+    :options="versionManagementOptions"
+    name="versionManagement"
+    data-testid="imported-version-management-radio"
+    @update:value="$emit('version-management-changed', $event)"
+  />
+  <div class="col mt-10">
+    <label
+      v-clean-html="globalConfigurationText"
+      class="summary"
+    /><br>
+    <label
+      v-clean-html="clusterConfigurationText"
+      class="summary mb-10"
+    />
+  </div>
+</template>
+
+<style lang='scss'>
+    .summary{
+        margin: 0pt
+    }
+</style>

--- a/pkg/imported/components/VersionManagement.vue
+++ b/pkg/imported/components/VersionManagement.vue
@@ -4,7 +4,7 @@ import { RadioGroup } from '@components/Form/Radio';
 import { mapGetters } from 'vuex';
 import { _EDIT } from '@shell/config/query-params';
 import Banner from '@components/Banner/Banner.vue';
-const VERSION_MANAGEMENT_DEFAULT = 'system-default';
+import { VERSION_MANAGEMENT_DEFAULT } from '@pkg/imported/util/shared.ts';
 
 export default defineComponent({
   emits: ['version-management-changed'],
@@ -66,7 +66,7 @@ export default defineComponent({
     },
 
     globalConfigurationText() {
-      return this.globalSetting ? this.t('imported.basics.versionManagement.summary.globallyEnabled', {}, true) : this.t('imported.basics.versionManagement.summary.globalDisabled', {}, true);
+      return this.globalSetting ? this.t('imported.basics.versionManagement.summary.globallyEnabled', {}, true) : this.t('imported.basics.versionManagement.summary.globallyDisabled', {}, true);
     },
     clusterConfigurationText() {
       if ( this.value === 'true') {

--- a/pkg/imported/l10n/en-us.yaml
+++ b/pkg/imported/l10n/en-us.yaml
@@ -4,6 +4,30 @@ imported:
   label: Imported
   agentEnv:
     header: Agent Environment Variables
+  basics:
+    versionMismatch: The selected version is lower than the actual version of this cluster.
+    versionManagement:
+      title: K8s version management
+      globalEnabled: Global default (enabled)
+      globalDisabled: Global default (disabled)
+      enabled: Enabled
+      disabled: Disabled
+      banner:
+        create:
+          nonDefault:
+            Future changes to this setting may result in redeployment of the cluster agent.
+          default:
+            Future changes to the system default setting will result in redeployment of the cluster agent.
+        edit:
+          different: This change will trigger cluster agent redeployment.
+          defaultToNonDefault: Future changes to the global setting will not affect the cluster.
+          nonDefaultToDefault: Future changes to the global setting will affect the cluster.
+      summary:
+        globallyEnabled: 'Version management for imported clusters is globally <b>enabled</b>.'
+        globallyDisabled: Version management for imported clusters is globally <b>disabled</b>.
+        canEnable: You can enable it at a cluster level.
+        willEnable: It will be manually <b>ENABLED</b> for this cluster.
+        willDisable: it will be manually <b>DISABLED</b> for this cluster.
   drainWorkerNodes:
     label: Drain Worker Nodes
   drainControlPlaneNodes:

--- a/pkg/imported/util/shared.ts
+++ b/pkg/imported/util/shared.ts
@@ -1,0 +1,1 @@
+export const VERSION_MANAGEMENT_DEFAULT = 'system-default';

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7642,6 +7642,7 @@ advancedSettings:
     'hide-local-cluster': Hide the local cluster
     'agent-tls-mode': "Rancher Certificate Verification. In `strict` mode the agents (system, cluster, fleet, etc) will only trust Rancher installations which are using a certificate signed by the CABundle in the `cacerts` setting. When the mode is system-store, the agents will trust any certificate signed by a CABundle in the operating system’s trust store."
     'k3s-based-upgrader-uninstall-concurrency': Defines the maximum number of clusters in which Rancher can concurrently uninstall the legacy `rancher-k3s-upgrader` or `rancher-rke2-upgrader` app from imported K3s or RKE2 clusters.
+    'imported-cluster-version-management': Enables version management for imported RKE2/K3s clusters, and the local cluster if it is an RKE2/K3s cluster. The per-cluster version management setting overrides this global setting at the cluster level. For existing clusters where the cluster-level version management is set to 'system-default', changing this flag will trigger a redeployment of the cluster agent during the next reconciliation (by default every 5 minutes, or as soon as the cluster is edited, whichever comes first).
   warnings:
     'agent-tls-mode': 'Changing this setting will cause all agents to be redeployed.'
   editHelp:

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -16,6 +16,7 @@ export const RESOURCE_QUOTA = 'field.cattle.io/resourceQuota';
 export const AZURE_MIGRATED = 'auth.cattle.io/azuread-endpoint-migrated';
 export const WORKSPACE_ANNOTATION = 'objectset.rio.cattle.io/id';
 export const NODE_ARCHITECTURE = 'kubernetes.io/arch';
+export const IMPORTED_CLUSTER_VERSION_MANAGEMENT = 'rancher.io/imported-cluster-version-management';
 
 export const KUBERNETES = {
   SERVICE_ACCOUNT_UID:  'kubernetes.io/service-account.uid',

--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -107,7 +107,8 @@ export const SETTING = {
   USER_LAST_LOGIN_DEFAULT:              'user-last-login-default',
   DISABLE_INACTIVE_USER_AFTER:          'disable-inactive-user-after',
   DELETE_INACTIVE_USER_AFTER:           'delete-inactive-user-after',
-  K3S_UPGRADER_UNINSTALL_CONCURRENCY:   'k3s-based-upgrader-uninstall-concurrency'
+  K3S_UPGRADER_UNINSTALL_CONCURRENCY:   'k3s-based-upgrader-uninstall-concurrency',
+  IMPORTED_CLUSTER_VERSION_MANAGEMENT:  'imported-cluster-version-management'
 } as const;
 
 // These are the settings that are allowed to be edited via the UI
@@ -164,9 +165,11 @@ export const ALLOWED_SETTINGS: GlobalSetting = {
   [SETTING.K3S_UPGRADER_UNINSTALL_CONCURRENCY]: {
     kind:    'integer',
     ruleSet: [{ name: 'minValue', factoryArg: 1 }]
-  }
+  },
+  [SETTING.IMPORTED_CLUSTER_VERSION_MANAGEMENT]: { kind: 'boolean' }
 };
 
+export const PROVISIONING_SETTINGS = ['engine-iso-url', 'engine-install-url', 'imported-cluster-version-management'];
 /**
  * Settings on how to handle warnings returning in api responses, specifically which to show as growls
  */


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13069 
<!-- Define findings related to the feature or bug issue. -->
Added an controls to disable version management for imported cluster.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added a new Radio button group to allow users to disable version management for the cluster. 
Please refer to the RFC and ux mockups for more detail

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. On cluster import switching between options should update warning text. Saving the cluster with 'global default' should set the value of 'rancher.io/imported-cluster-version-management' annotation to match the global setting.
2. On cluster edit, switching between options should update the warnings. 
3. On edit, if 'K8s version management' is set to disabled, K8s version information and Upgrade strategy controls should be hidden
4. If it is set to enabled, K8s version information and Upgrade strategy controls should be visible and editable
5. If it is Set to global default, which is set to true, K8s version information and Upgrade strategy controls should be visible and editable. 
6. If it is Set to global default, which is set to false, K8s version information and Upgrade strategy controls should be visible but not editable. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Harvester import may be affected

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1501" alt="Screenshot 2025-03-03 at 8 47 43 AM" src="https://github.com/user-attachments/assets/0a7b0e93-46f1-4ccf-8763-25751b9f4d27" />
<img width="1630" alt="Screenshot 2025-03-03 at 8 47 29 AM" src="https://github.com/user-attachments/assets/a5a1c893-9c29-4922-a4ed-49d4124f9113" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
