### PR TITLE
Replace actions in detail header with RcDropdown

### DIFF
--- a/cypress/e2e/po/components/action-menu.po.ts
+++ b/cypress/e2e/po/components/action-menu.po.ts
@@ -2,11 +2,11 @@ import ComponentPo from '@/cypress/e2e/po/components/component.po';
 
 export default class ActionMenuPo extends ComponentPo {
   constructor(arg:any) {
-    super(arg || cy.get('main > div > .menu'));
+    super(arg || cy.get('[dropdown-menu-collection]'));
   }
 
   clickMenuItem(index: number) {
-    return this.self().find('li').eq(index).click();
+    return this.self().find('[dropdown-menu-item]').eq(index).click();
   }
 
   getMenuItem(name: string) {

--- a/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
@@ -296,7 +296,7 @@ describe('Roles Templates', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
 
       const actionMenu = detailPage.detail().openMastheadActionMenu();
 
-      actionMenu.clickMenuItem(5);
+      actionMenu.clickMenuItem(4);
 
       const promptRemove = new PromptRemove();
 

--- a/pkg/rancher-components/src/components/RcButton/RcButton.vue
+++ b/pkg/rancher-components/src/components/RcButton/RcButton.vue
@@ -15,6 +15,7 @@ const buttonRoles: { role: keyof ButtonRoleProps, className: string }[] = [
   { role: 'secondary', className: 'role-secondary' },
   { role: 'tertiary', className: 'role-tertiary' },
   { role: 'link', className: 'role-link' },
+  { role: 'multiAction', className: 'role-multi-action' },
   { role: 'ghost', className: 'role-ghost' },
 ];
 

--- a/pkg/rancher-components/src/components/RcButton/types.ts
+++ b/pkg/rancher-components/src/components/RcButton/types.ts
@@ -9,6 +9,7 @@ export type ButtonRoleProps = {
   secondary?: boolean;
   tertiary?: boolean;
   link?: boolean;
+  multiAction?: boolean;
   ghost?: boolean;
 }
 

--- a/shell/components/ResourceDetail/Masthead.vue
+++ b/shell/components/ResourceDetail/Masthead.vue
@@ -13,6 +13,9 @@ import {
 import { ExtensionPoint, PanelLocation } from '@shell/core/types';
 import ExtensionPanel from '@shell/components/ExtensionPanel';
 import TabTitle from '@shell/components/TabTitle';
+import ActionMenu from '@shell/components/ActionMenuShell.vue';
+import { useRuntimeFlag } from '@shell/composables/useRuntimeFlag';
+import { useStore } from 'vuex';
 
 // i18n-uses resourceDetail.header.*
 
@@ -26,7 +29,12 @@ export default {
   name: 'MastheadResourceDetail',
 
   components: {
-    BadgeState, Banner, ButtonGroup, ExtensionPanel, TabTitle
+    BadgeState,
+    Banner,
+    ButtonGroup,
+    ExtensionPanel,
+    TabTitle,
+    ActionMenu,
   },
   props: {
     value: {
@@ -90,6 +98,13 @@ export default {
       type:    Boolean,
       default: false,
     }
+  },
+
+  setup() {
+    const store = useStore();
+    const { featureDropdownMenu } = useRuntimeFlag(store);
+
+    return { featureDropdownMenu };
   },
 
   data() {
@@ -561,17 +576,28 @@ export default {
               class="mr-10"
             />
 
-            <button
-              v-if="isView"
-              ref="actions"
-              data-testid="masthead-action-menu"
-              aria-haspopup="true"
-              type="button"
-              class="btn role-multi-action actions"
-              @click="showActions"
-            >
-              <i class="icon icon-actions" />
-            </button>
+            <template v-if="featureDropdownMenu">
+              <ActionMenu
+                v-if="isView"
+                button-role="multiAction"
+                button-size="compact"
+                :resource="value"
+                data-testid="masthead-action-menu"
+              />
+            </template>
+            <template v-else>
+              <button
+                v-if="isView"
+                ref="actions"
+                data-testid="masthead-action-menu"
+                aria-haspopup="true"
+                type="button"
+                class="btn role-multi-action actions"
+                @click="showActions"
+              >
+                <i class="icon icon-actions" />
+              </button>
+            </template>
           </div>
         </div>
       </slot>

--- a/shell/components/ResourceDetail/__tests__/Masthead.test.ts
+++ b/shell/components/ResourceDetail/__tests__/Masthead.test.ts
@@ -1,6 +1,7 @@
 import { mount, RouterLinkStub } from '@vue/test-utils';
 import { _VIEW } from '@shell/config/query-params';
 import Masthead from '@shell/components/ResourceDetail/Masthead.vue';
+import { createStore } from 'vuex';
 
 const mockedStore = () => {
   return {
@@ -17,12 +18,15 @@ const mockedStore = () => {
 };
 
 const requiredSetup = () => {
+  const store = createStore({ getters: { 'management/byId': () => jest.fn() } });
+
   return {
     stubs: {
       'router-link': RouterLinkStub,
       LiveDate:      true
     },
-    mocks: { $store: mockedStore() }
+    provide: { store },
+    mocks:   { $store: mockedStore() }
   };
 };
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This replaces the dropdown used in the header of the detail pages with the new dropdown component.

Fixes #13595 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Replace actions in detail header with RcDropdown
- Update unit tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

We need to keep the old implementation around for shell so that extensions will continue to work in Rancher 2.10.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Actions on Details pages should render the same menu options as before. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Actions on Details pages.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before

![image](https://github.com/user-attachments/assets/e55871d5-3d04-44ba-846c-f0f36b9fd7e7)

#### After

![image](https://github.com/user-attachments/assets/d976e37d-a366-45a4-b298-278d3d36ed66)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
