### PR TITLE
Fix dark mode color for dropdown group

### DIFF
--- a/pkg/aks/components/__tests__/Config.test.ts
+++ b/pkg/aks/components/__tests__/Config.test.ts
@@ -185,11 +185,7 @@ describe('aks provisioning form', () => {
     })).toHaveLength(2);
   });
 
-  /**
-   * TODO: Issue #13122 - bumping Vue and related deps to 3.5.x uncovered a
-   * legitimate bug that exists in master
-   */
-  it.skip('should display subnets grouped by network in the virtual network dropdown', async() => {
+  it('should display subnets grouped by network in the virtual network dropdown', async() => {
     const noneOption = { label: 'generic.none' };
     const config = {
       dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc'

--- a/shell/assets/styles/themes/_dark.scss
+++ b/shell/assets/styles/themes/_dark.scss
@@ -116,7 +116,7 @@
   --dropdown-hover-bg          : #{$slate};
   --dropdown-disabled-bg       : #{$disabled};
   --dropdown-disabled-text     : #{$disabled};
-  --dropdown-group-text        : #{$disabled};
+  --dropdown-group-text        : #{$lighter};
   --dropdown-highlight-text    : var(--link);
 
   --input-text                 : #{$lightest};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13122

### Occurred changes and/or fixed issues

Fixes the group style for dark mode in the dropdown.

Note, the style `` is only used in one place, so changing this color should not have other impact.

For now, have chosen the corresponding color to the light mode.

We will review all colors in a future release.

### Screenshot/Video

![image](https://github.com/user-attachments/assets/e56d8b84-2c30-4def-a051-a7086f1b06c1)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
