### PR TITLE
Enter edit mode if updating roles fails during user creation

### DIFF
--- a/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
@@ -543,6 +543,8 @@ describe('Users', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
       usersPo.waitForPage();
       usersPo.list().create();
 
+      const runTimestamp = +new Date();
+      const runPrefix = `e2e-test-${ runTimestamp }`;
       const adminUsername = `${ runPrefix }-admin-user`;
       const adminPassword = 'admin-password';
 

--- a/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/users.spec.ts
@@ -6,6 +6,8 @@ import * as path from 'path';
 import { generateUsersDataSmall } from '@/cypress/e2e/blueprints/users/users-get';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import SortableTablePo from '@/cypress/e2e/po/components/sortable-table.po';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import FixedBannerPo from '@/cypress/e2e/po/components/fixed-banner.po';
 
 const usersPo = new UsersPo('_');
 const userCreate = usersPo.createEdit();
@@ -504,6 +506,66 @@ describe('Users', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
       userIdsList.forEach((r) => cy.deleteRancherResource('v3', 'Users', r, false));
       // Ensure the default rows per page value is set after executing the tests
       cy.tableRowsPerPageAndNamespaceFilter(100, 'local', 'none', '{"local":["all://user"]}');
+    });
+  });
+
+  describe('Create admin user with standard user', () => {
+    before(() => {
+      cy.login();
+    });
+
+    it('User creation should complete after admin user fails to create for Standard user with Manage Users Role', () => {
+      // create standard user
+      usersPo.goTo();
+      usersPo.waitForPage();
+      usersPo.list().create();
+
+      userCreate.username().set(standardUsername);
+      userCreate.newPass().set(standardPassword);
+      userCreate.confirmNewPass().set(standardPassword);
+      userCreate.selectCheckbox('Manage Users').set();
+      userCreate.saveAndWaitForRequests('POST', '/v3/globalrolebindings', true);
+
+      // check that the user is on the list view before attempting to login
+      usersPo.goTo();
+      usersPo.waitForPage();
+      usersPo.list().elementWithName(standardUsername).should('exist');
+
+      // logout admin
+      cy.logout();
+
+      // login as standard user
+      cy.login(standardUsername, standardPassword);
+
+      // navigate to the users page and attempt to create an admin user
+      HomePagePo.goToAndWaitForGet();
+      usersPo.goTo();
+      usersPo.waitForPage();
+      usersPo.list().create();
+
+      const adminUsername = `${ runPrefix }-admin-user`;
+      const adminPassword = 'admin-password';
+
+      userCreate.username().set(adminUsername);
+      userCreate.newPass().set(adminPassword);
+      userCreate.confirmNewPass().set(adminPassword);
+      userCreate.selectCheckbox('Administrator').set();
+      userCreate.saveAndWaitForRequests('POST', '/v3/globalrolebindings');
+
+      // the error banner should be displayed
+      const banner = new FixedBannerPo('#cru-errors');
+
+      banner.checkExists();
+      banner.text().should('eq', 'You cannot assign Global Permissions that are higher than your own. Please verify the permissions you are attempting to assign.');
+
+      // update the Global Permissions
+      userCreate.selectCheckbox('User-Base').set();
+      userCreate.saveAndWaitForRequests('POST', '/v3/globalrolebindings');
+
+      // save and assert that the new user exists
+      usersPo.goTo();
+      usersPo.waitForPage();
+      usersPo.list().elementWithName(adminUsername).should('exist');
     });
   });
 });

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -329,7 +329,7 @@ layouts:
   unauthenticated: unauthenticated layout
   logout: logout layout
   verify: verify layout
-  
+
 windowmanager:
   closeTab: Close tab {tabId}
 about:
@@ -498,7 +498,7 @@ authConfig:
          4: 'Under Scopes for Google APIs, enable "email", "profile", and "openid".'
          5: 'Click on "Save".'
         topPrivateDomain: 'Top private domain of:'
-        ariaLabel: 
+        ariaLabel:
           hostname: Copy Hostname to clipboard
           serverUrl: Copy Server URL to clipboard
       2:
@@ -509,7 +509,7 @@ authConfig:
           3: 'Authorized redirect URIs:'
           4: 'Click "Create", and then click on the "Download JSON" button.'
           5: 'Upload the downloaded JSON file in the OAuth credentials box.'
-        ariaLabel: 
+        ariaLabel:
           serverUrlVerify: Copy Server Auth Verfication URL to clipboard
       3:
         title: 'Create Service Account credentials'
@@ -872,13 +872,13 @@ asyncButton:
     success: Generated
     waiting: Generating&hellip;
 
-backupRestoreOperator: 
+backupRestoreOperator:
   backup:
     label: Resource Set
     description: The Resource Set determines which resources the backup-restore-operator collects in a backup
     enableEncryptionWarning: 'Enabling encryption is highly recommended when using <b><i>Full Rancher backup resource set</i></b>, otherwise sensitive information will be backed up as plain-text. <a target="_blank" rel="noopener noreferrer nofollow" href="https://ranchermanager.docs.rancher.com/reference-guides/backup-restore-configuration/backup-configuration#resourcesets">Read more</a>.'
     missingResourceSetWarning: The <b><i>{resourceSet}</i></b> resource set doesn't exist, it's possible it has been deleted. Please select a different option.
