### PR TITLE
Enabling stalebot

### DIFF
--- a/.github/workflows/close-stale-enhancement-requests.yaml
+++ b/.github/workflows/close-stale-enhancement-requests.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          debug-only: true # Uncomment to switch back to dry-run
+          # debug-only: true # Uncomment to switch back to dry-run
           exempt-issue-labels: "JIRA" # We don't want to close jira issues as these came from customers
           only-issue-labels: "kind/enhancement"
           days-before-pr-stale: -1


### PR DESCRIPTION
I verified that our criteria is respected and we don't get erroneous closing. Right now the bot is actually too conservative.

Because we update labels, milestones etc practically none of our issues are considered stale. For the time being I marked everything that's older than 1.5 years as stale manually which will allow this bot to close them given our other criteria and leave the comment.

There's 3 options to allow this bot to run:
- We can manually mark things as stale periodically and this will run
- We can avoid updating issues unless we intend on actually prioritizing them
- We can use the `ignore-updates` option but this would also ignore comments. https://github.com/actions/stale?tab=readme-ov-file#ignore-updates . _(I'm in favor of this option since we welcome the users to re-open but I could see how this could lead to community issues.)_
- Maybe we make our own bot that ignores updates but considers comments.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes