### PR TITLE
Detail page

### DIFF
--- a/shell/assets/styles/app.scss
+++ b/shell/assets/styles/app.scss
@@ -7,6 +7,7 @@
 @import "./base/color";
 @import "./base/basic";
 @import "./base/typography";
+@import "./base/spacing";
 
 @import "./fonts/fontstack";
 @import "./fonts/dots";

--- a/shell/assets/styles/base/_spacing.scss
+++ b/shell/assets/styles/base/_spacing.scss
@@ -1,0 +1,29 @@
+// Text indent, margins, and paddings from 5-50px in 5px increments
+// e.g. p-10 - {padding: 10px}
+// e.g. mt-20 - {margin-top: 20px}
+$spacing-property-map: (
+    mm: margin,
+    mmt: margin-top,
+    mmr: margin-right,
+    mml: margin-left,
+    mmb: margin-bottom,
+    pp: padding,
+    ppt: padding-top,
+    ppb: padding-bottom,
+    ppl: padding-left,
+    ppr: padding-right,
+);
+
+@each $keyword, $property in $spacing-property-map {
+    .#{$keyword}-0 {
+        #{$property}: 0 !important;
+    }
+
+    @for $size from 1 through 10 {
+        $val: $size * 4;
+
+        .#{$keyword}-#{$size} {
+            #{$property}: $val * 1px !important;
+        }
+    }
+}

--- a/shell/assets/styles/themes/_dark.scss
+++ b/shell/assets/styles/themes/_dark.scss
@@ -226,6 +226,8 @@
   --badge-state-disabled-bg    : #{$medium};
   --badge-state-disabled-border: #{$lighter};
 
+  --bubble-bg                  : #{$darkest};
+
   $slate: #4B4F6B;
 
   --slate: #{$slate};

