### PR TITLE
Update Harvester validation on cpu/memory/disk fields

### DIFF
--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -579,9 +579,10 @@ export default {
         this.value.vmAffinity = base64Decode(this.value.vmAffinity);
       }
 
-      if (!this.value.cpuCount) {
-        const message = this.validatorRequiredField(
-          this.t('cluster.credential.harvester.cpu')
+      if (!this.value.cpuCount || Number(this.value.cpuCount) <= 0) {
+        const message = this.validatorMinimumField(
+          this.t('cluster.credential.harvester.cpu'),
+          1
         );
 
         errors.push(message);
@@ -595,9 +596,10 @@ export default {
         errors.push(message);
       }
 
-      if (!this.value.memorySize) {
-        const message = this.validatorRequiredField(
-          this.t('cluster.credential.harvester.memory')
+      if (!this.value.memorySize || Number(this.value.memorySize) <= 0) {
+        const message = this.validatorMinimumField(
+          this.t('cluster.credential.harvester.memory'),
+          1
         );
 
         errors.push(message);
@@ -624,6 +626,10 @@ export default {
       return this.t('validation.required', { key });
     },
 
+    validatorMinimumField(key, min) {
+      return this.t('validation.minValue', { key, min });
+    },
+
     validatorDiskAndNetowrk(errors) {
       const disks = JSON.parse(this.value.diskInfo).disks;
       const interfaces = JSON.parse(this.value.networkInfo).interfaces;
@@ -645,9 +651,10 @@ export default {
           errors.push(message);
         }
 
-        if (!disk.size) {
-          const message = this.validatorRequiredField(
-            this.t('cluster.credential.harvester.disk')
+        if (!disk.size || Number(disk.size) <= 0) {
+          const message = this.validatorMinimumField(
+            this.t('cluster.credential.harvester.disk'),
+            1
           );
 
           errors.push(message);
@@ -1186,6 +1193,7 @@ export default {
             suffix="C"
             output-as="string"
             required
+            min="1"
             :mode="mode"
             :disabled="disabled"
             :placeholder="t('cluster.harvester.machinePool.cpu.placeholder')"
@@ -1202,6 +1210,7 @@ export default {
             :mode="mode"
             :disabled="disabled"
             required
+            min="1"
             :placeholder="t('cluster.harvester.machinePool.memory.placeholder')"
           />
         </div>
@@ -1310,6 +1319,7 @@ export default {
                     :mode="mode"
                     :disabled="disabled"
                     required
+                    min="1"
                     :placeholder="t('cluster.harvester.machinePool.disk.placeholder')"
                     @update:value="update"
                   />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13067 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Previously `cpuCount`, `memorySize` and `disk.size` fields were only get validated for having a value, but now their value should be at least `1`.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Added `validatorMinimumField` to check for minimum value
- Replaced `validatorRequiredField` with `validatorMinimumField` for the mentioned fields

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/b63729fd-9572-40c6-998c-a9d3da57b3d8


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
