### PR TITLE
Resource Search: Add ability to search by group

### DIFF
--- a/cypress/e2e/tests/pages/explorer2/resource-search.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/resource-search.spec.ts
@@ -42,12 +42,12 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer2', '@adm
     dialog.checkExists();
     dialog.checkVisible();
 
-    dialog.searchBox().type('fleet');
+    dialog.searchBox().type('auth');
 
     // Wait for less than 20 - then we know the results are updated for our search
     dialog.results().should('have.length.lt', 20);
     dialog.results().should('have.length.gt', 1);
-    dialog.results().first().should('have.text', 'Contents (contents.fleet.cattle.io)');
+    dialog.results().first().should('have.text', 'SelfSubjectReviews (selfsubjectreviews.authentication.k8s.io)');
 
     dialog.close();
 

--- a/cypress/e2e/tests/pages/explorer2/resource-search.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/resource-search.spec.ts
@@ -52,7 +52,7 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer2', '@adm
     dialog.close();
 
     dialog.checkNotExists();
-  });  
+  });
 
   it('can show resource dialog when namespace chooser is open', () => {
     const namespacePicker = new NamespaceFilterPo();

--- a/cypress/e2e/tests/pages/explorer2/resource-search.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/resource-search.spec.ts
@@ -33,6 +33,27 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer2', '@adm
     dialog.checkNotExists();
   });
 
