### PR TITLE
Removing some some extra `toRef` usages that seemed to be causing some issues for our deployment EnvVars component.

### DIFF
--- a/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
@@ -195,6 +195,22 @@ export class WorkloadsCreatePageBasePo extends PagePo {
     return new AsyncButtonPo('[data-testid="form-save"]', this.self());
   }
 
+  addEnvironmentVariable() {
+    cy.get('[data-testid="add-env-var"]').click();
+  }
+
+  removeEnvironmentVariable(index: number) {
+    cy.get(`[data-testid="env-var-row-${ index }"] .remove button`).click();
+  }
+
+  environmentVariableKeyInput(index: number) {
+    return LabeledInputPo.bySelector(this.self(), `[data-testid="env-var-row-${ index }"] .name`);
+  }
+
+  environmentVariableValueInput(index: number) {
+    return LabeledInputPo.bySelector(this.self(), `[data-testid="env-var-row-${ index }"] .single-value`);
+  }
+
   /**
    *
    * @returns po for the top level tabs in workloads ie general workload, pod, and one more per container

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -157,6 +157,35 @@ describe('Cluster Explorer', () => {
         });
       });
 
+      it('should be able to add and remove EnvVars', () => {
+        // The viewport needs to be a little larger for cypress to consider the key value input components to be visible
+        cy.viewport(1440, 900);
+
+        deploymentsCreatePage.goTo();
+        deploymentsCreatePage.waitForPage();
+
+        deploymentsCreatePage.horizontalTabs().clickTabWithSelector('li#container-0');
+
+        deploymentsCreatePage.addEnvironmentVariable();
+        deploymentsCreatePage.addEnvironmentVariable();
+        deploymentsCreatePage.addEnvironmentVariable();
+
+        // // Ensure the default key and value are empty as expected
+        deploymentsCreatePage.environmentVariableKeyInput(0).value().should('eq', '');
+        deploymentsCreatePage.environmentVariableValueInput(0).value().should('eq', '');
+
+        deploymentsCreatePage.environmentVariableKeyInput(0).set('a');
+        deploymentsCreatePage.environmentVariableValueInput(0).set('a');
+        deploymentsCreatePage.environmentVariableKeyInput(1).set('b');
+        deploymentsCreatePage.environmentVariableValueInput(1).set('b');
+        deploymentsCreatePage.environmentVariableKeyInput(2).set('c');
+        deploymentsCreatePage.environmentVariableValueInput(2).set('c');
+
+        // Ensure when we remove the variable we remove the correct row
+        deploymentsCreatePage.removeEnvironmentVariable(1);
+        deploymentEditConfigPage.environmentVariableKeyInput(1).value().should('eq', 'c');
+      });
+
       it('should be able to select Pod CSI storage option', () => {
         deploymentsCreatePage.goTo();
         deploymentsCreatePage.waitForPage();

--- a/shell/components/form/EnvVars.vue
+++ b/shell/components/form/EnvVars.vue
@@ -115,6 +115,7 @@ export default {
     <div
       v-for="(row, i) in allEnv"
       :key="row.id"
+      :data-testid="`env-var-row-${i}`"
     >
       <ValueFromResource
         v-model:value="row.value"

--- a/shell/components/form/ValueFromResource.vue
+++ b/shell/components/form/ValueFromResource.vue
@@ -4,7 +4,7 @@ import { get } from '@shell/utils/object';
 import { _VIEW } from '@shell/config/query-params';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { LabeledInput } from '@components/Form/LabeledInput';
-import { ref, toRef, watch } from 'vue';
+import { ref, watch } from 'vue';
 
 export default {
   emits: ['update:value', 'remove'],
@@ -83,14 +83,14 @@ export default {
 
     switch (type.value) {
     case 'resourceFieldRef':
-      name.value = toRef(props.value.name);
-      refName.value = toRef(props.value.valueFrom[type.value].containerName);
+      name.value = props.value.name;
+      refName.value = props.value.valueFrom[type.value].containerName;
       key.value = props.value.valueFrom[type.value].resource || '';
       break;
     case 'configMapKeyRef':
-      name.value = toRef(props.value.name);
+      name.value = props.value.name;
       key.value = props.value.valueFrom[type.value].key || '';
-      refName.value = toRef(props.value.valueFrom[type.value].name);
+      refName.value = props.value.valueFrom[type.value].name;
       referenced.value = props.allConfigMaps.filter((resource) => {
         return resource.metadata.name === refName.value;
       })[0];
@@ -100,13 +100,13 @@ export default {
       break;
     case 'secretRef':
     case 'configMapRef':
-      name.value = toRef(props.value.prefix);
-      refName.value = toRef(props.value[type.value].name);
+      name.value = props.value.prefix;
+      refName.value = props.value[type.value].name;
       break;
     case 'secretKeyRef':
-      name.value = toRef(props.value.name);
+      name.value = props.value.name;
       key.value = props.value.valueFrom[type.value].key || '';
-      refName.value = toRef(props.value.valueFrom[type.value].name);
+      refName.value = props.value.valueFrom[type.value].name;
       referenced.value = props.allSecrets.filter((resource) => {
         return resource.metadata.name === refName.value;
       })[0];
@@ -116,11 +116,11 @@ export default {
       break;
     case 'fieldRef':
       fieldPath.value = get(props.value.valueFrom, `${ type.value }.fieldPath`) || '';
-      name.value = toRef(props.value.name);
+      name.value = props.value.name;
       break;
     default:
-      name.value = toRef(props.value.name);
-      valStr.value = toRef(props.value.value);
+      name.value = props.value.name;
+      valStr.value = props.value.value;
       break;
     }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Removing some some extra `toRef` usages that seemed to be causing some issues for our deployment EnvVars component.

Fixes #14068

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
I found this issue when looking at https://github.com/rancher/dashboard/issues/14071#event-17211287597. It would render objects in the EnvVars component by default.

 

https://github.com/user-attachments/assets/77665fc1-a8e8-4bbe-9833-32880476c200



### Areas or cases that should be tested
Deployment EnvVars component.

### Areas which could experience regressions
Anywhere there's EnvVars

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
