### PR TITLE
[2.11.2] Allow cluster create and import locations to be overridden

### DIFF
--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -374,6 +374,11 @@ export interface ConfigureTypeOptions {
   customRoute?: Object;
 
   /**
+   * Custom options vary pre resource type
+   */
+  custom?: any;
+
+  /**
    * Leaving these here for completeness but I don't think these should be advertised as useable to plugin creators.
    */
   // alias

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -113,24 +113,32 @@ export default {
     },
 
     createLocation() {
-      return {
-        name:   'c-cluster-product-resource-create',
-        params: {
-          product:  this.$store.getters['currentProduct'].name,
-          resource: this.resource
-        },
+      const options = this.$store.getters[`type-map/optionsFor`](this.resource)?.custom || {};
+      const params = {
+        product:  this.$store.getters['currentProduct'].name,
+        resource: this.resource
       };
+      const defaultLocation = {
+        name: 'c-cluster-product-resource-create',
+        params
+      };
+
+      return options.createLocation ? options.createLocation(params) : defaultLocation;
     },
 
     importLocation() {
-      return {
-        name:   'c-cluster-product-resource-create',
-        params: {
-          product:  this.$store.getters['currentProduct'].name,
-          resource: this.resource
-        },
+      const options = this.$store.getters[`type-map/optionsFor`](this.resource)?.custom || {};
+      const params = {
+        product:  this.$store.getters['currentProduct'].name,
+        resource: this.resource
+      };
+      const defaultLocation = {
+        name:  'c-cluster-product-resource-create',
+        params,
         query: { [MODE]: _IMPORT }
       };
+
+      return options.importLocation ? options.importLocation(params) : defaultLocation;
     },
 
     canImport() {

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -49,6 +49,21 @@ export default defineComponent({
   mixins: [PageHeaderActions],
 
   data() {
+    const options = this.$store.getters[`type-map/optionsFor`](CAPI.RANCHER_CLUSTER)?.custom || {};
+    const params = {
+      product:  MANAGER,
+      cluster:  BLANK_CLUSTER,
+      resource: CAPI.RANCHER_CLUSTER
+    };
+    const defaultCreateLocation = {
+      name: 'c-cluster-product-resource-create',
+      params,
+    };
+    const defaultImportLocation = {
+      ...defaultCreateLocation,
+      query: { [MODE]: _IMPORT }
+    };
+
     return {
       HIDE_HOME_PAGE_CARDS,
       fullVersion: getVersionInfo(this.$store).fullVersion,
@@ -87,24 +102,9 @@ export default defineComponent({
         },
       },
 
-      createLocation: {
-        name:   'c-cluster-product-resource-create',
-        params: {
-          product:  MANAGER,
-          cluster:  BLANK_CLUSTER,
-          resource: CAPI.RANCHER_CLUSTER
-        },
-      },
+      createLocation: options.createLocation ? options.createLocation(params) : defaultCreateLocation,
 
-      importLocation: {
-        name:   'c-cluster-product-resource-create',
-        params: {
-          product:  MANAGER,
-          cluster:  BLANK_CLUSTER,
-          resource: CAPI.RANCHER_CLUSTER
-        },
-        query: { [MODE]: _IMPORT }
-      },
+      importLocation: options.importLocation ? options.importLocation(params) : defaultImportLocation,
 
       headers: [
         STATE,

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -107,6 +107,7 @@
 //                               graphConfig: undefined   -- Use this to pass along the graph configuration
 //                               notFilterNamespace:  undefined -- Define namespaces that do not need to be filtered
 //                               localOnly: False -- Hide this type from the nav/search bar on downstream clusters
+//                               custom: any - Custom options for a given type
 //                           }
 // )
 // ignoreGroup(group):        Never show group or any types in it
@@ -524,6 +525,7 @@ export const getters = {
       depaginate:             false,
       customRoute:            undefined,
       resourceEditMasthead:   true,
+      custom:                 {},
     };
 
     return (schemaOrType, pagination) => {
@@ -1729,6 +1731,8 @@ export const mutations = {
     let obj = { ...options, match };
 
     if ( idx >= 0 ) {
+      // Merge the custom data object - multiple configures will update existing rather than overwrite
+      obj.custom = Object.assign(state.typeOptions[idx].custom || {}, obj.custom || {});
       obj = Object.assign(state.typeOptions[idx], obj);
       state.typeOptions.splice(idx, 1, obj);
     } else {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14067 

Backport of https://github.com/rancher/dashboard/pull/14041 for 2.11.2.

### Occurred changes and/or fixed issues

This PR adds configuration for the provisioning cluster resource to allow the `create` and `import` locations to be overridden by an extension.

This is then wired into the cluster list and home page views.

Extensions can change the locations - an example use case is where you might want a user to only be able to create or import a single cluster type - for example, adding this in a product file in an extension would only allow them to create/import EKS clusters:

```

export function init(plugin: any, store: any) {
  const {configureType } = plugin.DSL(store, 'manager');

  configureType('provisioning.cattle.io.cluster', {
    custom: {
      createLocation: (params: any) => {
        return {
          name:  'c-cluster-product-resource-create',
          query: {
            type: 'amazoneks'
          },
          params
        }
      },
      importLocation: (params: any) => {
        return {
          name:  'c-cluster-product-resource-create',
          query: {
            mode: 'import',
            type: 'amazoneks'
          },
          params
        }
      },
    }
  });
}
```

This is considered an advanced use case and experimental and will be documented once stable. 

### Areas or cases that should be tested

Testing should focus on testing that the existing UI is not broken by this change.

Both on the home page and the cluster list page, check that clicking the 'Create' and 'Import' buttons takes the user to the default pages allowing them to chose the cluster type.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
