### PR TITLE
fix azure credential test function

### DIFF
--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
@@ -77,4 +77,8 @@ export default class ClusterManagerCreatePagePo extends ClusterManagerCreateImpo
   credentialsBanner() {
     return new BannersPo(this.self().find('.banner').contains(`Ok, Let's create a new credential`));
   }
+
+  errorsBanner() {
+    return new BannersPo('.banner.error', this.self());
+  }
 }

--- a/shell/cloud-credential/azure.vue
+++ b/shell/cloud-credential/azure.vue
@@ -61,7 +61,7 @@ export default {
           const parsed = parseAzureError(e.error);
 
           if (parsed) {
-            return { errors: [parsed] };
+            throw ( new Error(parsed));
           }
         }
 

--- a/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -194,6 +194,8 @@ export default {
         } catch (e) {
           this.errors = [e];
           btnCb(false);
+
+          return;
         }
       }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13590 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
There are 2 components to this fix:
1. The SelectCredential component expects test functions to either return true, false, or throw an error: when the azure credential test fails, the test function should throw an error instead of returning a parsed error message
2. When the SelectCredential component catches an error thrown by a test function it should return, not saving the bad credential


### Areas or cases that should be tested
Attempt creating azure credentials with invalid values during AKS cluster creation and rke2 azure cluster creation

### Areas which could experience regressions
Creating valid azure credentials

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
