### PR TITLE
[FIX] Scheduling customization adjustments

### DIFF
--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -253,11 +253,7 @@ export default defineComponent({
     },
     async actuallySave() {
       if (this.isEdit) {
-        if (this.needsReplace) {
-          return await this.normanCluster._save({ replace: true });
-        } else {
-          return await this.normanCluster.save();
-        }
+        return await this.normanCluster.save({ replace: this.needsReplace });
       } else {
         await this.normanCluster.save();
 

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -90,7 +90,10 @@ export default defineComponent({
     if (!this.isRKE1) {
       await this.initVersionManagement();
     }
-    await this.initSchedulingCustomization();
+    if (!this.isLocal) {
+      // The rancher agent that runs on the local cluster is embedded in the rancher pods that are run in the local cluster, so this is not needed.
+      await this.initSchedulingCustomization();
+    }
   },
 
   data() {
@@ -232,7 +235,7 @@ export default defineComponent({
       return this.normanCluster.clusterAgentDeploymentCustomization || {};
     },
     schedulingCustomizationVisible() {
-      return this.schedulingCustomizationFeatureEnabled || (this.isEdit && this.normanCluster.clusterAgentDeploymentCustomization?.schedulingCustomization );
+      return !this.isLocal && (this.schedulingCustomizationFeatureEnabled || (this.isEdit && this.normanCluster.clusterAgentDeploymentCustomization?.schedulingCustomization ));
     },
   },
 

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -110,6 +110,8 @@ export default defineComponent({
       schedulingCustomizationFeatureEnabled: false,
       clusterAgentDefaultPC:                 null,
       clusterAgentDefaultPDB:                null,
+      // When disabling clusterAgentDeploymentCustomization, we need to replace the whole object
+      needsReplace:                          false,
       fvFormRuleSets:                        [{
         path:  'name',
         rules: ['clusterNameRequired', 'clusterNameChars', 'clusterNameStartEnd', 'clusterNameLength'],
@@ -251,7 +253,11 @@ export default defineComponent({
     },
     async actuallySave() {
       if (this.isEdit) {
-        return await this.normanCluster.save();
+        if (this.needsReplace) {
+          return await this.normanCluster._save({ replace: true });
+        } else {
+          return await this.normanCluster.save();
+        }
       } else {
         await this.normanCluster.save();
 
@@ -371,8 +377,10 @@ export default defineComponent({
     },
     setSchedulingCustomization(val) {
       if (val) {
+        this.needsReplace = false;
         set(this.normanCluster, 'clusterAgentDeploymentCustomization.schedulingCustomization', { priorityClass: this.clusterAgentDefaultPC, podDisruptionBudget: this.clusterAgentDefaultPDB });
       } else {
+        this.needsReplace = true;
         delete this.normanCluster.clusterAgentDeploymentCustomization.schedulingCustomization;
       }
     },

--- a/shell/components/form/SchedulingCustomization.vue
+++ b/shell/components/form/SchedulingCustomization.vue
@@ -42,7 +42,7 @@ export default {
       const pdbMismatch = !!this.value?.podDisruptionBudget && (this.value?.podDisruptionBudget.maxUnavailable !== this.defaultPDB.maxUnavailable || this.value?.podDisruptionBudget.minAvailable !== this.defaultPDB.minAvailable);
       const pcMismatch = !!this.value?.priorityClass && (this.value?.priorityClass.value !== this.defaultPC.value || this.value?.priorityClass.preemptionPolicy !== this.defaultPC.preemptionPolicy);
 
-      return this.isEdit && (pdbMismatch || pcMismatch);
+      return this.feature && this.isEdit && (pdbMismatch || pcMismatch);
     },
   }
 };

--- a/shell/components/form/SchedulingCustomization.vue
+++ b/shell/components/form/SchedulingCustomization.vue
@@ -39,10 +39,14 @@ export default {
       return !!this.value;
     },
     settingMissmatch() {
-      const pdbMismatch = !!this.value?.podDisruptionBudget && (this.value?.podDisruptionBudget.maxUnavailable !== this.defaultPDB.maxUnavailable || this.value?.podDisruptionBudget.minAvailable !== this.defaultPDB.minAvailable);
-      const pcMismatch = !!this.value?.priorityClass && (this.value?.priorityClass.value !== this.defaultPC.value || this.value?.priorityClass.preemptionPolicy !== this.defaultPC.preemptionPolicy);
+      const pdbMaxUnavailableMismatch = this.value?.podDisruptionBudget.maxUnavailable !== this.defaultPDB.maxUnavailable;
+      const pdbMinAvailableMismatch = this.value?.podDisruptionBudget.minAvailable !== this.defaultPDB.minAvailable;
+      const pcValueMismatch = this.value?.priorityClass.value !== this.defaultPC.value;
+      const pcPreemptionMismatch = this.value?.priorityClass.preemptionPolicy !== this.defaultPC.preemptionPolicy;
+      const pdbMismatch = !!this.value?.podDisruptionBudget && ( pdbMaxUnavailableMismatch || pdbMinAvailableMismatch);
+      const pcMismatch = !!this.value?.priorityClass && ( pcValueMismatch || pcPreemptionMismatch);
 
-      return this.feature && this.isEdit && (pdbMismatch || pcMismatch);
+      return pdbMismatch || pcMismatch;
     },
   }
 };
@@ -50,7 +54,6 @@ export default {
 
 <template>
   <div
-
     class="mt-20"
   >
     <Checkbox
@@ -62,7 +65,7 @@ export default {
       @update:value="$emit('scheduling-customization-changed', $event)"
     >
       <template
-        v-if="settingMissmatch"
+        v-if="feature && isEdit && settingMissmatch"
         #extra
       >
         <Banner

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2425,11 +2425,11 @@ export default {
 
         <!-- Cluster Agent Configuration -->
         <Tab
+          v-if="value.spec.clusterAgentDeploymentCustomization"
           name="clusteragentconfig"
           label-key="cluster.agentConfig.tabs.cluster"
         >
           <AgentConfiguration
-            v-if="value.spec.clusterAgentDeploymentCustomization"
             v-model:value="value.spec.clusterAgentDeploymentCustomization"
             data-testid="rke2-cluster-agent-config"
             type="cluster"

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1057,8 +1057,16 @@ export default {
 
     async initSchedulingCustomization() {
       this.schedulingCustomizationFeatureEnabled = this.features(SCHEDULING_CUSTOMIZATION);
-      this.clusterAgentDefaultPC = JSON.parse((await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.CLUSTER_AGENT_DEFAULT_PRIORITY_CLASS })).value) || null;
-      this.clusterAgentDefaultPDB = JSON.parse((await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.CLUSTER_AGENT_DEFAULT_POD_DISTRIBUTION_BUDGET })).value) || null;
+      try {
+        this.clusterAgentDefaultPC = JSON.parse((await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.CLUSTER_AGENT_DEFAULT_PRIORITY_CLASS })).value) || null;
+      } catch (e) {
+        this.errors.push(e);
+      }
+      try {
+        this.clusterAgentDefaultPDB = JSON.parse((await this.$store.dispatch('management/find', { type: MANAGEMENT.SETTING, id: SETTING.CLUSTER_AGENT_DEFAULT_POD_DISTRIBUTION_BUDGET })).value) || null;
+      } catch (e) {
+        this.errors.push(e);
+      }
 
       if (this.schedulingCustomizationFeatureEnabled && this.mode === _CREATE && isEmpty(this.value?.spec?.clusterAgentDeploymentCustomization?.schedulingCustomization)) {
         set(this.value, 'spec.clusterAgentDeploymentCustomization.schedulingCustomization', { priorityClass: this.clusterAgentDefaultPC, podDisruptionBudget: this.clusterAgentDefaultPDB });

--- a/shell/models/cluster.js
+++ b/shell/models/cluster.js
@@ -14,6 +14,7 @@ export const ANNOTATIONS_CONTAINS_PROTECTED = [
   'k3s.io',
   'kubernetes.io',
   'k3s.io',
+  'rancher.io'
 ];
 export default class NormanCluster extends NormanModel {
   get systemLabels() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13615 #13611 #13630
<!-- Define findings related to the feature or bug issue. -->
- Hid  'Cluster agent' tab for local cluster
- Adjusted Scheduling customization behavior when feature is disabled

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Enable 'cluster-agent-scheduling-customization' feature flag
2. Cluster management -> Edit Local cluster -> 'Cluster agent' tab should be hidden
3. When editing local cluster, 'clusterAgentDeploymentCustomization.schedulingCustomization' field should not be present in the request
3. Provision a new RKE2 cluster
4. Have Scheduling Customization enabled
5. Disable 'cluster-agent-scheduling-customization' feature flag 
6. Go back to the cluster you just created
7. Scheduling Customization  should be enabled, but 'Apply global settings for Priority Class and Pod Disruption Budget' should be hidden

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Imported cluster behavior can be affected

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
