### PR TITLE
Fixed feedback left from scheduling customization feature

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -243,20 +243,21 @@ export default {
       fvFormRuleSets:                  [{
         path: 'metadata.name', rules: ['subDomain'], translationKey: 'nameNsDescription.name.label'
       }],
-      harvesterVersionRange:                 {},
-      cisOverride:                           false,
+      harvesterVersionRange:                    {},
+      cisOverride:                              false,
       truncateLimit,
-      busy:                                  false,
-      machinePoolValidation:                 {}, // map of validation states for each machine pool
-      machinePoolErrors:                     {},
-      addonConfigValidation:                 {}, // validation state of each addon config (boolean of whether codemirror's yaml lint passed)
-      allNamespaces:                         [],
-      extensionTabs:                         getApplicableExtensionEnhancements(this, ExtensionPoint.TAB, TabLocation.CLUSTER_CREATE_RKE2, this.$route, this),
-      clusterAgentDeploymentCustomization:   null,
-      schedulingCustomizationFeatureEnabled: false,
-      clusterAgentDefaultPC:                 null,
-      clusterAgentDefaultPDB:                null,
-      activeTab:                             null,
+      busy:                                     false,
+      machinePoolValidation:                    {}, // map of validation states for each machine pool
+      machinePoolErrors:                        {},
+      addonConfigValidation:                    {}, // validation state of each addon config (boolean of whether codemirror's yaml lint passed)
+      allNamespaces:                            [],
+      extensionTabs:                            getApplicableExtensionEnhancements(this, ExtensionPoint.TAB, TabLocation.CLUSTER_CREATE_RKE2, this.$route, this),
+      clusterAgentDeploymentCustomization:      null,
+      schedulingCustomizationFeatureEnabled:    false,
+      schedulingCustomizationOriginallyEnabled: false,
+      clusterAgentDefaultPC:                    null,
+      clusterAgentDefaultPDB:                   null,
+      activeTab:                                null,
       REGISTRIES_TAB_NAME,
       labelForAddon
 
@@ -1061,7 +1062,7 @@ export default {
         this.defaultK3s = defaultK3s;
       }
     },
-
+    // This method is duplicated in pkg/imported/components/CruImported. If you are making changes to this function, you might need to change it there too
     async initSchedulingCustomization() {
       this.schedulingCustomizationFeatureEnabled = this.features(SCHEDULING_CUSTOMIZATION);
       try {
@@ -1077,6 +1078,10 @@ export default {
 
       if (this.schedulingCustomizationFeatureEnabled && this.mode === _CREATE && isEmpty(this.value?.spec?.clusterAgentDeploymentCustomization?.schedulingCustomization)) {
         set(this.value, 'spec.clusterAgentDeploymentCustomization.schedulingCustomization', { priorityClass: this.clusterAgentDefaultPC, podDisruptionBudget: this.clusterAgentDefaultPDB });
+      }
+
+      if (this.mode === _EDIT && !!this.value?.spec?.clusterAgentDeploymentCustomization?.schedulingCustomization) {
+        this.schedulingCustomizationOriginallyEnabled = true;
       }
     },
 
@@ -2450,6 +2455,7 @@ export default {
             :scheduling-customization-feature-enabled="schedulingCustomizationFeatureEnabled"
             :default-p-c="clusterAgentDefaultPC"
             :default-p-d-b="clusterAgentDefaultPDB"
+            :scheduling-customization-originally-enabled="schedulingCustomizationOriginallyEnabled"
             @scheduling-customization-changed="setSchedulingCustomization"
           />
         </Tab>

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -65,7 +65,6 @@ import ClusterAppearance from '@shell/components/form/ClusterAppearance';
 import AddOnAdditionalManifest from '@shell/edit/provisioning.cattle.io.cluster/tabs/AddOnAdditionalManifest';
 import VsphereUtils, { VMWARE_VSPHERE } from '@shell/utils/v-sphere';
 import { mapGetters } from 'vuex';
-import { SCHEDULING_CUSTOMIZATION } from '@shell/store/features';
 const HARVESTER = 'harvester';
 const HARVESTER_CLOUD_PROVIDER = 'harvester-cloud-provider';
 const NETBIOS_TRUNCATION_LENGTH = 15;

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/AgentConfiguration.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/AgentConfiguration.vue
@@ -48,6 +48,11 @@ export default {
       type:     Boolean,
       required: false
     },
+    schedulingCustomizationOriginallyEnabled: {
+      type:    Boolean,
+      default: false
+    },
+
     defaultPC: {
       type:    Object,
       default: () => {},
@@ -149,7 +154,7 @@ export default {
     },
 
     schedulingCustomizationVisible() {
-      return this.schedulingCustomizationFeatureEnabled || (this.isEdit && this.value.schedulingCustomization );
+      return this.schedulingCustomizationFeatureEnabled || this.schedulingCustomizationOriginallyEnabled;
     },
 
     affinityOptions() {

--- a/shell/store/features.js
+++ b/shell/store/features.js
@@ -1,4 +1,5 @@
 import { MANAGEMENT } from '@shell/config/types';
+import { SCHEDULING_CUSTOMIZATION as SCHEDULING_CUSTOMIZATION_FEATURE } from '@shell/config/features';
 
 const definitions = {};
 
@@ -36,7 +37,7 @@ export const FLEET_WORKSPACE_BACK = create('provisioningv2-fleet-workspace-back-
 export const STEVE_CACHE = create('ui-sql-cache', false);
 export const UIEXTENSION = create('uiextension', true);
 export const PROVISIONING_PRE_BOOTSTRAP = create('provisioningprebootstrap', false);
-export const SCHEDULING_CUSTOMIZATION = create('cluster-agent-scheduling-customization', false);
+export const SCHEDULING_CUSTOMIZATION = create(SCHEDULING_CUSTOMIZATION_FEATURE, false);
 
 // Not currently used.. no point defining ones we don't use
 // export const EMBEDDED_CLUSTER_API = create('embedded-cluster-api', true);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13665
<!-- Define findings related to the feature or bug issue. -->
Fixed comments left from Scheduling customization feature

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Added comment indicating that if initSchedulingCustomization needs to be changed, we should do it in 2 files
- Made sure that if you create a cluster with scheduling customization enabled, then disable the feature, edit the cluster and disable scheduling customization, it won't disappear before save
- Added error catching for JSON parse

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
For rke2 and imported generic cluster:
1. Enable Scheduling customization feature
2. Create 2 clusters: one with scheduling customization checkbox checked and one with it unchecked
3. Disable feature
4. Go to edit clusters:
5. For the one created with SC unchecked, scheduling customization checkbox should not be visible
6. Fore the one with SC checked, scheduling customization section should be visible and checking and unchecking checkbox should not affect it. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/32bc91d3-8b54-4e41-bc79-8c039a9bdb6d


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
