### PR TITLE
Improve handling of missing schemas

### DIFF
--- a/shell/detail/node.vue
+++ b/shell/detail/node.vue
@@ -49,23 +49,25 @@ export default {
   },
 
   async fetch() {
-    this.filterByApi = this.$store.getters[`cluster/paginationEnabled`](POD);
+    if (this.podSchema) {
+      this.filterByApi = this.$store.getters[`cluster/paginationEnabled`](POD);
 
-    if (this.filterByApi) {
+      if (this.filterByApi) {
       // Only get pods associated with this node. The actual values used are from a get all in node model `pods` getter (this works as it just gets all...)
-      const opt = { // Of type ActionFindPageArgs
-        pagination: new FilterArgs({
-          sort:    [{ field: 'metadata.name', asc: true }],
-          filters: PaginationParamFilter.createSingleField({
-            field: 'spec.nodeName',
-            value: this.value.id,
+        const opt = { // Of type ActionFindPageArgs
+          pagination: new FilterArgs({
+            sort:    [{ field: 'metadata.name', asc: true }],
+            filters: PaginationParamFilter.createSingleField({
+              field: 'spec.nodeName',
+              value: this.value.id,
+            })
           })
-        })
-      };
+        };
 
-      this.$store.dispatch(`cluster/findPage`, { type: POD, opt });
-    } else {
-      this.$store.dispatch('cluster/findAll', { type: POD });
+        this.$store.dispatch(`cluster/findPage`, { type: POD, opt });
+      } else {
+        this.$store.dispatch('cluster/findAll', { type: POD });
+      }
     }
 
     this.showMetrics = await allDashboardsExist(this.$store, this.currentCluster.id, [NODE_METRICS_DETAIL_URL, NODE_METRICS_SUMMARY_URL]);
@@ -97,6 +99,7 @@ export default {
         VALUE,
         EFFECT
       ],
+      podSchema,
       podTableHeaders: this.$store.getters['type-map/headersFor'](podSchema),
       NODE_METRICS_DETAIL_URL,
       NODE_METRICS_SUMMARY_URL,
@@ -241,6 +244,7 @@ export default {
       @update:value="$emit('input', $event)"
     >
       <Tab
+        v-if="podSchema"
         name="pods"
         :label="t('node.detail.tab.pods')"
         :weight="4"

--- a/shell/store/type-map.utils.ts
+++ b/shell/store/type-map.utils.ts
@@ -62,12 +62,12 @@ export function createHeaders(
   } = columns;
   const { rootGetters } = ctx;
   const out = typeOptions.showState ? [stateColumn] : [];
-  const attributes = (schema.attributes as SchemaAttribute) || {};
-  const columnsFromSchema = attributes.columns || [];
+  const attributes = (schema?.attributes as SchemaAttribute) || {};
+  const columnsFromSchema = attributes?.columns || [];
 
   // A specific list has been provided
-  if ( headers?.[schema.id]?.length ) {
-    return headers[schema.id].map((entry: any) => {
+  if ( headers?.[schema?.id]?.length ) {
+    return headers[schema?.id].map((entry: any) => {
       if ( typeof entry === 'string' ) {
         const col = findBy(columnsFromSchema, 'name', entry);
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13747
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- make ported `createHeaders` schema null safe
- ensure node detail page handles no pods permissions
- both are pre 2.11 issues (though some code has changed locations)
- similar concept to https://github.com/rancher/dashboard/pull/13478, but not same specifics 
  - user could not see events so no schema
  - in data we access headers for events with missing schema
- discovered when investigating https://github.com/rancher/dashboard/issues/13722


### Areas or cases that should be tested
- as per issue

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
