### PR TITLE
Ensure product-level navigation highlights the correct item

### DIFF
--- a/cypress/e2e/po/pages/users-and-auth/roles.po.ts
+++ b/cypress/e2e/po/pages/users-and-auth/roles.po.ts
@@ -8,6 +8,7 @@ import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import ClusterPage from '@/cypress/e2e/po/pages/cluster-page.po';
 import PaginationPo from '~/cypress/e2e/po/components/pagination.po';
+import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 
 export default class RolesPo extends ClusterPage {
   static goTo(path: string): Cypress.Chainable<Cypress.AUTWindow> {
@@ -67,5 +68,9 @@ export default class RolesPo extends ClusterPage {
 
   paginatedTab(tabIdSelector: 'GLOBAL' | 'CLUSTER' | 'NAMESPACE') {
     return new PaginationPo(`#${ tabIdSelector } div.paging`);
+  }
+
+  tabs() {
+    return new TabbedPo('[data-testid="tabbed-block"]');
   }
 }

--- a/cypress/e2e/po/side-bars/product-side-nav.po.ts
+++ b/cypress/e2e/po/side-bars/product-side-nav.po.ts
@@ -81,4 +81,12 @@ export default class ProductNavPo extends ComponentPo {
   version() {
     return new VersionNumberPo('.side-menu .version');
   }
+
+  /**
+   * Active navigation item
+   */
+  activeNavItem() {
+    return this.groups().get('.router-link-active').should('exist').invoke('text')
+      .then((s) => s.trim());
+  }
 }

--- a/cypress/e2e/tests/navigation/side-nav/product-side-nav-highlighting.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/product-side-nav-highlighting.spec.ts
@@ -1,0 +1,87 @@
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+import { ChartsPage } from '@/cypress/e2e/po/pages/explorer/charts/charts.po';
+import { ChartPage } from '@/cypress/e2e/po/pages/explorer/charts/chart.po';
+import UsersPo from '@/cypress/e2e/po/pages/users-and-auth/users.po';
+import RolesPo from '@/cypress/e2e/po/pages/users-and-auth/roles.po';
+import ClusterProjectMembersPo from '@/cypress/e2e/po/pages/explorer/cluster-project-members.po';
+import { BLANK_CLUSTER } from '@shell/store/store-types.js';
+
+Cypress.config();
+describe('Side navigation: Highlighting ', { tags: ['@navigation', '@adminUser'] }, () => {
+  const chartsPage = new ChartsPage();
+  const chartPage = new ChartPage();
+  const CHART = {
+    name: 'Alerting Drivers',
+    id:   'rancher-alerting-drivers',
+    repo: 'rancher-charts'
+  };
+
+  beforeEach(() => {
+    cy.login();
+    HomePagePo.goTo();
+  });
+
+  it('Cluster and Project members is highlighted correctly', () => {
+    HomePagePo.goTo();
+
+    const productNavPo = new ProductNavPo();
+    const clusterMembership = new ClusterProjectMembersPo('local', 'cluster-membership');
+
+    clusterMembership.navToClusterMenuEntry('local');
+    // if we do not wait for the cluster page to load, then we get the old side nav from Users & Authentication
+    clusterMembership.waitForPageWithSpecificUrl('/c/local/explorer');
+    clusterMembership.navToSideMenuEntryByLabel('Cluster and Project Members');
+    clusterMembership.waitForPage();
+    productNavPo.activeNavItem().should('equal', 'Cluster and Project Members');
+  });
+
+  it('Chart and sub-pages are highlighted correctly', () => {
+    HomePagePo.goTo();
+    chartsPage.goTo();
+
+    const productNavPo = new ProductNavPo();
+
+    productNavPo.visibleNavTypes().eq(0).should('be.visible').click()
+      .then((link) => {
+        cy.url().should('equal', link.prop('href'));
+      });
+    productNavPo.activeNavItem().should('equal', 'Charts');
+
+    // Go to install page
+    chartsPage.charts().select(CHART.name);
+    chartPage.waitForChartPage(CHART.repo, CHART.id);
+    productNavPo.activeNavItem().should('equal', 'Charts');
+
+    chartPage.goToInstall();
+    productNavPo.activeNavItem().should('equal', 'Charts');
+  });
+
+  it('User Retention highlighting', () => {
+    const usersPo = new UsersPo();
+    const productNavPo = new ProductNavPo();
+
+    usersPo.goTo();
+    usersPo.waitForPage();
+    productNavPo.activeNavItem().should('equal', 'Users');
+
+    usersPo.userRetentionLink().click();
+    productNavPo.activeNavItem().should('equal', 'Users');
+  });
+
+  it('Roles Template checks handling of hash in URL', () => {
+    const productNavPo = new ProductNavPo();
+    const roles = new RolesPo(BLANK_CLUSTER);
+    const GLOBAL = 'GLOBAL';
+    const CLUSTER = 'CLUSTER';
+
+    roles.goTo(undefined, GLOBAL);
+    roles.waitForPage(undefined, GLOBAL);
+    roles.list(GLOBAL).rowWithName('Administrator').checkExists();
+    productNavPo.activeNavItem().should('equal', 'Role Templates');
+
+    roles.tabs().clickTabWithName(CLUSTER);
+    roles.list(CLUSTER).rowWithName('Cluster Owner').checkExists();
+    productNavPo.activeNavItem().should('equal', 'Role Templates');
+  });
+});

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -169,12 +169,6 @@ export default {
         parentPath = parentPath === '/' ? undefined : parentPath;
       }
 
-      if (!parentPath) {
-        const metaNav = this.$route.meta?.nav;
-
-        parentPath = metaNav ? metaNav.replace(':cluster', cluster) : undefined;
-      }
-
       for (const item of items.children) {
         if (item.children && this.hasActiveRoute(item)) {
           return true;

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -158,6 +158,23 @@ export default {
         items = this.group;
       }
 
+      let parentPath = '';
+      const cluster = this.$route.params?.cluster;
+
+      // Where we use nested route configuration, consider the parent route when trying to identify the nav location
+      if (this.$route.matched.length > 1) {
+        const parentRoute = this.$route.matched[this.$route.matched.length - 2];
+
+        parentPath = parentRoute.path.replace(':cluster', cluster);
+        parentPath = parentPath === '/' ? undefined : parentPath;
+      }
+
+      if (!parentPath) {
+        const metaNav = this.$route.meta?.nav;
+
+        parentPath = metaNav ? metaNav.replace(':cluster', cluster) : undefined;
+      }
+
       for (const item of items.children) {
         if (item.children && this.hasActiveRoute(item)) {
           return true;
@@ -166,8 +183,11 @@ export default {
           const matchesNavLevel = navLevels.filter((param) => !this.$route.params[param] || this.$route.params[param] !== item.route.params[param]).length === 0;
           const withoutHash = this.$route.hash ? this.$route.fullPath.slice(0, this.$route.fullPath.indexOf(this.$route.hash)) : this.$route.fullPath;
           const withoutQuery = withoutHash.split('?')[0];
+          const itemFullPath = this.$router.resolve(item.route).fullPath;
 
-          if (matchesNavLevel || this.$router.resolve(item.route).fullPath === withoutQuery) {
+          if (matchesNavLevel || itemFullPath === withoutQuery) {
+            return true;
+          } else if (parentPath && itemFullPath === parentPath) {
             return true;
           }
         }

--- a/shell/components/nav/Type.vue
+++ b/shell/components/nav/Type.vue
@@ -58,7 +58,18 @@ export default {
 
     isActive() {
       const typeFullPath = this.$router.resolve(this.type.route)?.fullPath.toLowerCase();
-      const pageFullPath = this.$route.fullPath?.toLowerCase();
+      const pageFullPath = this.$route.fullPath?.toLowerCase().split('#')[0]; // Ignore the shebang when comparing routes
+      const routeMetaNav = this.$route.meta?.nav;
+
+      // If the route explicitly declares the nav path that should be highlighted, then use that
+      if (routeMetaNav) {
+        const cluster = this.$route.params?.cluster;
+        const navPath = routeMetaNav.replace(':cluster', cluster);
+
+        if (navPath === typeFullPath) {
+          return true;
+        }
+      }
 
       if ( !this.type.exact) {
         const typeSplit = typeFullPath.split('/');

--- a/shell/config/router/routes.js
+++ b/shell/config/router/routes.js
@@ -276,14 +276,25 @@ export default [
         name:      'c-cluster-neuvector',
         meta:      { ...installRedirectRouteMeta(NEUVECTOR_NAME, NEUVECTOR_CHART_NAME, undefined, false) }
       }, {
-        path:      '/c/:cluster/apps/charts',
-        component: () => interopDefault(import('@shell/pages/c/_cluster/apps/charts/index.vue')),
-        name:      'c-cluster-apps-charts'
-      },
-      {
-        path:      '/c/:cluster/apps/charts/install',
-        component: () => interopDefault(import('@shell/pages/c/_cluster/apps/charts/install.vue')),
-        name:      'c-cluster-apps-charts-install'
+        path:     '/c/:cluster/apps/charts',
+        meta:     { nav: '/c/:cluster/apps/charts' },
+        children: [
+          {
+            path:      '',
+            component: () => interopDefault(import('@shell/pages/c/_cluster/apps/charts/index.vue')),
+            name:      'c-cluster-apps-charts'
+          },
+          {
+            path:      'chart',
+            component: () => interopDefault(import('@shell/pages/c/_cluster/apps/charts/chart.vue')),
+            name:      'c-cluster-apps-charts-chart',
+          },
+          {
+            path:      'install',
+            component: () => interopDefault(import('@shell/pages/c/_cluster/apps/charts/install.vue')),
+            name:      'c-cluster-apps-charts-install',
+          },
+        ]
       },
       {
         path:      '/c/:cluster/auth/config',
@@ -354,17 +365,14 @@ export default [
         component: () => interopDefault(import('@shell/pages/c/_cluster/settings/performance.vue')),
         name:      'c-cluster-settings-performance'
       }, {
-        path:      '/c/:cluster/apps/charts/chart',
-        component: () => interopDefault(import('@shell/pages/c/_cluster/apps/charts/chart.vue')),
-        name:      'c-cluster-apps-charts-chart'
-      }, {
         path:      '/c/:cluster/auth/group.principal/assign-edit',
         component: () => interopDefault(import('@shell/pages/c/_cluster/auth/group.principal/assign-edit.vue')),
         name:      'c-cluster-auth-group.principal-assign-edit'
       }, {
         path:      '/c/:cluster/auth/user.retention',
         component: () => interopDefault(import('@shell/pages/c/_cluster/auth/user.retention/index.vue')),
-        name:      'c-cluster-auth-user.retention'
+        name:      'c-cluster-auth-user.retention',
+        meta:      { nav: '/c/:cluster/auth/management.cattle.io.user' }
       }, {
         path:      '/c/:cluster/manager/cloudCredential/create',
         component: () => interopDefault(import('@shell/pages/c/_cluster/manager/cloudCredential/create.vue')),

--- a/shell/config/router/routes.js
+++ b/shell/config/router/routes.js
@@ -277,7 +277,6 @@ export default [
         meta:      { ...installRedirectRouteMeta(NEUVECTOR_NAME, NEUVECTOR_CHART_NAME, undefined, false) }
       }, {
         path:     '/c/:cluster/apps/charts',
-        meta:     { nav: '/c/:cluster/apps/charts' },
         children: [
           {
             path:      '',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10997
Fixes #11335

### Occurred changes and/or fixed issues

This PR improves the highlighting mechanism for the product side navigation to address a number of bugs where the navigation does not expand the appropriate group and/or does not highlight the appropriate navigation item:

1. Cluster and Project Members
2. Role Templates
3. Charts - Chart detail and Chart install pages
4. User retention settings

(1) and (2) are fixed by ensuring we ignore the # in the URL - these pages have tabs which places the tab name in the URL after the hash and previously we were doing an exact URL match. Now we ignore the shebang
(3) Is caused by simply not knowing the parent navigation item - this is fixed by placing the routes in a group, as children of a base route and updating the active check logic to look at the parent route where appropriate
(4) Is caused by simply not knowing the parent navigation item - this can not be fixed by grouping, as the parent is a `c-cluster-resource` style route. To address this, we add the ability to include a `nav` field on a route `meta` property to indicate what the parent route should be when considering highlighting

### Areas or cases that should be tested

e2e tests cover checking the highlighting in the above cases.

### Screenshot/Video

In all of the cases shown below, in the current codebase, before this PR, nothing would be highlighted in the side navigation:

![image](https://github.com/user-attachments/assets/a4cfaa1a-6b83-492e-9a63-89b93651f3d0)
![Screenshot 2025-04-09 at 12 40 53](https://github.com/user-attachments/assets/c94cb2a7-9fe8-429f-8b98-47e225ad1cef)
![Screenshot 2025-04-09 at 12 41 21](https://github.com/user-attachments/assets/3e41cdca-1bbd-429a-90f1-973c9f5d9364)
![Screenshot 2025-04-09 at 12 41 47](https://github.com/user-attachments/assets/bcff1661-07e1-409b-9684-95d123b75881)
![Screenshot 2025-04-09 at 12 42 20](https://github.com/user-attachments/assets/41a8c426-dae9-4e42-8287-3bd32b52ab5e)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
