### PR TITLE
Added error listener to NodeGroups in EKS

### DIFF
--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -752,6 +752,7 @@ export default defineComponent({
               :loading-launch-templates="loadingLaunchTemplates"
               :loading-ssh-key-pairs="loadingSshKeyPairs"
               :norman-cluster="normanCluster"
+              @error="errors.push($event)"
             />
           </Tab>
         </Tabbed>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13753 
<!-- Define findings related to the feature or bug issue. -->
Added error listener to NodeGroups in EKS. This ensures we don't swallow the errors that happen while fetching LaunchTemplate info

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added a listener to emitted error event.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
EKS creation and edit:
1. Force a network error while loading launchTemplate versions. (or programmatically throw an error inside fetchLaunchTemplateVersionInfo)
2. Verify that the error is displayed

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1509" alt="Screenshot 2025-03-31 at 11 45 40 AM" src="https://github.com/user-attachments/assets/f5389de5-dfb9-44d7-9de6-572eccdba79c" />

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
