### PR TITLE
saving some work on focus trap

### DIFF
--- a/shell/components/AppModal.vue
+++ b/shell/components/AppModal.vue
@@ -1,6 +1,11 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { DEFAULT_FOCUS_TRAP_OPTS, useBasicSetupFocusTrap, getFirstFocusableElement } from '@shell/composables/focusTrap';
+import {
+  DEFAULT_FOCUS_TRAP_OPTS,
+  useBasicSetupFocusTrap,
+  getFirstFocusableElement,
+  useWatcherBasedSetupFocusTrapWithDestroyIncluded
+} from '@shell/composables/focusTrap';
 
 export const DEFAULT_ITERABLE_NODE_SELECTOR = 'body;';
 
@@ -10,7 +15,8 @@ export default defineComponent({
   emits: ['close'],
 
   inheritAttrs: false,
-  props:        {
+
+  props: {
     /**
      * If set to false, it will not be possible to close modal by clicking on
      * the background or by pressing Esc key.
@@ -80,7 +86,25 @@ export default defineComponent({
     returnFocusFirstIterableNodeSelector: {
       type:    String,
       default: DEFAULT_ITERABLE_NODE_SELECTOR,
-    }
+    },
+    /**
+     * trigger focus trap - but watcher based
+     */
+    triggerFocusTrapWatcherBased: {
+      type:    Boolean,
+      default: false,
+    },
+    /**
+     * watcher-based focus trap variable to watch
+     */
+    focusTrapWatcherBasedVariable: {
+      type:    Boolean,
+      default: false,
+    },
+  },
+
+  data() {
+    return { fakeWatchVar: true };
   },
   computed: {
     modalWidth(): string {
@@ -131,9 +155,23 @@ export default defineComponent({
         };
       }
 
-      useBasicSetupFocusTrap('#modal-container-element', opts);
+      useWatcherBasedSetupFocusTrapWithDestroyIncluded(() => props.focusTrapWatcherBasedVariable || 'fakeWatchVar', '#modal-container-element', opts, true);
+
+      // if (!props.triggerFocusTrapWatcherBased) {
+      //   useBasicSetupFocusTrap('#modal-container-element', opts);
+      // }
     }
   },
+  // created() {
+  //   // This usecase is to cover the PromptModal scenario where it's renders a generic component inside.
+  //   // Due to the architecture of the PromptModal it needs to be handled with a watcher based focus trap
+  //   // but with a dedicated unmount hook
+  //   if (this.triggerFocusTrapWatcherBased) {
+  //     const opts:any = DEFAULT_FOCUS_TRAP_OPTS;
+
+  //     useWatcherBasedSetupFocusTrapWithDestroyIncluded(() => this.focusTrapWatcherBasedVariable, '#modal-container-element', opts, true);
+  //   }
+  // },
   mounted() {
     document.addEventListener('keydown', this.handleEscapeKey);
   },

--- a/shell/components/Dialog.vue
+++ b/shell/components/Dialog.vue
@@ -41,6 +41,8 @@ export default {
   },
 
   data() {
+    console.error('ON DIALOG COMPONENT....');
+
     return { closed: false };
   },
 

--- a/shell/components/__tests__/PromptModal.test.ts
+++ b/shell/components/__tests__/PromptModal.test.ts
@@ -1,0 +1,51 @@
+import { nextTick } from 'vue';
+import { shallowMount, mount } from '@vue/test-utils';
+import PromptModal from '@shell/components/PromptModal.vue';
+import GenericPrompt from '@shell/dialog/GenericPrompt.vue';
+import { createStore } from 'vuex';
+import { ExtendedVue, Vue } from 'vue/types/vue';
+import { DefaultProps } from 'vue/types/options';
+import { CAPI, NORMAN } from '@shell/config/types';
+import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
+
+describe('component: PromptModal', () => {
+  const store = createStore({
+    modules: {
+      'action-menu': {
+        namespaced: true,
+        state:      {
+          showModal: true,
+          modalData: {
+            whatever:            true,
+            closeOnClickOutside: true
+          }
+        },
+      },
+    },
+    getters: {
+      'type-map/importDialog': () => () => GenericPrompt,
+      'i18n/exists':           () => jest.fn(),
+      'i18n/t':                jest.fn()
+    },
+    // actions: { 'management/findAll': jest.fn().mockResolvedValue(snapShots), 'rancher/findAll': jest.fn().mockResolvedValue([]) }
+  });
+
+  it('should emit copied after click', async() => {
+    document.body.innerHTML = '<div id="modals"></div>';
+    const wrapper = mount(PromptModal,
+      {
+        attachTo: document.body,
+        data() {
+          return { opened: true };
+        },
+        global: { mocks: { $store: store } }
+      }
+    );
+
+    console.log(document.querySelector('#modals').innerHTML);
+
+    // await wrapper.find('code').trigger('click');
+
+    expect(wrapper.vm.opened).toBe(true);
+  });
+});

--- a/shell/composables/focusTrap.ts
+++ b/shell/composables/focusTrap.ts
@@ -46,12 +46,14 @@ export function useBasicSetupFocusTrap(focusElement: string | HTMLElement, opts:
   });
 }
 
-export function useWatcherBasedSetupFocusTrapWithDestroyIncluded(watchVar:any, focusElement: string | HTMLElement, opts:any = DEFAULT_FOCUS_TRAP_OPTS) {
+export function useWatcherBasedSetupFocusTrapWithDestroyIncluded(watchVar:any, focusElement: string | HTMLElement, opts:any = DEFAULT_FOCUS_TRAP_OPTS, useUnmountHook = false) {
   let focusTrapInstance: FocusTrap;
   let focusEl;
 
+  console.error('RUNNING WATCHER FOCUS TRAP');
   watch(watchVar, (neu) => {
-    if (neu) {
+    console.error('inside watcher');
+    if (neu && !focusTrapInstance) {
       nextTick(() => {
         focusEl = typeof focusElement === 'string' ? document.querySelector(focusElement) as HTMLElement : focusElement;
 
@@ -61,8 +63,16 @@ export function useWatcherBasedSetupFocusTrapWithDestroyIncluded(watchVar:any, f
           focusTrapInstance.activate();
         });
       });
-    } else if (!neu && Object.keys(focusTrapInstance).length) {
+    } else if (!neu && Object.keys(focusTrapInstance).length && !useUnmountHook) {
       focusTrapInstance.deactivate();
     }
-  });
+  }, { immediate: true });
+
+  if (useUnmountHook) {
+    onBeforeUnmount(() => {
+      if (Object.keys(focusTrapInstance).length) {
+        focusTrapInstance.deactivate();
+      }
+    });
+  }
 }

--- a/shell/dialog/GenericPrompt.vue
+++ b/shell/dialog/GenericPrompt.vue
@@ -98,6 +98,7 @@ export default {
           :label="err"
         />
         <div class="buttons">
+          ALEX
           <button
             class="btn role-secondary mr-10"
             @click="close"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
