### PR TITLE
Improve Banners settings screen reader output

### DIFF
--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.test.ts
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.test.ts
@@ -1,4 +1,4 @@
-import { shallowMount, Wrapper } from '@vue/test-utils';
+import { shallowMount, Wrapper, mount } from '@vue/test-utils';
 import { Checkbox } from './index';
 
 describe('checkbox.vue', () => {
@@ -64,5 +64,54 @@ describe('checkbox.vue', () => {
     await wrapper.vm.$nextTick();
 
     expect(wrapper.emitted('update:value')[0][0]).toBeNull();
+  });
+
+  it('a11y: adding ARIA props should correctly fill out the appropriate fields on the component', async() => {
+    const alternateLabel = 'some-alternate-aria-label';
+    const description = 'some-description';
+    const ariaDescribedById = 'some-external-id';
+
+    const wrapper: Wrapper<InstanceType<typeof Checkbox>> = mount(
+      Checkbox, 
+      { 
+        propsData: { value: false, alternateLabel, description },
+        attrs:     { 'aria-describedby': ariaDescribedById},
+      }
+    );
+
+    const field = wrapper.find('.checkbox-custom');
+    const ariaChecked = field.attributes('aria-checked');
+    const ariaLabel = field.attributes('aria-label');
+    const ariaLabelledBy = field.attributes('aria-labelledby');
+    const ariaDescribedBy = field.attributes('aria-describedby');
+
+    // validates type of input rendered
+    expect(ariaChecked).toBe('false');
+    expect(ariaLabelledBy).toBe(undefined)
+    expect(ariaLabel).toBe(alternateLabel);
+    expect(ariaDescribedBy).toBe(`${ariaDescribedById} ${wrapper.vm.describedById}`);
+  });
+
+  it('a11y: having a label should not render "aria-label" prop and have "aria-labelledby"', async() => {
+    const label = 'some-label'
+
+    const wrapper: Wrapper<InstanceType<typeof Checkbox>> = mount(
+      Checkbox, 
+      { 
+        propsData: { value: true, label }
+      }
+    );
+
+    const field = wrapper.find('.checkbox-custom');
+    const ariaChecked = field.attributes('aria-checked');
+    const ariaLabel = field.attributes('aria-label');
+    const ariaLabelledBy = field.attributes('aria-labelledby');
+
+    // validates type of input rendered
+    expect(field.exists()).toBe(true);
+    expect(ariaChecked).toBe('true');
+    expect(ariaLabelledBy).toBe(wrapper.vm.idForLabel)
+    expect(ariaLabel).toBe(undefined);
+    expect(wrapper.find(`#${wrapper.vm.idForLabel}`).text()).toBe(label)
   });
 });

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.test.ts
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.test.ts
@@ -72,10 +72,12 @@ describe('checkbox.vue', () => {
     const ariaDescribedById = 'some-external-id';
 
     const wrapper: Wrapper<InstanceType<typeof Checkbox>> = mount(
-      Checkbox, 
-      { 
-        propsData: { value: false, alternateLabel, description },
-        attrs:     { 'aria-describedby': ariaDescribedById},
+      Checkbox,
+      {
+        propsData: {
+          value: false, alternateLabel, description
+        },
+        attrs: { 'aria-describedby': ariaDescribedById },
       }
     );
 
@@ -87,19 +89,17 @@ describe('checkbox.vue', () => {
 
     // validates type of input rendered
     expect(ariaChecked).toBe('false');
-    expect(ariaLabelledBy).toBe(undefined)
+    expect(ariaLabelledBy).toBeUndefined();
     expect(ariaLabel).toBe(alternateLabel);
-    expect(ariaDescribedBy).toBe(`${ariaDescribedById} ${wrapper.vm.describedById}`);
+    expect(ariaDescribedBy).toBe(`${ ariaDescribedById } ${ wrapper.vm.describedById }`);
   });
 
   it('a11y: having a label should not render "aria-label" prop and have "aria-labelledby"', async() => {
-    const label = 'some-label'
+    const label = 'some-label';
 
     const wrapper: Wrapper<InstanceType<typeof Checkbox>> = mount(
-      Checkbox, 
-      { 
-        propsData: { value: true, label }
-      }
+      Checkbox,
+      { propsData: { value: true, label } }
     );
 
     const field = wrapper.find('.checkbox-custom');
@@ -110,8 +110,8 @@ describe('checkbox.vue', () => {
     // validates type of input rendered
     expect(field.exists()).toBe(true);
     expect(ariaChecked).toBe('true');
-    expect(ariaLabelledBy).toBe(wrapper.vm.idForLabel)
-    expect(ariaLabel).toBe(undefined);
-    expect(wrapper.find(`#${wrapper.vm.idForLabel}`).text()).toBe(label)
+    expect(ariaLabelledBy).toBe(wrapper.vm.idForLabel);
+    expect(ariaLabel).toBeUndefined();
+    expect(wrapper.find(`#${ wrapper.vm.idForLabel }`).text()).toBe(label);
   });
 });

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -133,6 +133,18 @@ export default defineComponent({
   },
 
   computed: {
+    ariaDescribedBy(): string | undefined {
+      const inheritedDescribedBy = this.$attrs['aria-describedby'];
+      const internalDescribedBy = this.descriptionKey || this.description ? this.describedById : undefined;
+
+      if (inheritedDescribedBy && internalDescribedBy) {
+        return `${ inheritedDescribedBy } ${ internalDescribedBy }`;
+      } else if (inheritedDescribedBy || internalDescribedBy) {
+        return `${ inheritedDescribedBy || internalDescribedBy }`;
+      }
+
+      return undefined;
+    },
     /**
      * Determines if the checkbox is disabled.
      * @returns boolean: True when the disabled prop is true or when mode is
@@ -167,7 +179,7 @@ export default defineComponent({
     },
 
     idForLabel():string {
-      return `${ this.id }-label`;
+      return `${ generateRandomAlphaString(12) }-checkbox-label`;
     }
   },
 
@@ -274,7 +286,7 @@ export default defineComponent({
         :aria-label="replacementLabel"
         :aria-checked="!!value"
         :aria-labelledby="labelKey || label ? idForLabel : undefined"
-        :aria-describedby="descriptionKey || description ? describedById : undefined"
+        :aria-describedby="ariaDescribedBy"
         role="checkbox"
       />
       <span

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
@@ -37,7 +37,7 @@ describe('component: LabeledInput', () => {
     expect(wrapper.emitted('update:value')).toHaveLength(1);
     expect(wrapper.emitted('update:value')![0][0]).toBe(value);
   });
-  
+
   describe('using type "chron"', () => {
     it.each([
       ['0 * * * *', 'Every hour, every day'],
@@ -67,9 +67,11 @@ describe('component: LabeledInput', () => {
       ['multiline-password', 'textarea', ariaLabelVal, subLabelVal, ariaDescribedByIdVal],
     ])('for type %p should correctly fill out the appropriate fields on the component', (type, validationType, ariaLabel, subLabel, ariaDescribedById) => {
       const wrapper = mount(LabeledInput, {
-        propsData: { value: '', type, ariaLabel, subLabel },
-        attrs:     { 'aria-describedby': ariaDescribedById},
-        mocks:     { $store: { getters: { 'i18n/t': jest.fn() } } }
+        propsData: {
+          value: '', type, ariaLabel, subLabel
+        },
+        attrs: { 'aria-describedby': ariaDescribedById },
+        mocks: { $store: { getters: { 'i18n/t': jest.fn() } } }
       });
 
       const field = wrapper.find(validationType);
@@ -79,7 +81,7 @@ describe('component: LabeledInput', () => {
       // validates type of input rendered
       expect(field.exists()).toBe(true);
       expect(ariaLabelProp).toBe(ariaLabel);
-      expect(ariaDescribedBy).toBe(`${ariaDescribedById} ${wrapper.vm.describedById}`);
+      expect(ariaDescribedBy).toBe(`${ ariaDescribedById } ${ wrapper.vm.describedById }`);
     });
   });
 
@@ -92,7 +94,8 @@ describe('component: LabeledInput', () => {
     });
 
     const mainInput = wrapper.find('input[type="text"]');
-    expect(mainInput.attributes('aria-label')).toBe(undefined)
-    expect(wrapper.find('label').text()).toBe(label)
+
+    expect(mainInput.attributes('aria-label')).toBeUndefined();
+    expect(wrapper.find('label').text()).toBe(label);
   });
 });

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
@@ -37,7 +37,7 @@ describe('component: LabeledInput', () => {
     expect(wrapper.emitted('update:value')).toHaveLength(1);
     expect(wrapper.emitted('update:value')![0][0]).toBe(value);
   });
-
+  
   describe('using type "chron"', () => {
     it.each([
       ['0 * * * *', 'Every hour, every day'],
@@ -53,5 +53,46 @@ describe('component: LabeledInput', () => {
 
       expect(subLabel.text()).toBe(hint);
     });
+  });
+
+  describe('a11y: adding ARIA props', () => {
+    const ariaLabelVal = 'some-aria-label';
+    const subLabelVal = 'some-sublabel';
+    const ariaDescribedByIdVal = 'some-external-id';
+
+    it.each([
+      ['text', 'input', ariaLabelVal, subLabelVal, ariaDescribedByIdVal],
+      ['cron', 'input', ariaLabelVal, subLabelVal, ariaDescribedByIdVal],
+      ['multiline', 'textarea', ariaLabelVal, subLabelVal, ariaDescribedByIdVal],
+      ['multiline-password', 'textarea', ariaLabelVal, subLabelVal, ariaDescribedByIdVal],
+    ])('for type %p should correctly fill out the appropriate fields on the component', (type, validationType, ariaLabel, subLabel, ariaDescribedById) => {
+      const wrapper = mount(LabeledInput, {
+        propsData: { value: '', type, ariaLabel, subLabel },
+        attrs:     { 'aria-describedby': ariaDescribedById},
+        mocks:     { $store: { getters: { 'i18n/t': jest.fn() } } }
+      });
+
+      const field = wrapper.find(validationType);
+      const ariaLabelProp = field.attributes('aria-label');
+      const ariaDescribedBy = field.attributes('aria-describedby');
+
+      // validates type of input rendered
+      expect(field.exists()).toBe(true);
+      expect(ariaLabelProp).toBe(ariaLabel);
+      expect(ariaDescribedBy).toBe(`${ariaDescribedById} ${wrapper.vm.describedById}`);
+    });
+  });
+
+  it('a11y: rendering a "label" should not render an "aria-label" prop', () => {
+    const label = 'some-label';
+
+    const wrapper = mount(LabeledInput, {
+      propsData: { type: 'text', label },
+      mocks:     { $store: { getters: { 'i18n/t': jest.fn() } } }
+    });
+
+    const mainInput = wrapper.find('input[type="text"]');
+    expect(mainInput.attributes('aria-label')).toBe(undefined)
+    expect(wrapper.find('label').text()).toBe(label)
   });
 });

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -161,6 +161,19 @@ export default defineComponent({
       return this.isCompact ? false : !!this.label || !!this.labelKey || !!this.$slots.label;
     },
 
+    ariaDescribedBy(): string | undefined {
+      const inheritedDescribedBy = this.$attrs['aria-describedby'];
+      const internalDescribedBy = this.cronHint || this.subLabel ? this.describedById : undefined;
+
+      if (inheritedDescribedBy && internalDescribedBy) {
+        return `${ inheritedDescribedBy } ${ internalDescribedBy }`;
+      } else if (inheritedDescribedBy || internalDescribedBy) {
+        return `${ inheritedDescribedBy || internalDescribedBy }`;
+      }
+
+      return undefined;
+    },
+
     /**
      * Determines if the Labeled Input should display a tooltip.
      */
@@ -381,7 +394,7 @@ export default defineComponent({
         :placeholder="_placeholder"
         autocapitalize="off"
         :class="{ conceal: type === 'multiline-password' }"
-        :aria-describedby="cronHint || subLabel ? describedById : undefined"
+        :aria-describedby="ariaDescribedBy"
         @update:value="onInput"
         @focus="onFocus"
         @blur="onBlur"
@@ -402,7 +415,7 @@ export default defineComponent({
         autocomplete="off"
         autocapitalize="off"
         :data-lpignore="ignorePasswordManagers"
-        :aria-describedby="cronHint || subLabel ? describedById : undefined"
+        :aria-describedby="ariaDescribedBy"
         @input="onInput"
         @focus="onFocus"
         @blur="onBlur"

--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.test.ts
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.test.ts
@@ -31,39 +31,38 @@ describe('radioButton.vue', () => {
     expect(wrapper.find('.radio-label').text()).toBe('Test Label - Slot');
   });
 
-  it('a11y: adding ARIA props should correctly fill out the appropriate fields on the component', async () => {
-      const val = 'foo';
-      const value = 'foo';
-      const description = 'some-description'
-      const itemLabel = 'some-label';
-      const radioOptionId = 'some-id-from-parent';
+  it('a11y: adding ARIA props should correctly fill out the appropriate fields on the component', async() => {
+    const val = 'foo';
+    const value = 'foo';
+    const description = 'some-description';
+    const itemLabel = 'some-label';
+    const radioOptionId = 'some-id-from-parent';
 
-      const wrapper = mount(
-        RadioButton,
-        {
-          propsData: {
-            label: itemLabel,
-            val, 
-            value,
-            description,
-            radioOptionId
-          }
-        });
-  
-      const radioInputElem = wrapper.find('span[role="radio"]');
-      const role = radioInputElem.attributes('role');
-      const ariaLabel = radioInputElem.attributes('aria-label');
-      const ariaChecked = radioInputElem.attributes('aria-checked');
-      const ariaDisabled = radioInputElem.attributes('aria-disabled');
-      const ariaDescribedBy = radioInputElem.attributes('aria-describedby');
-      const itemId = radioInputElem.attributes('id');
+    const wrapper = mount(
+      RadioButton,
+      {
+        propsData: {
+          label: itemLabel,
+          val,
+          value,
+          description,
+          radioOptionId
+        }
+      });
 
-  
-      expect(role).toBe('radio');
-      expect(ariaLabel).toBe(itemLabel);
-      expect(ariaChecked).toBe('true');
-      expect(ariaDisabled).toBe('false');
-      expect(ariaDescribedBy).toBe(wrapper.vm.describeById);
-      expect(itemId).toBe(radioOptionId);
-    });
+    const radioInputElem = wrapper.find('span[role="radio"]');
+    const role = radioInputElem.attributes('role');
+    const ariaLabel = radioInputElem.attributes('aria-label');
+    const ariaChecked = radioInputElem.attributes('aria-checked');
+    const ariaDisabled = radioInputElem.attributes('aria-disabled');
+    const ariaDescribedBy = radioInputElem.attributes('aria-describedby');
+    const itemId = radioInputElem.attributes('id');
+
+    expect(role).toBe('radio');
+    expect(ariaLabel).toBe(itemLabel);
+    expect(ariaChecked).toBe('true');
+    expect(ariaDisabled).toBe('false');
+    expect(ariaDescribedBy).toBe(wrapper.vm.describeById);
+    expect(itemId).toBe(radioOptionId);
+  });
 });

--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.test.ts
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.test.ts
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, mount } from '@vue/test-utils';
 import { RadioButton } from './index';
 
 describe('radioButton.vue', () => {
@@ -30,4 +30,40 @@ describe('radioButton.vue', () => {
 
     expect(wrapper.find('.radio-label').text()).toBe('Test Label - Slot');
   });
+
+  it('a11y: adding ARIA props should correctly fill out the appropriate fields on the component', async () => {
+      const val = 'foo';
+      const value = 'foo';
+      const description = 'some-description'
+      const itemLabel = 'some-label';
+      const radioOptionId = 'some-id-from-parent';
+
+      const wrapper = mount(
+        RadioButton,
+        {
+          propsData: {
+            label: itemLabel,
+            val, 
+            value,
+            description,
+            radioOptionId
+          }
+        });
+  
+      const radioInputElem = wrapper.find('span[role="radio"]');
+      const role = radioInputElem.attributes('role');
+      const ariaLabel = radioInputElem.attributes('aria-label');
+      const ariaChecked = radioInputElem.attributes('aria-checked');
+      const ariaDisabled = radioInputElem.attributes('aria-disabled');
+      const ariaDescribedBy = radioInputElem.attributes('aria-describedby');
+      const itemId = radioInputElem.attributes('id');
+
+  
+      expect(role).toBe('radio');
+      expect(ariaLabel).toBe(itemLabel);
+      expect(ariaChecked).toBe('true');
+      expect(ariaDisabled).toBe('false');
+      expect(ariaDescribedBy).toBe(wrapper.vm.describeById);
+      expect(itemId).toBe(radioOptionId);
+    });
 });

--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
@@ -4,7 +4,9 @@ import { _VIEW } from '@shell/config/query-params';
 import { generateRandomAlphaString } from '@shell/utils/string';
 
 export default defineComponent({
-  props: {
+
+  inheritAttrs: false,
+  props:        {
     /**
      * The name of the input, for grouping.
      */
@@ -79,16 +81,14 @@ export default defineComponent({
     },
 
     /**
-     * Radio option Id - used to link to aria-activedescendant 
+     * Radio option Id - used to link to aria-activedescendant
      * when using inside of the context of a Radio Group
      */
-     radioOptionId: {
+    radioOptionId: {
       type:    String,
       default: undefined
     },
   },
-
-  inheritAttrs: false,
 
   emits: ['update:value'],
 
@@ -177,6 +177,7 @@ export default defineComponent({
       @click.stop.prevent
     >
     <span
+      :id="radioOptionId"
       ref="custom"
       :class="[ isDisabled ? 'text-muted' : '', 'radio-custom']"
       :tabindex="isDisabled || preventFocusOnRadioGroups ? -1 : 0"
@@ -185,7 +186,6 @@ export default defineComponent({
       :aria-disabled="isDisabled"
       :aria-describedby="descriptionKey || description ? describeById : undefined"
       role="radio"
-      :id="radioOptionId"
     />
     <div class="labeling">
       <label
@@ -205,8 +205,8 @@ export default defineComponent({
       </label>
       <div
         v-if="descriptionKey || description"
-        class="radio-button-outer-container-description"
         :id="describeById"
+        class="radio-button-outer-container-description"
       >
         <t
           v-if="descriptionKey"

--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { _VIEW } from '@shell/config/query-params';
-import { randomStr } from '@shell/utils/string';
+import { generateRandomAlphaString } from '@shell/utils/string';
 
 export default defineComponent({
   props: {
@@ -76,15 +76,27 @@ export default defineComponent({
     preventFocusOnRadioGroups: {
       type:    Boolean,
       default: false
-    }
+    },
+
+    /**
+     * Radio option Id - used to link to aria-activedescendant 
+     * when using inside of the context of a Radio Group
+     */
+     radioOptionId: {
+      type:    String,
+      default: undefined
+    },
   },
+
+  inheritAttrs: false,
 
   emits: ['update:value'],
 
   data() {
     return {
       isChecked:    this.value === this.val,
-      randomString: `${ randomStr() }-radio`,
+      randomString: `${ generateRandomAlphaString(12) }-radio`,
+      describeById: `${ generateRandomAlphaString(12) }-radio-described-id`,
     };
   },
 
@@ -170,7 +182,10 @@ export default defineComponent({
       :tabindex="isDisabled || preventFocusOnRadioGroups ? -1 : 0"
       :aria-label="label"
       :aria-checked="isChecked"
+      :aria-disabled="isDisabled"
+      :aria-describedby="descriptionKey || description ? describeById : undefined"
       role="radio"
+      :id="radioOptionId"
     />
     <div class="labeling">
       <label
@@ -191,6 +206,7 @@ export default defineComponent({
       <div
         v-if="descriptionKey || description"
         class="radio-button-outer-container-description"
+        :id="describeById"
       >
         <t
           v-if="descriptionKey"

--- a/pkg/rancher-components/src/components/Form/Radio/RadioGroup.test.ts
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioGroup.test.ts
@@ -24,4 +24,39 @@ describe('component: RadioGroup', () => {
       expect(slot.disabled).toBe(disabled);
     });
   });
+
+  it('a11y: adding ARIA props should correctly fill out the appropriate fields on the component', async() => {
+      const inputLabel = 'some-label';
+      const ariaDescribedById = 'some-external-id';
+      const currValue = 'whatever';
+  
+      const wrapper = mount(RadioGroup, {
+        propsData: {
+          name:    'some-name',
+          label: inputLabel,
+          value: currValue,
+          options: [{ label: currValue, value: currValue }]
+        },
+        attrs: {
+          ['aria-describedby']: ariaDescribedById
+        }
+      });
+
+      const field = wrapper.find('[role="radiogroup"]');
+      const role = field.attributes('role');
+      const ariaLabel = field.attributes('aria-label');
+      const ariaDescribedBy = field.attributes('aria-describedby');
+      const ariaActiveDescendant = field.attributes('aria-activedescendant');
+  
+      expect(ariaLabel).toBe(inputLabel);
+      expect(role).toBe('radiogroup');
+      expect(ariaActiveDescendant).toBe(`${wrapper.vm.radioOptionsIdPrefix}0`);
+      expect(ariaDescribedBy).toBe(ariaDescribedById);
+      
+      const radioOption = wrapper.find(`.radio-custom`);
+
+      // make sure we validate when using RadioGroup without custom slot data
+      // we do assign an ID that is important to get 'aria-activedescendant' working
+      expect(radioOption.attributes('id')).toBe(`${wrapper.vm.radioOptionsIdPrefix}0`)
+    });
 });

--- a/pkg/rancher-components/src/components/Form/Radio/RadioGroup.test.ts
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioGroup.test.ts
@@ -26,37 +26,57 @@ describe('component: RadioGroup', () => {
   });
 
   it('a11y: adding ARIA props should correctly fill out the appropriate fields on the component', async() => {
-      const inputLabel = 'some-label';
-      const ariaDescribedById = 'some-external-id';
-      const currValue = 'whatever';
-  
-      const wrapper = mount(RadioGroup, {
-        propsData: {
-          name:    'some-name',
-          label: inputLabel,
-          value: currValue,
-          options: [{ label: currValue, value: currValue }]
-        },
-        attrs: {
-          ['aria-describedby']: ariaDescribedById
-        }
-      });
+    const inputLabel = 'some-label';
+    const ariaDescribedById = 'some-external-id';
+    const currValue = 'whatever';
 
-      const field = wrapper.find('[role="radiogroup"]');
-      const role = field.attributes('role');
-      const ariaLabel = field.attributes('aria-label');
-      const ariaDescribedBy = field.attributes('aria-describedby');
-      const ariaActiveDescendant = field.attributes('aria-activedescendant');
-  
-      expect(ariaLabel).toBe(inputLabel);
-      expect(role).toBe('radiogroup');
-      expect(ariaActiveDescendant).toBe(`${wrapper.vm.radioOptionsIdPrefix}0`);
-      expect(ariaDescribedBy).toBe(ariaDescribedById);
-      
-      const radioOption = wrapper.find(`.radio-custom`);
-
-      // make sure we validate when using RadioGroup without custom slot data
-      // we do assign an ID that is important to get 'aria-activedescendant' working
-      expect(radioOption.attributes('id')).toBe(`${wrapper.vm.radioOptionsIdPrefix}0`)
+    const wrapper = mount(RadioGroup, {
+      propsData: {
+        name:    'some-name',
+        label:   inputLabel,
+        value:   currValue,
+        options: [{ label: currValue, value: currValue }]
+      },
+      attrs: { 'aria-describedby': ariaDescribedById }
     });
+
+    const field = wrapper.find('[role="radiogroup"]');
+    const role = field.attributes('role');
+    const ariaLabel = field.attributes('aria-label');
+    const ariaDescribedBy = field.attributes('aria-describedby');
+    const ariaActiveDescendant = field.attributes('aria-activedescendant');
+
+    expect(ariaLabel).toBe(inputLabel);
+    expect(role).toBe('radiogroup');
+    expect(ariaActiveDescendant).toBe(`${ wrapper.vm.radioOptionsIdPrefix }0`);
+    expect(ariaDescribedBy).toBe(ariaDescribedById);
+
+    const radioOption = wrapper.find(`.radio-custom`);
+
+    // make sure we validate when using RadioGroup without custom slot data
+    // we do assign an ID that is important to get 'aria-activedescendant' working
+    expect(radioOption.attributes('id')).toBe(`${ wrapper.vm.radioOptionsIdPrefix }0`);
+  });
+
+  it('a11y: adding aria-label ($attrs) from parent should override label-based aria-label', async() => {
+    const inputLabel = 'some-label';
+    const overrideLabel = 'some-override-label';
+    const currValue = 'whatever';
+
+    const wrapper = mount(RadioGroup, {
+      propsData: {
+        name:    'some-name',
+        label:   inputLabel,
+        value:   currValue,
+        options: [{ label: currValue, value: currValue }]
+      },
+      attrs: { 'aria-label': overrideLabel }
+    });
+
+    const field = wrapper.find('[role="radiogroup"]');
+    const ariaLabel = field.attributes('aria-label');
+
+    expect(ariaLabel).toBe(overrideLabel);
+    expect(ariaLabel).not.toBe(inputLabel);
+  });
 });

--- a/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
@@ -108,9 +108,9 @@ export default defineComponent({
   emits: ['update:value'],
 
   data() {
-    return { 
-      currFocusedElem: undefined as undefined | EventTarget | null,
-      radioOptionsIdPrefix: `radio-option-${generateRandomAlphaString(12)}-`
+    return {
+      currFocusedElem:      undefined as undefined | EventTarget | null,
+      radioOptionsIdPrefix: `radio-option-${ generateRandomAlphaString(12) }-`
     };
   },
 
@@ -127,19 +127,19 @@ export default defineComponent({
         if (typeof opt === 'object' && opt) {
           out.push({
             ...opt,
-            radioOptionId: `${this.radioOptionsIdPrefix}${i}`
+            radioOptionId: `${ this.radioOptionsIdPrefix }${ i }`
           });
         } else if (this.labels) {
           out.push({
-            label: this.labels[i],
-            value: opt,
-            radioOptionId: `${this.radioOptionsIdPrefix}${i}`
+            label:         this.labels[i],
+            value:         opt,
+            radioOptionId: `${ this.radioOptionsIdPrefix }${ i }`
           });
         } else {
           out.push({
-            label: opt,
-            value: opt,
-            radioOptionId: `${this.radioOptionsIdPrefix}${i}`
+            label:         opt,
+            value:         opt,
+            radioOptionId: `${ this.radioOptionsIdPrefix }${ i }`
           });
         }
       }
@@ -164,16 +164,29 @@ export default defineComponent({
      * Radio Group Aria Label based on the label present on this input
      */
     radioGroupAriaLabel(): string | undefined {
+      // seems like VoiceOver screen reader isn't really picking up aria-labelledby
+      // let's just gather the label that comes in and assign it.
+      // We allow override with $attrs['aria-label'] for more control
+      if (this.$attrs['aria-label']) {
+        return this.$attrs['aria-label'] as string || undefined;
+      }
+
       return this.labelKey ? this.t(this.labelKey) : this.label ? this.label : undefined;
+    },
+    /**
+     * Radio Group Aria DescribedBy parent attribute for extendability
+     */
+    radioGroupAriaDescribedBy(): string | undefined {
+      return this.$attrs['aria-describedby'] as string || undefined;
     },
     /**
      * Radio Group value for aria-activedescendant HTML prop
      */
     ariaActiveDescendant(): string | undefined {
-      const activeOpt = this.normalizedOptions.find(opt => opt.value === this.value);
+      const activeOpt = this.normalizedOptions.find((opt) => opt.value === this.value);
 
       if (this.value && activeOpt) {
-        return activeOpt.radioOptionId
+        return activeOpt.radioOptionId;
       }
 
       return '';
@@ -224,35 +237,33 @@ export default defineComponent({
 </script>
 
 <template>
-  <fieldset>
+  <div>
     <!-- Label -->
     <div
       v-if="label || labelKey || tooltip || tooltipKey || $slots.label"
       class="radio-group label"
     >
-      <legend>
-        <slot name="label">
-          <h3>
-            <t
-              v-if="labelKey"
-              :k="labelKey"
-            />
-            <template v-else-if="label">
-              {{ label }}
-            </template>
-            <i
-              v-if="tooltipKey"
-              v-clean-tooltip="t(tooltipKey)"
-              class="icon icon-info icon-lg"
-            />
-            <i
-              v-else-if="tooltip"
-              v-clean-tooltip="tooltip"
-              class="icon icon-info icon-lg"
-            />
-          </h3>
-        </slot>
-      </legend>
+      <slot name="label">
+        <h3>
+          <t
+            v-if="labelKey"
+            :k="labelKey"
+          />
+          <template v-else-if="label">
+            {{ label }}
+          </template>
+          <i
+            v-if="tooltipKey"
+            v-clean-tooltip="t(tooltipKey)"
+            class="icon icon-info icon-lg"
+          />
+          <i
+            v-else-if="tooltip"
+            v-clean-tooltip="tooltip"
+            class="icon icon-info icon-lg"
+          />
+        </h3>
+      </slot>
     </div>
 
     <!-- Group -->
@@ -260,7 +271,7 @@ export default defineComponent({
       ref="radioGroup"
       role="radiogroup"
       :aria-label="radioGroupAriaLabel"
-      :aria-describedby="$attrs['aria-describedby'] || undefined"
+      :aria-describedby="radioGroupAriaDescribedBy"
       :aria-activedescendant="ariaActiveDescendant"
       class="radio-group"
       :class="{'row':row}"
@@ -296,7 +307,7 @@ export default defineComponent({
         </slot>
       </div>
     </div>
-  </fieldset>
+  </div>
 </template>
 
 <style lang='scss'>

--- a/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
@@ -2,11 +2,13 @@
 import { PropType, defineComponent } from 'vue';
 import { _VIEW } from '@shell/config/query-params';
 import RadioButton from '@components/Form/Radio/RadioButton.vue';
+import { generateRandomAlphaString } from '@shell/utils/string';
 
 interface Option {
   value: unknown,
   label: string,
   description?: string,
+  radioOptionId?: string,
 }
 
 export default defineComponent({
@@ -106,7 +108,10 @@ export default defineComponent({
   emits: ['update:value'],
 
   data() {
-    return { currFocusedElem: undefined as undefined | EventTarget | null };
+    return { 
+      currFocusedElem: undefined as undefined | EventTarget | null,
+      radioOptionsIdPrefix: `radio-option-${generateRandomAlphaString(12)}-`
+    };
   },
 
   computed: {
@@ -120,16 +125,21 @@ export default defineComponent({
         const opt = this.options[i];
 
         if (typeof opt === 'object' && opt) {
-          out.push(opt);
+          out.push({
+            ...opt,
+            radioOptionId: `${this.radioOptionsIdPrefix}${i}`
+          });
         } else if (this.labels) {
           out.push({
             label: this.labels[i],
-            value: opt
+            value: opt,
+            radioOptionId: `${this.radioOptionsIdPrefix}${i}`
           });
         } else {
           out.push({
             label: opt,
-            value: opt
+            value: opt,
+            radioOptionId: `${this.radioOptionsIdPrefix}${i}`
           });
         }
       }
@@ -150,8 +160,23 @@ export default defineComponent({
     isDisabled(): boolean {
       return (this.disabled || this.isView);
     },
-    radioGroupLabel(): string {
-      return this.labelKey ? this.t(this.labelKey) : this.label ? this.label : '';
+    /**
+     * Radio Group Aria Label based on the label present on this input
+     */
+    radioGroupAriaLabel(): string | undefined {
+      return this.labelKey ? this.t(this.labelKey) : this.label ? this.label : undefined;
+    },
+    /**
+     * Radio Group value for aria-activedescendant HTML prop
+     */
+    ariaActiveDescendant(): string | undefined {
+      const activeOpt = this.normalizedOptions.find(opt => opt.value === this.value);
+
+      if (this.value && activeOpt) {
+        return activeOpt.radioOptionId
+      }
+
+      return '';
     }
   },
 
@@ -234,7 +259,9 @@ export default defineComponent({
     <div
       ref="radioGroup"
       role="radiogroup"
-      :aria-label="radioGroupLabel"
+      :aria-label="radioGroupAriaLabel"
+      :aria-describedby="$attrs['aria-describedby'] || undefined"
+      :aria-activedescendant="ariaActiveDescendant"
       class="radio-group"
       :class="{'row':row}"
       tabindex="0"
@@ -257,6 +284,7 @@ export default defineComponent({
             :name="name"
             :value="value"
             :label="option.label"
+            :radio-option-id="option.radioOptionId"
             :description="option.description"
             :val="option.value"
             :disabled="isDisabled"

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7818,9 +7818,9 @@ performance:
 banner:
   label: Fixed Banners
   settingName: Banners
-  headerBanner: Header Banner
-  footerBanner: Footer Banner
-  loginScreenBanner: Login Screen Banner
+  bannerHeader: Header Banner
+  bannerFooter: Footer Banner
+  bannerConsent: Login Screen Banner
   text: Text
   buttonText: Accept Button Text
   textColor: Text Color

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -7131,9 +7131,9 @@ performance:
 banner:
   label: 固定横幅
   settingName: 横幅
-  headerBanner: 标题横幅
-  footerBanner: 页脚横幅
-  loginScreenBanner: 登录屏幕横幅
+  bannerHeader: 标题横幅
+  bannerFooter: 页脚横幅
+  bannerConsent: 登录屏幕横幅
   text: 文本
   buttonText: 同意按钮文本
   textColor: 文本颜色

--- a/shell/components/LandingPagePreference.vue
+++ b/shell/components/LandingPagePreference.vue
@@ -108,6 +108,7 @@ export default {
       :value="afterLoginRoute"
       name="login-route"
       :options="routeRadioOptions"
+      :aria-label="`${t('prefs.landing.label')} - ${ t('landing.landingPrefs.body')}`"
       @update:value="updateLoginRoute"
     >
       <template #label>
@@ -119,6 +120,7 @@ export default {
         <div class="custom-page">
           <RadioButton
             :label="option.label"
+            :radio-option-id="option.radioOptionId"
             :val="false"
             :value="afterLoginRoute=== 'home' || afterLoginRoute === 'last-visited'"
             :v-bind="$attrs"

--- a/shell/components/form/BannerSettings.vue
+++ b/shell/components/form/BannerSettings.vue
@@ -42,7 +42,8 @@ export default ({
       themeVars:               {
         bannerBgColor:   getComputedStyle(document.body).getPropertyValue('--default'),
         bannerTextColor: getComputedStyle(document.body).getPropertyValue('--banner-text-color')
-      }
+      },
+      bannerTitleId: `describe-banners-${this.bannerType}-id`
     };
   },
 
@@ -107,12 +108,19 @@ export default ({
   <div class="row mb-20">
     <div class="col span-12">
       <div class="row">
+        <p
+          :id="bannerTitleId"
+          class="sr-only"
+        >
+          {{ t(`banner.${bannerType}`) }}
+        </p>
         <div class="col span-6">
           <LabeledInput
             v-model:value="value[bannerType].text"
             :disabled="isUiDisabled"
             :label="t('banner.text')"
             type="multiline"
+            :aria-describedby="bannerTitleId"
           />
           <p
             v-if="isConsentBanner"
@@ -131,11 +139,13 @@ export default ({
               :mode="mode"
               :label="t('banner.showAsDialog.label')"
               :tooltip="t('banner.showAsDialog.tooltip')"
+              :aria-describedby="bannerTitleId"
             />
             <LabeledInput
               v-model:value="buttonText"
               :disabled="!showAsDialog || isUiDisabled"
               :label="t('banner.buttonText')"
+              :aria-describedby="bannerTitleId"
             />
           </div>
         </div>
@@ -148,10 +158,11 @@ export default ({
             :options="radioOptions.options"
             :labels="radioOptions.labels"
             :mode="mode"
+            :aria-describedby="bannerTitleId"
           />
         </div>
         <div class="col span-2">
-          <h3>
+          <h3 id="decoration-banner-title-id">
             {{ t('banner.bannerDecoration.label') }}
           </h3>
           <div
@@ -165,6 +176,7 @@ export default ({
               class="banner-decoration-checkbox"
               :mode="mode"
               :label="o.label"
+              :aria-describedby="`${bannerTitleId} decoration-banner-title-id`"
             />
           </div>
         </div>
@@ -175,6 +187,7 @@ export default ({
             :disabled="isUiDisabled"
             :label="t('banner.bannerFontSize.label')"
             :options="uiBannerFontSizeOptions"
+            :aria-describedby="bannerTitleId"
           />
         </div>
       </div>
@@ -185,6 +198,7 @@ export default ({
             :default-value="themeVars.bannerTextColor"
             :label="t('banner.textColor')"
             :mode="mode"
+            :aria-describedby="bannerTitleId"
           />
         </div>
         <div class="col span-6">
@@ -193,6 +207,7 @@ export default ({
             :default-value="themeVars.bannerBgColor"
             :label="t('banner.background')"
             :mode="mode"
+            :aria-describedby="bannerTitleId"
           />
         </div>
       </div>

--- a/shell/components/form/BannerSettings.vue
+++ b/shell/components/form/BannerSettings.vue
@@ -43,7 +43,7 @@ export default ({
         bannerBgColor:   getComputedStyle(document.body).getPropertyValue('--default'),
         bannerTextColor: getComputedStyle(document.body).getPropertyValue('--banner-text-color')
       },
-      bannerTitleId: `describe-banners-${this.bannerType}-id`
+      bannerTitleId: `describe-banners-${ this.bannerType }-id`
     };
   },
 
@@ -158,7 +158,7 @@ export default ({
             :options="radioOptions.options"
             :labels="radioOptions.labels"
             :mode="mode"
-            :aria-describedby="bannerTitleId"
+            :aria-label="`${t(`banner.${bannerType}`)} ${t('banner.bannerAlignment.label')}`"
           />
         </div>
         <div class="col span-2">
@@ -198,7 +198,7 @@ export default ({
             :default-value="themeVars.bannerTextColor"
             :label="t('banner.textColor')"
             :mode="mode"
-            :aria-describedby="bannerTitleId"
+            :aria-label="`${t(`banner.${bannerType}`)} ${t('banner.textColor')}`"
           />
         </div>
         <div class="col span-6">
@@ -207,7 +207,7 @@ export default ({
             :default-value="themeVars.bannerBgColor"
             :label="t('banner.background')"
             :mode="mode"
-            :aria-describedby="bannerTitleId"
+            :aria-label="`${t(`banner.${bannerType}`)} ${t('banner.background')}`"
           />
         </div>
       </div>

--- a/shell/components/form/ColorInput.vue
+++ b/shell/components/form/ColorInput.vue
@@ -1,5 +1,6 @@
 <script>
 import { _EDIT, _VIEW } from '@shell/config/query-params';
+import { generateRandomAlphaString } from '@shell/utils/string';
 
 export default {
   emits: ['update:value'],
@@ -67,6 +68,20 @@ export default {
       const disabled = this.disabled;
 
       return this.mode !== this.editMode || disabled;
+    },
+
+    ariaLabel() {
+      if (this.labelKey) {
+        return this.t(this.labelKey);
+      } else if (this.label) {
+        return this.label;
+      }
+
+      return this.$attrs['aria-label'] || this.t('generic.colorPicker');
+    },
+
+    ariaDescribedBy() {
+      return this.$attrs['aria-describedby'] || undefined;
     }
   },
 
@@ -99,12 +114,18 @@ export default {
     :tabindex="isDisabled ? -1 : 0"
     @keydown.space.prevent
     @keyup.enter.space.stop="handleKeyup($event)"
+    role="presentation"
   >
-    <label class="text-label"><t
-      v-if="labelKey"
-      :k="labelKey"
-      :raw="true"
-    />{{ label }}</label>
+    <label 
+      v-if="labelKey || label"
+      class="text-label">
+      <t
+        v-if="labelKey"
+        :k="labelKey"
+        :raw="true"
+      />
+      <template v-else-if="label">{{ label }}</template>
+    </label>
     <div
       :data-testid="componentTestid + '-color-input_preview-container'"
       class="preview-container"
@@ -117,7 +138,8 @@ export default {
         <input
           ref="input"
           :aria-disabled="isDisabled ? 'true' : 'false'"
-          :aria-label="t('generic.colorPicker')"
+          :aria-label="ariaLabel"
+          :aria-describedby="ariaDescribedBy"
           type="color"
           :disabled="isDisabled"
           tabindex="-1"

--- a/shell/components/form/ColorInput.vue
+++ b/shell/components/form/ColorInput.vue
@@ -1,9 +1,10 @@
 <script>
 import { _EDIT, _VIEW } from '@shell/config/query-params';
-import { generateRandomAlphaString } from '@shell/utils/string';
 
 export default {
   emits: ['update:value'],
+
+  inheritAttrs: false,
 
   props: {
     value: {
@@ -71,13 +72,16 @@ export default {
     },
 
     ariaLabel() {
-      if (this.labelKey) {
+      // We allow override with $attrs['aria-label'] for more control
+      if (this.$attrs['aria-label']) {
+        return this.$attrs['aria-label'];
+      } else if (this.labelKey) {
         return this.t(this.labelKey);
       } else if (this.label) {
         return this.label;
+      } else {
+        return this.t('generic.colorPicker');
       }
-
-      return this.$attrs['aria-label'] || this.t('generic.colorPicker');
     },
 
     ariaDescribedBy() {
@@ -114,11 +118,14 @@ export default {
     :tabindex="isDisabled ? -1 : 0"
     @keydown.space.prevent
     @keyup.enter.space.stop="handleKeyup($event)"
-    role="presentation"
   >
-    <label 
+    <!-- let make "label" not to be picked up by screen readers -->
+    <!-- because it's already included in aria-label (sr's announced it twice) -->
+    <label
       v-if="labelKey || label"
-      class="text-label">
+      class="text-label"
+      aria-hidden="true"
+    >
       <t
         v-if="labelKey"
         :k="labelKey"

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -116,9 +116,11 @@ export default {
 
   data() {
     return {
-      selectedVisibility: 'visible',
-      shouldOpen:         true,
-      uid:                generateRandomAlphaString(10)
+      selectedVisibility:   'visible',
+      shouldOpen:           true,
+      labeledSelectLabelId: `ls-label-id-${ generateRandomAlphaString(12) }`,
+      isOpen:               false,
+      generatedUid: `ls-uid-${ generateRandomAlphaString(12) }`
     };
   },
 
@@ -197,11 +199,13 @@ export default {
     },
 
     onOpen() {
+      this.isOpen = true;
       this.$emit('on-open');
       this.resizeHandler();
     },
 
     onClose() {
+      this.isOpen = false;
       this.$emit('on-close');
     },
 
@@ -279,6 +283,7 @@ export default {
 
 <template>
   <div
+    :id="hasLabel ? labeledSelectLabelId : undefined"
     ref="select"
     class="labeled-select"
     :class="[
@@ -296,7 +301,9 @@ export default {
       }
     ]"
     :tabindex="isView || disabled ? -1 : 0"
-    role="listbox"
+    role="combobox"
+    :aria-expanded="isOpen"
+    :aria-describedby="this.$attrs['aria-describedby'] || undefined"
     @click="focusSearch"
     @keydown.enter="focusSearch"
     @keydown.down.prevent="focusSearch"
@@ -308,7 +315,7 @@ export default {
     >
       <label
         v-if="hasLabel"
-        :id="`labeled-select-uid-${uid}`"
+        :for="labeledSelectLabelId"
       >
         <t
           v-if="labelKey"
@@ -324,7 +331,6 @@ export default {
     </div>
     <v-select
       ref="select-input"
-      :aria-labelledby="hasLabel ? `labeled-select-uid-${uid}` : ''"
       v-bind="filteredAttrs"
       class="inline"
       :append-to-body="appendToBody"
@@ -345,7 +351,8 @@ export default {
       :modelValue="value != null && !loading ? value : ''"
       :dropdown-should-open="dropdownShouldOpen"
       :tabindex="-1"
-      role="listitem"
+      :uid="generatedUid"
+      :aria-label="'-'"
       @update:modelValue="$emit('selecting', $event); $emit('update:value', $event)"
       @search:blur="onBlur"
       @search:focus="onFocus"

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -120,7 +120,7 @@ export default {
       shouldOpen:           true,
       labeledSelectLabelId: `ls-label-id-${ generateRandomAlphaString(12) }`,
       isOpen:               false,
-      generatedUid: `ls-uid-${ generateRandomAlphaString(12) }`
+      generatedUid:         `ls-uid-${ generateRandomAlphaString(12) }`
     };
   },
 
@@ -303,7 +303,7 @@ export default {
     :tabindex="isView || disabled ? -1 : 0"
     role="combobox"
     :aria-expanded="isOpen"
-    :aria-describedby="this.$attrs['aria-describedby'] || undefined"
+    :aria-describedby="$attrs['aria-describedby'] || undefined"
     @click="focusSearch"
     @keydown.enter="focusSearch"
     @keydown.down.prevent="focusSearch"

--- a/shell/components/form/NotificationSettings.vue
+++ b/shell/components/form/NotificationSettings.vue
@@ -24,7 +24,7 @@ export default ({
     },
 
     hiddenAriaDescribedLabel: {
-      type: String,
+      type:    String,
       default: ''
     },
   },
@@ -47,8 +47,8 @@ export default ({
           :mode="mode"
           :value="value.showMessage === 'true'"
           :label="t('notifications.loginError.showCheckboxLabel')"
-          @update:value="value.showMessage = $event.toString()"
           aria-describedby="hidden-label-notification-settings"
+          @update:value="value.showMessage = $event.toString()"
         />
       </div>
     </div>

--- a/shell/components/form/NotificationSettings.vue
+++ b/shell/components/form/NotificationSettings.vue
@@ -21,7 +21,12 @@ export default ({
         return [_EDIT, _VIEW].includes(value);
       },
       default: _EDIT,
-    }
+    },
+
+    hiddenAriaDescribedLabel: {
+      type: String,
+      default: ''
+    },
   },
 
 });
@@ -29,6 +34,13 @@ export default ({
 
 <template>
   <div>
+    <p
+      v-if="hiddenAriaDescribedLabel"
+      id="hidden-label-notification-settings"
+      class="sr-only"
+    >
+      {{ hiddenAriaDescribedLabel }}
+    </p>
     <div class="row mb-20">
       <div class="col span-6">
         <Checkbox
@@ -36,6 +48,7 @@ export default ({
           :value="value.showMessage === 'true'"
           :label="t('notifications.loginError.showCheckboxLabel')"
           @update:value="value.showMessage = $event.toString()"
+          aria-describedby="hidden-label-notification-settings"
         />
       </div>
     </div>
@@ -48,6 +61,7 @@ export default ({
               :mode="mode"
               :disabled="value.showMessage === 'false'"
               :label="t('notifications.loginError.messageLabel')"
+              aria-describedby="hidden-label-notification-settings"
             />
           </div>
         </div>

--- a/shell/components/form/__tests__/ColorInput.test.ts
+++ b/shell/components/form/__tests__/ColorInput.test.ts
@@ -31,9 +31,7 @@ describe('colorInput.vue', () => {
 
     const wrapper = shallowMount(ColorInput, {
       props: { label },
-      attrs: {
-        'aria-describedby': describeById
-      }
+      attrs: { 'aria-describedby': describeById }
     });
 
     const colorInput = wrapper.find('input');
@@ -41,24 +39,24 @@ describe('colorInput.vue', () => {
     const ariaLabel = colorInput.attributes('aria-label');
     const ariaDescribedBy = colorInput.attributes('aria-describedby');
 
-    expect(ariaDisabled).toBe('false')
-    expect(ariaLabel).toBe(label)
-    expect(ariaDescribedBy).toBe(describeById)
+    expect(ariaDisabled).toBe('false');
+    expect(ariaLabel).toBe(label);
+    expect(ariaDescribedBy).toBe(describeById);
   });
 
-  it('a11y: if no "label" is defined and we define "aria-label" on parent, it should use that "aria-label"', () => {
-    const ariaLabelText = 'some-label';
+  it('a11y: adding aria-label ($attrs) from parent should override label-based aria-label', () => {
+    const inputLabel = 'some-label';
+    const overrideLabel = 'some-override-label';
 
     const wrapper = shallowMount(ColorInput, {
-      props: {},
-      attrs: {
-        'aria-label': ariaLabelText
-      }
+      props: { label: inputLabel },
+      attrs: { 'aria-label': overrideLabel }
     });
 
     const colorInput = wrapper.find('input');
     const ariaLabel = colorInput.attributes('aria-label');
 
-    expect(ariaLabel).toBe(ariaLabelText)
+    expect(ariaLabel).toBe(overrideLabel);
+    expect(ariaLabel).not.toBe(inputLabel);
   });
 });

--- a/shell/components/form/__tests__/ColorInput.test.ts
+++ b/shell/components/form/__tests__/ColorInput.test.ts
@@ -24,4 +24,41 @@ describe('colorInput.vue', () => {
     expect(colorWrapper.classes()).not.toContain('disabled');
     expect(Object.keys(colorInput.attributes())).not.toContain('disabled');
   });
+
+  it('a11y: adding ARIA props should correctly fill out the appropriate fields on the component', () => {
+    const label = 'some-label';
+    const describeById = 'some-id';
+
+    const wrapper = shallowMount(ColorInput, {
+      props: { label },
+      attrs: {
+        'aria-describedby': describeById
+      }
+    });
+
+    const colorInput = wrapper.find('input');
+    const ariaDisabled = colorInput.attributes('aria-disabled');
+    const ariaLabel = colorInput.attributes('aria-label');
+    const ariaDescribedBy = colorInput.attributes('aria-describedby');
+
+    expect(ariaDisabled).toBe('false')
+    expect(ariaLabel).toBe(label)
+    expect(ariaDescribedBy).toBe(describeById)
+  });
+
+  it('a11y: if no "label" is defined and we define "aria-label" on parent, it should use that "aria-label"', () => {
+    const ariaLabelText = 'some-label';
+
+    const wrapper = shallowMount(ColorInput, {
+      props: {},
+      attrs: {
+        'aria-label': ariaLabelText
+      }
+    });
+
+    const colorInput = wrapper.find('input');
+    const ariaLabel = colorInput.attributes('aria-label');
+
+    expect(ariaLabel).toBe(ariaLabelText)
+  });
 });

--- a/shell/components/form/__tests__/LabeledSelect.test.ts
+++ b/shell/components/form/__tests__/LabeledSelect.test.ts
@@ -215,7 +215,7 @@ describe('component: LabeledSelect', () => {
     });
   });
 
-  it('a11y: adding ARIA props should correctly fill out the appropriate fields on the component', async () => {
+  it('a11y: adding ARIA props should correctly fill out the appropriate fields on the component', async() => {
     const label = 'Foo';
     const value = 'foo';
     const ariaDescribedById = 'some-described-by-id';
@@ -224,14 +224,12 @@ describe('component: LabeledSelect', () => {
     const wrapper = mount(LabeledSelect, {
       props: {
         value,
-        label: itemLabel,
+        label:   itemLabel,
         options: [
           { label, value },
         ],
       },
-      attrs: {
-        ['aria-describedby']: ariaDescribedById
-      }
+      attrs: { 'aria-describedby': ariaDescribedById }
     });
 
     const labeledSelectContainer = wrapper.find('.labeled-select');
@@ -242,8 +240,6 @@ describe('component: LabeledSelect', () => {
 
     const vSelectInput = wrapper.find('.v-select');
 
-    
-
     expect(ariaExpanded).toBe('false');
     expect(ariaDescribedBy).toBe(ariaDescribedById);
     expect(containerId).toBe(wrapper.vm.labeledSelectLabelId);
@@ -251,7 +247,7 @@ describe('component: LabeledSelect', () => {
 
     // make sure it's hardcoded to a "neutral" value so that
     // in the current architecture of the component
-    // screen readers won't pick up the default "Select option" aria-label 
+    // screen readers won't pick up the default "Select option" aria-label
     // from the library
     expect(vSelectInput.attributes('aria-label')).toBe('-');
   });

--- a/shell/components/form/__tests__/LabeledSelect.test.ts
+++ b/shell/components/form/__tests__/LabeledSelect.test.ts
@@ -214,4 +214,45 @@ describe('component: LabeledSelect', () => {
       expect(wrapper.vm.$data.myValue).toStrictEqual(expectation);
     });
   });
+
+  it('a11y: adding ARIA props should correctly fill out the appropriate fields on the component', async () => {
+    const label = 'Foo';
+    const value = 'foo';
+    const ariaDescribedById = 'some-described-by-id';
+    const itemLabel = 'some-label';
+
+    const wrapper = mount(LabeledSelect, {
+      props: {
+        value,
+        label: itemLabel,
+        options: [
+          { label, value },
+        ],
+      },
+      attrs: {
+        ['aria-describedby']: ariaDescribedById
+      }
+    });
+
+    const labeledSelectContainer = wrapper.find('.labeled-select');
+    const ariaExpanded = labeledSelectContainer.attributes('aria-expanded');
+    const ariaDescribedBy = labeledSelectContainer.attributes('aria-describedby');
+    const containerId = labeledSelectContainer.attributes('id');
+    const labelFor = wrapper.find('label').attributes('for');
+
+    const vSelectInput = wrapper.find('.v-select');
+
+    
+
+    expect(ariaExpanded).toBe('false');
+    expect(ariaDescribedBy).toBe(ariaDescribedById);
+    expect(containerId).toBe(wrapper.vm.labeledSelectLabelId);
+    expect(labelFor).toBe(wrapper.vm.labeledSelectLabelId);
+
+    // make sure it's hardcoded to a "neutral" value so that
+    // in the current architecture of the component
+    // screen readers won't pick up the default "Select option" aria-label 
+    // from the library
+    expect(vSelectInput.attributes('aria-label')).toBe('-');
+  });
 });

--- a/shell/pages/c/_cluster/settings/banners.vue
+++ b/shell/pages/c/_cluster/settings/banners.vue
@@ -207,7 +207,7 @@ export default {
 
       <!-- Header Settings -->
       <h2 class="mt-40 mb-10 setting-title">
-        {{ t('banner.headerBanner') }}
+        {{ t('banner.bannerHeader') }}
         <i
           v-if="!!uiBannerIndividual.bannerHeader"
           class="icon icon-lock"
@@ -242,7 +242,7 @@ export default {
 
       <!-- Footer settings -->
       <h2 class="mt-40 mb-10 setting-title">
-        {{ t('banner.footerBanner') }}
+        {{ t('banner.bannerFooter') }}
         <i
           v-if="!!uiBannerIndividual.bannerFooter"
           class="icon icon-lock"
@@ -277,7 +277,7 @@ export default {
 
       <!-- Consent settings -->
       <h2 class="mt-40 mb-10 setting-title">
-        {{ t('banner.loginScreenBanner') }}
+        {{ t('banner.bannerConsent') }}
         <i
           v-if="!!uiBannerIndividual.bannerConsent"
           class="icon icon-lock"
@@ -316,6 +316,7 @@ export default {
         v-model:value="bannerVal.loginError"
         :mode="mode"
         :label="t('notifications.loginError.messageLabel')"
+        :hidden-aria-described-label="t('notifications.loginError.header')"
       />
     </div>
     <template


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14092 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Fixes the settings area for `banners` in order to improve context of screen reader output for the UI elements involved
- Adds unit tests related to `a11y`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- Some of these fixes might differ in their pattern because, imo, our HTML markup is bloating some of our components, making it much more difficult to get the same screen readers outputs as one would get by browsing https://www.w3.org/WAI/ARIA/apg/patterns/ various examples with the screen reader

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
