### PR TITLE
[FIX] Hid version management for RKE1

### DIFF
--- a/pkg/imported/components/Basics.vue
+++ b/pkg/imported/components/Basics.vue
@@ -62,6 +62,10 @@ export default defineComponent({
       type:    Boolean,
       default: false
     },
+    showVersionManagement: {
+      type:    Boolean,
+      default: true
+    },
     versionManagementGlobalSetting: {
       type:     Boolean,
       required: true,
@@ -163,6 +167,7 @@ export default defineComponent({
     </div>
   </div>
   <VersionManagement
+    v-if="showVersionManagement"
     :value="versionManagement"
     :global-setting="versionManagementGlobalSetting"
     :mode="mode"

--- a/pkg/imported/components/VersionManagement.vue
+++ b/pkg/imported/components/VersionManagement.vue
@@ -2,7 +2,7 @@
 import { defineComponent } from 'vue';
 import { RadioGroup } from '@components/Form/Radio';
 import { mapGetters } from 'vuex';
-import { _EDIT } from '@shell/config/query-params';
+import { _EDIT, _CREATE } from '@shell/config/query-params';
 import Banner from '@components/Banner/Banner.vue';
 import { VERSION_MANAGEMENT_DEFAULT } from '@pkg/imported/util/shared.ts';
 
@@ -35,6 +35,9 @@ export default defineComponent({
     ...mapGetters({ t: 'i18n/t', features: 'features/get' }),
     isEdit() {
       return this.mode === _EDIT;
+    },
+    isCreate() {
+      return this.mode === _CREATE;
     },
     versionManagementOptions() {
       const defaultLabel = this.globalSetting ? this.t('imported.basics.versionManagement.globalEnabled') : this.t('imported.basics.versionManagement.globalDisabled');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13619 
<!-- Define findings related to the feature or bug issue. -->
Hid Cluster version management for RKE1 cluster

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Changed the conditions on when to show and initialize version management.
- Replaced a few cases checks that were supposed to only affect create but were also affecting config mode
- Hid Registries for Rke1
- Showed K8s version management for imported cluster in Pending state

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Refer to issue description for the test case

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
