### PR TITLE
Fix responsiveness for small screens for extensions catalog docs page

### DIFF
--- a/docusaurus/plugins/catalog/styles.css
+++ b/docusaurus/plugins/catalog/styles.css
@@ -38,3 +38,9 @@
   padding: 2px;
   text-align: center;
 }
+
+@media screen and (max-width: 1280px) {
+  .catalog-card-container {
+    grid-template-columns: 100%;
+  }
+}


### PR DESCRIPTION
Update for #13512

Small tweak to make the extensions catalog docs page responsive, so on small screens (e.g. phone), we use a single column to display the extensions.

Current page: https://extensions.rancher.io/extensions/next/catalog

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