--- a/shell/assets/styles/themes/_light.scss
+++ b/shell/assets/styles/themes/_light.scss
@@ -351,6 +351,8 @@ BODY, .theme-light {
   --border-width               : 1px;
   --border-radius              : 4px;
   --border-radius-lg           : 8px;
+  --border-radius-small        : 4px;
+  --border-radius-medium       : 6px;
   --outline                    : var(--primary);
   --outline-width              : 1px;
 
@@ -552,4 +554,6 @@ BODY, .theme-light {
   --badge-state-disabled-text  : #{$darker};
   --badge-state-disabled-bg    : #{$lighter};
   --badge-state-disabled-border: #{$medium};
+
+  --bubble-bg                  : #{$lighter};
 }

--- a/shell/components/Resource/Detail/Card/CpuUsageCard.vue
+++ b/shell/components/Resource/Detail/Card/CpuUsageCard.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import ResourceUsage from '@shell/components/Resource/Detail/Card/ResourceUsage/index.vue';
+</script>
+
+<template>
+  <ResourceUsage
+    :title="`CPU`"
+    :used="1.20"
+    :available="1.93"
+  />
+</template>

--- a/shell/components/Resource/Detail/Card/InsightsCard.vue
+++ b/shell/components/Resource/Detail/Card/InsightsCard.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import ResourceStateCard from '@shell/components/Resource/Detail/Card/ResourceStateCard.vue';
+
+const rows = [
+  {
+    label:  'Services',
+    to:     '#',
+    color:  'var(--error)',
+    counts: [{ label: 'failed', count: 1 }, { label: 'passed', count: 6 }]
+  },
+  {
+    label:  'Referred to by',
+    to:     '#',
+    color:  'var(--warning)',
+    counts: [{ label: 'warning', count: 1 }, { label: 'normal', count: 24 }]
+  }
+];
+</script>
+
+<template>
+  <ResourceStateCard
+    title="Insights"
+    :rows="rows"
+  />
+</template>

--- a/shell/components/Resource/Detail/Card/MemoryUsageCard.vue
+++ b/shell/components/Resource/Detail/Card/MemoryUsageCard.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import ResourceUsage from '@shell/components/Resource/Detail/Card/ResourceUsage/index.vue';
+</script>
+
+<template>
+  <ResourceUsage
+    :title="`Memory`"
+    :used="870"
+    :available="3290"
+    :availableFormatter="(n) => (n/1000).toFixed(2)"
+    :unit="`GiB`"
+  />
+</template>

--- a/shell/components/Resource/Detail/Card/PodUsageCard.vue
+++ b/shell/components/Resource/Detail/Card/PodUsageCard.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import ResourceUsage from '@shell/components/Resource/Detail/Card/ResourceUsage/index.vue';
+</script>
+
+<template>
+  <ResourceUsage
+    :title="`Pods`"
+    :used="9"
+    :available="17"
+  />
+</template>

--- a/shell/components/Resource/Detail/Card/PodsCard/Bubble.vue
+++ b/shell/components/Resource/Detail/Card/PodsCard/Bubble.vue
@@ -1,0 +1,13 @@
+<template>
+  <span class="bubble">
+    <slot name="default" />
+  </span>
+</template>
+
+<style lang="scss" scoped>
+.bubble {
+    border-radius: 40%;
+    background-color: var(--bubble-bg);
+    padding: 2px 6px;
+}
+</style>

--- a/shell/components/Resource/Detail/Card/PodsCard/index.vue
+++ b/shell/components/Resource/Detail/Card/PodsCard/index.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import Card from '@shell/components/Resource/Detail/Card/index.vue';
+import VerticalGap from '@shell/components/Resource/Detail/Card/VerticalGap.vue';
+import StatusBar from '@shell/components/Resource/Detail/StatusBar.vue';
+import StatusRow from '@shell/components/Resource/Detail/StatusRow.vue';
+
+const error = 'var(--error)';
+const info = 'var(--info)';
+const success = 'var(--success)';
+
+const healthSegments = [
+  {
+    color:   error,
+    percent: 55
+  },
+  {
+    color:   info,
+    percent: 25
+  },
+  {
+    color:   success,
+    percent: 20
+  }
+];
+
+</script>
+
+<template>
+  <Card title="Pods">
+    <StatusBar :segments="healthSegments" />
+    <VerticalGap />
+    <div class="pod-distribution">
+      <StatusRow
+        :color="error"
+        label="Init: 0/1"
+        :count="3"
+        :percent="60"
+      />
+      <StatusRow
+        :color="info"
+        label="ImagepullbackOff"
+        :count="1"
+        :percent="20"
+      />
+      <StatusRow
+        :color="success"
+        label="Running"
+        :count="1"
+        :percent="20"
+      />
+    </div>
+  </Card>
+</template>
+
+<style lang="scss" scoped>
+.pod-distribution {
+    display: flex;
+    flex-direction: column;
+}
+</style>

--- a/shell/components/Resource/Detail/Card/ResourceStateCard.vue
+++ b/shell/components/Resource/Detail/Card/ResourceStateCard.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import Card from '@shell/components/Resource/Detail/Card/index.vue';
+import ResourceRow, { Props as ResourceRowProps } from '@shell/components/Resource/Detail/ResourceRow.vue';
+
+export interface Props {
+    title: string;
+    rows: ResourceRowProps[];
+}
+
+const { title, rows } = defineProps<Props>();
+</script>
+
+<template>
+  <Card :title="title">
+    <div class="resource-rows">
+      <ResourceRow
+        v-for="(row, i) in rows"
+        :key="i"
+        :label="row.label"
+        :color="row.color"
+        :to="row.to"
+        :counts="row.counts"
+      />
+    </div>
+  </Card>
+</template>
+
+<style lang="scss" scoped>
+.resource-rows {
+    display: flex;
+    flex-direction: column;
+
+    & > *:not(:first-of-type) {
+        margin-top: 4px;
+    }
+}
+</style>

--- a/shell/components/Resource/Detail/Card/ResourceUsage/index.vue
+++ b/shell/components/Resource/Detail/Card/ResourceUsage/index.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import Card from '@shell/components/Resource/Detail/Card/index.vue';
+import PercentageBar from '@shell/components/Resource/Detail/PercentageBar.vue';
+import { computed } from 'vue';
+
+export interface Props {
+    title: string;
+    unit?: string;
+    used: number;
+    usedFormatter?: (n: number) => string;
+    available: number;
+    availableFormatter?: (n: number) => string
+}
+
+const {
+  title, unit, used, usedFormatter, available, availableFormatter
+} = withDefaults(
+  defineProps<Props>(),
+  {
+    usedFormatter:      (n: number) => n.toString(),
+    availableFormatter: (n: number) => n.toString(),
+    unit:               undefined
+  }
+);
+
+const percentage = computed(() => {
+  const numerator = used || 0;
+  const denominator = available || 0;
+
+  return denominator === 0 ? 0 : Math.floor((numerator / denominator) * 100);
+});
+</script>
+
+<template>
+  <Card :title="title">
+    <div class="numerical">
+      <div>Used</div>
+      <div>
+        {{ usedFormatter(used) }} of {{ availableFormatter(available) }}
+        <span
+          v-if="unit"
+          class="unit"
+        >
+          {{ unit }}
+        </span>
+        <span class="spacer">/</span>
+        <span class="percentage">{{ percentage }}%</span>
+      </div>
+    </div>
+    <PercentageBar :percent="percentage" />
+  </Card>
+</template>
+
+<style lang="scss" scoped>
+.numerical {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+
+  margin-bottom: 8px;
+
+  .spacer {
+    margin: 0 8px;
+  }
+
+  .percentage {
+    font-weight: bold;
+  }
+}
+</style>

--- a/shell/components/Resource/Detail/Card/ResourcesCard.vue
+++ b/shell/components/Resource/Detail/Card/ResourcesCard.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import ResourceStateCard from '@shell/components/Resource/Detail/Card/ResourceStateCard.vue';
+
+const rows = [
+  {
+    label:  'Services',
+    to:     '#',
+    color:  'var(--success)',
+    counts: [{ label: 'active', count: 3 }]
+  },
+  { label: 'Ingresses' },
+  {
+    label:  'Referred to by',
+    to:     '#',
+    color:  'var(--error)',
+    counts: [{ label: 'updating', count: 1 }, { label: 'active', count: 1 }]
+  },
+  {
+    label:  'Refers to',
+    to:     '#',
+    color:  'var(--success)',
+    counts: [{ label: 'active', count: 5 }]
+  }
+];
+</script>
+
+<template>
+  <ResourceStateCard
+    title="Resources"
+    :rows="rows"
+  />
+</template>

--- a/shell/components/Resource/Detail/Card/VerticalGap.vue
+++ b/shell/components/Resource/Detail/Card/VerticalGap.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="vertical-gap">
+&nbsp;
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.vertical-gap {
+    height: 12px;
+}
+</style>

--- a/shell/components/Resource/Detail/Card/index.vue
+++ b/shell/components/Resource/Detail/Card/index.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import VerticalGap from '@shell/components/Resource/Detail/Card/VerticalGap.vue';
+
+export interface CardProps {
+    title?: string;
+}
+
+const { title } = defineProps<CardProps>();
+
+</script>
+
+<template>
+  <div class="detail-card">
+    <div class="heading">
+      <slot name="heading">
+        <div class="title">
+          <slot name="title">
+            {{ title }}
+          </slot>
+        </div>
+      </slot>
+      <slot name="heading-action" />
+    </div>
+    <VerticalGap />
+    <div class="body">
+      <slot name="default" />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.detail-card {
+    padding: 16px;
+    border-radius: var(--border-radius-medium);
+    border: 1px solid var(--border);
+    min-width: 300px;
+
+    .vertical-gap {
+        height: 12px;
+    }
+
+    .heading {
+        height: 32px;
+
+        .title {
+            font-size: 18px;
+            font-weight: 600;
+            line-height: 21px;
+        }
+    }
+}
+</style>

--- a/shell/components/Resource/Detail/Metadata/Annotations.vue
+++ b/shell/components/Resource/Detail/Metadata/Annotations.vue
@@ -1,0 +1,44 @@
+<script lang="ts">
+import KeyValue, { Row } from '@shell/components/Resource/Detail/Metadata/KeyValue.vue';
+
+export const extractDefaultAnnotations = (resource: any): Row[] => {
+  return [
+    {
+      key:   'deployment.kubernetes.io/revision',
+      value: '1.2.3'
+    },
+    {
+      key:   'meta.helm.sh/release-name',
+      value: 'gemini'
+    },
+    {
+      key:   'meta.helm.sh/release-namespace',
+      value: 'release-1.2.3'
+    },
+    {
+      key:   'meta.helm.sh/release-name',
+      value: 'gemini'
+    }
+  ];
+};
+
+export type Annotation = Row;
+
+export interface AnnotationsProps {
+    annotations: Annotation[];
+}
+
+</script>
+
+<script setup lang="ts">
+const { annotations } = defineProps<AnnotationsProps>();
+</script>
+
+<template>
+  <KeyValue
+    :propertyName="`Annotations`"
+    :rows="annotations"
+    :maxRows="3"
+    :outline="true"
+  />
+</template>

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation.vue
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation.vue
@@ -1,0 +1,120 @@
+<script lang="ts">
+import { I18n } from '@shell/composables/useI18n';
+import { Vue } from 'vue';
+import { RouteLocationRaw } from 'vue-router';
+import LiveDate from '@shell/components/formatter/LiveDate.vue';
+
+export interface Row {
+    label: string;
+    value?: string;
+    valueOverride?: {
+      component: any,
+      props?: Object
+    },
+    to?: RouteLocationRaw;
+    status?: 'success' | 'warning' | 'info' | 'error',
+}
+
+export interface MetadataProps {
+    rows: Row[];
+}
+
+export const extractDefaultIdentifyingInformation = (resource: any, i18n: I18n): Row[] => {
+  return [
+    {
+      label: 'Namespace',
+      value: resource.namespace,
+    },
+    {
+      label:         'Age',
+      valueOverride: {
+        component: LiveDate,
+        props:     { value: resource.creationTimestamp }
+      },
+      value: resource.age,
+    },
+
+  ];
+};
+</script>
+
+<script setup lang="ts">
+const { rows } = defineProps<MetadataProps>();
+
+</script>
+
+<template>
+  <div class="identifying-information">
+    <div
+      v-for="row in rows"
+      :key="`${row.label}:${row.value}`"
+      class="row"
+    >
+      <div class="label text-muted">
+        {{ row.label }}
+      </div>
+      <div class="value">
+        <span
+          v-if="row.status"
+          :class="['status', row.status]"
+        >&nbsp;</span>
+        <router-link
+          v-if="row.to"
+          :to="row.to"
+        >
+          {{ row.value }}
+        </router-link>
+        <span v-else>{{ row.value }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.identifying-information {
+    display: flex;
+    flex-direction: column;
+
+    .row {
+      margin-bottom: 8px;
+
+      .value {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+      }
+
+      .label {
+        width: 30%;
+        min-width: 120px;
+      }
+
+      .status {
+        display: inline-block;
+        $size: 8px;
+        border-radius: 50%;
+        width: $size;
+        height: $size;
+        margin-right: 12px;
+
+        &.success {
+          background-color: var(--success);
+        }
+
+        &.warning {
+          background-color: var(--warning);
+        }
+
+        &.error {
+          background-color: var(--error);
+        }
+
+        &.info {
+          background-color: var(--info);
+        }
+      }
+
+    }
+
+}
+</style>

--- a/shell/components/Resource/Detail/Metadata/KeyValue.vue
+++ b/shell/components/Resource/Detail/Metadata/KeyValue.vue
@@ -1,0 +1,97 @@
+<script lang="ts">
+import { computed, ref, withDefaults } from 'vue';
+import { pluralize } from '@shell/utils/string';
+import Rectangle from '@shell/components/Resource/Detail/Metadata/Rectangle.vue';
+
+export type KeyValueType = {[key: string]: string};
+
+export interface Row {
+    key: string;
+    value: string;
+}
+
+export interface KeyValueProps {
+    propertyName: string;
+    rows: Row[];
+    maxRows: number;
+    outline?: boolean;
+}
+</script>
+
+<script setup lang="ts">
+const {
+  propertyName, rows, maxRows, outline
+} = withDefaults(
+  defineProps<KeyValueProps>(),
+  { outline: false }
+);
+
+const partialRowsLength = computed(() => Math.min(maxRows, rows.length));
+const partialRows = computed(() => rows.slice(0, partialRowsLength.value));
+
+const showToggleButton = computed(() => rows.length > maxRows);
+const showAll = ref<boolean>(false);
+const showAllLabel = computed(() => `Show all ${ pluralize(propertyName).toLowerCase() }`);
+const hideExtraLabel = computed(() => `Hide extra ${ pluralize(propertyName).toLowerCase() }`);
+
+const visibleRows = ref<Row[]>(partialRows.value);
+const toggleVisibility = () => {
+  showAll.value = !showAll.value;
+  visibleRows.value = showAll.value ? rows : partialRows.value;
+};
+
+</script>
+
+<template>
+  <div class="key-value">
+    <div class="heading">
+      <span class="title text-muted">{{ propertyName }}</span>
+      <span class="count">{{ rows.length }}</span>
+    </div>
+    <div
+      v-for="row in visibleRows"
+      :key="`${row.key}:${row.value}`"
+      class="row"
+    >
+      <Rectangle :outline="outline">
+        {{ row.key }} : {{ row.value }}
+      </Rectangle>
+    </div>
+    <a
+      v-if="showToggleButton"
+      href="#"
+      class="show-all"
+      @click="toggleVisibility"
+    >{{ showAll ? hideExtraLabel : showAllLabel }}</a>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.key-value {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    .count {
+        margin-left: 24px;
+    }
+
+    .heading {
+        margin-bottom: 4px;
+    }
+
+    .row {
+        &:not(:first-of-type) {
+            margin-top: 4px;
+        }
+
+        & {
+            margin-top: 8px;
+        }
+    }
+
+    .show-all {
+        margin-top: 8px;
+    }
+}
+</style>

--- a/shell/components/Resource/Detail/Metadata/Labels.vue
+++ b/shell/components/Resource/Detail/Metadata/Labels.vue
@@ -1,0 +1,41 @@
+<script lang="ts">
+import KeyValue, { Row } from '@shell/components/Resource/Detail/Metadata/KeyValue.vue';
+
+export const extractDefaultLabels = (resource: any): Row[] => {
+  return [{
+    key:   'beta.kubernetes.io/arch',
+    value: 'amd64'
+  },
+  {
+    key:   'beta.kubernetes.io/instance-type',
+    value: 't2.medium'
+  },
+  {
+    key:   'beta.kubernetes.io/os',
+    value: 'linux'
+  },
+  {
+    key:   'eks.amazonaws.com/capacityType',
+    value: 'ON_DEMAND'
+  }];
+};
+
+export type Label = Row;
+
+export interface LabelsProps {
+    labels: Label[];
+}
+
+</script>
+
+<script setup lang="ts">
+const { labels } = defineProps<LabelsProps>();
+</script>
+
+<template>
+  <KeyValue
+    :propertyName="`Labels`"
+    :rows="labels"
+    :maxRows="3"
+  />
+</template>

--- a/shell/components/Resource/Detail/Metadata/Rectangle.vue
+++ b/shell/components/Resource/Detail/Metadata/Rectangle.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { withDefaults } from 'vue';
+
+export interface RectangleProps {
+    outline?: boolean;
+}
+
+const { outline } = withDefaults(
+  defineProps<RectangleProps>(),
+  { outline: false }
+);
+
+</script>
+
+<template>
+  <div
+    class="rectangle"
+    :class="{outline}"
+  >
+    <slot />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.rectangle {
+    border: 1px solid var(--tag-bg);
+    border-radius: 4px;
+    padding: 4px;
+
+    &:not(.outline) {
+        background-color: var(--tag-bg);
+    }
+}
+</style>

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -1,0 +1,51 @@
+<script lang="ts">
+import IdentifyingInformation, { extractDefaultIdentifyingInformation, Row as IdentifyingInformationRow } from '@shell/components/Resource/Detail/Metadata/IdentifyingInformation.vue';
+import Labels, { extractDefaultLabels, Label } from '@shell/components/Resource/Detail/Metadata/Labels.vue';
+import Annotations, { extractDefaultAnnotations, Annotation } from '@shell/components/Resource/Detail/Metadata/Annotations.vue';
+import SpacedRow from '@shell/components/Resource/Detail/SpacedRow.vue';
+import { I18n } from '@shell/composables/useI18n';
+
+export const extractDefaultMetadata = (resource: any, i18n: I18n) => {
+  return {
+    identifyingInformation: extractDefaultIdentifyingInformation(resource, i18n),
+    labels:                 extractDefaultLabels(resource),
+    annotations:            extractDefaultAnnotations(resource)
+  };
+};
+</script>
+
+<script setup lang="ts">
+export interface MetadataProps {
+  identifyingInformation: IdentifyingInformationRow[],
+  labels: Label[],
+  annotations: Annotation[]
+}
+
+const { identifyingInformation, labels, annotations } = defineProps<MetadataProps>();
+</script>
+
+<template>
+  <SpacedRow class="metadata">
+    <div slot="identifying-info">
+      <IdentifyingInformation :rows="identifyingInformation" />
+    </div>
+    <div slot="labels">
+      <Labels :labels="labels" />
+    </div>
+    <div slot="annotations">
+      <Annotations :annotations="annotations" />
+    </div>
+  </SpacedRow>
+</template>
+
+<style lang="scss" scoped>
+.metadata {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+
+    & > * {
+        flex: 1;
+    }
+}
+</style>

--- a/shell/components/Resource/Detail/Page.vue
+++ b/shell/components/Resource/Detail/Page.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <div class="resource-detail-page">
+    <div
+      v-if="$slots['top-area']"
+      class="top-area"
+    >
+      <slot name="top-area" />
+    </div>
+    <div
+      v-if="$slots['middle-area']"
+      class="middle-area mmt-6"
+    >
+      <slot name="middle-area" />
+    </div>
+    <div
+      v-if="$slots['bottom-area']"
+      class="bottom-area mmt-6"
+    >
+      <slot name="bottom-area" />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+</style>

--- a/shell/components/Resource/Detail/PercentageBar.vue
+++ b/shell/components/Resource/Detail/PercentageBar.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+export interface Props {
+  percent: number;
+  percentageColor?: string;
+  baseColor?: string;
+}
+
+const { percent, percentageColor, baseColor } = withDefaults(
+  defineProps<Props>(),
+  {
+    baseColor:       'var(--progress-bg)',
+    percentageColor: 'var(--primary)'
+  }
+);
+
+const baseStyle = computed(() => ({ backgroundColor: baseColor }));
+const usedStyle = computed(() => ({
+  backgroundColor: percentageColor,
+  width:           `${ percent }%`
+}));
+</script>
+
+<template>
+  <div
+    class="percentage-bar"
+    :style="baseStyle"
+  >
+    <div
+      class="used"
+      :style="usedStyle"
+    >
+&nbsp;
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.percentage-bar {
+  border-radius: var(--border-radius-medium);
+  height: 16px;
+  overflow: hidden;
+}
+</style>

--- a/shell/components/Resource/Detail/ResourceRow.vue
+++ b/shell/components/Resource/Detail/ResourceRow.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import SubtleLink from '@shell/components/SubtleLink.vue';
+import { RouteLocationRaw } from 'vue-router';
+
+export interface Count {
+  label: string;
+  count: number;
+}
+
+export interface Props {
+        label: string;
+        to?: RouteLocationRaw;
+        color?: string;
+        counts?: Count[];
+}
+
+const {
+  label, to, counts, color
+} = defineProps<Props>();
+</script>
+
+<template>
+  <div class="resource-row">
+    <div class="left">
+      <SubtleLink
+        v-if="to"
+        :to="to"
+      >
+        {{ label }}
+      </SubtleLink>
+      <span
+        v-else
+        class="text-muted"
+      >
+        {{ label }}
+      </span>
+    </div>
+    <div class="right">
+      <div
+        v-if="!counts || counts.length == 0"
+        class="text-muted"
+      >
+        &mdash;
+      </div>
+      <div
+        v-else
+        class="counts"
+      >
+        <span
+          v-if="color"
+          class="dot"
+          :style="{backgroundColor: color}"
+        >
+&nbsp;
+        </span>
+        <span
+          v-for="(count, i) in counts"
+          :key="i"
+          class="count"
+        >
+          {{ count.count }} {{ count.label }}<span class="and">&nbsp;+&nbsp;</span>
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.resource-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    .right {
+      flex-grow: 1;
+      text-align: right;
+    }
+
+    .counts {
+      display: inline-flex;
+      flex-direction: row;
+      justify-content: flex-end;
+      align-items: center;
+    }
+
+    .count:last-of-type .and {
+      display: none;
+    }
+
+    .dot {
+      display: inline-block;
+
+      $size: 6px;
+      width: $size;
+      height: $size;
+
+      border-radius: 50%;
+      margin-right: 10px;
+    }
+}
+</style>

--- a/shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/CronJobsTab.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/CronJobsTab.vue
@@ -1,0 +1,52 @@
+<script lang="ts">
+import { Store, useStore } from 'vuex';
+import ResourceTable from '@shell/components/ResourceTable.vue';
+import Tab from '@shell/components/Tabbed/Tab.vue';
+import { useI18n } from '@shell/composables/useI18n';
+import { WORKLOAD_TYPES } from '@shell/config/types';
+
+export interface Props {
+  cronJobs?: any[];
+  cronJobsHeaders?: any[];
+  cronJobsSchema?: any;
+  weight?: number;
+}
+
+export const fetchDefaultCronJobsProps = async(store: Store<any>): Promise<Props> => {
+  const allCronJobs = await store.dispatch('cluster/findAll', { type: WORKLOAD_TYPES.CRON_JOB });
+  const schema = store.getters['cluster/schemaFor'](WORKLOAD_TYPES.CRON_JOB);
+
+  return {
+    cronJobs:        allCronJobs,
+    cronJobsHeaders: store.getters['type-map/headersFor'](schema),
+    cronJobsSchema:  schema
+  };
+};
+</script>
+
+<script lang="ts" setup>
+const {
+  cronJobs, cronJobsHeaders, cronJobsSchema, weight
+} = defineProps<Props>();
+
+const store = useStore();
+const { t } = useI18n(store);
+</script>
+
+<template>
+  <Tab
+    v-if="cronJobs"
+    name="jobs"
+    :label="t('tableHeaders.jobs')"
+    :weight="weight"
+  >
+    <ResourceTable
+      :rows="cronJobs"
+      :headers="cronJobsHeaders"
+      key-field="id"
+      :schema="cronJobsSchema"
+      :groupable="false"
+      :search="false"
+    />
+  </Tab>
+</template>

--- a/shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/IngressesTab.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/IngressesTab.vue
@@ -1,0 +1,87 @@
+<script lang="ts">
+import { Store, useStore } from 'vuex';
+import ResourceTable from '@shell/components/ResourceTable.vue';
+import Tab from '@shell/components/Tabbed/Tab.vue';
+import { useI18n } from '@shell/composables/useI18n';
+import { INGRESS, SERVICE } from '@shell/config/types';
+
+export interface Props {
+  ingresses?: any[];
+  ingressesHeaders?: any[];
+  ingressesSchema?: any;
+  servicesSchema?: any;
+  weight?: number;
+}
+
+export const fetchDefaultIngressesProps = async(store: Store<any>): Promise<Props> => {
+  const allIngresses = await store.dispatch('cluster/findAll', { type: INGRESS });
+  const ingressesSchema = store.getters['cluster/schemaFor'](INGRESS);
+  const servicesSchema = store.getters['cluster/schemaFor'](SERVICE);
+
+  return {
+    ingresses:        allIngresses,
+    ingressesHeaders: store.getters['type-map/headersFor'](ingressesSchema),
+    ingressesSchema,
+    servicesSchema
+  };
+};
+</script>
+
+<script lang="ts" setup>
+const {
+  ingresses, ingressesHeaders, ingressesSchema, servicesSchema, weight
+} = defineProps<Props>();
+
+const store = useStore();
+const { t } = useI18n(store);
+</script>
+
+<template>
+  <Tab
+    v-if="ingresses"
+    name="ingresses"
+    :label="t('workload.detail.ingresses')"
+    :weight="weight"
+  >
+    <p
+      v-if="!servicesSchema"
+      class="caption"
+    >
+      {{ t('workload.detail.cannotViewIngressesBecauseCannotViewServices') }}
+    </p>
+    <p
+      v-else-if="!ingressesSchema"
+      class="caption"
+    >
+      {{ t('workload.detail.cannotViewIngresses') }}
+    </p>
+    <p
+      v-else-if="ingresses.length === 0"
+      class="caption"
+    >
+      {{ t('workload.detail.cannotFindIngresses') }}
+    </p>
+    <p
+      v-else
+      class="caption"
+    >
+      {{ t('workload.detail.ingressListCaption') }}
+    </p>
+    <ResourceTable
+      v-if="ingressesSchema && ingresses.length > 0"
+      :rows="ingresses"
+      :headers="ingressesHeaders"
+      key-field="id"
+      :schema="ingressesSchema"
+      :groupable="false"
+      :search="false"
+      :table-actions="false"
+    />
+  </Tab>
+</template>
+
+<style lang="scss" scoped>
+.caption {
+  margin-bottom: .5em;
+}
+</style>

--- a/shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/MetricsTab.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/MetricsTab.vue
@@ -1,0 +1,86 @@
+<script lang="ts">
+import Tab from '@shell/components/Tabbed/Tab.vue';
+import { I18n } from '@shell/composables/useI18n';
+import { Store } from 'vuex';
+import { WORKLOAD_TYPES, WORKLOAD_TYPE_TO_KIND_MAPPING, NAMESPACE } from '@shell/config/types';
+import { allDashboardsExist } from '@shell/utils/grafana';
+import DashboardMetrics from '@shell/components/DashboardMetrics.vue';
+
+export interface Props {
+  tabLabel: string;
+  detailUrl: string;
+  summaryUrl: string;
+  graphVars: any;
+  weight?: number;
+}
+
+export const fetchDefaultMetricsProps = async(workload: any, i18n: I18n): Promise<Props> => {
+  const WORKLOAD_METRICS_DETAIL_URL = '/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/rancher-workload-pods-1/rancher-workload-pods?orgId=1';
+  const WORKLOAD_METRICS_SUMMARY_URL = '/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/rancher-workload-1/rancher-workload?orgId=1';
+  const graphVarsWorkload = workload.type === WORKLOAD_TYPES.DEPLOYMENT ? workload.replicaSetId : workload.shortId;
+
+  return {
+    tabLabel:   i18n.t('workload.container.titles.metrics'),
+    detailUrl:  WORKLOAD_METRICS_DETAIL_URL,
+    summaryUrl: WORKLOAD_METRICS_SUMMARY_URL,
+    graphVars:  {
+      namespace: workload.namespace,
+      kind:      WORKLOAD_TYPE_TO_KIND_MAPPING[workload.type],
+      workload:  graphVarsWorkload
+    }
+  };
+};
+
+export const fetchDefaultProjectMetricsProps = async(workload: any, store: Store<any>, i18n: I18n): Promise<Props> => {
+  const graphVarsWorkload = workload.type === WORKLOAD_TYPES.DEPLOYMENT ? workload.replicaSetId : workload.shortId;
+
+  const namespace = await store.dispatch('cluster/find', { type: NAMESPACE, id: workload.metadata.namespace });
+
+  const projectId = namespace?.metadata?.labels[PROJECT];
+
+  let WORKLOAD_PROJECT_METRICS_DETAIL_URL = '';
+  let WORKLOAD_PROJECT_METRICS_SUMMARY_URL = '';
+
+  if (projectId) {
+    WORKLOAD_PROJECT_METRICS_DETAIL_URL = `/api/v1/namespaces/cattle-project-${ projectId }-monitoring/services/http:cattle-project-${ projectId }-monitoring-grafana:80/proxy/d/rancher-pod-containers-1/rancher-workload-pods?orgId=1'`;
+    WORKLOAD_PROJECT_METRICS_SUMMARY_URL = `/api/v1/namespaces/cattle-project-${ projectId }-monitoring/services/http:cattle-project-${ projectId }-monitoring-grafana:80/proxy/d/rancher-pod-1/rancher-workload?orgId=1`;
+
+    const showProjectMetrics = await allDashboardsExist(store, this.currentCluster.id, [WORKLOAD_PROJECT_METRICS_DETAIL_URL, WORKLOAD_PROJECT_METRICS_SUMMARY_URL], 'cluster', projectId);
+  }
+
+  return {
+    tabLabel:   i18n.t('workload.container.titles.metrics'),
+    detailUrl:  WORKLOAD_PROJECT_METRICS_DETAIL_URL,
+    summaryUrl: WORKLOAD_PROJECT_METRICS_SUMMARY_URL,
+    graphVars:  {
+      namespace: workload.namespace,
+      kind:      WORKLOAD_TYPE_TO_KIND_MAPPING[workload.type],
+      workload:  graphVarsWorkload
+    }
+  };
+};
+</script>
+
+<script lang="ts" setup>
+const {
+  tabLabel, detailUrl, summaryUrl, graphVars, weight
+} = defineProps<Props>();
+</script>
+
+<template>
+  <Tab
+    :label="tabLabel"
+    :name="tabLabel"
+    :weight="weight"
+  >
+    <template #default="props">
+      <DashboardMetrics
+        v-if="props.active"
+        :detail-url="detailUrl"
+        :summary-url="summaryUrl"
+        :vars="graphVars"
+        graph-height="550px"
+      />
+    </template>
+  </Tab>
+</template>

--- a/shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/PodsTab.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/PodsTab.vue
@@ -1,0 +1,52 @@
+<script lang="ts">
+import { Store, useStore } from 'vuex';
+import ResourceTable from '@shell/components/ResourceTable.vue';
+import Tab from '@shell/components/Tabbed/Tab.vue';
+import { useI18n } from '@shell/composables/useI18n';
+import { POD } from '@shell/config/types';
+
+export interface Props {
+  pods?: any[];
+  podsHeaders?: any[];
+  podsSchema?: any;
+  weight?: number;
+}
+
+export const fetchDefaultPodsProps = async(store: Store<any>): Promise<Props> => {
+  const allPods = await store.dispatch('cluster/findAll', { type: POD });
+  const schema = store.getters['cluster/schemaFor'](POD);
+
+  return {
+    pods:        allPods,
+    podsHeaders: store.getters['type-map/headersFor'](schema),
+    podsSchema:  schema
+  };
+};
+</script>
+
+<script lang="ts" setup>
+const {
+  pods, podsHeaders, podsSchema, weight
+} = defineProps<Props>();
+
+const store = useStore();
+const { t } = useI18n(store);
+</script>
+
+<template>
+  <Tab
+    v-if="pods"
+    name="pods"
+    :label="t('tableHeaders.pods')"
+    :weight="weight"
+  >
+    <ResourceTable
+      :rows="pods"
+      :headers="podsHeaders"
+      key-field="id"
+      :schema="podsSchema"
+      :groupable="false"
+      :search="false"
+    />
+  </Tab>
+</template>

--- a/shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/ServicesTab.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/ServicesTab.vue
@@ -1,0 +1,78 @@
+<script lang="ts">
+import { Store, useStore } from 'vuex';
+import ResourceTable from '@shell/components/ResourceTable.vue';
+import Tab from '@shell/components/Tabbed/Tab.vue';
+import { useI18n } from '@shell/composables/useI18n';
+import { SERVICE } from '@shell/config/types';
+
+export interface Props {
+  services?: any[];
+  servicesHeaders?: Object;
+  servicesSchema?: any;
+  weight?: number;
+}
+
+export const fetchDefaultServicesProps = async(store: Store<any>): Promise<Props> => {
+  const allServices = await store.dispatch('cluster/findAll', { type: SERVICE });
+  const schema = store.getters['cluster/schemaFor'](SERVICE);
+
+  return {
+    services:        allServices,
+    servicesHeaders: store.getters['type-map/headersFor'](schema),
+    servicesSchema:  schema,
+  };
+};
+</script>
+
+<script lang="ts" setup>
+const {
+  services, servicesHeaders, servicesSchema, weight
+} = defineProps<Props>();
+
+const store = useStore();
+const { t } = useI18n(store);
+</script>
+
+<template>
+  <Tab
+    v-if="services"
+    name="services"
+    :label="t('workload.detail.services')"
+    :weight="weight"
+  >
+    <p
+      v-if="!servicesSchema"
+      class="caption"
+    >
+      {{ t('workload.detail.cannotViewServices') }}
+    </p>
+    <p
+      v-else-if="services.length === 0"
+      class="caption"
+    >
+      {{ t('workload.detail.cannotFindServices') }}
+    </p>
+    <p
+      v-else
+      class="caption"
+    >
+      {{ t('workload.detail.serviceListCaption') }}
+    </p>
+    <ResourceTable
+      v-if="servicesSchema && services.length > 0"
+      :rows="services"
+      :headers="servicesHeaders"
+      key-field="id"
+      :schema="servicesSchema"
+      :groupable="false"
+      :search="false"
+      :table-actions="false"
+    />
+  </Tab>
+</template>
+
+<style lang="scss" scoped>
+.caption {
+  margin-bottom: .5em;
+}
+</style>

--- a/shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/index.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/index.vue
@@ -1,0 +1,74 @@
+<script lang="ts">
+import CronJobsTab, { Props as CronJobsProps, fetchDefaultCronJobsProps } from '@shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/CronJobsTab.vue';
+import PodsTab, { Props as PodsProps, fetchDefaultPodsProps } from '@shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/PodsTab.vue';
+import MetricsTab, { Props as MetricsTabProps, fetchDefaultProjectMetricsProps, fetchDefaultMetricsProps } from '@shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/MetricsTab.vue';
+import ServicesTab, { Props as ServicesTabProps, fetchDefaultServicesProps } from '@shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/ServicesTab.vue';
+import IngressesTab, { Props as IngressesTabProps, fetchDefaultIngressesProps } from '@shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/IngressesTab.vue';
+import ResourceTabs from '@shell/components/form/ResourceTabs/index.vue';
+import { Store } from 'vuex';
+import { I18n } from '@shell/composables/useI18n';
+
+export interface Props {
+  cronJobsTab: CronJobsProps;
+  podsTab: PodsProps;
+  metricsTab: MetricsTabProps;
+  projectMetricsTab: MetricsTabProps;
+  servicesTab: ServicesTabProps;
+  ingressesTab: IngressesTabProps;
+}
+
+export const fetchDefaultWorkloadResourceTabs = async(store: Store<any>, i18n: I18n): Promise<Props> => {
+  return {
+    cronJobsTab:  await fetchDefaultCronJobsProps(store),
+    podsTab:      await fetchDefaultPodsProps(store),
+    metricsTab:   await fetchDefaultMetricsProps({}, i18n),
+    // projectMetricsTab: await fetchDefaultProjectMetricsProps({}, store, i18n),
+    servicesTab:  await fetchDefaultServicesProps(store),
+    ingressesTab: await fetchDefaultIngressesProps(store),
+  };
+};
+
+</script>
+
+<script setup lang="ts">
+
+const {
+  cronJobsTab,
+  podsTab,
+  metricsTab,
+  projectMetricsTab,
+  servicesTab,
+  ingressesTab,
+} = defineProps<Props>();
+
+</script>
+
+<template>
+  <ResourceTabs>
+    <CronJobsTab
+      v-bind="cronJobsTab"
+      :weight="4"
+    />
+    <PodsTab
+      v-bind="podsTab"
+      :weight="4"
+    />
+    <MetricsTab
+      v-bind="metricsTab"
+      :weight="3"
+    />
+    <!-- <MetricsTab v-bind="projectMetricsTab" :weight="3"/> -->
+    <ServicesTab
+      v-bind="servicesTab"
+      :weight="3"
+    />
+    <IngressesTab
+      v-bind="ingressesTab"
+      :weight="2"
+    />
+  </ResourceTabs>
+</template>
+
+<style lang='scss' scoped>
+
+</style>

--- a/shell/components/Resource/Detail/SpacedRow.vue
+++ b/shell/components/Resource/Detail/SpacedRow.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="spaced-row">
+    <slot />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.spaced-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  column-gap: 24px;
+
+  &:deep() > * {
+    flex: 1;
+  }
+}
+</style>

