### PR TITLE
Replace translated data prop with computed prop in ServiceType

### DIFF
--- a/shell/components/formatter/ServiceType.vue
+++ b/shell/components/formatter/ServiceType.vue
@@ -16,13 +16,13 @@ export default {
       default: () => {}
     },
   },
-  data() {
-    const cloned = this.getLabel(this.value.toLowerCase());
-
-    return { translated: cloned };
-  },
 
   computed: {
+    translated() {
+      const value = this.value;
+
+      return this.getLabel(value.toLocaleLowerCase());
+    },
     clusterIp() {
       return this.row?.spec?.clusterIP;
     },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This ensures that the translation properly updates when sorting by making the translation a computed property.

Fixes #12982
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Move the translation from data to a computed property

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This is really just a cherry pick of a change from one of the 2.12 PRs for correcting antipatterns in data props #13669 (a1e78f5fd7871764d86929387cdc86f5b2516d98).

I originally limited my change in an attempt to avoid disrupting too much, but it appears that the correct choice would have been to go all the way.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

See [this comment](https://github.com/rancher/dashboard/issues/12982#issuecomment-2712090380) for details

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Local Cluster => Service Discovery => Services => Sorting on Type should work correctly; the default translation should properly update in the cell if it is replace with a different string.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

- NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
