### PR TITLE
`ServiceType.vue`: Make `headless` and `clusterIp` computed props

### DIFF
--- a/shell/components/formatter/ServiceType.vue
+++ b/shell/components/formatter/ServiceType.vue
@@ -18,9 +18,17 @@ export default {
   },
   data() {
     const cloned = this.getLabel(this.value.toLowerCase());
-    const headless = this.value === 'ClusterIP' && this.row?.spec?.clusterIP === 'None' ? this.getLabel('headless') : undefined;
 
-    return { translated: cloned, headless };
+    return { translated: cloned };
+  },
+
+  computed: {
+    clusterIp() {
+      return this.row?.spec?.clusterIP;
+    },
+    headless() {
+      return this.value === 'ClusterIP' && this.clusterIp === 'None' ? this.getLabel('headless') : undefined;
+    }
   },
 
   methods: {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This makes `headless` and `clusterIp` into computed props so that they can be picked up better by reactivity.

Fixes #12982 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Make `headless` and `clusterIp` computed props in `ServiceType.vue`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

`headless` was defined in the body of `data` in such a way that it was preventing the component from picking up on reactive changes. This would cause the component to not re-render even when data changed. Specify computed props resolves the issue with the component.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

See issue for details.

Local Cluster => Service Discovery => Serivces => Apply sorting to the table

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Local Cluster => Service Discovery => Serivces => Apply sorting to the table

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/user-attachments/assets/10420cfb-3cdb-450c-b66b-04b34afdc031)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
