### PR TITLE
fix: missing error banner in edit harvesterhci.io.management.cluster

### DIFF
--- a/pkg/harvester-manager/edit/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester-manager/edit/harvesterhci.io.management.cluster.vue
@@ -32,6 +32,8 @@ export default {
 
   mixins: [CreateEditView],
 
+  inheritAttrs: false,
+
   props: {
     mode: {
       type:     String,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Fixes # https://github.com/harvester/harvester/issues/7809

### Occurred changes and/or fixed issues
Fix missing error banner in edit harvesterhci.io.management.cluster when input invalid cluster name : `1.5.0`.


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

https://github.com/user-attachments/assets/7360675e-ec9d-446c-930d-683bf8ca63ff



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
