### PR TITLE
Show credentials selector for Oracle OCI clusters

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -840,41 +840,43 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
   });
 
   describe('Credential Step', () => {
-    describe('should always show credentials', () => {
-      const driver = 'nutanix';
+    const drivers = ['nutanix', 'oci'];
 
-      it('should show credential step when `addCloudCredential` is true', () => {
-        cy.intercept({
-          method: 'GET',
-          path:   `/v1/management.cattle.io.nodedrivers*`,
-        }, (req) => {
-          req.continue((res) => {
-            res.body.data = nodeDriveResponse(true, driver).data;
+    Cypress._.each(drivers, (driver) => {
+      describe(`should always show credentials for ${ driver } driver`, () => {
+        it('should show credential step when `addCloudCredential` is true', () => {
+          cy.intercept({
+            method: 'GET',
+            path:   `/v1/management.cattle.io.nodedrivers*`,
+          }, (req) => {
+            req.continue((res) => {
+              res.body.data = nodeDriveResponse(true, driver).data;
+            });
           });
+          const clusterCreate = new ClusterManagerCreatePagePo();
+
+          clusterCreate.goTo(`type=${ driver }&rkeType=rke2`);
+          clusterCreate.waitForPage();
+
+          clusterCreate.credentialsBanner().checkExists();
         });
-        const clusterCreate = new ClusterManagerCreatePagePo();
 
-        clusterCreate.goTo(`type=${ driver }&rkeType=rke2`);
-        clusterCreate.waitForPage();
-
-        clusterCreate.credentialsBanner().checkExists();
-      });
-
-      it('should show credential step when `addCloudCredential` is false', () => {
-        cy.intercept({
-          method: 'GET',
-          path:   `/v1/management.cattle.io.nodedrivers*`,
-        }, (req) => {
-          req.continue((res) => {
-            res.body.data = nodeDriveResponse(false, driver).data;
+        it('should show credential step when `addCloudCredential` is false', () => {
+          cy.intercept({
+            method: 'GET',
+            path:   `/v1/management.cattle.io.nodedrivers*`,
+          }, (req) => {
+            req.continue((res) => {
+              res.body.data = nodeDriveResponse(false, driver).data;
+            });
           });
+          const clusterCreate = new ClusterManagerCreatePagePo();
+
+          clusterCreate.goTo(`type=${ driver }&rkeType=rke2`);
+          clusterCreate.waitForPage();
+
+          clusterCreate.credentialsBanner().checkExists();
         });
-        const clusterCreate = new ClusterManagerCreatePagePo();
-
-        clusterCreate.goTo(`type=${ driver }&rkeType=rke2`);
-        clusterCreate.waitForPage();
-
-        clusterCreate.credentialsBanner().checkExists();
       });
     });
 

--- a/shell/models/nodedriver.js
+++ b/shell/models/nodedriver.js
@@ -3,7 +3,10 @@ import Driver from '@shell/models/driver';
 /**
  * Overrides for spec.addCloudCredential
  */
-export const CLOUD_CREDENTIAL_OVERRIDE = { nutanix: true };
+export const CLOUD_CREDENTIAL_OVERRIDE = {
+  nutanix: true,
+  oci:     true
+};
 
 export default class NodeDriver extends Driver {
   get doneRoute() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13602
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
