### PR TITLE
Replace the done param fix and changed how we render the credential dynamic components

### DIFF
--- a/shell/edit/cloudcredential.vue
+++ b/shell/edit/cloudcredential.vue
@@ -100,6 +100,30 @@ export default {
   computed: {
     rke2Enabled: mapFeature(RKE2_FEATURE),
 
+    hasCustomCloudCredentialComponent() {
+      const driverName = this.driverName;
+
+      return this.$store.getters['type-map/hasCustomCloudCredentialComponent'](driverName);
+    },
+
+    cloudCredentialComponent() {
+      const driverName = this.driverName;
+
+      return this.$store.getters['type-map/importCloudCredential'](driverName);
+    },
+
+    genericCloudCredentialComponent() {
+      return this.$store.getters['type-map/importCloudCredential']('generic');
+    },
+
+    cloudComponent() {
+      if (this.hasCustomCloudCredentialComponent) {
+        return this.cloudCredentialComponent;
+      }
+
+      return this.genericCloudCredentialComponent;
+    },
+
     validationPassed() {
       return this.credCustomComponentValidation && this.nameRequiredValidation;
     },
@@ -110,14 +134,6 @@ export default {
 
     driverName() {
       return this.value?.provider;
-    },
-
-    cloudComponent() {
-      if (this.$store.getters['type-map/hasCustomCloudCredentialComponent'](this.driverName)) {
-        return this.$store.getters['type-map/importCloudCredential'](this.driverName);
-      }
-
-      return this.$store.getters['type-map/importCloudCredential']('generic');
     },
 
     // array of id, label, description, initials for type selection step
@@ -194,7 +210,6 @@ export default {
   },
 
   methods: {
-
     createValidationChanged(passed) {
       this.credCustomComponentValidation = passed;
     },
@@ -276,7 +291,6 @@ export default {
     <Loading v-if="$fetchState.pending" />
     <CruResource
       v-else
-      :done-params="$attrs['done-params'] /* Without this, changes to the validationPassed prop end up propagating all the way to the root of the app and force a re-render when the input becomes valid. I haven't found a reasonable explanation for why this happens. */"
       :mode="mode"
       :validation-passed="validationPassed"
       :selected-subtype="value._type"

--- a/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -81,6 +81,30 @@ export default {
   },
 
   computed: {
+    hasCustomCloudCredentialComponent() {
+      const driverName = this.driverName;
+
+      return this.$store.getters['type-map/hasCustomCloudCredentialComponent'](driverName);
+    },
+
+    cloudCredentialComponent() {
+      const driverName = this.driverName;
+
+      return this.$store.getters['type-map/importCloudCredential'](driverName);
+    },
+
+    genericCloudCredentialComponent() {
+      return this.$store.getters['type-map/importCloudCredential']('generic');
+    },
+
+    cloudComponent() {
+      if (this.hasCustomCloudCredentialComponent) {
+        return this.cloudCredentialComponent;
+      }
+
+      return this.genericCloudCredentialComponent;
+    },
+
     isNone() {
       return this.credentialId === null || this.credentialId === _NONE;
     },
@@ -140,14 +164,6 @@ export default {
       return out;
     },
 
-    createComponent() {
-      if (this.$store.getters['type-map/hasCustomCloudCredentialComponent'](this.driverName)) {
-        return this.$store.getters['type-map/importCloudCredential'](this.driverName);
-      }
-
-      return this.$store.getters['type-map/importCloudCredential']('generic');
-    },
-
     validationPassed() {
       if ( this.credentialId === _NONE ) {
         return false;
@@ -175,6 +191,7 @@ export default {
   },
 
   methods: {
+
     async save(btnCb) {
       if ( this.errors ) {
         clear(this.errors);
@@ -236,7 +253,6 @@ export default {
   <Loading v-if="$fetchState.pending" />
   <CruResource
     v-else
-    :done-params="$attrs['done-params'] /* Without this, changes to the validationPassed prop end up propagating all the way to the root of the app and force a re-render when the input becomes valid. I haven't found a reasonable explanation for why this happens. */"
     :mode="mode"
     :validation-passed="validationPassed"
     :resource="newCredential"
@@ -267,7 +283,7 @@ export default {
       />
 
       <component
-        :is="createComponent"
+        :is="cloudComponent"
         ref="create"
         v-model:value="newCredential"
         mode="create"


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Fixes #13802

### Occurred changes and/or fixed issues
I reverted the `done-param` changes, I still have no idea why those functioned. 

I was able to trace what was causing the re-renders further and it seems to be caused by re-computing the component that we wanted to render even if that component didn't change. We now manually compute these values which prevents the re-render from occurring when the form input becomes valid.

### Areas or cases that should be tested
Cloud credentials create pages, hosted providers create credentials  section, node provisioned cluster create credentials section.

### Areas which could experience regressions
Anywhere with creating/selecting credentials.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
