### PR TITLE
Update IngressClass labeled select to use `update:value` instead of `selecting`

### DIFF
--- a/shell/edit/networking.k8s.io.ingress/IngressClass.vue
+++ b/shell/edit/networking.k8s.io.ingress/IngressClass.vue
@@ -5,6 +5,7 @@ import { get, set, remove } from '@shell/utils/object';
 
 export default {
   components: { LabeledSelect },
+  emits:      ['update:value'],
   props:      {
     value: {
       type:    Object,
@@ -37,13 +38,15 @@ export default {
   },
   methods: {
     update(e) {
-      if (!e || e.label === this.t('generic.none')) {
+      if (!e || e === '' || e.label === this.t('generic.none')) {
         remove(this.value, 'spec.ingressClassName');
         this.ingressClassName = '';
       } else {
         // when a user manually types an ingress class name, the event emitted has a 'label' but no 'value'
-        this.ingressClassName = e.value ? e.value : e.label;
+        this.ingressClassName = e.label || e;
         set(this.value, 'spec.ingressClassName', this.ingressClassName);
+
+        this.$emit('update:value', this.value);
       }
     }
   }
@@ -59,7 +62,7 @@ export default {
       :label="t('ingress.ingressClass.label')"
       :options="ingressClassOptions"
       option-label="label"
-      @selecting="update"
+      @update:value="update"
     />
   </div>
 </template>

--- a/shell/edit/networking.k8s.io.ingress/IngressClass.vue
+++ b/shell/edit/networking.k8s.io.ingress/IngressClass.vue
@@ -41,6 +41,7 @@ export default {
       if (!e || e === '' || e.label === this.t('generic.none')) {
         remove(this.value, 'spec.ingressClassName');
         this.ingressClassName = '';
+        this.$emit('update:value', this.value);
       } else {
         // when a user manually types an ingress class name, the event emitted has a 'label' but no 'value'
         this.ingressClassName = e.label || e;

--- a/shell/edit/networking.k8s.io.ingress/__tests__/IngressClass.test.ts
+++ b/shell/edit/networking.k8s.io.ingress/__tests__/IngressClass.test.ts
@@ -1,0 +1,58 @@
+import { shallowMount } from '@vue/test-utils';
+import IngressClass from '@shell/edit/networking.k8s.io.ingress/IngressClass.vue';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
+import { _EDIT } from '@shell/config/query-params';
+
+jest.mock('@shell/components/form/LabeledSelect', () => ({
+  name:     'LabeledSelect',
+  template: '<div></div>',
+  props:    ['value', 'taggable', 'searchable', 'mode', 'label', 'options', 'optionLabel'],
+  emits:    ['update:value'],
+}));
+
+describe('ingressClass.vue', () => {
+  it('renders correctly', () => {
+    const wrapper = shallowMount(IngressClass, {
+      props: {
+        value:          {},
+        ingressClasses: [],
+        mode:           _EDIT,
+      },
+    });
+
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.findComponent(LabeledSelect).exists()).toBe(true);
+  });
+
+  it('updates ingressClassName correctly', async() => {
+    const wrapper = shallowMount(IngressClass, {
+      props: {
+        value:          {},
+        ingressClasses: [{ label: 'nginx', value: 'nginx' }],
+        mode:           _EDIT,
+      },
+    });
+
+    await wrapper.findComponent(LabeledSelect).vm.$emit('update:value', 'nginx');
+
+    expect(wrapper.vm.ingressClassName).toBe('nginx');
+    expect(wrapper.props('value').spec.ingressClassName).toBe('nginx');
+    expect(wrapper.emitted()['update:value']).toBeTruthy();
+  });
+
+  it('removes ingressClassName when none is selected', async() => {
+    const wrapper = shallowMount(IngressClass, {
+      props: {
+        value:          { spec: { ingressClassName: 'nginx' } },
+        ingressClasses: [{ label: 'nginx', value: 'nginx' }],
+        mode:           _EDIT,
+      },
+    });
+
+    await wrapper.findComponent(LabeledSelect).vm.$emit('update:value', '');
+
+    expect(wrapper.vm.ingressClassName).toBe('');
+    expect(wrapper.props('value').spec.ingressClassName).toBeUndefined();
+    expect(wrapper.emitted()['update:value']).toBeTruthy();
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates the IngressClass component so that it listens for the `update:value` event instead of `selecting`.

Fixes #14043 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Update the IngressClass component so that it listens for the `update:value` event instead of `selecting`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

While investigating this, I noticed that value wasn't updating because `@selecting` gets emitted twice. It appears that first emitted event contains the expected data formatted properly, while the second does not, deleting the selected value altogether. I'm opting to use `update:value` because this event should explicitly emit only when a value is selected by the user. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Ingress Class
- Cluster Explorer => Service Discovery => Ingresses

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Ingress Class
- Cluster Explorer => Service Discovery => Ingresses

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
