### PR TITLE
Fix chart maintainer link to work with urls and emails

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -69,7 +69,7 @@ export default {
         return {
           id:   m.name,
           text: m.name,
-          url:  `mailto:${ m.email }`
+          url:  m.email ? `mailto:${ m.email }` : m.url
         };
       });
     },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13911

### Occurred changes and/or fixed issues

Trivial fix - we aren't currently supporting maintainer info with the `url` - only those with the `email` field.

This PR fixes this.

### Areas or cases that should be tested

Add application collection to Rancher Manager.

Browse to any Application Collection chart and on the right hand side, observe that the link for the `SUSE LLC` maintainer is now a URL and clicking on it opens the SUSE Web site.

Previously, if you hovered on the link, you'd see the target was incorrectly `mailto:undefined`. 

### Screenshot/Video

![image](https://github.com/user-attachments/assets/88289e09-e143-4545-9e02-f63651bc7a57)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- x ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
