### PR TITLE
Overwrite default chart values with user supplied values

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -22,7 +22,7 @@ import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
 import { findBy, removeObject, clear } from '@shell/utils/array';
 import { createYaml } from '@shell/utils/create-yaml';
 import {
-  clone, diff, set, get, isEmpty, mergeWithReplaceArrays
+  clone, diff, set, get, isEmpty, mergeWithReplace
 } from '@shell/utils/object';
 import { allHash } from '@shell/utils/promise';
 import {
@@ -1305,7 +1305,7 @@ export default {
         delete clonedCurrentConfig.metadata;
 
         if (this.provider === VMWARE_VSPHERE) {
-          machinePool.config = mergeWithReplaceArrays(clonedLatestConfig, clonedCurrentConfig, true);
+          machinePool.config = mergeWithReplace(clonedLatestConfig, clonedCurrentConfig, { mutateOriginal: true });
         } else {
           machinePool.config = merge(clonedLatestConfig, clonedCurrentConfig);
         }
@@ -1691,7 +1691,7 @@ export default {
       const defaultChartValue = this.versionInfo[name];
       const key = this.chartVersionKey(name);
 
-      return mergeWithReplaceArrays(defaultChartValue?.values, this.userChartValues[key]);
+      return mergeWithReplace(defaultChartValue?.values, this.userChartValues[key]);
     },
 
     initServerAgentArgs() {

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1,6 +1,8 @@
 <script>
 import jsyaml from 'js-yaml';
 import merge from 'lodash/merge';
+import mergeWith from 'lodash/mergeWith';
+import isObject from 'lodash/isObject';
 import isEqual from 'lodash/isEqual';
 import { mapPref, DIFF } from '@shell/store/prefs';
 import { mapFeature, MULTI_CLUSTER, LEGACY } from '@shell/store/features';
@@ -328,15 +330,29 @@ export default {
       */
       this.removeGlobalValuesFrom(userValues);
 
+      const userKeys = Object.keys(userValues);
+      const customizer = (objValue, srcValue, key) => {
+        if (userKeys.includes(key) && isObject(srcValue)) {
+          return {
+            ...objValue,
+            ...srcValue
+          };
+        }
+      };
+
       /*
-        The merge() method is used to merge two or more objects
+        The mergeWith() method is used to merge two or more objects
         starting with the left-most to the right-most to create a
         parent mapping object. When two keys are the same, the
         generated object will have value for the rightmost key.
-        In this case, any values in userValues override any
+        With the customizer, any values in userValues override any
         matching values in versionInfo.
       */
-      this.chartValues = merge(merge({}, this.versionInfo?.values || {}), userValues);
+      this.chartValues = mergeWith(
+        merge({}, this.versionInfo?.values || {}),
+        userValues,
+        customizer
+      );
 
       if (this.showCustomRegistry) {
         /**

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1,8 +1,6 @@
 <script>
 import jsyaml from 'js-yaml';
 import merge from 'lodash/merge';
-import mergeWith from 'lodash/mergeWith';
-import isObject from 'lodash/isObject';
 import isEqual from 'lodash/isEqual';
 import { mapPref, DIFF } from '@shell/store/prefs';
 import { mapFeature, MULTI_CLUSTER, LEGACY } from '@shell/store/features';
@@ -34,7 +32,9 @@ import {
 import { CATALOG as CATALOG_ANNOTATIONS, PROJECT } from '@shell/config/labels-annotations';
 
 import { exceptionToErrorsArray } from '@shell/utils/error';
-import { clone, diff, get, set } from '@shell/utils/object';
+import {
+  clone, diff, get, mergeWithReplace, set
+} from '@shell/utils/object';
 import { ignoreVariables } from './install.helpers';
 import { findBy, insertAt } from '@shell/utils/array';
 import { saferDump } from '@shell/utils/create-yaml';
@@ -330,28 +330,10 @@ export default {
       */
       this.removeGlobalValuesFrom(userValues);
 
-      const userKeys = Object.keys(userValues);
-      const customizer = (objValue, srcValue, key) => {
-        if (userKeys.includes(key) && isObject(srcValue)) {
-          return {
-            ...objValue,
-            ...srcValue
-          };
-        }
-      };
-
-      /*
-        The mergeWith() method is used to merge two or more objects
-        starting with the left-most to the right-most to create a
-        parent mapping object. When two keys are the same, the
-        generated object will have value for the rightmost key.
-        With the customizer, any values in userValues override any
-        matching values in versionInfo.
-      */
-      this.chartValues = mergeWith(
+      this.chartValues = mergeWithReplace(
         merge({}, this.versionInfo?.values || {}),
         userValues,
-        customizer
+        { replaceObjectProps: true }
       );
 
       if (this.showCustomRegistry) {

--- a/shell/utils/__tests__/object.test.ts
+++ b/shell/utils/__tests__/object.test.ts
@@ -401,8 +401,42 @@ describe('fx: mergeWithReplace', () => {
     [undefined, {}, {}],
   ];
 
-  it.each(testCases)('should merge properly', (obj1, obj2, expected) => {
+  it.each(testCases)('should merge arrays properly', (obj1, obj2, expected) => {
     const result = mergeWithReplace(obj1, obj2);
+
+    expect(result).toStrictEqual(expected);
+  });
+
+  it.each([
+    [
+      { a: { b: false, c: false } }, { a: { b: true, c: null } }, { a: { b: true, c: null } }
+    ],
+    [
+      {
+        a: [{
+          b: 'test', c: 'test', value: true
+        }]
+      }, {
+        a: [{
+          b: 'test', c: 'test', operator: 'exists'
+        }]
+      }, {
+        a: [{
+          b: 'test', c: 'test', operator: 'exists'
+        }]
+      }
+    ],
+    [
+      {
+        a: { enabled: false }, b: { enabled: false }, c: { enabled: false }
+      },
+      { c: { enabled: true, stripUnderscores: true } },
+      {
+        a: { enabled: false }, b: { enabled: false }, c: { enabled: true, stripUnderscores: true }
+      }
+    ]
+  ])('should overwrite duplicate object properties when merging objects', (left, right, expected) => {
+    const result = mergeWithReplace(left, right, { replaceObjectProps: true });
 
     expect(result).toStrictEqual(expected);
   });

--- a/shell/utils/__tests__/object.test.ts
+++ b/shell/utils/__tests__/object.test.ts
@@ -1,6 +1,6 @@
 import { reactive, isReactive } from 'vue';
 import {
-  clone, get, getter, isEmpty, toDictionary, remove, diff, definedKeys, deepToRaw, mergeWithReplaceArrays
+  clone, get, getter, isEmpty, toDictionary, remove, diff, definedKeys, deepToRaw, mergeWithReplace
 } from '@shell/utils/object';
 
 describe('fx: get', () => {
@@ -379,7 +379,7 @@ describe('fx: deepToRaw', () => {
   });
 });
 
-describe('fx: mergeWithReplaceArrays', () => {
+describe('fx: mergeWithReplace', () => {
   const testCases: Array<[object?, object?, object?]> = [
     // Some array test cases, an array from the first object should be replaced with the array from the second object
     [{ a: ['one'] }, { a: [] }, { a: [] }],
@@ -402,7 +402,7 @@ describe('fx: mergeWithReplaceArrays', () => {
   ];
 
   it.each(testCases)('should merge properly', (obj1, obj2, expected) => {
-    const result = mergeWithReplaceArrays(obj1, obj2);
+    const result = mergeWithReplace(obj1, obj2);
 
     expect(result).toStrictEqual(expected);
   });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13980 

Changes to merge behavior so that user supplied values overwrite default values when merging. The lodash merge operation merges object properties recursively, meaning that any keys in the left-most object will remain present. The customizer function works to overwrite any duplicate properties present in the user values.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Updates merge behavior so that userValues overwrite default values

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I considered using lodash `assign`, but that behaves in such a way that the user values would completely pave over any and all default values. Using `mergeWith` with the spread operator for objects allows us to preserve existing default properties while overwriting and preserving user provided keys as they were provided.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

See issues for test cases.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This only really updates the merging behavior for user provided objects where keys match. Other types should follow the default merge rules like they did previously with lodash `merge`. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
