### PR TITLE
Update AppModal, PromptModal and focusTrap

### DIFF
--- a/shell/components/AppModal.vue
+++ b/shell/components/AppModal.vue
@@ -86,32 +86,20 @@ export default defineComponent({
       default: DEFAULT_ITERABLE_NODE_SELECTOR,
     },
     /**
-     * trigger focus trap - but watcher based
-     */
-    triggerFocusTrapWatcherBased: {
-      type:    Boolean,
-      default: false,
-    },
-    /**
      * watcher-based focus trap variable to watch
      */
     focusTrapWatcherBasedVariable: {
       type:    Boolean,
       default: undefined,
     },
-    fakeWatchVar: {
+    /**
+     * prop used to immediately trigger the focus trap when a proper watch variable is not required
+     * will default to this prop IF there's no "focusTrapWatcherBasedVariable" being passed
+     * prop used only in setup (if you need a proper watcher variable, pass it via "focusTrapWatcherBasedVariable")
+     */
+    autoTriggerFocusTrapWatcher: {
       type:    Boolean,
       default: true,
-    },
-    /**
-     * property need to manipulate focus-trap lib for unit tests
-     * as per https://github.com/focus-trap/tabbable#common-options
-     * which has to be "none" in order for them to work
-     * manual test on Rancher Dashboard shows all modals work fine without this
-     */
-    fixUnitTestTrapOptions: {
-      type:    Boolean,
-      default: false,
     }
   },
   computed: {
@@ -139,13 +127,6 @@ export default defineComponent({
         width: this.modalWidth,
         ...this.stylesPropToObj,
       };
-    },
-    watcherVariableForFocusTrap(): boolean {
-      if (this.focusTrapWatcherBasedVariable !== undefined) {
-        return this.focusTrapWatcherBasedVariable;
-      }
-
-      return true;
     }
   },
   setup(props) {
@@ -170,12 +151,7 @@ export default defineComponent({
         };
       }
 
-      // needed as a workaround/fix for PromptModal unit tests
-      if (props.fixUnitTestTrapOptions) {
-        opts.tabbableOptions = { displayCheck: 'none' };
-      }
-
-      useWatcherBasedSetupFocusTrapWithDestroyIncluded(() => props.focusTrapWatcherBasedVariable !== undefined ? props.focusTrapWatcherBasedVariable : props.fakeWatchVar, '#modal-container-element', opts, true);
+      useWatcherBasedSetupFocusTrapWithDestroyIncluded(() => props.focusTrapWatcherBasedVariable ?? props.autoTriggerFocusTrapWatcher, '#modal-container-element', opts, true);
     }
   },
   mounted() {

--- a/shell/components/AppModal.vue
+++ b/shell/components/AppModal.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, ref } from 'vue';
 import {
   DEFAULT_FOCUS_TRAP_OPTS,
   getFirstFocusableElement,
@@ -91,15 +91,6 @@ export default defineComponent({
     focusTrapWatcherBasedVariable: {
       type:    Boolean,
       default: undefined,
-    },
-    /**
-     * prop used to immediately trigger the focus trap when a proper watch variable is not required
-     * will default to this prop IF there's no "focusTrapWatcherBasedVariable" being passed
-     * prop used only in setup (if you need a proper watcher variable, pass it via "focusTrapWatcherBasedVariable")
-     */
-    autoTriggerFocusTrapWatcher: {
-      type:    Boolean,
-      default: true,
     }
   },
   computed: {
@@ -151,7 +142,10 @@ export default defineComponent({
         };
       }
 
-      useWatcherBasedSetupFocusTrapWithDestroyIncluded(() => props.focusTrapWatcherBasedVariable ?? props.autoTriggerFocusTrapWatcher, '#modal-container-element', opts, true);
+      // prop used to immediately trigger the focus trap when a proper watch variable is not required
+      const autoTriggerFocusTrapWatcher = ref(true);
+
+      useWatcherBasedSetupFocusTrapWithDestroyIncluded(() => props.focusTrapWatcherBasedVariable ?? autoTriggerFocusTrapWatcher, '#modal-container-element', opts, true);
     }
   },
   mounted() {

--- a/shell/components/PromptModal.vue
+++ b/shell/components/PromptModal.vue
@@ -14,15 +14,15 @@ export default {
 
   data() {
     return {
-      opened:            false,
-      backgroundClosing: null,
-      componentRendered: false
+      opened:                 false,
+      fixUnitTestTrapOptions: false,
+      backgroundClosing:      null,
+      componentRendered:      false
     };
   },
 
   computed: {
     ...mapState('action-menu', ['showModal', 'modalData']),
-
     resources() {
       let resources = this.modalData?.resources;
 
@@ -32,10 +32,27 @@ export default {
 
       return resources || [];
     },
-
+    testId() {
+      return this.modalData?.testId || 'prompt-modal-generic-testid';
+    },
+    returnFocusSelector() {
+      return this.modalData?.returnFocusSelector || undefined;
+    },
+    returnFocusFirstIterableNodeSelector() {
+      return this.modalData?.returnFocusFirstIterableNodeSelector || undefined;
+    },
     modalWidth() {
       // property set from workload.js to overwrite modal default width of 600px, with fallback value as well
       return this.modalData?.modalWidth || '600px';
+    },
+    customClass() {
+      return this.modalData?.customClass || undefined;
+    },
+    styles() {
+      return this.modalData?.styles || undefined;
+    },
+    height() {
+      return this.modalData?.height || undefined;
     },
     component() {
       // Looks for a dialog component by looking up in plugins and @shell/dialog/${name}.
@@ -52,6 +69,9 @@ export default {
     },
     closeOnClickOutside() {
       return this.modalData?.closeOnClickOutside;
+    },
+    modalName() {
+      return this.modalData?.modalName;
     }
   },
 
@@ -93,10 +113,18 @@ export default {
 <template>
   <app-modal
     v-if="opened && component"
+    :name="modalName"
     :click-to-close="closeOnClickOutside"
     :width="modalWidth"
-    :trigger-focus-trap-watcher-based="true"
+    :data-testid="testId"
+    :custom-class="customClass"
+    :styles="styles"
+    :height="height"
+    :trigger-focus-trap="true"
+    :return-focus-selector="returnFocusSelector"
+    :return-focus-first-iterable-node-selector="returnFocusFirstIterableNodeSelector"
     :focus-trap-watcher-based-variable="componentRendered"
+    :fix-unit-test-trap-options="fixUnitTestTrapOptions"
     @close="close()"
   >
     <component

--- a/shell/components/PromptModal.vue
+++ b/shell/components/PromptModal.vue
@@ -14,10 +14,9 @@ export default {
 
   data() {
     return {
-      opened:                 false,
-      fixUnitTestTrapOptions: false,
-      backgroundClosing:      null,
-      componentRendered:      false
+      opened:            false,
+      backgroundClosing: null,
+      componentRendered: false
     };
   },
 
@@ -124,7 +123,6 @@ export default {
     :return-focus-selector="returnFocusSelector"
     :return-focus-first-iterable-node-selector="returnFocusFirstIterableNodeSelector"
     :focus-trap-watcher-based-variable="componentRendered"
-    :fix-unit-test-trap-options="fixUnitTestTrapOptions"
     @close="close()"
   >
     <component

--- a/shell/components/__tests__/PromptModal.test.ts
+++ b/shell/components/__tests__/PromptModal.test.ts
@@ -95,7 +95,7 @@ describe('component: PromptModal', () => {
       {
         attachTo: document.body,
         data() {
-          return { opened: true }; // this controls modal content visibility
+          return { opened: true }; // this controls modal content visibility //
         },
         global: {
           mocks: {

--- a/shell/components/__tests__/PromptModal.test.ts
+++ b/shell/components/__tests__/PromptModal.test.ts
@@ -1,0 +1,116 @@
+import { mount } from '@vue/test-utils';
+import PromptModal from '@shell/components/PromptModal.vue';
+
+import GenericPrompt from '@shell/dialog/GenericPrompt.vue';
+import AddClusterMemberDialog from '@shell/dialog/AddClusterMemberDialog.vue';
+import AddCustomBadgeDialog from '@shell/dialog/AddCustomBadgeDialog.vue';
+import AddonConfigConfirmationDialog from '@shell/dialog/AddonConfigConfirmationDialog.vue';
+import AddProjectMemberDialog from '@shell/dialog/AddProjectMemberDialog.vue';
+import DeactivateDriverDialog from '@shell/dialog/DeactivateDriverDialog.vue';
+import DiagnosticTimingsDialog from '@shell/dialog/DiagnosticTimingsDialog.vue';
+import DrainNode from '@shell/dialog/DrainNode.vue';
+import ForceMachineRemoveDialog from '@shell/dialog/ForceMachineRemoveDialog.vue';
+import GitRepoForceUpdateDialog from '@shell/dialog/GitRepoForceUpdateDialog.vue';
+import RollbackWorkloadDialog from '@shell/dialog/RollbackWorkloadDialog.vue';
+import RotateCertificatesDialog from '@shell/dialog/RotateCertificatesDialog.vue';
+import RotateEncryptionKeyDialog from '@shell/dialog/RotateEncryptionKeyDialog.vue';
+import SaveAsRKETemplateDialog from '@shell/dialog/SaveAsRKETemplateDialog.vue';
+import ScaleMachineDownDialog from '@shell/dialog/ScaleMachineDownDialog.vue';
+import ScalePoolDownDialog from '@shell/dialog/ScalePoolDownDialog.vue';
+import SloDialog from '@shell/dialog/SloDialog.vue';
+
+import { createStore } from 'vuex';
+
+jest.mock('@shell/utils/clipboard', () => {
+  return { copyTextToClipboard: jest.fn(() => Promise.resolve({})) };
+});
+
+function generateStore(component: any):any {
+  return createStore({
+    modules: { // promptModal
+      'action-menu': {
+        namespaced: true,
+        state:      {
+          modalData: {
+            closeOnClickOutside: true,
+            resources:           [{ cluster: { isRke2: true, machines: [] } }], // ScaleMachineDownDialog
+            componentProps:      {
+              drivers:             [], // DeactivateDriverDialog
+              driverType:          'kontainerDrivers', // DeactivateDriverDialog
+              downloadData:        () => jest.fn(), // DiagnosticTimingsDialog
+              gatherResponseTimes: () => jest.fn(), // DiagnosticTimingsDialog
+              kubeNodes:           [{}], // DrainNode
+              repositories:        [], // GitRepoForceUpdateDialog
+              workload:            { metadata: {}, kind: '' }, // RollbackWorkloadDialog
+              catalog:             {}
+            },
+          },
+
+        },
+      },
+    },
+    getters: {
+      'type-map/importDialog': () => () => component, // promptModal
+      'i18n/exists':           () => jest.fn(), // promptModal
+      'i18n/t':                () => jest.fn(), // general usage
+      'rancher/schemaFor':     () => jest.fn(), // general usage
+      'prefs/get':             () => jest.fn(), // ScalePoolDownDialog
+      'type-map/allTypes':     () => jest.fn(), // SearchDialog
+      'type-map/labelFor':     () => jest.fn(), // ScaleMachineDownDialog
+      'type-map/getTree':      () => jest.fn().mockReturnValue([]), // SearchDialog
+      'cluster/all':           () => jest.fn(), // SearchDialog
+      currentProduct:          () => { // SearchDialog
+        return { inStore: 'cluster' };
+      },
+      currentCluster: () => { // general usage
+        'local';
+      },
+    }
+  });
+}
+
+describe('component: PromptModal', () => {
+  it.each([
+    // current prompt modals at time of coding
+    ['GenericPrompt', GenericPrompt],
+    ['AddClusterMemberDialog', AddClusterMemberDialog],
+    ['AddonConfigConfirmationDialog', AddonConfigConfirmationDialog],
+    ['AddProjectMemberDialog', AddProjectMemberDialog],
+    ['DeactivateDriverDialog', DeactivateDriverDialog],
+    ['DiagnosticTimingsDialog', DiagnosticTimingsDialog],
+    ['DrainNode', DrainNode],
+    ['ForceMachineRemoveDialog', ForceMachineRemoveDialog],
+    ['GitRepoForceUpdateDialog', GitRepoForceUpdateDialog],
+    ['RollbackWorkloadDialog', RollbackWorkloadDialog],
+    ['RotateCertificatesDialog', RotateCertificatesDialog],
+    ['RotateEncryptionKeyDialog', RotateEncryptionKeyDialog],
+    ['SaveAsRKETemplateDialog', SaveAsRKETemplateDialog],
+    ['SloDialog', SloDialog],
+    ['AddCustomBadgeDialog', AddCustomBadgeDialog],
+    ['ScaleMachineDownDialog', ScaleMachineDownDialog],
+    ['ScalePoolDownDialog', ScalePoolDownDialog]
+  ])('prompt Modal should render modal %p', (modalName, component) => {
+    document.body.innerHTML = '<div id="modals"></div>';
+    const wrapper = mount(PromptModal,
+      {
+        attachTo: document.body,
+        data() {
+          return {
+            opened:                 true, // this controls modal content visibility
+            fixUnitTestTrapOptions: true // promptModal flag to allow unit tests to run on focus trap
+          };
+        },
+        global: {
+          mocks: {
+            $store:      generateStore(component),
+            $fetchState: {}
+          },
+          stubs: { transition: false }
+        }
+      }
+    );
+
+    expect(wrapper.vm.opened).toBe(true);
+    expect(wrapper.findComponent(component as any).exists()).toBe(true);
+  });
+});

--- a/shell/components/__tests__/PromptModal.test.ts
+++ b/shell/components/__tests__/PromptModal.test.ts
@@ -95,9 +95,7 @@ describe('component: PromptModal', () => {
       {
         attachTo: document.body,
         data() {
-          return {
-            opened:                 true, // this controls modal content visibility
-            fixUnitTestTrapOptions: true // promptModal flag to allow unit tests to run on focus trap
+          return { opened: true, // this controls modal content visibility
           };
         },
         global: {

--- a/shell/components/__tests__/PromptModal.test.ts
+++ b/shell/components/__tests__/PromptModal.test.ts
@@ -95,8 +95,7 @@ describe('component: PromptModal', () => {
       {
         attachTo: document.body,
         data() {
-          return { opened: true, // this controls modal content visibility
-          };
+          return { opened: true }; // this controls modal content visibility
         },
         global: {
           mocks: {

--- a/shell/composables/focusTrap.ts
+++ b/shell/composables/focusTrap.ts
@@ -61,14 +61,14 @@ export function useWatcherBasedSetupFocusTrapWithDestroyIncluded(watchVar:any, f
           focusTrapInstance.activate();
         });
       });
-    } else if (!neu && Object.keys(focusTrapInstance).length && !useUnmountHook) {
+    } else if (!neu && focusTrapInstance && Object.keys(focusTrapInstance).length && !useUnmountHook) {
       focusTrapInstance.deactivate();
     }
-  });
+  }, { immediate: true });
 
   if (useUnmountHook) {
     onBeforeUnmount(() => {
-      if (Object.keys(focusTrapInstance).length) {
+      if (focusTrapInstance && Object.keys(focusTrapInstance).length) {
         focusTrapInstance.deactivate();
       }
     });

--- a/shell/dialog/AddCustomBadgeDialog.vue
+++ b/shell/dialog/AddCustomBadgeDialog.vue
@@ -216,7 +216,6 @@ export default {
   >
     <template #title>
       <h4 class="text-default-text">
-        ALEX
         {{ t('clusterBadge.modal.title') }}
       </h4>
     </template>

--- a/shell/dialog/AddCustomBadgeDialog.vue
+++ b/shell/dialog/AddCustomBadgeDialog.vue
@@ -213,10 +213,10 @@ export default {
   <Card
     class="prompt-badge"
     :show-highlight-border="false"
-    :trigger-focus-trap="true"
   >
     <template #title>
       <h4 class="text-default-text">
+        ALEX
         {{ t('clusterBadge.modal.title') }}
       </h4>
     </template>

--- a/shell/dialog/DrainNode.vue
+++ b/shell/dialog/DrainNode.vue
@@ -137,7 +137,7 @@ export default {
           {{ t('drainNode.titleMultiple', { count: kubeNodes.length }) }}
         </template>
         <template v-else>
-          {{ t('drainNode.titleOne', { name: kubeNodes[0].name }, true) }}
+          {{ t('drainNode.titleOne', { name: kubeNodes[0]?.name }, true) }}
         </template>
       </h4>
     </template>

--- a/shell/dialog/ForceMachineRemoveDialog.vue
+++ b/shell/dialog/ForceMachineRemoveDialog.vue
@@ -34,7 +34,7 @@ export default {
     ...mapGetters({ t: 'i18n/t' }),
 
     nameToMatch() {
-      return this.machine.spec.infrastructureRef.name;
+      return this.machine?.spec?.infrastructureRef?.name;
     },
 
     deleteDisabled() {

--- a/shell/dialog/ScalePoolDownDialog.vue
+++ b/shell/dialog/ScalePoolDownDialog.vue
@@ -27,7 +27,7 @@ export default {
   },
   computed: {
     machinenName() {
-      const name = this.resources.length > 0 ? this.resources[0].id.split('/')[1] : '';
+      const name = this.resources.length > 0 ? this.resources[0]?.id?.split('/')[1] : '';
 
       return name;
     },

--- a/shell/utils/__mocks__/tabbable.js
+++ b/shell/utils/__mocks__/tabbable.js
@@ -1,0 +1,13 @@
+// __mocks__/tabbable.js
+
+const lib = jest.requireActual('tabbable');
+
+const tabbable = {
+  ...lib,
+  tabbable:    (node, options) => lib.tabbable(node, { ...options, displayCheck: 'none' }),
+  focusable:   (node, options) => lib.focusable(node, { ...options, displayCheck: 'none' }),
+  isFocusable: (node, options) => lib.isFocusable(node, { ...options, displayCheck: 'none' }),
+  isTabbable:  (node, options) => lib.isTabbable(node, { ...options, displayCheck: 'none' }),
+};
+
+module.exports = tabbable;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14221
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- update `AppModal`, `PromptModal` and `focusTrap` to use only the watcher based focus trap and wire in required props for prompt modals
- add unit test for currently existing prompt modals display assertion
- minor tweaks to current prompt modals so that they work fine on unit tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
I've had to create a new `PromptModal` prop called `fixUnitTestTrapOptions` so that we are able to run these unit tests without the `focusTrap` directive complaining that it cannot find a target node to focus on, as per https://github.com/focus-trap/tabbable#common-options + https://github.com/focus-trap/tabbable#testing-in-jsdom

It does not have any impact whatsoever on the `AppModal` because it's off by default. Manual tests on all modals changed by this PR reveal zero problems with the added bonus of them having a working focus trap by default.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- check `DrainNode` modal -> `node` list view table action
- check `AddCustomBadgeDialog` modal -> Cluster explorer OR cluster provisioning edit view (badge config)
- check `ScalePoolDownDialog` modal ->provisioning cluster detail view (machine pools)
- check `ForceMachineRemove` modal -> `cluster.x-k8s.io.machine` list view table action

Double-check other modals if you feel it's necessary (check promptmodal unit test)

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
