### PR TITLE
add github template for feature with acceptance criteria

### DIFF
--- a/.github/ISSUE_TEMPLATE/acceptance-criteria-feature.yml
+++ b/.github/ISSUE_TEMPLATE/acceptance-criteria-feature.yml
@@ -1,14 +1,14 @@
-name:  Feature/ Issue / Epic that requires acceptance criteria
-description: Create feature / issue /epic with clear requirements on the expected behavior of the Rancher UI
-title: "Summarize feature in one line"
+name:  Feature / Issue / Epic that requires acceptance criteria
+description: Create feature / issue / epic with clear requirements on the expected behavior of the Rancher UI
+title: "<feature title: summarize feature in one line>"
 labels: ["kind/enhancement"]
 assignees: []
 body:
 - type: textarea
-  id: issue_scope
+  id: issue_description
   attributes:
-    label: Issue/Epic Scope
-    description: "A description of what the issue/epic is about and what it is being created for."
+    label: Description
+    description: "A description of what the issue / epic is about and what it is being created for."
     value: |
       **Is your feature request related to a problem? Please describe.**
       <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
@@ -27,9 +27,9 @@ body:
   id: acceptance_criteria
   attributes:
     label: Acceptance Criteria
-    description: "List applicable use cases, each of them with a clear description of the expected behavior or alternative link to a requirements document. Please, try to include all possible use-cases. The QA team can help and include more as needed."
+    description: "List conditions that the product or this feature must meet to be considered acceptable and complete. Please try to include all possible use-cases, each with a clear description of the expected behavior, or attach a requirements document."
     placeholder: |
-      List the steps or link sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically.   
+      <!-- List the scenarios or link sub-issues here using the issue number or URL. Progress will be tracked automatically. -->   
       - [ ] 
       - [ ]  
   validations:
@@ -38,9 +38,9 @@ body:
   id: uiux_dep
   attributes:
     label: UI/UX Dependencies
-    description: "List of sub-issues/steps required for the UI/UX team to complete the feature, accomplishing all the acceptance criteria."
+    description: "List of sub-issues / steps required for the UI / UX team to complete the feature, accomplishing all the acceptance criteria."
     placeholder: |  
-      List the steps or link sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically.
+      <!-- List the steps or link sub-issues here using the issue number or URL. Progress will be tracked automatically. -->
         - [ ] #issue_number or URL
         - [ ] 
   validations:
@@ -49,9 +49,9 @@ body:
   id: other_dep
   attributes:
     label: Other Dependencies
-    description: "List of sub-issues/steps required for the backend or other teams to complete the feature, accomplishing all the acceptance criteria."
+    description: "List of sub-issues / steps required for the backend or other teams to complete the feature, accomplishing all the acceptance criteria."
     placeholder: |
-      List the steps or link sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically.
+      <!-- List the steps or link sub-issues here using the issue_number or URL. Progress will be tracked automatically. -->
         - [ ]
         - [ ] 
   validations:
@@ -59,12 +59,12 @@ body:
 - type: textarea
   id: qa_testing
   attributes:
-    label: QA/Testing
+    label: QA / Testing
     description: |
-      List all testing steps/sub-issues to test the feature, covering all the acceptance criteria. For sub-issues please, label them as unit, e2e or manual tests. 
+      List all testing steps / sub-issues to test the feature, covering all the acceptance criteria. For sub-issues please, label them as unit, e2e or manual tests. 
       Testing steps directly described here are reproduction steps for manual testing.
     placeholder: |
-        List the testing steps or link automation sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically.
+        <!-- List the testing steps or link QA automation sub-issues here using issue number or URL. Progress will be tracked automatically. -->
         - [ ]
         - [ ] 
   validations:
@@ -73,7 +73,7 @@ body:
   id: rancher_teams
   attributes:
     label: Rancher Teams
-    description: "Tag a representative of each team involved in the completion of the feature, so they can track feature work."
+    description: "Comma-separated list of a representative from each team involved in the completion of this feature."
     placeholder: "Type @username of each of the team representatives involved"
   validations:
     required: false   

