### PR TITLE
Fix table headers word break

### DIFF
--- a/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
@@ -112,7 +112,7 @@ export class WorkloadsListPageBasePo extends PagePo {
   }
 
   deleteItemWithUI(name: string) {
-    this.sortableTable().rowActionMenuOpen(name).getMenuItem('Delete').click();
+    this.sortableTable().rowActionMenuOpen(name).getMenuItem('Delete').scrollIntoView().click();
 
     const promptRemove = new PromptRemove();
 

--- a/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
@@ -112,7 +112,8 @@ export class WorkloadsListPageBasePo extends PagePo {
   }
 
   deleteItemWithUI(name: string) {
-    this.sortableTable().rowActionMenuOpen(name).getMenuItem('Delete').scrollIntoView().click();
+    this.sortableTable().rowActionMenuOpen(name).getMenuItem('Delete').scrollIntoView()
+      .click();
 
     const promptRemove = new PromptRemove();
 

--- a/cypress/e2e/tests/components/yaml-editor.spec.ts
+++ b/cypress/e2e/tests/components/yaml-editor.spec.ts
@@ -11,6 +11,7 @@ describe('Yaml Editor', () => {
 
   beforeEach(() => {
     cy.login();
+    cy.viewport(1280, 720);
 
     // Create a new deployment resource
     deploymentsCreatePage.goTo();

--- a/shell/assets/styles/base/_helpers.scss
+++ b/shell/assets/styles/base/_helpers.scss
@@ -131,6 +131,10 @@ $spacing-property-map: (
   color: var(--input-label);
 }
 
+.text-no-break {
+  white-space: nowrap;
+}
+
 .hide {
   display: none !important;
 }

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -261,11 +261,10 @@ export default {
           >
             <span
               v-clean-html="labelFor(col)"
-              class="text-no-break"
             />
             <span
               v-if="col.subLabel"
-              class="text-muted text-no-break"
+              class="text-muted"
             >
               {{ col.subLabel }}
             </span>

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -261,10 +261,11 @@ export default {
           >
             <span
               v-clean-html="labelFor(col)"
+              class="text-no-break"
             />
             <span
               v-if="col.subLabel"
-              class="text-muted"
+              class="text-muted text-no-break"
             >
               {{ col.subLabel }}
             </span>

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -259,10 +259,13 @@ export default {
             v-clean-tooltip="tooltip(col)"
             class="content"
           >
-            <span v-clean-html="labelFor(col)" />
+            <span
+              v-clean-html="labelFor(col)"
+              class="text-no-break"
+            />
             <span
               v-if="col.subLabel"
-              class="text-muted"
+              class="text-muted text-no-break"
             >
               {{ col.subLabel }}
             </span>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7269 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Added a new CSS helper class for disabling word breaks on texts using `white-space: nowrap;`.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="821" alt="Screenshot 2025-04-14 at 1 56 20 PM" src="https://github.com/user-attachments/assets/8b0aead1-edfd-445a-b13c-54872e5f9a1b" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
