### PR TITLE
[backport v2.10.4] Generic OIDC group scope is not sent in the request formed by the UI 

### DIFF
--- a/shell/mixins/__tests__/auth-config.test.ts
+++ b/shell/mixins/__tests__/auth-config.test.ts
@@ -1,0 +1,74 @@
+import { mount } from '@vue/test-utils';
+import authConfigMixin from '@shell/mixins/auth-config';
+
+describe('mixin: authConfigMixin', () => {
+  describe('method: save', () => {
+    const componentMock = (model: any) => ({
+      data: () => ({
+        value: { configType: 'oidc' },
+        model,
+      }),
+      computed: { principal: () => ({ me: {} }) },
+      global:   {
+        mocks: {
+          $store: {
+            dispatch: () => model,
+            commit:   () => ({ 'auth/loggedInAs': jest.fn() }),
+          },
+          $route: {
+            params: { id: '123' },
+            query:  { mode: 'edit' },
+          },
+        }
+      }
+    });
+    const FakeComponent = {
+      render() {},
+      mixins:  [authConfigMixin],
+      methods: { applyHooks: jest.fn() },
+    };
+
+    it('should return error', async() => {
+      const instance = mount(FakeComponent, componentMock({
+        doAction: jest.fn(),
+        save:     'make it fail'
+      })).vm as any;
+      const fakeCallback = jest.fn();
+
+      await instance.save(fakeCallback);
+
+      expect(fakeCallback).toHaveBeenCalledWith(false);
+    });
+
+    it('should not return error', async() => {
+      const model = {
+        authConfigName: 'whatever',
+        doAction:       jest.fn(),
+        save:           async() => {}
+      };
+      const instance = mount(FakeComponent, componentMock(model)).vm as any;
+      const fakeCallback = jest.fn();
+
+      await instance.save(fakeCallback);
+
+      expect(fakeCallback).toHaveBeenCalledWith(true);
+    });
+
+    it.each([
+      'oidc'
+    ])('should keep custom scope on save', async(type) => {
+      const scope = 'openid profile email groups whatever';
+      const model = {
+        scope,
+        authConfigName: 'whatever',
+        doAction:       jest.fn(),
+        save:           async() => {}
+      };
+      const instance = mount(FakeComponent, componentMock(model)).vm as any;
+
+      await instance.save(jest.fn());
+
+      expect(instance.model.scope).toStrictEqual(scope);
+    });
+  });
+});

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -137,6 +137,14 @@ export default {
       }
     },
 
