### PR TITLE
fix focus trap in assignTo, CommunityLinks and ResourceCancelModal mo…

### DIFF
--- a/shell/components/AssignTo.vue
+++ b/shell/components/AssignTo.vue
@@ -115,6 +115,7 @@ export default {
     styles="background-color: var(--nav-bg); border-radius: var(--border-radius); max-height: 100vh;"
     height="auto"
     :scrollable="true"
+    :trigger-focus-trap="true"
     @close="close"
   >
     <Card
@@ -157,17 +158,20 @@ export default {
       </template>
 
       <template #actions>
-        <button
-          class="btn role-secondary"
-          @click="close"
-        >
-          {{ t('generic.cancel') }}
-        </button>
+        <div class="actions-container">
+          <button
+            class="btn role-secondary"
+            @click="close"
+          >
+            {{ t('generic.cancel') }}
+          </button>
 
-        <AsyncButton
-          mode="apply"
-          @click="apply"
-        />
+          <AsyncButton
+            class="apply-btn"
+            mode="apply"
+            @click="apply"
+          />
+        </div>
       </template>
     </Card>
   </app-modal>
@@ -180,6 +184,16 @@ export default {
     max-height: 100vh;
     & ::-webkit-scrollbar-corner {
       background: rgba(0,0,0,0);
+    }
+
+    .actions-container {
+      display: flex;
+      justify-content: flex-end;
+      width: 100%;
+
+      .apply-btn {
+        margin-left: 20px;
+      }
     }
   }
 </style>

--- a/shell/components/CommunityLinks.vue
+++ b/shell/components/CommunityLinks.vue
@@ -140,7 +140,7 @@ export default {
           :aria-label="t('footer.wechat.title')"
           role="link"
           @click="show"
-          @keyup.enter="show"
+          @keydown.enter="show"
         >
           {{ t('footer.wechat.title') }}
         </a>
@@ -151,6 +151,7 @@ export default {
       name="wechat-modal"
       height="auto"
       :width="640"
+      :trigger-focus-trap="true"
       @close="close"
     >
       <div class="wechat-modal">
@@ -164,8 +165,7 @@ export default {
             :aria-label="t('generic.close')"
             role="button"
             @click="close"
-            @keyup.enter="close"
-            @keyup.space="close"
+            @keydown.enter.stop
           >
             {{ t('generic.close') }}
           </button>

--- a/shell/components/ResourceCancelModal.vue
+++ b/shell/components/ResourceCancelModal.vue
@@ -56,6 +56,7 @@ export default {
     name="cancel-modal"
     :width="440"
     height="auto"
+    :trigger-focus-trap="true"
     @close="cancelCancel"
   >
     <div class="header">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13899
Fixes #13900
Fixes #13908 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix focus trap in `assignTo` modal + fix styling issues
- fix focus trap in `CommunityLinks` modal 
- fix focus trap in `ResourceCancelModal` modal

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- the `assignTo` modal needs a feature flag `provisioningv2-fleet-workspace-back-population` to be enabled first, then an option appears in the Fleet cluster list view for table actions called `Change Workspace`
- the `CommunityLinks` modal only appears in the links in the homepage IF the language is set to Chinese on the user preferences (it will be the last link)
- The `ResourceCancelModal` modal appears when editing a resource (edit view) then you click on the option in the footer `Edit as YAML`, make some change on the YAML, then click on `Back to Form`
 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

**`CommunityLinks` modal**
<img width="2323" alt="Screenshot 2025-03-27 at 18 20 46" src="https://github.com/user-attachments/assets/84ae3327-c5fe-4f7d-b182-b32ad29babf5" />
**`assignTo` modal**

_before_
<img width="2323" alt="Screenshot 2025-03-27 at 18 17 58" src="https://github.com/user-attachments/assets/a3d86c99-aabc-4068-8f34-e456a5294a68" />


_after_
<img width="2323" alt="Screenshot 2025-03-27 at 18 19 57" src="https://github.com/user-attachments/assets/577e1ca2-b7b4-4d6b-8abb-2b288541486b" />

 **`ResourceCancelModal` modal**
<img width="2323" alt="Screenshot 2025-03-27 at 18 17 08" src="https://github.com/user-attachments/assets/0b115b8a-232f-4e16-88ca-6c6f6729598e" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
