### PR TITLE
Save EKS clusters with empty array of nodegroups

### DIFF
--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -486,9 +486,6 @@ export default defineComponent({
     },
 
     async actuallySave(): Promise<void> {
-      if (!this.isNewOrUnprovisioned && !this.nodeGroups.length && !!this.normanCluster?.eksConfig?.nodeGroups) {
-        this.normanCluster.eksConfig['nodeGroups'] = null;
-      }
       await this.normanCluster.save();
 
       return await this.normanCluster.waitForCondition('InitialRolesPopulated');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11336 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR removes a workaround that was previously added to bypass some outdated backend validation. Since rancher now supports EKS clusters with exclusively self-managed nodes, users should be able to save EKS clusters without managed node groups defined (ie, no node groups configured in the form)

### Areas or cases that should be tested

I have a 2.11-head setup with the requisite EKS clusters already available that others may borrow to expedite testing

1. Create an EKS cluster w/ self-managed nodes
2. Import the cluster into Rancher
3. Edit the cluster, but do not add node groups: you should be able to save the cluster successfully
4. Edit and add a node group
5. Edit again and attempt to remove the node group you added in step 4
6. Verify that the network request to update the cluster includes an empty array of node groups
7. Backend returns an error - will be removed by https://github.com/rancher/rancher/pull/49338/files

### Areas which could experience regressions
EKS clusters created through the Rancher UI still require at least one managed node group - verify that you can't remove all node groups from an EKS cluster provisioned in the dashboard


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
