### PR TITLE
add a loading spinner to the import gke cluster dropdown

### DIFF
--- a/pkg/gke/components/Import.vue
+++ b/pkg/gke/components/Import.vue
@@ -71,7 +71,10 @@ export default defineComponent({
 
   data() {
     return {
-      clustersResponse: {} as getGKEClustersResponse, debouncedloadGKEClusters: () => {}, loadClusterFailed: false
+      clustersResponse:         {} as getGKEClustersResponse,
+      debouncedloadGKEClusters: () => {},
+      loadingClusters:          false,
+      loadClusterFailed:        false
     };
   },
 
@@ -99,6 +102,8 @@ export default defineComponent({
   methods: {
     // query for GKE clusters every time credentials or region change
     async loadGKEClusters() {
+      this.loadingClusters = true;
+      this.loadClusterFailed = false;
       try {
         const res = await getGKEClusters(this.$store, this.credential, this.project, { zone: this.zone, region: this.region });
 
@@ -111,6 +116,7 @@ export default defineComponent({
       } catch (err:any) {
         this.$emit('error', err);
       }
+      this.loadingClusters = false;
     },
   },
 
@@ -123,6 +129,7 @@ export default defineComponent({
       <div class="col span-6">
         <LabeledSelect
           v-if="!loadClusterFailed"
+          :loading="loadingClusters"
           :value="clusterName"
           :mode="mode"
           :label="t('gke.import.cluster.label')"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13686


### Screenshot/Video

https://github.com/user-attachments/assets/49837b2d-2e2f-4f13-9522-a71d7571f680



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
