### PR TITLE
Fixing the focus loss issue of the cloud credentials creator on the create cluster pages

### DIFF
--- a/cypress/e2e/po/pages/cluster-manager/cloud-credentials-create.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/cloud-credentials-create.po.ts
@@ -1,5 +1,5 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
-import CloudCredentialsCreateAWSPagePo from '~/cypress/e2e/po/pages/cluster-manager/cloud-credentials-create-aws.po';
+import CloudCredentialsCreateAWSPagePo from '@/cypress/e2e/po/pages/cluster-manager/cloud-credentials-create-aws.po';
 
 export default class CloudCredentialsCreatePagePo extends PagePo {
   private static createPath(clusterId: string) {

--- a/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
@@ -4,7 +4,9 @@ import { machinePoolConfigResponse } from '@/cypress/e2e/blueprints/manager/mach
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterManagerEditGenericPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-generic.po';
 import ClusterManagerCreateRke2AzurePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-azure.po';
-import CloudCredentialsCreatePagePo from '~/cypress/e2e/po/pages/cluster-manager/cloud-credentials-create.po';
+import CloudCredentialsCreatePagePo from '@/cypress/e2e/po/pages/cluster-manager/cloud-credentials-create.po';
+import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po';
+import CloudCredentialsCreateAWSPagePo from '@/cypress/e2e/po/pages/cluster-manager/cloud-credentials-create-aws.po';
 
 describe('Cloud Credential', { testIsolation: 'off' }, () => {
   const clusterList = new ClusterManagerListPagePo();
@@ -243,6 +245,33 @@ describe('Cloud Credential', { testIsolation: 'off' }, () => {
     const createCredentialsAwsPo = createCredentialsPo.selectAws();
 
     createCredentialsAwsPo.waitForPageWithExactUrl();
+
+    createCredentialsAwsPo.accessKeyInput().set(access);
+    createCredentialsAwsPo.secretKeyInput().set(secret);
+    createCredentialsAwsPo.credentialNameInput().set(name);
+
+    createCredentialsAwsPo.credentialNameInput().value().should('eq', name);
+
+    createCredentialsAwsPo.clickCreate();
+    // In the previous bug this text would get truncated to the first letter
+    createCredentialsAwsPo.errorBanner().should('contain.text', errorMessage);
+  });
+
+  it('Ensure we validate credentials and show an error when invalid when creating a credential from the create cluster page', { tags: ['@manager', '@adminUser'] }, () => {
+    // We're doing this odd page navigation and input verification to ensure we don't run into a very specific error which required this order of events described in https://github.com/rancher/dashboard/issues/13802
+    const name = 'name';
+    const access = 'access';
+    const secret = 'secret';
+    const errorMessage = 'Authentication test failed, please check your credentials';
+
+    const clusterCreate = new ClusterManagerCreatePagePo();
+
+    clusterCreate.goTo();
+    clusterCreate.waitForPage();
+    clusterCreate.selectCreate(0);
+    clusterCreate.rke2PageTitle().should('include', 'Create Amazon EC2');
+
+    const createCredentialsAwsPo = new CloudCredentialsCreateAWSPagePo();
 
     createCredentialsAwsPo.accessKeyInput().set(access);
     createCredentialsAwsPo.secretKeyInput().set(secret);

--- a/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -236,6 +236,7 @@ export default {
   <Loading v-if="$fetchState.pending" />
   <CruResource
     v-else
+    :done-params="$attrs['done-params'] /* Without this, changes to the validationPassed prop end up propagating all the way to the root of the app and force a re-render when the input becomes valid. I haven't found a reasonable explanation for why this happens. */"
     :mode="mode"
     :validation-passed="validationPassed"
     :resource="newCredential"


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13802
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Added the same changes we made in https://github.com/rancher/dashboard/pull/13921 to the SelectCredential.vue component

### Areas or cases that should be tested
The create cloud credentials component on the create cluster page.

### Areas which could experience regressions
The create cloud credentials component on the create cluster page.

### Screenshot/Video
Demonstrated on the azure page because I had aws creds which would prevent me from seeing this component. You have to refresh on the provider page to reproduce without this change.

https://github.com/user-attachments/assets/9690b725-b990-43db-b533-6fa479719fb3

### Checklist




- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
