### PR TITLE
Fix AKS import page when no aks clusters are found

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -205,7 +205,7 @@ export default defineComponent({
 
       loadingLocations: false,
 
-      fvFormRuleSets: [{
+      fvFormRuleSets: this.isImport ? [{
         path:  'name',
         rules: ['nameRequired', 'clusterNameChars', 'clusterNameStartEnd', 'clusterNameLength'],
       },
@@ -213,7 +213,10 @@ export default defineComponent({
         path:  'clusterName',
         rules: ['importedName']
       }
-      ],
+      ] : [{
+        path:  'name',
+        rules: ['nameRequired', 'clusterNameChars', 'clusterNameStartEnd', 'clusterNameLength'],
+      }],
     };
   },
 
@@ -466,10 +469,11 @@ export default defineComponent({
       <Import
         v-if="isImport"
         v-model:cluster-name="config.clusterName"
-
         v-model:resource-group="config.resourceGroup"
+
         v-model:resource-location="config.resourceLocation"
         v-model:enable-network-policy="normanCluster.enableNetworkPolicy"
+        data-testid="cruaks-import"
         :azure-credential-secret="config.azureCredentialSecret"
         :rules="{clusterName: fvGetAndReportPathRules('clusterName')}"
         :mode="mode"

--- a/pkg/aks/components/Import.vue
+++ b/pkg/aks/components/Import.vue
@@ -76,7 +76,13 @@ export default defineComponent({
       this.loadingClusters = true;
 
       try {
-        this.allClusters = await getAKSClusters(this.$store, this.azureCredentialSecret);
+        const clusters = await getAKSClusters(this.$store, this.azureCredentialSecret);
+
+        if (clusters?.length) {
+          this.allClusters = clusters;
+        } else {
+          this.allClusters = [];
+        }
       } catch (err) {
         this.$emit('error', err);
       }

--- a/pkg/aks/components/__tests__/CruAks.test.ts
+++ b/pkg/aks/components/__tests__/CruAks.test.ts
@@ -88,4 +88,41 @@ describe('aks provisioning form', () => {
     expect(regionDropdown.exists()).toBe(true);
     expect(regionDropdown.props().value).toBe(mockRegions[0].name);
   });
+
+  it('should show an input with clusters to register when the mode is import', async() => {
+    const setup = {
+      global: {
+        mocks: {
+          $store:      mockedStore({ value: '<=1.27.x' }),
+          $route:      { query: { mode: 'import' } },
+          $fetchState: {},
+        },
+        stubs: { CruResource: false, Accordion: false }
+      }
+    };
+    const wrapper = shallowMount(CruAks, {
+      propsData: { value: {}, mode: _CREATE },
+      ...setup
+    });
+
+    await setCredential(wrapper);
+    const clusterDropdown = wrapper.find('[data-testid="cruaks-import"]');
+
+    expect(clusterDropdown.exists()).toBe(true);
+  });
+
+  // https://github.com/rancher/dashboard/issues/13647
+  it('should not render the import cluster dropdown nor run its validation when the mode is not import', async() => {
+    const wrapper = shallowMount(CruAks, {
+      propsData: { value: {}, mode: _CREATE },
+      ...requiredSetup()
+    });
+
+    await setCredential(wrapper);
+    const clusterDropdown = wrapper.find('[data-testid="cruaks-import"]');
+
+    expect(clusterDropdown.exists()).toBe(false);
+
+    expect(wrapper.vm.fvUnreportedValidationErrors).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13647

Fixes #12407 - see [comment](https://github.com/rancher/dashboard/issues/12407#issuecomment-2699640626)
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR corrects some error handling around the aks import cluster component: previously when no clusters were found in azure the dropdown component received `null` options and broke the page.

This PR also fixes an issue where the imported cluster name validator would run when loading the regular AKS provisioning form


### Areas or cases that should be tested
 Import an AKS cluster - test that the form loads when AKS clusters are not available and when they are

Also test scenario described in #13647 (create new AKS cluster)


### Screenshot/Video
![Screenshot 2025-03-07 at 10 23 52 AM](https://github.com/user-attachments/assets/e4470f69-7c13-4aeb-8db8-cc7236d396cd)

old ui for comparison:
![Screenshot 2025-03-07 at 9 36 38 AM](https://github.com/user-attachments/assets/5a4df001-80f1-4c54-b8d0-1f77718579ea)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
