### PR TITLE
[2.11.2] Added error listener to NodeGroups in EKS

### DIFF
--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -749,6 +749,7 @@ export default defineComponent({
               :loading-launch-templates="loadingLaunchTemplates"
               :loading-ssh-key-pairs="loadingSshKeyPairs"
               :norman-cluster="normanCluster"
+              @error="errors.push($event)"
             />
           </Tab>
         </Tabbed>

--- a/pkg/eks/components/NodeGroup.vue
+++ b/pkg/eks/components/NodeGroup.vue
@@ -333,7 +333,7 @@ export default defineComponent({
     selectedLaunchTemplate: {
       get(): AWS.LaunchTemplate {
         if (this.hasRancherLaunchTemplate) {
-          return { LaunchTemplateName: this.t('eks.nodeGroups.launchTemplate.rancherManaged', { name: this.rancherTemplate }) };
+          return { LaunchTemplateId: this.rancherTemplate, LaunchTemplateName: this.t('eks.nodeGroups.launchTemplate.rancherManaged', { name: this.rancherTemplate }) };
         }
         const id = this.launchTemplate?.id;
 
@@ -356,17 +356,15 @@ export default defineComponent({
     },
 
     launchTemplateVersionOptions(): number[] {
-      if (this.selectedLaunchTemplate && this.selectedLaunchTemplate.LatestVersionNumber) {
-        const { LatestVersionNumber } = this.selectedLaunchTemplate;
-
-        return [...Array(LatestVersionNumber).keys()].map((version) => version + 1);
+      if (this.selectedLaunchTemplateInfo && this.selectedLaunchTemplateInfo?.LaunchTemplateVersions) {
+        return this.selectedLaunchTemplateInfo.LaunchTemplateVersions.map((version) => version.VersionNumber).sort();
       }
 
       return [];
     },
 
     selectedVersionInfo(): AWS.LaunchTemplateVersion | null {
-      return (this.selectedLaunchTemplateInfo?.LaunchTemplateVersions || []).find((v: any) => v.VersionNumber === this.launchTemplate.version) || null;
+      return (this.selectedLaunchTemplateInfo?.LaunchTemplateVersions || []).find((v: any) => v.VersionNumber === this.launchTemplate?.version) || null;
     },
 
     selectedVersionData(): AWS.LaunchTemplateVersionData | undefined {
@@ -455,7 +453,13 @@ export default defineComponent({
       const ec2Client = await store.dispatch('aws/ec2', { region, cloudCredentialId: amazonCredentialSecret });
 
       try {
-        this.selectedLaunchTemplateInfo = await ec2Client.describeLaunchTemplateVersions({ LaunchTemplateId: launchTemplate.LaunchTemplateId, Versions: [...this.launchTemplateVersionOptions] });
+        if (launchTemplate.LaunchTemplateName !== this.defaultTemplateOption.LaunchTemplateName) {
+          if (launchTemplate.LaunchTemplateId) {
+            this.selectedLaunchTemplateInfo = await ec2Client.describeLaunchTemplateVersions({ LaunchTemplateId: launchTemplate.LaunchTemplateId });
+          } else {
+            this.selectedLaunchTemplateInfo = await ec2Client.describeLaunchTemplateVersions({ LaunchTemplateName: launchTemplate.LaunchTemplateName });
+          }
+        }
       } catch (err) {
         this.$emit('error', err);
       }

--- a/pkg/eks/components/__tests__/NodeGroup.test.ts
+++ b/pkg/eks/components/__tests__/NodeGroup.test.ts
@@ -1,4 +1,3 @@
-
 /* eslint-disable jest/no-mocks-import */
 import { shallowMount } from '@vue/test-utils';
 import NodeGroup from '@pkg/eks/components/NodeGroup.vue';
@@ -56,7 +55,10 @@ describe('eKS Node Groups: create', () => {
           id: 'lt-123123', name: 'test-template', version: 4
         },
         region:                 'foo',
-        amazonCredentialSecret: 'bar'
+        amazonCredentialSecret: 'bar',
+        launchTemplates:        [{
+          LaunchTemplateId: 'lt-123123', LaunchTemplateName: 'test-template', version: 4
+        }]
       },
       ...setup
     });
@@ -77,7 +79,10 @@ describe('eKS Node Groups: create', () => {
           id: 'lt-123123', name: 'test-template', version: 4
         },
         region:                 'foo',
-        amazonCredentialSecret: 'bar'
+        amazonCredentialSecret: 'bar',
+        launchTemplates:        [{
+          LaunchTemplateId: 'lt-123123', LaunchTemplateName: 'test-template', version: 4
+        }]
       },
       ...setup
     });
@@ -98,6 +103,9 @@ describe('eKS Node Groups: create', () => {
         },
         region:                 'foo',
         amazonCredentialSecret: 'bar',
+        launchTemplates:        [{
+          LaunchTemplateId: 'lt-123123', LaunchTemplateName: 'test-template', version: 4
+        }]
       },
       ...setup
     });
@@ -123,6 +131,9 @@ describe('eKS Node Groups: create', () => {
         },
         region:                 'foo',
         amazonCredentialSecret: 'bar',
+        launchTemplates:        [{
+          LaunchTemplateId: 'lt-123123', LaunchTemplateName: 'test-template', version: 4
+        }]
       },
       ...setup
     });
@@ -194,6 +205,9 @@ describe('eKS Node Groups: create', () => {
         },
         region:                 'foo',
         amazonCredentialSecret: 'bar',
+        launchTemplates:        [{
+          LaunchTemplateId: 'lt-123123', LaunchTemplateName: 'test-template', version: 4
+        }]
       },
       ...setup
     });

--- a/pkg/eks/types/aws-sdk.d.ts
+++ b/pkg/eks/types/aws-sdk.d.ts
@@ -55,7 +55,7 @@ export interface LaunchTemplateVersionData {
   UserData: string
 }
 export interface LaunchTemplateVersion {
-  VersionNumber: string,
+  VersionNumber: number,
   LaunchTemplateName: string,
   LaunchTemplateData: LaunchTemplateVersionData,
   LaunchTemplateId: string,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14061
<!-- Define findings related to the feature or bug issue. -->
Backport. Added error listener to NodeGroups in EKS. This ensures we don't swallow the errors that happen while fetching LaunchTemplate info

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
EKS creation and edit:

Force a network error while loading launchTemplate versions. (or programmatically throw an error inside fetchLaunchTemplateVersionInfo)
Verify that the error is displayed

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
