### PR TITLE
Prevent formatterOpts.getCustomDetailLink from being overridden

### DIFF
--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1457,9 +1457,9 @@ export default {
                           :value="col.value"
                           :row="row.row"
                           :col="col.col"
+                          :get-custom-detail-link="getCustomDetailLink"
                           v-bind="col.col.formatterOpts"
                           :row-key="row.key"
-                          :get-custom-detail-link="getCustomDetailLink"
                         />
                         <component
                           :is="col.component"


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Prevent formatterOpts.getCustomDetailLink from being overridden

Fixes #9884
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
The order of `v-bind` vs other props/attributes matter https://v3-migration.vuejs.org/breaking-changes/v-bind#_3-x-syntax.

### Areas or cases that should be tested
I created a extension so that we can test this issue

Add this extension repository:

- url: https://github.com/codyrancher/custom-detail-link.git
- branch: gh-pages

![image](https://github.com/user-attachments/assets/e92445ab-f83c-46d6-9f80-c2e1d0414ec8)

And install the 0.1.2 of the `Custom-Detail-Link` extension
![image](https://github.com/user-attachments/assets/1b1ac06c-f7b8-4fb2-af27-2d3df4b2db14)

Then go to a configmap and note the new column. In previous versions of rancher you'll see it links to the resource detail page and in the fixed version of rancher you'll see that it links to home. (You can see the target url in the bottom left of the screenshots)

![image](https://github.com/user-attachments/assets/f1f3dda9-22d3-476a-ad01-d60fe8f7c68d)

![image](https://github.com/user-attachments/assets/5441a64c-436e-4e98-b7d3-93953388ff07)


### Areas which could experience regressions
Shouldn't be any. The rancher codebase doesn't make use of this property.

### Notes
Because this requires the installation of an extension and given the low severity I don't think we want to bloat our e2e tests with this so I've left this as manual.


### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
