### PR TITLE
Change Fleet agent from StatefulSet to Deployment for Fleet Healthbox calculation

### DIFF
--- a/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/explorer/__tests__/index.test.ts
@@ -71,7 +71,7 @@ describe('page: cluster dashboard', () => {
   });
 
   describe.each([
-    ['local', 'fleet', true, ['fleetDeployment', 'fleetStatefulSet'], [
+    ['local', 'fleet', true, ['fleetControllerResource', 'fleetAgentResource'], [
       [STATES_ENUM.IN_PROGRESS, 'icon-spinner', false, false, false, '', 0, 0],
       [STATES_ENUM.UNHEALTHY, 'icon-warning', true, false, false, [{ status: 'False' }], 0, 0],
       [STATES_ENUM.UNHEALTHY, 'icon-warning', true, false, true, [{ status: 'True' }], 0, 0],
@@ -80,7 +80,7 @@ describe('page: cluster dashboard', () => {
       [STATES_ENUM.WARNING, 'icon-warning', true, false, false, [{ status: 'True' }], 0, 1],
       [STATES_ENUM.HEALTHY, 'icon-checkmark', true, false, false, [{ status: 'True' }], 1, 0],
     ]],
-    ['downstream RKE2', 'fleet', false, ['fleetStatefulSet'], [
+    ['downstream RKE2', 'fleet', false, ['fleetAgentResource'], [
       [STATES_ENUM.IN_PROGRESS, 'icon-spinner', false, false, false, '', 0, 0],
       [STATES_ENUM.UNHEALTHY, 'icon-warning', true, false, false, [{ status: 'False' }], 0, 0],
       [STATES_ENUM.UNHEALTHY, 'icon-warning', true, false, true, [{ status: 'True' }], 0, 0],
@@ -89,7 +89,7 @@ describe('page: cluster dashboard', () => {
       [STATES_ENUM.WARNING, 'icon-warning', true, false, false, [{ status: 'True' }], 0, 1],
       [STATES_ENUM.HEALTHY, 'icon-checkmark', true, false, false, [{ status: 'True' }], 1, 0],
     ]],
-    ['downstream RKE2', 'cattle', false, ['cattleDeployment'], [
+    ['downstream RKE2', 'cattle', false, ['cattleAgentResource'], [
       [STATES_ENUM.IN_PROGRESS, 'icon-spinner', false, false, false, '', 0, 0],
       [STATES_ENUM.UNHEALTHY, 'icon-warning', true, false, false, [{ status: 'False' }], 0, 0],
       [STATES_ENUM.UNHEALTHY, 'icon-warning', true, true, false, [{ status: 'True' }], 0, 0],
@@ -137,7 +137,7 @@ describe('page: cluster dashboard', () => {
   });
 
   describe.each([
-    ['local', 'fleet', true, ['fleetDeployment', 'fleetStatefulSet'], [
+    ['local', 'fleet', true, ['fleetControllerResource', 'fleetAgentResource'], [
       [STATES_ENUM.IN_PROGRESS, 'icon-spinner', false, false, false, false, '', 0, 0],
       [STATES_ENUM.UNHEALTHY, 'icon-warning', true, true, false, false, [{ status: 'False' }], 0, 0],
       [STATES_ENUM.UNHEALTHY, 'icon-warning', true, true, false, true, [{ status: 'True' }], 0, 0],
@@ -146,7 +146,7 @@ describe('page: cluster dashboard', () => {
       [STATES_ENUM.WARNING, 'icon-warning', true, true, false, false, [{ status: 'True' }], 0, 1],
       [STATES_ENUM.HEALTHY, 'icon-checkmark', false, true, false, false, [{ status: 'True' }], 1, 0],
     ]],
-    ['downstream RKE2', 'fleet', false, ['fleetStatefulSet'], [
+    ['downstream RKE2', 'fleet', false, ['fleetAgentResource'], [
       [STATES_ENUM.IN_PROGRESS, 'icon-spinner', false, false, false, false, '', 0, 0],
       [STATES_ENUM.UNHEALTHY, 'icon-warning', true, true, false, false, [{ status: 'False' }], 0, 0],
       [STATES_ENUM.UNHEALTHY, 'icon-warning', true, true, false, true, [{ status: 'True' }], 0, 0],
@@ -155,7 +155,7 @@ describe('page: cluster dashboard', () => {
       [STATES_ENUM.WARNING, 'icon-warning', true, true, false, false, [{ status: 'True' }], 0, 1],
       [STATES_ENUM.HEALTHY, 'icon-checkmark', false, true, false, false, [{ status: 'True' }], 1, 0],
     ]],
-    ['downstream RKE2', 'cattle', false, ['cattleDeployment'], [
+    ['downstream RKE2', 'cattle', false, ['cattleAgentResource'], [
       [STATES_ENUM.IN_PROGRESS, 'icon-spinner', false, false, false, false, '', 0, 0],
       [STATES_ENUM.UNHEALTHY, 'icon-warning', true, true, false, false, [{ status: 'False' }], 0, 0],
       [STATES_ENUM.UNHEALTHY, 'icon-warning', true, true, true, false, [{ status: 'True' }], 0, 0],
@@ -228,9 +228,9 @@ describe('page: cluster dashboard', () => {
     const wrapper = shallowMount(Dashboard, {
       ...options,
       data: () => ({
-        cattleDeployment: 'loading',
-        disconnected:     false,
-        canViewAgents:    true
+        cattleAgentResource: 'loading',
+        disconnected:        false,
+        canViewAgents:       true
       })
     });
 

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -134,17 +134,17 @@ export default {
 
     return {
       nodeHeaders,
-      constraints:        [],
-      cattleDeployment:   'loading',
-      fleetDeployment:    'loading',
-      fleetStatefulSet:   'loading',
-      disconnected:       false,
-      events:             [],
-      nodeMetrics:        [],
-      showClusterMetrics: false,
-      showK8sMetrics:     false,
-      showEtcdMetrics:    false,
-      canViewMetrics:     false,
+      constraints:             [],
+      cattleAgentResource:     'loading',
+      fleetControllerResource: 'loading',
+      fleetAgentResource:      'loading',
+      disconnected:            false,
+      events:                  [],
+      nodeMetrics:             [],
+      showClusterMetrics:      false,
+      showK8sMetrics:          false,
+      showEtcdMetrics:         false,
+      canViewMetrics:          false,
       CLUSTER_METRICS_DETAIL_URL,
       CLUSTER_METRICS_SUMMARY_URL,
       K8S_METRICS_DETAIL_URL,
@@ -153,9 +153,9 @@ export default {
       ETCD_METRICS_SUMMARY_URL,
       STATES_ENUM,
       clusterCounts,
-      selectedTab:        'cluster-events',
-      extensionCards:     getApplicableExtensionEnhancements(this, ExtensionPoint.CARD, CardLocation.CLUSTER_DASHBOARD_CARD, this.$route),
-      canViewEvents:      !!this.$store.getters['cluster/schemaFor'](EVENT),
+      selectedTab:             'cluster-events',
+      extensionCards:          getApplicableExtensionEnhancements(this, ExtensionPoint.CARD, CardLocation.CLUSTER_DASHBOARD_CARD, this.$route),
+      canViewEvents:           !!this.$store.getters['cluster/schemaFor'](EVENT),
       clusterServiceIcons,
     };
   },
@@ -327,7 +327,7 @@ export default {
     },
 
     cattleAgent() {
-      const resources = [this.cattleDeployment];
+      const resources = [this.cattleAgentResource];
 
       return this.getAgentStatus(resources, { checkDisconnected: true });
     },
@@ -335,12 +335,12 @@ export default {
     fleetAgent() {
       const resources = this.currentCluster.isLocal ? [
         /**
-         * 'fleetStatefulSet' could take a while to be created by rancher.
-         * During that startup period, only 'fleetDeployment' will be used to calculate the fleet agent status.
+         * 'fleetAgentResource' could take a while to be created by rancher.
+         * During that startup period, only 'fleetControllerResource' will be used to calculate the fleet agent status.
          */
-        ...(this.fleetStatefulSet ? [this.fleetStatefulSet, this.fleetDeployment] : [this.fleetDeployment]),
+        ...(this.fleetAgentResource ? [this.fleetAgentResource, this.fleetControllerResource] : [this.fleetControllerResource]),
       ] : [
-        this.fleetStatefulSet
+        this.fleetAgentResource
       ];
 
       return this.getAgentStatus(resources);
@@ -488,14 +488,14 @@ export default {
     loadAgents() {
       if (this.fleetAgentNamespace) {
         if (this.currentCluster.isLocal) {
-          this.setAgentResource('fleetDeployment', 'cattle-fleet-system/fleet-controller');
-          this.setAgentResource('fleetStatefulSet', 'cattle-fleet-local-system/fleet-agent');
+          this.setAgentResource('fleetControllerResource', 'cattle-fleet-system/fleet-controller');
+          this.setAgentResource('fleetAgentResource', 'cattle-fleet-local-system/fleet-agent');
         } else {
-          this.setAgentResource('fleetStatefulSet', 'cattle-fleet-system/fleet-agent');
+          this.setAgentResource('fleetAgentResource', 'cattle-fleet-system/fleet-agent');
         }
       }
       if (this.cattleAgentNamespace) {
-        this.setAgentResource('cattleDeployment', 'cattle-system/cattle-cluster-agent');
+        this.setAgentResource('cattleAgentResource', 'cattle-system/cattle-cluster-agent');
         this.interval = setInterval(() => {
           this.disconnected = !!this.$store.getters['cluster/inError']({ type: NODE });
         }, 1000);

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -197,11 +197,7 @@ export default {
     },
 
     fleetAgentNamespace() {
-      if (this.currentCluster.isLocal) {
-        return this.$store.getters['cluster/canList'](WORKLOAD_TYPES.DEPLOYMENT) && this.$store.getters['cluster/canList'](WORKLOAD_TYPES.STATEFUL_SET) && this.$store.getters['cluster/byId'](NAMESPACE, 'cattle-fleet-system');
-      }
-
-      return this.$store.getters['cluster/canList'](WORKLOAD_TYPES.STATEFUL_SET) && this.$store.getters['cluster/byId'](NAMESPACE, 'cattle-fleet-system');
+      return this.$store.getters['cluster/canList'](WORKLOAD_TYPES.DEPLOYMENT) && this.$store.getters['cluster/byId'](NAMESPACE, 'cattle-fleet-system');
     },
 
     cattleAgentNamespace() {
@@ -492,23 +488,23 @@ export default {
     loadAgents() {
       if (this.fleetAgentNamespace) {
         if (this.currentCluster.isLocal) {
-          this.setAgentResource('fleetDeployment', WORKLOAD_TYPES.DEPLOYMENT, 'cattle-fleet-system/fleet-controller');
-          this.setAgentResource('fleetStatefulSet', WORKLOAD_TYPES.STATEFUL_SET, 'cattle-fleet-local-system/fleet-agent');
+          this.setAgentResource('fleetDeployment', 'cattle-fleet-system/fleet-controller');
+          this.setAgentResource('fleetStatefulSet', 'cattle-fleet-local-system/fleet-agent');
         } else {
-          this.setAgentResource('fleetStatefulSet', WORKLOAD_TYPES.STATEFUL_SET, 'cattle-fleet-system/fleet-agent');
+          this.setAgentResource('fleetStatefulSet', 'cattle-fleet-system/fleet-agent');
         }
       }
       if (this.cattleAgentNamespace) {
-        this.setAgentResource('cattleDeployment', WORKLOAD_TYPES.DEPLOYMENT, 'cattle-system/cattle-cluster-agent');
+        this.setAgentResource('cattleDeployment', 'cattle-system/cattle-cluster-agent');
         this.interval = setInterval(() => {
           this.disconnected = !!this.$store.getters['cluster/inError']({ type: NODE });
         }, 1000);
       }
     },
 
-    async setAgentResource(agent, type, id) {
+    async setAgentResource(agent, id) {
       try {
-        this[agent] = await this.$store.dispatch('cluster/find', { type, id });
+        this[agent] = await this.$store.dispatch('cluster/find', { type: WORKLOAD_TYPES.DEPLOYMENT, id });
       } catch (err) {
         this[agent] = null;
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13580
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

The UI calculates the Fleet status based on the status of `fleet-agent` StatefulSet.
Fleet agent is changed from `StatefulSet` to `Deployment` in 2.11

![image](https://github.com/user-attachments/assets/74ee821b-e9f7-455f-8479-7df3421c1f4b)


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Permissions to GET StatefulSet resources is not more required:

```
this.$store.getters['cluster/canList'](WORKLOAD_TYPES.STATEFUL_SET)
```
### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Local cluster explorer -> Dashboard -> Fleet healthbox
- Downstream clusters -> Dashboard -> Fleet healthbox


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

Fleet healthbox

![image](https://github.com/user-attachments/assets/c560cb16-3fb4-4a29-8237-0112975722e0)

Fleet Deployment API call

![image](https://github.com/user-attachments/assets/4b7e25fa-2d01-4f33-9ac2-9a1f8920d56b)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