--- a/shell/components/Resource/Detail/StatusBar.vue
+++ b/shell/components/Resource/Detail/StatusBar.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+export interface Segment {
+        color: string;
+        percent: number;
+}
+
+export interface Props {
+        segments: Segment[]
+}
+
+const { segments } = defineProps<Props>();
+
+const computeStyle = (segment: Segment) => {
+  return {
+    backgroundColor: segment.color,
+    width:           `${ segment.percent }%`
+  };
+};
+</script>
+
+<template>
+  <div class="status-bar">
+    <div
+      v-for="(segment, i) in segments"
+      :key="i"
+      class="segment"
+      :style="computeStyle(segment)"
+    >
+&nbsp;
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.status-bar {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+
+    column-gap: 2px;
+    height: 21px;
+
+    .segment {
+        height: 4px;
+
+        &:first-of-type {
+          border-top-left-radius: 4px;
+          border-bottom-left-radius: 4px;
+        }
+
+        &:last-of-type {
+          border-top-right-radius: 4px;
+          border-bottom-right-radius: 4px;
+        }
+    }
+}
+</style>

--- a/shell/components/Resource/Detail/StatusRow.vue
+++ b/shell/components/Resource/Detail/StatusRow.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import Bubble from '@shell/components/Resource/Detail/Card/PodsCard/Bubble.vue';
+
+export interface Props {
+        color: string;
+        label: string;
+        count: number;
+        percent: number;
+}
+
+const {
+  color, label, count, percent
+} = defineProps<Props>();
+</script>
+
+<template>
+  <div class="status-row">
+    <div
+      class="indicator"
+      :style="{backgroundColor: color}"
+    >
+&nbsp;
+    </div>
+    <div class="label">
+      {{ label }}
+    </div>
+    <div class="count">
+      <Bubble>{{ count }}</Bubble>
+    </div>
+    <div class="percent text-muted">
+      {{ percent.toFixed(1) }}%
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.status-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+
+    &:not(:first-of-type) {
+      margin-top: 8px;
+    }
+
+    .label {
+      flex-grow: 1;
+    }
+
+    .indicator {
+      height: 4px;
+      border-radius: 4px;
+      width: 20px;
+      margin-right: 10px;
+    }
+
+    .percent {
+      width: 60px;
+      text-align: right;
+    }
+}
+</style>

