### PR TITLE
Use `Shift+Escape` for terminal and editor escape sequence 

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2343,7 +2343,7 @@ resource:
     update: "Error updating {name}"
 
 codeMirror:
-  escapeText: Press Escape key to blur from editor
+  escapeText: Press Shift+Escape to blur from editor
   keymap:
     tooltip: Key mapping preference.
     indicatorToolip: "Key mapping: {name}"
@@ -6341,7 +6341,7 @@ wm:
     resizeShellWindow: Resize Shell window - use arrow keys {arrow1} and {arrow2} to resize with keyboard
     tabIcon: Shell tab icon
     closeShellTab: Close Shell tab - {tab}
-    escapeText: Press Escape key to blur from terminal
+    escapeText: Press Shift+Escape to blur from terminal
     clear: Clear
     containerName: "Container: {label}"
     failed: "Unable to open a shell to the container (none of the shell commands succeeded)\n\r"

--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -162,10 +162,16 @@ export default {
     },
 
     handleKeyPress(ev) {
-      // make focus leave the editor for it's parent container so that we can tab
+      // allows pressing escape in the editor, useful for modal editing with vim
       if (this.isCodeMirrorFocused && ev.code === 'Escape') {
         ev.preventDefault();
         ev.stopPropagation();
+      }
+
+      // make focus leave the editor for it's parent container so that we can tab
+      const didPressEscapeSequence = ev.shiftKey && ev.code === 'Escape';
+
+      if (this.isCodeMirrorFocused && didPressEscapeSequence) {
         this.$refs?.codeMirrorContainer?.focus();
       }
 

--- a/shell/components/nav/WindowManager/ContainerShell.vue
+++ b/shell/components/nav/WindowManager/ContainerShell.vue
@@ -198,7 +198,9 @@ export default {
       ev.stopPropagation();
 
       // make focus leave the shell for it's parent container so that we can tab
-      if (this.isXtermFocused && ev.code === 'Escape') {
+      const didPressEscapeSequence = ev.shiftKey && ev.code === 'Escape';
+
+      if (this.isXtermFocused && didPressEscapeSequence) {
         this.$refs.xterm.focus();
       }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The escape key conflicts with modal editing when working in VIM mode. Using `Shift+Escape` helps to prevent that conflict.

Fixes #13601 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Use `Shift+Escape` to exit code mirror and shell focus trap

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I think there's an argument that can be made for making this key combo a configurable preference in the future.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Code Mirror
  - Default Keybinds
  - Vim Keybinds
  - Emacs Keybinds
- Shell

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Code Mirror
- Shell

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/user-attachments/assets/5f4cc6f0-675a-474d-aefe-735ebc886047)

![image](https://github.com/user-attachments/assets/40bf1afd-8945-44ba-af3a-50712b32489f)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
