### PR TITLE
Replace table group actions with new dropdown component

### DIFF
--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -17,7 +17,7 @@ import ResourceFetch from '@shell/mixins/resource-fetch';
 import DOMPurify from 'dompurify';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import ActionMenu from '@shell/components/ActionMenuShell.vue';
-import { useFeatureFlag } from '@shell/composables/useFeatureFlag';
+import { useRuntimeFlag } from '@shell/composables/useRuntimeFlag';
 
 export default {
   name:       'ListProjectNamespace',
@@ -63,7 +63,7 @@ export default {
 
   setup() {
     const store = useStore();
-    const { featureDropdownMenu } = useFeatureFlag(store);
+    const { featureDropdownMenu } = useRuntimeFlag(store);
 
     return { featureDropdownMenu };
   },

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -1,5 +1,5 @@
 <script>
-import { mapGetters } from 'vuex';
+import { mapGetters, useStore } from 'vuex';
 import ResourceTable, { defaultTableSortGenerationFn } from '@shell/components/ResourceTable';
 import { STATE, AGE, NAME, NS_SNAPSHOT_QUOTA } from '@shell/config/table-headers';
 import { uniq } from '@shell/utils/array';
@@ -16,6 +16,8 @@ import { NAMESPACE_FILTER_ALL_ORPHANS } from '@shell/utils/namespace-filter';
 import ResourceFetch from '@shell/mixins/resource-fetch';
 import DOMPurify from 'dompurify';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
+import ActionMenu from '@shell/components/ActionMenuShell.vue';
+import { useFeatureFlag } from '@shell/composables/useFeatureFlag';
 
 export default {
   name:       'ListProjectNamespace',
@@ -25,6 +27,7 @@ export default {
     MoveModal,
     ResourceTable,
     ButtonMultiAction,
+    ActionMenu,
   },
   mixins: [ResourceFetch],
 
@@ -56,6 +59,13 @@ export default {
 
     await this.$fetchType(NAMESPACE);
     this.projects = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.PROJECT, opt: { force: true } });
+  },
+
+  setup() {
+    const store = useStore();
+    const { featureDropdownMenu } = useFeatureFlag(store);
+
+    return { featureDropdownMenu };
   },
 
   data() {
@@ -339,6 +349,10 @@ export default {
       return location;
     },
 
+    getProjectActions(group) {
+      return group.rows[0].project;
+    },
+
     showProjectAction(event, group) {
       const project = group.rows[0].project;
 
@@ -467,7 +481,7 @@ export default {
               {{ projectDescription(group.group) }}
             </div>
           </div>
-          <div class="right">
+          <div class="right mr-10">
             <router-link
               v-if="isNamespaceCreatable && (canSeeProjectlessNamespaces || group.group.key !== notInProjectKey)"
               class="create-namespace btn btn-sm role-secondary mr-5"
@@ -475,13 +489,26 @@ export default {
             >
               {{ t('projectNamespaces.createNamespace') }}
             </router-link>
-            <ButtonMultiAction
-              class="project-action mr-10"
-              :borderless="true"
-              :aria-label="t('projectNamespaces.tableActionsLabel', { resource: projectResource(group.group) })"
-              :invisible="!showProjectActionButton(group.group)"
-              @click="showProjectAction($event, group.group)"
-            />
+            <template v-if="featureDropdownMenu">
+              <ActionMenu
+                v-if="showProjectActionButton(group.group)"
+                :resource="getProjectActions(group.group)"
+                :button-aria-label="t('projectNamespaces.tableActionsLabel', { resource: projectResource(group.group) })"
+              />
+              <div
+                v-else
+                class="invisible"
+              />
+            </template>
+            <template v-else>
+              <ButtonMultiAction
+                class="project-action"
+                :borderless="true"
+                :aria-label="t('projectNamespaces.tableActionsLabel', { resource: projectResource(group.group) })"
+                :invisible="!showProjectActionButton(group.group)"
+                @click="showProjectAction($event, group.group)"
+              />
+            </template>
           </div>
         </div>
       </template>
@@ -546,6 +573,11 @@ export default {
   </div>
 </template>
 <style lang="scss" scoped>
+.invisible {
+  display: inline-block;
+  min-width: 28px;
+}
+
 .project-namespaces {
   & :deep() {
     .project-namespaces-table table {

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1,8 +1,7 @@
 <script>
-import { mapGetters } from 'vuex';
+import { mapGetters, useStore } from 'vuex';
 import { defineAsyncComponent, ref, onMounted, onBeforeUnmount } from 'vue';
 import day from 'dayjs';
-import semver from 'semver';
 import isEmpty from 'lodash/isEmpty';
 import { dasherize, ucFirst } from '@shell/utils/string';
 import { get, clone } from '@shell/utils/object';
@@ -25,7 +24,7 @@ import { getParent } from '@shell/utils/dom';
 import { FORMATTERS } from '@shell/components/SortableTable/sortable-config';
 import ButtonMultiAction from '@shell/components/ButtonMultiAction.vue';
 import ActionMenu from '@shell/components/ActionMenuShell.vue';
-import { getVersionInfo } from '@shell/utils/version';
+import { useFeatureFlag } from '@shell/composables/useFeatureFlag';
 
 // Uncomment for table performance debugging
 // import tableDebug from './debug';
@@ -546,7 +545,13 @@ export default {
       table.value.removeEventListener('keyup', handleEnterKey);
     });
 
-    return { table };
+    const store = useStore();
+    const { featureDropdownMenu } = useFeatureFlag(store);
+
+    return {
+      table,
+      featureDropdownMenu,
+    };
   },
 
   created() {
@@ -768,12 +773,6 @@ export default {
 
       return rows;
     },
-
-    featureDropdownMenu() {
-      const { fullVersion } = getVersionInfo(this.$store);
-
-      return semver.gte(semver.coerce(fullVersion).version, '2.11.0');
-    }
   },
 
   methods: {

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -24,7 +24,7 @@ import { getParent } from '@shell/utils/dom';
 import { FORMATTERS } from '@shell/components/SortableTable/sortable-config';
 import ButtonMultiAction from '@shell/components/ButtonMultiAction.vue';
 import ActionMenu from '@shell/components/ActionMenuShell.vue';
-import { useFeatureFlag } from '@shell/composables/useFeatureFlag';
+import { useRuntimeFlag } from '@shell/composables/useRuntimeFlag';
 
 // Uncomment for table performance debugging
 // import tableDebug from './debug';
@@ -546,7 +546,7 @@ export default {
     });
 
     const store = useStore();
-    const { featureDropdownMenu } = useFeatureFlag(store);
+    const { featureDropdownMenu } = useRuntimeFlag(store);
 
     return {
       table,

--- a/shell/composables/useFeatureFlag.ts
+++ b/shell/composables/useFeatureFlag.ts
@@ -1,0 +1,21 @@
+import { computed } from 'vue';
+import { Store } from 'vuex';
+import semver from 'semver';
+
+import { getVersionInfo } from '@shell/utils/version';
+
+let store: Store<any>;
+
+export const useFeatureFlag = (vuexStore: Store<any>) => {
+  store = vuexStore;
+
+  return { featureDropdownMenu };
+};
+
+const featureDropdownMenu = computed(() => {
+  const { fullVersion } = getVersionInfo(store);
+
+  const coerced = semver.coerce(fullVersion) || { version: '0.0.0' };
+
+  return semver.gte(coerced.version, '2.11.0');
+});

--- a/shell/composables/useRuntimeFlag.ts
+++ b/shell/composables/useRuntimeFlag.ts
@@ -6,12 +6,20 @@ import { getVersionInfo } from '@shell/utils/version';
 
 let store: Store<any>;
 
+/**
+ * Initializes runtime flags.
+ * @param vuexStore The Vuex store instance
+ */
 export const useRuntimeFlag = (vuexStore: Store<any>) => {
   store = vuexStore;
 
   return { featureDropdownMenu };
 };
 
+/**
+ * Check if the dropdown menu feature is enabled
+ * @returns A boolean indicating whether the dropdownMenu feature is enabled.
+ */
 const featureDropdownMenu = computed(() => {
   const { fullVersion } = getVersionInfo(store);
 

--- a/shell/composables/useRuntimeFlag.ts
+++ b/shell/composables/useRuntimeFlag.ts
@@ -6,7 +6,7 @@ import { getVersionInfo } from '@shell/utils/version';
 
 let store: Store<any>;
 
-export const useFeatureFlag = (vuexStore: Store<any>) => {
+export const useRuntimeFlag = (vuexStore: Store<any>) => {
   store = vuexStore;
 
   return { featureDropdownMenu };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This replaces the grouped table actions in the projects namespaces explorer with the new dropdown menu.

Fixes #13938 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Create a `useFeatureFlag` composable for sharing feature flags across components
- Replace the grouped table actions with the new dropdown menu component

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- This is behind a feature flag to maintain Rancher Shell backwards compatibility with Rancher 2.10

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Projects/Namespaces should show the new dropdown menu 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Menu options should be the same as they were before
- Styles and spacing when working with the new component

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before

![image](https://github.com/user-attachments/assets/0f5f0d68-6678-4c4e-b760-72f4124169f3)

#### After

![image](https://github.com/user-attachments/assets/dbff5956-7859-4bb3-a73b-8df52f808592)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
