### PR TITLE
Fleet, fix pollingInterval format

### DIFF
--- a/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
@@ -123,6 +123,7 @@ describe('Git Repo', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] }, (
         gitRepoCreateRequest.metadata.labels['fleet.cattle.io/created-by-user-id'] = adminUserId;
         gitRepoCreateRequest.spec.helmSecretName = helmSecretName;
         gitRepoCreateRequest.spec.clientSecretName = gitSecretName; // Git SSH credentials
+        gitRepoCreateRequest.spec.pollingInterval = '13s';
 
         expect(response.statusCode).to.eq(201);
         expect(request.body).to.deep.eq(gitRepoCreateRequest);

--- a/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
+++ b/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
@@ -155,6 +155,12 @@ describe.each([
     ['1', 'custom 1 second', 1, '1'],
     ['60', 'custom 60 seconds', 60, '60'],
     ['15', 'custom 15 seconds', 15, '15'],
+    ['0s', `default ${ defaultPollingInterval } seconds`, 0, defaultPollingInterval],
+    ['1s', 'custom 1 second', '1s', '1'],
+    ['60s', 'custom 60 seconds', '1m', '60'],
+    ['1m3s', 'custom 63 seconds', '1m3s', '63'],
+    ['1h2m3s', 'custom 3723 seconds', '1h2m3s', '3723'],
+    ['15', 'custom 15 seconds', '15s', '15'],
   ])('show Polling Interval input with source: %p, value: %p', async(
     descr1,
     descr2,

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -27,6 +27,7 @@ import { checkSchemasForFindAllHash } from '@shell/utils/auth';
 import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 import FormValidation from '@shell/mixins/form-validation';
 import UnitInput from '@shell/components/form/UnitInput';
+import { toSeconds } from '@shell/utils/duration';
 
 const MINIMUM_POLLING_INTERVAL = 15;
 const DEFAULT_POLLING_INTERVAL = 60;
@@ -97,7 +98,7 @@ export default {
   },
 
   data() {
-    let pollingInterval = this.value.spec.pollingInterval;
+    let pollingInterval = toSeconds(this.value.spec.pollingInterval) || this.value.spec.pollingInterval;
 
     if (!pollingInterval) {
       if (this.realMode === _CREATE) {
@@ -550,11 +551,11 @@ export default {
     updatePollingInterval(value) {
       if (!value) {
         this.pollingInterval = DEFAULT_POLLING_INTERVAL;
-        this.value.spec.pollingInterval = DEFAULT_POLLING_INTERVAL.toString();
+        this.value.spec.pollingInterval = this.durationSeconds(DEFAULT_POLLING_INTERVAL);
       } else if (value === MINIMUM_POLLING_INTERVAL) {
         delete this.value.spec.pollingInterval;
       } else {
-        this.value.spec.pollingInterval = value.toString();
+        this.value.spec.pollingInterval = this.durationSeconds(value);
       }
     },
 
@@ -576,6 +577,10 @@ export default {
         this.value.metadata.labels[FLEET_LABELS.CREATED_BY_USER_NAME] = this.value.currentUser.username;
       }
     },
+
+    durationSeconds(value) {
+      return `${ value }s`;
+    }
   }
 };
 </script>

--- a/shell/edit/monitoring.coreos.com.prometheusrule/AlertingRule.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/AlertingRule.vue
@@ -11,7 +11,7 @@ import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import UnitInput from '@shell/components/form/UnitInput';
 import { _VIEW } from '@shell/config/query-params';
-import { toMilliseconds } from './duration.js';
+import { toSeconds } from '@shell/utils/duration';
 
 const IGNORED_ANNOTATIONS = [
   'summary',
@@ -207,7 +207,10 @@ export default {
     waitToFireFor: {
       get() {
         if (![null, undefined].includes(this.value.for)) {
-          return Math.floor(toMilliseconds(this.value.for) / 1000);
+          // see:
+          // https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#rule
+          // https://prometheus.io/docs/prometheus/latest/configuration/configuration/#duration
+          return toSeconds(this.value.for);
         }
 
         return undefined;

--- a/shell/edit/monitoring.coreos.com.prometheusrule/index.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/index.vue
@@ -13,7 +13,7 @@ import { _CREATE, _VIEW } from '@shell/config/query-params';
 import isString from 'lodash/isString';
 import isEmpty from 'lodash/isEmpty';
 import GroupRules from './GroupRules';
-import { toMilliseconds } from './duration.js';
+import { toSeconds } from '@shell/utils/duration';
 
 export default {
   components: {
@@ -118,7 +118,10 @@ export default {
 
     getGroupInterval(interval) {
       if (![null, undefined].includes(interval)) {
-        return Math.floor(toMilliseconds(interval) / 1000);
+        // see:
+        // https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#rule
+        // https://prometheus.io/docs/prometheus/latest/configuration/configuration/#duration
+        return toSeconds(interval);
       }
     }
   },

--- a/shell/utils/duration.js
+++ b/shell/utils/duration.js
@@ -8,9 +8,7 @@ const UNIT_TO_MS =
     w:  7 * 24 * 60 * 60 * 1000,
     y:  365 * 24 * 60 * 60 * 1000
   };
-// see:
-// https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#rule
-// https://prometheus.io/docs/prometheus/latest/configuration/configuration/#duration
+
 const DURATION_REGEX = /^(?:([0-9]+)y)?(?:([0-9]+)w)?(?:([0-9]+)d)?(?:([0-9]+)h)?(?:([0-9]+)m)?(?:([0-9]+)s)?(?:([0-9]+)ms)?$/;
 
 export function toMilliseconds(input) {
@@ -38,4 +36,8 @@ export function toMilliseconds(input) {
   }
 
   return 0;
+}
+
+export function toSeconds(input) {
+  return Math.floor(toMilliseconds(input) / 1000);
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13661
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- The UI now accepts `pollingInterval` string in both integer and ISO 8601 duration format (i.e.: `1m3s` = `63` seconds).
- The UI now converts the `pollingInterval` value from int string to duration string before saving.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Edit 
- Go to local cluster -> Open Kubectl Shell
- Create some new GitRepos in `fleet-local` workspace
   ```
   kubectl -n fleet-local apply -f https://raw.githubusercontent.com/manno/fleet-experiments/refs/heads/main/gitrepo-lots.yaml
   ```
- Select one of the new GitRepos and edit the `pollingInterval` field -> save.

Create
- Clone one of the GitRepos, edit the `pollingInterval` and save.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

[Screencast from 2025-03-10 18-45-13.webm](https://github.com/user-attachments/assets/e4e41e87-73b6-4ce2-861d-60683b849943)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
