### PR TITLE
Last Project Member removal in Rancher Dashboard

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -65,6 +65,10 @@ beforeAll(() => {
   });
 });
 
+jest.mock('@shell/composables/useI18n', () => ({ useI18n: () => (key) => key }));
+// eslint-disable-next-line no-console
+jest.spyOn(console, 'warn').mockImplementation((warning) => warning.includes('[Vue warn]') ? null : console.log(warning));
+
 /**
  * Common initialization for each test, required for resetting states
  */

--- a/shell/components/auth/Principal.vue
+++ b/shell/components/auth/Principal.vue
@@ -20,23 +20,7 @@ export default {
   },
 
   async fetch() {
-    this.principal = this.$store.getters['rancher/byId'](NORMAN.PRINCIPAL, this.value);
-
-    if ( this.principal ) {
-      return;
-    }
-
-    const principalId = escape(this.value).replace(/\//g, '%2F');
-
-    try {
-      this.principal = await this.$store.dispatch('rancher/find', {
-        type: NORMAN.PRINCIPAL,
-        id:   this.value,
-        opt:  { url: `/v3/principals/${ principalId }` }
-      });
-    } catch (e) {
-      console.error('Failed to fetch principal', this.value, principalId); // eslint-disable-line no-console
-    }
+    this.loadData();
   },
 
   data() {
@@ -49,6 +33,34 @@ export default {
       const p = this.principal;
 
       return p.name && p.loginName && p.name.trim().toLowerCase() !== p.loginName.trim().toLowerCase();
+    }
+  },
+
+  methods: {
+    async loadData() {
+      this.principal = this.$store.getters['rancher/byId'](NORMAN.PRINCIPAL, this.value);
+
+      if ( this.principal ) {
+        return;
+      }
+
+      const principalId = escape(this.value).replace(/\//g, '%2F');
+
+      try {
+        this.principal = await this.$store.dispatch('rancher/find', {
+          type: NORMAN.PRINCIPAL,
+          id:   this.value,
+          opt:  { url: `/v3/principals/${ principalId }` }
+        });
+      } catch (e) {
+        console.error('Failed to fetch principal', this.value, principalId); // eslint-disable-line no-console
+      }
+    }
+  },
+
+  watch: {
+    value() {
+      this.loadData();
     }
   },
 };

--- a/shell/components/auth/__tests__/Principal.test.ts
+++ b/shell/components/auth/__tests__/Principal.test.ts
@@ -1,0 +1,40 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import Principal from '@shell/components/auth/Principal.vue';
+
+describe('component: Principal', () => {
+  it('should render the component', () => {
+    const wrapper = mount(Principal, {
+      props:  { value: 'whatever' },
+      global: { mocks: { $fetchState: { pending: false } } },
+    });
+
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('should update principal displayed properties on value change', async() => {
+    const wrapper: VueWrapper<any, any> = mount(Principal, {
+      props:  { value: 'whatever' },
+      global: {
+        mocks: {
+          $fetchState: { pending: false },
+          $store:      {
+            getters: {
+              'rancher/byId': (_: any, id: 'first' | 'second') => {
+                const options = {
+                  first:  { name: 'first name' },
+                  second: { name: 'second name' }
+                };
+
+                return options[id];
+              }
+            }
+          },
+        },
+      },
+    });
+
+    await wrapper.setProps({ value: 'second' });
+
+    expect(wrapper.vm.principal.name).toStrictEqual('second name');
+  });
+});

--- a/shell/components/auth/__tests__/Principal.test.ts
+++ b/shell/components/auth/__tests__/Principal.test.ts
@@ -5,7 +5,12 @@ describe('component: Principal', () => {
   it('should render the component', () => {
     const wrapper = mount(Principal, {
       props:  { value: 'whatever' },
-      global: { mocks: { $fetchState: { pending: false } } },
+      global: {
+        mocks: {
+          $fetchState: { pending: false },
+          $store:      { getters: { 'rancher/byId': () => ({ name: 'name' }) } },
+        }
+      },
     });
 
     expect(wrapper.exists()).toBe(true);

--- a/shell/components/auth/__tests__/Principal.test.ts
+++ b/shell/components/auth/__tests__/Principal.test.ts
@@ -5,12 +5,7 @@ describe('component: Principal', () => {
   it('should render the component', () => {
     const wrapper = mount(Principal, {
       props:  { value: 'whatever' },
-      global: {
-        mocks: {
-          $fetchState: { pending: false },
-          $store:      { getters: { 'rancher/byId': () => ({ name: 'name' }) } },
-        }
-      },
+      global: { mocks: { $fetchState: { pending: false } } },
     });
 
     expect(wrapper.exists()).toBe(true);

--- a/shell/components/form/Members/MembershipEditor.vue
+++ b/shell/components/form/Members/MembershipEditor.vue
@@ -180,14 +180,17 @@ export default {
         </div>
       </div>
     </template>
-    <template #columns="{row}">
+    <template #columns="{row, i}">
       <div class="columns row">
         <div class="col span-6">
           <Principal
             :value="row.value.principalId"
           />
         </div>
-        <div class="col span-6 role">
+        <div
+          :data-testid="`role-item-${i}`"
+          class="col span-6 role"
+        >
           {{ row.value.roleDisplay }}
         </div>
       </div>
@@ -209,7 +212,7 @@ export default {
         type="button"
         :disabled="isView"
         class="btn role-link"
-        data-testid="remove-item-{{ i }}"
+        :data-testid="`remove-item-${i}`"
         @click="remove"
       >
         {{ t('generic.remove') }}

--- a/shell/components/form/Members/MembershipEditor.vue
+++ b/shell/components/form/Members/MembershipEditor.vue
@@ -196,6 +196,7 @@ export default {
       <button
         type="button"
         class="btn role-primary mt-10"
+        data-testid="add-item"
         @click="addMember"
       >
         {{ t('generic.add') }}
@@ -208,6 +209,7 @@ export default {
         type="button"
         :disabled="isView"
         class="btn role-link"
+        data-testid="remove-item-{{ i }}"
         @click="remove"
       >
         {{ t('generic.remove') }}

--- a/shell/components/form/Members/MembershipEditor.vue
+++ b/shell/components/form/Members/MembershipEditor.vue
@@ -1,6 +1,7 @@
 <script>
 import { MANAGEMENT, NORMAN } from '@shell/config/types';
 import ArrayList from '@shell/components/form/ArrayList';
+import Principal from '@shell/components/auth/Principal';
 import Loading from '@shell/components/Loading';
 import { _CREATE, _VIEW } from '@shell/config/query-params';
 import { get, set } from '@shell/utils/object';
@@ -18,7 +19,9 @@ export function canViewMembershipEditor(store, needsProject = false) {
 export default {
   emits: ['membership-update'],
 
-  components: { ArrayList, Loading },
+  components: {
+    ArrayList, Loading, Principal
+  },
 
   props: {
     addMemberDialogName: {

--- a/shell/components/form/Members/__tests__/MembershipEditor.test.ts
+++ b/shell/components/form/Members/__tests__/MembershipEditor.test.ts
@@ -41,6 +41,7 @@ describe('component: MembershipEditor', () => {
           $store:      { getters: { 'rancher/schemaFor': () => ({ type: 'object' }) } },
           $fetchState: { pending: false },
         },
+        stubs: { Principal: true },
       }
     });
   });

--- a/shell/components/form/Members/__tests__/MembershipEditor.test.ts
+++ b/shell/components/form/Members/__tests__/MembershipEditor.test.ts
@@ -6,18 +6,41 @@ describe('component: MembershipEditor', () => {
 
   beforeEach(() => {
     wrapper = mount(MembershipEditor, {
+      data() {
+        return {
+          schema:            null,
+          lastSavedBindings: [],
+          bindings:          [
+            {
+              principalId: 'local://user-nkkph',
+              roleDisplay: 'Cluster Owner',
+            },
+            {
+              principalId: 'local://u-jsvzm',
+              roleDisplay: 'Cluster Member 1',
+            },
+            {
+              principalId: 'local://u-rgcfw',
+              roleDisplay: 'Cluster Member 2',
+            },
+            {
+              principalId: 'local://u-gxsrz',
+              roleDisplay: 'Cluster Member 3',
+            }
+          ] as any,
+        };
+      },
       props: {
         addMemberDialogName: 'addMemberDialogName',
         parentKey:           'parentKey',
         mode:                'edit',
         type:                'no idea',
-        value:               [], // This value is not listed in the props but required
       },
       global: {
         mocks: {
           $store:      { getters: { 'rancher/schemaFor': () => ({ type: 'object' }) } },
           $fetchState: { pending: false },
-        }
+        },
       }
     });
   });
@@ -26,7 +49,13 @@ describe('component: MembershipEditor', () => {
     expect(wrapper.exists()).toBe(true);
   });
 
-  it('should remove the correct member', () => {
-    expect(wrapper.vm.members).toStrictEqual([]);
+  it('should remove the correct member', async() => {
+    await wrapper.find('[data-testid="remove-item-1"]').trigger('click');
+
+    const removedMember = wrapper.find('[data-testid="role-item-1"]').text();
+    const lastMember = wrapper.find('[data-testid="role-item-4"]');
+
+    expect(removedMember).toStrictEqual('Cluster Member 2');
+    expect(lastMember.exists()).toBe(false);
   });
 });

--- a/shell/components/form/Members/__tests__/MembershipEditor.test.ts
+++ b/shell/components/form/Members/__tests__/MembershipEditor.test.ts
@@ -1,0 +1,31 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import MembershipEditor from '@shell/components/form/Members/MembershipEditor.vue';
+
+describe('component: MembershipEditor', () => {
+  let wrapper: VueWrapper<any, any>;
+
+  beforeEach(() => {
+    wrapper = mount(MembershipEditor, {
+      props: {
+        addMemberDialogName: 'addMemberDialogName',
+        parentKey:           'parentKey',
+        mode:                'edit',
+        type:                'no idea',
+      },
+      global: {
+        mocks: {
+          $store:      { getters: { 'rancher/schemaFor': () => ({ type: 'object' }) } },
+          $fetchState: { pending: false },
+        }
+      }
+    });
+  });
+
+  it('should render the component', () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('should remove the correct member', () => {
+    expect(wrapper.vm.members).toStrictEqual([]);
+  });
+});

--- a/shell/components/form/Members/__tests__/MembershipEditor.test.ts
+++ b/shell/components/form/Members/__tests__/MembershipEditor.test.ts
@@ -11,6 +11,7 @@ describe('component: MembershipEditor', () => {
         parentKey:           'parentKey',
         mode:                'edit',
         type:                'no idea',
+        value:               [], // This value is not listed in the props but required
       },
       global: {
         mocks: {

--- a/shell/components/form/__tests__/ArrayList.test.ts
+++ b/shell/components/form/__tests__/ArrayList.test.ts
@@ -47,19 +47,22 @@ describe('the ArrayList', () => {
     expect(arrayListBoxes).toHaveLength(2);
   });
 
-  it('contracts when a delete button is clicked', async() => {
+  it('should remove the correct item, emit the removed item and the updated values', async() => {
     const wrapper = mount(ArrayList, {
       props: {
-        value: ['string 1', 'string 2'],
+        value: ['string 0', 'string 1', 'string 2'],
         mode:  _EDIT,
       },
     });
-    const deleteButton = wrapper.get('[data-testid^="remove-item"]').element as HTMLElement;
 
-    await deleteButton.click();
-    const arrayListBoxes = wrapper.findAll('[data-testid^="array-list-box"]');
+    jest.useFakeTimers();
+    await (wrapper.get('[data-testid="remove-item-1"]').element as HTMLElement).click();
+    jest.advanceTimersByTime(50);
+    jest.useRealTimers();
 
-    expect(arrayListBoxes).toHaveLength(1);
+    expect(wrapper.find('[data-testid="remove-item-2"]').exists()).toBe(false);
+    expect((wrapper.emitted('remove')![0][0] as any).row.value).toStrictEqual('string 1');
+    expect(wrapper.emitted('update:value')![0][0]).toStrictEqual(['string 0', 'string 2']);
   });
 
   it('add button is hidden in read-only mode', () => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13167
Fixes #13319
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

Made component Principal (the user card) to fetch again the member data on prop change (the ID passed in the array).

### Technical notes summary

- Moved `Principal` logic within a method and called on prop change
- Added Jest setup configuration to prevent Vue warns to spam the console while debugging
- Added unit tests
  - `ArrayList` 
     - Added case with more items
     - Update test to get correct emitters (the removed one is confusing) which require mocked timers
  - `MembershipEditor` ensured removing a member is still working correctly as in the component
  - `Principal` test to update fetched values on prop change

### Areas or cases that should be tested
As by issue

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video


https://github.com/user-attachments/assets/f918b82d-a465-4e72-adaf-a0e42aeba31e



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
