### PR TITLE
[backport 2.11.1] EnvVars Removal Fix

### DIFF
--- a/shell/components/form/EnvVars.vue
+++ b/shell/components/form/EnvVars.vue
@@ -107,7 +107,7 @@ export default {
   <div :style="{'width':'100%'}">
     <div
       v-for="(row, i) in allEnv"
-      :key="i"
+      :key="row.id"
     >
       <ValueFromResource
         v-model:value="row.value"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14096

<!-- Define findings related to the feature or bug issue. -->
From the UI, it visually removed { name: 'y', value: 'z' } (the last row) — not { name: 'c', value: 'd' } which data shows was removed.
Even though the method removed the correct item from the array, Vue uses the key value (:key="i") to track DOM elements, and seems here the issue arises...
![image](https://github.com/user-attachments/assets/a87a2ba3-9b7e-4492-b4de-c2749eb9a9cb)

### Areas or cases that should be tested
Deployment environment variables.

### Areas which could experience regressions
Anywhere EnvVars are used.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
