### PR TITLE
AKS-Allow version upgrade only from current version to > 1 minor version

### DIFF
--- a/pkg/aks/components/Config.vue
+++ b/pkg/aks/components/Config.vue
@@ -457,34 +457,45 @@ export default defineComponent({
 
     // filter out versions outside ui-k8s-supported-versions-range global setting and versions < current version
     // sort versions, descending
-    aksVersionOptions(): Array<any> {
-      const filteredAndSortable = this.allAksVersions.filter((v: string) => {
-        if (this.supportedVersionRange && !semver.satisfies(v, this.supportedVersionRange)) {
-          return false;
-        }
-        if (this.originalVersion && semver.gt(this.originalVersion, v)) {
-          return false;
-        }
+    aksVersionOptions(): { value: string, label: string, sort?: string, disabled?: boolean }[] {
+      const validVersions = this.allAksVersions.reduce((versions, v: string) => {
+        const coerced = semver.coerce(v);
 
-        return true;
-      }).map((v: string) => {
-        let label = v;
-
-        if (v === this.originalVersion) {
-          label = this.t('aks.kubernetesVersion.current', { version: v });
+        if (!coerced || (this.supportedVersionRange && !semver.satisfies(coerced.version, this.supportedVersionRange))) {
+          return versions;
         }
 
-        return {
-          value: v,
-          label,
-          sort:  sortable(v)
-        };
+        if (!this.originalVersion) {
+          versions.push({ value: v, label: v });
+        } else if (semver.lte(semver.coerce(this.originalVersion), coerced)) {
+          const highestSupportedMinor = semver.coerce(this.originalVersion)?.minor + 1;
+
+          if (highestSupportedMinor && highestSupportedMinor < coerced?.minor) {
+            versions.push({
+              value:    v,
+              label:    `${ v } ${ this.t('aks.kubernetesVersion.upgradeWarning') }`,
+              disabled: true
+            });
+          } else {
+            const label = v === this.originalVersion ? this.t('aks.kubernetesVersion.current', { version: v }) : v;
+
+            versions.push({ value: v, label });
+          }
+        }
+
+        return versions;
+      }, [] as { value: string, label: string, sort?: string, disabled?: boolean }[]);
+
+      validVersions.forEach((v) => {
+        v.sort = sortable(v.value);
       });
 
-      const sorted = sortBy(filteredAndSortable, 'sort', true);
+      const sorted = sortBy(validVersions, 'sort', true); // Descending order
 
       if (!this.config.kubernetesVersion) {
-        this.config['kubernetesVersion'] = sorted[0]?.value;
+        const firstValid = sorted.find((v) => !v.disabled);
+
+        this.config.kubernetesVersion = firstValid?.value;
       }
 
       return sorted;

--- a/pkg/aks/l10n/en-us.yaml
+++ b/pkg/aks/l10n/en-us.yaml
@@ -12,6 +12,7 @@ aks:
   kubernetesVersion:
     label: Kubernetes Version
     current: '{version} (Current)'
+    upgradeWarning: (minor version >1 not allowed by AKS)
     notAvailableInRegion: This version is not available in the selected region.
   nodeResourceGroup:
     tooltip: 'The cluster resource group contains the Kubernetes Service resource. The node resource group contains all infrastructure resources associated with the cluster. If left blank, Azure will automatically create a name in the format MC_resource-group_cluster-name_location. This value cannot exceed 80 characters.'


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes  https://github.com/rancher/dashboard/issues/11884
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
filters the available versions to only include versions that are:
- The same minor version as originalVersion
- OR Upgrades to one version above

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Create AKS cluster from Rancher UI and select lowest supported k8s version
- Upgrade version to highest supported version

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![image](https://github.com/user-attachments/assets/6d37e823-4b74-4fa5-99f2-c378428109b1)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
