### PR TITLE
automation: select all custom permissions

### DIFF
--- a/cypress/e2e/po/pages/explorer/cluster-project-members.po.ts
+++ b/cypress/e2e/po/pages/explorer/cluster-project-members.po.ts
@@ -5,7 +5,7 @@ import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import RadioGroupInputPo from '@/cypress/e2e/po/components/radio-group-input.po';
 import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
 import SortableTablePo from '@/cypress/e2e/po/components/sortable-table.po';
-
+import BannersPo from '@/cypress/e2e/po/components/banners.po';
 export default class ClusterProjectMembersPo extends PagePo {
   private static createPath(clusterId: string, tabId: string) {
     return `/c/${ clusterId }/explorer/members#${ tabId }`;
@@ -45,6 +45,10 @@ export default class ClusterProjectMembersPo extends PagePo {
     permissionOptions.set(3);
   }
 
+  customPermissionsCheckboxes() {
+    return cy.get('.custom-permissions').find('.checkbox-container');
+  }
+
   checkTheseProjectCustomPermissions(permissionIndices: number[]) {
     permissionIndices.forEach((permissionIndex) => {
       const checkbox = new CheckboxInputPo(`[data-testid="custom-permission-${ permissionIndex }"]`);
@@ -64,6 +68,10 @@ export default class ClusterProjectMembersPo extends PagePo {
 
   cancelCreateForm(): AsyncButtonPo {
     return new AsyncButtonPo('[data-testid="form-cancel"]', this.self());
+  }
+
+  createFormErrorBanner(): BannersPo {
+    return new BannersPo('.card-body [data-testid="banner-content"]');
   }
 
   resourcesList() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1747

This PR updates an existing test (`cypress/e2e/tests/pages/explorer2/cluster-project-members.spec.ts => "Can create a member with custom permissions"`) to select all custom permissions. Selecting all options will catch issues like https://github.com/rancher/dashboard/issues/13764

Ignore the test failure in CI as it's expected. A fix is needed for the above issue before merging this code.

<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
