### PR TITLE
prevent focus from keyboard nav on radiogroups

### DIFF
--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.test.ts
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.test.ts
@@ -99,13 +99,19 @@ describe('checkbox.vue', () => {
 
     const wrapper: Wrapper<InstanceType<typeof Checkbox>> = mount(
       Checkbox,
-      { propsData: { value: true, label } }
+      {
+        propsData: {
+          value: true, label, disabled: true
+        }
+      }
     );
 
     const field = wrapper.find('.checkbox-custom');
     const ariaChecked = field.attributes('aria-checked');
     const ariaLabel = field.attributes('aria-label');
     const ariaLabelledBy = field.attributes('aria-labelledby');
+    const ariaDisabled = field.attributes('aria-disabled');
+    const tabIndex = field.attributes('tabindex');
 
     // validates type of input rendered
     expect(field.exists()).toBe(true);
@@ -113,5 +119,8 @@ describe('checkbox.vue', () => {
     expect(ariaLabelledBy).toBe(wrapper.vm.idForLabel);
     expect(ariaLabel).toBeUndefined();
     expect(wrapper.find(`#${ wrapper.vm.idForLabel }`).text()).toBe(label);
+
+    expect(ariaDisabled).toBe('true');
+    expect(tabIndex).toBe('-1');
   });
 });

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -292,6 +292,7 @@ export default defineComponent({
         class="checkbox-custom"
         :class="{indeterminate: indeterminate}"
         :tabindex="isDisabled ? -1 : 0"
+        :aria-disabled="isDisabled"
         :aria-label="replacementLabel"
         :aria-checked="!!value"
         :aria-labelledby="labelKey || label ? idForLabel : undefined"

--- a/pkg/rancher-components/src/components/Form/Radio/RadioGroup.test.ts
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioGroup.test.ts
@@ -65,18 +65,23 @@ describe('component: RadioGroup', () => {
 
     const wrapper = mount(RadioGroup, {
       propsData: {
-        name:    'some-name',
-        label:   inputLabel,
-        value:   currValue,
-        options: [{ label: currValue, value: currValue }]
+        name:     'some-name',
+        label:    inputLabel,
+        value:    currValue,
+        disabled: true,
+        options:  [{ label: currValue, value: currValue }]
       },
       attrs: { 'aria-label': overrideLabel }
     });
 
     const field = wrapper.find('[role="radiogroup"]');
     const ariaLabel = field.attributes('aria-label');
+    const ariaDisabled = field.attributes('aria-disabled');
+    const tabIndex = field.attributes('tabindex');
 
     expect(ariaLabel).toBe(overrideLabel);
     expect(ariaLabel).not.toBe(inputLabel);
+    expect(ariaDisabled).toBe('true');
+    expect(tabIndex).toBe('-1');
   });
 });

--- a/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
@@ -275,7 +275,8 @@ export default defineComponent({
       :aria-activedescendant="ariaActiveDescendant"
       class="radio-group"
       :class="{'row':row}"
-      tabindex="0"
+      :tabindex="isDisabled ? -1 : 0"
+      :aria-disabled="isDisabled"
       @keydown.down.prevent.stop="clickNext(1)"
       @keydown.up.prevent.stop="clickNext(-1)"
       @keydown.space.enter.stop.prevent


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14252 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- prevent focus from keyboard nav on `radiogroups`
- improve a11y disabled state in `checkbox` component
- add unit tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
