### PR TITLE
[Backport 2.11.2] - Machine pool validation

### DIFF
--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-rke2.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-rke2.po.ts
@@ -1,6 +1,7 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
+import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 
 export default class MachinePoolRke2 extends ComponentPo {
   constructor(selector = '.dashboard-root') {
@@ -9,6 +10,14 @@ export default class MachinePoolRke2 extends ComponentPo {
 
   nameNsDescription() {
     return new NameNsDescription(this.self());
+  }
+
+  poolName() {
+    return new LabeledInputPo('[data-testid="machine-pool-name-input"]');
+  }
+
+  poolQuantity() {
+    return new LabeledInputPo('[data-testid="machine-pool-quantity-input"]');
   }
 
   networks(): LabeledSelectPo {

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-azure-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-azure-rke2.spec.ts
@@ -117,6 +117,23 @@ describe('Deploy RKE2 cluster using node driver on Azure', { testIsolation: 'off
     createRKE2ClusterPage.nameNsDescription().name().set(this.rke2AzureClusterName);
     createRKE2ClusterPage.nameNsDescription().description().set(`${ this.rke2AzureClusterName }-description`);
 
+    // validate pool name and pool quantity inputs
+    // pool name is required
+    createRKE2ClusterPage.machinePoolTab().poolName().clear();
+    createRKE2ClusterPage.resourceDetail().createEditView().saveButtonPo().expectToBeDisabled();
+    createRKE2ClusterPage.machinePoolTab().poolName().set('pool1');
+    createRKE2ClusterPage.resourceDetail().createEditView().saveButtonPo().expectToBeEnabled();
+    // pool quantity should be a number
+    createRKE2ClusterPage.machinePoolTab().poolQuantity().set('abc');
+    createRKE2ClusterPage.resourceDetail().createEditView().saveButtonPo().expectToBeDisabled();
+    createRKE2ClusterPage.machinePoolTab().poolQuantity().set('1');
+    createRKE2ClusterPage.resourceDetail().createEditView().saveButtonPo().expectToBeEnabled();
+    // pool quantity should not be negative
+    createRKE2ClusterPage.machinePoolTab().poolQuantity().set('-1');
+    createRKE2ClusterPage.resourceDetail().createEditView().saveButtonPo().expectToBeDisabled();
+    createRKE2ClusterPage.machinePoolTab().poolQuantity().set('1');
+    createRKE2ClusterPage.resourceDetail().createEditView().saveButtonPo().expectToBeEnabled();
+
     // Get latest kubernetes version
     cy.wait('@getRke2Releases').then(({ response }) => {
       expect(response.statusCode).to.eq(200);

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
@@ -8,6 +8,8 @@ import AdvancedSection from '@shell/components/AdvancedSection.vue';
 import { Banner } from '@components/Banner';
 import UnitInput from '@shell/components/form/UnitInput.vue';
 import { randomStr } from '@shell/utils/string';
+import FormValidation from '@shell/mixins/form-validation';
+import { MACHINE_POOL_VALIDATION } from '@shell/utils/validators/machine-pool';
 
 export default {
 
@@ -24,6 +26,8 @@ export default {
     Banner,
     UnitInput
   },
+
+  mixins: [FormValidation],
 
   props: {
     value: {
@@ -122,6 +126,12 @@ export default {
       uuid: randomStr(),
 
       unhealthyNodeTimeoutInteger: this.value.pool.unhealthyNodeTimeout ? parseDuration(this.value.pool.unhealthyNodeTimeout) : 0,
+
+      validationErrors: [],
+
+      MACHINE_POOL_VALIDATION,
+
+      fvFormRuleSets: MACHINE_POOL_VALIDATION.RULESETS,
     };
   },
 
@@ -136,7 +146,7 @@ export default {
 
     isWindows() {
       return this.value?.config?.os === 'windows';
-    },
+    }
   },
 
   watch: {
@@ -148,6 +158,20 @@ export default {
       } else {
         this.value.pool.machineOS = 'linux';
       }
+    },
+
+    validationErrors: {
+      handler(newValue) {
+        this.$emit('validationChanged', newValue.length === 0);
+      },
+      deep: true
+    },
+
+    fvFormIsValid: {
+      handler(newValue) {
+        this.$emit('validationChanged', newValue);
+      },
+      deep: true
     }
   },
 
@@ -227,6 +251,8 @@ export default {
           :label="t('cluster.machinePool.name.label')"
           :required="true"
           :disabled="!value.config || !!value.config.id || busy"
+          :rules="fvGetAndReportPathRules(MACHINE_POOL_VALIDATION.FIELDS.NAME)"
+          data-testid="machine-pool-name-input"
         />
       </div>
       <div class="col span-4">
@@ -238,6 +264,8 @@ export default {
           type="number"
           min="0"
           :required="true"
+          :rules="fvGetAndReportPathRules(MACHINE_POOL_VALIDATION.FIELDS.QUANTITY)"
+          data-testid="machine-pool-quantity-input"
         />
       </div>
       <div class="col span-4 pt-5">

--- a/shell/utils/validators/machine-pool.ts
+++ b/shell/utils/validators/machine-pool.ts
@@ -1,0 +1,20 @@
+const FIELDS = {
+  NAME:     'pool.name',
+  QUANTITY: 'pool.quantity'
+};
+
+const RULESETS = [
+  {
+    path:  FIELDS.QUANTITY,
+    rules: ['requiredInt', 'isPositive'],
+  },
+  {
+    path:  FIELDS.NAME,
+    rules: ['required'],
+  }
+];
+
+export const MACHINE_POOL_VALIDATION = {
+  FIELDS,
+  RULESETS
+};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14020 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
