### PR TITLE
Fixed broken banner text in Global settings

### DIFF
--- a/cypress/e2e/po/pages/global-settings/settings.po.ts
+++ b/cypress/e2e/po/pages/global-settings/settings.po.ts
@@ -1,6 +1,7 @@
 import RootClusterPage from '@/cypress/e2e/po/pages/root-cluster-page';
 import SettingsEditPo from '@/cypress/e2e/po/edit/settings.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+import BannersPo from '@/cypress/e2e/po/components/banners.po';
 export class SettingsPagePo extends RootClusterPage {
   private static createPath(clusterId: string) {
     return `/c/${ clusterId }/settings/management.cattle.io.setting`;
@@ -16,6 +17,10 @@ export class SettingsPagePo extends RootClusterPage {
 
   static navTo() {
     BurgerMenuPo.burgerMenuNavToMenubyLabel('Global Settings');
+  }
+
+  settingBanner() {
+    return new BannersPo('[data-testid="global-settings-banner"]', this.self());
   }
 
   /**

--- a/cypress/e2e/tests/pages/global-settings/settings.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings.spec.ts
@@ -34,6 +34,46 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingBanner().banner().contains(BANNER_TEXT);
   });
 
+  it('can update engine-iso-url', { tags: ['@globalSettings', '@adminUser'] }, () => {
+    // Update setting
+    SettingsPagePo.navTo();
+    settingsPage.editSettingsByLabel('engine-iso-url');
+
+    const settingsEdit = settingsPage.editSettings('local', 'engine-iso-url');
+
+    settingsEdit.waitForPage();
+    settingsEdit.title().contains('Setting: engine-iso-url').should('be.visible');
+    settingsEdit.settingsInput().set(settings['engine-iso-url'].new);
+    settingsEdit.saveAndWait('engine-iso-url').then(({ request, response }) => {
+      expect(response?.statusCode).to.eq(200);
+      expect(request.body).to.have.property('value', settings['engine-iso-url'].new);
+      expect(response?.body).to.have.property('value', settings['engine-iso-url'].new);
+    });
+    settingsPage.waitForPage();
+    settingsPage.settingsValue('engine-iso-url').contains(settings['engine-iso-url'].new);
+    // Scroll to the setting
+    cy.get('.main-layout').scrollTo('bottom');
+    settingsPage.modifiedLabel('engine-iso-url').should('be.visible'); // modified label should display after update
+
+    // Reset
+    SettingsPagePo.navTo();
+    settingsPage.waitForPage();
+    settingsPage.editSettingsByLabel('engine-iso-url');
+
+    settingsEdit.waitForPage();
+    settingsEdit.title().contains('Setting: engine-iso-url').should('be.visible');
+    settingsEdit.useDefaultButton().click();
+    settingsEdit.saveAndWait('engine-iso-url').then(({ request, response }) => {
+      expect(response?.statusCode).to.eq(200);
+      expect(request.body).to.have.property('value', settings['engine-iso-url'].original);
+      expect(response?.body).to.have.property('value', settings['engine-iso-url'].original);
+    });
+
+    settingsPage.waitForPage();
+    settingsPage.settingsValue('engine-iso-url').contains(settings['engine-iso-url'].original);
+    settingsPage.modifiedLabel('engine-iso-url').should('not.exist'); // modified label should not display after reset
+  });
+
   it('can update password-min-length', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
@@ -377,44 +417,5 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(obj.apiVersion).to.equal('v1');
       expect(obj.kind).to.equal('Config');
     });
-  });
-  it('can update engine-iso-url', { tags: ['@globalSettings', '@adminUser'] }, () => {
-    // Update setting
-    SettingsPagePo.navTo();
-    settingsPage.editSettingsByLabel('engine-iso-url');
-
-    const settingsEdit = settingsPage.editSettings('local', 'engine-iso-url');
-
-    settingsEdit.waitForPage();
-    settingsEdit.title().contains('Setting: engine-iso-url').should('be.visible');
-    settingsEdit.settingsInput().set(settings['engine-iso-url'].new);
-    settingsEdit.saveAndWait('engine-iso-url').then(({ request, response }) => {
-      expect(response?.statusCode).to.eq(200);
-      expect(request.body).to.have.property('value', settings['engine-iso-url'].new);
-      expect(response?.body).to.have.property('value', settings['engine-iso-url'].new);
-    });
-    settingsPage.waitForPage();
-    settingsPage.settingsValue('engine-iso-url').contains(settings['engine-iso-url'].new);
-    // Scroll to the setting
-    cy.get('.main-layout').scrollTo('bottom');
-    settingsPage.modifiedLabel('engine-iso-url').should('be.visible'); // modified label should display after update
-
-    // Reset
-    SettingsPagePo.navTo();
-    settingsPage.waitForPage();
-    settingsPage.editSettingsByLabel('engine-iso-url');
-
-    settingsEdit.waitForPage();
-    settingsEdit.title().contains('Setting: engine-iso-url').should('be.visible');
-    settingsEdit.useDefaultButton().click();
-    settingsEdit.saveAndWait('engine-iso-url').then(({ request, response }) => {
-      expect(response?.statusCode).to.eq(200);
-      expect(request.body).to.have.property('value', settings['engine-iso-url'].original);
-      expect(response?.body).to.have.property('value', settings['engine-iso-url'].original);
-    });
-
-    settingsPage.waitForPage();
-    settingsPage.settingsValue('engine-iso-url').contains(settings['engine-iso-url'].original);
-    settingsPage.modifiedLabel('engine-iso-url').should('not.exist'); // modified label should not display after reset
   });
 });

--- a/cypress/e2e/tests/pages/global-settings/settings.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings.spec.ts
@@ -27,46 +27,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     cy.title().should('eq', 'Rancher - Global Settings - Settings');
   });
 
-  // Need to add a scroller since the location of this setting changed
-  //   it('can update engine-iso-url', { tags: ['@globalSettings', '@adminUser'] }, () => {
-  //     // Update setting
-  //     SettingsPagePo.navTo();
-  //     settingsPage.editSettingsByLabel('engine-iso-url');
-
-  //     const settingsEdit = settingsPage.editSettings('local', 'engine-iso-url');
-
-  //     settingsEdit.waitForPage();
-  //     settingsEdit.title().contains('Setting: engine-iso-url').should('be.visible');
-  //     settingsEdit.settingsInput().set(settings['engine-iso-url'].new);
-  //     settingsEdit.saveAndWait('engine-iso-url').then(({ request, response }) => {
-  //       expect(response?.statusCode).to.eq(200);
-  //       expect(request.body).to.have.property('value', settings['engine-iso-url'].new);
-  //       expect(response?.body).to.have.property('value', settings['engine-iso-url'].new);
-  //     });
-  //     settingsPage.waitForPage();
-  //     settingsPage.settingsValue('engine-iso-url').contains(settings['engine-iso-url'].new);
-  //     settingsPage.modifiedLabel('engine-iso-url').should('be.visible'); // modified label should display after update
-
-  //     // Reset
-  //     SettingsPagePo.navTo();
-  //     settingsPage.waitForPage();
-  //     settingsPage.editSettingsByLabel('engine-iso-url');
-
-  //     settingsEdit.waitForPage();
-  //     settingsEdit.title().contains('Setting: engine-iso-url').should('be.visible');
-  //     settingsEdit.useDefaultButton().click();
-  //     settingsEdit.saveAndWait('engine-iso-url').then(({ request, response }) => {
-  //       expect(response?.statusCode).to.eq(200);
-  //       expect(request.body).to.have.property('value', settings['engine-iso-url'].original);
-  //       expect(response?.body).to.have.property('value', settings['engine-iso-url'].original);
-  //     });
-
-  //     settingsPage.waitForPage();
-  //     settingsPage.settingsValue('engine-iso-url').contains(settings['engine-iso-url'].original);
-  //     settingsPage.modifiedLabel('engine-iso-url').should('not.exist'); // modified label should not display after reset
-  //   });
-
-  it('can update password-min-length', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it.skip('can update password-min-length', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('password-min-length');
@@ -117,7 +78,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('password-min-length').contains(settings['password-min-length'].original);
   });
 
-  it('can update ingress-ip-domain', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it.skip('can update ingress-ip-domain', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('ingress-ip-domain');
@@ -153,7 +114,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('ingress-ip-domain').contains(settings['ingress-ip-domain'].original);
   });
 
-  it('can update auth-user-info-max-age-seconds', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it.skip('can update auth-user-info-max-age-seconds', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('auth-user-info-max-age-seconds');
@@ -189,7 +150,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('auth-user-info-max-age-seconds').contains(settings['auth-user-info-max-age-seconds'].original);
   });
 
-  it('can update auth-user-session-ttl-minutes', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it.skip('can update auth-user-session-ttl-minutes', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('auth-user-session-ttl-minutes');
@@ -225,7 +186,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('auth-user-session-ttl-minutes').contains(settings['auth-user-session-ttl-minutes'].original);
   });
 
-  it('can update auth-token-max-ttl-minutes', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it.skip('can update auth-token-max-ttl-minutes', { tags: ['@globalSettings', '@adminUser'] }, () => {
     userMenu.getMenuItem('Account & API Keys').should('be.visible'); // Flaky test. Check required menu item visible (and not hidden later on due to content of test)
     userMenu.self().click();
 
@@ -264,7 +225,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('auth-token-max-ttl-minutes').contains(settings['auth-token-max-ttl-minutes'].original);
   });
 
-  it('can update agent-tls-mode', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it.skip('can update agent-tls-mode', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('agent-tls-mode');
@@ -292,7 +253,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('agent-tls-mode').contains('Strict');
   });
 
-  it('can update kubeconfig-default-token-ttl-minutes', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it.skip('can update kubeconfig-default-token-ttl-minutes', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('kubeconfig-default-token-ttl-minutes');
@@ -328,7 +289,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('kubeconfig-default-token-ttl-minutes').contains(settings['kubeconfig-default-token-ttl-minutes'].original);
   });
 
-  it('can update auth-user-info-resync-cron', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it.skip('can update auth-user-info-resync-cron', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('auth-user-info-resync-cron');
@@ -364,7 +325,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('auth-user-info-resync-cron').contains(settings['auth-user-info-resync-cron'].original);
   });
 
-  it('can update kubeconfig-generate-token', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it.skip('can update kubeconfig-generate-token', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('kubeconfig-generate-token');
@@ -409,5 +370,44 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(obj.apiVersion).to.equal('v1');
       expect(obj.kind).to.equal('Config');
     });
+  });
+  it('can update engine-iso-url', { tags: ['@globalSettings', '@adminUser'] }, () => {
+    // Update setting
+    SettingsPagePo.navTo();
+    settingsPage.editSettingsByLabel('engine-iso-url');
+
+    const settingsEdit = settingsPage.editSettings('local', 'engine-iso-url');
+
+    settingsEdit.waitForPage();
+    settingsEdit.title().contains('Setting: engine-iso-url').should('be.visible');
+    settingsEdit.settingsInput().set(settings['engine-iso-url'].new);
+    settingsEdit.saveAndWait('engine-iso-url').then(({ request, response }) => {
+      expect(response?.statusCode).to.eq(200);
+      expect(request.body).to.have.property('value', settings['engine-iso-url'].new);
+      expect(response?.body).to.have.property('value', settings['engine-iso-url'].new);
+    });
+    settingsPage.waitForPage();
+    settingsPage.settingsValue('engine-iso-url').contains(settings['engine-iso-url'].new);
+    // Scroll to the setting
+    cy.get('.main-layout').scrollTo('bottom');
+    settingsPage.modifiedLabel('engine-iso-url').should('be.visible'); // modified label should display after update
+
+    // Reset
+    SettingsPagePo.navTo();
+    settingsPage.waitForPage();
+    settingsPage.editSettingsByLabel('engine-iso-url');
+
+    settingsEdit.waitForPage();
+    settingsEdit.title().contains('Setting: engine-iso-url').should('be.visible');
+    settingsEdit.useDefaultButton().click();
+    settingsEdit.saveAndWait('engine-iso-url').then(({ request, response }) => {
+      expect(response?.statusCode).to.eq(200);
+      expect(request.body).to.have.property('value', settings['engine-iso-url'].original);
+      expect(response?.body).to.have.property('value', settings['engine-iso-url'].original);
+    });
+
+    settingsPage.waitForPage();
+    settingsPage.settingsValue('engine-iso-url').contains(settings['engine-iso-url'].original);
+    settingsPage.modifiedLabel('engine-iso-url').should('not.exist'); // modified label should not display after reset
   });
 });

--- a/cypress/e2e/tests/pages/global-settings/settings.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings.spec.ts
@@ -14,6 +14,7 @@ const accountPage = new AccountPagePo();
 const createKeyPage = new CreateKeyPagePo();
 const clusterList = new ClusterManagerListPagePo();
 const userMenu = new UserMenuPo();
+const BANNER_TEXT = "Typical users will not need to change these. Proceed with caution, incorrect values can break your Explorer installation. Settings which have been customized from default settings are tagged 'Modified'.";
 
 describe('Settings', { testIsolation: 'off' }, () => {
   before(() => {
@@ -27,7 +28,13 @@ describe('Settings', { testIsolation: 'off' }, () => {
     cy.title().should('eq', 'Rancher - Global Settings - Settings');
   });
 
-  it.skip('can update password-min-length', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it('has the correct banner text', { tags: ['@globalSettings', '@adminUser'] }, () => {
+    SettingsPagePo.navTo();
+
+    settingsPage.settingBanner().banner().contains(BANNER_TEXT);
+  });
+
+  it('can update password-min-length', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('password-min-length');
@@ -78,7 +85,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('password-min-length').contains(settings['password-min-length'].original);
   });
 
-  it.skip('can update ingress-ip-domain', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it('can update ingress-ip-domain', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('ingress-ip-domain');
@@ -114,7 +121,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('ingress-ip-domain').contains(settings['ingress-ip-domain'].original);
   });
 
-  it.skip('can update auth-user-info-max-age-seconds', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it('can update auth-user-info-max-age-seconds', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('auth-user-info-max-age-seconds');
@@ -150,7 +157,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('auth-user-info-max-age-seconds').contains(settings['auth-user-info-max-age-seconds'].original);
   });
 
-  it.skip('can update auth-user-session-ttl-minutes', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it('can update auth-user-session-ttl-minutes', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('auth-user-session-ttl-minutes');
@@ -186,7 +193,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('auth-user-session-ttl-minutes').contains(settings['auth-user-session-ttl-minutes'].original);
   });
 
-  it.skip('can update auth-token-max-ttl-minutes', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it('can update auth-token-max-ttl-minutes', { tags: ['@globalSettings', '@adminUser'] }, () => {
     userMenu.getMenuItem('Account & API Keys').should('be.visible'); // Flaky test. Check required menu item visible (and not hidden later on due to content of test)
     userMenu.self().click();
 
@@ -225,7 +232,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('auth-token-max-ttl-minutes').contains(settings['auth-token-max-ttl-minutes'].original);
   });
 
-  it.skip('can update agent-tls-mode', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it('can update agent-tls-mode', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('agent-tls-mode');
@@ -253,7 +260,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('agent-tls-mode').contains('Strict');
   });
 
-  it.skip('can update kubeconfig-default-token-ttl-minutes', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it('can update kubeconfig-default-token-ttl-minutes', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('kubeconfig-default-token-ttl-minutes');
@@ -289,7 +296,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('kubeconfig-default-token-ttl-minutes').contains(settings['kubeconfig-default-token-ttl-minutes'].original);
   });
 
-  it.skip('can update auth-user-info-resync-cron', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it('can update auth-user-info-resync-cron', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('auth-user-info-resync-cron');
@@ -325,7 +332,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.settingsValue('auth-user-info-resync-cron').contains(settings['auth-user-info-resync-cron'].original);
   });
 
-  it.skip('can update kubeconfig-generate-token', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it('can update kubeconfig-generate-token', { tags: ['@globalSettings', '@adminUser'] }, () => {
     // Update setting
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('kubeconfig-generate-token');

--- a/shell/list/management.cattle.io.setting.vue
+++ b/shell/list/management.cattle.io.setting.vue
@@ -5,6 +5,7 @@ import { Banner } from '@components/Banner';
 import Loading from '@shell/components/Loading';
 import { VIEW_IN_API } from '@shell/store/prefs';
 import Setting from '@shell/components/Setting';
+import { mapGetters } from 'vuex';
 
 export default {
   components: {
@@ -69,7 +70,8 @@ export default {
 
   data() {
     return { settings: null, provisioningSettings: null };
-  }
+  },
+  computed: { ...mapGetters({ t: 'i18n/t' }) }
 };
 </script>
 
@@ -79,6 +81,7 @@ export default {
     <Banner
       color="warning"
       class="settings-banner"
+      data-testid="global-settings-banner"
     >
       <div>
         {{ t('advancedSettings.subtext') }}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13587 
<!-- Define findings related to the feature or bug issue. -->
Fixed broken text.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Re-enabled skipped 'can update engine-iso-url' test

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
