### PR TITLE
Remove rollback action from ReplicaSet resource

### DIFF
--- a/cypress/e2e/po/components/action-menu-shell.po.ts
+++ b/cypress/e2e/po/components/action-menu-shell.po.ts
@@ -1,7 +1,7 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 
 export default class ActionMenuPo extends ComponentPo {
-  constructor(arg:any) {
+  constructor(arg?:any) {
     super(arg || cy.get('[dropdown-menu-collection]'));
   }
 
@@ -11,5 +11,15 @@ export default class ActionMenuPo extends ComponentPo {
 
   getMenuItem(name: string) {
     return this.self().get('[dropdown-menu-item]').contains(name);
+  }
+
+  menuItemNames() {
+    return this.self().get('[dropdown-menu-item]').then(($els) => {
+      return (
+        Cypress.$.makeArray($els)
+          // and extract inner text from each
+          .map((el) => el.innerText)
+      );
+    });
   }
 }

--- a/cypress/e2e/po/pages/explorer/workloads-replicasets.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads-replicasets.po.ts
@@ -1,0 +1,93 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
+import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
+import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
+import ResourceListMastheadPo from '@/cypress/e2e/po/components/ResourceList/resource-list-masthead.po';
+import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
+import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
+
+export class WorkloadsReplicasetsListPagePo extends PagePo {
+  private static createPath(clusterId: string) {
+    return `/c/${ clusterId }/explorer/apps.replicaset`;
+  }
+
+  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(WorkloadsReplicasetsListPagePo.createPath(clusterId));
+  }
+
+  constructor(clusterId = 'local') {
+    super(WorkloadsReplicasetsListPagePo.createPath(clusterId));
+  }
+
+  masthead() {
+    return new ResourceListMastheadPo(this.self());
+  }
+
+  createReplicaset() {
+    return this.masthead().create();
+  }
+
+  goToeditItemWithName(name:string) {
+    const baseResourceList = new BaseResourceList(this.self());
+
+    return baseResourceList.actionMenu(name).getMenuItem('Edit Config').click();
+  }
+
+  baseResourceList() {
+    return new BaseResourceList(this.self());
+  }
+
+  listElementWithName(name:string) {
+    const baseResourceList = new BaseResourceList(this.self());
+
+    return baseResourceList.resourceTable().sortableTable().rowElementWithName(name);
+  }
+
+  sortableTable() {
+    const baseResourceList = new BaseResourceList(this.self());
+
+    return baseResourceList.resourceTable().sortableTable();
+  }
+}
+
+export class WorkloadsReplicasetsEditPagePo extends PagePo {
+  static url: string;
+
+  private static createPath(daemonsetId: string, clusterId: string, namespaceId: string, queryParams?: Record<string, string>) {
+    const urlStr = `/c/${ clusterId }/explorer/apps.replicaset/${ namespaceId }/${ daemonsetId }`;
+
+    if (!queryParams) {
+      return urlStr;
+    }
+
+    const params = new URLSearchParams(queryParams);
+
+    return `${ urlStr }?${ params.toString() }`;
+  }
+
+  static goTo(): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(this.url);
+  }
+
+  constructor(daemonsetId: string, queryParams?: Record<string, string>, clusterId = 'local', namespaceId = 'default') {
+    super(WorkloadsReplicasetsEditPagePo.createPath(daemonsetId, clusterId, namespaceId, queryParams));
+
+    WorkloadsReplicasetsEditPagePo.url = WorkloadsReplicasetsEditPagePo.createPath(daemonsetId, clusterId, namespaceId, queryParams);
+  }
+
+  nameNsDescription() {
+    return new NameNsDescription(this.self());
+  }
+
+  containerImageInput(): LabeledInputPo {
+    return LabeledInputPo.byLabel(this.self(), 'Container Image');
+  }
+
+  clickTab(selector: string) {
+    return new TabbedPo().clickTabWithSelector(selector);
+  }
+
+  saveCreateForm(): AsyncButtonPo {
+    return new AsyncButtonPo('[data-testid="form-save"]', this.self());
+  }
+}

--- a/cypress/e2e/po/prompts/ResourceSearchDialog.po.ts
+++ b/cypress/e2e/po/prompts/ResourceSearchDialog.po.ts
@@ -33,4 +33,20 @@ export default class ResourceSearchDialog extends ComponentPo {
   results() {
     return this.self().get('.results li.child .label');
   }
+
+  /**
+   * Use the resource search dialog to go to a specific resource page
+   */
+  static goToResource(name: string) {
+    const dialog = new ResourceSearchDialog();
+
+    dialog.open();
+    dialog.checkExists();
+    dialog.checkVisible();
+
+    dialog.searchBox().type(name);
+    dialog.results().should('have.length', 1);
+    dialog.results().first().should('have.text', name);
+    dialog.results().first().click();    
+  }
 }

--- a/cypress/e2e/po/prompts/ResourceSearchDialog.po.ts
+++ b/cypress/e2e/po/prompts/ResourceSearchDialog.po.ts
@@ -47,6 +47,6 @@ export default class ResourceSearchDialog extends ComponentPo {
     dialog.searchBox().type(name);
     dialog.results().should('have.length', 1);
     dialog.results().first().should('have.text', name);
-    dialog.results().first().click();    
+    dialog.results().first().click();
   }
 }

