### PR TITLE
Bump current version from 2.10 to 2.11

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3161,8 +3161,8 @@ landing:
       other {cores}}
     cpuUsed: CPU Used
     memoryUsed: Memory Used
-  seeWhatsNew: Learn more about the improvements and new capabilities in this version and read about the UI framework migration in 2.10
-  whatsNewLink: "What's new in 2.10"
+  seeWhatsNew: Learn more about the improvements and new capabilities in this version and read about the UI framework migration in {version}
+  whatsNewLink: "What's new in {version}"
   learnMore: Learn More
   support: Support
   community:

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -2720,8 +2720,6 @@ landing:
       other {核}}
     cpuUsed: 已用 CPU
     memoryUsed: 已用内存
-  seeWhatsNew: 点击右侧链接，了解此版本的新功能和优化。
-  whatsNewLink: "2.8 的新功能"
   learnMore: 了解更多
   support: 支持
   community:

--- a/shell/config/version.js
+++ b/shell/config/version.js
@@ -30,4 +30,4 @@ export function setKubeVersionData(v) {
   _kubeVersionData = JSON.parse(JSON.stringify(v));
 }
 
-export const CURRENT_RANCHER_VERSION = '2.10';
+export const CURRENT_RANCHER_VERSION = '2.11';

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -29,6 +29,7 @@ import { PaginationParamFilter, FilterArgs, PaginationFilterField, PaginationArg
 import ProvCluster from '@shell/models/provisioning.cattle.io.cluster';
 import { sameContents } from '@shell/utils/array';
 import { PagTableFetchPageSecondaryResourcesOpts, PagTableFetchSecondaryResourcesOpts, PagTableFetchSecondaryResourcesReturns } from '@shell/types/components/paginatedResourceTable';
+import { CURRENT_RANCHER_VERSION } from '@shell/config/version';
 
 export default defineComponent({
   name:       'Home',
@@ -203,6 +204,8 @@ export default defineComponent({
       ],
 
       clusterCount: 0,
+
+      CURRENT_RANCHER_VERSION
     };
   },
 
@@ -527,7 +530,7 @@ export default defineComponent({
             color="info whats-new"
           >
             <div>
-              {{ t('landing.seeWhatsNew') }}
+              {{ t('landing.seeWhatsNew', { version: CURRENT_RANCHER_VERSION }) }}
             </div>
             <a
               class="hand banner-link"
@@ -535,10 +538,10 @@ export default defineComponent({
               role="link"
               target="_blank"
               rel="noopener noreferrer nofollow"
-              :aria-label="t('landing.whatsNewLink')"
+              :aria-label="t('landing.whatsNewLink', { version: CURRENT_RANCHER_VERSION })"
               @click.stop="showWhatsNew"
               @keyup.stop.enter="showWhatsNew"
-            ><span v-clean-html="t('landing.whatsNewLink')" /></a>
+            ><span v-clean-html="t('landing.whatsNewLink', { version: CURRENT_RANCHER_VERSION })" /></a>
           </Banner>
         </div>
       </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes: #13603
Bump current version from 2.10 to 2.11
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- bump version const
  - const only seems to be used on doc links
  - community docs for 2.11 are up, prime docs pending
- use version const in what's new link text in home page

### Areas or cases that should be tested
- Home Page --> `Links` card --> Docs link should go to https://ranchermanager.docs.rancher.com/v2.11 (and not v2.10
- Selection of other links. Nice way to check, see https://github.com/rancher/dashboard/blob/master/pkg/rancher-prime/docs.ts#L16 and search for $V$

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
