### PR TITLE
Minor fix to gh project automation script logging

### DIFF
--- a/.github/workflows/scripts/pr-gh-project.js
+++ b/.github/workflows/scripts/pr-gh-project.js
@@ -145,7 +145,13 @@ async function processClosedAction() {
   // If not, then the issue has been completed, so we can process it
   r.forEach(openPR => {
     const fixed = getReferencedIssues(openPR.body);
-    fixed.forEach(issue => issueMap[issue] = false);
+    fixed.forEach(issue => {
+      // If the other PR fixes one of the issues that is fixed by this PR, then we need to update our map
+      // so that we ignore it, as there is still an open PR linked to the issue
+      if (issueMap[issue]) {
+        issueMap[issue] = false;
+      }
+    });
   });
 
   // Filter down the list of issues that should be closed because this PR was merged


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13882

### Occurred changes and/or fixed issues

Tweak to script to only log PRs that fix the same issue as the PR being closed.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
