### PR TITLE
fix grouping of RadioGroup with meaningful title

### DIFF
--- a/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
@@ -205,9 +205,9 @@ export default defineComponent({
       v-if="label || labelKey || tooltip || tooltipKey || $slots.label"
       class="radio-group label"
     >
-      <slot name="label">
-        <h3>
-          <legend>
+      <legend>
+        <slot name="label">
+          <h3>
             <t
               v-if="labelKey"
               :k="labelKey"
@@ -215,19 +215,19 @@ export default defineComponent({
             <template v-else-if="label">
               {{ label }}
             </template>
-          </legend>
-          <i
-            v-if="tooltipKey"
-            v-clean-tooltip="t(tooltipKey)"
-            class="icon icon-info icon-lg"
-          />
-          <i
-            v-else-if="tooltip"
-            v-clean-tooltip="tooltip"
-            class="icon icon-info icon-lg"
-          />
-        </h3>
-      </slot>
+            <i
+              v-if="tooltipKey"
+              v-clean-tooltip="t(tooltipKey)"
+              class="icon icon-info icon-lg"
+            />
+            <i
+              v-else-if="tooltip"
+              v-clean-tooltip="tooltip"
+              class="icon icon-info icon-lg"
+            />
+          </h3>
+        </slot>
+      </legend>
     </div>
 
     <!-- Group -->

--- a/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
@@ -199,7 +199,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <div>
+  <fieldset>
     <!-- Label -->
     <div
       v-if="label || labelKey || tooltip || tooltipKey || $slots.label"
@@ -207,13 +207,15 @@ export default defineComponent({
     >
       <slot name="label">
         <h3>
-          <t
-            v-if="labelKey"
-            :k="labelKey"
-          />
-          <template v-else-if="label">
-            {{ label }}
-          </template>
+          <legend>
+            <t
+              v-if="labelKey"
+              :k="labelKey"
+            />
+            <template v-else-if="label">
+              {{ label }}
+            </template>
+          </legend>
           <i
             v-if="tooltipKey"
             v-clean-tooltip="t(tooltipKey)"
@@ -266,7 +268,7 @@ export default defineComponent({
         </slot>
       </div>
     </div>
-  </div>
+  </fieldset>
 </template>
 
 <style lang='scss'>

--- a/shell/assets/styles/base/_basic.scss
+++ b/shell/assets/styles/base/_basic.scss
@@ -148,4 +148,5 @@ HR.vertical {
 fieldset {
   border: 0;
   padding: 0;
+  margin-inline: 0;
 }

--- a/shell/assets/styles/base/_basic.scss
+++ b/shell/assets/styles/base/_basic.scss
@@ -144,3 +144,8 @@ HR.vertical {
 .force-wrap       { @include force-wrap }
 .bordered-section { @include bordered-section }
 .section-divider  { @include section-divider }
+
+fieldset {
+  border: 0;
+  padding: 0;
+}

--- a/shell/components/LandingPagePreference.vue
+++ b/shell/components/LandingPagePreference.vue
@@ -102,12 +102,7 @@ export default {
 </script>
 
 <template>
-  <fieldset>
-    <legend>
-      <p class="set-landing-leadin">
-        {{ t('landing.landingPrefs.body') }}
-      </p>
-    </legend>
+  <div>
     <RadioGroup
       id="login-route"
       :value="afterLoginRoute"
@@ -115,6 +110,11 @@ export default {
       :options="routeRadioOptions"
       @update:value="updateLoginRoute"
     >
+      <template #label>
+        <p class="set-landing-leadin">
+          {{ t('landing.landingPrefs.body') }}
+        </p>
+      </template>
       <template #2="{option}">
         <div class="custom-page">
           <RadioButton
@@ -137,7 +137,7 @@ export default {
         </div>
       </template>
     </RadioGroup>
-  </fieldset>
+  </div>
 </template>
 
 <style lang="scss" scoped>

--- a/shell/components/LandingPagePreference.vue
+++ b/shell/components/LandingPagePreference.vue
@@ -102,10 +102,12 @@ export default {
 </script>
 
 <template>
-  <div>
-    <p class="set-landing-leadin">
-      {{ t('landing.landingPrefs.body') }}
-    </p>
+  <fieldset>
+    <legend>
+      <p class="set-landing-leadin">
+        {{ t('landing.landingPrefs.body') }}
+      </p>
+    </legend>
     <RadioGroup
       id="login-route"
       :value="afterLoginRoute"
@@ -135,7 +137,7 @@ export default {
         </div>
       </template>
     </RadioGroup>
-  </div>
+  </fieldset>
 </template>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13837
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix grouping of `RadioGroup` with meaningful title/description

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
