### PR TITLE
Update `namespaceFilter` accessibility features

### DIFF
--- a/pkg/rancher-components/src/components/RcButton/RcButton.vue
+++ b/pkg/rancher-components/src/components/RcButton/RcButton.vue
@@ -51,7 +51,7 @@ defineExpose({ focus });
   <button
     ref="RcFocusTarget"
     role="button"
-    :class="{ ...buttonClass, ...($attrs.class || { }) }"
+    :class="{ ...buttonClass }"
   >
     <slot name="before">
       <!-- Empty Content -->

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3945,7 +3945,7 @@ namespaceFilter:
       other {{total} items selected}
       }
   input: Filter namespace options
-  buttons:
+  button:
     clear: Remove applied namespace filters
     clearFilter: Clear namespace options filter 
 

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3944,6 +3944,10 @@ namespaceFilter:
       one {1 item selected}
       other {{total} items selected}
       }
+  input: Filter namespace options
+  buttons:
+    clear: Remove applied namespace filters
+    clearFilter: Clear namespace options filter 
 
 namespaceList:
   selectLabel: Namespace

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -800,12 +800,17 @@ export default {
       data-testid="namespaces-menu"
     >
       <div class="ns-controls">
-        <div class="ns-input">
+        <div
+          class="ns-input"
+          role="status"
+          aria-live="polite"
+        >
           <input
             ref="filterInput"
             v-model="filter"
             tabindex="0"
             class="ns-filter-input"
+            :aria-label="t('namespaceFilter.input')"
             @click="focusFilter"
             @keydown="inputKeyHandler($event)"
           >
@@ -814,6 +819,7 @@ export default {
             small
             ghost
             class="ns-filter-clear"
+            :aria-label="t('namespaceFilter.button.clearFilter')"
             @click="clearFilter"
             @keydown.enter.stop="clearFilter"
           >
@@ -836,6 +842,7 @@ export default {
           small
           ghost
           class="ns-clear"
+          :aria-label="t('namespaceFilter.button.clear')"
           @click="clear()"
           @keydown.enter.stop="clear()"
         >
@@ -850,6 +857,7 @@ export default {
         class="ns-options"
         role="listbox"
         tabindex="0"
+        aria-live="polite"
         @keydown.down.enter.stop="down"
         @keydown.escape="close()"
         @keydown.tab.exact.stop="close()"

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -542,10 +542,10 @@ export default {
       this.activeElement = null;
     },
     down(input) {
-      const exising = this.activeElement || document.activeElement;
+      const existing = this.activeElement || document.activeElement;
 
       // Focus the first element in the list
-      if (input || !exising) {
+      if (input || !existing) {
         if (this.$refs.options) {
           const c = this.$refs.options.children;
 
@@ -554,15 +554,11 @@ export default {
           }
         }
       } else {
-        let next = exising.nextSibling;
+        let next = existing.nextElementSibling;
 
-        if (next?.children?.length) {
-          const item = next.children[0];
-
-          // Skip over dividers (assumes we don't have two dividers next to each other)
-          if (item.classList.contains('ns-divider')) {
-            next = next.nextSibling;
-          }
+        // Skip over dividers (assumes we don't have two dividers next to each other)
+        if (next.classList.contains('ns-divider')) {
+          next = next.nextElementSibling;
         }
 
         if (next?.focus) {
@@ -572,14 +568,10 @@ export default {
     },
     up() {
       if (document.activeElement) {
-        let prev = document.activeElement.previousSibling;
+        let prev = document.activeElement.previousElementSibling;
 
-        if (prev?.children?.length) {
-          const item = prev.children[0];
-
-          if (item.classList.contains('ns-divider')) {
-            prev = prev.previousSibling;
-          }
+        if (prev.classList.contains('ns-divider')) {
+          prev = prev.previousElementSibling;
         }
 
         if (prev?.focus) {
@@ -693,7 +685,7 @@ export default {
     data-testid="namespaces-filter"
     tabindex="0"
     @mousedown.prevent
-    @focus="open()"
+    @keydown.down="open"
   >
     <div
       v-if="isOpen"
@@ -833,43 +825,49 @@ export default {
       <div
         ref="options"
         class="ns-options"
-        role="list"
+        role="listbox"
       >
-        <div
+        <template
           v-for="(opt, i) in cachedFiltered"
-          :id="opt.elementId"
           :key="opt.id"
-          tabindex="0"
-          class="ns-option"
-          :disabled="opt.enabled ? null : true"
-          :class="{
-            'ns-selected': opt.selected,
-            'ns-single-match': cachedFiltered.length === 1 && !opt.selected,
-          }"
-          :data-testid="`namespaces-option-${i}`"
-          @click="opt.enabled && selectOption(opt)"
-          @mouseover="opt.enabled && mouseOver($event)"
-          @keydown="itemKeyHandler($event, opt)"
         >
-          <div
+          <hr
             v-if="opt.kind === NAMESPACE_FILTER_KINDS.DIVIDER"
+            role="separator"
+            aria-orientation="horizontal"
             class="ns-divider"
-          />
+          >
           <div
             v-else
-            class="ns-item"
+            :id="opt.elementId"
+            tabindex="-1"
+            role="option"
+            class="ns-option"
+            :disabled="opt.enabled ? null : true"
+            :class="{
+              'ns-selected': opt.selected,
+              'ns-single-match': cachedFiltered.length === 1 && !opt.selected,
+            }"
+            :data-testid="`namespaces-option-${i}`"
+            @click="opt.enabled && selectOption(opt)"
+            @mouseover="opt.enabled && mouseOver($event)"
+            @keydown="itemKeyHandler($event, opt)"
           >
-            <i
-              v-if="opt.kind === NAMESPACE_FILTER_KINDS.NAMESPACE"
-              class="icon icon-folder"
-            />
-            <div>{{ opt.label }}</div>
-            <i
-              v-if="opt.selected"
-              class="icon icon-checkmark"
-            />
+            <div
+              class="ns-item"
+            >
+              <i
+                v-if="opt.kind === NAMESPACE_FILTER_KINDS.NAMESPACE"
+                class="icon icon-folder"
+              />
+              <div>{{ opt.label }}</div>
+              <i
+                v-if="opt.selected"
+                class="icon icon-checkmark"
+              />
+            </div>
           </div>
-        </div>
+        </template>
         <div
           v-if="cachedFiltered.length === 0"
           class="ns-none"

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -20,6 +20,7 @@ import { KEY } from '@shell/utils/platform';
 import pAndNFiltering from '@shell/plugins/steve/projectAndNamespaceFiltering.utils';
 import { SETTING } from '@shell/config/settings';
 import paginationUtils from '@shell/utils/pagination-utils';
+import { randomStr } from '@shell/utils/string';
 import { RcButton } from '@components/RcButton';
 
 const forcedNamespaceValidTypes = [NAMESPACE_FILTER_KINDS.DIVIDER, NAMESPACE_FILTER_KINDS.PROJECT, NAMESPACE_FILTER_KINDS.NAMESPACE];
@@ -38,6 +39,7 @@ export default {
       cachedFiltered:      [],
       NAMESPACE_FILTER_KINDS,
       namespaceFilterMode: undefined,
+      containerId:         `dropdown-${ randomStr() }`,
     };
   },
 
@@ -694,6 +696,8 @@ export default {
     v-if="!$fetchState.pending"
     ref="namespaceFilterInput"
     role="combobox"
+    :aria-expanded="isOpen"
+    :aria-activedescendant="containerId"
     class="ns-filter"
     data-testid="namespaces-filter"
     tabindex="0"
@@ -708,6 +712,7 @@ export default {
 
     <!-- Select Dropdown control -->
     <div
+      :id="containerId"
       ref="dropdown"
       class="ns-dropdown"
       data-testid="namespaces-dropdown"
@@ -878,6 +883,7 @@ export default {
             tabindex="-1"
             role="option"
             class="ns-option"
+            :aria-selected="opt.selected"
             :disabled="opt.enabled ? null : true"
             :class="{
               'ns-selected': opt.selected,

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -20,10 +20,13 @@ import { KEY } from '@shell/utils/platform';
 import pAndNFiltering from '@shell/plugins/steve/projectAndNamespaceFiltering.utils';
 import { SETTING } from '@shell/config/settings';
 import paginationUtils from '@shell/utils/pagination-utils';
+import { RcButton } from '@components/RcButton';
 
 const forcedNamespaceValidTypes = [NAMESPACE_FILTER_KINDS.DIVIDER, NAMESPACE_FILTER_KINDS.PROJECT, NAMESPACE_FILTER_KINDS.NAMESPACE];
 
 export default {
+
+  components: { RcButton },
 
   data() {
     return {
@@ -594,6 +597,10 @@ export default {
       this.addCloseKeyHandler();
       this.layout();
     },
+    clearFilter() {
+      this.filter = '';
+      this.focusFilter();
+    },
     focusFilter() {
       this.$refs.filter.focus();
     },
@@ -796,11 +803,18 @@ export default {
             @click="focusFilter"
             @keydown="inputKeyHandler($event)"
           >
-          <i
+          <RcButton
             v-if="hasFilter"
-            class="ns-filter-clear icon icon-close"
-            @click="filter = ''"
-          />
+            small
+            ghost
+            class="ns-filter-clear"
+            @click="clearFilter"
+            @keydown.enter.stop="clearFilter"
+          >
+            <i
+              class="icon icon-close"
+            />
+          </RcButton>
         </div>
         <div
           v-if="namespaceFilterMode"
@@ -811,15 +825,18 @@ export default {
             class="icon icon-info"
           />
         </div>
-        <div
+        <RcButton
           v-else
+          small
+          ghost
           class="ns-clear"
+          @click="clear()"
+          @keydown.enter.stop="clear()"
         >
           <i
             class="icon icon-close"
-            @click="clear()"
           />
-        </div>
+        </RcButton>
       </div>
       <div class="ns-divider mt-0" />
       <div
@@ -908,18 +925,15 @@ export default {
     }
 
     .ns-clear {
+      padding: 0 5px;
       &:hover {
         color: var(--primary);
-        cursor: pointer;
       }
     }
 
     .ns-singleton-info, .ns-clear {
       align-items: center;
       display: flex;
-      > i {
-        padding-right: 5px;
-      }
     }
 
     .ns-input {
@@ -936,10 +950,11 @@ export default {
       cursor: pointer;
       position: absolute;
       right: 10px;
-      top: 5px;
+      top: 10px;
       line-height: 24px;
       text-align: center;
-      width: 24px;
+      width: 14px;
+      min-height: 14px;
     }
 
     .ns-dropdown-menu {

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -702,7 +702,7 @@ export default {
     data-testid="namespaces-filter"
     tabindex="0"
     @mousedown.prevent
-    @keydown.down.enter="open"
+    @keydown.down.enter.space="open"
   >
     <div
       v-if="isOpen"
@@ -848,8 +848,9 @@ export default {
           ghost
           class="ns-clear"
           :aria-label="t('namespaceFilter.button.clear')"
-          @click="clear()"
-          @keydown.enter.stop="clear()"
+          @click="clear"
+          @keydown.enter.stop="clear"
+          @keydown.tab.exact.prevent="down"
         >
           <i
             class="icon icon-close"
@@ -864,8 +865,8 @@ export default {
         tabindex="0"
         aria-live="polite"
         @keydown.down.enter.stop="down"
-        @keydown.escape="close()"
-        @keydown.tab.exact.stop="close()"
+        @keydown.escape="close"
+        @keydown.tab.exact.stop="close"
       >
         <template
           v-for="(opt, i) in cachedFiltered"

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -702,7 +702,7 @@ export default {
     data-testid="namespaces-filter"
     tabindex="0"
     @mousedown.prevent
-    @keydown.down.enter.space="open"
+    @keydown.down.enter.space.prevent="open"
   >
     <div
       v-if="isOpen"

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -764,13 +764,18 @@ export default {
         >
           <div>{{ ns.label }}</div>
           <!-- block user from removing the last selection if ns forced filtering is on -->
-          <i
+          <RcButton
             v-if="!namespaceFilterMode || value.length > 1"
-            class="icon icon-close"
+            small
+            ghost
+            class="ns-chip-button"
             :data-testid="`namespaces-values-close-${j}`"
             @click="removeOption(ns, $event)"
+            @keydown.enter.space.stop="removeOption(ns, $event)"
             @mousedown="handleValueMouseDown(ns, $event)"
-          />
+          >
+            <i class="icon icon-close" />
+          </RcButton>
         </div>
       </div>
 
@@ -980,6 +985,10 @@ export default {
       line-height: 24px;
       text-align: center;
       width: 14px;
+      min-height: 14px;
+    }
+
+    .ns-chip-button {
       min-height: 14px;
     }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates the namespace filter to make is more keyboard accessible. This also updates aria attributes so that different elements and behaviors of the namespace filter can be better detected by screen readers.

Fixes #12779
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Fix roles for namespace filter options
- Replace namespace filter icons with buttons
- Fix RcButton classes
- Update namespace filter roles and keyboard behavior
- Update aria attributes

Most notably, the keyboard behavior has been updated so that all elements are accessible via keyboard:

- Namespace filter is focused
   - Down/Enter opens the namespace filter and focuses on the filter input
- Namespace filter is opened
  - Tab will focus the next element
  - Down will enter the list of options
  - Tabbing away from final element in the dropdown will close the dropdown and focus the next element in tab order
  - Escape will close the dropdown and return focus to the namespace filter
- Namespace filter items have focus
  - Keyboard up/down will focus the next/previous element
  - Focus will loop to top/bottom when moving past last/first element
  - Tab will close the dropdown and focus next element in tab order
  - Escape will close the dropdown and return focus to the namespace filter
  - Shift+Tab will focus previous element in dropdown

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I explored potential options like using `vue-select` or `RcDropdown` to perform a larger refactor and get better out of the box accessibility support. Each approach had major downsides that would either alter the design of the namespace filter component greatly or require a great deal of customization to retain the current design and behavior. Because of this, I opted to apply fixes to the existing component. 

It appears that this namespace filter most closely follows the combobox pattern[^1], but not entirely. I did my best to apply the guidelines so that the namespace filter follows the correct patterns.

[^1]: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Namespace filter

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Namespace filter

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
