### PR TITLE
update kontainer driver deactivation test to use LKE driver

### DIFF
--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -20,7 +20,6 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
   const oracleDriver = 'Oracle OKE';
   const googleDriver = 'Google GKE';
   const linodeDriver = 'Linode LKE';
-  const tencentDriver = 'Tencent TKE';
   const exampleDriver = 'Example';
   const amazonDriver = 'Amazon EKS';
   const azureDriver = 'Azure AKS';
@@ -154,16 +153,16 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
   });
 
   it('will show error if could not activate driver', () => {
-    cy.intercept('POST', '/v3/kontainerDrivers/tencentkubernetesengine?action=activate', {
+    cy.intercept('POST', '/v3/kontainerDrivers/linodekubernetesengine?action=activate', {
       statusCode: 500,
       body:       { message: `Could not activate driver` }
     }).as('activationError');
 
     KontainerDriversPagePo.navTo();
     driversPage.waitForPage();
-    driversPage.list().details(tencentDriver, 1).should('contain', 'Inactive');
+    driversPage.list().details(linodeDriver, 1).should('contain', 'Inactive');
 
-    driversPage.list().actionMenu(tencentDriver).getMenuItem('Activate').click();
+    driversPage.list().actionMenu(linodeDriver).getMenuItem('Activate').click();
 
     cy.wait('@activationError').then(() => {
       cy.get('.growl-text').contains('Could not activate driver').should('be.visible');


### PR DESCRIPTION

### Summary
The Tencent TKE kontainer driver has been removed - see https://github.com/rancher/rancher/issues/48759

This PR updates an e2e test that referenced the TKE driver to use LKE instead.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
