### PR TITLE
Hide the 'scale down' action on the kontainer driver cluster detail page

### DIFF
--- a/shell/models/management.cattle.io.node.js
+++ b/shell/models/management.cattle.io.node.js
@@ -168,11 +168,11 @@ export default class MgmtNode extends HybridModel {
   }
 
   get canScaleDown() {
-    if (!this.isEtcd && !this.isControlPlane) {
+    const hasAction = this.norman?.actions?.scaledown;
+
+    if (!this.isEtcd && !this.isControlPlane && hasAction) {
       return true;
     }
-
-    const hasAction = this.norman?.actions?.scaledown;
 
     return hasAction && notOnlyOfRole(this, this.provisioningCluster?.nodes);
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11624 

Note my comment on the above issue - there are still problems with the kontainer cluster detail view, but they will be addressed in 2.12/when certain pagination work is ready

### Occurred changes and/or fixed issues
This PR updates the management node model to hide the 'scale down' action if the norman representation of the node doesn't have a 'scaledown' link defined. 


### Technical notes summary
The management node scaledown action uses the `ScaleMachineDownDialog` component, which, in turn, tries to use a 'scaledown' norman action: https://github.com/rancher/dashboard/blob/master/shell/dialog/ScaleMachineDownDialog.vue#L80-L87 - so this change should be safe for all cluster types.


### Areas or cases that should be tested
 Kontainer driver cluster detail page should not show a 'scale down' action in the 'machine pools' tab


### Areas which could experience regressions
rke1 clusters should still show the 'scale down' action when the cluster has finished provisioning


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
