### PR TITLE
Use CSS flexbox for LDAP schema columns

### DIFF
--- a/shell/edit/auth/ldap/config.vue
+++ b/shell/edit/auth/ldap/config.vue
@@ -279,157 +279,125 @@ export default {
       color="info"
       label-key="authConfig.ldap.oktaSchema"
     />
-    <div class="row">
-      <div class="col span-6">
+    <div class="schema-container">
+      <div class="schema-column">
         <h4>{{ t('authConfig.ldap.users') }}</h4>
-      </div>
-      <div class="col span-6">
-        <h4>{{ t('authConfig.ldap.groups') }}</h4>
-      </div>
-    </div>
-    <div class="row mb-20">
-      <div class="col span-6">
         <LabeledInput
           v-model:value="model.userObjectClass"
           :mode="mode"
           :label="t('authConfig.ldap.objectClass')"
         />
-      </div>
-      <div class="col span-6">
-        <LabeledInput
-          v-model:value="model.groupObjectClass"
-          :mode="mode"
-          :label="t('authConfig.ldap.objectClass')"
-        />
-      </div>
-    </div>
-    <div class="row mb-20">
-      <div class="col span-6">
         <LabeledInput
           v-model:value="model.userNameAttribute"
           :mode="mode"
           :label="t('authConfig.ldap.usernameAttribute')"
         />
-      </div>
-      <div class="col span-6">
-        <LabeledInput
-          v-model:value="model.groupNameAttribute"
-          :mode="mode"
-          :label="t('authConfig.ldap.nameAttribute')"
-        />
-      </div>
-    </div>
-    <div class="row mb-20">
-      <div class="col span-6">
         <LabeledInput
           v-model:value="model.userLoginAttribute"
           :mode="mode"
           :label="t('authConfig.ldap.loginAttribute')"
         />
-      </div>
-      <div class="col span-6">
-        <LabeledInput
-          v-model:value="model.groupMemberUserAttribute"
-          :mode="mode"
-          :label="t('authConfig.ldap.groupMemberUserAttribute')"
-        />
-      </div>
-    </div>
-    <div class="row mb-20">
-      <div class="col span-6">
         <LabeledInput
           v-model:value="model.userMemberAttribute"
           :mode="mode"
           :label="t('authConfig.ldap.userMemberAttribute')"
         />
-      </div>
-      <div class="col span-6">
-        <LabeledInput
-          v-model:value="model.groupSearchAttribute"
-          :mode="mode"
-          :label="t('authConfig.ldap.searchAttribute')"
-        />
-      </div>
-    </div>
-    <div class="row mb-20">
-      <div class="col span-6">
         <LabeledInput
           v-model:value="model.userLoginFilter"
           data-testid="user-login-filter"
           :mode="mode"
           :label="t('authConfig.ldap.userLoginFilter')"
         />
-      </div>
-      <div class="col span-6">
         <LabeledInput
           v-model:value="model.userSearchAttribute"
           :mode="mode"
           :label="t('authConfig.ldap.searchAttribute')"
         />
-      </div>
-    </div>
-    <div class="row mb-20">
-      <div class="col span-6">
-        <LabeledInput
-          v-model:value="model.groupSearchFilter"
-          :mode="mode"
-          :label="t('authConfig.ldap.searchFilter')"
-        />
-      </div>
-      <div class="col span-6">
         <LabeledInput
           v-model:value="model.userSearchFilter"
           :mode="mode"
           :label="t('authConfig.ldap.searchFilter')"
         />
-      </div>
-    </div>
-    <div class="row mb-20">
-      <div class="col span-6">
-        <LabeledInput
-          v-model:value="model.groupMemberMappingAttribute"
-          :mode="mode"
-          :label="t('authConfig.ldap.groupMemberMappingAttribute')"
-        />
-      </div>
-      <div class="col span-6">
         <LabeledInput
           v-model:value="model.userEnabledAttribute"
           :mode="mode"
           :label="t('authConfig.ldap.userEnabledAttribute')"
         />
-      </div>
-    </div>
-    <div class="row mb-20">
-      <div class="col span-6">
-        <LabeledInput
-          v-model:value="model.groupDNAttribute"
-          :mode="mode"
-          :label="t('authConfig.ldap.groupDNAttribute')"
-        />
-      </div>
-      <div class="col span-6">
         <LabeledInput
           v-model:value="model.disabledStatusBitmask"
           :mode="mode"
           :label="t('authConfig.ldap.disabledStatusBitmask')"
         />
       </div>
-    </div>
-    <div class="row mb-20">
-      <div
-        v-if="!isSamlProvider"
-        class=" col span-6"
-      >
-        <RadioGroup
-          v-model:value="model.nestedGroupMembershipEnabled"
+      <div class="schema-column">
+        <h4>{{ t('authConfig.ldap.groups') }}</h4>
+        <LabeledInput
+          v-model:value="model.groupObjectClass"
           :mode="mode"
-          name="nested"
-          class="full-height"
-          :options="[true, false]"
-          :labels="[t('authConfig.ldap.nestedGroupMembership.options.nested'), t('authConfig.ldap.nestedGroupMembership.options.direct')]"
+          :label="t('authConfig.ldap.objectClass')"
         />
+        <LabeledInput
+          v-model:value="model.groupNameAttribute"
+          :mode="mode"
+          :label="t('authConfig.ldap.nameAttribute')"
+        />
+        <LabeledInput
+          v-model:value="model.groupMemberUserAttribute"
+          :mode="mode"
+          :label="t('authConfig.ldap.groupMemberUserAttribute')"
+        />
+        <LabeledInput
+          v-model:value="model.groupSearchAttribute"
+          :mode="mode"
+          :label="t('authConfig.ldap.searchAttribute')"
+        />
+        <LabeledInput
+          v-model:value="model.groupSearchFilter"
+          :mode="mode"
+          :label="t('authConfig.ldap.searchFilter')"
+        />
+        <LabeledInput
+          v-model:value="model.groupMemberMappingAttribute"
+          :mode="mode"
+          :label="t('authConfig.ldap.groupMemberMappingAttribute')"
+        />
+        <LabeledInput
+          v-model:value="model.groupDNAttribute"
+          :mode="mode"
+          :label="t('authConfig.ldap.groupDNAttribute')"
+        />
+        <template
+          v-if="!isSamlProvider"
+        >
+          <RadioGroup
+            v-model:value="model.nestedGroupMembershipEnabled"
+            :mode="mode"
+            name="nested"
+            class="full-height"
+            :options="[true, false]"
+            :labels="[t('authConfig.ldap.nestedGroupMembership.options.nested'), t('authConfig.ldap.nestedGroupMembership.options.direct')]"
+          />
+        </template>
       </div>
     </div>
   </div>
 </template>
+
+<style lang="scss" scoped>
+  .schema-container {
+    display: flex;
+    gap: 1.75%;
+    flex-wrap: wrap;
+  }
+
+  .schema-column {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 16rem;
+
+    > :not(:first-child) {
+      margin-bottom: 20px;
+    }
+  }
+</style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This restores all form inputs for the Customize Schema section for the LDAP configuration form to their appropriate columns by refactoring this section to use CSS flexbox.

Fixes #13616
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Replace custom rows and columns for the Customize Schema section of the LDAP form with a CSS flexbox implementation

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

🗒️ NOTE: if this refactor it too risky, we can revert to the previous implementation and manually shuffle around inputs in the rows/columns. I took on this effort because it was rather straightforward to implement and it improves the developer experience for managing these inputs moving forward.

PR #13464 introduced a change that regressed the layout of the Customize Schema section in the LDAP forms. I think that relying on CSS flexbox to layout the columns makes it much more clear that fields in these columns need to be grouped together. It wasn't clear that the first item in each row needed to be user-related and the second item needed to be group-related in the previous implementation.

This change will also reduce the need to manually "reflow" form elements to remove gaps in the columns when new inputs are added in the future.

We also get the benefit of updating the layout if the viewport width becomes too small to comfortably render the inputs side-by-side. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- LDAP Auth Providers

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- LDAP Auth Providers

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before (2.10)

![image](https://github.com/user-attachments/assets/187284ff-e03c-44e7-af1f-2fb7e1e41e82)

![image](https://github.com/user-attachments/assets/7d22dd31-f4ed-4df6-bc18-1a3278a631ca)

#### After

![image](https://github.com/user-attachments/assets/54fb111e-9f92-480a-9d3c-4bec2b9d4619)

![image](https://github.com/user-attachments/assets/6ad7fe3b-3a1d-4545-b2a0-bb5f7cd20505)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
