### PR TITLE
Replace container logs actions with new dropdown menu component

### DIFF
--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdown.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdown.vue
@@ -121,6 +121,7 @@ const applyShow = () => {
         }
 
         .v-popper__inner {
+          overflow: unset;
           padding: 10px 0 10px 0;
         }
       }

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownItem.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownItem.vue
@@ -2,56 +2,12 @@
 /**
  * An item for a dropdown menu. Used in conjunction with RcDropdown.
  */
-import { inject } from 'vue';
-import { DropdownContext, defaultContext } from './types';
+import { useDropdownItem } from '@components/RcDropdown/useDropdownItem';
 
 const props = defineProps({ disabled: Boolean });
 const emits = defineEmits(['click']);
 
-const { close, dropdownItems } = inject<DropdownContext>('dropdownContext') || defaultContext;
-
-/**
- * Handles keydown events to navigate between dropdown items.
- * @param {KeyboardEvent} e - The keydown event.
- */
-const handleKeydown = (e: KeyboardEvent) => {
-  const activeItem = document.activeElement;
-
-  const activeIndex = dropdownItems.value.indexOf(activeItem || new HTMLElement());
-
-  if (activeIndex < 0) {
-    return;
-  }
-
-  const shouldAdvance = e.key === 'ArrowDown';
-
-  const newIndex = findNewIndex(shouldAdvance, activeIndex, dropdownItems.value);
-
-  if (dropdownItems.value[newIndex] instanceof HTMLElement) {
-    dropdownItems.value[newIndex].focus();
-  }
-};
-
-/**
- * Finds the new index for the dropdown item based on the key pressed.
- * @param shouldAdvance - Whether to advance to the next or previous item.
- * @param activeIndex - Current active index.
- * @param itemsArr - Array of dropdown items.
- * @returns The new index.
- */
-const findNewIndex = (shouldAdvance: boolean, activeIndex: number, itemsArr: Element[]) => {
-  const newIndex = shouldAdvance ? activeIndex + 1 : activeIndex - 1;
-
-  if (newIndex > itemsArr.length - 1) {
-    return 0;
-  }
-
-  if (newIndex < 0) {
-    return itemsArr.length - 1;
-  }
-
-  return newIndex;
-};
+const { handleKeydown, close, handleActivate } = useDropdownItem();
 
 const handleClick = (e: MouseEvent) => {
   if (props.disabled) {
@@ -62,15 +18,6 @@ const handleClick = (e: MouseEvent) => {
   close();
 };
 
-/**
- * Handles keydown events to activate the dropdown item.
- * @param e - The keydown event.
- */
-const handleActivate = (e: KeyboardEvent) => {
-  if (e?.target instanceof HTMLElement) {
-    e?.target?.click();
-  }
-};
 </script>
 
 <template>

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownItemCheckbox.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownItemCheckbox.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+/**
+ * An item for a dropdown menu. Used in conjunction with RcDropdown.
+ */
+import { Checkbox as RcCheckbox } from '@components/Form/Checkbox';
+import { useDropdownItem } from '@components/RcDropdown/useDropdownItem';
+
+const props = defineProps({ modelValue: Boolean, disabled: Boolean });
+const emits = defineEmits(['click']);
+
+const { handleKeydown, handleActivate } = useDropdownItem();
+
+const handleClick = () => {
+  if (props.disabled) {
+    return;
+  }
+
+  emits('click', !props.modelValue);
+};
+</script>
+
+<template>
+  <div
+    ref="dropdownMenuItem"
+    dropdown-menu-item
+    tabindex="-1"
+    role="menuitemcheckbox"
+    :disabled="disabled || null"
+    :aria-disabled="disabled || false"
+    @click.stop="handleClick"
+    @keydown.enter.space="handleActivate"
+    @keydown.up.down.prevent.stop="handleKeydown"
+  >
+    <rc-checkbox :value="modelValue">
+      <template #label>
+        <slot name="default">
+          <!--Empty slot content-->
+        </slot>
+      </template>
+    </rc-checkbox>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  [dropdown-menu-item] {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    padding: 9px 8px;
+    margin: 0 9px;
+    border-radius: 4px;
+
+    &:hover {
+      cursor: pointer;
+      background-color: var(--dropdown-hover-bg);
+    }
+    &:focus-visible, &:focus {
+      @include focus-outline;
+      outline-offset: 0;
+    }
+    &[disabled] {
+      color: var(--disabled-text);
+      &:hover {
+        cursor: not-allowed;
+      }
+    }
+  }
+</style>

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownItemSelect.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownItemSelect.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+/**
+ * An item for a dropdown menu. Used in conjunction with RcDropdown.
+ */
+import LabeledSelect from '@shell/components/form/LabeledSelect';
+import { useDropdownItem } from '@components/RcDropdown/useDropdownItem';
+import { ref } from 'vue';
+
+defineProps({
+  modelValue: {
+    type:    String,
+    default: ''
+  },
+  disabled: Boolean,
+  options:  {
+    type: Array,
+    default() {
+      return [];
+    }
+  },
+});
+const emits = defineEmits(['click', 'select']);
+
+const { handleKeydown, handleActivate } = useDropdownItem();
+
+const dropdownMenuItem = ref<HTMLDivElement | null>(null);
+const menuItemSelect = ref<any>(null);
+
+const handleClick = () => {
+  menuItemSelect?.value?.focusSearch();
+};
+
+const focusMenuItem = () => {
+  dropdownMenuItem?.value?.focus();
+};
+</script>
+
+<template>
+  <div
+    ref="dropdownMenuItem"
+    dropdown-menu-item
+    tabindex="-1"
+    role="menuitemselect"
+    :disabled="disabled || null"
+    :aria-disabled="disabled || false"
+    @click.stop="handleClick"
+    @keydown.enter.space="handleActivate"
+    @keydown.up.down.prevent.stop="handleKeydown"
+  >
+    <LabeledSelect
+      ref="menuItemSelect"
+      :value="modelValue"
+      :label="t('wm.containerLogs.range.label')"
+      :options="options"
+      :clearable="false"
+      placement="top"
+      @keydown.enter.stop
+      @update:value="emits('select', $event)"
+      @on-close="focusMenuItem"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  [dropdown-menu-item] {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    padding: 9px 8px;
+    margin: 0 9px;
+    border-radius: 4px;
+
+    &:hover {
+      cursor: pointer;
+      background-color: var(--dropdown-hover-bg);
+    }
+    &:focus-visible, &:focus {
+      @include focus-outline;
+      outline-offset: 0;
+    }
+    &[disabled] {
+      color: var(--disabled-text);
+      &:hover {
+        cursor: not-allowed;
+      }
+    }
+  }
+</style>

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownItemSelect.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownItemSelect.vue
@@ -6,6 +6,10 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { useDropdownItem } from '@components/RcDropdown/useDropdownItem';
 import { ref } from 'vue';
 
+type LabeledSelectComponent = {
+  focusSearch: () => void;
+};
+
 defineProps({
   modelValue: {
     type:    String,
@@ -24,7 +28,7 @@ const emits = defineEmits(['click', 'select']);
 const { handleKeydown, handleActivate } = useDropdownItem();
 
 const dropdownMenuItem = ref<HTMLDivElement | null>(null);
-const menuItemSelect = ref<any>(null);
+const menuItemSelect = ref<LabeledSelectComponent | null>(null);
 
 const handleClick = () => {
   menuItemSelect?.value?.focusSearch();
@@ -40,7 +44,7 @@ const focusMenuItem = () => {
     ref="dropdownMenuItem"
     dropdown-menu-item
     tabindex="-1"
-    role="menuitemselect"
+    role="menuitem"
     :disabled="disabled || null"
     :aria-disabled="disabled || false"
     @click.stop="handleClick"

--- a/pkg/rancher-components/src/components/RcDropdown/index.ts
+++ b/pkg/rancher-components/src/components/RcDropdown/index.ts
@@ -1,5 +1,6 @@
 export { default as RcDropdown } from './RcDropdown.vue';
 export { default as RcDropdownItem } from './RcDropdownItem.vue';
+export { default as RcDropdownItemCheckbox } from './RcDropdownItemCheckbox.vue';
 export { default as RcDropdownSeparator } from './RcDropdownSeparator.vue';
 export { default as RcDropdownTrigger } from './RcDropdownTrigger.vue';
 export { default as RcDropdownMenu } from './RcDropdownMenu.vue';

--- a/pkg/rancher-components/src/components/RcDropdown/index.ts
+++ b/pkg/rancher-components/src/components/RcDropdown/index.ts
@@ -1,6 +1,7 @@
 export { default as RcDropdown } from './RcDropdown.vue';
 export { default as RcDropdownItem } from './RcDropdownItem.vue';
 export { default as RcDropdownItemCheckbox } from './RcDropdownItemCheckbox.vue';
+export { default as RcDropdownItemSelect } from './RcDropdownItemSelect.vue';
 export { default as RcDropdownSeparator } from './RcDropdownSeparator.vue';
 export { default as RcDropdownTrigger } from './RcDropdownTrigger.vue';
 export { default as RcDropdownMenu } from './RcDropdownMenu.vue';

--- a/pkg/rancher-components/src/components/RcDropdown/useDropdownItem.ts
+++ b/pkg/rancher-components/src/components/RcDropdown/useDropdownItem.ts
@@ -1,0 +1,63 @@
+import { inject } from 'vue';
+import { DropdownContext, defaultContext } from './types';
+
+export const useDropdownItem = () => {
+  const { dropdownItems, close } = inject<DropdownContext>('dropdownContext') || defaultContext;
+
+  /**
+   * Handles keydown events to navigate between dropdown items.
+   * @param {KeyboardEvent} e - The keydown event.
+   */
+  const handleKeydown = (e: KeyboardEvent) => {
+    const activeItem = document.activeElement;
+
+    const activeIndex = dropdownItems.value.indexOf(activeItem || new HTMLElement());
+
+    if (activeIndex < 0) {
+      return;
+    }
+
+    const shouldAdvance = e.key === 'ArrowDown';
+
+    const newIndex = findNewIndex(shouldAdvance, activeIndex, dropdownItems.value);
+
+    if (dropdownItems.value[newIndex] instanceof HTMLElement) {
+      dropdownItems.value[newIndex].focus();
+    }
+  };
+
+  /**
+   * Finds the new index for the dropdown item based on the key pressed.
+   * @param shouldAdvance - Whether to advance to the next or previous item.
+   * @param activeIndex - Current active index.
+   * @param itemsArr - Array of dropdown items.
+   * @returns The new index.
+   */
+  const findNewIndex = (shouldAdvance: boolean, activeIndex: number, itemsArr: Element[]) => {
+    const newIndex = shouldAdvance ? activeIndex + 1 : activeIndex - 1;
+
+    if (newIndex > itemsArr.length - 1) {
+      return 0;
+    }
+
+    if (newIndex < 0) {
+      return itemsArr.length - 1;
+    }
+
+    return newIndex;
+  };
+
+  /**
+   * Handles keydown events to activate the dropdown item.
+   * @param e - The keydown event.
+   */
+  const handleActivate = (e: KeyboardEvent) => {
+    if (e?.target instanceof HTMLElement) {
+      e?.target?.click();
+    }
+  };
+
+  return {
+    handleKeydown, close, handleActivate
+  };
+};

--- a/shell/components/LocaleSelector.vue
+++ b/shell/components/LocaleSelector.vue
@@ -4,7 +4,7 @@ import Select from '@shell/components/form/Select.vue';
 import { RcDropdown, RcDropdownTrigger, RcDropdownItem } from '@components/RcDropdown';
 
 export default {
-  name: 'LocalSelector',
+  name: 'LocaleSelector',
 
   components: {
     Select,

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -160,21 +160,6 @@ export default {
         return;
       }
 
-      // we need this override as in a "closeOnSelect" type of component
-      // if we don't have this override, it would open again
-      if (this.overridesMixinPreventDoubleTriggerKeysOpen) {
-        this.$nextTick(() => {
-          const el = this.$refs['select'];
-
-          if ( el ) {
-            el.focus();
-          }
-
-          this.overridesMixinPreventDoubleTriggerKeysOpen = false;
-        });
-
-        return;
-      }
       this.$refs['select-input'].open = true;
 
       this.$nextTick(() => {
@@ -354,6 +339,7 @@ export default {
       @close="onClose"
       @option:selecting="$emit('selecting', $event)"
       @option:deselecting="$emit('deselecting', $event)"
+      @keydown.enter.stop
     >
       <template #option="option">
         <template v-if="showTagPrompts">

--- a/shell/components/form/Select.vue
+++ b/shell/components/form/Select.vue
@@ -125,21 +125,6 @@ export default {
     },
 
     focusSearch() {
-      // we need this override as in a "closeOnSelect" type of component
-      // if we don't have this override, it would open again
-      if (this.overridesMixinPreventDoubleTriggerKeysOpen) {
-        this.$nextTick(() => {
-          const el = this.$refs['select'];
-
-          if ( el ) {
-            el.focus();
-          }
-
-          this.overridesMixinPreventDoubleTriggerKeysOpen = false;
-        });
-
-        return;
-      }
       this.$refs['select-input'].open = true;
 
       this.$nextTick(() => {
@@ -317,6 +302,7 @@ export default {
       @open="onOpen"
       @close="onClose"
       @option:created="(e) => $emit('createdListItem', e)"
+      @keydown.enter.stop
     >
       <template
         #option="option"

--- a/shell/components/nav/WindowManager/ContainerLogs.vue
+++ b/shell/components/nav/WindowManager/ContainerLogs.vue
@@ -12,7 +12,9 @@ import VirtualList from 'vue3-virtual-scroll-list';
 import LogItem from '@shell/components/LogItem';
 import ContainerLogsActions from '@shell/components/nav/WindowManager/ContainerLogsActions.vue';
 import { shallowRef } from 'vue';
+import { useStore } from 'vuex';
 import { debounce } from 'lodash';
+import { useRuntimeFlag } from '@shell/composables/useRuntimeFlag';
 
 import { escapeRegex } from '@shell/utils/string';
 import { HARVESTER_NAME as VIRTUAL } from '@shell/config/features';
@@ -130,6 +132,13 @@ export default {
       type:    String,
       default: null,
     }
+  },
+
+  setup() {
+    const store = useStore();
+    const { featureDropdownMenu } = useRuntimeFlag(store);
+
+    return { featureDropdownMenu };
   },
 
   data() {
@@ -639,81 +648,85 @@ export default {
         </div>
 
         <div class="log-action log-action-group ml-5">
-          <ContainerLogsActions
-            :range="range"
-            :range-options="rangeOptions"
-            :wrap="wrap"
-            :timestamps="timestamps"
-            @toggle-range="toggleRange"
-            @toggle-wrap="toggleWrap"
-            @toggle-timestamps="toggleTimestamps"
-          />
-          <div
-            role="menu"
-            tabindex="0"
-            :aria-label="t('wm.containerLogs.logActionMenu')"
-            @click="openContainerMenu"
-            @blur.capture="closeContainerMenu"
-            @keyup.enter="openContainerMenu"
-            @keyup.space="openContainerMenu"
-          >
-            <v-dropdown
-              :triggers="[]"
-              :shown="isContainerMenuOpen"
-              placement="top"
-              popperClass="containerLogsDropdown"
-              :autoHide="false"
-              :flip="false"
-              :container="false"
-              @focus.capture="openContainerMenu"
+          <template v-if="featureDropdownMenu">
+            <ContainerLogsActions
+              :range="range"
+              :range-options="rangeOptions"
+              :wrap="wrap"
+              :timestamps="timestamps"
+              @toggle-range="toggleRange"
+              @toggle-wrap="toggleWrap"
+              @toggle-timestamps="toggleTimestamps"
+            />
+          </template>
+          <template v-else>
+            <div
+              role="menu"
+              tabindex="0"
+              :aria-label="t('wm.containerLogs.logActionMenu')"
+              @click="openContainerMenu"
+              @blur.capture="closeContainerMenu"
+              @keyup.enter="openContainerMenu"
+              @keyup.space="openContainerMenu"
             >
-              <button
-                class="btn role-primary btn-cog"
-                role="button"
-                :aria-label="t('wm.containerLogs.options')"
+              <v-dropdown
+                :triggers="[]"
+                :shown="isContainerMenuOpen"
+                placement="top"
+                popperClass="containerLogsDropdown"
+                :autoHide="false"
+                :flip="false"
+                :container="false"
+                @focus.capture="openContainerMenu"
               >
-                <i
-                  class="icon icon-gear"
-                  :alt="t('wm.containerLogs.options')"
-                />
-                <i
-                  class="icon icon-chevron-up"
-                  :alt="t('wm.containerLogs.expand')"
-                />
-              </button>
-
-              <template #popper>
-                <div class="filter-popup">
-                  <LabeledSelect
-                    v-model:value="range"
-                    class="range"
-                    :label="t('wm.containerLogs.range.label')"
-                    :options="rangeOptions"
-                    :clearable="false"
-                    placement="top"
-                    role="menuitem"
-                    @update:value="toggleRange($event)"
+                <button
+                  class="btn role-primary btn-cog"
+                  role="button"
+                  :aria-label="t('wm.containerLogs.options')"
+                >
+                  <i
+                    class="icon icon-gear"
+                    :alt="t('wm.containerLogs.options')"
                   />
-                  <div>
-                    <Checkbox
-                      :label="t('wm.containerLogs.wrap')"
-                      :value="wrap"
+                  <i
+                    class="icon icon-chevron-up"
+                    :alt="t('wm.containerLogs.expand')"
+                  />
+                </button>
+
+                <template #popper>
+                  <div class="filter-popup">
+                    <LabeledSelect
+                      v-model:value="range"
+                      class="range"
+                      :label="t('wm.containerLogs.range.label')"
+                      :options="rangeOptions"
+                      :clearable="false"
+                      placement="top"
                       role="menuitem"
-                      @update:value="toggleWrap"
+                      @update:value="toggleRange($event)"
                     />
+                    <div>
+                      <Checkbox
+                        :label="t('wm.containerLogs.wrap')"
+                        :value="wrap"
+                        role="menuitem"
+                        @update:value="toggleWrap"
+                      />
+                    </div>
+                    <div>
+                      <Checkbox
+                        :label="t('wm.containerLogs.timestamps')"
+                        :value="timestamps"
+                        role="menuitem"
+                        @update:value="toggleTimestamps"
+                      />
+                    </div>
                   </div>
-                  <div>
-                    <Checkbox
-                      :label="t('wm.containerLogs.timestamps')"
-                      :value="timestamps"
-                      role="menuitem"
-                      @update:value="toggleTimestamps"
-                    />
-                  </div>
-                </div>
-              </template>
-            </v-dropdown>
-          </div>
+                </template>
+              </v-dropdown>
+            </div>
+          </template>
         </div>
 
         <div class="log-action log-action-group ml-5">

--- a/shell/components/nav/WindowManager/ContainerLogs.vue
+++ b/shell/components/nav/WindowManager/ContainerLogs.vue
@@ -12,6 +12,12 @@ import VirtualList from 'vue3-virtual-scroll-list';
 import LogItem from '@shell/components/LogItem';
 import { shallowRef } from 'vue';
 import { debounce } from 'lodash';
+import {
+  RcDropdown,
+  RcDropdownTrigger,
+  RcDropdownItemCheckbox,
+  RcDropdownItemSelect,
+} from '@components/RcDropdown';
 
 import { escapeRegex } from '@shell/utils/string';
 import { HARVESTER_NAME as VIRTUAL } from '@shell/config/features';
@@ -91,6 +97,10 @@ export default {
     Checkbox,
     AsyncButton,
     VirtualList,
+    RcDropdown,
+    RcDropdownTrigger,
+    RcDropdownItemCheckbox,
+    RcDropdownItemSelect,
   },
 
   props: {
@@ -145,7 +155,8 @@ export default {
       lines:               [],
       now:                 new Date(),
       logItem:             shallowRef(LogItem),
-      isContainerMenuOpen: false
+      isContainerMenuOpen: false,
+      range:               '',
     };
   },
 
@@ -636,6 +647,39 @@ export default {
         </div>
 
         <div class="log-action log-action-group ml-5">
+          <rc-dropdown>
+            <rc-dropdown-trigger class="condensed">
+              <i
+                class="icon icon-gear"
+                :alt="t('wm.containerLogs.options')"
+              />
+              <template #after>
+                <i
+                  class="icon icon-chevron-up"
+                  :alt="t('wm.containerLogs.expand')"
+                />
+              </template>
+            </rc-dropdown-trigger>
+            <template #dropdownCollection>
+              <rc-dropdown-item-select
+                :model-value="range"
+                :options="rangeOptions"
+                @select="toggleRange($event)"
+              />
+              <rc-dropdown-item-checkbox
+                :model-value="wrap"
+                @click="toggleWrap"
+              >
+                {{ t('wm.containerLogs.wrap') }}
+              </rc-dropdown-item-checkbox>
+              <rc-dropdown-item-checkbox
+                :model-value="timestamps"
+                @click="toggleTimestamps"
+              >
+                {{ t('wm.containerLogs.timestamps') }}
+              </rc-dropdown-item-checkbox>
+            </template>
+          </rc-dropdown>
           <div
             role="menu"
             tabindex="0"
@@ -873,5 +917,10 @@ export default {
         }
       }
     }
+  }
+
+  .condensed {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
   }
 </style>

--- a/shell/components/nav/WindowManager/ContainerLogs.vue
+++ b/shell/components/nav/WindowManager/ContainerLogs.vue
@@ -10,14 +10,9 @@ import AsyncButton from '@shell/components/AsyncButton';
 import Select from '@shell/components/form/Select';
 import VirtualList from 'vue3-virtual-scroll-list';
 import LogItem from '@shell/components/LogItem';
+import ContainerLogsActions from '@shell/components/nav/WindowManager/ContainerLogsActions.vue';
 import { shallowRef } from 'vue';
 import { debounce } from 'lodash';
-import {
-  RcDropdown,
-  RcDropdownTrigger,
-  RcDropdownItemCheckbox,
-  RcDropdownItemSelect,
-} from '@components/RcDropdown';
 
 import { escapeRegex } from '@shell/utils/string';
 import { HARVESTER_NAME as VIRTUAL } from '@shell/config/features';
@@ -97,10 +92,7 @@ export default {
     Checkbox,
     AsyncButton,
     VirtualList,
-    RcDropdown,
-    RcDropdownTrigger,
-    RcDropdownItemCheckbox,
-    RcDropdownItemSelect,
+    ContainerLogsActions,
   },
 
   props: {
@@ -647,39 +639,15 @@ export default {
         </div>
 
         <div class="log-action log-action-group ml-5">
-          <rc-dropdown>
-            <rc-dropdown-trigger class="condensed">
-              <i
-                class="icon icon-gear"
-                :alt="t('wm.containerLogs.options')"
-              />
-              <template #after>
-                <i
-                  class="icon icon-chevron-up"
-                  :alt="t('wm.containerLogs.expand')"
-                />
-              </template>
-            </rc-dropdown-trigger>
-            <template #dropdownCollection>
-              <rc-dropdown-item-select
-                :model-value="range"
-                :options="rangeOptions"
-                @select="toggleRange($event)"
-              />
-              <rc-dropdown-item-checkbox
-                :model-value="wrap"
-                @click="toggleWrap"
-              >
-                {{ t('wm.containerLogs.wrap') }}
-              </rc-dropdown-item-checkbox>
-              <rc-dropdown-item-checkbox
-                :model-value="timestamps"
-                @click="toggleTimestamps"
-              >
-                {{ t('wm.containerLogs.timestamps') }}
-              </rc-dropdown-item-checkbox>
-            </template>
-          </rc-dropdown>
+          <ContainerLogsActions
+            :range="range"
+            :range-options="rangeOptions"
+            :wrap="wrap"
+            :timestamps="timestamps"
+            @toggle-range="toggleRange"
+            @toggle-wrap="toggleWrap"
+            @toggle-timestamps="toggleTimestamps"
+          />
           <div
             role="menu"
             tabindex="0"
@@ -919,8 +887,4 @@ export default {
     }
   }
 
-  .condensed {
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
-  }
 </style>

--- a/shell/components/nav/WindowManager/ContainerLogsActions.vue
+++ b/shell/components/nav/WindowManager/ContainerLogsActions.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import {
+  RcDropdown,
+  RcDropdownTrigger,
+  RcDropdownItemCheckbox,
+  RcDropdownItemSelect,
+} from '@components/RcDropdown';
+
+defineProps({
+  range: {
+    type:    String,
+    default: '',
+  },
+  rangeOptions: {
+    type: Array,
+    default() {
+      return [];
+    },
+  },
+  wrap:       Boolean,
+  timestamps: Boolean,
+});
+
+defineEmits([
+  'toggleRange',
+  'toggleWrap',
+  'toggleTimestamps',
+]);
+
+</script>
+
+<template>
+  <rc-dropdown>
+    <rc-dropdown-trigger
+      class="condensed"
+    >
+      <i
+        class="icon icon-gear"
+        :alt="t('wm.containerLogs.options')"
+      />
+      <template #after>
+        <i
+          class="icon icon-chevron-up"
+          :alt="t('wm.containerLogs.expand')"
+        />
+      </template>
+    </rc-dropdown-trigger>
+    <template #dropdownCollection>
+      <rc-dropdown-item-select
+        :model-value="range"
+        :options="rangeOptions"
+        @select="$emit('toggleRange', $event)"
+      />
+      <rc-dropdown-item-checkbox
+        :model-value="wrap"
+        @click="$emit('toggleWrap', $event)"
+      >
+        {{ t('wm.containerLogs.wrap') }}
+      </rc-dropdown-item-checkbox>
+      <rc-dropdown-item-checkbox
+        :model-value="timestamps"
+        @click="$emit('toggleTimestamps', $event)"
+      >
+        {{ t('wm.containerLogs.timestamps') }}
+      </rc-dropdown-item-checkbox>
+    </template>
+  </rc-dropdown>
+</template>
+
+<style lang="scss" scoped>
+  .condensed {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    min-height: 30px;
+  }
+</style>

--- a/shell/mixins/vue-select-overrides.js
+++ b/shell/mixins/vue-select-overrides.js
@@ -1,8 +1,5 @@
 
 export default {
-  data() {
-    return { overridesMixinPreventDoubleTriggerKeysOpen: false };
-  },
   methods: {
     mappedKeys(map, vm) {
       // Defaults found at - https://github.com/sagalbot/vue-select/blob/master/src/components/Select.vue#L947
@@ -63,7 +60,6 @@ export default {
           if (vm.closeOnSelect) {
             // this ties in to the Select component implementation
             // so that the enter key handler doesn't open the dropdown again
-            this.overridesMixinPreventDoubleTriggerKeysOpen = false;
             vm.open = false;
             vm.typeAheadPointer = -1;
           }

--- a/shell/mixins/vue-select-overrides.js
+++ b/shell/mixins/vue-select-overrides.js
@@ -63,7 +63,7 @@ export default {
           if (vm.closeOnSelect) {
             // this ties in to the Select component implementation
             // so that the enter key handler doesn't open the dropdown again
-            this.overridesMixinPreventDoubleTriggerKeysOpen = true;
+            this.overridesMixinPreventDoubleTriggerKeysOpen = false;
             vm.open = false;
             vm.typeAheadPointer = -1;
           }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This replaces the custom container actions dropdown menu with the new dropdown menu component.

Fixes #14157
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Create a new dropdown menu item checkbox component
- Create a new dropdown menu item select component
- Abstract duplicated dropdown menu item logic into new composable, `useDropdownItem`
- Create a dedicated component for comtainer logs actions
- Replace container logs actions implementation with new component

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I opted to keep the design as close as possible to the existing implementation. Unfortunately, this means that we are utilizing a non-standard pattern with the Labeled Select in the menu, but it keeps the design consistent with what we had before. I attempted to create a sub-menu abstraction that I had 90% working, but I was taking too much time to finalize the components; the approach that I took in this PR was much faster to implement. 

We can also take an alternative approach to implement the range select as a group of radio buttons, this would better adhere to design patterns prescribed by the APG. I would like to sync with @edenhernandez-suse so that we can settle on a preferred approach.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Container logs

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Container logs

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before

![image](https://github.com/user-attachments/assets/dcb80dd4-0604-4136-8755-cc304b7c1e1c)

![image](https://github.com/user-attachments/assets/951c1fc6-4851-404c-8c5a-49a81751080a)

#### After

![image](https://github.com/user-attachments/assets/b522a9ce-882e-4fb8-af30-4fe52db4deb3)

![image](https://github.com/user-attachments/assets/0566026f-8758-438f-8695-5bd6b5e7ccef)

![image](https://github.com/user-attachments/assets/b52eda26-074f-425e-bff9-3f34c48068ae)

![image](https://github.com/user-attachments/assets/b4978db5-04c6-437c-b9db-6f05ef367706)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
