### PR TITLE
Hid Basics tab for imported RKE1 cluster

### DIFF
--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -225,7 +225,7 @@ export default defineComponent({
     showBasics() {
       const hasFieldsToShow = !!this.config || !!this.normanCluster.annotations[IMPORTED_CLUSTER_VERSION_MANAGEMENT];
 
-      return this.isCreate || (!this.isRKE1 && hasFieldsToShow);
+      return (!this.isRKE1 && hasFieldsToShow) || this.isCreate;
     },
     enableInstanceDescription() {
       return this.isLocal || this.isCreate;

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -223,7 +223,9 @@ export default defineComponent({
     },
 
     showBasics() {
-      return this.isCreate || (!this.isRKE1 && (!!this.config || !!this.normanCluster.annotations[IMPORTED_CLUSTER_VERSION_MANAGEMENT]));
+      const hasFieldsToShow = !!this.config || !!this.normanCluster.annotations[IMPORTED_CLUSTER_VERSION_MANAGEMENT];
+
+      return this.isCreate || (!this.isRKE1 && hasFieldsToShow);
     },
     enableInstanceDescription() {
       return this.isLocal || this.isCreate;

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -223,7 +223,7 @@ export default defineComponent({
     },
 
     showBasics() {
-      return this.isCreate || !!this.config || !!this.normanCluster.annotations[IMPORTED_CLUSTER_VERSION_MANAGEMENT];
+      return this.isCreate || (!this.isRKE1 && (!!this.config || !!this.normanCluster.annotations[IMPORTED_CLUSTER_VERSION_MANAGEMENT]));
     },
     enableInstanceDescription() {
       return this.isLocal || this.isCreate;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13778 
<!-- Define findings related to the feature or bug issue. -->
Removed basics tab for imported RKE1 cluster

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Import RKE1 cluster -> edit -> check that only 'Member roles' and 'Labels and annotations' tabs are visible
Make sure that Basics tab is still visible for :
- generic cluster import
- local non-RKE1 cluster
- editing imported non-RKE1 cluster

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1842" alt="Screenshot 2025-04-09 at 1 30 10 PM" src="https://github.com/user-attachments/assets/9d4bb8a5-d43a-4468-8c75-a4dd5c64fbb2" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
