### PR TITLE
add aria-required attribute to LabeledSelect and LabeledInput components

### DIFF
--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
@@ -59,6 +59,7 @@ describe('component: LabeledInput', () => {
     const ariaLabelVal = 'some-aria-label';
     const subLabelVal = 'some-sublabel';
     const ariaDescribedByIdVal = 'some-external-id';
+    const ariaRequiredVal = 'true';
 
     it.each([
       ['text', 'input', ariaLabelVal, subLabelVal, ariaDescribedByIdVal],
@@ -68,7 +69,7 @@ describe('component: LabeledInput', () => {
     ])('for type %p should correctly fill out the appropriate fields on the component', (type, validationType, ariaLabel, subLabel, ariaDescribedById) => {
       const wrapper = mount(LabeledInput, {
         propsData: {
-          value: '', type, ariaLabel, subLabel
+          value: '', type, ariaLabel, subLabel, required: true
         },
         attrs: { 'aria-describedby': ariaDescribedById },
         mocks: { $store: { getters: { 'i18n/t': jest.fn() } } }
@@ -77,11 +78,13 @@ describe('component: LabeledInput', () => {
       const field = wrapper.find(validationType);
       const ariaLabelProp = field.attributes('aria-label');
       const ariaDescribedBy = field.attributes('aria-describedby');
+      const ariaRequired = field.attributes('aria-required');
 
       // validates type of input rendered
       expect(field.exists()).toBe(true);
       expect(ariaLabelProp).toBe(ariaLabel);
       expect(ariaDescribedBy).toBe(`${ ariaDescribedById } ${ wrapper.vm.describedById }`);
+      expect(ariaRequired).toBe(ariaRequiredVal);
     });
   });
 

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -375,6 +375,7 @@ export default defineComponent({
         <span
           v-if="requiredField"
           class="required"
+          :aria-hidden="true"
         >*</span>
       </label>
     </slot>
@@ -390,11 +391,13 @@ export default defineComponent({
         v-stripped-aria-label="!hasLabel && ariaLabel ? ariaLabel : undefined"
         :maxlength="_maxlength"
         :disabled="isDisabled"
+        :aria-disabled="isDisabled"
         :value="value || ''"
         :placeholder="_placeholder"
         autocapitalize="off"
         :class="{ conceal: type === 'multiline-password' }"
         :aria-describedby="ariaDescribedBy"
+        :aria-required="requiredField"
         @update:value="onInput"
         @focus="onFocus"
         @blur="onBlur"
@@ -409,6 +412,7 @@ export default defineComponent({
         v-bind="$attrs"
         :maxlength="_maxlength"
         :disabled="isDisabled"
+        :aria-disabled="isDisabled"
         :type="type === 'cron' ? 'text' : type"
         :value="value"
         :placeholder="_placeholder"
@@ -416,6 +420,7 @@ export default defineComponent({
         autocapitalize="off"
         :data-lpignore="ignorePasswordManagers"
         :aria-describedby="ariaDescribedBy"
+        :aria-required="requiredField"
         @input="onInput"
         @focus="onFocus"
         @blur="onBlur"

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -304,6 +304,7 @@ export default {
     role="combobox"
     :aria-expanded="isOpen"
     :aria-describedby="$attrs['aria-describedby'] || undefined"
+    :aria-required="requiredField"
     @click="focusSearch"
     @keydown.enter="focusSearch"
     @keydown.down.prevent="focusSearch"
@@ -326,6 +327,7 @@ export default {
         <span
           v-if="requiredField"
           class="required"
+          :aria-hidden="true"
         >*</span>
       </label>
     </div>

--- a/shell/components/form/__tests__/LabeledSelect.test.ts
+++ b/shell/components/form/__tests__/LabeledSelect.test.ts
@@ -228,6 +228,7 @@ describe('component: LabeledSelect', () => {
         options: [
           { label, value },
         ],
+        required: true
       },
       attrs: { 'aria-describedby': ariaDescribedById }
     });
@@ -235,6 +236,7 @@ describe('component: LabeledSelect', () => {
     const labeledSelectContainer = wrapper.find('.labeled-select');
     const ariaExpanded = labeledSelectContainer.attributes('aria-expanded');
     const ariaDescribedBy = labeledSelectContainer.attributes('aria-describedby');
+    const ariaRequired = labeledSelectContainer.attributes('aria-required');
     const containerId = labeledSelectContainer.attributes('id');
     const labelFor = wrapper.find('label').attributes('for');
 
@@ -242,6 +244,7 @@ describe('component: LabeledSelect', () => {
 
     expect(ariaExpanded).toBe('false');
     expect(ariaDescribedBy).toBe(ariaDescribedById);
+    expect(ariaRequired).toBe('true');
     expect(containerId).toBe(wrapper.vm.labeledSelectLabelId);
     expect(labelFor).toBe(wrapper.vm.labeledSelectLabelId);
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14255 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add `aria-required` attribute to `LabeledSelect` and `LabeledInput` components (most used components to have the required *)
- add unit tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [X] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [X] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [X] The PR template has been filled out
- [X] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [X] The PR has a reviewer assigned
- [X] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [X] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
