### PR TITLE
Updating how we move the title using css

### DIFF
--- a/cypress/e2e/tests/pages/explorer2/cluster-project-members.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/cluster-project-members.spec.ts
@@ -89,6 +89,9 @@ describe('Cluster Project and Members', { tags: ['@explorer2', '@adminUser'] }, 
     cy.wait('@createProjectMembership');
     cy.get('.modal-overlay').should('not.exist');
 
+    projectMembership.goTo();
+    projectMembership.waitForPageWithSpecificUrl('/c/local/explorer/members#project-membership');
+
     cy.get('body tbody').then((el) => {
       if (el.find('tr.no-rows').is(':visible')) {
         cy.reload();

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -609,11 +609,8 @@ export default {
   }
 
   HEADER {
-    margin: 0 0 0 -5px;
-
-    .title {
-      overflow-x: hidden;
-    }
+    margin: 0;
+    grid-template-columns: minmax(0, 1fr) auto;
   }
 
   .primaryheader {
@@ -622,14 +619,13 @@ export default {
     align-items: center;
 
     h1 {
-      margin: 0;
+      margin: 0 0 0 -5px;
       overflow-x: hidden;
       display: flex;
       flex-direction: row;
       align-items: center;
 
       .masthead-resource-title {
-        padding: 0 8px;
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;
@@ -660,6 +656,7 @@ export default {
   }
 
   .masthead-state {
+    margin-left: 8px;
     font-size: initial;
   }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/13546
Fixes https://github.com/rancher/dashboard/issues/13570

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
It looks like https://github.com/rancher/dashboard/commit/c6db1b70dfd5a4a7b252585e7904ff45b59c3e0f#diff-dcf43af1960ee931344da2d37e6237c086acbdacc5d16489ec02e67319c27338R590 wanted to shift just the title over but inadvertently shifted the namespace as well. We now make the same change but on a more specific element.

### Areas or cases that should be tested
Detail pages with namespaces (secret, configmap)

### Areas which could experience regressions
Detail pages with namespaces (secret, configmap)

### Screenshot/Video
You can see that we still display list page mastheads as expected, focus appears to not be cut off, we handle overflow of long names and the title and namespaces are now aligned.

https://github.com/user-attachments/assets/efea8763-d957-47a5-8602-db644f20c6f0

Fixed the spacing with the badge state
![image](https://github.com/user-attachments/assets/ad2af9de-fab0-4334-9f15-10d9a78a8b27)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
