### PR TITLE
[BUG] Keycloak generated Auth and Issuer endpoints are using outdated URL patterns

### DIFF
--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -148,4 +148,35 @@ describe('oidc.vue', () => {
     expect(groupSearchCheckbox.isVisible()).toBe(true);
     expect(wrapper.vm.model.groupSearchEnabled).toBe(true);
   });
+
+  it('changing URL should update issuer and auth-endpoint if Keycloak', async() => {
+    wrapper.vm.model.id = 'keycloakoidc';
+    const newUrl = 'whatever';
+
+    await wrapper.find(`[data-testid="oidc-url"]`).setValue(newUrl);
+    await wrapper.vm.$nextTick();
+
+    const issuer = (wrapper.find('[data-testid="oidc-issuer"]').element as HTMLInputElement).value;
+    const endpoint = (wrapper.find('[data-testid="oidc-auth-endpoint"]').element as HTMLInputElement).value;
+
+    expect(issuer).toBe(`${ newUrl }/realms/`);
+    expect(endpoint).toBe(`${ newUrl }/realms//protocol/openid-connect/auth`);
+  });
+
+  it('changing realm should update issuer and auth-endpoint if Keycloak', async() => {
+    const newRealm = 'newRealm';
+    const oldUrl = 'oldUrl';
+
+    wrapper.vm.model.id = 'keycloakoidc';
+    wrapper.vm.oidcUrls.url = oldUrl;
+
+    await wrapper.find(`[data-testid="oidc-realm"]`).setValue(newRealm);
+    await wrapper.vm.$nextTick();
+
+    const issuer = (wrapper.find('[data-testid="oidc-issuer"]').element as HTMLInputElement).value;
+    const endpoint = (wrapper.find('[data-testid="oidc-auth-endpoint"]').element as HTMLInputElement).value;
+
+    expect(issuer).toBe(`${ oldUrl }/realms/${ newRealm }`);
+    expect(endpoint).toBe(`${ oldUrl }/realms/${ newRealm }/protocol/openid-connect/auth`);
+  });
 });

--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -1,6 +1,6 @@
 import { nextTick } from 'vue';
 /* eslint-disable jest/no-hooks */
-import { mount } from '@vue/test-utils';
+import { mount, type VueWrapper } from '@vue/test-utils';
 import { _EDIT } from '@shell/config/query-params';
 
 import oidc from '@shell/edit/auth/oidc.vue';
@@ -32,7 +32,7 @@ const mockModel = {
 };
 
 describe('oidc.vue', () => {
-  let wrapper: any;
+  let wrapper: VueWrapper<any, any>;
   const requiredSetup = () => ({
     data() {
       return {
@@ -44,7 +44,7 @@ describe('oidc.vue', () => {
         originalModel:  null,
         principals:     [],
         authConfigName: 'oidc',
-      };
+      } as any; // any is necessary as in pre-existing tests we are including inherited mixins values
     },
     global: {
       mocks: {

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -136,7 +136,7 @@ export default {
       const isKeycloak = this.model.id === 'keycloakoidc';
 
       const url = this.oidcUrls.url.replaceAll(' ', '');
-      const realmsPath = isKeycloak ? 'auth/realms' : 'realms';
+      const realmsPath = 'realms';
 
       this.model.issuer = `${ url }/${ realmsPath }/${ this.oidcUrls.realm || '' }`;
 

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/Advanced.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/Advanced.test.ts
@@ -45,8 +45,6 @@ describe('component: Advanced', () => {
         mountOptions
       );
 
-      // eslint-disable-next-line no-console
-      console.log(wrapper.html());
       const inputElem = wrapper.find('[data-testid="array-list-box0"]');
 
       expect(inputElem.exists()).toBe(false);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12926

Since the issue is not clear, the steps are:
- Navigate to `User & Authentication` > `Auth Provider` > `Keycloak OIDC`, or `/c/local/auth/config/keycloakoidc?mode=edit`
- Scroll down and add an URL or any string value to `Endpoints > URL`
- `Issuer` URL should get prefixed with specified URL
- Add `realm` input
- The realm value should be appended to both `Issuer` and `Auth endpoint`

### Occurred changes and/or fixed issues

Changed auto-generated URL structure:
- From: `https://my.url/auth/realms/my-realm`
- To: `https://my.url/realms/my-realm`

### Technical notes summary

- Removed `console.log()` from `shell/edit/provisioning.cattle.io.cluster/__tests__/Advanced.test.ts`
- Added unit tests for the input autocompletion

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

https://github.com/user-attachments/assets/45cdfb8f-ca0e-47a2-91e0-52469592e35a

### Checklist

- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
