### PR TITLE
[2.11] Hid Networking and Advanced accordions for RKE1 imported cluster

### DIFF
--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -517,7 +517,7 @@ export default defineComponent({
         />
       </Accordion>
       <Accordion
-        v-if="!isCreate"
+        v-if="!isCreate & !isRKE1"
         class="mb-20 accordion"
         title-key="imported.accordions.networking"
         data-testid="network-accordion"
@@ -579,6 +579,7 @@ export default defineComponent({
         />
       </Accordion>
       <Accordion
+        v-if="!isRKE1"
         class="mb-20 accordion"
         title-key="imported.accordions.advanced"
         :open-initially="false"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13798
<!-- Define findings related to the feature or bug issue. -->
Backport issue. Hid accordions that should not be shown for RKE1 when editing or viewing config an imported RKE1 cluster.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Import RKE1 cluster
Go to edit
Only Member roles and Labels and annotations accordions should be shown
Go to View Config for that cluster
Only Member roles and Labels and annotations accordions should be shown

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
