### PR TITLE
Remove duplicate container selector in Logging, create Cluster Flow page

### DIFF
--- a/shell/edit/logging-flow/Match.vue
+++ b/shell/edit/logging-flow/Match.vue
@@ -119,27 +119,6 @@ export default {
       <div v-if="isClusterFlow">
         <div class="spacer" />
         <h3>
-          {{ value.select ? t('logging.flow.matches.containerNames.title.include') : t('logging.flow.matches.containerNames.title.exclude') }}
-        </h3>
-        <div class="row">
-          <div class="col span-12">
-            <Select
-              v-model:value="value.namespaces"
-              class="lg"
-              :options="namespaces"
-              :placeholder="t('logging.flow.matches.namespaces.placeholder')"
-              :multiple="true"
-              :taggable="true"
-              :clearable="true"
-              :searchable="true"
-              :close-on-select="false"
-              no-options-label-key="logging.flow.matches.containerNames.enter"
-              placement="top"
-            />
-          </div>
-        </div>
-        <div class="spacer" />
-        <h3>
           {{ value.select ? t('logging.flow.matches.namespaces.title.include') : t('logging.flow.matches.namespaces.title.exclude') }}
         </h3>
         <div class="row">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/13600
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
