### PR TITLE
Fix RKE2 Addon Config Values Persistency

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1691,7 +1691,7 @@ export default {
       const defaultChartValue = this.versionInfo[name];
       const key = this.chartVersionKey(name);
 
-      return merge({}, defaultChartValue?.values || {}, this.userChartValues[key] || {});
+      return mergeWithReplaceArrays(defaultChartValue?.values, this.userChartValues[key]);
     },
 
     initServerAgentArgs() {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1305,7 +1305,7 @@ export default {
         delete clonedCurrentConfig.metadata;
 
         if (this.provider === VMWARE_VSPHERE) {
-          machinePool.config = mergeWithReplaceArrays(clonedLatestConfig, clonedCurrentConfig);
+          machinePool.config = mergeWithReplaceArrays(clonedLatestConfig, clonedCurrentConfig, true);
         } else {
           machinePool.config = merge(clonedLatestConfig, clonedCurrentConfig);
         }

--- a/shell/utils/object.js
+++ b/shell/utils/object.js
@@ -488,7 +488,7 @@ export function deepToRaw(obj, cache = new WeakSet()) {
  * More info: https://github.com/lodash/lodash/issues/1313
  *
  * This helper function addresses the issue by always replacing the old array with the new array during the merge process.
- * 
+ *
  * This helper is also used for another case in rke2.vue to handle merging addon chart default values with the user's current values.
  * It fixed https://github.com/rancher/dashboard/issues/12418
  */

--- a/shell/utils/object.js
+++ b/shell/utils/object.js
@@ -488,9 +488,12 @@ export function deepToRaw(obj, cache = new WeakSet()) {
  * More info: https://github.com/lodash/lodash/issues/1313
  *
  * This helper function addresses the issue by always replacing the old array with the new array during the merge process.
+ * 
+ * This helper is also used for another case in rke2.vue to handle merging addon chart default values with the user's current values.
+ * It fixed https://github.com/rancher/dashboard/issues/12418
  */
 export function mergeWithReplaceArrays(obj1 = {}, obj2 = {}) {
-  return mergeWith(obj1, obj2, (obj1Value, obj2Value) => {
+  return mergeWith({}, obj1, obj2, (obj1Value, obj2Value) => {
     if (Array.isArray(obj1Value) && Array.isArray(obj2Value)) {
       return obj2Value;
     }

--- a/shell/utils/object.js
+++ b/shell/utils/object.js
@@ -491,9 +491,19 @@ export function deepToRaw(obj, cache = new WeakSet()) {
  *
  * This helper is also used for another case in rke2.vue to handle merging addon chart default values with the user's current values.
  * It fixed https://github.com/rancher/dashboard/issues/12418
+ *
+ * If `mutateOriginal` is true, the merge is done directly into `obj1` (mutating it).
+ * This is useful in cases like:
+ *   machinePool.config = mergeWithReplaceArrays(clonedLatestConfig, clonedCurrentConfig, true)
+ * where merging into a new empty object may lead to incomplete structure.
+ *
+ * Use `mutateOriginal` when you want to preserve obj1’s original shape, references,
+ * or when assigning the result directly to an existing object.
  */
-export function mergeWithReplaceArrays(obj1 = {}, obj2 = {}) {
-  return mergeWith({}, obj1, obj2, (obj1Value, obj2Value) => {
+export function mergeWithReplaceArrays(obj1 = {}, obj2 = {}, mutateOriginal = false) {
+  const destination = mutateOriginal ? obj1 : {};
+
+  return mergeWith(destination, obj1, obj2, (obj1Value, obj2Value) => {
     if (Array.isArray(obj1Value) && Array.isArray(obj2Value)) {
       return obj2Value;
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12418 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

We had to revert the previous fix for the issue since it caused a regression. This PR addresses the issue again without causing a regression.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The reason behind the regression was mutating the original object when merging the default values with the user's current values. Now, by passing an empty object as the first argument to the Lodash's `mergeWith` function, we clone the object so the original object doesn't get mutated anymore.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
We have unit tests for the helper function in `shell/utils/__tests__/object.test.ts`, but a manual test should be done

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
We need to re-test [this issue](https://github.com/rancher/dashboard/issues/13768)

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/369dafe6-7761-4c4f-8c53-a74ef6e44329


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
