### PR TITLE
Adding a stale bot to close out `kind/enhancement` issues which haven't seen activity in more than a 1.5 years.

### DIFF
--- a/.github/workflows/close-stale-enhancement-requests.yaml
+++ b/.github/workflows/close-stale-enhancement-requests.yaml
@@ -1,0 +1,24 @@
+name: Close Stale `kind/enhancement` issues
+
+on:
+  schedule:
+    - cron: '0 */4 * * *' # Every 4 hours until we go through all the issues (The action is rate limited). After we go through all the issues we should probably run this once a day or maybe week.
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          debug-only: true # Dry-run
+          exempt-issue-labels: "JIRA" # We don't want to close jira issues as these came from customers
+          stale-issue-label: "kind/enhancement"
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          days-before-issue-stale: 548
+          days-before-issue-close: 0
+          close-issue-label: "auto-close"
+          close-issue-message: "We're closing this enhancement because it hasn't been active nor has been prioritized in over 1.5 years. If this enhancement is still needed in the latest version of Rancher, please re-open and let us know why you think this should be prioritized. Upon this enhancement being re-opened we'll review it and provide an update."


### PR DESCRIPTION
This is an effort to de-clutter our issues to make prioritization easier.

This PR will enable a dry-run only for testing.

Details:

- This will run ever 4 hours initially because we're rate limited on how many issues we can process at a time. This should change in the future.
- We will not close any issues that have the `JIRA` label because we won't want to close customer issues by accident.
- We will only close issues with the label `kind/enhancement`
- We will only close issues after 548 days or 1.5 years
- We will add the label `auto-close` so we can periodically look to see if someone has re-opened and updated on of these issues.
- We will add this message when closing `We're closing this enhancement because it hasn't been active nor has been prioritized in over 1.5 years. If this enhancement is still needed in the latest version of Rancher, please re-open and let us know why you think this should be prioritized. Upon this enhancement being re-opened we'll review it and provide an update.` @gaktive would you mind approving or making some suggestions for this messaging?




### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
