### PR TITLE
Fix AKS edit button title

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -277,6 +277,10 @@ export default defineComponent({
       return canViewClusterMembershipEditor(this.$store);
     },
 
+    finishButtonMode() {
+      return this.isImport ? 'import' : this.mode === _CREATE ? 'create' : 'edit';
+    },
+
     CREATE(): string {
       return _CREATE;
     },
@@ -403,7 +407,7 @@ export default defineComponent({
     :done-route="doneRoute"
     :errors="[...fvUnreportedValidationErrors, ...configUnreportedErrors]"
     :validation-passed="fvFormIsValid && ( configIsValid || isImport)"
-    :finish-button-mode="isImport ? 'import' : 'create'"
+    :finish-button-mode="finishButtonMode"
     @error="e=>errors=e"
     @finish="save"
   >

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -278,7 +278,7 @@ export default defineComponent({
     },
 
     finishButtonMode() {
-      return this.isImport ? 'import' : this.mode === _CREATE ? 'create' : 'edit';
+      return this.isImport ? 'import' : this.mode === _EDIT ? 'edit' : 'create';
     },
 
     CREATE(): string {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13673 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Covered the edit mode for the CruResource action button.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
