### PR TITLE
[backport v2.11.1] In Auth Provider Keycloak (OIDC) page, empty the issuer and the auth endpoint inputs if URL gets cleared in Generate mode

### DIFF
--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -179,4 +179,20 @@ describe('oidc.vue', () => {
     expect(issuer).toBe(`${ oldUrl }/realms/${ newRealm }`);
     expect(endpoint).toBe(`${ oldUrl }/realms/${ newRealm }/protocol/openid-connect/auth`);
   });
+
+  it('clear URL should clear issuer and auth-endpoint if Keycloak', async() => {
+    wrapper.vm.model.id = 'keycloakoidc';
+    const newUrl = 'whatever';
+    const urlInput = wrapper.find(`[data-testid="oidc-url"]`);
+
+    await urlInput.setValue(newUrl);
+    await wrapper.vm.$nextTick();
+    await urlInput.setValue('');
+    await wrapper.vm.$nextTick();
+    const issuer = (wrapper.find('[data-testid="oidc-issuer"]').element as HTMLInputElement).value;
+    const endpoint = (wrapper.find('[data-testid="oidc-auth-endpoint"]').element as HTMLInputElement).value;
+
+    expect(issuer).toBe('');
+    expect(endpoint).toBe('');
+  });
 });

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -130,10 +130,16 @@ export default {
 
   methods: {
     updateEndpoints() {
+      const isKeycloak = this.model.id === 'keycloakoidc';
+
       if (!this.oidcUrls.url) {
+        this.model.issuer = '';
+        if (isKeycloak) {
+          this.model.authEndpoint = '';
+        }
+
         return;
       }
-      const isKeycloak = this.model.id === 'keycloakoidc';
 
       const url = this.oidcUrls.url.replaceAll(' ', '');
       const realmsPath = 'realms';


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13115

Backport of these PRs:
https://github.com/rancher/dashboard/pull/11650
https://github.com/rancher/dashboard/pull/13968
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
