### PR TITLE
Disable manage button in virt manage page for non-supported harvester version

### DIFF
--- a/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
@@ -408,12 +408,13 @@ export default {
         </template>
 
         <template #cell:harvester="{row}">
-          <router-link
+          <button
             class="btn btn-sm role-primary"
-            :to="row.detailLocation"
+            :disabled="!row.isSupportedHarvester"
+            @click="$router.push(row.detailLocation)"
           >
             {{ t('harvesterManager.manage') }}
-          </router-link>
+          </button>
         </template>
       </ResourceTable>
       <div v-else>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes # https://github.com/harvester/harvester/issues/8054

### Occurred changes and/or fixed issues

Disable `Manage` button in virt manage page for non-support harvester version

### Technical notes summary
We will backport to 2.11.1 once this PR merged.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
**Disabled**

https://github.com/user-attachments/assets/354e18db-8761-44f0-ac95-94ac7476e6c4



**Enabled**

https://github.com/user-attachments/assets/c2b70360-47e1-4f98-b291-60086e7fb4d1


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