--- a/cypress/e2e/tests/pages/explorer2/workloads/replicasets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/replicasets.spec.ts
@@ -1,0 +1,38 @@
+import { WorkloadsReplicasetsListPagePo, WorkloadsReplicasetsEditPagePo } from '@/cypress/e2e/po/pages/explorer/workloads-replicasets.po';
+
+describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser'] }, () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  describe('Workloads', () => {
+    describe('Replicasets', () => {
+      const replicasetName = 'replicaset-test';
+
+      it('should not be able to rollback a replicaset', () => {
+        // list view for replicasets
+        const workloadsDaemonsetsListPage = new WorkloadsReplicasetsListPagePo('local');
+
+        workloadsDaemonsetsListPage.goTo();
+        workloadsDaemonsetsListPage.waitForPage();
+        workloadsDaemonsetsListPage.createReplicaset();
+
+        // create a new replicaset
+        const workloadsDaemonsetsEditPage = new WorkloadsReplicasetsEditPagePo('local');
+
+        workloadsDaemonsetsEditPage.nameNsDescription().name().set(replicasetName);
+        workloadsDaemonsetsEditPage.containerImageInput().set('nginx');
+        workloadsDaemonsetsEditPage.saveCreateForm().click();
+
+        workloadsDaemonsetsListPage.goTo();
+        workloadsDaemonsetsListPage.waitForPage();
+
+        workloadsDaemonsetsListPage.sortableTable().filter(replicasetName);
+        workloadsDaemonsetsListPage.listElementWithName(replicasetName).should('be.visible');
+        workloadsDaemonsetsListPage.baseResourceList().actionMenu(replicasetName).menuItemNames().should('not.contain', 'Rollback');
+
+        cy.deleteRancherResource('v1', 'apps.replicasets', `default/${ replicasetName }`);
+      });
+    });
+  });
+});

--- a/cypress/e2e/tests/pages/explorer2/workloads/replicasets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/replicasets.spec.ts
@@ -1,4 +1,5 @@
 import { WorkloadsReplicasetsListPagePo, WorkloadsReplicasetsEditPagePo } from '@/cypress/e2e/po/pages/explorer/workloads-replicasets.po';
+import ResourceSearchDialog from '@/cypress/e2e/po/prompts/ResourceSearchDialog.po';
 
 describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser'] }, () => {
   beforeEach(() => {
@@ -11,11 +12,11 @@ describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser'] }, () => {
 
       it('should not be able to rollback a replicaset', () => {
         // list view for replicasets
-        const workloadsDaemonsetsListPage = new WorkloadsReplicasetsListPagePo('local');
+        const workloadsReplicasetsListPage = new WorkloadsReplicasetsListPagePo('local');
 
-        workloadsDaemonsetsListPage.goTo();
-        workloadsDaemonsetsListPage.waitForPage();
-        workloadsDaemonsetsListPage.createReplicaset();
+        workloadsReplicasetsListPage.goTo();
+        workloadsReplicasetsListPage.waitForPage();
+        workloadsReplicasetsListPage.createReplicaset();
 
         // create a new replicaset
         const workloadsDaemonsetsEditPage = new WorkloadsReplicasetsEditPagePo('local');
@@ -24,11 +25,12 @@ describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser'] }, () => {
         workloadsDaemonsetsEditPage.containerImageInput().set('nginx');
         workloadsDaemonsetsEditPage.saveCreateForm().click();
 
-        workloadsDaemonsetsListPage.goTo();
-        workloadsDaemonsetsListPage.waitForPage();
+        ResourceSearchDialog.goToResource('ReplicaSets');
 
-        workloadsDaemonsetsListPage.listElementWithName(replicasetName).should('be.visible');
-        workloadsDaemonsetsListPage.baseResourceList().actionMenu(replicasetName).menuItemNames().should('not.contain', 'Rollback');
+        workloadsReplicasetsListPage.waitForPage();
+
+        workloadsReplicasetsListPage.listElementWithName(replicasetName).should('be.visible');
+        workloadsReplicasetsListPage.baseResourceList().actionMenu(replicasetName).menuItemNames().should('not.contain', 'Rollback');
 
         cy.deleteRancherResource('v1', 'apps.replicasets', `default/${ replicasetName }`);
       });

--- a/cypress/e2e/tests/pages/explorer2/workloads/replicasets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/replicasets.spec.ts
@@ -7,7 +7,7 @@ describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser'] }, () => {
 
   describe('Workloads', () => {
     describe('Replicasets', () => {
-      const replicasetName = 'replicaset-test';
+      const replicasetName = '0000-replicaset-test';
 
       it('should not be able to rollback a replicaset', () => {
         // list view for replicasets
@@ -27,7 +27,6 @@ describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser'] }, () => {
         workloadsDaemonsetsListPage.goTo();
         workloadsDaemonsetsListPage.waitForPage();
 
-        workloadsDaemonsetsListPage.sortableTable().filter(replicasetName);
         workloadsDaemonsetsListPage.listElementWithName(replicasetName).should('be.visible');
         workloadsDaemonsetsListPage.baseResourceList().actionMenu(replicasetName).menuItemNames().should('not.contain', 'Rollback');
 

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -34,7 +34,10 @@ export default class Workload extends WorkloadService {
       enabled: !!this.links.update,
     });
 
-    if (type !== WORKLOAD_TYPES.JOB && type !== WORKLOAD_TYPES.CRON_JOB) {
+    if (type !== WORKLOAD_TYPES.JOB &&
+      type !== WORKLOAD_TYPES.CRON_JOB &&
+      type !== WORKLOAD_TYPES.REPLICA_SET
+    ) {
       insertAt(out, 0, {
         action:  'toggleRollbackModal',
         label:   this.t('action.rollback'),


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13885

### Occurred changes and/or fixed issues

This PR removes the Rollback action for resource sets and adds an e2e test for this.

The fix is trivial - https://github.com/rancher/dashboard/pull/13915/files#diff-0543f2863aeb84f2e4f2d12196a7f8cb5c7ba9e06f11990b0a0f4cd27dbbe560R37-R40

The bulk of this PR is the new e2e test.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
