### PR TITLE
fix missing describedby on Checkbox and LabeledInput

### DIFF
--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -128,6 +128,10 @@ export default defineComponent({
 
   emits: ['update:value'],
 
+  data() {
+    return { describedById: `described-by-${ generateRandomAlphaString(12) }` };
+  },
+
   computed: {
     /**
      * Determines if the checkbox is disabled.
@@ -270,6 +274,7 @@ export default defineComponent({
         :aria-label="replacementLabel"
         :aria-checked="!!value"
         :aria-labelledby="labelKey || label ? idForLabel : undefined"
+        :aria-describedby="descriptionKey || description ? describedById : undefined"
         role="checkbox"
       />
       <span
@@ -311,10 +316,13 @@ export default defineComponent({
     >
       <t
         v-if="descriptionKey"
+        :id="describedById"
         :k="descriptionKey"
       />
       <template v-else-if="description">
-        {{ description }}
+        <p :id="describedById">
+          {{ description }}
+        </p>
       </template>
     </div>
     <div class="checkbox-outer-container-extra">

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -148,7 +148,8 @@ export default defineComponent({
     return {
       updated:          false,
       validationErrors: '',
-      inputId:          `input-${ generateRandomAlphaString(12) }`
+      inputId:          `input-${ generateRandomAlphaString(12) }`,
+      describedById:    `described-by-${ generateRandomAlphaString(12) }`
     };
   },
 
@@ -380,6 +381,7 @@ export default defineComponent({
         :placeholder="_placeholder"
         autocapitalize="off"
         :class="{ conceal: type === 'multiline-password' }"
+        :aria-describedby="cronHint || subLabel ? describedById : undefined"
         @update:value="onInput"
         @focus="onFocus"
         @blur="onBlur"
@@ -400,6 +402,7 @@ export default defineComponent({
         autocomplete="off"
         autocapitalize="off"
         :data-lpignore="ignorePasswordManagers"
+        :aria-describedby="cronHint || subLabel ? describedById : undefined"
         @input="onInput"
         @focus="onFocus"
         @blur="onBlur"
@@ -428,13 +431,15 @@ export default defineComponent({
     >
       <div
         v-if="cronHint"
+        :id="describedById"
         role="alert"
         :aria-label="cronHint"
       >
         {{ cronHint }}
       </div>
       <div
-        v-if="subLabel"
+        v-else-if="subLabel"
+        :id="describedById"
         v-clean-html="subLabel"
       />
     </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13829
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix missing `describedby` on `Checkbox` and `LabeledInput`
- update `LabeledInput` to only show either `cronHint` or `subLabel` (I don't both at the same time would work)

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- work based on https://benmyers.dev/blog/aria-labels-and-descriptions/#providing-multiple-ids + https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-describedby

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
