### PR TITLE
Switching from using the `stale-issue-label` to the `only-issue-labels` option

### DIFF
--- a/.github/workflows/close-stale-enhancement-requests.yaml
+++ b/.github/workflows/close-stale-enhancement-requests.yaml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          debug-only: true # Dry-run
+          debug-only: true # Uncomment to switch back to dry-run
           exempt-issue-labels: "JIRA" # We don't want to close jira issues as these came from customers
-          stale-issue-label: "kind/enhancement"
+          only-issue-labels: "kind/enhancement"
           days-before-pr-stale: -1
           days-before-pr-close: -1
           days-before-issue-stale: 548


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The `stale-issue-label` removed the label from the issue after it's closed. We don't want to remove the kind/enhancement labels.

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
