### PR TITLE
Ensure long cluster names are truncated

### DIFF
--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -805,6 +805,12 @@ export default defineComponent({
     .cluster-name {
       display: flex;
       align-items: center;
+
+      // Ensure long cluster names truncate with ellipsis
+      > A {
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     }
 
     .cluster-description {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10791

### Occurred changes and/or fixed issues

Simple fix to make sure cluster names on the home page don't overflow but are displayed truncated with ellipsis.

Manual test required, since this is a visual issue. 

### Areas or cases that should be tested

Create a cluster with a long name and validate that on the home page, this is correctly displayed with ellipsis and does not overflow onto the text for the next column.

### Screenshot/Video

With this PR fix:

![image](https://github.com/user-attachments/assets/42ea16f1-dec8-4f8f-8f75-5e18ff6c1abf)

before:

![image](https://github.com/user-attachments/assets/29dcd107-4b59-40e5-abb3-189db2a1d7ff)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