-    resourceSetOptions: 
+    resourceSetOptions:
       'rancher-resource-set-basic': 'Basic Rancher backup resource set'
       'rancher-resource-set-full': 'Full Rancher backup resource set'
       custom: Custom
@@ -1366,7 +1366,7 @@ cluster:
     registrationCommand:
       label: Registration Command
       linuxDetail: Run this command on each of the existing Linux machines you want to register.
-      windowsDetail: Run this command in PowerShell on each of the existing Windows machines you want to register. 
+      windowsDetail: Run this command in PowerShell on each of the existing Windows machines you want to register.
       windowsWorkersOnly: <b>Windows nodes can only be workers.</b>
       windowsNotReady: The cluster must be up and running with Linux etcd, control plane, and worker nodes before the registration command for adding Windows workers will display.<br /> <br /><b>Windows nodes can only be workers.</b>
       windowsWarning: Workload pods, including some deployed by Rancher charts, will be scheduled on both Linux and Windows nodes by default. Edit NodeSelector in the chart to direct them to be placed onto a compatible node.
@@ -1884,11 +1884,11 @@ cluster:
     subGroups:
       podAffinityAnti: Pod Affinity/Anti-Affinity
       nodeAffinity: Node Affinity
-      schedulingCustomization: 
+      schedulingCustomization:
         label: Prevent Rancher cluster agent pod eviction
         description: This ensures that the cluster agent pod is not evicted due to node pressure, resource constraints or scheduler policies.
         banner: This feature has been enabled with settings that are different from the global default settings.
-        innerCheckbox: Apply global settings for Priority Class and Pod Disruption Budget  
+        innerCheckbox: Apply global settings for Priority Class and Pod Disruption Budget
     banners:
       advanced: These are advanced configuration options. Generally, they should be left as-is.
       tolerations: Additional Pod Tolerations will be added to the default Tolerations applied by Rancher.
@@ -2215,7 +2215,7 @@ cluster:
       snapshotScheduleCron:
         label: Cron Schedule
       snapshotRetention:
-        label: Snapshot retention count 
+        label: Snapshot retention count
         tooltip: Each backup records 1 snapshot per etcd node. If you specify 3 snapshots and you have 3 etcd nodes you will only retain 1 full backup.
       exportMetric:
         label: Metrics
@@ -5141,6 +5141,8 @@ rbac:
         label: Login Access
       clustertemplaterevisions-create:
         label: Create RKE Template Revisions
+  errors:
+    escalation: You cannot assign Global Permissions that are higher than your own. Please verify the permissions you are attempting to assign.
 
 resourceDetail:
   detailTop:

