### PR TITLE
Revert Vue 3.5 features added to dashboard to maintain compatibility with Vue 3.2

### DIFF
--- a/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.vue
+++ b/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, onMounted, onBeforeUnmount, useTemplateRef } from 'vue';
+import { defineComponent, onMounted, onBeforeUnmount, ref } from 'vue';
 
 type StateType = boolean | 'true' | 'false' | undefined;
 
@@ -34,7 +34,7 @@ export default defineComponent({
   emits: ['update:value'],
 
   setup() {
-    const switchChrome = useTemplateRef<HTMLElement>('switchChrome');
+    const switchChrome = ref<HTMLElement | null>(null);
     const focus = () => {
       switchChrome.value?.classList.add('focus');
     };
@@ -43,7 +43,7 @@ export default defineComponent({
       switchChrome.value?.classList.remove('focus');
     };
 
-    const switchInput = useTemplateRef<HTMLInputElement>('switchInput');
+    const switchInput = ref<HTMLInputElement | null>(null);
 
     onMounted(() => {
       switchInput.value?.addEventListener('focus', focus);

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdown.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdown.vue
@@ -20,7 +20,7 @@
  *    </template>
  *  </rc-dropdown>
  */
-import { useTemplateRef } from 'vue';
+import { ref } from 'vue';
 import { useClickOutside } from '@shell/composables/useClickOutside';
 import { useDropdownContext } from '@components/RcDropdown/useDropdownContext';
 
@@ -42,8 +42,8 @@ const {
 
 provideDropdownContext();
 
-const popperContainer = useTemplateRef<HTMLElement>('popperContainer');
-const dropdownTarget = useTemplateRef<HTMLElement>('dropdownTarget');
+const popperContainer = ref(null);
+const dropdownTarget = ref(null);
 
 useClickOutside(dropdownTarget, () => showMenu(false));
 

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownMenu.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownMenu.vue
@@ -8,8 +8,10 @@ import {
 import { RcDropdownMenuComponentProps, DropdownOption } from './types';
 import IconOrSvg from '@shell/components/IconOrSvg';
 
-// eslint-disable-next-line vue/no-setup-props-destructure
-const { buttonRole = 'primary', buttonSize = '' } = defineProps<RcDropdownMenuComponentProps>();
+withDefaults(defineProps<RcDropdownMenuComponentProps>(), {
+  buttonRole: 'primary',
+  buttonSize: undefined,
+});
 
 const emit = defineEmits(['update:open', 'select']);
 

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownTrigger.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownTrigger.vue
@@ -2,7 +2,7 @@
 /**
  * A button that opens a menu. Used in conjunction with `RcDropdown.vue`.
  */
-import { inject, onMounted, useTemplateRef } from 'vue';
+import { inject, onMounted, ref } from 'vue';
 import { RcButton, RcButtonType } from '@components/RcButton';
 import { DropdownContext, defaultContext } from './types';
 
@@ -13,7 +13,7 @@ const {
   handleKeydown,
 } = inject<DropdownContext>('dropdownContext') || defaultContext;
 
-const dropdownTrigger = useTemplateRef<RcButtonType>('dropdownTrigger');
+const dropdownTrigger = ref<RcButtonType | null>(null);
 
 onMounted(() => {
   registerTrigger(dropdownTrigger.value);

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1,6 +1,6 @@
 <script>
 import { mapGetters } from 'vuex';
-import { defineAsyncComponent, useTemplateRef, onMounted, onBeforeUnmount } from 'vue';
+import { defineAsyncComponent, ref, onMounted, onBeforeUnmount } from 'vue';
 import day from 'dayjs';
 import isEmpty from 'lodash/isEmpty';
 import { dasherize, ucFirst } from '@shell/utils/string';
@@ -528,7 +528,7 @@ export default {
     },
   },
   setup(_props, { emit }) {
-    const table = useTemplateRef('table');
+    const table = ref(null);
 
     const handleEnterKey = (event) => {
       if (event.key === 'Enter' && !event.target?.classList?.contains('checkbox-custom')) {
@@ -543,6 +543,8 @@ export default {
     onBeforeUnmount(() => {
       table.value.removeEventListener('keyup', handleEnterKey);
     });
+
+    return { table };
   },
 
   created() {

--- a/shell/components/StatusBadge.vue
+++ b/shell/components/StatusBadge.vue
@@ -19,10 +19,16 @@ const STATUS = {
   }
 };
 
-const { status = 'success', label } = defineProps<{
-  status?: 'success' | 'warning' | 'info' | 'error',
-  label?: string
-}>();
+withDefaults(
+  defineProps<{
+    status?: 'success' | 'warning' | 'info' | 'error',
+    label?: string
+  }>(),
+  {
+    status: 'success',
+    label:  '',
+  }
+);
 
 </script>
 <template>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This reverts any Vue 3.5 features that might be used in Rancher Dashboard so that Rancher Shell can maintain compatibility with Rancher Dashboard v2.10/Vue 3.2. 

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Replace `useTemplateRef` with `ref` for Vue 3.2.47 compatibility of shell
- Replace Reactive Props Destructure with `withDefaults` macro

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Several Vue 3.5 features that were added to Rancher Dashboard for v2.11 have caused backwards incompatibility issues with recent shell versions and Rancher Dashboard v2.10. Dashboard 2.10 still has a dependency on Vue 3.2.47. Therefore, any apis introduced for Vue 3.5 will throw an error when accessed in extensions that are loaded in Dashboard 2.10.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

This was uncovered in the latest Harvester extension loaded on Rancher Dashboard 2.10. This change will need to be tested in a similar setup.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- New Dropdown Menu
- Status Badge
- Toggle Switch
- Sortable Table

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
