### PR TITLE
Fix Press Escape key to blur from terminal shows when terminal does not have focus

### DIFF
--- a/shell/components/nav/WindowManager/ContainerShell.vue
+++ b/shell/components/nav/WindowManager/ContainerShell.vue
@@ -151,7 +151,8 @@ export default {
 
   beforeUnmount() {
     document.removeEventListener('keyup', this.handleKeyPress);
-    this.$refs?.containerShell?.$el?.removeEventListener('focusin', this.focusChanged);
+    this.$refs?.containerShell?.$el?.removeEventListener('focusin', this.focusInHandler);
+    this.$refs?.xterm.removeEventListener('focusout', this.focusOutHandler);
 
     clearInterval(this.keepAliveTimer);
     this.cleanup();
@@ -159,7 +160,8 @@ export default {
 
   async mounted() {
     document.addEventListener('keyup', this.handleKeyPress);
-    this.$refs?.containerShell?.$el?.addEventListener('focusin', this.focusChanged);
+    this.$refs?.containerShell?.$el?.addEventListener('focusin', this.focusInHandler);
+    this.$refs?.xterm.addEventListener('focusout', this.focusOutHandler);
 
     const nodeId = this.pod.spec?.nodeName;
 
@@ -183,8 +185,12 @@ export default {
   },
 
   methods: {
-    focusChanged(ev) {
+    focusInHandler(ev) {
       this.currFocusedElem = ev.target;
+    },
+
+    focusOutHandler(ev) {
+      this.currFocusedElem = undefined;
     },
 
     handleKeyPress(ev) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13555 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Fixes scenario where when user clicks outside shell window should clear message "press escape to blur"

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
