### PR TITLE
[Backport 2.10.6] - Logging chart yaml

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -22,11 +22,10 @@ import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
 import { findBy, removeObject, clear } from '@shell/utils/array';
 import { createYaml } from '@shell/utils/create-yaml';
 import {
-  clone, diff, set, get, isEmpty
+  clone, diff, set, get, isEmpty, mergeWithReplace
 } from '@shell/utils/object';
 import { allHash } from '@shell/utils/promise';
 import { sortBy } from '@shell/utils/sort';
-import { vspherePoolConfigMerge } from '@shell/machine-config/vmwarevsphere-pool-config-merge';
 
 import { compare, sortable } from '@shell/utils/version';
 import { isHarvesterSatisfiesVersion, labelForAddon } from '@shell/utils/cluster';
@@ -1263,7 +1262,7 @@ export default {
         delete clonedCurrentConfig.metadata;
 
         if (this.provider === VMWARE_VSPHERE) {
-          machinePool.config = vspherePoolConfigMerge(clonedLatestConfig, clonedCurrentConfig);
+          machinePool.config = mergeWithReplace(clonedLatestConfig, clonedCurrentConfig, { mutateOriginal: true });
         } else {
           machinePool.config = merge(clonedLatestConfig, clonedCurrentConfig);
         }
@@ -1649,7 +1648,7 @@ export default {
       const defaultChartValue = this.versionInfo[name];
       const key = this.chartVersionKey(name);
 
-      return merge({}, defaultChartValue?.values || {}, this.userChartValues[key] || {});
+      return mergeWithReplace(defaultChartValue?.values, this.userChartValues[key]);
     },
 
     initServerAgentArgs() {

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -32,7 +32,9 @@ import {
 import { CATALOG as CATALOG_ANNOTATIONS, PROJECT } from '@shell/config/labels-annotations';
 
 import { exceptionToErrorsArray } from '@shell/utils/error';
-import { clone, diff, get, set } from '@shell/utils/object';
+import {
+  clone, diff, get, mergeWithReplace, set
+} from '@shell/utils/object';
 import { ignoreVariables } from './install.helpers';
 import { findBy, insertAt } from '@shell/utils/array';
 import { saferDump } from '@shell/utils/create-yaml';
@@ -312,15 +314,11 @@ export default {
       */
       this.removeGlobalValuesFrom(userValues);
 
-      /*
-        The merge() method is used to merge two or more objects
-        starting with the left-most to the right-most to create a
-        parent mapping object. When two keys are the same, the
-        generated object will have value for the rightmost key.
-        In this case, any values in userValues override any
-        matching values in versionInfo.
-      */
-      this.chartValues = merge(merge({}, this.versionInfo?.values || {}), userValues);
+      this.chartValues = mergeWithReplace(
+        merge({}, this.versionInfo?.values || {}),
+        userValues,
+        { replaceObjectProps: true }
+      );
 
       if (this.showCustomRegistry) {
         /**

--- a/shell/utils/__tests__/object.test.ts
+++ b/shell/utils/__tests__/object.test.ts
@@ -1,6 +1,6 @@
 import { reactive, isReactive } from 'vue';
 import {
-  clone, get, getter, isEmpty, toDictionary, remove, diff, definedKeys, deepToRaw
+  clone, get, getter, isEmpty, toDictionary, remove, diff, definedKeys, deepToRaw, mergeWithReplace
 } from '@shell/utils/object';
 
 describe('fx: get', () => {
@@ -376,5 +376,68 @@ describe('fx: deepToRaw', () => {
       func:  null,
       sym:   null,
     });
+  });
+});
+
+describe('fx: mergeWithReplace', () => {
+  const testCases: Array<[object?, object?, object?]> = [
+    // Some array test cases, an array from the first object should be replaced with the array from the second object
+    [{ a: ['one'] }, { a: [] }, { a: [] }],
+    [{ a: ['one', 'two'] }, { a: ['one', 'two', 'three'] }, { a: ['one', 'two', 'three'] }],
+    [{ a: ['one', 'two'], b: ['three', 'four'] }, { a: ['one'], b: [] }, { a: ['one'], b: [] }],
+    [{
+      a: ['one', 'two'], b: ['three', 'four'], c: 'five'
+    }, { a: ['one'], b: [] }, {
+      a: ['one'], b: [], c: 'five'
+    }],
+    // Some other test cases
+    [{ a: 'one' }, { b: 'two' }, { a: 'one', b: 'two' }],
+    [{ a: 'one' }, { a: '', b: 'two' }, { a: '', b: 'two' }],
+    [{ a: 'one', b: 'two' }, { a: 1, c: { d: null } }, {
+      a: 1, b: 'two', c: { d: null }
+    }],
+    [undefined, undefined, {}],
+    [{}, undefined, {}],
+    [undefined, {}, {}],
+  ];
+
+  it.each(testCases)('should merge arrays properly', (obj1, obj2, expected) => {
+    const result = mergeWithReplace(obj1, obj2);
+
+    expect(result).toStrictEqual(expected);
+  });
+
+  it.each([
+    [
+      { a: { b: false, c: false } }, { a: { b: true, c: null } }, { a: { b: true, c: null } }
+    ],
+    [
+      {
+        a: [{
+          b: 'test', c: 'test', value: true
+        }]
+      }, {
+        a: [{
+          b: 'test', c: 'test', operator: 'exists'
+        }]
+      }, {
+        a: [{
+          b: 'test', c: 'test', operator: 'exists'
+        }]
+      }
+    ],
+    [
+      {
+        a: { enabled: false }, b: { enabled: false }, c: { enabled: false }
+      },
+      { c: { enabled: true, stripUnderscores: true } },
+      {
+        a: { enabled: false }, b: { enabled: false }, c: { enabled: true, stripUnderscores: true }
+      }
+    ]
+  ])('should overwrite duplicate object properties when merging objects', (left, right, expected) => {
+    const result = mergeWithReplace(left, right, { replaceObjectProps: true });
+
+    expect(result).toStrictEqual(expected);
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14258 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