--- a/shell/components/Resource/Detail/TitleBar.vue
+++ b/shell/components/Resource/Detail/TitleBar.vue
@@ -1,0 +1,95 @@
+<script lang="ts">
+import BadgeState from '~/pkg/rancher-components/src/components/BadgeState/BadgeState.vue';
+import { RouteLocationRaw, RouteLocationNormalizedLoaded } from 'vue-router';
+import { Store } from 'vuex';
+
+export interface Badge {
+  color: 'bg-success' | 'bg-error' | 'bg-warning' | 'bg-info';
+  label: string;
+}
+
+export interface TitleBarProps {
+  resourceTypeLabel: string;
+  resourceTo?: RouteLocationRaw;
+  resourceName: string;
+
+  description?: string;
+  badge?: Badge;
+}
+
+export const extractDefaultTitleBarData = (resource: any, route: RouteLocationNormalizedLoaded, store: Store<any> ): TitleBarProps => {
+  return {
+    resourceTypeLabel: store.getters['type-map/labelFor']({ id: resource.type }, 2),
+    resourceTo:        {
+      name:   'c-cluster-product-resource',
+      params: {
+        product:   'explorer',
+        cluster:   route.params.cluster,
+        namespace: resource.namespace,
+        resource:  resource.type
+      }
+    },
+    resourceName: resource.nameDisplay,
+    badge:        {
+      color: resource.stateBackground,
+      label: resource.stateDisplay
+    }
+  };
+};
+</script>
+
+<script setup lang="ts">
+
+const {
+  resourceTypeLabel, resourceTo, resourceName, description, badge
+} = defineProps<TitleBarProps>();
+</script>
+
+<template>
+  <div class="title-bar">
+    <div class="top">
+      <h1>
+        <router-link
+          v-if="resourceTo"
+          :to="resourceTo"
+        >
+          {{ resourceTypeLabel }}:
+        </router-link>
+        <span v-else>
+          {{ resourceTypeLabel }}:
+        </span>
+        {{ resourceName }}
+        <BadgeState
+          v-if="badge"
+          :color="badge.color"
+          :label="badge.label"
+        />
+      </h1>
+    </div>
+    <div
+      v-if="description"
+      class="bottom"
+    >
+      {{ description }}
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.title-bar {
+
+  h1 {
+    display: inline-block;
+    align-items: center;
+    line-height: 18px;
+  }
+
+  &:deep() .badge-state {
+    font-size: 16px;
+    margin-left: 4px;
+    top: -4px;
+    position: relative;
+
+  }
+}
+</style>

