### PR TITLE
Auth Provider create/edit form can be saved with some mandatory fields in blank

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -658,7 +658,7 @@ authConfig:
     scope:
       label: Scopes
       placeholder: openid
-      protip: The <code>openid</code> scope is required. If you are using custom scopes, ensure that it is included.
+      protip: The <code>openid</code>, <code>profile</code>, and <code>email</code> scopes are required and cannot be removed.
     cert:
       label: Certificate
       placeholder: Paste in the certificate, starting with -----BEGIN CERTIFICATE-----

--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -32,151 +32,178 @@ const mockModel = {
 };
 
 describe('oidc.vue', () => {
-  let wrapper: VueWrapper<any, any>;
-  const requiredSetup = () => ({
-    data() {
-      return {
-        isEnabling:     false,
-        editConfig:     false,
-        model:          { ...mockModel },
-        serverSetting:  null,
-        errors:         [],
-        originalModel:  null,
-        principals:     [],
-        authConfigName: 'oidc',
-      } as any; // any is necessary as in pre-existing tests we are including inherited mixins values
-    },
-    global: {
-      mocks: {
-        $fetchState: { pending: false },
-        $store:      {
-          getters: {
-            currentStore:              () => 'current_store',
-            'current_store/schemaFor': jest.fn(),
-            'current_store/all':       jest.fn(),
-            'i18n/t':                  (val: string) => val,
-            'i18n/exists':             jest.fn(),
-          },
-          dispatch: jest.fn()
-        },
-        $route:  { query: { AS: '' }, params: { id: 'oicd' } },
-        $router: { applyQuery: jest.fn() },
+  describe('given default valid values', () => {
+    let wrapper: VueWrapper<any, any>;
+    const requiredSetup = () => ({
+      data() {
+        return {
+          isEnabling:     false,
+          editConfig:     false,
+          model:          { ...mockModel },
+          serverSetting:  null,
+          errors:         [],
+          originalModel:  null,
+          principals:     [],
+          authConfigName: 'oidc',
+        } as any; // any is necessary as in pre-existing tests we are including inherited mixins values
       },
-    },
-    props: {
-      value: { applicationSecret: '' },
-      mode:  _EDIT,
-    },
-  });
+      global: {
+        mocks: {
+          $fetchState: { pending: false },
+          $store:      {
+            getters: {
+              currentStore:              () => 'current_store',
+              'current_store/schemaFor': jest.fn(),
+              'current_store/all':       jest.fn(),
+              'i18n/t':                  (val: string) => val,
+              'i18n/exists':             jest.fn(),
+            },
+            dispatch: jest.fn()
+          },
+          $route:  { query: { AS: '' }, params: { id: 'oicd' } },
+          $router: { applyQuery: jest.fn() },
+        },
+      },
+      props: {
+        value: { applicationSecret: '' },
+        mode:  _EDIT,
+      },
+    });
 
-  beforeEach(() => {
-    wrapper = mount(oidc, { ...requiredSetup() });
-  });
-  afterEach(() => {
-    wrapper.unmount();
-  });
+    beforeEach(() => {
+      wrapper = mount(oidc, { ...requiredSetup() });
+    });
 
-  it('have "Create" button enabled when provider is enabled and not editing config', async() => {
-    wrapper.setData({ model: { enabled: true }, editConfig: false });
-    await nextTick();
+    afterEach(() => {
+      wrapper.unmount();
+    });
 
-    const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+    describe('have "Create" button disabled', () => {
+      it('given missing Auth endpoint URL', () => {
+        wrapper.vm.model.authEndpoint = '';
+        wrapper.vm.model.scopes = 'openid profile email'; // set scope to be sure
+        wrapper.vm.oidcScope = ['openid', 'profile', 'email']; // TODO #13457: this is duplicated due wrong format of scopes
 
-    expect(saveButton.disabled).toBe(false);
-  });
+        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
 
-  it('have "Create" button disabled when provider is disabled and editing config before fields are filled in', async() => {
-    wrapper.setData({ model: {}, editConfig: true });
-    await nextTick();
+        expect(saveButton.disabled).toBe(true);
+      });
 
-    const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+      it('given missing required basic scopes', () => {
+        wrapper.vm.model.authEndpoint = 'whatever'; // set auth endpoint to be sure
+        wrapper.vm.model.scopes = 'something else'; // set wrong scope
+        wrapper.vm.oidcScope = ['something', 'else']; // TODO #13457: this is duplicated due wrong format of scopes
 
-    expect(saveButton.disabled).toBe(true);
-  });
+        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
 
-  it('have "Create" button disabled when provider is disabled and editing config after required fields and scope is missing openid', async() => {
-    wrapper.setData({ oidcUrls: { url: validUrl, realm: validRealm } });
-    await nextTick();
+        expect(saveButton.disabled).toBe(true);
+      });
 
-    const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+      it('when provider is disabled and editing config before fields are filled in', async() => {
+        wrapper.setData({ model: {}, editConfig: true });
+        await nextTick();
 
-    expect(saveButton.disabled).toBe(true);
-  });
+        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
 
-  it('have "Create" button enabled when customEndpoint is disabled and required fields are filled in', async() => {
-    wrapper.setData({ oidcUrls: { url: validUrl, realm: validRealm }, oidcScope: validScope.split(' ') });
-    await nextTick();
+        expect(saveButton.disabled).toBe(true);
+      });
 
-    const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+      it('when provider is disabled and editing config after required fields and scope is missing openid', async() => {
+        wrapper.setData({ oidcUrls: { url: validUrl, realm: validRealm } });
+        await nextTick();
 
-    expect(saveButton.disabled).toBe(false);
-  });
+        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
 
-  it('have "Create" button enabled when customEndpoint is enabled and required fields are filled in', async() => {
-    wrapper.setData({ customEndpoint: { value: true }, oidcScope: validScope.split(' ') });
-    await nextTick();
+        expect(saveButton.disabled).toBe(true);
+      });
+    });
 
-    const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+    describe('have "Create" button enabled', () => {
+      it('when customEndpoint is disabled and required fields are filled in', async() => {
+        wrapper.setData({ oidcUrls: { url: validUrl, realm: validRealm }, oidcScope: validScope.split(' ') });
+        await nextTick();
 
-    expect(saveButton.disabled).toBe(false);
-  });
+        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
 
-  it('updates issuer endpoint when oidcUrls.url and oidcUrls.realm changes', async() => {
-    wrapper.setData({ oidcUrls: { url: validUrl } });
-    await nextTick();
+        expect(saveButton.disabled).toBe(false);
+      });
 
-    expect(wrapper.vm.model.issuer).toBe(`${ validUrl }/realms/`);
+      it('when customEndpoint is enabled and required fields are filled in', async() => {
+        wrapper.setData({ customEndpoint: { value: true }, oidcScope: validScope.split(' ') });
+        await nextTick();
 
-    wrapper.setData({ oidcUrls: { realm: validRealm } });
-    await nextTick();
+        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
 
-    expect(wrapper.vm.model.issuer).toBe(`${ validUrl }/realms/${ validRealm }`);
-  });
+        expect(saveButton.disabled).toBe(false);
+      });
 
-  it('`groupSearchEnabled` defaults to false', async() => {
-    const groupSearchCheckbox = wrapper.getComponent('[data-testid="input-group-search"]');
+      it('when provider is enabled and not editing config', async() => {
+        wrapper.setData({ model: { enabled: true }, editConfig: false });
+        await nextTick();
 
-    expect(groupSearchCheckbox.isVisible()).toBe(true);
-    expect(wrapper.vm.model.groupSearchEnabled).toBe(false);
-  });
+        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
 
-  it('`groupSearchEnabled` updates when checkbox is clicked', async() => {
-    const groupSearchCheckbox = wrapper.getComponent('[data-testid="input-group-search"]');
+        expect(saveButton.disabled).toBe(false);
+      });
+    });
 
-    await groupSearchCheckbox.find('[role="checkbox"]').trigger('click');
+    it('updates issuer endpoint when oidcUrls.url and oidcUrls.realm changes', async() => {
+      wrapper.setData({ oidcUrls: { url: validUrl } });
+      await nextTick();
 
-    expect(groupSearchCheckbox.isVisible()).toBe(true);
-    expect(wrapper.vm.model.groupSearchEnabled).toBe(true);
-  });
+      expect(wrapper.vm.model.issuer).toBe(`${ validUrl }/realms/`);
 
-  it('changing URL should update issuer and auth-endpoint if Keycloak', async() => {
-    wrapper.vm.model.id = 'keycloakoidc';
-    const newUrl = 'whatever';
+      wrapper.setData({ oidcUrls: { realm: validRealm } });
+      await nextTick();
 
-    await wrapper.find(`[data-testid="oidc-url"]`).setValue(newUrl);
-    await wrapper.vm.$nextTick();
+      expect(wrapper.vm.model.issuer).toBe(`${ validUrl }/realms/${ validRealm }`);
+    });
 
-    const issuer = (wrapper.find('[data-testid="oidc-issuer"]').element as HTMLInputElement).value;
-    const endpoint = (wrapper.find('[data-testid="oidc-auth-endpoint"]').element as HTMLInputElement).value;
+    it('`groupSearchEnabled` defaults to false', async() => {
+      const groupSearchCheckbox = wrapper.getComponent('[data-testid="input-group-search"]');
 
-    expect(issuer).toBe(`${ newUrl }/realms/`);
-    expect(endpoint).toBe(`${ newUrl }/realms//protocol/openid-connect/auth`);
-  });
+      expect(groupSearchCheckbox.isVisible()).toBe(true);
+      expect(wrapper.vm.model.groupSearchEnabled).toBe(false);
+    });
 
-  it('changing realm should update issuer and auth-endpoint if Keycloak', async() => {
-    const newRealm = 'newRealm';
-    const oldUrl = 'oldUrl';
+    it('`groupSearchEnabled` updates when checkbox is clicked', async() => {
+      const groupSearchCheckbox = wrapper.getComponent('[data-testid="input-group-search"]');
 
-    wrapper.vm.model.id = 'keycloakoidc';
-    wrapper.vm.oidcUrls.url = oldUrl;
+      await groupSearchCheckbox.find('[role="checkbox"]').trigger('click');
 
-    await wrapper.find(`[data-testid="oidc-realm"]`).setValue(newRealm);
-    await wrapper.vm.$nextTick();
+      expect(groupSearchCheckbox.isVisible()).toBe(true);
+      expect(wrapper.vm.model.groupSearchEnabled).toBe(true);
+    });
 
-    const issuer = (wrapper.find('[data-testid="oidc-issuer"]').element as HTMLInputElement).value;
-    const endpoint = (wrapper.find('[data-testid="oidc-auth-endpoint"]').element as HTMLInputElement).value;
+    it('changing URL should update issuer and auth-endpoint if Keycloak', async() => {
+      wrapper.vm.model.id = 'keycloakoidc';
+      const newUrl = 'whatever';
 
-    expect(issuer).toBe(`${ oldUrl }/realms/${ newRealm }`);
-    expect(endpoint).toBe(`${ oldUrl }/realms/${ newRealm }/protocol/openid-connect/auth`);
+      await wrapper.find(`[data-testid="oidc-url"]`).setValue(newUrl);
+      await wrapper.vm.$nextTick();
+
+      const issuerValue = (wrapper.find('[data-testid="oidc-issuer"]').element as HTMLInputElement).value;
+      const endpointValue = (wrapper.find('[data-testid="oidc-auth-endpoint"]').element as HTMLInputElement).value;
+
+      expect(issuerValue).toBe(`${ newUrl }/realms/`);
+      expect(endpointValue).toBe(`${ newUrl }/realms//protocol/openid-connect/auth`);
+    });
+
+    it('changing realm should update issuer and auth-endpoint if Keycloak', async() => {
+      const newRealm = 'newRealm';
+      const oldUrl = 'oldUrl';
+
+      wrapper.vm.model.id = 'keycloakoidc';
+      wrapper.vm.oidcUrls.url = oldUrl;
+
+      await wrapper.find(`[data-testid="oidc-realm"]`).setValue(newRealm);
+      await wrapper.vm.$nextTick();
+
+      const issuerValue = (wrapper.find('[data-testid="oidc-issuer"]').element as HTMLInputElement).value;
+      const endpointValue = (wrapper.find('[data-testid="oidc-auth-endpoint"]').element as HTMLInputElement).value;
+
+      expect(issuerValue).toBe(`${ oldUrl }/realms/${ newRealm }`);
+      expect(endpointValue).toBe(`${ oldUrl }/realms/${ newRealm }/protocol/openid-connect/auth`);
+    });
   });
 });

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -12,6 +12,7 @@ import ArrayList from '@shell/components/form/ArrayList';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import { RadioGroup } from '@components/Form/Radio';
 import { Checkbox } from '@components/Form/Checkbox';
+import { BASE_SCOPES } from '@shell/store/auth';
 
 export default {
   components: {
@@ -77,7 +78,7 @@ export default {
 
       const { clientId, clientSecret } = this.model;
       const isMissingAuthEndpoint = (this.requiresAuthEndpoint && !this.model.authEndpoint);
-      const isMissingScopes = !this.oidcScope?.includes('openid');
+      const isMissingScopes = !this.requiredScopes.every((scope) => this.oidcScope.includes(scope));
 
       if ( isMissingAuthEndpoint || isMissingScopes ) {
         return false;
@@ -97,6 +98,15 @@ export default {
     requiresAuthEndpoint() {
       return ['genericoidc', 'keycloakoidc'].includes(this.model.id);
     },
+
+    /**
+     * TODO #13457: Refactor scopes to be an array of terms
+     * Return valid scopes
+     * The scopes for given auth provider (model.id) have format of ['scope1 scope2 scope3']
+     */
+    requiredScopes() {
+      return this.model.id ? (BASE_SCOPES[this.model.id] || []) ? (BASE_SCOPES[this.model.id] || [])[0].split(' ') : [] : [];
+    }
   },
 
   watch: {
@@ -206,6 +216,7 @@ export default {
 
         <h3>{{ t(`authConfig.oidc.${NAME}`) }}</h3>
 
+        <!-- Auth credentials -->
         <div class="row mb-20">
           <div class="col span-6">
             <LabeledInput
@@ -227,6 +238,7 @@ export default {
           </div>
         </div>
 
+        <!-- Key/Certificate -->
         <div class="row mb-20">
           <div class="col span-6">
             <LabeledInput
@@ -260,6 +272,7 @@ export default {
           </div>
         </div>
 
+        <!-- Allow group search -->
         <div class="row mb-20">
           <div class="col span-6">
             <Checkbox
@@ -272,6 +285,7 @@ export default {
           </div>
         </div>
 
+        <!-- Scopes -->
         <div class="row mb-20">
           <div class="col span-6">
             <ArrayList
@@ -285,6 +299,7 @@ export default {
           </div>
         </div>
 
+        <!-- Generated vs Specific Endpoints -->
         <div class="row mb-20">
           <div class="col span-6">
             <RadioGroup
@@ -302,6 +317,7 @@ export default {
           </div>
         </div>
 
+        <!-- Generated endpoints -->
         <div class="row mb-20">
           <div class="col span-6">
             <LabeledInput
@@ -325,6 +341,7 @@ export default {
           </div>
         </div>
 
+        <!-- Specific Endpoints -->
         <div class="row mb-20">
           <div class="col span-6">
             <LabeledInput
@@ -361,6 +378,7 @@ export default {
           </div>
         </div>
 
+        <!-- Advanced section -->
         <AdvancedSection :mode="mode">
           <div class="row mb-20">
             <div class="col span-6">

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -76,9 +76,10 @@ export default {
       }
 
       const { clientId, clientSecret } = this.model;
-      const isValidScope = this.model.id === 'keycloakoidc' || this.oidcScope?.includes('openid');
+      const isMissingAuthEndpoint = (this.requiresAuthEndpoint && !this.model.authEndpoint);
+      const isMissingScopes = !this.oidcScope?.includes('openid');
 
-      if ( !isValidScope ) {
+      if ( isMissingAuthEndpoint || isMissingScopes ) {
         return false;
       }
 
@@ -91,7 +92,11 @@ export default {
 
         return !!(clientId && clientSecret && rancherUrl && issuer);
       }
-    }
+    },
+
+    requiresAuthEndpoint() {
+      return ['genericoidc', 'keycloakoidc'].includes(this.model.id);
+    },
   },
 
   watch: {
@@ -350,7 +355,7 @@ export default {
               :label="t(`authConfig.oidc.authEndpoint`)"
               :mode="mode"
               :disabled="!customEndpoint.value"
-              :required="model.id === 'keycloakoidc'"
+              :required="requiresAuthEndpoint"
               data-testid="oidc-auth-endpoint"
             />
           </div>

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -51,6 +51,7 @@ export default {
         tokenEndpoint:    null,
         userInfoEndpoint: null,
       },
+      // TODO #13457: this is duplicated due wrong format
       oidcScope: []
     };
   },
@@ -80,7 +81,7 @@ export default {
       const isMissingAuthEndpoint = (this.requiresAuthEndpoint && !this.model.authEndpoint);
       const isMissingScopes = !this.requiredScopes.every((scope) => this.oidcScope.includes(scope));
 
-      if ( isMissingAuthEndpoint || isMissingScopes ) {
+      if (isMissingAuthEndpoint || isMissingScopes) {
         return false;
       }
 
@@ -119,6 +120,7 @@ export default {
     },
 
     'model.enabled'(neu) {
+      // TODO #13457: Refactor scopes to be an array of terms
       // Cover case where oidc gets disabled and we return to the edit screen with a reset model
       if (!neu) {
         this.oidcUrls = {
@@ -129,8 +131,10 @@ export default {
           userInfoEndpoint: null,
         };
         this.customEndpoint.value = false;
+        // TODO #13457: Refactor scopes to be an array of terms
         this.oidcScope = this.model?.scope?.split(' ');
       } else {
+        // TODO #13457: Refactor scopes to be an array of terms
         this.oidcScope = this.model?.scope?.split(' ');
       }
     },

--- a/storybook/src/stories/Components/ArrayList.stories.ts
+++ b/storybook/src/stories/Components/ArrayList.stories.ts
@@ -25,13 +25,13 @@ const Template: Story = {
       return { args };
     },
     template: `<ArrayList v-bind="args">
-                 <template v-if="args.titleSlot" v-slot:title>{{ args.titleSlot }}</template>
-                 <template v-if="args.columnHeadersSlot" v-slot:column-headers>{{ args.columnHeadersSlot }}</template>
-                 <template v-if="args.columnsSlot" v-slot:columns>{{ args.columnsSlot }}</template>
-                 <template v-if="args.valueSlot" v-slot:value>{{ args.valueSlot }}</template>
-                 <template v-if="args.removeButtonSlot" v-slot:remove-button>{{ args.removeButtonSlot }}</template>
-                 <template v-if="args.emptySlot" v-slot:empty>{{ args.emptySlot }}</template>
-                 <template v-if="args.addSlot" v-slot:add>{{ args.addSlot }}</template>
+                 <template v-if="args.titleSlot" v-slot:title><div :innerHTML="args.titleSlot"></template>
+                 <template v-if="args.columnHeadersSlot" v-slot:column-headers><div :innerHTML="args.columnHeadersSlot"></template>
+                 <template v-if="args.columnsSlot" v-slot:columns><div :innerHTML="args.columnsSlot"></template>
+                 <template v-if="args.valueSlot" v-slot:value><div :innerHTML="args.valueSlot"></template>
+                 <template v-if="args.removeButtonSlot" v-slot:remove-button><div :innerHTML="args.removeButtonSlot"></template>
+                 <template v-if="args.emptySlot" v-slot:empty><div :innerHTML="args.emptySlot"></template>
+                 <template v-if="args.addSlot" v-slot:add><div :innerHTML="args.addSlot"></template>
                </ArrayList>`,
   }),
 };

--- a/storybook/src/stories/Components/KeyValue.stories.ts
+++ b/storybook/src/stories/Components/KeyValue.stories.ts
@@ -27,10 +27,13 @@ export const Protected: Story = {
   ...Default,
   args: {
     value: {
-      foo: 'bar',
-      bar: 'foo',
+      before:    'value',
+      foo:       'bar',
+      bar:       'foo',
+      something: 'else'
     },
-    toggleFilter: true,
+    protectedKeys: ['foo', 'bar'],
+    toggleFilter:  true,
   },
 };
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13771
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

- Updated validation to prevent the described scenario
  - Auth endpoint it's now required from the form
  - Basic scopes are now required from the view, as they are equally added programmatically in the store
- Updated tooltip for the scopes

### Technical notes summary

- Updated KeyValue Story while testing around a similar requirement
- Grouped existing tests
- Added test to ensure the save button is disabled (check the title, too much movement due grouping tests):
  - `given missing required basic scopes`
  - `given missing Auth endpoint URL`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

https://github.com/user-attachments/assets/16229b9d-ca49-41eb-89b2-0746c18473a0




### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