--- a/.github/ISSUE_TEMPLATE/acceptance-criteria-feature.yml
+++ b/.github/ISSUE_TEMPLATE/acceptance-criteria-feature.yml
@@ -1,0 +1,70 @@
+name:  Feature/Issue/Epic that require acceptance criteria
+about: All approved features/issues/epics with clear requirements on the expected behavior of the Rancher Dashboard
+title: "<feature title: summarize feature in one line>"
+labels: ["kind/enhancement"]
+assignees: ''
+body:
+- type: textarea
+  attributes:
+    label: Issue/Epic Scope
+    description: "A clear and concise description of what the issue/epic is about and what is it being created for."
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Acceptance Criteria
+    description: "List all the use cases you can think about, each of them with a clear description of the expected behavior."
+    placeholder: |
+        Please, try to include all possible use-cases. The QA team can help and include more as needed :)
+        - [ ] 
+        - [ ]  
+  validations:
+    required: true    
+- type: textarea
+  attributes:
+    label: UI tracking
+    description: "List of sub-issues/steps required for the dashboard team to complete the feature accomplishing all the acceptance criteria"
+    placeholder: |
+        List the steps or link sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically. 
+        - [ ] #issue_number or URL
+        - [ ] 
+  validations:
+    required: false 
+- type: textarea
+  attributes:
+    label: UX tracking
+    description: "List of sub-issues/steps required for the UX team to complete the feature accomplishing all the acceptance criteria"
+    placeholder: |
+        List the steps or link sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically. 
+        - [ ] #issue_number or URL
+        - [ ] 
+  validations:
+    required: false          
+- type: textarea
+  attributes:
+    label: Backend tracking
+    description: "List of sub-issues/steps required for the backend to complete the feature accomplishing all the acceptance criteria"
+    placeholder: |
+        List the steps or link sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically.
+        - [ ]
+        - [ ] 
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: QA/Testing
+    description: "List all testing steps/sub-issues to test the feature, covering all the acceptance criteria"
+    placeholder: |
+        List the testing steps or link automation sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically.
+        For sub-issues please, label them as unit, e2e or manual tests. Testing steps directly described here should be reproduction steps for manual testing.
+        - [ ]
+        - [ ] 
+  validations:
+    required: false 
+- type: input
+  attributes:
+    label: If this is an issue that requires collaboration of multiple teams
+    description: "Tag a representative of each team involved in the completion of the feature, so they can track feature work."
+    placeholder: "Use @ and type the github username of easch of the team representatives involved"
+  validations:
+    required: false   

--- a/.github/ISSUE_TEMPLATE/acceptance-criteria-feature.yml
+++ b/.github/ISSUE_TEMPLATE/acceptance-criteria-feature.yml
@@ -27,9 +27,9 @@ body:
   id: acceptance_criteria
   attributes:
     label: Acceptance Criteria
-    description: "List applicable use cases, each of them with a clear description of the expected behavior or alternative link to a requirements document."
-    value: |
-      Please, try to include all possible use-cases. The QA team can help and include more as needed.    
+    description: "List applicable use cases, each of them with a clear description of the expected behavior or alternative link to a requirements document. Please, try to include all possible use-cases. The QA team can help and include more as needed."
+    placeholder: |
+      List the steps or link sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically.   
       - [ ] 
       - [ ]  
   validations:
@@ -39,7 +39,7 @@ body:
   attributes:
     label: UI/UX Dependencies
     description: "List of sub-issues/steps required for the UI/UX team to complete the feature, accomplishing all the acceptance criteria."
-    value: |  
+    placeholder: |  
       List the steps or link sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically.
         - [ ] #issue_number or URL
         - [ ] 
@@ -50,7 +50,7 @@ body:
   attributes:
     label: Other Dependencies
     description: "List of sub-issues/steps required for the backend or other teams to complete the feature, accomplishing all the acceptance criteria."
-    value: |
+    placeholder: |
       List the steps or link sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically.
         - [ ]
         - [ ] 
@@ -63,7 +63,7 @@ body:
     description: |
       List all testing steps/sub-issues to test the feature, covering all the acceptance criteria. For sub-issues please, label them as unit, e2e or manual tests. 
       Testing steps directly described here are reproduction steps for manual testing.
-    value: |
+    placeholder: |
         List the testing steps or link automation sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically.
         - [ ]
         - [ ] 

--- a/.github/ISSUE_TEMPLATE/acceptance-criteria-feature.yml
+++ b/.github/ISSUE_TEMPLATE/acceptance-criteria-feature.yml
@@ -1,5 +1,5 @@
-name:  Feature/Issue/Epic that requires acceptance criteria
-description: Create features/issues/epics with clear requirements on the expected behavior of the Rancher UI
+name:  Feature/ Issue / Epic that requires acceptance criteria
+description: Create feature / issue /epic with clear requirements on the expected behavior of the Rancher UI
 title: "Summarize feature in one line"
 labels: ["kind/enhancement"]
 assignees: []

--- a/.github/ISSUE_TEMPLATE/acceptance-criteria-feature.yml
+++ b/.github/ISSUE_TEMPLATE/acceptance-criteria-feature.yml
@@ -1,70 +1,79 @@
-name:  Feature/Issue/Epic that require acceptance criteria
-about: All approved features/issues/epics with clear requirements on the expected behavior of the Rancher Dashboard
-title: "<feature title: summarize feature in one line>"
+name:  Feature/Issue/Epic that requires acceptance criteria
+description: Create features/issues/epics with clear requirements on the expected behavior of the Rancher UI
+title: "Summarize feature in one line"
 labels: ["kind/enhancement"]
