### PR TITLE
fix missing types for weightGroup and weightType

### DIFF
--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -472,6 +472,24 @@ export interface DSLReturnType {
   virtualType: (options: ConfigureVirtualTypeOptions) => void;
 
   /**
+   * Side menu ordering for grouping of pages
+   * @param input Name of the group
+   * @param weight Ordering to be applied for the specified group
+   * @param forBasic Apply to basic type instead of regular type tree
+   * @returns {@link void}
+   */
+  weightGroup: (input: string, weight: number, forBasic: boolean) => void;
+
+  /**
+   * Side menu ordering for simple pages
+   * @param input Name of the page/resource
+   * @param weight Ordering to be applied for the specified page/resource
+   * @param forBasic Apply to basic type instead of regular type tree
+   * @returns {@link void}
+   */
+  weightType: (input: string, weight: number, forBasic: boolean) => void;
+
+  /**
    * Leaving these here for completeness but I don't think these should be advertised as useable to plugin creators.
    */
   // componentForType: (type: string, replacementType: string)
@@ -484,8 +502,6 @@ export interface DSLReturnType {
   // moveType: (match, group)
   // setGroupDefaultType: (input, defaultType)
   // spoofedType: (obj)
-  // weightGroup: (input, weight, forBasic)
-  // weightType: (input, weight, forBasic)
 }
 
 /**

--- a/shell/package.json
+++ b/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rancher/shell",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Rancher Dashboard Shell",
   "repository": "https://github.com/rancherlabs/dashboard",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13858 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix missing types for `weightGroup` and `weightType`
- bump shell version

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- advertised for extension developers as per https://extensions.rancher.io/extensions/next/api/nav/side-menu

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