+    /**
+     * On save several operations are executed to return a URL or open pop-up:
+     * - Retrieve data from the UI
+     * - "Test" the configuration through action and override the model
+     * - Retrieve scopes from redirect URL
+     * - Set default scopes and merge them with the ones from the redirect URL and from the "test" action
+     * @param {*} btnCb
+     */
     async save(btnCb) {
       await this.applyHooks(BEFORE_SAVE_HOOKS);
 

--- a/shell/store/__tests__/auth.test.ts
+++ b/shell/store/__tests__/auth.test.ts
@@ -1,0 +1,120 @@
+import { actions } from '@shell/store/auth';
+import { createStore } from 'vuex';
+
+// jest.mock('@shell/utils/url', () => ({
+//   addParams:   () => ({}),
+//   parse:       () => ({}),
+//   removeParam: () => ({}),
+// }));
+
+describe('action: redirectTo', () => {
+  it('should include query parameters from redirect', async() => {
+    jest.spyOn(window, 'window', 'get');
+    const store = { dispatch: jest.fn() };
+    const clientId = '123';
+    const uri = 'anyURI';
+    const scope = 'anything';
+    const expectation = `:///?client_id=${ clientId }&redirect_uri=${ uri }&response_type=code&response_mode=query&scope=${ scope }&state=undefined`;
+    const options = {
+      provider:    'azuread',
+      redirect:    false,
+      redirectUrl: `?client_id=${ clientId }&redirect_uri=${ uri }&scope=${ scope }`,
+    };
+
+    const url = await actions.redirectTo(store as any, options);
+
+    expect(url).toStrictEqual(expectation);
+  });
+
+  it.each([
+    ['genericoidc', '://myhost/?redirect_uri=anyURI&scope=openid%20profile%20email&state=undefined'],
+  ])('given provider %p should return URL %p', async(provider, expectation) => {
+    jest.spyOn(window, 'window', 'get');
+    const store = { dispatch: jest.fn() };
+    const uri = 'anyURI'; // This field is added anyway, so we set a random value
+    const options = {
+      provider,
+      redirect:    false,
+      redirectUrl: `myhost?redirect_uri=${ uri }`,
+    };
+
+    const url = await actions.redirectTo(store as any, options);
+
+    expect(url).toStrictEqual(expectation);
+  });
+
+  describe.each([
+    // 'whatever',
+    // 'github',
+    // 'googleoauth',
+    // 'azuread',
+    // 'keycloakoidc',
+    'genericoidc',
+  ])('given provider %p', (provider) => {
+    it('should keep scope from options', async() => {
+      const customScope = 'myScope';
+      const options = {
+        provider,
+        redirectUrl: 'anyURL',
+        scopes:      customScope,
+        // scopesJoinChar: ' ', // it's not used for genericoidc
+        test:        true,
+        redirect:    false
+      };
+      const store = { dispatch: jest.fn() };
+
+      jest.spyOn(window, 'window', 'get');
+      const url = await actions.redirectTo(store as any, options);
+
+      expect(url).toContain(customScope);
+    });
+
+    it('should merge scopes into a single string and avoid duplication', async() => {
+      const defaultScopes = 'openid profile email';
+      const customScope = 'myScope';
+      const options = {
+        provider,
+        redirectUrl: 'anyURL',
+        scopes:      `${ defaultScopes } ${ customScope }`,
+        test:        true,
+        redirect:    false
+      };
+      const store = { dispatch: jest.fn() };
+
+      jest.spyOn(window, 'window', 'get');
+      const url = await actions.redirectTo(store as any, options);
+
+      expect(url).toContain('scope=openid%20profile%20email%20myScope&');
+    });
+  });
+});
+
+jest.mock('@shell/utils/auth');
+
+describe('action: test', () => {
+  describe('given providers with an action (github, google, azuread, oidc)', () => {
+    it('should call redirectTo with all the options', async() => {
+      const dispatchSpy = jest.fn().mockReturnValue('anyURL');
+      const store = createStore({
+        actions: {
+          getAuthConfig: () => ({ doAction: () => 'no action' }),
+          redirectTo:    dispatchSpy,
+        }
+      });
+      const provider = 'anyProvider';
+      const redirectUrl = undefined;
+      const body = { scope: ['any scope'] };
+      const options = {
+        provider,
+        redirectUrl,
+        scopes:   body.scope,
+        test:     true,
+        redirect: false
+      };
+
+      await actions.test(store, { provider, body });
+
+      expect(dispatchSpy.mock.calls[0][1]).toStrictEqual(options);
+    });
+  });
+});

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -1,7 +1,7 @@
 import { GITHUB_NONCE, GITHUB_REDIRECT, GITHUB_SCOPE } from '@shell/config/query-params';
 import { NORMAN } from '@shell/config/types';
 import { _MULTI } from '@shell/plugins/dashboard-store/actions';
-import { addObjects, findBy } from '@shell/utils/array';
+import { addObjects, findBy, joinStringList } from '@shell/utils/array';
 import { openAuthPopup, returnTo } from '@shell/utils/auth';
 import { base64Encode } from '@shell/utils/crypto';
 import { removeEmberPage } from '@shell/utils/ember-page';
@@ -230,18 +230,22 @@ export const actions = {
     const encodedNonce = await dispatch('encodeNonce', baseNonce);
 
     const fromQuery = unescape(parseUrl(redirectUrl).query?.[GITHUB_SCOPE] || '');
-    const scopes = fromQuery.split(/[, ]+/).filter((x) => !!x);
+    let scopes = fromQuery.split(/[, ]+/).filter((x) => !!x);
 
     if (BASE_SCOPES[provider]) {
       addObjects(scopes, BASE_SCOPES[provider]);
     }
 
-    if ( opt.scopes ) {
-      addObjects(scopes, opt.scopes);
+    // Need to merge these 2 formats preventing duplicates between code and UI, e.g.
+    // [ 'openid profile email' ] from BASE_SCOPES
+    // 'openid profile email customScope' from the UI
+    if (opt.scopes) {
+      scopes = [joinStringList(scopes[0], opt.scopes)];
     }
 
     let url = removeParam(redirectUrl, GITHUB_SCOPE);
 
+    // TODO: #13457 - Verify use case of scopesJoinChar anywhere outside this repository
     const params = {
       [GITHUB_SCOPE]: scopes.join(opt.scopesJoinChar || ','), // Some providers won't accept comma separated scopes
       [GITHUB_NONCE]: encodedNonce
@@ -310,6 +314,7 @@ export const actions = {
         const url = await dispatch('redirectTo', {
           provider,
           redirectUrl,
+          scopes:   body.scope,
           test:     true,
           redirect: false
         });

--- a/shell/utils/__tests__/array.test.ts
+++ b/shell/utils/__tests__/array.test.ts
@@ -1,5 +1,5 @@
 import {
-  addObject, addObjects, clear, filterBy, findBy, getUniqueLabelKeys, insertAt, isArray, removeAt, removeObject, removeObjects, replaceWith, sameContents, uniq
+  addObject, addObjects, clear, filterBy, findBy, getUniqueLabelKeys, insertAt, isArray, joinStringList, removeAt, removeObject, removeObjects, replaceWith, sameContents, uniq
 } from '@shell/utils/array';
 
 interface Obj {
@@ -498,5 +498,17 @@ describe('fx: getUniqueLabelKeys', () => {
     const result = getUniqueLabelKeys(resources);
 
     expect(result).toStrictEqual(expected);
+  });
+});
+
+describe('fx: joinStringList', () => {
+  it('should join two lists of strings', () => {
+    const a = 'a b c';
+    const b = 'b c d';
+    const separator = ' ';
+
+    const result = joinStringList(a, b, separator);
+
+    expect(result).toBe('a b c d');
   });
 });

--- a/shell/utils/array.ts
+++ b/shell/utils/array.ts
@@ -241,3 +241,16 @@ export function getUniqueLabelKeys<T extends KubeResource>(aryResources: T[]): s
 
   return Object.keys(uniqueObj).sort();
 }
+
+/**
+ * Join list as string into a new string without duplicates
+ * @param {string} a 'a b c'
+ * @param {string} b 'b c d'
+ * @param {string} [separator=' ']
+ * @return {string} 'a b c d'
+ */
+export const joinStringList = (a: string, b: string, separator = ' '): string => {
+  const all = a.split(separator).concat(b.split(separator));
+
+  return [...new Set(all)].join(separator);
+};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12589

Check original PR for details https://github.com/rancher/dashboard/pull/13514

### Occurred changes and/or fixed issues

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
