### PR TITLE
[2.12] Handle pagination in EKS AWS ListRoles request

### DIFF
--- a/pkg/eks/components/Config.vue
+++ b/pkg/eks/components/Config.vue
@@ -106,7 +106,7 @@ export default defineComponent({
     const t = store.getters['i18n/t'];
 
     return {
-      kmsInfo:               {} as {Keys:AWS.KmsKey[]},
+      kmsKeys:               [] as AWS.KmsKey[],
       canReadKms:            false,
       supportedVersionRange,
       customServiceRole:     !!this.serviceRole && !!this.serviceRole.length,
@@ -213,7 +213,7 @@ export default defineComponent({
     },
 
     kmsOptions(): string[] {
-      return (this.kmsInfo?.Keys || []).map((k) => k.KeyArn);
+      return (this.kmsKeys || []).map((k) => k.KeyArn);
     }
   },
 
@@ -228,9 +228,7 @@ export default defineComponent({
       this.loadingVersions = true;
       try {
         const eksClient = await this.$store.dispatch('aws/eks', { region: this.config.region, cloudCredentialId: this.config.amazonCredentialSecret });
-
-        const res = await eksClient.describeAddonVersions({});
-        const addons = res?.addons;
+        const addons = await this.$store.dispatch('aws/depaginateList', { client: eksClient, cmd: 'describeAddonVersions' });
 
         if (!addons) {
           return;
@@ -264,7 +262,8 @@ export default defineComponent({
       const kmsClient = await store.dispatch('aws/kms', { region, cloudCredentialId: amazonCredentialSecret });
 
       try {
-        this.kmsInfo = await kmsClient.listKeys({});
+        this.kmsKeys = await this.$store.dispatch('aws/depaginateList', { client: kmsClient, cmd: 'listKeys' });
+
         this.canReadKms = true;
       } catch (e) {
         this.canReadKms = false;

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -260,7 +260,7 @@ export default defineComponent({
       loadingLaunchTemplates: false,
       loadingSshKeyPairs:     false,
       loadingIam:             false,
-      iamInfo:                {} as {Roles: AWS.IamRole[]},
+      iamInfo:                [] as AWS.IamRole[],
       ec2Roles:               [] as AWS.IamRole[],
       eksRoles:               [] as AWS.IamRole[],
       sshKeyPairs:            [] as string[],
@@ -276,12 +276,12 @@ export default defineComponent({
   },
 
   watch: {
-    'iamInfo'(neu: {Roles: AWS.IamRole[]}) {
+    'iamInfo'(neu: AWS.IamRole[]) {
       const ec2Roles = [] as AWS.IamRole[];
       const eksRoles = [] as AWS.IamRole[];
-      const allRoles = neu?.Roles;
+      const allRoles = neu;
 
-      allRoles.forEach((role: AWS.IamRole) => {
+      (allRoles || []).forEach((role: AWS.IamRole) => {
         const policy = JSON.parse(decodeURIComponent(role.AssumeRolePolicyDocument));
         const statement = policy.Statement;
 
@@ -559,9 +559,9 @@ export default defineComponent({
       try {
         const ec2Client = await store.dispatch('aws/ec2', { region: this.config.region, cloudCredentialId: this.config.amazonCredentialSecret });
 
-        const launchTemplateInfo = await ec2Client.describeLaunchTemplates({ DryRun: false });
-
-        this.launchTemplates = launchTemplateInfo.LaunchTemplates;
+        this.launchTemplates = await store.dispatch('aws/depaginateList', {
+          client: ec2Client, cmd: 'describeLaunchTemplates', opt: { DryRun: false }
+        });
       } catch (err: any) {
         const errors = this.errors as any[];
 
@@ -581,7 +581,9 @@ export default defineComponent({
       const iamClient = await store.dispatch('aws/iam', { region, cloudCredentialId: amazonCredentialSecret });
 
       try {
-        this.iamInfo = await iamClient.listRoles({});
+        const res = await store.dispatch('aws/depaginateList', { client: iamClient, cmd: 'listRoles' });
+
+        this.iamInfo = res;
       } catch (err: any) {
         const errors = this.errors as any[];
 

--- a/pkg/eks/components/Networking.vue
+++ b/pkg/eks/components/Networking.vue
@@ -114,8 +114,8 @@ export default defineComponent({
     return {
       loadingVpcs:           false,
       loadingSecurityGroups: false,
-      vpcInfo:               {} as {Vpcs: AWS.VPC[]},
-      subnetInfo:            {} as {Subnets: AWS.Subnet[]},
+      vpcInfo:               [] as AWS.VPC[],
+      subnetInfo:            [] as AWS.Subnet[],
       securityGroupInfo:     {} as {SecurityGroups: AWS.SecurityGroup[]},
       chooseSubnet:          !!this.subnets && !!this.subnets.length
     };
@@ -127,8 +127,8 @@ export default defineComponent({
     // {[vpc id]: [subnets]}
     vpcOptions() {
       const out: {key:string, label:string, _isSubnet?:boolean, kind?:string}[] = [];
-      const vpcs: AWS.VPC[] = this.vpcInfo?.Vpcs || [];
-      const subnets: AWS.Subnet[] = this.subnetInfo?.Subnets || [];
+      const vpcs: AWS.VPC[] = this.vpcInfo || [];
+      const subnets: AWS.Subnet[] = this.subnetInfo || [];
       const mappedSubnets: {[key:string]: AWS.Subnet[]} = {};
 
       subnets.forEach((s) => {
@@ -204,7 +204,7 @@ export default defineComponent({
         return null;
       }
 
-      return (this.subnetInfo?.Subnets || []).find((s) => this.subnets.includes(s.SubnetId))?.VpcId;
+      return (this.subnetInfo || []).find((s) => this.subnets.includes(s.SubnetId))?.VpcId;
     },
 
     isNew(): boolean {
@@ -228,8 +228,8 @@ export default defineComponent({
       const ec2Client = await store.dispatch('aws/ec2', { region, cloudCredentialId: amazonCredentialSecret });
 
       try {
-        this.vpcInfo = await ec2Client.describeVpcs({ });
-        this.subnetInfo = await ec2Client.describeSubnets({ });
+        this.vpcInfo = await this.$store.dispatch('aws/depaginateList', { client: ec2Client, cmd: 'describeVpcs' });
+        this.subnetInfo = await this.$store.dispatch('aws/depaginateList', { client: ec2Client, cmd: 'describeSubnets' });
       } catch (err) {
         this.$emit('error', err);
       }

--- a/pkg/eks/components/__tests__/Config.test.ts
+++ b/pkg/eks/components/__tests__/Config.test.ts
@@ -29,16 +29,15 @@ const mockedStore = (versionSetting: any) => {
         return versionSetting;
       },
     },
-    dispatch: () => {
-      return {
-        listKeys: () => {
-          return listKeysResponseData;
-        },
-        describeAddonVersions: () => {
-          return describeAddonVersionsResponseData;
-        }
-
-      };
+    dispatch: (ctx: any, { cmd }:{cmd?:string}) => {
+      switch (cmd) {
+      case 'listKeys':
+        return listKeysResponseData.Keys;
+      case 'describeAddonVersions':
+        return describeAddonVersionsResponseData.addons;
+      default:
+        return {};
+      }
     }
   };
 };
@@ -107,11 +106,11 @@ describe('eKS K8s configuration', () => {
     expect(wrapper.exists()).toBe(true);
     expect(spy).toHaveBeenCalledTimes(0);
     await setCredential(wrapper);
-    expect(spy).toHaveBeenCalledTimes(4);
+    expect(spy).toHaveBeenCalledTimes(8);
 
     wrapper.setProps({ config: { amazonCredentialSecret: 'foo', region: 'rab' } });
     await flushPromises();
-    expect(spy).toHaveBeenCalledTimes(6);
+    expect(spy).toHaveBeenCalledTimes(12);
     expect(spy).toHaveBeenCalledWith('aws/eks', { cloudCredentialId: 'foo', region: 'rab' });
     expect(spy).toHaveBeenCalledWith('aws/kms', { cloudCredentialId: 'foo', region: 'rab' });
   });
@@ -134,11 +133,11 @@ describe('eKS K8s configuration', () => {
 
     expect(spy).toHaveBeenCalledTimes(0);
     await setCredential(wrapper);
-    expect(spy).toHaveBeenCalledTimes(4);
+    expect(spy).toHaveBeenCalledTimes(8);
 
     wrapper.setProps({ config: { amazonCredentialSecret: 'oof', region: 'bar' } });
     await flushPromises();
-    expect(spy).toHaveBeenCalledTimes(6);
+    expect(spy).toHaveBeenCalledTimes(12);
     expect(spy).toHaveBeenCalledWith('aws/eks', { cloudCredentialId: 'oof', region: 'bar' });
     expect(spy).toHaveBeenCalledWith('aws/kms', { cloudCredentialId: 'oof', region: 'bar' });
   });
@@ -310,16 +309,15 @@ describe('eKS K8s configuration', () => {
   it('should show a text input for kms key arns if no data if the api call throws an error', async() => {
     const failingStoreMock = {
       ...mockedStore({ value: '<=1.27.x' }),
-      dispatch: () => {
-        return {
-          listKeys: () => {
-            throw new Error('failed to load keys blah blah');
-          },
-          describeAddonVersions: () => {
-            return describeAddonVersionsResponseData;
-          }
-
-        };
+      dispatch: (ctx: any, { cmd }:{cmd?:string}) => {
+        switch (cmd) {
+        case 'listKeys':
+          throw new Error('failed to load keys');
+        case 'describeAddonVersions':
+          return describeAddonVersionsResponseData.addons;
+        default:
+          return {};
+        }
       }
     };
 

--- a/pkg/eks/components/__tests__/CruEKS.test.ts
+++ b/pkg/eks/components/__tests__/CruEKS.test.ts
@@ -22,18 +22,20 @@ const mockedStore = (versionSetting: any) => {
         return {};
       }
     },
-    dispatch: () => {
-      return {
-        describeKeyPairs: () => {
-          return describeKeyPairs;
-        },
-        describeLaunchTemplates: () => {
-          return describeLaunchTemplates;
-        },
-        listRoles: () => {
-          return { Roles: [] };
-        }
-      };
+
+    dispatch: (ctx: any, { cmd }:{cmd?:string}) => {
+      switch (cmd) {
+      case 'describeLaunchTemplates':
+        return describeLaunchTemplates.LaunchTemplates;
+      case 'listRoles':
+        return [];
+      default:
+        return {
+          describeKeyPairs: () => {
+            return describeKeyPairs;
+          }
+        };
+      }
     }
   };
 };

--- a/pkg/eks/components/__tests__/Networking.test.ts
+++ b/pkg/eks/components/__tests__/Networking.test.ts
@@ -128,7 +128,7 @@ describe('eKS Networking', () => {
     });
 
     const fetchVpcsSpy = jest.spyOn(Networking.methods, 'fetchVpcs').mockImplementation(() => {
-      wrapper.setData({ subnetInfo: SubnetData, vpcInfo: VpcData });
+      wrapper.setData({ subnetInfo: SubnetData.Subnets, vpcInfo: VpcData.Vpcs });
     });
 
     wrapper = shallowMount(Networking, {
@@ -160,7 +160,7 @@ describe('eKS Networking', () => {
     });
 
     jest.spyOn(Networking.methods, 'fetchVpcs').mockImplementation(() => {
-      wrapper.setData({ subnetInfo: SubnetData, vpcInfo: VpcData });
+      wrapper.setData({ subnetInfo: SubnetData.Subnets, vpcInfo: VpcData.Vpcs });
     });
 
     wrapper = shallowMount(Networking, {
@@ -197,7 +197,7 @@ describe('eKS Networking', () => {
     });
 
     jest.spyOn(Networking.methods, 'fetchVpcs').mockImplementation(() => {
-      wrapper.setData({ subnetInfo: SubnetData, vpcInfo: VpcData });
+      wrapper.setData({ subnetInfo: SubnetData.Subnets, vpcInfo: VpcData.Vpcs });
     });
 
     wrapper = shallowMount(Networking, {
@@ -230,7 +230,7 @@ describe('eKS Networking', () => {
     });
 
     jest.spyOn(Networking.methods, 'fetchVpcs').mockImplementation(() => {
-      wrapper.setData({ subnetInfo: SubnetData, vpcInfo: VpcData });
+      wrapper.setData({ subnetInfo: SubnetData.Subnets, vpcInfo: VpcData.Vpcs });
     });
 
     wrapper = shallowMount(Networking, {

--- a/shell/store/aws.js
+++ b/shell/store/aws.js
@@ -241,8 +241,15 @@ export const actions = {
       }
 
       addObjects(out, res[key]);
-      opt.NextToken = res.NextToken;
-      hasNext = !!res.NextToken;
+      if (res.NextToken) {
+        opt.NextToken = res.NextToken;
+        hasNext = true;
+      } else if (res.Marker) {
+        opt.Marker = res.Marker;
+        hasNext = true;
+      } else {
+        hasNext = false;
+      }
     }
 
     return out;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11554 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates aws api calls made in the EKS provisioning form to account for pagination. The instance type api call already handled pagination. `describeKeyPairs` and `describeSecurityGroups` are not paginated.


### Technical notes summary
[DescribeAddonVersions](https://docs.aws.amazon.com/eks/latest/APIReference/API_DescribeAddonVersions.html) 
[ListRoles](https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListRoles.html) 
[DescribeLaunchTemplates](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeLaunchTemplates.html) 
[DescribeKeyPairs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeKeyPairs.html) - not paginated
[ListKeys](https://docs.aws.amazon.com/kms/latest/APIReference/API_ListKeys.html)
[DescribeVpcs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVpcs.html)
[DescribeSubnets](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html) 
[DescribeSecurityGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html) - not paginated

### Areas or cases that should be tested
We have too few of most types of resources to get paginated responses from aws by default. I found the easiest way to test pagination was to alter the dashboard code to lower the number of items returned in a response. Different API calls use a different parameter to do that: describeX calls accept `MaxIResults` while `ListRoles` accepts `MaxItems` and `ListKeys` accepts `Limit` eg

`const addons = await this.$store.dispatch('aws/depaginateList', { client: eksClient, cmd: 'describeAddonVersions', opt:{MaxResults: 3} });`

To verify pagination, you may set a limit on the number of items returned per request, then watch the network tab and verify that multiple requests are made to fetch all items

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
