### PR TITLE
Fix Decoding secret of e2e GKE cluster provisioning test

### DIFF
--- a/cypress/e2e/tests/pages/manager/gke-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/gke-cluster-provisioning.spec.ts
@@ -19,17 +19,19 @@ describe('Deploy GKE cluster with default settings', { tags: ['@manager', '@admi
   let clusterId = '';
   let clusterDescription = '';
   const base64EncodedServiceAccount = Cypress.env('gkeServiceAccount');
+  let serviceAccount: any;
   let gkeProjectId = '';
 
   // Check if the base64 string is defined and valid
   if (base64EncodedServiceAccount) {
     try {
       // Decode the base64 string into a JSON string
-      const decodedServiceAccountJson = atob(base64EncodedServiceAccount);
+      const decodedServiceAccountJson = Buffer.from(base64EncodedServiceAccount, 'base64').toString('utf-8');
 
       // Parse the decoded JSON string
-      const serviceAccount = JSON.parse(decodedServiceAccountJson);
-
+      serviceAccount = JSON.parse(decodedServiceAccountJson);
+      /* eslint-disable no-console */
+      console.log(serviceAccount);
       // Now you can access the project_id
       gkeProjectId = serviceAccount.project_id;
       /* eslint-disable no-console */
@@ -85,7 +87,7 @@ describe('Deploy GKE cluster with default settings', { tags: ['@manager', '@admi
     // create GKE cloud credential
     cloudCredForm.saveButton().expectToBeDisabled();
     cloudCredForm.nameNsDescription().name().set(this.gkeCloudCredentialName);
-    cloudCredForm.serviceAccount().set(Cypress.env('gkeServiceAccount'));
+    cloudCredForm.serviceAccount().set(serviceAccount);
     cloudCredForm.saveButton().expectToBeEnabled();
     cy.intercept('GET', '/v1/management.cattle.io.users?exclude=metadata.managedFields').as('pageLoad');
     cloudCredForm.saveCreateForm().cruResource().saveAndWaitForRequests('POST', '/v3/cloudcredentials').then((req) => {

--- a/cypress/e2e/tests/pages/manager/gke-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/gke-cluster-provisioning.spec.ts
@@ -30,12 +30,9 @@ describe('Deploy GKE cluster with default settings', { tags: ['@manager', '@admi
 
       // Parse the decoded JSON string
       serviceAccount = JSON.parse(decodedServiceAccountJson);
-      /* eslint-disable no-console */
-      console.log(serviceAccount);
       // Now you can access the project_id
       gkeProjectId = serviceAccount.project_id;
       /* eslint-disable no-console */
-      console.log(gkeProjectId); // Check if the value is correct
     } catch (error) {
       // Handle any error that occurs during decoding or parsing
       console.error('Error decoding or parsing service account JSON:', error);

--- a/cypress/e2e/tests/pages/manager/gke-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/gke-cluster-provisioning.spec.ts
@@ -87,6 +87,8 @@ describe('Deploy GKE cluster with default settings', { tags: ['@manager', '@admi
     // create GKE cloud credential
     cloudCredForm.saveButton().expectToBeDisabled();
     cloudCredForm.nameNsDescription().name().set(this.gkeCloudCredentialName);
+    // while issue #1717 in qa-tasks is open, line 91 is duplicated as a workaround. The duplicate line needs to be removed after issue is fixed
+    cloudCredForm.serviceAccount().set(serviceAccount);
     cloudCredForm.serviceAccount().set(serviceAccount);
     cloudCredForm.saveButton().expectToBeEnabled();
     cy.intercept('GET', '/v1/management.cattle.io.users?exclude=metadata.managedFields').as('pageLoad');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->

### Summary
Fixes https://github.com/rancher/qa-tasks/issues/1716 - but first this PR needs to be merged https://github.com/rancherlabs/corral-packages/pull/75

Fix decoding the secret of e2e GKE cluster provisioning test. It was being encoded twice. 
Also, it includes a temporary workaround while bug https://github.com/rancher/qa-tasks/issues/1717 is not fixed, which consists of a duplicate line of code that types the entire input string in the Service Account field when creating GKE cloud credential.

### Areas or cases that should be tested
Running the `gke-cluster-provisioning.spec.ts` in Jenkins. Test is expected to pass

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
