### PR TITLE
Fixed missing banner when editing local cluster

### DIFF
--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -471,6 +471,11 @@ export default defineComponent({
         :open-initially="true"
       >
         <Banner
+          v-if="isLocal"
+          color="warning"
+          label-key="imported.memberRoles.localBanner"
+        />
+        <Banner
           v-if="isEdit"
           color="info"
         >

--- a/pkg/imported/l10n/en-us.yaml
+++ b/pkg/imported/l10n/en-us.yaml
@@ -32,6 +32,8 @@ imported:
     label: Drain Worker Nodes
   drainControlPlaneNodes:
     label: Drain Control Plane Nodes
+  memberRoles:
+    localBanner: 'Caution: This is the cluster that Rancher is using as a data store. Only administrators should be given write access to this cluster. <br> Users with write access to this cluster can use it to grant themselves access to any other cluster managed by this installation.' 
   network:
     banner: The imported cluster must support Kubernetes NetworkPolicy resources for Project Network Isolation to be enforced
   accordions:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13303 
<!-- Define findings related to the feature or bug issue. -->
Added missing banner.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Cluster management -> Local -> edit
Make sure Member roles accordion has a warning banner 
"Caution: This is the cluster that Rancher is using as a data store. Only administrators should be given write access to this cluster.
Users with write access to this cluster can use it to grant themselves access to any other cluster managed by this installation."

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Imported cluster creation and edit should not show the banner

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1487" alt="Screenshot 2025-03-11 at 9 39 28 AM" src="https://github.com/user-attachments/assets/0aeb1463-1228-46d6-856d-a39ab1d0b0c8" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
