### PR TITLE
Adding another indentation level in our navigation menu

### DIFF
--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -403,6 +403,10 @@ export default {
           padding: 10px 7px 9px 7px !important;
         }
       }
+
+      &:deep() .type-link > .label {
+        padding-left: 10px;
+      }
     }
 
     &:not(.depth-0) {


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/11228
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Adding one more level of indentation for our navigation elements.

### Areas or cases that should be tested
Side navigation in explorer

### Areas which could experience regressions
Possibly something with the class `label` could have additional `padding-left` but I believe the scope is sufficiently narrow to avoid this.

### Screenshot/Video
![image](https://github.com/user-attachments/assets/46514fdf-edd7-4c15-b8c6-7603c414a943)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
