### PR TITLE
Adding a test to ensure we can create resource without custom forms via yaml

### DIFF
--- a/cypress/e2e/po/pages/explorer/coordination.k8s.io.lease.ts
+++ b/cypress/e2e/po/pages/explorer/coordination.k8s.io.lease.ts
@@ -1,0 +1,32 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
+
+export class LeasesPagePo extends PagePo {
+  private static createPath(clusterId: string) {
+    return `/c/${ clusterId }/explorer/coordination.k8s.io.lease`;
+  }
+
+  urlPath(clusterId = 'local') {
+    return LeasesPagePo.createPath(clusterId);
+  }
+
+  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(LeasesPagePo.createPath(clusterId));
+  }
+
+  constructor(clusterId = 'local') {
+    super(LeasesPagePo.createPath(clusterId));
+  }
+
+  list() {
+    return new BaseResourceList(this.self());
+  }
+
+  clickCreateYaml() {
+    return this.list().masthead().createYaml();
+  }
+
+  listElementWithName(name: string) {
+    return this.list().resourceTable().sortableTable().rowElementWithName(name);
+  }
+}

--- a/cypress/e2e/tests/pages/explorer/more-resources/yaml/no-form-resource.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/more-resources/yaml/no-form-resource.spec.ts
@@ -1,0 +1,30 @@
+import { LeasesPagePo } from '@/cypress/e2e/po/pages/explorer/coordination.k8s.io.lease';
+
+const leasesPage = new LeasesPagePo();
+
+describe('No Custom Form Resource', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, () => {
+  before(() => {
+    cy.login();
+  });
+
+  describe('List', { tags: ['@adminUser'] }, () => {
+    before('set up', () => {
+      cy.updateNamespaceFilter('local', 'none', '{"local":["all://user"]}');
+    });
+
+    it(`can create a resource using the 'Create from YAML' button`, () => {
+      leasesPage.goTo();
+      leasesPage.waitForPage();
+
+      leasesPage.clickCreateYaml();
+
+      cy.get('[data-testid="action-button-async-button"]').click();
+
+      leasesPage.waitForPage();
+      leasesPage.list().resourceTable().sortableTable().rowNames()
+        .then((names) => {
+          expect(names).to.have.length.greaterThan(0);
+        });
+    });
+  });
+});


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/5092

### Occurred changes and/or fixed issues
We add one e2e test to cover a case where we had a bug in the past around creating a new resource via yaml when the resource doesn't have a custom form.


### Areas or cases that should be tested
None

### Areas which could experience regressions
None

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
