### PR TITLE
Improve handling of har files generated with older versions

### DIFF
--- a/shell/server/har-file.js
+++ b/shell/server/har-file.js
@@ -9,7 +9,7 @@ const RESET_URL = '/api/v1/namespaces/cattle-ui-plugin-system/services/http:ui-p
 const EXCLUDE_QS = 'exclude';
 
 const LEGACY_UI_PLUGIN_INDEX = '/api/v1/namespaces/cattle-ui-plugin-system/services/http:ui-plugin-operator:80/proxy/index.json';
-const NEW_UI_PLUGIN_INDEX = '/v1/uiplugins'
+const NEW_UI_PLUGIN_INDEX = '/v1/uiplugins';
 
 /**
  * Load the network requests/responses from the har file


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13934 

### Occurred changes and/or fixed issues

Improves the HAR file replay:

- Maps old operator-based URL for ui extensions to the built-in API
- Supports requests with the query string which contains `excludes` and 1 or more other query string parameters - previously only supported the `excludes` query string parameter

This makes is possible to use a HAR file created on an older version of Rancher (e.g. 2.8) with the latest code.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