-assignees: ''
+assignees: []
 body:
 - type: textarea
+  id: issue_scope
   attributes:
     label: Issue/Epic Scope
-    description: "A clear and concise description of what the issue/epic is about and what is it being created for."
+    description: "A description of what the issue/epic is about and what it is being created for."
+    value: |
+      **Is your feature request related to a problem? Please describe.**
+      <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+      **Describe the solution you'd like**
+      <!-- A clear and concise description of what you want to happen. -->
+
+      **Describe alternatives you've considered**
+      <!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+      **Additional context**
+      <!-- Add any other context or screenshots about the feature request here. -->
   validations:
     required: true
 - type: textarea
+  id: acceptance_criteria
   attributes:
     label: Acceptance Criteria
-    description: "List all the use cases you can think about, each of them with a clear description of the expected behavior."
-    placeholder: |
-        Please, try to include all possible use-cases. The QA team can help and include more as needed :)
-        - [ ] 
-        - [ ]  
+    description: "List applicable use cases, each of them with a clear description of the expected behavior or alternative link to a requirements document."
+    value: |
+      Please, try to include all possible use-cases. The QA team can help and include more as needed.    
+      - [ ] 
+      - [ ]  
   validations:
     required: true    
 - type: textarea
+  id: uiux_dep
   attributes:
-    label: UI tracking
-    description: "List of sub-issues/steps required for the dashboard team to complete the feature accomplishing all the acceptance criteria"
-    placeholder: |
-        List the steps or link sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically. 
+    label: UI/UX Dependencies
+    description: "List of sub-issues/steps required for the UI/UX team to complete the feature, accomplishing all the acceptance criteria."
+    value: |  
+      List the steps or link sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically.
         - [ ] #issue_number or URL
         - [ ] 
   validations:
-    required: false 
+    required: false        
 - type: textarea
+  id: other_dep
   attributes:
-    label: UX tracking
-    description: "List of sub-issues/steps required for the UX team to complete the feature accomplishing all the acceptance criteria"
-    placeholder: |
-        List the steps or link sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically. 
-        - [ ] #issue_number or URL
-        - [ ] 
-  validations:
-    required: false          
-- type: textarea
-  attributes:
-    label: Backend tracking
-    description: "List of sub-issues/steps required for the backend to complete the feature accomplishing all the acceptance criteria"
-    placeholder: |
-        List the steps or link sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically.
+    label: Other Dependencies
+    description: "List of sub-issues/steps required for the backend or other teams to complete the feature, accomplishing all the acceptance criteria."
+    value: |
+      List the steps or link sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically.
         - [ ]
         - [ ] 
   validations:
     required: false
 - type: textarea
+  id: qa_testing
   attributes:
     label: QA/Testing
-    description: "List all testing steps/sub-issues to test the feature, covering all the acceptance criteria"
-    placeholder: |
+    description: |
+      List all testing steps/sub-issues to test the feature, covering all the acceptance criteria. For sub-issues please, label them as unit, e2e or manual tests. 
+      Testing steps directly described here are reproduction steps for manual testing.
+    value: |
         List the testing steps or link automation sub-issues here using `- [ ] #issue_number` or URL. Progress will be tracked automatically.
-        For sub-issues please, label them as unit, e2e or manual tests. Testing steps directly described here should be reproduction steps for manual testing.
         - [ ]
         - [ ] 
   validations:
     required: false 
 - type: input
+  id: rancher_teams
   attributes:
-    label: If this is an issue that requires collaboration of multiple teams
+    label: Rancher Teams
     description: "Tag a representative of each team involved in the completion of the feature, so they can track feature work."
-    placeholder: "Use @ and type the github username of easch of the team representatives involved"
+    placeholder: "Type @username of each of the team representatives involved"
   validations:
     required: false   


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->

### Occurred changes and/or fixed issues
This PR adds a github template for issues/features/epics that require acceptance criteria

### Areas or cases that should be tested
- creating an issue with the new template, observing if the fields are working as expected
- try to create the issue without filling the mandatory fields
- After the issue is created, observed if the workflows work as expected: e.g
- Backport issues are created
- the proper labels are assigned according to the template
- the GitHub-project-automation automatically adds the issue to the UI Project Board
- the GitHub-project-automation automatically moves the issue to To Triage in  UI Project Board
- github-actions adds the label QA/dev-automation

### Areas which could experience regressions
The workflows implemented by the github Project automation and github actions


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
