### PR TITLE
Fix: Correctly Handle K8s Distro Directory

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
@@ -78,8 +78,8 @@ export default {
           this.k8sDistroSubDir = DEFAULT_SUBDIRS.K8S_DISTRO_RKE2;
         }
 
-        if (this.value.k8sDistro) {
-          this.value.k8sDistro = `${ neu }/${ this.k8sDistroSubDir }`;
+        if (this.dataConfigRadioValue === DATA_DIR_RADIO_OPTIONS.COMMON && this.commonConfig) {
+          this.value.k8sDistro = `${ this.commonConfig }/${ this.k8sDistroSubDir }`;
         }
       }
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/rancher/issues/49651
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This update refines how the Kubernetes distribution directory is handled. 
It ensures that the directory path is automatically updated to reflect Kubernetes version changes only when the "Common data directory configuration" mode is selected, while respecting the user-defined paths in "Custom" mode and the system defaults in "Default" mode.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Test creating and editing clusters with all three directory configuration options (Default, Common, Custom) and changing the Kubernetes version during and after creation to ensure the directory settings behave as described.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
