### PR TITLE
Fix issue where ToggleSwitch didn't apply focus styles

### DIFF
--- a/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
+++ b/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts
@@ -91,4 +91,21 @@ describe('toggleSwitch.vue', () => {
     expect(wrapper.emitted('update:value')).toHaveLength(1);
     expect(wrapper.emitted('update:value')[0][0]).toBe(offValue);
   });
+
+  it('adds focus class when input is focused', async() => {
+    const wrapper = shallowMount(ToggleSwitch);
+
+    await wrapper.find('input').trigger('focus');
+
+    expect(wrapper.find('.slider').classes()).toContain('focus');
+  });
+
+  it('removes focus class when input is blurred', async() => {
+    const wrapper = shallowMount(ToggleSwitch);
+
+    await wrapper.find('input').trigger('focus');
+    await wrapper.find('input').trigger('blur');
+
+    expect(wrapper.find('.slider').classes()).not.toContain('focus');
+  });
 });

--- a/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.vue
+++ b/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.vue
@@ -54,6 +54,11 @@ export default defineComponent({
       switchInput.value?.removeEventListener('focus', focus);
       switchInput.value?.removeEventListener('blur', blur);
     });
+
+    return {
+      switchChrome,
+      switchInput,
+    };
   },
 
   data() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
#13880 introduced a regression that caused the ToggleSwitch to no longer apply focus styles. The update from `useTemplateRef` to `ref`[^1] required that the ref be returned from `setup()`:

[^1]: https://vuejs.org/guide/essentials/template-refs

> If not using <script setup>, make sure to also return the ref from setup():

Adding return statements for the refs resolves this error. A similar change was made to `shell/components/SortableTable/index.vue` in the aforementioned PR, but the same change was not applied to ToggleSwitch.

Fixes #13566 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add a return statement for refs in ToggleSwitch.vue
- Add unit tests to assert that focus styles are applied when ToggleSwitch receives focus

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- The update from `useTemplateRef` to `ref`[^1] required that the ref be returned from `setup()`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- ToggleSwitch focus
   - Provisioning a new Cluster
   - User Retention 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

NA

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

![image](https://github.com/user-attachments/assets/b48e0a11-7f76-41c5-9437-dd6e5013ddb8)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
