### PR TITLE
Forwardport the fix for vSphere cpi/csi config

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1701,7 +1701,7 @@ export default {
       const defaultChartValue = this.versionInfo[name];
       const key = this.chartVersionKey(name);
 
-      return mergeWithReplaceArrays(defaultChartValue?.values, this.userChartValues[key]);
+      return merge({}, defaultChartValue?.values || {}, this.userChartValues[key] || {});
     },
 
     initServerAgentArgs() {

--- a/shell/utils/object.js
+++ b/shell/utils/object.js
@@ -488,9 +488,6 @@ export function deepToRaw(obj, cache = new WeakSet()) {
  * More info: https://github.com/lodash/lodash/issues/1313
  *
  * This helper function addresses the issue by always replacing the old array with the new array during the merge process.
- *
- * This helper is used for another case in rke2.vue to handle merging addon chart default values with the user's current values.
- * It fixed https://github.com/rancher/dashboard/issues/12418
  */
 export function mergeWithReplaceArrays(obj1 = {}, obj2 = {}) {
   return mergeWith(obj1, obj2, (obj1Value, obj2Value) => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13770 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
