### PR TITLE
[backport 2.11.1] Preventing the re-render of cloud credentials when validation takes place

### DIFF
--- a/cypress/e2e/po/pages/cluster-manager/cloud-credentials-create-aws.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/cloud-credentials-create-aws.po.ts
@@ -1,0 +1,36 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
+
+export default class CloudCredentialsCreateAWSPagePo extends PagePo {
+  private static createPath(clusterId: string) {
+    return `/c/${ clusterId }/manager/cloudCredential/create?type=aws`;
+  }
+
+  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(CloudCredentialsCreateAWSPagePo.createPath(clusterId));
+  }
+
+  constructor(private clusterId = '_') {
+    super(CloudCredentialsCreateAWSPagePo.createPath(clusterId));
+  }
+
+  accessKeyInput() {
+    return new LabeledInputPo('[data-testid="access-key"]');
+  }
+
+  secretKeyInput() {
+    return new LabeledInputPo('[data-testid="secret-key"]');
+  }
+
+  credentialNameInput() {
+    return new LabeledInputPo('[data-testid="name-ns-description-name"] .labeled-input input');
+  }
+
+  errorBanner() {
+    return this.self().find('[data-testid="banner-content"]');
+  }
+
+  clickCreate() {
+    return this.self().find('[data-testid="form-save"]').click();
+  }
+}

--- a/cypress/e2e/po/pages/cluster-manager/cloud-credentials-create.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/cloud-credentials-create.po.ts
@@ -1,0 +1,22 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import CloudCredentialsCreateAWSPagePo from '~/cypress/e2e/po/pages/cluster-manager/cloud-credentials-create-aws.po';
+
+export default class CloudCredentialsCreatePagePo extends PagePo {
+  private static createPath(clusterId: string) {
+    return `/c/${ clusterId }/manager/cloudCredential/create`;
+  }
+
+  static goTo(clusterId = '_'): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(CloudCredentialsCreatePagePo.createPath(clusterId));
+  }
+
+  constructor(private clusterId = '_') {
+    super(CloudCredentialsCreatePagePo.createPath(clusterId));
+  }
+
+  selectAws(): CloudCredentialsCreateAWSPagePo {
+    this.self().find('[data-testid="subtype-banner-item-aws"]').click();
+
+    return new CloudCredentialsCreateAWSPagePo();
+  }
+}

--- a/shell/cloud-credential/aws.vue
+++ b/shell/cloud-credential/aws.vue
@@ -78,6 +78,7 @@ export default {
       :rules="fvGetAndReportPathRules('decodedData.accessKey')"
       :mode="mode"
       :required="true"
+      data-testid="access-key"
       @update:value="$emit('valueChanged', 'accessKey', $event)"
     />
     <LabeledInput
@@ -89,6 +90,7 @@ export default {
       :rules="fvGetAndReportPathRules('decodedData.secretKey')"
       :mode="mode"
       :required="true"
+      data-testid="secret-key"
       @update:value="$emit('valueChanged', 'secretKey', $event)"
     />
     <LabeledSelect

--- a/shell/edit/cloudcredential.vue
+++ b/shell/edit/cloudcredential.vue
@@ -276,6 +276,7 @@ export default {
     <Loading v-if="$fetchState.pending" />
     <CruResource
       v-else
+      :done-params="$attrs['done-params'] /* Without this, changes to the validationPassed prop end up propagating all the way to the root of the app and force a re-render when the input becomes valid. I haven't found a reasonable explanation for why this happens. */"
       :mode="mode"
       :validation-passed="validationPassed"
       :selected-subtype="value._type"


### PR DESCRIPTION


### Summary
Fixes #13804
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
This one is frustrating, it's absolutely not obvious what the root problem is. I found a fix through trial and error to narrow the change down.

For some reason if you visit the page after selecting the subtype if you then make the form valid it causes an event/state change to propagate all the to the root of the app and forces a re-render. 

The issue stopped once I removed the wrapping element but that broke other aspects because inherrited attributes were overwriting expected values for props. I then narrowed this down to `done-params` being present ultimately fixed the behavior.

Looking at all references to `done-params` doesn't explain the fix. And just adding other attributes in it's place doesn't either.

### Areas or cases that should be tested
Cloud credentials which have validation. Azure, AWS, and S3 Compatible all had this issue when I tested.

### Areas which could experience regressions
Cloud credentials in general, creating and editing.


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
