### PR TITLE
Replace ActionDropdown with RcDropdown

### DIFF
--- a/cypress/e2e/po/components/sortable-table.po.ts
+++ b/cypress/e2e/po/components/sortable-table.po.ts
@@ -43,7 +43,7 @@ export default class SortableTablePo extends ComponentPo {
    * @returns
    */
   bulkActionDropDownPopOver() {
-    return this.bulkActionDropDown().find(`.v-popper .v-popper__inner`);
+    return cy.get('body').find('[dropdown-menu-collection]');
   }
 
   /**
@@ -54,7 +54,7 @@ export default class SortableTablePo extends ComponentPo {
 
     popOver.should('be.visible');
 
-    return popOver.find('li').contains(name);
+    return popOver.find('[dropdown-menu-item]').contains(name);
   }
 
   /**

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdown.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdown.vue
@@ -24,9 +24,18 @@ import { ref } from 'vue';
 import { useClickOutside } from '@shell/composables/useClickOutside';
 import { useDropdownContext } from '@components/RcDropdown/useDropdownContext';
 
-defineProps<{
-  ariaLabel?: string
-}>();
+import type { Placement } from 'floating-vue';
+
+withDefaults(
+  defineProps<{
+    // eslint-disable-next-line vue/require-default-prop
+    ariaLabel?: string;
+    // eslint-disable-next-line vue/require-default-prop
+    distance?: number;
+    placement?: Placement;
+  }>(),
+  { placement: 'bottom-end' }
+);
 
 const emit = defineEmits(['update:open']);
 
@@ -61,7 +70,8 @@ const applyShow = () => {
     :shown="isMenuOpen"
     :auto-hide="false"
     :container="popperContainer"
-    :placement="'bottom-end'"
+    :placement="placement"
+    :distance="distance"
     @apply-show="applyShow"
   >
     <slot name="default">

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdown.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdown.vue
@@ -88,8 +88,8 @@ const applyShow = () => {
         dropdown-menu-collection
         :aria-label="ariaLabel || 'Dropdown Menu'"
         @keydown="handleKeydown"
-        @keydown.down="setFocus('down')"
-        @keydown.up="setFocus('up')"
+        @keydown.down.prevent="setFocus('down')"
+        @keydown.up.prevent="setFocus('up')"
       >
         <slot name="dropdownCollection">
           <!--Empty slot content-->

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownItem.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownItem.vue
@@ -83,7 +83,7 @@ const handleActivate = (e: KeyboardEvent) => {
     :aria-disabled="disabled || false"
     @click.stop="handleClick"
     @keydown.enter.space="handleActivate"
-    @keydown.up.down.stop="handleKeydown"
+    @keydown.up.down.prevent.stop="handleKeydown"
   >
     <slot name="before">
       <!--Empty slot content-->

--- a/shell/components/ActionDropdownShell.vue
+++ b/shell/components/ActionDropdownShell.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { RcDropdown, RcDropdownTrigger, RcDropdownItem } from '@components/RcDropdown';
+type HiddenAction = {
+  action: string;
+  enabled: boolean;
+  icon: string;
+  label: string;
+  bulkable: boolean;
+  bulkAction: string;
+  allEnabled: boolean;
+  anyEnabled: boolean;
+}
+
+defineProps<{
+  disabled: boolean,
+  hiddenActions: HiddenAction[],
+  actionTooltip: unknown,
+}>();
+
+const emit = defineEmits(['click', 'mouseover', 'mouseleave']);
+
+const applyTableAction = (act: HiddenAction, args: unknown, event: Event) => {
+  emit('click', act, args, event);
+};
+
+const setBulkActionOfInterest = (act: HiddenAction | null, event: 'mouseover' | 'mouseleave' = 'mouseover') => {
+  emit(event, act);
+};
+</script>
+
+<template>
+  <rc-dropdown
+    :distance="14"
+    placement="bottom"
+  >
+    <rc-dropdown-trigger
+      class="bulk-actions-dropdown"
+      :disabled="disabled"
+    >
+      <template #before>
+        <i class="icon icon-gear" />
+      </template>
+      <span>{{ t('sortableTable.bulkActions.collapsed.label') }}</span>
+      <template #after>
+        <i class="ml-10 icon icon-chevron-down" />
+      </template>
+    </rc-dropdown-trigger>
+    <template #dropdownCollection>
+      <rc-dropdown-item
+        v-for="(act, i) in hiddenActions"
+        :key="i"
+        v-clean-tooltip="{
+          content: actionTooltip,
+          placement: 'right'
+        }"
+        :disabled="!act.enabled"
+        @click="applyTableAction(act, null, $event)"
+        @mouseover="setBulkActionOfInterest(act)"
+        @mouseleave="setBulkActionOfInterest(null, 'mouseleave')"
+      >
+        <template #before>
+          <i
+            v-if="act.icon"
+            :class="act.icon"
+          />
+        </template>
+        <span v-clean-html="act.label" />
+      </rc-dropdown-item>
+    </template>
+  </rc-dropdown>
+</template>

--- a/shell/components/SortableTable/actions.js
+++ b/shell/components/SortableTable/actions.js
@@ -1,7 +1,7 @@
 import debounce from 'lodash/debounce';
 
 // Use a visible display type to reduce flickering
-const displayType = 'inline-block';
+const displayType = 'inline-flex';
 
 export default {
 

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -25,6 +25,7 @@ import { FORMATTERS } from '@shell/components/SortableTable/sortable-config';
 import ButtonMultiAction from '@shell/components/ButtonMultiAction.vue';
 import ActionMenu from '@shell/components/ActionMenuShell.vue';
 import { useRuntimeFlag } from '@shell/composables/useRuntimeFlag';
+import ActionDropdownShell from '@shell/components/ActionDropdownShell.vue';
 
 // Uncomment for table performance debugging
 // import tableDebug from './debug';
@@ -61,6 +62,7 @@ export default {
     LabeledSelect,
     ButtonMultiAction,
     ActionMenu,
+    ActionDropdownShell,
   },
   mixins: [
     filtering,
@@ -1103,47 +1105,59 @@ export default {
                 />
                 <span v-clean-html="act.label" />
               </button>
-              <ActionDropdown
-                :class="bulkActionsDropdownClass"
-                class="bulk-actions-dropdown"
-                :disable-button="!selectedRows.length"
-                size="sm"
-              >
-                <template #button-content>
-                  <button
-                    ref="actionDropDown"
-                    class="btn bg-primary mr-0"
-                    :disabled="!selectedRows.length"
-                  >
-                    <i class="icon icon-gear" />
-                    <span>{{ t('sortableTable.bulkActions.collapsed.label') }}</span>
-                    <i class="ml-10 icon icon-chevron-down" />
-                  </button>
-                </template>
-                <template #popover-content>
-                  <ul class="list-unstyled menu">
-                    <li
-                      v-for="(act, i) in hiddenActions"
-                      :key="i"
-                      v-close-popper
-                      v-clean-tooltip="{
-                        content: actionTooltip,
-                        placement: 'right'
-                      }"
-                      :class="{ disabled: !act.enabled }"
-                      @click="applyTableAction(act, null, $event)"
-                      @mouseover="setBulkActionOfInterest(act)"
-                      @mouseleave="setBulkActionOfInterest(null)"
+              <template v-if="featureDropdownMenu">
+                <ActionDropdownShell
+                  :disabled="!selectedRows.length"
+                  :hidden-actions="hiddenActions"
+                  :action-tooltip="actionTooltip"
+                  @click="applyTableAction"
+                  @mouseover="setBulkActionOfInterest"
+                  @mouseleave="setBulkActionOfInterest"
+                />
+              </template>
+              <template v-else>
+                <ActionDropdown
+                  :class="bulkActionsDropdownClass"
+                  class="bulk-actions-dropdown"
+                  :disable-button="!selectedRows.length"
+                  size="sm"
+                >
+                  <template #button-content>
+                    <button
+                      ref="actionDropDown"
+                      class="btn bg-primary mr-0"
+                      :disabled="!selectedRows.length"
                     >
-                      <i
-                        v-if="act.icon"
-                        :class="act.icon"
-                      />
-                      <span v-clean-html="act.label" />
-                    </li>
-                  </ul>
-                </template>
-              </ActionDropdown>
+                      <i class="icon icon-gear" />
+                      <span>{{ t('sortableTable.bulkActions.collapsed.label') }}</span>
+                      <i class="ml-10 icon icon-chevron-down" />
+                    </button>
+                  </template>
+                  <template #popover-content>
+                    <ul class="list-unstyled menu">
+                      <li
+                        v-for="(act, i) in hiddenActions"
+                        :key="i"
+                        v-close-popper
+                        v-clean-tooltip="{
+                          content: actionTooltip,
+                          placement: 'right'
+                        }"
+                        :class="{ disabled: !act.enabled }"
+                        @click="applyTableAction(act, null, $event)"
+                        @mouseover="setBulkActionOfInterest(act)"
+                        @mouseleave="setBulkActionOfInterest(null)"
+                      >
+                        <i
+                          v-if="act.icon"
+                          :class="act.icon"
+                        />
+                        <span v-clean-html="act.label" />
+                      </li>
+                    </ul>
+                  </template>
+                </ActionDropdown>
+              </template>
               <label
                 v-if="selectedRowsText"
                 :class="bulkActionAvailabilityClass"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This replaces the ActionDropdown implementation with one that uses the new dropdown component.

Fixes #13196 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Create new `ActionDropdownShell.vue` component
- Replace `ActionDropdown` with `ActionDropdownShell`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

We keep the two components because we need to support Rancher v2.10 in extensions. We can remove the `ActionDropdown` implementation after we drop support for Rancher v2.10.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Bulk action menus throughout dashboard should render the same options. All options should work the same as before.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Action menus used throughout dashboard. Clicking on items might not work as expected. Items might not render when they should.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
