### PR TITLE
Footer CSS variable

### DIFF
--- a/shell/assets/styles/base/_variables.scss
+++ b/shell/assets/styles/base/_variables.scss
@@ -8,6 +8,7 @@ $min-width: 75% !default;
 $input-height: 61px;
 $unlabeled-input-height: 40px;
 $unlabaled-select-padding: 3px 0;
+$footer-height: 60px;
 
 $input-padding-lg: 18px;
 $input-padding-sm: 10px;

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -906,6 +906,8 @@ form.create-resource-container .cru {
     position: sticky;
     bottom: 0;
     background-color: var(--header-bg);
+    height: $footer-height;
+    box-sizing: border-box;
 
     // Overrides outlet padding
     margin-left: -$space-m;

--- a/shell/components/Wizard.vue
+++ b/shell/components/Wizard.vue
@@ -426,7 +426,7 @@ export default {
         </div>
         <div
           id="wizard-footer-controls"
-          class="controls-row pt-20"
+          class="controls-row"
         >
           <slot
             name="cancel"
@@ -674,7 +674,7 @@ $spacer: 10px;
 // We have to account for the absolute position of the .controls-row
 .footer-error {
   margin-top: -40px;
-  margin-bottom: 70px;
+  margin-bottom: calc($footer-height + 10px);
 }
 
   .controls-row {

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1858,7 +1858,7 @@ export default {
       }
 
       .namespace-create-banner {
-        margin-bottom: 70px;
+        margin-bottom: calc($footer-height + 10px);
       }
     }
     &__values {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12410 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- A new CSS variable added for the footer's height
- Replaced hardcoded values with the new variable
- Fixed extra padding on the wizard's footer caused by `pt-20` class:

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Places where we display the footer, please check with multiple browsers

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Places where we display the footer, please check with multiple browsers

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
@edenhernandez-suse while working on the issue I found the extra padding on the wizard's footer when installing a chart, I believe it was not intentional.

![image](https://github.com/user-attachments/assets/83ad9414-4939-4637-a11e-b7c3d0bfb28f)
![image](https://github.com/user-attachments/assets/17eff379-cea8-40c5-b05b-317c3a281a76)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
