### PR TITLE
Disallow matching charts with undefined home values

### DIFF
--- a/shell/models/__tests__/catalog.cattle.io.app.test.ts
+++ b/shell/models/__tests__/catalog.cattle.io.app.test.ts
@@ -1,5 +1,6 @@
 import CatalogApp from '@shell/models/catalog.cattle.io.app';
 import { APP_UPGRADE_STATUS } from '@shell/store/catalog';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
 
 const latestVersion = '1.16.2';
 const secondLatestVersion = '1.16.1';
@@ -88,9 +89,10 @@ const certManagerOfficialMatchingChart2 = {
 
 const installedCertManagerAppCoFromRancherUI = {
   metadata: {
-    name:    chartName,
-    home:    appCo.home,
-    version: secondLatestVersion
+    annotations: { [CATALOG_ANNOTATIONS.SOURCE_REPO_NAME]: appCo.repoName },
+    name:        chartName,
+    home:        appCo.home,
+    version:     secondLatestVersion
   }
 };
 
@@ -104,9 +106,10 @@ const installedCertManagerOfficialFromCli = {
 
 const installedCertManagerOfficialFromRancherUI = {
   metadata: {
-    name:    chartName,
-    home:    certManagerOfficial.oldHome,
-    version: secondLatestVersion
+    annotations: { [CATALOG_ANNOTATIONS.SOURCE_REPO_NAME]: certManagerOfficial.repoName },
+    name:        chartName,
+    home:        certManagerOfficial.oldHome,
+    version:     secondLatestVersion
   }
 };
 

--- a/shell/models/catalog.cattle.io.app.js
+++ b/shell/models/catalog.cattle.io.app.js
@@ -90,8 +90,8 @@ export default class CatalogApp extends SteveModel {
         const { version, home } = versions[i];
 
         // Finding the exact version, if the version is not there, then most likely it's not a match
-        // if the exact version is found, then we can compare the home values when they exist
-        if (version === this.currentVersion && (!home || !thisHome || home === thisHome)) {
+        // if the exact version is found, then we can compare the home value
+        if (version === this.currentVersion && (home === thisHome)) {
           return true;
         }
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13704 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Made matching chart logic more strict
- Updated unit test mocks to be more accurate

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
