### PR TITLE
Fixing two issues around generic import registries accordion

### DIFF
--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -517,7 +517,7 @@ export default defineComponent({
         />
       </Accordion>
       <Accordion
-        v-if="isEdit"
+        v-if="!isCreate"
         class="mb-20 accordion"
         title-key="imported.accordions.networking"
         data-testid="network-accordion"
@@ -548,7 +548,7 @@ export default defineComponent({
         />
       </Accordion>
       <Accordion
-        v-if="isEdit && !isRKE1"
+        v-if="!isCreate && !isRKE1"
         class="mb-20 accordion"
         title-key="imported.accordions.registries"
         data-testid="registries-accordion"
@@ -563,6 +563,7 @@ export default defineComponent({
         <Checkbox
           v-model:value="showPrivateRegistryInput"
           class="mb-20"
+          :mode="mode"
           :label="t('cluster.privateRegistry.label')"
           data-testid="private-registry-enable-checkbox"
         />

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -383,7 +383,7 @@ export default defineComponent({
   },
 
   watch: {
-    showCustomRegistryInput(value) {
+    showPrivateRegistryInput(value) {
       if (!value) {
         this.normanCluster.importedConfig.privateRegistryURL = null;
       }


### PR DESCRIPTION
### Summary
We no properly reset the registry value if the enable checkbox is disabled
We now show both the networking and registry accordions in the detail config view

Fixes #13864
Fixes #13863


### Technical notes summary
- A variable rename didn't include updating a watcher function
- I initially decided we didn't want to show the registry accordion based on the networking accordion but it looks like we want to show both.

### Areas or cases that should be tested
Generic import cluster detail and edit pages

### Areas which could experience regressions
Generic import cluster detail and edit pages

### Screenshots

Create:
![image](https://github.com/user-attachments/assets/8c71e211-fe5a-4b6f-8428-1e252dd67bed)

Edit:
![image](https://github.com/user-attachments/assets/d746c83e-cdfc-47a5-b902-212a1b0ea725)

Detail:
![image](https://github.com/user-attachments/assets/4a9b4418-6e14-481b-9b43-edf7eeaa5f55)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
