### PR TITLE
Ensure correct Output col in Flow list view by filtering ns

### DIFF
--- a/shell/models/__tests__/logging.banzaicloud.io.flow.test.ts
+++ b/shell/models/__tests__/logging.banzaicloud.io.flow.test.ts
@@ -1,0 +1,88 @@
+import LogFlow from '@shell/models/logging.banzaicloud.io.flow';
+
+describe('class LogFlow', () => {
+  it('prop "outputs" should take namespace in consideration when filtering logging v2 "outputs"', () => {
+    const logOutputs = [
+      {
+        apiVersion: 'logging.banzaicloud.io/v1beta1',
+        kind:       'Output',
+        metadata:   {
+          creationTimestamp: '2025-03-17T10:51:55Z',
+          namespace:         'default',
+          name:              'output1',
+          uid:               '927b4a2e-6be0-476f-9bdd-cf30c4a27d8b'
+        },
+        name:   'output1',
+        spec:   { awsElasticsearch: { endpoint: {} } },
+        status: { active: false }
+      },
+      {
+        apiVersion: 'logging.banzaicloud.io/v1beta1',
+        kind:       'Output',
+        metadata:   {
+          creationTimestamp: '2025-03-17T10:51:55Z',
+          namespace:         'cattle-fleet-system',
+          name:              'output2',
+          uid:               '927b4a2e-6be0-476f-9bdd-cf30c4a27d8c'
+        },
+        name:   'output2',
+        spec:   { awsElasticsearch: { endpoint: {} } },
+        status: { active: false }
+      },
+      {
+        apiVersion: 'logging.banzaicloud.io/v1beta1',
+        kind:       'Output',
+        metadata:   {
+          creationTimestamp: '2025-03-17T10:51:55Z',
+          namespace:         'cattle-fleet-system',
+          name:              'output3',
+          uid:               '927b4a2e-6be0-476f-9bdd-cf30c4a27d8d'
+        },
+        name:   'output3',
+        spec:   { awsElasticsearch: { endpoint: {} } },
+        status: { active: false }
+      },
+      {
+        apiVersion: 'logging.banzaicloud.io/v1beta1',
+        kind:       'Output',
+        metadata:   {
+          creationTimestamp: '2025-03-17T10:51:55Z',
+          namespace:         'kube-system',
+          name:              'output4',
+          uid:               '927b4a2e-6be0-476f-9bdd-cf30c4a27d8e'
+        },
+        name:   'output4',
+        spec:   { awsElasticsearch: { endpoint: {} } },
+        status: { active: false }
+      },
+    ];
+
+    const logFlowData = {
+      apiVersion: 'logging.banzaicloud.io/v1beta1',
+      kind:       'Flow',
+      metadata:   {
+        name:              'flow2',
+        creationTimestamp: '2025-03-17T10:53:02Z',
+        generation:        1,
+        namespace:         'cattle-fleet-system',
+        resourceVersion:   '4070',
+        uid:               'fdf7d553-d101-4c37-91b0-784f95dc950a',
+        fields:            [
+          'flow2', true, null
+        ]
+      },
+      spec: {
+        localOutputRefs: [
+          'output2',
+          'output3'
+        ]
+      }
+    };
+
+    const logFlow = new LogFlow(logFlowData);
+
+    jest.spyOn(logFlow, 'allOutputs', 'get').mockReturnValue(logOutputs);
+
+    expect(logFlow.outputs).toStrictEqual([logOutputs[1], logOutputs[2]]);
+  });
+});

--- a/shell/models/logging.banzaicloud.io.flow.js
+++ b/shell/models/logging.banzaicloud.io.flow.js
@@ -64,7 +64,8 @@ export default class LogFlow extends SteveModel {
   get outputs() {
     const localOutputRefs = this.spec?.localOutputRefs || [];
 
-    return this.allOutputs.filter((output) => localOutputRefs.includes(output.name));
+    return this.allOutputs.filter((output) => localOutputRefs.includes(output.name) &&
+    output.metadata?.namespace === this.metadata?.namespace);
   }
 
   get outputsSortable() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/13743 (based on https://github.com/rancher/dashboard/pull/13744, credits to @skanakal for finding the problem and solution)
<!-- Define findings related to the feature or bug issue. -->

@skanakal I found it easier to reproduce your fix on my fork and work on the unit test from it. Thank you for the fix 🙇 

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
The issue is that [get outputs()](https://github.com/rancher/dashboard/blob/master/shell/models/logging.banzaicloud.io.flow.js#L64) is fetching outputs based only on their names `(output.name)`. Since multiple outputs can share the same name but exist in different namespaces, the filtering logic does not distinguish between outputs from different namespaces.
- Also add unit test

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Install rancher-logging latest
2. Create multiple logging outputs with the same name (e.g., "output-file") in several different namespaces (e.g., "default", "kube-system", "cattle-system", "cattle-logging-system").
3. Create flows for these namespaces (e.g., "default", "kube-system", "cattle-system", "cattle-logging-system"). that use a localOutputRefs entry to reference the output with the shared name (e.g., "output-file").
4. Navigate to the flow overview in the Rancher UI and notice the duplicate entry:

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![image](https://github.com/user-attachments/assets/9fe0825c-4a88-49ae-80dc-d4992e24fb75)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
