### PR TITLE
fix issue with CA cert bundle not resizing properly on cluster edit

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -88,6 +88,8 @@ const NODE_TOTAL = {
 const CLUSTER_AGENT_CUSTOMIZATION = 'clusterAgentDeploymentCustomization';
 const FLEET_AGENT_CUSTOMIZATION = 'fleetAgentDeploymentCustomization';
 
+const REGISTRIES_TAB_NAME = 'registry';
+
 const isAzureK8sUnsupported = (version) => semver.gte(version, '1.30.0');
 
 export default {
@@ -254,6 +256,8 @@ export default {
       schedulingCustomizationFeatureEnabled: false,
       clusterAgentDefaultPC:                 null,
       clusterAgentDefaultPDB:                null,
+      activeTab:                             null,
+      REGISTRIES_TAB_NAME,
       labelForAddon
 
     };
@@ -261,6 +265,9 @@ export default {
 
   computed: {
     ...mapGetters({ features: 'features/get' }),
+    isActiveTabRegistries() {
+      return this.activeTab?.selectedName === REGISTRIES_TAB_NAME;
+    },
     clusterName() {
       return this.value.metadata?.name || '';
     },
@@ -2077,6 +2084,10 @@ export default {
     addonConfigValidationChanged(configName, isValid) {
       this.addonConfigValidation[configName] = isValid;
     },
+
+    handleTabChange(data) {
+      this.activeTab = data;
+    }
   }
 };
 </script>
@@ -2244,6 +2255,7 @@ export default {
       <Tabbed
         :side-tabs="true"
         class="min-height"
+        @changed="handleTabChange"
       >
         <Tab
           name="basic"
@@ -2354,10 +2366,11 @@ export default {
 
         <!-- Registries -->
         <Tab
-          name="registry"
+          :name="REGISTRIES_TAB_NAME"
           label-key="cluster.tabs.registry"
         >
           <Registries
+            v-if="isActiveTabRegistries"
             v-model:value="localValue"
             :mode="mode"
             :register-before-hook="registerBeforeHook"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12967 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix issue with `CA cert bundle` not resizing properly by displaying it's parent component ONLY if the `registry` tab is active

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
As per https://github.com/rancher/dashboard/issues/12967#issuecomment-2701831931, 

This is broken in 2.10 (2.10.0). I believe the problem lies with the repro steps:

Go to Cluster Managements -> Create a new RKE2 cluster
Click on Registries tab
Add a new Registry Authentication in the array group field
Add a long text in "Ca Bundle" field

Now, if you do an `edit` to that cluster, it get's you into the edit interface, but on the "basics" tab. If you click on the "registries" tab, you'll see the element "broken".

If you refresh the edit page interface, but with the `Registry` tab already open (url with `#registry`) then you get the visual of the UI element without any bug.

Root cause seems to be https://github.com/rancher/dashboard/blob/master/pkg/rancher-components/src/components/Form/TextArea/TextAreaAutoGrow.vue#L171 where `el.scrollHeight` is always `0` when the component is mounted but the element is not visible on screen. This seems to be a default behaviour for browsers handling non-visible elements.

This is the easiest fix that could be found without having expensive logic or binding the component to another, unnecessarily.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
