### PR TITLE
Revert "Auth Providers: Add search_using_service_account field #13223"

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -546,9 +546,6 @@ authConfig:
     starttls:
       label: Start TLS
       tip: Upgrades non-encrypted connections by wrapping with TLS during the connection process. Can not be used in conjunction with TLS.
-    searchUsingServiceAccount: 
-      label: Enable Service Account Search
-      tip: When enabled, Rancher will use the service account instead of the user account to search for users and groups.
     tls: TLS
     userEnabledAttribute: User Enabled Attribute
     userMemberAttribute: User Member Attribute

--- a/shell/edit/auth/ldap/__tests__/config.test.ts
+++ b/shell/edit/auth/ldap/__tests__/config.test.ts
@@ -2,20 +2,6 @@ import { mount } from '@vue/test-utils';
 import LDAPConfig from '@shell/edit/auth/ldap/config.vue';
 
 describe('lDAP config', () => {
-  it.each([
-    'openldap', 'freeipa'
-  ])('should display searchUsingServiceAccount checkbox if type %p', (type) => {
-    const wrapper = mount(LDAPConfig, {
-      propsData: {
-        value: {},
-        type,
-      }
-    });
-    const checkbox = wrapper.find('[data-testid="searchUsingServiceAccount"]');
-
-    expect(checkbox).toBeDefined();
-  });
-
   it('updates user login filter when value is entered', async() => {
     const wrapper = mount(
       LDAPConfig,

--- a/shell/edit/auth/ldap/config.vue
+++ b/shell/edit/auth/ldap/config.vue
@@ -11,8 +11,6 @@ const DEFAULT_TLS_PORT = 636;
 
 export const SHIBBOLETH = 'shibboleth';
 export const OKTA = 'okta';
-export const OPEN_LDAP = 'openldap';
-export const FREE_IPA = 'freeipa';
 
 export default {
   emits: ['update:value'],
@@ -66,11 +64,6 @@ export default {
     // Does the auth provider support LDAP for search in addition to SAML?
     isSamlProvider() {
       return this.type === SHIBBOLETH || this.type === OKTA;
-    },
-
-    // Allow to enable user search just for these providers
-    isSearchAllowed() {
-      return this.type === OPEN_LDAP || this.type === FREE_IPA;
     }
   },
 
@@ -233,23 +226,6 @@ export default {
         />
       </div>
     </div>
-
-    <div
-      v-if="isSearchAllowed"
-      class="row mb-20"
-    >
-      <div class="col">
-        <Checkbox
-          v-model:value="model.searchUsingServiceAccount"
-          :mode="mode"
-          data-testid="searchUsingServiceAccount"
-          class="full-height"
-          :label="t('authConfig.ldap.searchUsingServiceAccount.label')"
-          :tooltip="t('authConfig.ldap.searchUsingServiceAccount.tip')"
-        />
-      </div>
-    </div>
-
     <div class="row mb-20">
       <div class="col span-6">
         <LabeledInput


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This reverts commit 85c31a40731652231cf51f6945a699bec04d3571.

Testing exposed that this feature requires all three attributes (`searchUsingServiceAccount` flag, plus separate credentials via `searchServiceAccountDistinguishedName` and `searchServiceAccountPassword`) to function properly.

Reverting this change will prevent confusion until a fix can be applied to make the feature functional.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Revert commit 85c31a40731652231cf51f6945a699bec04d3571

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

See the original issue/PR for more context

- https://github.com/rancher/dashboard/issues/12871
- #13223

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

`searchUsingServiceAccount` field should be removed from config forms for openLDAP and freeIPA auth providers. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Auth providers should successfully create with this field removed.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes