### PR TITLE
[backport v2.10.5] Workload Mixin: Remove call to `selectContainer` from `created` hook

### DIFF
--- a/cypress/e2e/po/components/workloads/pod.po.ts
+++ b/cypress/e2e/po/components/workloads/pod.po.ts
@@ -26,4 +26,12 @@ export default class PodPo extends CreateEditViewPo {
 
     shell.openTerminal();
   }
+
+  addButton() {
+    return this.self().find('[data-testid="workload-button-add-container"]');
+  }
+
+  tabsPrimary() {
+    return this.self().find('[data-testid="workload-horizontal-tabs"]');
+  }
 }

--- a/cypress/e2e/tests/pages/explorer2/workloads/pods.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/pods.spec.ts
@@ -281,6 +281,27 @@ describe('Pods', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, (
     });
   });
 
+  describe('When creating a pod using the web Form', () => {
+    const singlePodName = Cypress._.uniqueId(Date.now().toString());
+
+    it(`should properly add container tabs to the tablist`, () => {
+      workloadsPodPage.goTo();
+      workloadsPodPage.createPod();
+
+      const podDetails = new PodPo();
+
+      podDetails.nameNsDescription().name().set(singlePodName);
+      podDetails.addButton().click();
+
+      podDetails.tabsPrimary().within(() => {
+        cy.get('[data-testid="btn-pod"]').should('contain.text', 'Pod');
+        cy.get('[data-testid="btn-container-0"]').should('contain.text', 'container-0');
+        cy.get('[data-testid="btn-container-1"]').should('contain.text', 'container-1');
+        cy.get('[data-testid="workload-button-add-container"]').should('contain.text', 'Add Container');
+      });
+    });
+  });
+
   // describe.skip('[Vue3 Skip]: should delete pod', () => {
   //   const podName = `pod-${ Date.now() }`;
 

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -597,6 +597,7 @@ export default {
               v-if="!isView"
               type="button"
               class="btn-sm role-link"
+              data-testid="workload-button-add-container"
               @click="addContainerBtn"
             >
               <i class="icon icon-plus pr-5" /> {{ t('workload.container.addContainer') }}

--- a/shell/edit/workload/mixins/workload.js
+++ b/shell/edit/workload/mixins/workload.js
@@ -618,8 +618,6 @@ export default {
     this.registerBeforeHook(this.getPorts, 'getPorts');
 
     this.registerAfterHook(this.saveService, 'saveService');
-
-    this.selectContainer(this.container);
   },
 
   methods: {


### PR DESCRIPTION
fixes #13971

Original PR body:

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
0c6eb6473d7809fb94576bd66c96c29f260f2090 introduced a change that moved the call to `selectContainer` out `data` and into the `created` hook. Before this change, any modifications made by invoking `selectContainer` would get overwritten by setting container in the data prop. `selectContainer` only needs to be invoked once on first render, and the changed method in `shell/edit/workload/index.vue` satisfies this requirement.

Fixes #13958 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Remove call to `selectContainer` in `created` hook of `shell/edit/workload/mixins/workload.js`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This was only an issue for Pods, other forms like Deployments were not affected by this behavior. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Workload creation: Pods, but also Deployments, Jobs, Daemonsets, etc..

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Workload creation: Pods, but also Deployments, Jobs, Daemonsets, etc..

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/8a936dde-fc3d-41ee-ba5c-5b939ddbe591

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes

