### PR TITLE
fix focus trap in various modals

### DIFF
--- a/shell/components/DisableAuthProviderModal.vue
+++ b/shell/components/DisableAuthProviderModal.vue
@@ -44,6 +44,7 @@ export default {
     :width="400"
     height="auto"
     styles="max-height: 100vh;"
+    :trigger-focus-trap="true"
     @close="close"
   >
     <Card

--- a/shell/components/ModalWithCard.vue
+++ b/shell/components/ModalWithCard.vue
@@ -65,6 +65,7 @@ export default {
     v-bind="$attrs"
     class="modal"
     data-testid="mvc__card"
+    :trigger-focus-trap="true"
     @close="$emit('finish', $event)"
   >
     <Card

--- a/shell/components/MoveModal.vue
+++ b/shell/components/MoveModal.vue
@@ -93,6 +93,7 @@ export default {
     :name="modalName"
     :width="440"
     height="auto"
+    :trigger-focus-trap="true"
     @close="close"
   >
     <Loading v-if="$fetchState.pending" />

--- a/shell/components/form/SSHKnownHosts/KnownHostsEditDialog.vue
+++ b/shell/components/form/SSHKnownHosts/KnownHostsEditDialog.vue
@@ -40,8 +40,9 @@ export default {
 
     return {
       codeMirrorOptions,
-      text:      this.value,
-      showModal: false,
+      text:                this.value,
+      showModal:           false,
+      returnFocusSelector: '#known-ssh-hosts-trigger'
     };
   },
 
@@ -83,6 +84,8 @@ export default {
     data-testid="sshKnownHostsDialog"
     height="auto"
     :scrollable="true"
+    :trigger-focus-trap="true"
+    :return-focus-selector="returnFocusSelector"
     @close="closeDialog(false)"
   >
     <div

--- a/shell/components/form/SSHKnownHosts/KnownHostsEditDialog.vue
+++ b/shell/components/form/SSHKnownHosts/KnownHostsEditDialog.vue
@@ -22,12 +22,7 @@ export default {
     mode: {
       type:    String,
       default: _EDIT
-    },
-
-    disableFocusTrapForUnitTests: {
-      type:    Boolean,
-      default: false
-    },
+    }
   },
 
   data() {
@@ -89,7 +84,7 @@ export default {
     data-testid="sshKnownHostsDialog"
     height="auto"
     :scrollable="true"
-    :trigger-focus-trap="disableFocusTrapForUnitTests ? false : true"
+    :trigger-focus-trap="true"
     :return-focus-selector="returnFocusSelector"
     @close="closeDialog(false)"
   >

--- a/shell/components/form/SSHKnownHosts/KnownHostsEditDialog.vue
+++ b/shell/components/form/SSHKnownHosts/KnownHostsEditDialog.vue
@@ -23,6 +23,11 @@ export default {
       type:    String,
       default: _EDIT
     },
+
+    disableFocusTrapForUnitTests: {
+      type:    Boolean,
+      default: false
+    },
   },
 
   data() {
@@ -84,7 +89,7 @@ export default {
     data-testid="sshKnownHostsDialog"
     height="auto"
     :scrollable="true"
-    :trigger-focus-trap="true"
+    :trigger-focus-trap="disableFocusTrapForUnitTests ? false : true"
     :return-focus-selector="returnFocusSelector"
     @close="closeDialog(false)"
   >

--- a/shell/components/form/SSHKnownHosts/__tests__/KnownHostsEditDialog.test.ts
+++ b/shell/components/form/SSHKnownHosts/__tests__/KnownHostsEditDialog.test.ts
@@ -20,8 +20,9 @@ describe('component: KnownHostsEditDialog', () => {
     wrapper = mount(KnownHostsEditDialog, {
       attachTo: document.body,
       props:    {
-        mode:  _EDIT,
-        value: 'line1\nline2\n',
+        mode:                         _EDIT,
+        value:                        'line1\nline2\n',
+        disableFocusTrapForUnitTests: true
       },
       ...requiredSetup(),
     });

--- a/shell/components/form/SSHKnownHosts/__tests__/KnownHostsEditDialog.test.ts
+++ b/shell/components/form/SSHKnownHosts/__tests__/KnownHostsEditDialog.test.ts
@@ -14,15 +14,25 @@ const requiredSetup = () => {
   return { global: { mocks: { $store: mockedStore() } } };
 };
 
+jest.mock('focus-trap', () => {
+  return {
+    createFocusTrap: jest.fn().mockImplementation(() => {
+      return {
+        activate:   jest.fn(),
+        deactivate: jest.fn(),
+      };
+    }),
+  };
+});
+
 describe('component: KnownHostsEditDialog', () => {
   beforeEach(() => {
     document.body.innerHTML = '<div id="modals"></div>';
     wrapper = mount(KnownHostsEditDialog, {
       attachTo: document.body,
       props:    {
-        mode:                         _EDIT,
-        value:                        'line1\nline2\n',
-        disableFocusTrapForUnitTests: true
+        mode:  _EDIT,
+        value: 'line1\nline2\n'
       },
       ...requiredSetup(),
     });

--- a/shell/components/form/SSHKnownHosts/index.vue
+++ b/shell/components/form/SSHKnownHosts/index.vue
@@ -22,6 +22,10 @@ export default defineComponent({
 
   components: { KnownHostsEditDialog },
 
+  data() {
+    return { disableFocusTrapForUnitTests: false };
+  },
+
   computed: {
     isViewMode() {
       return this.mode === _VIEW;
@@ -83,6 +87,7 @@ export default defineComponent({
         ref="editDialog"
         :value="value"
         :mode="mode"
+        :disable-focus-trap-for-unit-tests="disableFocusTrapForUnitTests"
         @closed="dialogClosed"
       />
     </template>

--- a/shell/components/form/SSHKnownHosts/index.vue
+++ b/shell/components/form/SSHKnownHosts/index.vue
@@ -22,10 +22,6 @@ export default defineComponent({
 
   components: { KnownHostsEditDialog },
 
-  data() {
-    return { disableFocusTrapForUnitTests: false };
-  },
-
   computed: {
     isViewMode() {
       return this.mode === _VIEW;
@@ -87,7 +83,6 @@ export default defineComponent({
         ref="editDialog"
         :value="value"
         :mode="mode"
-        :disable-focus-trap-for-unit-tests="disableFocusTrapForUnitTests"
         @closed="dialogClosed"
       />
     </template>

--- a/shell/components/form/SSHKnownHosts/index.vue
+++ b/shell/components/form/SSHKnownHosts/index.vue
@@ -65,12 +65,18 @@ export default defineComponent({
     </div>
     <template v-if="!isViewMode">
       <button
+        id="known-ssh-hosts-trigger"
         ref="button"
+        role="button"
+        :aria-label="t('secret.ssh.editKnownHosts.title')"
         data-testid="input-known-ssh-hosts_open-dialog"
         class="show-dialog-btn btn"
         @click="openDialog"
       >
-        <i class="icon icon-edit" />
+        <i
+          class="icon icon-edit"
+          :alt="t('secret.ssh.editKnownHosts.title')"
+        />
       </button>
 
       <KnownHostsEditDialog
@@ -94,8 +100,16 @@ export default defineComponent({
     }
 
     .show-dialog-btn {
-      display: contents;
       background-color: transparent;
+      padding: 4px;
+      height: 22px;
+      margin: -3px -3px 0 0;
+      min-height: unset;
+
+      &:focus-visible {
+        @include focus-outline;
+        outline-offset: 1px;
+      }
     }
   }
 </style>

--- a/shell/components/form/__tests__/SSHKnownHosts.test.ts
+++ b/shell/components/form/__tests__/SSHKnownHosts.test.ts
@@ -15,7 +15,10 @@ describe('component: SSHKnownHosts', () => {
       props: {
         mode: _VIEW,
         value,
-      }
+      },
+      data() {
+        return { disableFocusTrapForUnitTests: true };
+      },
     });
 
     const knownSshHostsSummary = wrapper.find('[data-testid="input-known-ssh-hosts_summary"]');
@@ -31,7 +34,10 @@ describe('component: SSHKnownHosts', () => {
       props: {
         mode:  _EDIT,
         value: 'line1\nline2\n',
-      }
+      },
+      data() {
+        return { disableFocusTrapForUnitTests: true };
+      },
     });
 
     const knownSshHostsSummary = wrapper.find('[data-testid="input-known-ssh-hosts_summary"]');
@@ -46,7 +52,10 @@ describe('component: SSHKnownHosts', () => {
       props: {
         mode:  _EDIT,
         value: '',
-      }
+      },
+      data() {
+        return { disableFocusTrapForUnitTests: true };
+      },
     });
 
     const knownSshHostsOpenDialog = wrapper.find('[data-testid="input-known-ssh-hosts_open-dialog"]');

--- a/shell/components/form/__tests__/SSHKnownHosts.test.ts
+++ b/shell/components/form/__tests__/SSHKnownHosts.test.ts
@@ -2,6 +2,17 @@ import { mount } from '@vue/test-utils';
 import { _EDIT, _VIEW } from '@shell/config/query-params';
 import SSHKnownHosts from '@shell/components/form/SSHKnownHosts/index.vue';
 
+jest.mock('focus-trap', () => {
+  return {
+    createFocusTrap: jest.fn().mockImplementation(() => {
+      return {
+        activate:   jest.fn(),
+        deactivate: jest.fn(),
+      };
+    }),
+  };
+});
+
 describe('component: SSHKnownHosts', () => {
   it.each([
     ['0 entities', '', 0],
@@ -15,10 +26,7 @@ describe('component: SSHKnownHosts', () => {
       props: {
         mode: _VIEW,
         value,
-      },
-      data() {
-        return { disableFocusTrapForUnitTests: true };
-      },
+      }
     });
 
     const knownSshHostsSummary = wrapper.find('[data-testid="input-known-ssh-hosts_summary"]');
@@ -34,10 +42,7 @@ describe('component: SSHKnownHosts', () => {
       props: {
         mode:  _EDIT,
         value: 'line1\nline2\n',
-      },
-      data() {
-        return { disableFocusTrapForUnitTests: true };
-      },
+      }
     });
 
     const knownSshHostsSummary = wrapper.find('[data-testid="input-known-ssh-hosts_summary"]');
@@ -52,10 +57,7 @@ describe('component: SSHKnownHosts', () => {
       props: {
         mode:  _EDIT,
         value: '',
-      },
-      data() {
-        return { disableFocusTrapForUnitTests: true };
-      },
+      }
     });
 
     const knownSshHostsOpenDialog = wrapper.find('[data-testid="input-known-ssh-hosts_open-dialog"]');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13901 
Fixes #13902 
Fixes #13903 
Fixes #13909 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Fix focus trap for `DisableAuthProviderModal` modal
- Fix focus trap for `ModalWithCard` modal
- Fix focus trap for `MoveModal` modal
- Fix focus trap for `KnowHostsEditDialog` modal + style and aria related fixes
- Disable focus trap for units tests in `KnowHostsEditDialog.test.ts` and `SSHKnowHosts.test.ts`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Had to disable focus trap for units tests in `KnowHostsEditDialog.test.ts` and `SSHKnowHosts.test.ts` since I couldn't really fix the render issues that prevent the focus trap from finding an assignable target at activation-time.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- To test the `DisableAuthProviderModal` modal you'll need to enable an auth provider like OpenLDAP (check internal guide), then when disabling it the modal is triggered
- To test the `ModalWithCard` modal you'll need to enable the performance setting for inactivity and set it to a really low value like `0.1`

<img width="2323" alt="inactivity_setting" src="https://github.com/user-attachments/assets/252a538f-5e36-4ca2-9091-cc2af3c963ad" />

- To test the `MoveModal` modal just go to the `namespace` list view, then trigger the row action `Move` on any `namespace`

- To test the `KnowHostsEditDialog` modal you'll need to go and create a Fleet git repo, then on the `Advanced` step, set git authentication to `SSH key secret` and the input for `Known Hosts` appears in the UI. The icon on the input triggers the modal


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/3bf722f1-1bed-403b-b080-789fe1f1133b


https://github.com/user-attachments/assets/f2f4097d-0dee-44d2-b2f4-07526d901876


https://github.com/user-attachments/assets/22f41924-8c04-45b3-b5cc-137a2224ef7e


https://github.com/user-attachments/assets/84ae3274-218c-4623-ab8f-a37704f7a93a


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
