### PR TITLE
Initial `$shell` api - add `ModalManager` and `SlideInPanelManager`

### DIFF
--- a/shell/components/GrowlManager.vue
+++ b/shell/components/GrowlManager.vue
@@ -107,6 +107,7 @@ export default {
               @click="close(growl)"
             />
             <div
+              v-if="growl.title"
               :id="`growl-title-${ growl.id }`"
               class="growl-text-title"
             >

--- a/shell/components/ModalManager.vue
+++ b/shell/components/ModalManager.vue
@@ -1,0 +1,61 @@
+<script lang="ts" setup>
+import { computed, ref } from 'vue';
+import { useStore } from 'vuex';
+
+import AppModal from '@shell/components/AppModal.vue';
+
+const store = useStore();
+
+const isOpen = computed(() => store.getters['modal/isOpen']);
+const component = computed(() => store.getters['modal/component']);
+const componentProps = computed(() => store.getters['modal/componentProps']);
+const resources = computed(() => store.getters['modal/resources']);
+const closeOnClickOutside = computed(() => store.getters['modal/closeOnClickOutside']);
+const modalWidth = computed(() => store.getters['modal/modalWidth']);
+// const modalSticky = computed(() => store.getters['modal/modalSticky']); // TODO: Implement sticky modals
+
+const backgroundClosing = ref<Function | null>(null);
+
+function close() {
+  if (!isOpen.value) return;
+
+  if (backgroundClosing.value) {
+    backgroundClosing.value();
+  }
+
+  store.commit('modal/closeModal');
+}
+
+function registerBackgroundClosing(fn: Function) {
+  backgroundClosing.value = fn;
+}
+</script>
+
+<template>
+  <app-modal
+    v-if="isOpen && component"
+    :click-to-close="closeOnClickOutside"
+    :width="modalWidth"
+    :style="{ '--prompt-modal-width': modalWidth }"
+    @close="close"
+  >
+    <component
+      :is="component"
+      v-bind="componentProps || {}"
+      :resources="resources"
+      :register-background-closing="registerBackgroundClosing"
+      @close="close"
+    />
+  </app-modal>
+</template>
+
+<style lang='scss'>
+.promptModal-modal {
+  border-radius: var(--border-radius);
+  overflow: scroll;
+  max-height: 100vh;
+  & ::-webkit-scrollbar-corner {
+    background: rgba(0,0,0,0);
+  }
+}
+</style>

--- a/shell/components/ModalManager.vue
+++ b/shell/components/ModalManager.vue
@@ -32,30 +32,22 @@ function registerBackgroundClosing(fn: Function) {
 </script>
 
 <template>
-  <app-modal
-    v-if="isOpen && component"
-    :click-to-close="closeOnClickOutside"
-    :width="modalWidth"
-    :style="{ '--prompt-modal-width': modalWidth }"
-    @close="close"
-  >
-    <component
-      :is="component"
-      v-bind="componentProps || {}"
-      :resources="resources"
-      :register-background-closing="registerBackgroundClosing"
+  <Teleport to="#modals">
+    <app-modal
+      v-if="isOpen && component"
+      :click-to-close="closeOnClickOutside"
+      :width="modalWidth"
+      :style="{ '--prompt-modal-width': modalWidth }"
       @close="close"
-    />
-  </app-modal>
+    >
+      <component
+        :is="component"
+        v-bind="componentProps || {}"
+        data-testid="modal-manager-component"
+        :resources="resources"
+        :register-background-closing="registerBackgroundClosing"
+        @close="close"
+      />
+    </app-modal>
+  </Teleport>
 </template>
-
-<style lang='scss'>
-.promptModal-modal {
-  border-radius: var(--border-radius);
-  overflow: scroll;
-  max-height: 100vh;
-  & ::-webkit-scrollbar-corner {
-    background: rgba(0,0,0,0);
-  }
-}
-</style>

--- a/shell/components/ModalManager.vue
+++ b/shell/components/ModalManager.vue
@@ -38,6 +38,8 @@ function registerBackgroundClosing(fn: Function) {
       :click-to-close="closeOnClickOutside"
       :width="modalWidth"
       :style="{ '--prompt-modal-width': modalWidth }"
+      :trigger-focus-trap="true"
+      tabindex="0"
       @close="close"
     >
       <component

--- a/shell/components/SlideInPanelManager.vue
+++ b/shell/components/SlideInPanelManager.vue
@@ -32,37 +32,42 @@ function closePanel() {
 </script>
 
 <template>
-  <div id="slide-in-panel">
-    <div
-      v-show="isOpen"
-      class="slide-in-glass"
-      :class="{ 'slide-in-glass-open': isOpen }"
-      @click="closePanel"
-    />
-    <div
-      class="slide-in"
-      :class="{ 'slide-in-open': isOpen }"
-      :style="{ width: panelWidth, right: panelRight, top: panelTop, height: panelHeight }"
-    >
-      <div class="header">
-        <div class="title">
-          {{ panelTitle }}
+  <Teleport to="#slides">
+    <div id="slide-in-panel-manager">
+      <div
+        v-show="isOpen"
+        data-testid="slide-in-glass"
+        class="slide-in-glass"
+        :class="{ 'slide-in-glass-open': isOpen }"
+        @click="closePanel"
+      />
+      <div
+        class="slide-in"
+        :class="{ 'slide-in-open': isOpen }"
+        :style="{ width: panelWidth, right: panelRight, top: panelTop, height: panelHeight }"
+      >
+        <div class="header">
+          <div class="title">
+            {{ panelTitle }}
+          </div>
+          <i
+            class="icon icon-close"
+            data-testid="slide-in-close"
+            @click="closePanel"
+          />
         </div>
-        <i
-          class="icon icon-close"
-          @click="closePanel"
-        />
-      </div>
-      <div class="main-panel">
-        <component
-          :is="currentComponent"
-          v-if="isOpen || currentComponent"
-          v-bind="currentProps"
-          class="dynamic-panel-content"
-        />
+        <div class="main-panel">
+          <component
+            :is="currentComponent"
+            v-if="isOpen || currentComponent"
+            v-bind="currentProps"
+            data-testid="slide-in-panel-component"
+            class="dynamic-panel-content"
+          />
+        </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <style lang="scss" scoped>

--- a/shell/components/SlideInPanelManager.vue
+++ b/shell/components/SlideInPanelManager.vue
@@ -1,0 +1,119 @@
+<script lang="ts" setup>
+import { computed } from 'vue';
+import { useStore } from 'vuex';
+
+const HEADER_HEIGHT = 55;
+
+const store = useStore();
+const isOpen = computed(() => store.getters['slideInPanel/isOpen']);
+const currentComponent = computed(() => store.getters['slideInPanel/component']);
+const currentProps = computed(() => store.getters['slideInPanel/componentProps']);
+
+const panelTop = computed(() => {
+  const banner = document.getElementById('banner-header');
+  let height = HEADER_HEIGHT;
+
+  if (banner) {
+    height += banner.clientHeight;
+  }
+
+  return `${ height }px`;
+});
+
+const panelHeight = computed(() => `calc(100vh - ${ panelTop?.value })`);
+const panelWidth = computed(() => currentProps?.value?.width || '33%');
+const panelRight = computed(() => (isOpen?.value ? '0' : `-${ panelWidth?.value }`));
+
+const panelTitle = computed(() => currentProps?.value?.title || 'Details');
+
+function closePanel() {
+  store.commit('slideInPanel/close');
+}
+</script>
+
+<template>
+  <div id="slide-in-panel">
+    <div
+      v-show="isOpen"
+      class="slide-in-glass"
+      :class="{ 'slide-in-glass-open': isOpen }"
+      @click="closePanel"
+    />
+    <div
+      class="slide-in"
+      :class="{ 'slide-in-open': isOpen }"
+      :style="{ width: panelWidth, right: panelRight, top: panelTop, height: panelHeight }"
+    >
+      <div class="header">
+        <div class="title">
+          {{ panelTitle }}
+        </div>
+        <i
+          class="icon icon-close"
+          @click="closePanel"
+        />
+      </div>
+      <div class="main-panel">
+        <component
+          :is="currentComponent"
+          v-if="isOpen || currentComponent"
+          v-bind="currentProps"
+          class="dynamic-panel-content"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.slide-in-glass {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 100vw;
+}
+.slide-in-glass-open {
+  background-color: var(--body-bg);
+  display: block;
+  opacity: 0.5;
+  z-index: 1000;
+}
+
+.slide-in {
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  top: 0;
+  z-index: 2000;
+  transition: right 0.5s ease;
+  border-left: 1px solid var(--border);
+  background-color: var(--body-bg);
+}
+
+.slide-in-open {
+  right: 0;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  padding: 4px;
+  border-bottom: 1px solid var(--border);
+
+  .title {
+    flex: 1;
+    font-weight: bold;
+  }
+
+  .icon-close {
+    cursor: pointer;
+  }
+}
+
+.main-panel {
+  padding: 10px;
+  overflow: auto;
+}
+</style>

--- a/shell/components/SlideInPanelManager.vue
+++ b/shell/components/SlideInPanelManager.vue
@@ -53,6 +53,8 @@ function closePanel() {
           <i
             class="icon icon-close"
             data-testid="slide-in-close"
+            :trigger-focus-trap="true"
+            tabindex="0"
             @click="closePanel"
           />
         </div>

--- a/shell/components/__tests__/ModalManager.spec.ts
+++ b/shell/components/__tests__/ModalManager.spec.ts
@@ -1,0 +1,176 @@
+import { mount } from '@vue/test-utils';
+import { createStore, Store } from 'vuex';
+import { nextTick } from 'vue';
+
+import ModalManager from '@shell/components/ModalManager.vue';
+
+interface ModalManagerMethods {
+  registerBackgroundClosing(fn: Function): void;
+  close(): void;
+}
+
+const MockComponent = {
+  template: '<div data-testid="modal-manager-component">Mock Content</div>',
+  props:    ['someProp', 'resources', 'registerBackgroundClosing']
+};
+
+describe('modalManager.vue with Teleport', () => {
+  let store: Store<any>;
+  let getters: Record<string, () => any>;
+  let modalsDiv: HTMLDivElement;
+
+  beforeEach(() => {
+    // Create the teleport target container
+    modalsDiv = document.createElement('div');
+    modalsDiv.setAttribute('id', 'modals');
+    document.body.appendChild(modalsDiv);
+
+    getters = {
+      'modal/isOpen':              () => true,
+      'modal/component':           () => MockComponent,
+      'modal/componentProps':      () => ({ someProp: 'testValue' }),
+      'modal/resources':           () => ({ data: 'mockData' }),
+      'modal/closeOnClickOutside': () => true,
+      'modal/modalWidth':          () => '500px'
+    };
+
+    store = createStore({
+      getters,
+      mutations: { 'modal/closeModal': jest.fn() }
+    });
+  });
+
+  afterEach(() => {
+    // Clean up the teleport container after each test
+    document.body.removeChild(modalsDiv);
+  });
+
+  const factory = () => {
+    return mount(ModalManager, {
+      attachTo: document.body, // attach so Teleport can work properly
+      global:   {
+        plugins: [store],
+        stubs:   {
+          AppModal: {
+            name:     'AppModal',
+            template: `<div data-testid="app-modal" @close="$emit('close')" :style="{ '--prompt-modal-width': width }"><slot /></div>`,
+            props:    ['clickToClose', 'width']
+          }
+        }
+      }
+    });
+  };
+
+  it('renders the AppModal and dynamic component when modal is open', async() => {
+    factory();
+
+    await nextTick();
+
+    // Because Teleport moves content out of the normal wrapper,
+    // we query the document for the teleported elements.
+    const appModal = document.querySelector('[data-testid="app-modal"]');
+    const dynamicComponent = document.querySelector('[data-testid="modal-manager-component"]');
+
+    expect(appModal).toBeTruthy();
+    expect(dynamicComponent).toBeTruthy();
+    expect(appModal?.getAttribute('style')).toContain('--prompt-modal-width: 500px');
+
+    // We assume the mock component is rendered correctly if its markup is found.
+  });
+
+  it('does not render the AppModal when modal is closed', async() => {
+    getters['modal/isOpen'] = () => false;
+    store = createStore({
+      getters,
+      mutations: { 'modal/closeModal': jest.fn() }
+    });
+    factory();
+    await nextTick();
+
+    const appModal = document.querySelector('[data-testid="app-modal"]');
+
+    expect(appModal).toBeNull();
+  });
+
+  it('does not render the AppModal when dynamic component is null', async() => {
+    getters['modal/component'] = () => null;
+    store = createStore({
+      getters,
+      mutations: { 'modal/closeModal': jest.fn() }
+    });
+    factory();
+    await nextTick();
+
+    const appModal = document.querySelector('[data-testid="app-modal"]');
+
+    expect(appModal).toBeNull();
+  });
+
+  it('calls store commit when close is triggered', async() => {
+    const closeModalMutation = jest.fn();
+
+    getters['modal/isOpen'] = () => true;
+    store = createStore({
+      getters,
+      mutations: { 'modal/closeModal': closeModalMutation }
+    });
+    const wrapper = factory();
+
+    await nextTick();
+
+    const appModalWrapper = wrapper.findComponent({ name: 'AppModal' });
+
+    appModalWrapper.vm.$emit('close');
+    await nextTick();
+
+    expect(closeModalMutation).toHaveBeenCalledWith({}, undefined);
+  });
+
+  it('calls registered background closing function on close', async() => {
+    const closeModalMutation = jest.fn();
+
+    getters['modal/isOpen'] = () => true;
+    store = createStore({
+      getters,
+      mutations: { 'modal/closeModal': closeModalMutation }
+    });
+    const wrapper = factory();
+
+    await nextTick();
+
+    const backgroundFn = jest.fn();
+
+    (wrapper.vm as unknown as ModalManagerMethods).registerBackgroundClosing(backgroundFn);
+    await nextTick();
+
+    const appModalWrapper = wrapper.findComponent({ name: 'AppModal' });
+
+    appModalWrapper.vm.$emit('close');
+    await nextTick();
+
+    expect(backgroundFn).toHaveBeenCalledWith();
+    expect(closeModalMutation).toHaveBeenCalledWith({}, undefined);
+  });
+
+  it('does nothing if modal is already closed when close is triggered', async() => {
+    const closeModalMutation = jest.fn();
+
+    getters['modal/isOpen'] = () => false;
+    store = createStore({
+      getters,
+      mutations: { 'modal/closeModal': closeModalMutation }
+    });
+    const wrapper = factory();
+
+    await nextTick();
+
+    const modalManager = wrapper.vm as unknown as ModalManagerMethods;
+    const spy = jest.spyOn(modalManager, 'close');
+
+    modalManager.close();
+    await nextTick();
+
+    expect(spy).toHaveBeenCalledWith();
+    expect(closeModalMutation).not.toHaveBeenCalled();
+  });
+});

--- a/shell/components/__tests__/SlideInPanelManager.spec.ts
+++ b/shell/components/__tests__/SlideInPanelManager.spec.ts
@@ -1,0 +1,166 @@
+import { mount } from '@vue/test-utils';
+import { createStore, Store } from 'vuex';
+import { nextTick } from 'vue';
+import SlideInPanelManager from '@shell/components/SlideInPanelManager.vue';
+
+const MockComponent = {
+  template: '<div data-testid="slide-in-panel-component">Mock Panel Content</div>',
+  props:    ['width', 'title', 'extraProp']
+};
+
+describe('slideInPanelManager.vue with Teleport', () => {
+  let store: Store<any>;
+  let getters: Record<string, () => any>;
+  let slidesDiv: HTMLDivElement;
+
+  beforeEach(() => {
+    // Create teleport target container
+    slidesDiv = document.createElement('div');
+    slidesDiv.setAttribute('id', 'slides');
+    document.body.appendChild(slidesDiv);
+
+    getters = {
+      'slideInPanel/isOpen':         () => true,
+      'slideInPanel/component':      () => MockComponent,
+      'slideInPanel/componentProps': () => ({
+        width: '40%', title: 'Test Title', extraProp: 'extra'
+      })
+    };
+
+    store = createStore({
+      getters,
+      mutations: { 'slideInPanel/close': jest.fn() }
+    });
+  });
+
+  afterEach(() => {
+    // Clean up the teleport container
+    document.body.removeChild(slidesDiv);
+  });
+
+  const factory = () => {
+    return mount(SlideInPanelManager, {
+      attachTo: document.body, // attach to document so Teleport renders
+      global:   { plugins: [store] }
+    });
+  };
+
+  it('renders slide in panel with proper style when open', async() => {
+    factory();
+    await nextTick();
+
+    const slidePanel = document.querySelector('#slides .slide-in') as HTMLElement;
+    const slideGlass = document.querySelector('[data-testid="slide-in-glass"]') as HTMLElement;
+    const slideComponent = document.querySelector('[data-testid="slide-in-panel-component"]') as HTMLElement;
+    const headerTitle = document.querySelector('#slides .slide-in .header .title') as HTMLElement;
+
+    expect(slidePanel).toBeTruthy();
+    expect(slideGlass).toBeTruthy();
+    expect(slideComponent).toBeTruthy();
+    expect(headerTitle.textContent?.trim()).toBe('Test Title');
+
+    const styleAttr = slidePanel.getAttribute('style') || '';
+
+    expect(styleAttr).toContain('width: 40%');
+    expect(styleAttr).toContain('top: 55px');
+    expect(styleAttr).toContain('height: calc(100vh - 55px)');
+    expect(styleAttr).toContain('right: 0');
+  });
+
+  it('renders default panel title when no title is provided', async() => {
+    // Update getter so that no title is provided
+    getters['slideInPanel/componentProps'] = () => ({ width: '40%' });
+    store = createStore({
+      getters,
+      mutations: { 'slideInPanel/close': jest.fn() }
+    });
+    factory();
+    await nextTick();
+
+    const headerTitle = document.querySelector('#slides #slide-in-panel-manager .header .title') as HTMLElement;
+
+    expect(headerTitle.textContent?.trim()).toBe('Details');
+  });
+
+  it('computes panelTop correctly when a banner exists', async() => {
+    // Create a banner element with a simulated clientHeight.
+    const banner = document.createElement('div');
+
+    banner.setAttribute('id', 'banner-header');
+    document.body.appendChild(banner);
+    // Simulate a banner with a clientHeight of 100.
+    Object.defineProperty(banner, 'clientHeight', { value: 100, configurable: true });
+
+    factory();
+    await nextTick();
+
+    const slidePanel = document.querySelector('#slides .slide-in') as HTMLElement;
+    const styleAttr = slidePanel.getAttribute('style') || '';
+
+    // Expected panelTop = HEADER_HEIGHT (55) + banner.clientHeight (100) = "155px"
+    expect(styleAttr).toContain('top: 155px');
+    expect(styleAttr).toContain('height: calc(100vh - 155px)');
+
+    document.body.removeChild(banner);
+  });
+
+  it('renders slide in glass as hidden and panel with negative right when closed', async() => {
+    // Set isOpen to false.
+    getters['slideInPanel/isOpen'] = () => false;
+    store = createStore({
+      getters,
+      mutations: { 'slideInPanel/close': jest.fn() }
+    });
+    factory();
+    await nextTick();
+
+    const slideGlass = document.querySelector('[data-testid="slide-in-glass"]') as HTMLElement;
+
+    expect(slideGlass).toBeTruthy();
+    expect(slideGlass.style.display).toBe('none');
+
+    const slidePanel = document.querySelector('#slides .slide-in') as HTMLElement;
+    const styleAttr = slidePanel.getAttribute('style') || '';
+
+    // With currentProps width "40%", panelRight should be "-40%" when closed.
+    expect(styleAttr).toContain('right: -40%');
+  });
+
+  it('calls store commit when clicking on the slide-in glass overlay', async() => {
+    const closeMutation = jest.fn();
+
+    getters['slideInPanel/isOpen'] = () => true;
+    store = createStore({
+      getters,
+      mutations: { 'slideInPanel/close': closeMutation }
+    });
+    factory();
+    await nextTick();
+
+    const slideGlass = document.querySelector('[data-testid="slide-in-glass"]') as HTMLElement;
+
+    slideGlass.click();
+    await nextTick();
+
+    expect(closeMutation).toHaveBeenCalledWith({}, undefined);
+  });
+
+  it('calls store commit when clicking on the slide-in close icon', async() => {
+    const closeMutation = jest.fn();
+
+    getters['slideInPanel/isOpen'] = () => true;
+    store = createStore({
+      getters,
+      mutations: { 'slideInPanel/close': closeMutation }
+    });
+    factory();
+    await nextTick();
+
+    const closeIcon = document.querySelector('[data-testid="slide-in-close"]') as HTMLElement;
+
+    closeIcon.click();
+    await nextTick();
+
+    expect(closeMutation).toHaveBeenCalledWith({}, undefined);
+  });
+});

--- a/shell/components/templates/default.vue
+++ b/shell/components/templates/default.vue
@@ -7,6 +7,8 @@ import {
 } from '@shell/store/prefs';
 import ActionMenu from '@shell/components/ActionMenu';
 import GrowlManager from '@shell/components/GrowlManager';
+import ModalManager from '@shell/components/ModalManager';
+import SlideInPanelManager from '@shell/components/SlideInPanelManager';
 import WindowManager from '@shell/components/nav/WindowManager';
 import PromptRemove from '@shell/components/PromptRemove';
 import PromptRestore from '@shell/components/PromptRestore';
@@ -39,6 +41,8 @@ export default {
     Header,
     ActionMenu,
     GrowlManager,
+    ModalManager,
+    SlideInPanelManager,
     WindowManager,
     FixedBanner,
     AwsComplianceBanner,
@@ -209,6 +213,7 @@ export default {
         <PromptRestore />
         <AssignTo />
         <PromptModal />
+        <ModalManager />
         <button
           v-if="noLocaleShortcut"
           v-shortkey.once="['shift','l']"
@@ -259,6 +264,7 @@ export default {
     </div>
     <FixedBanner :footer="true" />
     <GrowlManager />
+    <SlideInPanelManager />
     <Inactivity />
     <DraggableZone ref="draggableZone" />
   </div>

--- a/shell/components/templates/home.vue
+++ b/shell/components/templates/home.vue
@@ -3,6 +3,8 @@ import Header from '@shell/components/nav/Header';
 import Brand from '@shell/mixins/brand';
 import FixedBanner from '@shell/components/FixedBanner';
 import GrowlManager from '@shell/components/GrowlManager';
+import ModalManager from '@shell/components/ModalManager';
+import SlideInPanelManager from '@shell/components/SlideInPanelManager';
 import { mapPref, THEME_SHORTCUT } from '@shell/store/prefs';
 import AwsComplianceBanner from '@shell/components/AwsComplianceBanner';
 import AzureWarning from '@shell/components/auth/AzureWarning';
@@ -17,6 +19,8 @@ export default {
     Header,
     FixedBanner,
     GrowlManager,
+    ModalManager,
+    SlideInPanelManager,
     AzureWarning,
     AwsComplianceBanner,
     Inactivity,
@@ -58,6 +62,7 @@ export default {
     <AwsComplianceBanner />
     <AzureWarning />
     <PromptModal />
+    <ModalManager />
     <div
       class="dashboard-content"
       :class="{'dashboard-padding-left': showTopLevelMenu}"
@@ -79,6 +84,7 @@ export default {
     </div>
     <FixedBanner :footer="true" />
     <GrowlManager />
+    <SlideInPanelManager />
     <button
       v-if="themeShortcut"
       v-shortkey.once="['shift','t']"

--- a/shell/components/templates/plain.vue
+++ b/shell/components/templates/plain.vue
@@ -8,6 +8,8 @@ import IndentedPanel from '@shell/components/IndentedPanel';
 import Brand from '@shell/mixins/brand';
 import FixedBanner from '@shell/components/FixedBanner';
 import GrowlManager from '@shell/components/GrowlManager';
+import ModalManager from '@shell/components/ModalManager';
+import SlideInPanelManager from '@shell/components/SlideInPanelManager';
 import AwsComplianceBanner from '@shell/components/AwsComplianceBanner';
 import AzureWarning from '@shell/components/auth/AzureWarning';
 import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
@@ -26,6 +28,8 @@ export default {
     PromptModal,
     FixedBanner,
     GrowlManager,
+    ModalManager,
+    SlideInPanelManager,
     AwsComplianceBanner,
     AzureWarning,
     Inactivity
@@ -81,6 +85,7 @@ export default {
         <ActionMenu />
         <PromptRemove />
         <PromptModal />
+        <ModalManager />
         <AssignTo />
         <button
           v-if="themeShortcut"
@@ -99,6 +104,7 @@ export default {
 
     <FixedBanner :footer="true" />
     <GrowlManager />
+    <SlideInPanelManager />
     <Inactivity />
   </div>
 </template>

--- a/shell/config/store.js
+++ b/shell/config/store.js
@@ -27,10 +27,12 @@ let store = {};
   resolveStoreModules(require('../store/growl.js'), 'growl.js');
   resolveStoreModules(require('../store/i18n.js'), 'i18n.js');
   resolveStoreModules(require('../store/linode.js'), 'linode.js');
+  resolveStoreModules(require('../store/modal.ts'), 'modal.ts');
   resolveStoreModules(require('../store/plugins.js'), 'plugins.js');
   resolveStoreModules(require('../store/pnap.js'), 'pnap.js');
   resolveStoreModules(require('../store/prefs.js'), 'prefs.js');
   resolveStoreModules(require('../store/resource-fetch.js'), 'resource-fetch.js');
+  resolveStoreModules(require('../store/slideInPanel.ts'), 'slideInPanel.ts');
   resolveStoreModules(require('../store/type-map.js'), 'type-map.js');
   resolveStoreModules(require('../store/uiplugins.ts'), 'uiplugins.ts');
   resolveStoreModules(require('../store/wm.js'), 'wm.js');
@@ -54,10 +56,12 @@ let store = {};
       '../store/i18n.js',
       '../store/index.js',
       '../store/linode.js',
+      '../store/modal.ts',
       '../store/plugins.js',
       '../store/pnap.js',
       '../store/prefs.js',
       '../store/resource-fetch.js',
+      '../store/slideInPanel.ts',
       '../store/type-map.js',
       '../store/uiplugins.ts',
       '../store/wm.js',

--- a/shell/plugins/internal-api/shell/shell.api.ts
+++ b/shell/plugins/internal-api/shell/shell.api.ts
@@ -1,0 +1,106 @@
+import { GrowlConfig } from '@shell/types/internal-api/shell/growl';
+import { ModalConfig } from '@shell/types/internal-api/shell/modal';
+import { SlideInConfig } from '@shell/types/internal-api/shell/slideIn';
+
+import { BaseApi } from '@shell/plugins/internal-api/shared/base-api';
+
+export default class ShellApi extends BaseApi {
+  static apiName = 'shell';
+
+  /**
+   * Dispatches a growl notification.
+   *
+   * @param config - Configuration for the growl notification.
+   * - If `message` is a string, it is treated as the main content of the notification.
+   * - If `message` is a `DetailedMessage` object, `title` and `description` are extracted.
+   *
+   * Example:
+   * ```ts
+   * this.$shell.growl({ message: 'Operation successful!', type: 'success' });
+   * this.$shell.growl({ message: { title: 'Warning', description: 'Check your input.' }, type: 'warning' });
+   * ```
+   */
+  protected growl(config: GrowlConfig): void {
+    const { type = 'error', timeout = 5000 } = config;
+
+    let title = '';
+    let description = '';
+
+    if (typeof config.message === 'string') {
+      description = config.message;
+    } else {
+      title = config.message.title || '';
+      description = config.message.description;
+    }
+
+    this.$store.dispatch(
+      `growl/${ type }`,
+      {
+        title,
+        message: description,
+        timeout,
+      },
+      { root: true }
+    );
+  }
+
+  /**
+   * Opens a modal by committing to the Vuex store.
+   *
+   * This method updates the store's `modal` module to show a modal with the
+   * specified configuration. The modal is rendered using the `ModalManager` component,
+   * and its content is dynamically loaded based on the `component` field in the configuration.
+   *
+   * @param config A `ModalConfig` object defining the modal’s content and behavior.
+   *
+   * Example:
+   * ```ts
+   * this.$shell.modal({
+   *   component: MyCustomModal,
+   *   componentProps: { title: 'Hello Modal' },
+   *   resources: [someResource],
+   *   modalWidth: '800px',
+   *   closeOnClickOutside: false
+   * });
+   * ```
+   */
+  protected modal(config: ModalConfig): void {
+    this.$store.commit('modal/openModal', {
+      component:           config.component,
+      componentProps:      config.componentProps || {},
+      resources:           config.resources || [],
+      modalWidth:          config.modalWidth || '600px',
+      closeOnClickOutside: config.closeOnClickOutside ?? true,
+      // modalSticky:         config.modalSticky ?? false // Not implemented yet
+    });
+  }
+
+  /**
+   * Opens the slide-in panel with the specified component and props.
+   *
+   * This method commits the `open` mutation to the `slideInPanel` Vuex module,
+   * which sets the current component to be rendered and its associated props.
+   * The slide-in panel becomes visible after the mutation.
+   *
+   * @param config - The configuration object for the slide-in panel.
+   *
+   * Example Usage:
+   * ```ts
+   * import MyComponent from '@/components/MyComponent.vue';
+   *
+   * this.$shell.slideInPanel({
+   *   component: MyComponent,
+   *   componentProps: { foo: 'bar' }
+   * });
+   * ```
+   *
+   * @param config.component - A Vue component (imported SFC, functional component, etc.) to be rendered in the panel.
+   * @param config.componentProps - (Optional) Props to pass to the component. These should align with the component's defined props.
+   */
+  protected slideInPanel(config: SlideInConfig): void {
+    this.$store.commit('slideInPanel/open', {
+      component:      config.component,
+      componentProps: config.componentProps || {}
+    });
+  }
+}

--- a/shell/plugins/internal-api/shell/shell.api.ts
+++ b/shell/plugins/internal-api/shell/shell.api.ts
@@ -5,7 +5,9 @@ import { SlideInConfig } from '@shell/types/internal-api/shell/slideIn';
 import { BaseApi } from '@shell/plugins/internal-api/shared/base-api';
 
 export default class ShellApi extends BaseApi {
-  static apiName = 'shell';
+  static apiName() {
+    return 'shell';
+  }
 
   /**
    * Dispatches a growl notification.

--- a/shell/public/index.html
+++ b/shell/public/index.html
@@ -16,6 +16,7 @@
         </div>
     </div>
     <div id="modals"><!--Portal content here--></div>
+    <div id="slides"></div>
 
     <script>
         (() => {

--- a/shell/store/modal.ts
+++ b/shell/store/modal.ts
@@ -1,0 +1,71 @@
+import { markRaw, Component } from 'vue';
+import { MutationTree, GetterTree, ActionTree } from 'vuex';
+
+export interface ModalState {
+  isOpen: boolean;
+  component: Component | null;
+  componentProps: Record<string, any>;
+  resources: any[];
+  closeOnClickOutside: boolean;
+  modalWidth: string;
+  modalSticky: boolean;
+}
+
+const state = (): ModalState => ({
+  isOpen:              false,
+  component:           null,
+  componentProps:      {},
+  resources:           [],
+  closeOnClickOutside: false,
+  modalWidth:          '600px',
+  modalSticky:         false
+});
+
+const getters: GetterTree<ModalState, any> = {
+  isOpen:              (state) => state.isOpen,
+  component:           (state) => state.component,
+  componentProps:      (state) => state.componentProps,
+  resources:           (state) => state.resources,
+  closeOnClickOutside: (state) => state.closeOnClickOutside,
+  modalWidth:          (state) => state.modalWidth,
+  modalSticky:         (state) => state.modalSticky,
+};
+
+const mutations: MutationTree<ModalState> = {
+  openModal(state, payload: {
+    component: Component;
+    componentProps?: Record<string, any>;
+    resources?: any[];
+    closeOnClickOutside?: boolean;
+    modalWidth?: string;
+    modalSticky?: boolean;
+  }) {
+    state.isOpen = true;
+    state.component = markRaw(payload.component);
+    state.componentProps = payload.componentProps || {};
+    state.resources = Array.isArray(payload.resources) ? payload.resources : (payload.resources ? [payload.resources] : []);
+    state.closeOnClickOutside = payload.closeOnClickOutside ?? false;
+    state.modalWidth = payload.modalWidth || '600px';
+    state.modalSticky = payload.modalSticky ?? false;
+  },
+
+  closeModal(state) {
+    state.isOpen = false;
+    state.component = null;
+    state.componentProps = {};
+    state.resources = [];
+    state.closeOnClickOutside = false;
+    state.modalWidth = '600px';
+    state.modalSticky = false;
+  }
+};
+
+const actions: ActionTree<ModalState, any> = {};
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  mutations,
+  actions
+};

--- a/shell/store/slideInPanel.ts
+++ b/shell/store/slideInPanel.ts
@@ -1,0 +1,47 @@
+import { markRaw, Component } from 'vue';
+import { MutationTree, GetterTree, ActionTree } from 'vuex';
+
+export interface SlideInPanelState {
+  isOpen: boolean;
+  component: Component | null;
+  componentProps: Record<string, any>;
+}
+
+const state = (): SlideInPanelState => ({
+  isOpen:         false,
+  component:      null,
+  componentProps: {}
+});
+
+const getters: GetterTree<SlideInPanelState, any> = {
+  isOpen:         (state) => state.isOpen,
+  component:      (state) => state.component,
+  componentProps: (state) => state.componentProps
+};
+
+const mutations: MutationTree<SlideInPanelState> = {
+  open(state, payload: { component: Component; componentProps?: Record<string, any> }) {
+    state.isOpen = true;
+    state.component = markRaw(payload.component);
+    state.componentProps = payload.componentProps || {};
+  },
+  close(state) {
+    state.isOpen = false;
+
+    // Delay clearing component/props for 500ms (same as transition duration)
+    setTimeout(() => {
+      state.component = null;
+      state.componentProps = {};
+    }, 500);
+  }
+};
+
+const actions: ActionTree<SlideInPanelState, any> = {};
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  mutations,
+  actions
+};

--- a/shell/types/internal-api/shell/growl.d.ts
+++ b/shell/types/internal-api/shell/growl.d.ts
@@ -1,0 +1,25 @@
+export interface DetailedMessage {
+  title?: string;
+  description: string;
+}
+
+export interface GrowlConfig {
+  /**
+   * The content of the notification message.
+   * Either a simple string or an object with `title` and `description` for detailed notifications.
+   */
+  message: string | DetailedMessage;
+
+  /**
+   * Optional type of the growl notification.
+   * Determines the visual style of the notification.
+   * Defaults to `'error'` if not provided.
+   */
+  type?: 'success' | 'info' | 'warning' | 'error';
+
+  /**
+   * Optional duration (in milliseconds) for which the notification should be displayed.
+   * Defaults to `5000` milliseconds. A value of `0` keeps the notification indefinitely.
+   */
+  timeout?: number;
+}

--- a/shell/types/internal-api/shell/modal.d.ts
+++ b/shell/types/internal-api/shell/modal.d.ts
@@ -1,0 +1,77 @@
+import { Component } from 'vue';
+
+/**
+ * Configuration object for opening a modal.
+ */
+export interface ModalConfig {
+  /**
+   * The Vue component to be displayed inside the modal.
+   * This can be any SFC (Single-File Component) imported and passed in as a `Component`.
+   *
+   * Example:
+   * ```ts
+   * import MyCustomModal from '@/components/MyCustomModal.vue';
+   *
+   * this.$shell.modal({
+   *   component: MyCustomModal,
+   *   componentProps: { title: 'Hello Modal' }
+   * });
+   * ```
+   */
+  component: Component;
+
+  /**
+   * Optional props to pass directly to the component rendered inside the modal.
+   *
+   * Example:
+   * ```ts
+   * componentProps: { title: 'Hello Modal', isVisible: true }
+   * ```
+   */
+  componentProps?: Record<string, any>;
+
+  /**
+   * Optional array of resources that the modal component might need.
+   * These are passed directly into the modal's `resources` prop.
+   *
+   * Example:
+   * ```ts
+   * resources: [myResource, anotherResource]
+   * ```
+   */
+  resources?: any[];
+
+  /**
+   * Custom width for the modal. Defaults to `600px`.
+   * The width can be specified as a string with a valid unit (`px`, `%`, `rem`, etc.).
+   *
+   * Examples:
+   * ```ts
+   * modalWidth: '800px' // Width in pixels
+   * modalWidth: '75%'   // Width as a percentage
+   * ```
+   */
+  modalWidth?: string;
+
+  /**
+   * Determines if clicking outside the modal will close it. Defaults to `true`.
+   * Set this to `false` to prevent closing via outside clicks.
+   *
+   * Example:
+   * ```ts
+   * closeOnClickOutside: false
+   * ```
+   */
+  closeOnClickOutside?: boolean;
+
+  /**
+   * If true, the modal is considered "sticky" and may not close automatically
+   * on certain user interactions. Defaults to `false`.
+   *
+   * Example:
+   * ```ts
+   * modalSticky: true
+   * ```
+   */
+  // modalSticky?: boolean; // Not implemented yet
+}

--- a/shell/types/internal-api/shell/slideIn.d.ts
+++ b/shell/types/internal-api/shell/slideIn.d.ts
@@ -1,0 +1,15 @@
+import type { Component } from 'vue';
+
+/**
+ * Configuration object for opening a slide-in panel.
+ *
+ * @property component - The Vue component to render in the slide-in panel.
+ *                       This should be a valid Vue Component, such as an imported SFC or functional component.
+ *
+ * @property componentProps - (Optional) An object containing props to be passed to the component rendered in the slide-in panel.
+ *                            Keys should match the props defined in the provided component.
+ */
+export interface SlideInConfig {
+  component: Component | null;
+  componentProps?: Record<string, any>;
+}

--- a/shell/types/vue-shim.d.ts
+++ b/shell/types/vue-shim.d.ts
@@ -1,4 +1,6 @@
 /* eslint-disable */
+import type ShellApi from '@shell/plugins/internal-api/shell/shell.api';
+
 export {};
 
 declare module 'vue' {
@@ -15,6 +17,7 @@ declare module 'vue' {
       getters: Record<string, any>,
       dispatch: (action: string, payload?: any) => Promise<any>,
       commit: (mutation: string, payload?: any) => void,
-    }
+    },
+    $shell: ShellApi,
   }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Related #12705 
Follow on #13839
<!-- Define findings related to the feature or bug issue. -->

Follow-on to the previous PR, this introduces two new components (`ModalManager` and `SlideInPanelManager`) and a new `ShellApi` (`$shell`). These additions enable programmatic control of modals, notifications, and slide-in panels through a unified API.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Introduced a new internal API (`shell.api.ts`) that extends `BaseApi` and provides three methods:
  - `growl`: Dispatches growl notifications via Vuex.
  - `modal`: Opens modals by committing to the `modal` store module.
  - `slideInPanel`: Opens a slide-in panel via the `slideInPanel` store module.
- `ModalManager` is a new component that listens to the `modal` store module to render dynamic modals.
- `SlideInPanelManager` is a new component that listens to the `slideInPanel` store module and renders a slide-in panel with dynamic content.
- The `default`, `home`, and `plain` templates have been updated to include the new `ModalManager` and `SlideInPanelManager` components.
- Added `shell/store/modal.ts` and `shell/store/slideInPanel.ts` to manage the state for modals and slide-in panels.
- Modified `vue-shim.d.ts` to include the new `ShellApi`.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- The `ShellApi` consolidates UI-related functions (growl, modal, and slide-in panel) under one API (`$shell`).

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Verify that invoking `this.$shell.growl`, `this.$shell.modal`, and `this.$shell.slideInPanel` triggers the appropriate store mutations and results in the expected UI changes.
- Validate that the updated `default`, `home`, and `plain` templates render the new components correctly.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
