### PR TITLE
feat: emit keyup event for labeledinput

### DIFF
--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -383,6 +383,7 @@ export default defineComponent({
         @update:value="onInput"
         @focus="onFocus"
         @blur="onBlur"
+        @keyup="$emit('keyup', $event)"
       />
       <input
         v-else
@@ -404,6 +405,7 @@ export default defineComponent({
         @focus="onFocus"
         @blur="onBlur"
         @change="onChange"
+        @keyup="$emit('keyup', $event)"
       >
     </slot>
 

--- a/shell/components/form/UnitInput.vue
+++ b/shell/components/form/UnitInput.vue
@@ -237,6 +237,7 @@ export default {
     :hide-arrows="hideArrows"
     @change="update($event.target.value)"
     @blur="update($event.target.value)"
+    @keyup="update($event.target.value)"
   >
     <template #suffix>
       <div


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Allow LabeledInput to emit keyup event to let users handle immediate validation, etc.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Adding extra prop to LabeledInput to allow adding extra logic on typing without removing focus from the input.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Chrome was used to test the changes. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Probably any uses for LabeledInput, UnitInput

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