--- a/shell/components/Resource/Detail/Top/index.vue
+++ b/shell/components/Resource/Detail/Top/index.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <div class="resource-detail-page-top">
+    <div
+      v-if="$slots['header']"
+      class="header"
+    >
+      <slot name="header" />
+    </div>
+    <div
+      v-if="$slots['system-messages']"
+      class="system-messages"
+    >
+      <slot name="system-messages" />
+    </div>
+    <div
+      v-if="$slots['metadata']"
+      class="metadata"
+    >
+      <slot name="metadata" />
+    </div>
+    <div
+      v-if="$slots['extension-content']"
+      class="extension-content"
+    >
+      <slot name="extension-content" />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+</style>

--- a/shell/components/StatusBadge.vue
+++ b/shell/components/StatusBadge.vue
@@ -19,11 +19,13 @@ const STATUS = {
   }
 };
 
+export interface Props {
+  status?: 'success' | 'warning' | 'info' | 'error',
+  label?: string
+}
+
 withDefaults(
-  defineProps<{
-    status?: 'success' | 'warning' | 'info' | 'error',
-    label?: string
-  }>(),
+  defineProps<Props>(),
   {
     status: 'success',
     label:  '',

--- a/shell/components/SubtleLink.vue
+++ b/shell/components/SubtleLink.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { RouterLink, RouteLocationRaw } from 'vue-router';
+
+export interface Props {
+  to: RouteLocationRaw;
+}
+
+const { to } = defineProps<Props>();
+</script>
+
+<template>
+  <RouterLink
+    class="subtle-link"
+    :to="to"
+  >
+    <slot name="default" />
+  </RouterLink>
+</template>
+
+<style lang="scss" scoped>
+.subtle-link {
+    text-decoration: underline;
+    color: var(--body-text);
+}
+</style>

--- a/shell/components/form/ResourceTabs/index.vue
+++ b/shell/components/form/ResourceTabs/index.vue
@@ -290,3 +290,17 @@ export default {
     </Tab>
   </Tabbed>
 </template>
+
+<style lang="scss" scoped>
+:deep() .tabs.horizontal {
+  border: none;
+}
+
+:deep() .tabs.horizontal + .tab-container {
+  border: none;
+  border-top: 1px solid var(--border);
+
+  padding: 0;
+  padding-top: 24px;
+}
+</style>

--- a/shell/components/templates/default.vue
+++ b/shell/components/templates/default.vue
@@ -206,8 +206,13 @@ export default {
       >
         <router-view
           :key="$route.path"
+          v-slot="{ Component }"
           class="outlet"
-        />
+        >
+          <Suspense>
+            <component :is="Component" />
+          </Suspense>
+        </router-view>
         <ActionMenu />
         <PromptRemove />
         <PromptRestore />
@@ -245,8 +250,13 @@ export default {
       >
         <router-view
           :key="$route.path"
+          v-slot="{ Component }"
           class="outlet"
-        />
+        >
+          <Suspense>
+            <component :is="Component" />
+          </Suspense>
+        </router-view>
       </main>
       <div
         v-if="$refs.draggableZone"

--- a/shell/composables/useI18n.ts
+++ b/shell/composables/useI18n.ts
@@ -3,17 +3,6 @@ import { Store } from 'vuex';
 import { stringFor } from '@shell/plugins/i18n';
 
 let store: Store<any> | null = null;
-
-export const useI18n = (vuexStore: Store<any>): { t: typeof t } => {
-  store = vuexStore;
-
-  if (!store) {
-    throw new Error('usI18n() must be called from setup()');
-  }
-
-  return { t };
-};
-
 /**
  * Allows for consuming i18n strings with the Vue composition API.
  * @param key - The key for the i18n string to translate.
@@ -23,4 +12,16 @@ export const useI18n = (vuexStore: Store<any>): { t: typeof t } => {
  */
 const t = (key: string, args?: unknown, raw?: boolean): string => {
   return stringFor(store, key, args, raw);
+};
+
+export type I18n = { t: typeof t };
+
+export const useI18n = (vuexStore: Store<any>): I18n => {
+  store = vuexStore;
+
+  if (!store) {
+    throw new Error('usI18n() must be called from setup()');
+  }
+
+  return { t };
 };

--- a/shell/config/router/routes.js
+++ b/shell/config/router/routes.js
@@ -480,7 +480,18 @@ export default [
         path:      '/c/:cluster/:product/:resource/:id',
         component: () => interopDefault(import('@shell/pages/c/_cluster/_product/_resource/_id.vue')),
         name:      'c-cluster-product-resource-id'
-      }, {
+      },
+      {
+        path:      '/c/:cluster/:product/batch.cronjob/:namespace/:id/detail',
+        component: () => interopDefault(import('@shell/pages/explorer/resource/detail/batch.cronjob.vue')),
+        name:      'batch.cronjob-detail'
+      },
+      {
+        path:      '/c/:cluster/:product/apps.deployment/:namespace/:id/detail',
+        component: () => interopDefault(import('@shell/pages/explorer/resource/detail/apps.deployment.vue')),
+        name:      'apps.deployment-detail'
+      },
+      {
         path:      '/c/:cluster/:product/:resource/:namespace/:id',
         component: () => interopDefault(import('@shell/pages/c/_cluster/_product/_resource/_namespace/_id.vue')),
         name:      'c-cluster-product-resource-namespace-id'

--- a/shell/pages/explorer/resource/detail/apps.deployment.vue
+++ b/shell/pages/explorer/resource/detail/apps.deployment.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useStore } from 'vuex';
+import { useRoute } from 'vue-router';
+
+import DetailPage from '@shell/components/Resource/Detail/Page.vue';
+import SpacedRow from '@shell/components/Resource/Detail/SpacedRow.vue';
+import CpuUsageCard from '@shell/components/Resource/Detail/Card/CpuUsageCard.vue';
+import MemoryUsageCard from '@shell/components/Resource/Detail/Card/MemoryUsageCard.vue';
+import PodUsageCard from '@shell/components/Resource/Detail/Card/PodUsageCard.vue';
+import PodsCard from '@shell/components/Resource/Detail/Card/PodsCard/index.vue';
+import ResourcesCard from '@shell/components/Resource/Detail/Card/ResourcesCard.vue';
+import InsightsCard from '@shell/components/Resource/Detail/Card/InsightsCard.vue';
+import WorkloadResourceTabs, { fetchDefaultWorkloadResourceTabs } from '@shell/components/Resource/Detail/ResourceTabs/WorkloadResourceTabs/index.vue';
+import TitleBar, { extractDefaultTitleBarData } from '@shell/components/Resource/Detail/TitleBar.vue';
+import Metadata, { extractDefaultMetadata } from '@shell/components/Resource/Detail/Metadata/index.vue';
+import { WORKLOAD_TYPES } from '@shell/config/types';
+import { useI18n } from '@shell/composables/useI18n';
+
+const store = useStore();
+const route = useRoute();
+const i18n = useI18n(store);
+
+const fetch = async() => {
+  const id = `${ route.params.namespace }/${ route.params.id }`;
+
+  const deployment = await store.dispatch('cluster/find', { type: WORKLOAD_TYPES.DEPLOYMENT, id });
+
+  return {
+    titleBar:     extractDefaultTitleBarData(deployment, route, store),
+    metadata:     extractDefaultMetadata(deployment, i18n),
+    resourceTabs: await fetchDefaultWorkloadResourceTabs(store, i18n)
+  };
+};
+
+const data = ref(await fetch());
+
+</script>
+<template>
+  <DetailPage>
+    <template #top-area>
+      <TitleBar
+        :resourceTypeLabel="data.titleBar.resourceTypeLabel"
+        :resourceTo="data.titleBar.resourceTo"
+        :resourceName="data.titleBar.resourceName"
+        :description="data.titleBar.description"
+        :badge="data.titleBar.badge"
+      />
+      <Metadata
+        class="mmt-6"
+        :identifying-information="data.metadata.identifyingInformation"
+        :labels="data.metadata.labels"
+        :annotations="data.metadata.annotations"
+      />
+    </template>
+    <template #middle-area>
+      <SpacedRow>
+        <CpuUsageCard />
+        <MemoryUsageCard />
+        <PodUsageCard />
+      </SpacedRow>
+      <SpacedRow class="mmt-6">
+        <PodsCard />
+        <ResourcesCard />
+        <InsightsCard />
+      </SpacedRow>
+    </template>
+    <template #bottom-area>
+      <WorkloadResourceTabs
+        :cronJobsTab="data.resourceTabs.cronJobsTab"
+        :podsTab="data.resourceTabs.podsTab"
+        :metricsTab="data.resourceTabs.metricsTab"
+        :projectMetricsTab="data.resourceTabs.projectMetricsTab"
+        :servicesTab="data.resourceTabs.servicesTab"
+        :ingressesTab="data.resourceTabs.ingressesTab"
+      />
+    </template>
+  </DetailPage>
+</template>

--- a/shell/pages/explorer/resource/detail/batch.cronjob.vue
+++ b/shell/pages/explorer/resource/detail/batch.cronjob.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useStore } from 'vuex';
+import { useRoute } from 'vue-router';
+
+import DetailPage from '@shell/components/Resource/Detail/Page.vue';
+import SpacedRow from '@shell/components/Resource/Detail/SpacedRow.vue';
+import CpuUsageCard from '@shell/components/Resource/Detail/Card/CpuUsageCard.vue';
+import MemoryUsageCard from '@shell/components/Resource/Detail/Card/MemoryUsageCard.vue';
+import PodUsageCard from '@shell/components/Resource/Detail/Card/PodUsageCard.vue';
+import PodsCard from '@shell/components/Resource/Detail/Card/PodsCard/index.vue';
+import ResourcesCard from '@shell/components/Resource/Detail/Card/ResourcesCard.vue';
+import InsightsCard from '@shell/components/Resource/Detail/Card/InsightsCard.vue';
+import TitleBar, { extractDefaultTitleBarData } from '@shell/components/Resource/Detail/TitleBar.vue';
+import Metadata, { extractDefaultMetadata } from '@shell/components/Resource/Detail/Metadata/index.vue';
+import { WORKLOAD_TYPES } from '@shell/config/types';
+
+const store = useStore();
+const route = useRoute();
+
+const fetch = async() => {
+  const id = `${ route.params.namespace }/${ route.params.id }`;
+
+  const cronJob = await store.dispatch('cluster/find', { type: WORKLOAD_TYPES.CRON_JOB, id });
+
+  return {
+    titleBar: extractDefaultTitleBarData(cronJob),
+    metadata: extractDefaultMetadata(cronJob)
+  };
+};
+
+const data = ref(await fetch());
+
+</script>
+<template>
+  <DetailPage>
+    <template #top-area>
+      <TitleBar
+        resourceTypeLabel="CronJob"
+        resourceTo="#"
+        :resourceName="data.titleBar.resourceName"
+
+        description="A CronJob creates Jobs on a repeating schedule."
+        :badge="{label: 'Active', color: 'bg-success'}"
+      />
+      <Metadata
+        class="mmt-6"
+        :identifying-information="data.metadata.identifyingInformation"
+        :labels="data.metadata.labels"
+        :annotations="data.metadata.annotations"
+      />
+    </template>
+    <template #middle-area>
+      <SpacedRow>
+        <CpuUsageCard />
+        <MemoryUsageCard />
+        <PodUsageCard />
+      </SpacedRow>
+      <SpacedRow class="mmt-6">
+        <PodsCard />
+        <ResourcesCard />
+        <InsightsCard />
+      </SpacedRow>
+    </template>
+    <template #bottom-area>
+      <div>Bottom</div>
+    </template>
+  </DetailPage>
+</template>


### PR DESCRIPTION
The eventual goal is to make these design changes https://confluence.suse.com/display/CU/Resource+page+redesign . While doing this I'm trying to move us in the direction of idiomatic vue3 rather than just modifying styles here and there.

This is nowhere near done but I'd like to get some feedback on the following: 

- general organization
- component design 
- fetching patterns

I think it's easiest to start at this page component:
[shell/pages/explorer/resource/detail/apps.deployment.vue](https://github.com/rancher/dashboard/compare/master...codyrancher:dashboard:detail-page?expand=1#diff-7d0976f24eefa02ccce988873ffb94ec5ceec0ae290b89c7ef187890be99489f)

And the most fetching going on right now is with the `<WorkloadResourceTabs />` component.