### PR TITLE
Restore resourceNames util for extensions compatibility

### DIFF
--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -354,7 +354,7 @@ export default {
         <div class="mb-10">
           <template v-if="!hasCustomRemove">
             {{ t('promptRemove.attemptingToRemove', { type }) }} <span
-              v-clean-html="resourceNames(names, t)"
+              v-clean-html="resourceNames(names, null, t)"
             />
           </template>
 

--- a/shell/dialog/DeactivateDriverDialog.vue
+++ b/shell/dialog/DeactivateDriverDialog.vue
@@ -31,12 +31,12 @@ export default {
   },
   computed: {
     formattedText() {
-      const namesSliced = this.drivers.map((obj) => obj.nameDisplay);
-      const count = namesSliced.length;
-      const remaining = namesSliced.length > 5 ? namesSliced.length - 5 : 0;
+      const driverNames = this.drivers.map((obj) => obj.nameDisplay);
+      const count = driverNames.length;
+      const remaining = driverNames.length > 5 ? driverNames.length - 5 : 0;
 
       const plusMore = this.t('drivers.deactivate.andOthers', { count: remaining });
-      const names = resourceNames(namesSliced, this.t, { plusMore, endString: false });
+      const names = resourceNames(driverNames, plusMore, this.t, false);
       const warningDrivers = this.t('drivers.deactivate.warningDrivers', { names, count });
 
       return this.t('drivers.deactivate.warning', { warningDrivers, count });

--- a/shell/dialog/GitRepoForceUpdateDialog.vue
+++ b/shell/dialog/GitRepoForceUpdateDialog.vue
@@ -84,7 +84,7 @@ export default {
     <template #body>
       <div class="mb-20">
         {{ t('fleet.gitRepo.actions.forceUpdate.promptNames') }} <span
-          v-clean-html="resourceNames(names, t)"
+          v-clean-html="resourceNames(names, null, t)"
           class="body"
         />
       </div>

--- a/shell/promptRemove/management.cattle.io.fleetworkspace.vue
+++ b/shell/promptRemove/management.cattle.io.fleetworkspace.vue
@@ -71,7 +71,7 @@ export default {
   <div class="mt-10">
     <div class="mb-10">
       {{ t('promptRemove.attemptingToRemove', { type }) }} <span
-        v-clean-html="resourceNames(names, t)"
+        v-clean-html="resourceNames(names, null, t)"
         class="description"
       />
     </div>

--- a/shell/promptRemove/management.cattle.io.globalrole.vue
+++ b/shell/promptRemove/management.cattle.io.globalrole.vue
@@ -21,7 +21,7 @@ export default {
 
 <template>
   <div>
-    {{ t('promptRemove.attemptingToRemove', { type }) }} <span v-clean-html="resourceNames(names, t)" />
+    {{ t('promptRemove.attemptingToRemove', { type }) }} <span v-clean-html="resourceNames(names, null, t)" />
     <div
       v-if="info"
       class="text info mb-10 mt-20"

--- a/shell/promptRemove/management.cattle.io.project.vue
+++ b/shell/promptRemove/management.cattle.io.project.vue
@@ -94,7 +94,7 @@ export default {
         <template v-if="!canSeeProjectlessNamespaces">
           <span class="delete-warning"> {{ t('promptRemove.willDeleteAssociatedNamespaces') }}</span> <br>
           <div
-            v-clean-html="resourceNames(names, t)"
+            v-clean-html="resourceNames(names, null, t)"
             class="mt-10"
           />
         </template>
@@ -108,7 +108,7 @@ export default {
           :label="t('promptRemove.deleteAssociatedNamespaces')"
         />
         <div class="mt-10 ml-20">
-          <span v-clean-html="resourceNames(names, t)" />
+          <span v-clean-html="resourceNames(names, null, t)" />
         </div>
       </div>
     </div>

--- a/shell/promptRemove/management.cattle.io.roletemplate.vue
+++ b/shell/promptRemove/management.cattle.io.roletemplate.vue
@@ -22,7 +22,7 @@ export default {
 <template>
   <div>
     {{ t('promptRemove.attemptingToRemove', { type }) }} <span
-      v-clean-html="resourceNames(names, t)"
+      v-clean-html="resourceNames(names, null, t)"
     />
     <div
       v-if="info"

--- a/shell/promptRemove/pod.vue
+++ b/shell/promptRemove/pod.vue
@@ -98,7 +98,7 @@ export default {
   <div class="mt-10">
     <div class="mb-30">
       {{ t('promptRemove.attemptingToRemove', { type }) }} <span
-        v-clean-html="resourceNames(names, t)"
+        v-clean-html="resourceNames(names, null, t)"
         class="body"
       />
     </div>

--- a/shell/utils/__tests__/string.test.ts
+++ b/shell/utils/__tests__/string.test.ts
@@ -81,9 +81,9 @@ describe('fx: resourceNames', () => {
     it.each(args)(`having: %p`, (
       names,
       expectation,
-      options,
+      options: any,
     ) => {
-      const result = resourceNames(names, t, options);
+      const result = resourceNames(names, options.plusMore, t, options.endString);
 
       expect(result).toStrictEqual(expectation);
     });

--- a/shell/utils/string.js
+++ b/shell/utils/string.js
@@ -151,10 +151,8 @@ export function pluralize(str) {
   }
 }
 
-export function resourceNames(names, t, options = {}) {
+export function resourceNames(names, plusMore, t, endString) {
   const MAX_NAMES_COUNT = 5;
-
-  let { plusMore, endString } = options;
 
   // plusMore default value
   if (!plusMore) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
