### PR TITLE
fix focus trap for `PromptModal`component

### DIFF
--- a/shell/components/AppModal.vue
+++ b/shell/components/AppModal.vue
@@ -165,6 +165,9 @@ export default defineComponent({
       useWatcherBasedSetupFocusTrapWithDestroyIncluded(() => this.focusTrapWatcherBasedVariable, '#modal-container-element', opts, true);
     }
   },
+  mounted() {
+    document.addEventListener('keydown', this.handleEscapeKey);
+  },
   beforeUnmount() {
     document.removeEventListener('keydown', this.handleEscapeKey);
   },

--- a/shell/components/AppModal.vue
+++ b/shell/components/AppModal.vue
@@ -1,6 +1,11 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { DEFAULT_FOCUS_TRAP_OPTS, useBasicSetupFocusTrap, getFirstFocusableElement } from '@shell/composables/focusTrap';
+import {
+  DEFAULT_FOCUS_TRAP_OPTS,
+  useBasicSetupFocusTrap,
+  getFirstFocusableElement,
+  useWatcherBasedSetupFocusTrapWithDestroyIncluded
+} from '@shell/composables/focusTrap';
 
 export const DEFAULT_ITERABLE_NODE_SELECTOR = 'body;';
 
@@ -80,7 +85,21 @@ export default defineComponent({
     returnFocusFirstIterableNodeSelector: {
       type:    String,
       default: DEFAULT_ITERABLE_NODE_SELECTOR,
-    }
+    },
+    /**
+     * trigger focus trap - but watcher based
+     */
+    triggerFocusTrapWatcherBased: {
+      type:    Boolean,
+      default: false,
+    },
+    /**
+     * watcher-based focus trap variable to watch
+     */
+    focusTrapWatcherBasedVariable: {
+      type:    Boolean,
+      default: false,
+    },
   },
   computed: {
     modalWidth(): string {
@@ -131,11 +150,20 @@ export default defineComponent({
         };
       }
 
-      useBasicSetupFocusTrap('#modal-container-element', opts);
+      if (!props.triggerFocusTrapWatcherBased) {
+        useBasicSetupFocusTrap('#modal-container-element', opts);
+      }
     }
   },
-  mounted() {
-    document.addEventListener('keydown', this.handleEscapeKey);
+  created() {
+    // This usecase is to cover the PromptModal scenario where it's renders a generic component inside.
+    // Due to the architecture of the PromptModal it needs to be handled with a watcher based focus trap
+    // but with a dedicated unmount hook
+    if (this.triggerFocusTrapWatcherBased) {
+      const opts:any = DEFAULT_FOCUS_TRAP_OPTS;
+
+      useWatcherBasedSetupFocusTrapWithDestroyIncluded(() => this.focusTrapWatcherBasedVariable, '#modal-container-element', opts, true);
+    }
   },
   beforeUnmount() {
     document.removeEventListener('keydown', this.handleEscapeKey);

--- a/shell/components/PromptModal.vue
+++ b/shell/components/PromptModal.vue
@@ -13,7 +13,11 @@ export default {
   components: { AppModal },
 
   data() {
-    return { opened: false, backgroundClosing: null };
+    return {
+      opened:            false,
+      backgroundClosing: null,
+      componentRendered: false
+    };
   },
 
   computed: {
@@ -54,10 +58,15 @@ export default {
   watch: {
     showModal(show) {
       this.opened = show;
-    },
+    }
   },
 
   methods: {
+    onSlotComponentMounted() {
+      // variable for the watcher based focus-trap
+      // so that we know when the component is rendered
+      this.componentRendered = true;
+    },
     close() {
       if (!this.opened) {
         return;
@@ -69,6 +78,7 @@ export default {
         this.backgroundClosing();
       }
 
+      this.componentRendered = false;
       this.opened = false;
     },
 
@@ -85,6 +95,8 @@ export default {
     v-if="opened && component"
     :click-to-close="closeOnClickOutside"
     :width="modalWidth"
+    :trigger-focus-trap-watcher-based="true"
+    :focus-trap-watcher-based-variable="componentRendered"
     @close="close()"
   >
     <component
@@ -92,6 +104,7 @@ export default {
       :is="component"
       :resources="resources"
       :register-background-closing="registerBackgroundClosing"
+      @vue:mounted="onSlotComponentMounted"
       @close="close()"
     />
   </app-modal>

--- a/shell/composables/focusTrap.ts
+++ b/shell/composables/focusTrap.ts
@@ -46,12 +46,12 @@ export function useBasicSetupFocusTrap(focusElement: string | HTMLElement, opts:
   });
 }
 
-export function useWatcherBasedSetupFocusTrapWithDestroyIncluded(watchVar:any, focusElement: string | HTMLElement, opts:any = DEFAULT_FOCUS_TRAP_OPTS) {
+export function useWatcherBasedSetupFocusTrapWithDestroyIncluded(watchVar:any, focusElement: string | HTMLElement, opts:any = DEFAULT_FOCUS_TRAP_OPTS, useUnmountHook = false) {
   let focusTrapInstance: FocusTrap;
   let focusEl;
 
   watch(watchVar, (neu) => {
-    if (neu) {
+    if (neu && !focusTrapInstance) {
       nextTick(() => {
         focusEl = typeof focusElement === 'string' ? document.querySelector(focusElement) as HTMLElement : focusElement;
 
@@ -61,8 +61,16 @@ export function useWatcherBasedSetupFocusTrapWithDestroyIncluded(watchVar:any, f
           focusTrapInstance.activate();
         });
       });
-    } else if (!neu && Object.keys(focusTrapInstance).length) {
+    } else if (!neu && Object.keys(focusTrapInstance).length && !useUnmountHook) {
       focusTrapInstance.deactivate();
     }
   });
+
+  if (useUnmountHook) {
+    onBeforeUnmount(() => {
+      if (Object.keys(focusTrapInstance).length) {
+        focusTrapInstance.deactivate();
+      }
+    });
+  }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13905
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Fix focus trap for `PromptModal` component

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- Given the architecture of the component we need to adjust the type of focus trap used in `AppModal` because when `AppModal` is rendered the generic component inside the `default` slot isn't rendered yet

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Go to `Fleet` and create a `GitRepo`. Then just go Fleet `GitRepo` table row actions `Force Update`

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/97853244-72d0-4822-851c-3d43194e90a5


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
