### PR TITLE
fix: allow image prefix to be empty

### DIFF
--- a/shell/scripts/extension/publish
+++ b/shell/scripts/extension/publish
@@ -57,7 +57,7 @@ while getopts "hvr:o:pi:fcb:t:s:lne" opt; do
       REGISTRY_ORG="${OPTARG}"
       ;;
     i)
-      IMAGE_PREFIX="${OPTARG}"
+      IMAGE_PREFIX="${OPTARG-}"
       ;;
     f)
       FORCE="true"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
When I  was trying to use extension catalog image in https://github.com/harvester/harvester-ui-extension/pull/181, I noticed that `IMAGE_PREFIX` couldn't be empty. In our requirement, we don't need `ui-extension-` prefix. I think we could allow this filed to be empty if users give empty string.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Use `yarn publish-pkgs -c -r ${{ inputs.registry_target }} -o ${{ inputs.registry_user }}  -i  ""` to test that the image name shouldn't contain `ui-extension-` prefix.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
