### PR TITLE
adds visual test to fleet icon messages

### DIFF
--- a/cypress/e2e/po/pages/fleet/gitrepo-create.po.ts
+++ b/cypress/e2e/po/pages/fleet/gitrepo-create.po.ts
@@ -82,4 +82,25 @@ export class GitRepoCreatePo extends PagePo {
   setPollingInterval(value: number) {
     return LabeledInputPo.byLabel(this.self(), 'Polling Interval').set(value);
   }
+
+  displayAlwaysKeepInformationMessage() {
+    this.self().get('[data-testid="checkbox-info-icon"]').eq(0).as('always');
+
+    cy.get('@always').realHover();
+    cy.get('@always').should('have.attr', 'data-popper-shown');
+  }
+
+  displayPollingInvervalTimeInformationMessage() {
+    this.self().get('[data-testid="checkbox-info-icon"]').eq(1).as('polling');
+
+    cy.get('@polling').realHover();
+    cy.get('@polling').should('have.attr', 'data-popper-shown');
+  }
+
+  displaySelfHealingInformationMessage() {
+    this.self().get('[data-testid="labeledTooltip-info-icon"]').eq(0).as('selfhealingicon');
+
+    cy.get('@selfhealingicon').realHover();
+    cy.get('@selfhealingicon').should('have.attr', 'data-popper-shown');
+  }
 }

--- a/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
@@ -6,6 +6,7 @@ import { generateFakeClusterDataAndIntercepts } from '@/cypress/e2e/blueprints/n
 import PreferencesPagePo from '@/cypress/e2e/po/pages/preferences.po';
 import { EXTRA_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
+import 'cypress-real-events/support';
 
 const fakeProvClusterId = 'some-fake-cluster-id';
 const fakeMgmtClusterId = 'some-fake-mgmt-id';
@@ -88,6 +89,16 @@ describe('Git Repo', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] }, (
       gitRepoCreatePage.gitAuthSelectOrCreate().createSSHAuth('test1', 'test1', 'KNOWN_HOSTS');
       gitRepoCreatePage.helmAuthSelectOrCreate().createBasicAuth('test', 'test');
       gitRepoCreatePage.setHelmRepoURLRegex(helmRepoURLRegex);
+      // #Percy tests
+      gitRepoCreatePage.displaySelfHealingInformationMessage();
+
+      cy.percySnapshot('Self-Healing test');
+      gitRepoCreatePage.displayAlwaysKeepInformationMessage();
+
+      cy.percySnapshot('Always Keep Resource test');
+      gitRepoCreatePage.displayPollingInvervalTimeInformationMessage();
+
+      cy.percySnapshot('Polling Interval test');
       gitRepoCreatePage.setPollingInterval(13);
 
       cy.wait('@getSecrets', EXTRA_LONG_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);

--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
     "cypress-axe": "1.5.0",
     "cypress-delete-downloads-folder": "0.0.4",
     "cypress-mochawesome-reporter": "3.8.2",
+    "cypress-real-events": "1.14.0",
     "eslint": "7.32.0",
     "eslint-config-standard": "16.0.3",
     "eslint-import-resolver-node": "0.3.9",

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -124,6 +124,15 @@ export default defineComponent({
       type:    String,
       default: undefined
     },
+
+    /**
+     * Inherited global identifier prefix for tests
+     * Define a term based on the parent component to avoid conflicts on multiple components
+     */
+    componentTestid: {
+      type:    String,
+      default: 'checkbox'
+    },
   },
 
   emits: ['update:value'],
@@ -298,6 +307,7 @@ export default defineComponent({
             v-clean-tooltip="{content: t(tooltipKey), triggers: ['hover', 'touch', 'focus']}"
             v-stripped-aria-label="t(tooltipKey)"
             class="checkbox-info icon icon-info icon-lg"
+            :data-testid="componentTestid + '-info-icon'"
             :tabindex="isDisabled ? -1 : 0"
           />
           <i
@@ -305,6 +315,7 @@ export default defineComponent({
             v-clean-tooltip="{content: tooltip, triggers: ['hover', 'touch', 'focus']}"
             v-stripped-aria-label="tooltip"
             class="checkbox-info icon icon-info icon-lg"
+            :data-testid="componentTestid + '-info-icon'"
             :tabindex="isDisabled ? -1 : 0"
           />
         </slot>

--- a/pkg/rancher-components/src/components/LabeledTooltip/LabeledTooltip.vue
+++ b/pkg/rancher-components/src/components/LabeledTooltip/LabeledTooltip.vue
@@ -26,7 +26,15 @@ export default defineComponent({
     hover: {
       type:    Boolean,
       default: true
-    }
+    },
+    /**
+     * Inherited global identifier prefix for tests
+     * Define a term based on the parent component to avoid conflicts on multiple components
+     */
+    componentTestid: {
+      type:    String,
+      default: 'labeledTooltip-info-icon'
+    },
   },
   computed: {
     iconClass(): string {
@@ -64,6 +72,7 @@ export default defineComponent({
         :class="{'hover':!value, [iconClass]: true}"
         class="icon status-icon"
         tabindex="0"
+        :data-testid="componentTestid"
       />
     </template>
     <template v-else>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6937,6 +6937,11 @@ cypress-mochawesome-reporter@3.8.2:
     mochawesome-merge "^4.2.1"
     mochawesome-report-generator "^6.2.0"
 
+cypress-real-events@1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.14.0.tgz#c5495db50a2bd247f4accde983af7153566945d3"
+  integrity sha512-XmI8y3OZLh6cjRroPalzzS++iv+pGCaD9G9kfIbtspgv7GVsDt30dkZvSXfgZb4rAN+3pOkMVB7e0j4oXydW7Q==
+
 cypress@11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-11.1.0.tgz#b8f16495a8a5d8f9a7dd3374ae7b2cef45e9c779"
@@ -8144,6 +8149,7 @@ eslint-plugin-jest@24.4.0:
 
 "eslint-plugin-local-rules@link:./eslint-plugin-local-rules":
   version "0.0.0"
+  uid ""
 
 "eslint-plugin-local-rules@link:eslint-plugin-local-rules":
   version "0.0.0"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Adds visual test coverage to git repo banners:
https://github.com/rancher/qa-tasks/issues/1679
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
