### PR TITLE
Set the value for the name input when `nameKey` is provided 

### DIFF
--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -482,6 +482,7 @@ export default {
         ref="nameInput"
         key="name"
         v-model:value="name"
+        data-testid="NameNsDescriptionNameInput"
         :label="t(nameLabel)"
         :placeholder="t(namePlaceholder)"
         :disabled="nameReallyDisabled"

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -196,7 +196,7 @@ export default {
     });
 
     if (props.nameKey) {
-      name.value = get(v, props.nameKey);
+      name.value = get(v.value, props.nameKey);
     } else {
       name.value = metadata?.name || '';
     }

--- a/shell/components/form/__tests__/NameNsDescription.test.ts
+++ b/shell/components/form/__tests__/NameNsDescription.test.ts
@@ -86,4 +86,88 @@ describe('component: NameNsDescription', () => {
 
     expect(wrapper.emitted().isNamespaceNew?.[0][0]).toBe(true);
   });
+
+  it('renders the name input with the expected value', () => {
+    const namespaceName = 'test';
+    const store = createStore({
+      getters: {
+        allowedNamespaces:   () => () => ({ [namespaceName]: true }),
+        currentStore:        () => () => 'cluster',
+        'cluster/schemaFor': () => jest.fn()
+      }
+    });
+    const wrapper = mount(NameNsDescription, {
+      props: {
+        value: {
+          setAnnotation: jest.fn(),
+          metadata:      { name: 'Default' }
+        },
+        mode: 'create',
+      },
+      global: {
+        provide: { store },
+        mocks:   {
+          $store: {
+            dispatch: jest.fn(),
+            getters:  {
+              namespaces:                         jest.fn(),
+              'customizations/getPreviewCluster': {
+                ready:   true,
+                isLocal: false,
+                badge:   {},
+              },
+              'i18n/t': jest.fn(),
+            },
+          },
+        },
+      },
+    });
+
+    const nameInput = wrapper.find('[data-testid="NameNsDescriptionNameInput"]');
+
+    expect(nameInput.element.value).toBe('Default');
+  });
+
+  it('sets the name using the nameKey prop', () => {
+    const namespaceName = 'test';
+    const store = createStore({
+      getters: {
+        allowedNamespaces:   () => () => ({ [namespaceName]: true }),
+        currentStore:        () => () => 'cluster',
+        'cluster/schemaFor': () => jest.fn()
+      }
+    });
+    const wrapper = mount(NameNsDescription, {
+      props: {
+        value: {
+          setAnnotation: jest.fn(),
+          metadata:      {},
+          spec:          { displayName: 'Default' }
+        },
+        mode:    'create',
+        nameKey: 'spec.displayName'
+      },
+      global: {
+        provide: { store },
+        mocks:   {
+          $store: {
+            dispatch: jest.fn(),
+            getters:  {
+              namespaces:                         jest.fn(),
+              'customizations/getPreviewCluster': {
+                ready:   true,
+                isLocal: false,
+                badge:   {},
+              },
+              'i18n/t': jest.fn(),
+            },
+          },
+        },
+      },
+    });
+
+    const nameInput = wrapper.find('[data-testid="NameNsDescriptionNameInput"]');
+
+    expect(nameInput.element.value).toBe('Default');
+  });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This sets a value for the name input in the NameNsDescription component when the `nameKey` prop is provided.

Fixes #13952 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Properly sets the name input in the NameNsDescription component when the `nameKey` prop is provided
- Unit test the input

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The root cause of this issue has to do with improperly accesses the `v` value after refactoring. 

- regression introduced in #13703

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

NameNsDescription should provide properly set values when: 

- navigating to Local Cluster Explorer => Projects/Namespaces
- click on "Group by Project"
- click on "Edit Config" in the dropdown menu next to "Create Namespace"

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

NA

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
