### PR TITLE
[backport v2.11.1] [BUG] Keycloak generated Auth and Issuer endpoints are using outdated URL patterns

### DIFF
--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -1,6 +1,6 @@
 import { nextTick } from 'vue';
 /* eslint-disable jest/no-hooks */
-import { mount } from '@vue/test-utils';
+import { mount, type VueWrapper } from '@vue/test-utils';
 import { _EDIT } from '@shell/config/query-params';
 
 import oidc from '@shell/edit/auth/oidc.vue';
@@ -32,7 +32,7 @@ const mockModel = {
 };
 
 describe('oidc.vue', () => {
-  let wrapper: any;
+  let wrapper: VueWrapper<any, any>;
   const requiredSetup = () => ({
     data() {
       return {
@@ -44,7 +44,7 @@ describe('oidc.vue', () => {
         originalModel:  null,
         principals:     [],
         authConfigName: 'oidc',
-      };
+      } as any; // any is necessary as in pre-existing tests we are including inherited mixins values
     },
     global: {
       mocks: {
@@ -147,5 +147,36 @@ describe('oidc.vue', () => {
 
     expect(groupSearchCheckbox.isVisible()).toBe(true);
     expect(wrapper.vm.model.groupSearchEnabled).toBe(true);
+  });
+
+  it('changing URL should update issuer and auth-endpoint if Keycloak', async() => {
+    wrapper.vm.model.id = 'keycloakoidc';
+    const newUrl = 'whatever';
+
+    await wrapper.find(`[data-testid="oidc-url"]`).setValue(newUrl);
+    await wrapper.vm.$nextTick();
+
+    const issuer = (wrapper.find('[data-testid="oidc-issuer"]').element as HTMLInputElement).value;
+    const endpoint = (wrapper.find('[data-testid="oidc-auth-endpoint"]').element as HTMLInputElement).value;
+
+    expect(issuer).toBe(`${ newUrl }/realms/`);
+    expect(endpoint).toBe(`${ newUrl }/realms//protocol/openid-connect/auth`);
+  });
+
+  it('changing realm should update issuer and auth-endpoint if Keycloak', async() => {
+    const newRealm = 'newRealm';
+    const oldUrl = 'oldUrl';
+
+    wrapper.vm.model.id = 'keycloakoidc';
+    wrapper.vm.oidcUrls.url = oldUrl;
+
+    await wrapper.find(`[data-testid="oidc-realm"]`).setValue(newRealm);
+    await wrapper.vm.$nextTick();
+
+    const issuer = (wrapper.find('[data-testid="oidc-issuer"]').element as HTMLInputElement).value;
+    const endpoint = (wrapper.find('[data-testid="oidc-auth-endpoint"]').element as HTMLInputElement).value;
+
+    expect(issuer).toBe(`${ oldUrl }/realms/${ newRealm }`);
+    expect(endpoint).toBe(`${ oldUrl }/realms/${ newRealm }/protocol/openid-connect/auth`);
   });
 });

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -136,7 +136,7 @@ export default {
       const isKeycloak = this.model.id === 'keycloakoidc';
 
       const url = this.oidcUrls.url.replaceAll(' ', '');
-      const realmsPath = isKeycloak ? 'auth/realms' : 'realms';
+      const realmsPath = 'realms';
 
       this.model.issuer = `${ url }/${ realmsPath }/${ this.oidcUrls.realm || '' }`;
 

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/Advanced.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/Advanced.test.ts
@@ -45,8 +45,6 @@ describe('component: Advanced', () => {
         mountOptions
       );
 
-      // eslint-disable-next-line no-console
-      console.log(wrapper.html());
       const inputElem = wrapper.find('[data-testid="array-list-box0"]');
 
       expect(inputElem.exists()).toBe(false);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13878

Backport PR: https://github.com/rancher/dashboard/pull/13767

Just cherry-picked.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