--- a/shell/components/GlobalRoleBindings.vue
+++ b/shell/components/GlobalRoleBindings.vue
@@ -49,6 +49,10 @@ export default {
     userId: {
       type:    String,
       default: ''
+    },
+    watchOverride: {
+      type:    Boolean,
+      default: true,
     }
   },
   async fetch() {
@@ -138,7 +142,7 @@ export default {
       this.update();
     },
     userId(userId, oldUserId) {
-      if (userId === oldUserId) {
+      if (userId === oldUserId || this.watchOverride === true) {
         return;
       }
       this.update();

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -384,18 +384,7 @@ export default {
   },
 
   created() {
-    // eslint-disable-next-line prefer-const
-    const id = this.$route.params.id;
-    const resource = this.resourceOverride || this.$route.params.resource;
-    const options = this.$store.getters[`type-map/optionsFor`](resource);
-
-    const detailResource = options.resourceDetail || options.resource || resource;
-    const editResource = options.resourceEdit || options.resource || resource;
-
-    // FIXME: These aren't right... signature is (rawType, subType).. not (rawType, resourceId)
-    // Remove id? How does subtype get in (cluster/node)
-    this.detailComponent = this.$store.getters['type-map/importDetail'](detailResource, id);
-    this.editComponent = this.$store.getters['type-map/importEdit'](editResource, id);
+    this.configureResource();
   },
 
   methods: {
@@ -414,6 +403,50 @@ export default {
     closeError(index) {
       this.errors = this.errors.filter((_, i) => i !== index);
     },
+    /**
+     * Initializes the resource components based on the provided user and
+     * resource override.
+     *
+     * Configures the detail and edit components for a resource based on the
+     * user's ID and the specified resource.
+     *
+     * @param {Object} user - The user object containing user-specific
+     * information.
+     * @param {string|null} resourceOverride - An optional resource override
+     * string. If not provided, the method will use the default resource from
+     * the route parameters or the instance's resourceOverride property.
+     */
+    configureResource(user = {}, resourceOverride = null) {
+      const id = user?.id || this.$route.params.id;
+      const resource = resourceOverride || this.resourceOverride || this.$route.params.resource;
+      const options = this.$store.getters[`type-map/optionsFor`](resource);
+
+      const detailResource = options.resourceDetail || options.resource || resource;
+      const editResource = options.resourceEdit || options.resource || resource;
+
+      // FIXME: These aren't right... signature is (rawType, subType).. not (rawType, resourceId)
+      // Remove id? How does subtype get in (cluster/node)
+      this.detailComponent = this.$store.getters['type-map/importDetail'](detailResource, id);
+      this.editComponent = this.$store.getters['type-map/importEdit'](editResource, id);
+    },
+    /**
+     * Sets the mode and initializes the resource components.
+     *
+     * This method sets the mode of the component and configures the resource
+     * components based on the provided user and resource.
+     *
+     * @param {Object} payload - An object containing the mode, user, and
+     * resource properties.
+     * @param {string} payload.mode - The mode to set.
+     * @param {Object} payload.user - The user object containing user-specific
+     * information.
+     * @param {string} payload.resource - The resource string to use for
+     * initialization.
+     */
+    setMode({ mode, user, resource }) {
+      this.mode = mode;
+      this.configureResource(user, resource);
+    }
   }
 };
 </script>
@@ -491,6 +524,7 @@ export default {
       :real-mode="realMode"
       :class="{'flex-content': flexContent}"
       @update:value="$emit('input', $event)"
+      @update:mode="setMode"
       @set-subtype="setSubtype"
     />
 

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -416,8 +416,8 @@ export default {
      * string. If not provided, the method will use the default resource from
      * the route parameters or the instance's resourceOverride property.
      */
-    configureResource(user = {}, resourceOverride = null) {
-      const id = user?.id || this.$route.params.id;
+    configureResource(userId = '', resourceOverride = null) {
+      const id = userId || this.$route.params.id;
       const resource = resourceOverride || this.resourceOverride || this.$route.params.resource;
       const options = this.$store.getters[`type-map/optionsFor`](resource);
 
@@ -443,9 +443,10 @@ export default {
      * @param {string} payload.resource - The resource string to use for
      * initialization.
      */
-    setMode({ mode, user, resource }) {
+    setMode({ mode, userId, resource }) {
       this.mode = mode;
-      this.configureResource(user, resource);
+      this.value.id = userId;
+      this.configureResource(userId, resource);
     }
   }
 };

--- a/shell/edit/management.cattle.io.user.vue
+++ b/shell/edit/management.cattle.io.user.vue
@@ -118,7 +118,11 @@ export default {
         this.$router.replace({ name: this.doneRoute });
         buttonDone(true);
       } catch (err) {
-        this.errors = exceptionToErrorsArray(err);
+        if (err?.message?.includes('errors due to escalation')) {
+          this.errors = [this.t('rbac.errors.escalation')];
+        } else {
+          this.errors = exceptionToErrorsArray(err);
+        }
         buttonDone(false);
       }
     },

--- a/shell/edit/management.cattle.io.user.vue
+++ b/shell/edit/management.cattle.io.user.vue
@@ -42,7 +42,7 @@ export default {
         roles:        !showGlobalRoles,
         rolesChanged: false,
       },
-      user: {},
+      watchOverride: false,
     };
   },
 
@@ -107,9 +107,9 @@ export default {
       this.errors = [];
       try {
         if (this.isCreate) {
-          this.user = await this.createUser();
+          const user = await this.createUser();
 
-          await this.updateRoles(this.user.id);
+          await this.updateRoles(user.id);
         } else {
           await this.editUser();
           await this.updateRoles();
@@ -196,11 +196,12 @@ export default {
         await this.$refs.grb.save(userId);
       } catch (err) {
         if (this.isCreate) {
+          this.watchOverride = true;
           this.$emit(
             'update:mode',
             {
+              userId,
               mode:     _EDIT,
-              user:     this.user,
               resource: 'management.cattle.io.user',
             }
           );
@@ -275,9 +276,10 @@ export default {
     >
       <GlobalRoleBindings
         ref="grb"
-        :user-id="value.id || liveValue.id || user.id"
+        :user-id="value.id || liveValue.id"
         :mode="mode"
         :real-mode="realMode"
+        :watch-override="watchOverride"
         type="user"
         @hasChanges="validation.rolesChanged = $event"
         @canLogIn="validation.roles = $event"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This emits  an `update:mode` event that sets to mode to "edit" and refreshes all resource-related variables when the `updateRoles()` method fails during user creation. This provides an opportunity for users to correct mistakes while still staying in the "Create User" context.

Fixes #13539 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Switch mode to "edit" if the `updateRoles()` method fails during user creation
- Add a user readable error message if an escalation error is raised

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

An alternate approach that explored navigating to an edit route was explored, but this required re-rendering the entire form and would eliminate the error message; additional state to persist the error messages would be required and I found that requirement to be more complex than the approach taken here.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

User Creation: See details in the associated issue.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

User Creation: Ensuring that the form still functions properly after an error is raised during user creation.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/user-attachments/assets/57b4c9c9-85fe-45cf-b32f-a1af02fd706d)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
