### PR TITLE
[2.11.1] Adjusted HPA to handle non-resource metrics

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2779,6 +2779,7 @@ hpa:
       label: Metric Name
       placeholder: e.g. packets-per-second
     selector:
+      header: Metric Selector
       label: Add Selector
   metricTarget:
     averageVal:

--- a/shell/components/form/MatchExpressions.vue
+++ b/shell/components/form/MatchExpressions.vue
@@ -242,6 +242,10 @@ export default {
 
 <template>
   <div>
+    <slot
+      v-if="rules.length"
+      name="header"
+    />
     <button
       v-if="showRemove && !isView"
       type="button"

--- a/shell/detail/__tests__/autoscaling.horizontalpodautoscaler.test.ts
+++ b/shell/detail/__tests__/autoscaling.horizontalpodautoscaler.test.ts
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils';
+import camelCase from 'lodash/camelCase';
 import HorizontalPodAutoScaler from '@shell/detail/autoscaling.horizontalpodautoscaler/index.vue';
 
 describe('view: autoscaling.horizontalpodautoscaler', () => {
@@ -43,7 +44,7 @@ describe('view: autoscaling.horizontalpodautoscaler', () => {
 
   };
 
-  const value = {
+  const valueWithResourceMetrics = {
     status: {
       currentMetrics: [
         {
@@ -100,36 +101,109 @@ describe('view: autoscaling.horizontalpodautoscaler', () => {
       }
     }
   };
+  const valueWithOtherMetrics = {
+    status: {
+      currentMetrics: [
 
-  const metricsValue = Object.values(value.spec.metrics);
-  const currentMetrics = Object.values(value.status.currentMetrics);
+        {
+          external: {
+            metric:  { name: 's1-prometheus' },
+            current: { averageValue: 50 }
+          },
+          type: 'External'
 
-  const wrapper = mount(HorizontalPodAutoScaler, {
-    props:  { value },
-    global: { mocks, stubs },
+        }
+      ],
+    },
+    spec: {
+      maxReplicas: 10,
+      metrics:     [
+        {
+          external: {
+            metric: {
+              name:     's1-prometheus',
+              selector: { matchLabels: { 'scaledobject.keda.sh/name': 'test' } }
+            },
+            target: {
+              averageValue: 50,
+              type:         'AverageValue'
+            }
+          },
+          type: 'External'
+        }
+      ],
+      minReplicas:    1,
+      scaleTargetRef: {
+        apiVersion: 'apps/v1',
+        kind:       'Deployment',
+        name:       'php-apache'
+      }
+    }
+  }
+;
+
+  describe('with resource metrics:', () => {
+    const metricsValue = Object.values(valueWithResourceMetrics.spec.metrics);
+    const currentMetrics = Object.values(valueWithResourceMetrics.status.currentMetrics);
+
+    const wrapper = mount(HorizontalPodAutoScaler, {
+      props:  { value: valueWithResourceMetrics },
+      global: { mocks, stubs },
+    });
+
+    describe.each(valueWithResourceMetrics.spec.metrics)('should display metrics for each resource:', (metric) => {
+      const name = metric.resource.name;
+
+      it(`${ name }:`, () => {
+      // Resource metrics
+        const resourceValue = wrapper.get(`[data-testid="resource-metrics-value-${ name }"]`);
+        const resourceName = wrapper.get(`[data-testid="resource-metrics-name-${ name }"]`);
+        const metricValue = metricsValue.find((f) => f.resource.name === name)?.resource;
+
+        // Current Metrics
+        const averageUtilization = wrapper.get(`[data-testid="current-metrics-Average Utilization-${ name }"]`);
+        const averageValue = wrapper.get(`[data-testid="current-metrics-Average Value-${ name }"]`);
+        const currentResource = currentMetrics.find((f) => f.resource.name === name)?.resource.current;
+
+        // Resource metrics
+        expect(resourceValue.element.textContent).toBe(`${ metricValue?.target?.averageUtilization }`);
+        expect(resourceName.element.textContent).toBe(`${ metricValue?.name }`);
+
+        // Current Metrics
+        expect(averageUtilization.element.textContent).toBe(`${ currentResource?.averageUtilization }`);
+        expect(averageValue.element.textContent).toBe(`${ currentResource?.averageValue }`);
+      });
+    });
   });
 
-  describe.each(value.spec.metrics)('should display metrics for each resource:', (metric) => {
-    const name = metric.resource.name;
+  describe('with other metrics:', () => {
+    const currentMetrics = Object.values(valueWithOtherMetrics.status.currentMetrics);
 
-    it(`${ name }:`, () => {
-      // Resource metrics
-      const resourceValue = wrapper.get(`[data-testid="resource-metrics-value-${ name }"]`);
-      const resourceName = wrapper.get(`[data-testid="resource-metrics-name-${ name }"]`);
-      const metricValue = metricsValue.find((f) => f.resource.name === name)?.resource;
+    const wrapper = mount(HorizontalPodAutoScaler, {
+      props:  { value: valueWithOtherMetrics },
+      global: { mocks, stubs },
+    });
 
-      // Current Metrics
-      const averageUtilization = wrapper.get(`[data-testid="current-metrics-Average Utilization-${ name }"]`);
-      const averageValue = wrapper.get(`[data-testid="current-metrics-Average Value-${ name }"]`);
-      const currentResource = currentMetrics.find((f) => f.resource.name === name)?.resource.current;
+    describe.each(valueWithOtherMetrics.spec.metrics)('should display metrics for each resource:', (metric) => {
+      const metricType = camelCase(metric.type);
+      const name = metric[metricType as keyof typeof metric].metric.name;
 
-      // Resource metrics
-      expect(resourceValue.element.textContent).toBe(`${ metricValue?.target?.averageUtilization }`);
-      expect(resourceName.element.textContent).toBe(`${ metricValue?.name }`);
+      it(`${ name }:`, () => {
+        // Resource metrics
+        const resourceValue = wrapper.get(`[data-testid="resource-metrics-value-${ name }"]`);
+        const metricValue = metric[metricType as keyof typeof metric];
 
-      // Current Metrics
-      expect(averageUtilization.element.textContent).toBe(`${ currentResource?.averageUtilization }`);
-      expect(averageValue.element.textContent).toBe(`${ currentResource?.averageValue }`);
+        // Current Metrics
+        const averageValue = wrapper.get(`[data-testid="current-metrics-Average Value-${ name }"]`);
+        const currentMatch = currentMetrics.find((f) => f[metricType as keyof typeof metric]?.metric.name === name);
+        const currentValue = currentMatch[metricType as keyof typeof metric]?.current;
+
+        // Resource metrics
+        expect(resourceValue.element.textContent).toBe(`${ metricValue?.target?.averageValue }`);
+
+        // Current Metrics
+        expect(averageValue.element.textContent).toBe(`${ currentValue?.averageValue }`);
+      });
     });
   });
 });

--- a/shell/edit/autoscaling.horizontalpodautoscaler/metric-identifier.vue
+++ b/shell/edit/autoscaling.horizontalpodautoscaler/metric-identifier.vue
@@ -65,14 +65,17 @@ export default {
     </div>
     <div class="row">
       <div class="col span-12">
-        <h3>Metric Selector</h3>
         <MatchExpressions
           :mode="mode"
           :value="matchExpressions"
           :label="t('hpa.metricIdentifier.selector.label')"
           :show-remove="false"
           @input="matchChanged($event)"
-        />
+        >
+          <template #header>
+            <h3>{{ t('hpa.metricIdentifier.selector.header') }}</h3>
+          </template>
+        </MatchExpressions>
       </div>
     </div>
   </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13538 
<!-- Define findings related to the feature or bug issue. -->
Backport of https://github.com/rancher/dashboard/pull/13776

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Fixed how we process metrics
- Fixed metric selector header being shown when no metrics are visible ( HorizontalPodAutoscaler -> Config)

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Local -> Service discovery -> HorizontalPodAutoscalers

Create an HPA with metrics that include an external metric or any other non-resource metric
HPA-> detail
All metrics should be displayed. No error should be thrown to the console

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
