### PR TITLE
RKE2 Cluster Detail Page: Machine Pools List is not grouped by pool / machine deployment

### DIFF
--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -188,6 +188,11 @@ export default {
       type:    Number,
       default: null, // Default comes from the user preference
     },
+
+    hideGroupingControls: {
+      type:    Boolean,
+      default: false
+    }
   },
 
   data() {
@@ -591,7 +596,7 @@ export default {
     @enter="handleEnterKeyPress"
   >
     <template
-      v-if="showGrouping"
+      v-if="!hideGroupingControls && showGrouping"
       #header-middle
     >
       <slot name="more-header-middle" />

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -776,6 +776,7 @@ export default {
           group-ref="pool"
           :group-sort="['pool.nameDisplay']"
           :sort-generation-fn="machineSortGenerationFn"
+          :hide-grouping-controls="true"
         >
           <template #main-row:isFake="{fullColspan}">
             <tr class="main-row">

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -863,6 +863,7 @@ export default {
           group-ref="pool"
           :group-sort="['pool.nameDisplay']"
           :sort-generation-fn="nodeSortGenerationFn"
+          :hide-grouping-controls="true"
         >
           <template #main-row:isFake="{fullColspan}">
             <tr class="main-row">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13659 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- hide grouping controls for `machines` and `machine pools` in prov cluster details view corresponding tab

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
I couldn't reproduce this in a very recent backend version + current master.

However I did notice that the grouping controls in the issue screenshots was not there, but on my env it was present but not actually performing anything meaningful. I think that we want to continue to display the grouping by pools as it was it's default but it's pointless to see those in this table by namespace as they will always belong to the same namespace.

I've created a prop that hides the grouping controls without disabling the grouping enforced by this resource table (pools)

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Re-test this with the described env to double-check that we can't repro the original issue

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- I don't think this will introduce any regressions as it's properly gated

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
**Result - RKE2 cluster**
<img width="2328" alt="Screenshot 2025-03-06 at 11 19 44" src="https://github.com/user-attachments/assets/2abbc030-b526-4dd1-a8d4-e7d0a67d6e39" />

**Result - custom cluster**
<img width="2328" alt="Screenshot 2025-03-06 at 11 19 46" src="https://github.com/user-attachments/assets/68a3a853-c639-46bb-9b93-8c38acc85663" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
