### PR TITLE
Prevent default form submit behavior for open ldap

### DIFF
--- a/shell/components/auth/login/ldap.vue
+++ b/shell/components/auth/login/ldap.vue
@@ -54,7 +54,7 @@ export default {
 </script>
 
 <template>
-  <form>
+  <form @submit.prevent>
     <template v-if="open">
       <div class="span-6 offset-3">
         <div class="mb-20">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14235 

This prevents the default form submit behavior in `ldap.vue`.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add `@submit.prevent` to ldap login form

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

#13954 introduced a change to resolve issues with focus behavior when the async button component entered a disabled state. It turns out that the disabled attributed on the button was preventing the default submit behavior, and changing this reintroduced the default form submit behavior.

The recommended way to submit forms in vue is to utilize `@submit.prevent` to disable the default form submit behavior and define our own submit logic. We want to retain the changes made to async button so that keyboard focus remains consistent.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- OpenLDAP login

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- NA

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
