### PR TITLE
Set keyboard focus color for suse/prime theme

### DIFF
--- a/shell/assets/styles/themes/_light.scss
+++ b/shell/assets/styles/themes/_light.scss
@@ -26,7 +26,6 @@ $disabled  : $medium;
 $primary         : #3D98D3;
 $secondary       : $darker;
 $link            : #3D98D3;
-$keyboard-focus  : #{darken($primary, 10%)};
 
 // Status colors
 $success         : #5D995D;
@@ -54,7 +53,7 @@ BODY, .theme-light {
   --primary-border             : #{$primary};
   --primary-banner-bg          : #{rgba($primary, 0.15)};
   --primary-light-bg           : #{rgba($primary, 0.05)};
-  --primary-keyboard-focus     : #{$keyboard-focus};
+  --primary-keyboard-focus     : hsl(from var(--primary) h s calc(l - 10));
 
 
   .text-primary {

--- a/shell/assets/styles/themes/_suse.scss
+++ b/shell/assets/styles/themes/_suse.scss
@@ -12,6 +12,7 @@
   --primary-border             : #{$primary};
   --primary-banner-bg          : #{rgba($primary, 0.15)};
   --primary-light-bg           : #{rgba($primary, 0.05)};
+  --primary-keyboard-focus     : hsl(from var(--primary) h s calc(l - 10));
 
   --info                    : #{$info};
   --info-text               : #{contrast-color($info)};

--- a/shell/utils/color.js
+++ b/shell/utils/color.js
@@ -19,14 +19,15 @@ export function createCssVars(color, theme = 'light', name = 'primary') {
   const contrastOpts = theme === 'light' ? LIGHT_CONTRAST_COLORS : DARK_CONTRAST_COLORS;
 
   return {
-    [`--${ name }`]:             color,
-    [`--${ name }-text `]:       contrastColor(color, contrastOpts),
-    [`--${ name }-hover-bg`]:    lighten(color, -10),
-    [`--${ name }-active-bg`]:   lighten(color, -25),
-    [`--${ name }-active-text`]: contrastColor(lighten(color, -25), contrastOpts),
-    [`--${ name }-border`]:      color,
-    [`--${ name }-banner-bg`]:   opacity(color, 0.15),
-    [`--${ name }-light-bg`]:    opacity(color, 0.05),
+    [`--${ name }`]:                color,
+    [`--${ name }-text `]:          contrastColor(color, contrastOpts),
+    [`--${ name }-hover-bg`]:       lighten(color, -10),
+    [`--${ name }-active-bg`]:      lighten(color, -25),
+    [`--${ name }-active-text`]:    contrastColor(lighten(color, -25), contrastOpts),
+    [`--${ name }-border`]:         color,
+    [`--${ name }-banner-bg`]:      opacity(color, 0.15),
+    [`--${ name }-light-bg`]:       opacity(color, 0.05),
+    [`--${ name }-keyboard-focus`]: lighten(color, -10),
   };
 }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This ensures that the keyboard focus color is consistent with the theme by using HSL() for programmatic color control of keyboard focus. SASS variables don't help in scenarios where the theme can be modified.

Fixes #13566 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add css variable to control the color of keyboard focus
- Use HSL() to for programmatic color control of keyboard focus
- Update brand css variables

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

`shell/utils/color.js` appears to have a little quirk. Our themes darken primary color for `--primary-hover-bg`, but setting a custom color for branding will lighten the color instead. I added a line to override the keyboard focus so that it remains consistent.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Keyboard focus colors and themes:

- Default light
- Default dark
- Suse/prime
- Custom primary colors

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

NA

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before 

##### SUSE/Prime

![image](https://github.com/user-attachments/assets/4da44076-7007-4b74-913d-56dcac14aa00)

![image](https://github.com/user-attachments/assets/8cef3579-1e4d-4fa7-b590-f26fa259b762)

##### Custom primary colors

![image](https://github.com/user-attachments/assets/8f9c6cb4-a79c-4d60-b77f-73078dd00e0e)

![image](https://github.com/user-attachments/assets/2e67db7e-6068-4356-9c52-55ee0961a8ae)

#### After

##### SUSE/Prime

![image](https://github.com/user-attachments/assets/6c376927-d0ad-43ff-bf2a-ea6717c1c271)

![image](https://github.com/user-attachments/assets/61aeec26-319e-4b66-8996-3d6b2d0de79d)

##### Custom primary colors

![image](https://github.com/user-attachments/assets/9f403d6e-374c-40fc-8afa-583257b0bfb3)

![image](https://github.com/user-attachments/assets/78a92458-f153-46f6-b25c-5603a0f85315)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
