### PR TITLE
Fix vSphere MOID not showing up for previously selected networks

### DIFF
--- a/shell/machine-config/__tests__/vmwarevsphere.test.ts
+++ b/shell/machine-config/__tests__/vmwarevsphere.test.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount, shallowMount } from '@vue/test-utils';
 import vmwarevsphere from '@shell/machine-config/vmwarevsphere.vue';
 import { DEFAULT_VALUES, SENTINEL } from '@shell/machine-config/vmwarevsphere-config';
 
@@ -172,12 +172,12 @@ describe('component: vmwarevsphere', () => {
         name:     'tag_name',
         category: 'tag_category',
       };
-      const expectedReslut = [{
+      const expectedResult = [{
         ...tag, label: `${ tag.category } / ${ tag.name }`, value: tag.id
       }];
       const wrapper = mount(vmwarevsphere, defaultCreateSetup);
 
-      expect(wrapper.vm.mapTagsToContent([tag])).toStrictEqual(expectedReslut);
+      expect(wrapper.vm.mapTagsToContent([tag])).toStrictEqual(expectedResult);
     });
   });
 
@@ -252,6 +252,51 @@ describe('component: vmwarevsphere', () => {
 
         expect(wrapper.vm.$data.validationErrors[poolId]).toBeUndefined();
       });
+    });
+  });
+
+  describe('syncNetworkValueForLegacyLabels', () => {
+    it('should update the current network value properly', () => {
+      const legacyName = 'legacy_name';
+      const legacyValue = 'legacy_value';
+      const networkLabel = 'network_label';
+
+      const wrapper = shallowMount(vmwarevsphere, {
+        ...defaultEditSetup,
+        propsData: {
+          ...defaultEditSetup.propsData,
+          value: {
+            ...defaultEditSetup.propsData.value,
+            network: [legacyName]
+          }
+        },
+        computed: {
+          networks: () => [
+            {
+              name: legacyName, label: networkLabel, value: legacyValue
+            },
+            {
+              name: 'name1', label: 'label1', value: 'value1'
+            },
+            {
+              name: 'name2', label: 'label2', value: 'value2'
+            },
+            {
+              name: 'name3', label: 'label3', value: 'value3'
+            },
+            {
+              name: 'name4', label: 'label4', value: 'value4'
+            },
+          ]
+        }
+      });
+
+      // check the current network before updating
+      expect(wrapper.vm.value.network).toStrictEqual([legacyName]);
+
+      wrapper.vm.syncNetworkValueForLegacyLabels();
+
+      expect(wrapper.vm.value.network).toStrictEqual([legacyValue]);
     });
   });
 });

--- a/shell/machine-config/vmwarevsphere.vue
+++ b/shell/machine-config/vmwarevsphere.vue
@@ -558,6 +558,7 @@ export default {
       this.resetValueIfNecessary('network', content, options, true);
 
       set(this, 'networksResults', content);
+      this.syncNetworkValueForLegacyLabels();
       this.vappMode = this.getInitialVappMode(this.value);
     },
 
@@ -666,6 +667,21 @@ export default {
         }
       } else {
         this.manageErrors(errorActions.DELETE, key);
+      }
+    },
+
+    // Network labels have been updated to include the MOID.
+    // To ensure previously selected networks remain consistent with this change,
+    // we update the current network value to allow correct selection from the network list.
+    syncNetworkValueForLegacyLabels() {
+      const currentNetwork = this.value.network[0];
+
+      if (this.mode !== _CREATE && currentNetwork) {
+        const networkMatch = this.networks.find((network) => currentNetwork === network.name && currentNetwork !== network.label);
+
+        if (networkMatch) {
+          this.value.network = [networkMatch.value];
+        }
       }
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12590 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
We've updated networks to include MOID when creating a vSphere cluster, but for previously created clusters with a selected network we would still show the old network without MOID. This PR makes sure a correct network is selected for them by looking at the list of the available networks and finding a match.
### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- `syncNetworkValueForLegacyLabels` created to find a network match
-  unit test

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
For the dev env, you can checkout to a commit before the change we made to support moid(e.g. 614826f92b), and create a vsphere cluster while a network is selected. Then checkout to this PR and see that the issue is fixed.
### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1160" alt="image" src="https://github.com/user-attachments/assets/9c7fe2d7-f698-41b4-9585-f3d6ebe3a5a6" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
