### PR TITLE
Fix rows limit in Harvester clusters table

### DIFF
--- a/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
@@ -208,6 +208,20 @@ export default {
     typeDisplay() {
       return this.t(`typeLabel."${ HCI.CLUSTER }"`, { count: this.rows?.length || 0 });
     },
+
+    rowsPerPage() {
+      // Using 5 as a rows limit to leave space below the table to display extension's messages.
+      if (
+        this.harvester.hasErrors ||
+        this.harvester.toInstall ||
+        this.harvester.toUpdate
+      ) {
+        return 5;
+      }
+
+      // No custom rows limit; 'Table Rows Per Page' preference will be used.
+      return null;
+    }
   },
 
   methods: {
@@ -385,7 +399,7 @@ export default {
         :is-creatable="true"
         :namespaced="false"
         :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
-        :rows-per-page="5"
+        :rows-per-page="rowsPerPage"
       >
         <template #col:name="{row}">
           <td>

--- a/shell/components/SortableTable/paging.js
+++ b/shell/components/SortableTable/paging.js
@@ -49,6 +49,21 @@ export default {
       return this.$store.getters['i18n/t'](this.pagingLabel, opt);
     },
 
+    perPage() {
+      let out = this.rowsPerPage || 0;
+
+      if ( out <= 0 ) {
+        out = parseInt(this.$store.getters['prefs/get'](ROWS_PER_PAGE), 10) || 0;
+      }
+
+      // This should ideally never happen, but the preference value could be invalid, so return something...
+      if ( out <= 0 ) {
+        out = 10;
+      }
+
+      return out;
+    },
+
     pagedRows() {
       if (this.externalPaginationEnabled) {
         return this.rows;
@@ -61,9 +76,7 @@ export default {
   },
 
   data() {
-    const perPage = this.getPerPage();
-
-    return { page: 1, perPage };
+    return { page: 1 };
   },
 
   watch: {
@@ -89,22 +102,6 @@ export default {
   },
 
   methods: {
-    getPerPage() {
-      // perPage can not change while the list is displayed
-      let out = this.rowsPerPage || 0;
-
-      if ( out <= 0 ) {
-        out = parseInt(this.$store.getters['prefs/get'](ROWS_PER_PAGE), 10) || 0;
-      }
-
-      // This should ideally never happen, but the preference value could be invalid, so return something...
-      if ( out <= 0 ) {
-        out = 10;
-      }
-
-      return out;
-    },
-
     setPage(num) {
       if (this.page === num) {
         return;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14179
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- We want to keep 5 as rows limit to leave some extra space below to the table for the extensions messages and use the value from 'Table rows per Page' preference when there are no messages.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

[Screencast from 2025-04-30 11-20-36.webm](https://github.com/user-attachments/assets/939c3e9b-3b96-46d5-b21a-7efb714a54e8)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
