### PR TITLE
Fixed error shown in console when importing GKE

### DIFF
--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -222,21 +222,21 @@ export default defineComponent({
       if (!this.normanCluster.gkeConfig.privateClusterConfig) {
         this.normanCluster.gkeConfig['privateClusterConfig'] = cloneDeep(defaultGkeConfig.privateClusterConfig);
       }
+      this.nodePools = this.normanCluster.gkeConfig.nodePools;
+
+      this.nodePools.forEach((pool) => {
+        pool['_id'] = randomStr();
+        pool['_isNewOrUnprovisioned'] = this.isNewOrUnprovisioned;
+        if (!pool.management) {
+          pool['management'] = {};
+        }
+        if (!pool.autoscaling) {
+          pool['autoscaling'] = {};
+        }
+      });
     }
 
     this.config = this.normanCluster.gkeConfig;
-    this.nodePools = this.normanCluster.gkeConfig.nodePools;
-
-    this.nodePools.forEach((pool) => {
-      pool['_id'] = randomStr();
-      pool['_isNewOrUnprovisioned'] = this.isNewOrUnprovisioned;
-      if (!pool.management) {
-        pool['management'] = {};
-      }
-      if (!pool.autoscaling) {
-        pool['autoscaling'] = {};
-      }
-    });
   },
 
   data() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13562 
<!-- Define findings related to the feature or bug issue. -->
Moved nodePools configuration to non-imported block, since cluster import doesn't need it and doesn't have them defined

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Import GKE -> select credential -> no error should be shown in the console
- Edit imported GKE -> no error should be shown in the console
- Create GKE -> no error should be shown in the console
- Edit existing GKE -> no error should be shown in the console

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
GKE provisioning and import (both create and edit)

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
