### PR TITLE
Schedule: When creating a CIS Benchmark scan the input @daily is accepted but the 'Create' button remains greyed out

### DIFF
--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
@@ -158,6 +158,7 @@ export default defineComponent({
       :disabled="isDisabled"
       :name="name"
       :value="''+val"
+      :data-testid="label"
       :checked="isChecked"
       type="radio"
       :tabindex="-1"

--- a/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
@@ -258,6 +258,7 @@ export default defineComponent({
             :description="option.description"
             :val="option.value"
             :disabled="isDisabled"
+            :data-testid="`radio-button-${i}`"
             :mode="mode"
             :prevent-focus-on-radio-groups="true"
             @update:value="$emit('update:value', $event)"

--- a/shell/edit/__tests__/cis.cattle.io.clusterscan.test.ts
+++ b/shell/edit/__tests__/cis.cattle.io.clusterscan.test.ts
@@ -1,0 +1,35 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import cisEditor from '@shell/edit/cis.cattle.io.clusterscan.vue';
+
+describe('view: cisEditor', () => {
+  it('renders the component', () => {
+    const wrapper: VueWrapper<any, any> = mount(cisEditor, {
+      props: {
+        value: {
+          spec:           { scanProfileName: 'whatever' },
+          canBeScheduled: () => true,
+        }
+      },
+      global: {
+        mocks: {
+          $fetchState: { pending: false },
+          $route:      {
+            name:  'whatever',
+            query: { AS: 'whatever' },
+          },
+          $store: {
+            getters: {
+              'i18n/t':             () => 'whatever',
+              currentStore:         () => 'whatever',
+              'whatever/schemaFor': jest.fn(),
+            },
+            dispatch: jest.fn(),
+          },
+        },
+        stubs: { AsyncButton: true }
+      }
+    });
+
+    expect(wrapper.exists()).toBe(true);
+  });
+});

--- a/shell/edit/__tests__/cis.cattle.io.clusterscan.test.ts
+++ b/shell/edit/__tests__/cis.cattle.io.clusterscan.test.ts
@@ -2,11 +2,13 @@ import { mount, type VueWrapper } from '@vue/test-utils';
 import cisEditor from '@shell/edit/cis.cattle.io.clusterscan.vue';
 
 describe('view: cisEditor', () => {
-  it('renders the component', () => {
-    const wrapper: VueWrapper<any, any> = mount(cisEditor, {
+  let wrapper: VueWrapper<any, any>;
+
+  beforeEach(() => {
+    wrapper = mount(cisEditor, {
       props: {
         value: {
-          spec:           { scanProfileName: 'whatever' },
+          spec:           { scanProfileName: null, canBeScheduled: () => true },
           canBeScheduled: () => true,
         }
       },
@@ -29,7 +31,31 @@ describe('view: cisEditor', () => {
         stubs: { AsyncButton: true }
       }
     });
+  });
 
+  it('renders the component', () => {
     expect(wrapper.exists()).toBe(true);
+  });
+
+  it('should prevent to save', () => {
+    const saveButton = wrapper.find('[data-testid="form-save"]');
+
+    expect(saveButton.attributes().disabled).toStrictEqual('true');
+  });
+
+  describe('should allow to save', () => {
+    it('given a scanProfileName', async() => {
+      wrapper.setProps({
+        value: {
+          spec:           { scanProfileName: 'this is valid', canBeScheduled: () => true },
+          canBeScheduled: () => true,
+        }
+      });
+      await wrapper.vm.$nextTick();
+
+      const saveButton = wrapper.find('[data-testid="form-save"]');
+
+      expect(saveButton.attributes().disabled).toStrictEqual('false');
+    });
   });
 });

--- a/shell/edit/cis.cattle.io.clusterscan.vue
+++ b/shell/edit/cis.cattle.io.clusterscan.vue
@@ -192,7 +192,19 @@ export default {
         if (!schedule) {
           return false;
         } else {
-          return isValidCron(schedule) && !!this.value.spec.scanProfileName;
+          // TODO - #13202: This is required due use of 2 libraries and 3 different libraries through the code.
+          const predefined = [
+            '@yearly',
+            '@annually',
+            '@monthly',
+            '@weekly',
+            '@daily',
+            '@midnight',
+            '@hourly'
+          ];
+          const isPredefined = predefined.includes(schedule);
+
+          return (isPredefined || isValidCron(schedule)) && !!this.value.spec.scanProfileName;
         }
       }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13376
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

Extended further custom validation for CIS Benchmark as for other 3 cases.

### Technical notes summary

- Added `data-testid` of `RadioButton`
- Created validation for CIS Benchmark

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