+  it('can search by resource group', () => {
+    // Open the resource search
+    clusterDashboard.clusterActionsHeader().resourceSearchButton().click();
+
+    const dialog = new ResourceSearchDialog();
+
+    dialog.checkExists();
+    dialog.checkVisible();
+
+    dialog.searchBox().type('fleet');
+
+    // Wait for less than 20 - then we know the results are updated for our search
+    dialog.results().should('have.length.lt', 20);
+    dialog.results().should('have.length.gt', 1);
+    dialog.results().first().should('have.text', 'Contents (contents.fleet.cattle.io)');
+
+    dialog.close();
+
+    dialog.checkNotExists();
+  });  
+
   it('can show resource dialog when namespace chooser is open', () => {
     const namespacePicker = new NamespaceFilterPo();
 

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -238,10 +238,10 @@ nav:
     clusters: clusters
     ariaLabel: Filter clusters on main menu
   resourceSearch:
-    label: Resource Search
+    label: Resource Type Search
     prompt: Search for a Kubernetes Resource/Custom Resource type
-    toolTip: Resource Search {key}
-    placeholder: Type to search for a resource...
+    toolTip: Resource Type Search {key}
+    placeholder: Type to search for a resource type...
     filteringDescription: Using this input will immediately filter the results in the list below
   header:
     setLoginPage: Set as login page

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -239,6 +239,7 @@ nav:
     ariaLabel: Filter clusters on main menu
   resourceSearch:
     label: Resource Search
+    prompt: Search for a Kubernetes Resource/Custom Resource type
     toolTip: Resource Search {key}
     placeholder: Type to search for a resource...
     filteringDescription: Using this input will immediately filter the results in the list below

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -99,6 +99,11 @@ export default {
     },
 
     groupSelected() {
+      // Can not click on groups that are fixed open
+      if (this.fixedOpen) {
+        return;
+      }
+
       // Don't auto-select first group entry if we're already expanded and contain the currently-selected nav item
       if (this.hasActiveRoute() && this.isExpanded) {
         return;
@@ -219,14 +224,14 @@ export default {
 <template>
   <div
     class="accordion"
-    :class="{[`depth-${depth}`]: true, 'expanded': isExpanded, 'has-children': hasChildren, 'group-highlight': isGroupActive}"
+    :class="{[`depth-${depth}`]: true, 'expanded': isExpanded, 'has-children': hasChildren, 'group-highlight': isGroupActive }"
   >
     <div
       v-if="showHeader"
       class="header"
-      :class="{'active': isOverview, 'noHover': !canCollapse}"
+      :class="{'active': isOverview, 'noHover': !canCollapse || fixedOpen}"
       role="button"
-      tabindex="0"
+      :tabindex="fixedOpen ? -1 : 0"
       :aria-label="group.labelDisplay || group.label || ''"
       @click="groupSelected()"
       @keyup.enter="groupSelected()"
@@ -371,6 +376,9 @@ export default {
       }
       &:hover:not(.active) {
         background-color: var(--nav-hover);
+      }
+      &:hover:not(.active).noHover {
+        background-color: inherit;
       }
     }
   }

--- a/shell/components/nav/Jump.vue
+++ b/shell/components/nav/Jump.vue
@@ -41,7 +41,7 @@ export default {
       const allTypes = allTypesByMode[TYPE_MODES.ALL];
       const out = this.$store.getters['type-map/getTree'](productId, TYPE_MODES.ALL, allTypes, clusterId, BOTH, null, this.value);
 
-      // Suplement the output with count info. Usualy the `Type` component would handle this individualy... but scales real bad so give it
+      // Supplement the output with count info. Usually the `Type` component would handle this individually... but scales real bad so give it
       // some help
       const counts = this.$store.getters[`${ product.inStore }/all`](COUNT)?.[0]?.counts || {};
 
@@ -77,16 +77,22 @@ export default {
     >
       {{ t('nav.resourceSearch.filteringDescription') }}
     </p>
-    <input
-      ref="input"
-      v-model="value"
-      :placeholder="t('nav.resourceSearch.placeholder')"
-      class="search"
-      role="textbox"
-      :aria-label="t('nav.resourceSearch.label')"
-      aria-describedby="describe-filter-resource-search"
-      @keyup.esc="$emit('closeSearch')"
-    >
+    <div class="dialog-title">
+      <div>{{ t('nav.resourceSearch.label') }}</div>
+      <p>{{ t('nav.resourceSearch.prompt') }}</p>
+    </div>
+    <div class="search-box">
+      <input
+        ref="input"
+        v-model="value"
+        :placeholder="t('nav.resourceSearch.placeholder')"
+        class="search"
+        role="textbox"
+        :aria-label="t('nav.resourceSearch.label')"
+        aria-describedby="describe-filter-resource-search"
+        @keyup.esc="$emit('closeSearch')"
+      >
+    </div>
     <div class="results">
       <div
         v-for="g in groups"
@@ -119,8 +125,22 @@ export default {
     box-shadow: none;
   }
 
+  .search-box {
+    margin: 8px;
+  }
+
   .search:focus-visible {
     outline-offset: -2px;
+  }
+
+  .dialog-title {
+    padding: 8px;
+
+    > div {
+      font-size: 16px;
+      font-weight: bold;
+      margin: 8px 0;
+    }
   }
 
   .results {
@@ -129,7 +149,7 @@ export default {
     padding: 10px;
     color: var(--dropdown-text);
     background-color: var(--dropdown-bg);
-    border: 1px solid var(--dropdown-border);
+    border-top: 1px solid var(--dropdown-border);
     height: 75vh;
   }
 </style>

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -659,7 +659,14 @@ export const getters = {
 
         const label = typeObj.labelKey ? rootGetters['i18n/t'](typeObj.labelKey) || typeObj.label : typeObj.label;
 
-        const labelDisplay = highlightLabel(label, count, typeObj.schema);
+        let labelDisplay = highlightLabel(label, count, typeObj.schema);
+
+        // If we did not match on just the label, add the schema name and see if that matches
+        if (!labelDisplay && typeObj.schema?.attributes) {
+          const schemaName = `${ typeObj.schema.attributes.resource }.${ typeObj.schema.attributes.group }`;
+
+          labelDisplay = highlightLabel(`${ label } (${ schemaName })`, count, typeObj.schema);
+        }
 
         if ( !labelDisplay ) {
           // Search happens in highlight and returns null if not found


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12648

^ @richard-cox Well, partially fixes the issue above - does not support filtering on the shortNames - we don't have those on the schemas - we'd have to fetch the k8s schema info, which is a large amount of data, so I suggest we don't do this for now - with what we have, I think you can find what you are looking for.

### Occurred changes and/or fixed issues

Simple fix - if the human-readable label does not match, then we use the string `Human Label (resource name.resource group)` and search on that.

In addition, fixed a couple of small bugs:

- The group headers no longer receive focus, don't show hover styling and can't be clicked - previously, you could click on these and it would navigate under the dialog
- Added a header to the dialog and a short text line to make this feature slightly clearer
- Changed label and tooltip to 'Resource Type Search' to be clearer this is searching for resource types rather than instances of resources
- Added an extra e2e test that validates searching by group name

### Screenshot/Video

This is how it looks when matching on the group:

![image](https://github.com/user-attachments/assets/6c7294b3-d9c4-47e9-8c24-2515378bbae9)

mixture:

![image](https://github.com/user-attachments/assets/b56dd15f-6983-4e28-8bff-10f505d16ac5)

tooltip:

![image](https://github.com/user-attachments/assets/13245306-8905-4d05-86db-12557d1e85c5)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
