### PR TITLE
Made the new s3 snapshot units/tooltip show when s3 is selected

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2097,7 +2097,8 @@ cluster:
         title: Save Machine Configurations
         body: Machine Configurations define how machines in Pools are deployed.<br><br> They will be saved upfront to ensure valid Cluster YAML can be saved.
     snapshots:
-      suffix: Snapshots
+      suffix: Snapshots per node
+      s3Suffix: Snapshots
     systemService:
       rke2-coredns: 'CoreDNS'
       rke2-ingress-nginx: 'NGINX Ingress'

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/etcd/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/etcd/index.vue
@@ -90,8 +90,8 @@ export default {
           v-model:value="etcd.snapshotRetention"
           :mode="mode"
           :label="t('cluster.rke2.etcd.snapshotRetention.label')"
-          :suffix="t('cluster.rke2.snapshots.suffix')"
-          :tooltip="t('cluster.rke2.etcd.snapshotRetention.tooltip')"
+          :suffix="s3Backup ? t('cluster.rke2.snapshots.s3Suffix') : t('cluster.rke2.snapshots.suffix')"
+          :tooltip="s3Backup ? t('cluster.rke2.etcd.snapshotRetention.tooltip') : undefined"
         />
       </div>
     </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13920
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Someone noticed that this should only apply to S3 and the original issue called for that as well. I just missed that bit when implementing.

### Technical notes summary
Now we conditionally show the S3 messaging when S3 is selected.

### Areas or cases that should be tested
The etcd tab in cluster creation/editing for rke2

### Areas which could experience regressions
The etcd tab in cluster creation/editing for rke2

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


https://github.com/user-attachments/assets/1de747fd-022c-4e74-9972-330c6e147d94


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
