### PR TITLE
Add extension catalog page and initial contents

### DIFF
--- a/docusaurus/docs/extensions/catalog.mdx
+++ b/docusaurus/docs/extensions/catalog.mdx
@@ -1,0 +1,43 @@
+# Extensions Catalog
+
+import Catalog from '../../plugins/catalog/Catalog.tsx'
+
+For information on adding your extension to this page, see here. For information of developing your own extension, check out the [developer documentation](http://localhost:3000/extensions/next/extensions-getting-started).
+
+**Prime**
+
+Prime Extensions are developed by [SUSE](https://www.suse.com/) and available to [Rancher Prime](https://www.rancher.com/products/rancher-platform) customers.
+
+<Catalog group="prime"/>
+
+**Partner**
+
+Partner Extensions are developed by [SUSE Partners](https://www.suse.com/partners/) and are available to all Rancher users form the partner extensions catalog that is installed by default.
+
+<Catalog group="partner"/>
+
+**Community**
+
+Community Extensions cover all other extensions developed by the community. SUSE has not vetted, reviewed or verified these extensions and takes no liability for them. Use of
+these extensions is at your own risk.
+
+<Catalog/>
+
+## Add your extension to this page
+
+Fork this repository and create a new yaml file in the `docusaurus/docs/extensions/catalog`, name it with the name of your extension and a file extension of `.yaml`.
+
+The content for this file should be based off of this template:
+
+```
+name: <Name of your extension>
+author: <Name to show as the author of the extension>
+authorUrl: <URL to open in a new tab when the user clicks on the author name>
+description: <Short description of the extension - please limit to around 120 characters>
+url: <URL to open in a new tab when the user clicks on the 'Learn More...' link>
+icon: <URL for the icon to show for your extension - this should 48x48 pixels>
+```
+
+Open a PR that adds your yaml file. The team will review your PR and once approved and merged, your extension will appear here.
+
+For examples, see https://github.com/rancher/dashboard/tree/master/docusaurus/extensions/catalog

--- a/docusaurus/docs/extensions/catalog.mdx
+++ b/docusaurus/docs/extensions/catalog.mdx
@@ -36,7 +36,7 @@ author: <Name to show as the author of the extension>
 authorUrl: <URL to open in a new tab when the user clicks on the author name>
 description: <Short description of the extension - please limit to around 120 characters>
 url: <URL to open in a new tab when the user clicks on the 'Learn More...' link>
-icon: <URL for the icon to show for your extension - this should 48x48 pixels>
+icon: <URL for the icon to show for your extension - this should be sized 48x48 pixels>
 ```
 
 Open a PR that adds your yaml file. The team will review your PR and once approved and merged, your extension will appear here.

--- a/docusaurus/docs/extensions/catalog.mdx
+++ b/docusaurus/docs/extensions/catalog.mdx
@@ -18,8 +18,9 @@ Partner Extensions are developed by [SUSE Partners](https://www.suse.com/partner
 
 **Community**
 
-Community Extensions cover all other extensions developed by the community. SUSE has not vetted, reviewed or verified these extensions and takes no liability for them. Use of
-these extensions is at your own risk.
+Community Extensions cover all other extensions developed by the community. **SUSE has not vetted, reviewed or verified these extensions and takes no liability for them. Use of
+these extensions is at your own risk**. SUSE reserves the right to reject or remove extensions which are broken, dangerous, or expose known vulnerabilities. To report an issue with an
+extension on this page, contact SUSE via the #extensions channel on the [Rancher User's Slack](https://rancher-users.slack.com/archives/C04PPGWAWNR).
 
 <Catalog/>
 

--- a/docusaurus/docs/extensions/catalog.mdx
+++ b/docusaurus/docs/extensions/catalog.mdx
@@ -2,7 +2,7 @@
 
 import Catalog from '../../plugins/catalog/Catalog.tsx'
 
-For information on adding your extension to this page, see here. For information of developing your own extension, check out the [developer documentation](http://localhost:3000/extensions/next/extensions-getting-started).
+For information on adding your extension to this page, see [here](#add-your-extension). For information of developing your own extension, check out the [developer documentation](http://localhost:3000/extensions/next/extensions-getting-started).
 
 **Prime**
 
@@ -23,7 +23,7 @@ these extensions is at your own risk.
 
 <Catalog/>
 
-## Add your extension to this page
+## <a name="add-your-extension"></a>Add your extension to this page
 
 Fork this repository and create a new yaml file in the `docusaurus/docs/extensions/catalog`, name it with the name of your extension and a file extension of `.yaml`.
 

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -90,6 +90,7 @@ const config = {
         },
       },
     ],
+    ['./plugins/catalog', {}]
   ],
 
   themeConfig:
@@ -115,6 +116,13 @@ const config = {
             docsPluginId: 'extensions',
             position:     'right',
             label:        'Docs',
+          },
+          {
+            type:         'doc',
+            docId:        'catalog',
+            docsPluginId: 'extensions',
+            position:     'right',
+            label:        'Catalog',
           },
           {
             to: '/blog', label: 'Blog', position: 'right'

--- a/docusaurus/extensionSidebar.js
+++ b/docusaurus/extensionSidebar.js
@@ -80,6 +80,7 @@ const sidebars = {
           ]
         },
         'publishing',
+        'catalog',
         {
           type:  'category',
           label: 'Use cases/Examples',

--- a/docusaurus/extensions/catalog/partner/cloudcasa.yaml
+++ b/docusaurus/extensions/catalog/partner/cloudcasa.yaml
@@ -1,0 +1,6 @@
+name: CloudCasa
+author: CloudCasa
+authorUrl: https://cloudcasa.io
+description: CloudCasa One-Click Installation and Monitoring for Rancher Clusters
+url: https://github.com/catalogicsoftware/cloudcasa-rancher-extension
+icon: https://raw.githubusercontent.com/catalogicsoftware/cloudcasa-rancher-extension/refs/heads/main/pkg/cloud-casa-extension/assets/icon.svg

--- a/docusaurus/extensions/catalog/partner/kamaji.yaml
+++ b/docusaurus/extensions/catalog/partner/kamaji.yaml
@@ -1,0 +1,5 @@
+name: Kamaji
+author: Clastix
+description: Deploys and operates Kubernetes Control Plane at scale with a fraction of the operational burden
+url: https://kamaji.clastix.io/
+icon: https://kamaji.clastix.io/images/logo.png

--- a/docusaurus/extensions/catalog/partner/nutanix.yaml
+++ b/docusaurus/extensions/catalog/partner/nutanix.yaml
@@ -1,0 +1,6 @@
+name: Nutanix
+author: Nutanix
+authorUrl: https://www.nutanix.com
+description: Nutanix UI Extension provides a seamless interface for configuring Rancher clusters on Nutanix Cloud Platform
+icon: https://raw.githubusercontent.com/nutanix-cloud-native/nutanix-rancher-extension/refs/heads/main/pkg/nutanix/assets/icon-nutanix.svg
+url: https://github.com/nutanix-cloud-native/nutanix-rancher-extension

--- a/docusaurus/extensions/catalog/prime/elemental.yaml
+++ b/docusaurus/extensions/catalog/prime/elemental.yaml
@@ -1,0 +1,6 @@
+name: Elemental
+author: SUSE
+authorUrl: https://www.rancher.com/products/rancher-platform
+description: Adds support for OS Management to Rancher Manager through Elemental
+url: https://elemental.docs.rancher.com
+icon: https://elemental.docs.rancher.com/img/logo.svg

--- a/docusaurus/extensions/catalog/prime/kubewarden.yaml
+++ b/docusaurus/extensions/catalog/prime/kubewarden.yaml
@@ -1,0 +1,6 @@
+name: Kubewarden
+author: SUSE
+authorUrl: https://www.rancher.com/products/rancher-platform
+description: Kubewarden extension for Rancher Manager
+url: https://www.kubewarden.io
+icon: https://raw.githubusercontent.com/rancher/kubewarden-ui/refs/heads/main/pkg/kubewarden/assets/icon-kubewarden.svg

--- a/docusaurus/extensions/catalog/prime/neuvector.yaml
+++ b/docusaurus/extensions/catalog/prime/neuvector.yaml
@@ -1,0 +1,6 @@
+name: NeuVector
+author: SUSE
+authorUrl: https://www.rancher.com/products/rancher-platform
+description: NeuVector extension for Rancher Manager
+url: https://www.suse.com/products/rancher/security
+icon: https://raw.githubusercontent.com/rancher/ui-plugin-charts/refs/heads/main/icons/neuvector-ui-ext/2.1.2-nv-icon.svg

--- a/docusaurus/extensions/catalog/prime/observability.yaml
+++ b/docusaurus/extensions/catalog/prime/observability.yaml
@@ -1,0 +1,6 @@
+name: Observability
+author: SUSE
+authorUrl: https://www.rancher.com/products/rancher-platform
+description: SUSE Rancher Prime Observability Extension
+url: https://www.suse.com/solutions/observability
+icon: https://raw.githubusercontent.com/rancher/ui-plugin-charts/refs/heads/main/icons/observability/2.0.0-rancher-observability.svg

--- a/docusaurus/plugins/catalog/Catalog.tsx
+++ b/docusaurus/plugins/catalog/Catalog.tsx
@@ -1,0 +1,26 @@
+// Shows a set of cards for the catalog for a given group
+
+import DATA from '../../.docusaurus/catalog.json'
+import CatalogCard from './CatalogCard.tsx'
+import './styles.css';
+
+const Catalog = (props) => {
+  const group = props.group;
+
+  const thisGroup = DATA.filter((item) => item.group === group);
+
+  const listItems = thisGroup.map((link) =>
+    <CatalogCard item={link} />
+  );
+
+  return (
+    <div>
+      <div className="catalog-card-container">
+        {listItems}
+      </div>
+      {!thisGroup.length && <div className="catalog-card-none">Be the first to contribute an extension!</div>}
+    </div>
+  );
+};
+
+export default Catalog;

--- a/docusaurus/plugins/catalog/CatalogCard.tsx
+++ b/docusaurus/plugins/catalog/CatalogCard.tsx
@@ -1,0 +1,23 @@
+// Catalog card for a single extension
+
+const CatalogCard = (props) => {
+  console.log(props);
+
+  const item = props.item;
+
+  return (
+    <div className="catalog-card">
+      <div className="catalog-card-icon">
+        <img src={ item.icon } />
+      </div>
+      <div className="catalog-card-metadata">
+        <div>{ item.name }</div>
+        <div>by <a href={ item.authorUrl } target="_blank">{ item.author }</a></div>
+        <div>{ item.description }</div>
+        <div className="catalog-more-info"><a href={item.url} target="_blank">Learn More...</a></div>
+      </div>
+    </div>
+  );
+};
+
+export default CatalogCard;

--- a/docusaurus/plugins/catalog/CatalogCard.tsx
+++ b/docusaurus/plugins/catalog/CatalogCard.tsx
@@ -1,8 +1,6 @@
 // Catalog card for a single extension
 
 const CatalogCard = (props) => {
-  console.log(props);
-
   const item = props.item;
 
   return (

--- a/docusaurus/plugins/catalog/index.js
+++ b/docusaurus/plugins/catalog/index.js
@@ -1,0 +1,67 @@
+// Docusaurus plugin
+
+// Reads the extension catalog and processes it into a single index file
+// Declares a watch path, so that changes to the catalog files will
+// regenerate the index file
+import { parse } from 'yaml';
+
+const fs = require('fs');
+const path = require('path');
+const FOLDER = './extensions/catalog';
+
+function readAndMergeCatalogFiles(out, folder, group) {
+  const files = fs.readdirSync(folder);
+
+  files.forEach((entry) => {
+    const fp = path.join(folder, entry);
+    const stats = fs.statSync(fp);
+
+    if (stats.isDirectory()) {
+      readAndMergeCatalogFiles(out, fp, entry);
+    } else if (entry.endsWith('.yaml')) {
+      try {
+        const yaml = fs.readFileSync(fp);
+        const obj = parse(yaml.toString('utf8'));
+
+        obj.group = group;
+
+        out.push(obj);
+      } catch (e) {
+        console.log(`Error reading file ${ entry }`); // eslint-disable-line no-console
+      }
+    }
+  });
+}
+
+function go() {
+  const data = [];
+
+  // Discover, read and merge the individual yaml files into an array
+  readAndMergeCatalogFiles(data, FOLDER);
+
+  // Sort by name
+  data.sort((a, b) => {
+    return a.name.localeCompare(b.name);
+  });
+
+  // Write the catalog index out to a JSON file
+  fs.writeFileSync('./.docusaurus/catalog.json', JSON.stringify(data));
+}
+
+// Generate catalog file
+// Plugin will ensure the catalog json file is created from the folder of yaml files
+// in `extensions/catalog`
+export default async function extensionsCatalogPlugin(context, options) {
+  return {
+    name: 'extensions-catalog-generator',
+
+    getPathsToWatch() {
+      return [`${ FOLDER }/**/*.yaml`];
+    },
+
+    contentLoaded() {
+      // When docusaurus rebuilds, rebuild the catalog index
+      go();
+    }
+  };
+}

--- a/docusaurus/plugins/catalog/styles.css
+++ b/docusaurus/plugins/catalog/styles.css
@@ -1,0 +1,40 @@
+:root {
+  --border: #ccc;
+}
+
+.catalog-card-container {
+  display: grid;
+  grid-template-columns: 50% 50%;
+}
+
+.catalog-card-container .catalog-card {
+  display: flex;
+  border: 1px solid var(--border);
+  margin: 10px;
+  padding: 10px;
+}
+
+.catalog-card-icon > img {
+  width: 48px;
+  height: 48px;
+  margin-right: 10px;
+}
+
+.catalog-card-metadata {
+  flex: 1;
+}
+
+.catalog-card-metadata > :not(:first-child) {
+  font-size: 14px;
+}
+
+.catalog-more-info {
+  text-align: right;
+  margin-top: 5px;
+}
+
+.catalog-card-none {
+  border: 1px solid var(--border);
+  padding: 2px;
+  text-align: center;
+}


### PR DESCRIPTION
### Summary
Fixes #13512

The goal here is to have a new page as part of the extensions documentation - https://extensions.rancher.io/ - where we can list extensions and provide a mechanism for the community to share details of their extensions.

### Occurred changes and/or fixed issues

This PR adds an extensions catalog page to our extension docs.

Each extension is declared in a yaml file and a custom docusaurus plugin generates an index from these.

A custom mdx page renders the catalog page.

This also includes information on how users can submit their extensions to the catalog.

This PR also populates the initial catalog based on Prime and Partner extensions.

### Screenshot/Video

Example of the generated page: 

[ExtensionsCatalog.pdf](https://github.com/user-attachments/files/19250652/ExtensionsCatalog.pdf)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
