### PR TITLE
Eks automation - e2e tests

### DIFF
--- a/cypress/e2e/blueprints/cluster_management/eks-default-settings.ts
+++ b/cypress/e2e/blueprints/cluster_management/eks-default-settings.ts
@@ -30,17 +30,17 @@ export const DEFAULT__IMPORT_CLUSTER = {
 export const DEFAULT_REGION = 'us-west-2';
 
 export const DEFAULT_NODE_GROUP_CONFIG = {
-  desiredSize:          2,
-  diskSize:             20,
+  desiredSize:          '2',
+  diskSize:             '20',
   ec2SshKey:            '',
   gpu:                  false,
   imageId:              null,
   instanceType:         't3.medium',
   labels:               {},
-  maxSize:              2,
-  minSize:              2,
-  nodegroupName:        '',
-  nodeRole:             '',
+  maxSize:              '2',
+  minSize:              '2',
+  nodegroupName:        'group1',
+  nodeRole:             'Default (One will be created automatically)',
   requestSpotInstances: false,
   resourceTags:         {},
   spotInstanceTypes:    [],

--- a/cypress/e2e/blueprints/cluster_management/eks-default-settings.ts
+++ b/cypress/e2e/blueprints/cluster_management/eks-default-settings.ts
@@ -1,0 +1,63 @@
+// original eks default attributes are declared in @/pkg/eks/components/CruEKS.vue. This file is a typescript file to be consumed by cypress. Any changes in the default values must also be updated here.
+export const DEFAULT_CLUSTER = {
+  dockerRootDir:                       '/var/lib/docker',
+  enableClusterAlerting:               false,
+  enableClusterMonitoring:             false,
+  enableNetworkPolicy:                 false,
+  labels:                              {},
+  annotations:                         {},
+  windowsPreferedCluster:              false,
+  fleetAgentDeploymentCustomization:   {},
+  clusterAgentDeploymentCustomization: {}
+};
+
+export const DEFAULT__IMPORT_CLUSTER = {
+  dockerRootDir:                       '/var/lib/docker',
+  enableNetworkPolicy:                 false,
+  labels:                              {},
+  annotations:                         {},
+  windowsPreferedCluster:              false,
+  fleetAgentDeploymentCustomization:   {},
+  clusterAgentDeploymentCustomization: {},
+  eksConfig:                           {
+    amazonCredentialSecret: '',
+    displayName:            '',
+    imported:               true,
+    region:                 ''
+  }
+};
+
+export const DEFAULT_REGION = 'us-west-2';
+
+export const DEFAULT_NODE_GROUP_CONFIG = {
+  desiredSize:          2,
+  diskSize:             20,
+  ec2SshKey:            '',
+  gpu:                  false,
+  imageId:              null,
+  instanceType:         't3.medium',
+  labels:               {},
+  maxSize:              2,
+  minSize:              2,
+  nodegroupName:        '',
+  nodeRole:             '',
+  requestSpotInstances: false,
+  resourceTags:         {},
+  spotInstanceTypes:    [],
+  subnets:              [],
+  tags:                 {},
+  type:                 'nodeGroup',
+  userData:             '',
+  _isNew:               true,
+};
+
+export const DEFAULT_EKS_CONFIG = {
+  publicAccess:        true,
+  privateAccess:       false,
+  publicAccessSources: [],
+  secretsEncryption:   false,
+  securityGroups:      [],
+  tags:                {},
+  subnets:             [],
+  loggingTypes:        [],
+};

--- a/cypress/e2e/po/components/labeled-select.po.ts
+++ b/cypress/e2e/po/components/labeled-select.po.ts
@@ -38,6 +38,12 @@ export default class LabeledSelectPo extends ComponentPo {
     });
   }
 
+  checkContainsOptionSelected(label: string): Cypress.Chainable {
+    return this.self().find('.vs__selected-options > span.vs__selected').should((elm) => {
+      expect(elm.text().trim()).to.include(label);
+    });
+  }
+
   /**
    * Get dropdown options
    * @returns
@@ -68,5 +74,9 @@ export default class LabeledSelectPo extends ComponentPo {
    */
   filterByName(name: string) {
     return this.self().type(name);
+  }
+
+  static bySelector(selector: string): LabeledSelectPo {
+    return new LabeledSelectPo(selector);
   }
 }

--- a/cypress/e2e/po/components/labeled-select.po.ts
+++ b/cypress/e2e/po/components/labeled-select.po.ts
@@ -76,13 +76,4 @@ export default class LabeledSelectPo extends ComponentPo {
   filterByName(name: string) {
     return this.self().type(name);
   }
-
-  static byLabel(self: CypressChainable, label: string): LabeledSelectPo {
-    return new LabeledSelectPo(
-      self
-        .find('.labeled-select', { includeShadowDom: true })
-        .contains(label)
-        .next()
-    );
-  }
 }

--- a/cypress/e2e/po/components/labeled-select.po.ts
+++ b/cypress/e2e/po/components/labeled-select.po.ts
@@ -1,6 +1,4 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
-import { CypressChainable } from '@/cypress/e2e/po/po.types';
-
 export default class LabeledSelectPo extends ComponentPo {
   toggle() {
     return this.self().click();

--- a/cypress/e2e/po/components/labeled-select.po.ts
+++ b/cypress/e2e/po/components/labeled-select.po.ts
@@ -1,4 +1,5 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import { CypressChainable } from '@/cypress/e2e/po/po.types';
 
 export default class LabeledSelectPo extends ComponentPo {
   toggle() {
@@ -76,7 +77,12 @@ export default class LabeledSelectPo extends ComponentPo {
     return this.self().type(name);
   }
 
-  static bySelector(selector: string): LabeledSelectPo {
-    return new LabeledSelectPo(selector);
+  static byLabel(self: CypressChainable, label: string): LabeledSelectPo {
+    return new LabeledSelectPo(
+      self
+        .find('.labeled-select', { includeShadowDom: true })
+        .contains(label)
+        .next()
+    );
   }
 }

--- a/cypress/e2e/po/edit/cloud-credentials-eks.po.ts
+++ b/cypress/e2e/po/edit/cloud-credentials-eks.po.ts
@@ -1,12 +1,4 @@
-import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import AmazonCloudCredentialsCreateEditPo from '@/cypress/e2e/po/edit/cloud-credentials-amazon.po';
 
 export default class EKSCloudCredentialsCreateEditPo extends AmazonCloudCredentialsCreateEditPo {
-  region(): LabeledSelectPo {
-    return new LabeledSelectPo('[.vs__dropdown-toggl]');
-  }
-
-  defaultRegion(): LabeledSelectPo {
-    return new LabeledSelectPo('[.vs__dropdown-toggle]');
-  }
 }

--- a/cypress/e2e/po/edit/cloud-credentials-eks.po.ts
+++ b/cypress/e2e/po/edit/cloud-credentials-eks.po.ts
@@ -3,10 +3,10 @@ import AmazonCloudCredentialsCreateEditPo from '@/cypress/e2e/po/edit/cloud-cred
 
 export default class EKSCloudCredentialsCreateEditPo extends AmazonCloudCredentialsCreateEditPo {
   region(): LabeledSelectPo {
-    return new LabeledSelectPo('[id$=__combobox]');
+    return new LabeledSelectPo('[#vs1__combobox]');
   }
 
   defaultRegion(): LabeledSelectPo {
-    return new LabeledSelectPo('[id$=__combobox]');
+    return new LabeledSelectPo('[#vs2__combobox]');
   }
 }

--- a/cypress/e2e/po/edit/cloud-credentials-eks.po.ts
+++ b/cypress/e2e/po/edit/cloud-credentials-eks.po.ts
@@ -3,10 +3,10 @@ import AmazonCloudCredentialsCreateEditPo from '@/cypress/e2e/po/edit/cloud-cred
 
 export default class EKSCloudCredentialsCreateEditPo extends AmazonCloudCredentialsCreateEditPo {
   region(): LabeledSelectPo {
-    return new LabeledSelectPo('.vs1__combobox');
+    return new LabeledSelectPo('[id$=__combobox]');
   }
 
   defaultRegion(): LabeledSelectPo {
-    return new LabeledSelectPo('.vs2__combobox');
+    return new LabeledSelectPo('[id$=__combobox]');
   }
 }

--- a/cypress/e2e/po/edit/cloud-credentials-eks.po.ts
+++ b/cypress/e2e/po/edit/cloud-credentials-eks.po.ts
@@ -3,10 +3,10 @@ import AmazonCloudCredentialsCreateEditPo from '@/cypress/e2e/po/edit/cloud-cred
 
 export default class EKSCloudCredentialsCreateEditPo extends AmazonCloudCredentialsCreateEditPo {
   region(): LabeledSelectPo {
-    return new LabeledSelectPo('[#vs1__combobox]');
+    return new LabeledSelectPo('[.vs__dropdown-toggl]');
   }
 
   defaultRegion(): LabeledSelectPo {
-    return new LabeledSelectPo('[#vs2__combobox]');
+    return new LabeledSelectPo('[.vs__dropdown-toggle]');
   }
 }

--- a/cypress/e2e/po/edit/cloud-credentials-eks.po.ts
+++ b/cypress/e2e/po/edit/cloud-credentials-eks.po.ts
@@ -1,0 +1,12 @@
+import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+import AmazonCloudCredentialsCreateEditPo from '@/cypress/e2e/po/edit/cloud-credentials-amazon.po';
+
+export default class EKSCloudCredentialsCreateEditPo extends AmazonCloudCredentialsCreateEditPo {
+  region(): LabeledSelectPo {
+    return new LabeledSelectPo('.vs1__combobox');
+  }
+
+  defaultRegion(): LabeledSelectPo {
+    return new LabeledSelectPo('.vs2__combobox');
+  }
+}

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po.ts
@@ -1,0 +1,30 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po';
+import ClusterManagerCreateRke2AmazonPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-amazon.po';
+import EKSCloudCredentialsCreateEditPo from '@/cypress/e2e/po/edit/cloud-credentials-eks.po';
+import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
+
+/**
+ * Create page for an EKS cluster
+ */
+export default class ClusterManagerCreateEKSPagePo extends ClusterManagerCreateRke2AmazonPagePo {
+  static url(clusterId: string) {
+    return `${ ClusterManagerCreatePagePo.url(clusterId) }/create?type=amazoneks&rkeType=rke2`;
+  }
+
+  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return PagePo.goTo(ClusterManagerCreateRke2AmazonPagePo.url(clusterId));
+  }
+
+  goToAmazonClusterCreation(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return PagePo.goTo(`${ ClusterManagerCreatePagePo.url(clusterId) }?type=amazoneks&rkeType=rke2`);
+  }
+
+  cloudCredentialsForm(): EKSCloudCredentialsCreateEditPo {
+    return new EKSCloudCredentialsCreateEditPo();
+  }
+
+  getClusterName() {
+    return new LabeledInputPo('[data-testid="eks-name-input"]');
+  }
+}

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po.ts
@@ -37,7 +37,7 @@ export default class ClusterManagerCreateEKSPagePo extends ClusterManagerCreateR
   }
 
   getRegion() {
-    return LabeledSelectPo.byLabel(cy.get('[data-testid="cru-form"]'), 'Region');
+    return new LabeledSelectPo('[data-testid="eks_region"]');
   }
 
   getVersion() {

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po.ts
@@ -37,7 +37,7 @@ export default class ClusterManagerCreateEKSPagePo extends ClusterManagerCreateR
   }
 
   getRegion() {
-    return new LabeledSelectPo('[id="vs10__combobox"]');
+    return LabeledSelectPo.byLabel(cy.get('[data-testid="cru-form"]'), 'Region');
   }
 
   getVersion() {

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po.ts
@@ -3,6 +3,8 @@ import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattl
 import ClusterManagerCreateRke2AmazonPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-amazon.po';
 import EKSCloudCredentialsCreateEditPo from '@/cypress/e2e/po/edit/cloud-credentials-eks.po';
 import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
+import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+import eksVersions from '@/pkg/eks/assets/data/eks-versions.js';
 
 /**
  * Create page for an EKS cluster
@@ -30,5 +32,31 @@ export default class ClusterManagerCreateEKSPagePo extends ClusterManagerCreateR
 
   getClusterDescription() {
     return new LabeledInputPo('[placeholder*="better describes this resource"]');
-}
+  }
+
+  getEKSzoneSelect() {
+    return new LabeledSelectPo('[id="vs1__combobox"]');
+  }
+
+  getEKSversionSelect() {
+    return new LabeledSelectPo('[id="vs9__combobox"]');
+  }
+
+  getEKSnodeGroup() {
+    return new LabeledSelectPo('[data-testid="eks-nodegroup-name"]');
+  }
+
+  getLatestEKSversion() {
+    let latestVersion = 0;
+
+    eksVersions.forEach((version: string) => {
+      const versionNumber = Number(version);
+
+      if (versionNumber > latestVersion) {
+        latestVersion = versionNumber;
+      }
+    });
+
+    return String(latestVersion);
+  }
 }

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po.ts
@@ -27,4 +27,8 @@ export default class ClusterManagerCreateEKSPagePo extends ClusterManagerCreateR
   getClusterName() {
     return new LabeledInputPo('[data-testid="eks-name-input"]');
   }
+
+  getClusterDescription() {
+    return new LabeledInputPo('[placeholder*="better describes this resource"]');
+}
 }

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po.ts
@@ -5,6 +5,8 @@ import EKSCloudCredentialsCreateEditPo from '@/cypress/e2e/po/edit/cloud-credent
 import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import eksVersions from '@/pkg/eks/assets/data/eks-versions.js';
+import RadioGroupInputPo from '@/cypress/e2e/po/components/radio-group-input.po';
+import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
 
 /**
  * Create page for an EKS cluster
@@ -34,16 +36,56 @@ export default class ClusterManagerCreateEKSPagePo extends ClusterManagerCreateR
     return new LabeledInputPo('[placeholder*="better describes this resource"]');
   }
 
-  getEKSzoneSelect() {
-    return new LabeledSelectPo('[id="vs1__combobox"]');
+  getRegion() {
+    return new LabeledSelectPo('[id="vs10__combobox"]');
   }
 
-  getEKSversionSelect() {
-    return new LabeledSelectPo('[id="vs9__combobox"]');
+  getVersion() {
+    return new LabeledSelectPo('[data-testid="eks-version-dropdown"]');
   }
 
-  getEKSnodeGroup() {
-    return new LabeledSelectPo('[data-testid="eks-nodegroup-name"]');
+  getNodeGroup() {
+    return new LabeledInputPo('[data-testid="eks-nodegroup-name"]');
+  }
+
+  getNodeRole() {
+    return new LabeledSelectPo('[data-testid="eks-noderole"]');
+  }
+
+  getLauchTemplate() {
+    return new LabeledSelectPo('[data-testid="eks-launch-template-dropdown"]');
+  }
+
+  getDesiredASGSize() {
+    return LabeledInputPo.byLabel(cy.get('[data-testid="cru-form"]'), 'Desired ASG Size');
+  }
+
+  getMinASGSize() {
+    return LabeledInputPo.byLabel(cy.get('[data-testid="cru-form"]'), 'Minimum ASG Size');
+  }
+
+  getMaxASGSize() {
+    return LabeledInputPo.byLabel(cy.get('[data-testid="cru-form"]'), 'Maximum ASG Size');
+  }
+
+  getInstanceType() {
+    return new LabeledSelectPo('[data-testid="eks-instance-type-dropdown"]');
+  }
+
+  getDiskSize() {
+    return new LabeledInputPo('[data-testid="eks-disksize-input"]');
+  }
+
+  getServiceRole() {
+    return new RadioGroupInputPo('[data-testid="radio-button-0"]');
+  }
+
+  getPublicAccess() {
+    return CheckboxInputPo.byLabel(this.self(), 'Public Access');
+  }
+
+  getPrivateAccess() {
+    return CheckboxInputPo.byLabel(this.self(), 'Private Access');
   }
 
   getLatestEKSversion() {

--- a/cypress/e2e/tests/pages/manager/eks-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/eks-cluster-provisioning.spec.ts
@@ -69,7 +69,6 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     });
     cloudCredForm.accessKey().set(Cypress.env('awsAccessKey'));
     cloudCredForm.secretKey().set(Cypress.env('awsSecretKey'));
-    cloudCredForm.secretKey().set(Cypress.env('awsSecretKey'));
     cloudCredForm.saveButton().expectToBeEnabled();
 
     cy.intercept('GET', '/v1/management.cattle.io.users?exclude=metadata.managedFields').as('pageLoad');
@@ -140,7 +139,7 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     createEKSClusterPage.getLauchTemplate().checkOptionSelected(eksSettings.launchTemplate);
 
     // Check the default instance type
-    // createEKSClusterPage.getInstanceType().checkContainsOptionSelected(eksSettings.instanceType);
+    createEKSClusterPage.getInstanceType().checkContainsOptionSelected(eksSettings.instanceType);
 
     // Check the default volume Size
     createEKSClusterPage.getDiskSize().shouldHaveValue(eksSettings.diskSize);

--- a/cypress/e2e/tests/pages/manager/eks-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/eks-cluster-provisioning.spec.ts
@@ -7,6 +7,7 @@ import LoadingPo from '@/cypress/e2e/po/components/loading.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 import ClusterManagerCreateEKSPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po';
+import AmazonCloudCredentialsCreateEditPo from '@/cypress/e2e/po/edit/cloud-credentials-amazon.po';
 
 /******
  *  Running this test will delete all Amazon cloud credentials from the target cluster
@@ -66,11 +67,8 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     cloudCredForm.saveButton().expectToBeDisabled();
     cloudCredForm.nameNsDescription().name().set(this.eksCloudCredentialName);
     cloudCredForm.accessKey().set(Cypress.env('awsAccessKey'));
-    cloudCredForm.secretKey().set(Cypress.env('awsSecretKey'), true);
-    cloudCredForm.defaultRegion().toggle();
-    cloudCredForm.defaultRegion().clickOptionWithLabel(eksDefaultRegion);
-    cloudCredForm.region().toggle();
-    cloudCredForm.region().clickOptionWithLabel(eksDefaultRegion);
+    cloudCredForm.secretKey().set(Cypress.env('awsSecretKey'));
+    cloudCredForm.secretKey().set(Cypress.env('awsSecretKey'));
     cloudCredForm.saveButton().expectToBeEnabled();
 
     cy.intercept('GET', '/v1/management.cattle.io.users?exclude=metadata.managedFields').as('pageLoad');
@@ -80,14 +78,14 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
       // removeCloudCred = true;
     });
 
-    //
+    
     cy.wait('@pageLoad').its('response.statusCode').should('eq', 200);
     loadingPo.checkNotExists();
     createEKSClusterPage.waitForPage('type=amazoneks&rkeType=rke2#group1%200');
     createEKSClusterPage.getClusterName().set(this.eksClusterName);
-    createEKSClusterPage.nameNsDescription().description().set(`${ this.eksClusterName }-description`);
+    createEKSClusterPage.getClusterDescription().set(`${ this.eksClusterName }-description`);
 
-    // Get latest kubernetes version
+    //Get latest kubernetes version
     // cy.wait('@getRke2Releases').then(({ response }) => {
     //   expect(response.statusCode).to.eq(200);
     //   const length = response.body.data.length - 1;
@@ -104,8 +102,9 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     createEKSClusterPage.create();
     cy.wait('@createEKSCluster').then(({ response }) => {
       expect(response?.statusCode).to.eq(201);
-      expect(response?.body).to.have.property('kind', 'Cluster');
-      expect(response?.body.metadata).to.have.property('name', this.eksClusterName);
+      expect(response?.body).to.have.property('type', 'cluster');
+      expect(response?.body).to.have.property('name', this.eksClusterName);
+      expect(response?.body).to.have.property('description', `${ this.eksClusterName }-description`);
       // expect(response?.body.spec).to.have.property('kubernetesVersion').contains(version);
       clusterId = response?.body.id;
     });
@@ -134,5 +133,5 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
         });
       }
     });
-  });
+});
 });

--- a/cypress/e2e/tests/pages/manager/eks-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/eks-cluster-provisioning.spec.ts
@@ -3,6 +3,7 @@ import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/clu
 import LoadingPo from '@/cypress/e2e/po/components/loading.po';
 import ClusterManagerCreateEKSPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po';
 import * as eksDefaultSettings from '@/cypress/e2e/blueprints/cluster_management/eks-default-settings';
+import RadioGroupInputPo from '~/cypress/e2e/po/components/radio-group-input.po';
 
 /******
  *  Running this test will delete all Amazon cloud credentials from the target cluster
@@ -12,26 +13,26 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
   const clusterList = new ClusterManagerListPagePo();
   const loadingPo = new LoadingPo('.loading-indicator');
 
-  let cloudcredentialId = '';
   let clusterId = '';
 
-  let eksSettings = {
-    eksRegion:     eksDefaultSettings.DEFAULT_REGION,
-    nodegroupName: eksDefaultSettings.DEFAULT_NODE_GROUP_CONFIG.nodegroupName,
-    nodeRole:      eksDefaultSettings.DEFAULT_NODE_GROUP_CONFIG.nodeRole,
-    desiredSize:   eksDefaultSettings.DEFAULT_NODE_GROUP_CONFIG.desiredSize,
-    maxSize:       eksDefaultSettings.DEFAULT_NODE_GROUP_CONFIG.maxSize,
-    minSize:       eksDefaultSettings.DEFAULT_NODE_GROUP_CONFIG.minSize,
-    diskSize:      eksDefaultSettings.DEFAULT_NODE_GROUP_CONFIG.diskSize,
-    instanceType:  eksDefaultSettings.DEFAULT_NODE_GROUP_CONFIG.instanceType,
-    publicAccess:  eksDefaultSettings.DEFAULT_EKS_CONFIG.publicAccess,
-    privateAccess: eksDefaultSettings.DEFAULT_EKS_CONFIG.privateAccess
-  }
+  const eksSettings = {
+    eksRegion:      eksDefaultSettings.DEFAULT_REGION,
+    nodegroupName:  eksDefaultSettings.DEFAULT_NODE_GROUP_CONFIG.nodegroupName,
+    nodeRole:       eksDefaultSettings.DEFAULT_NODE_GROUP_CONFIG.nodeRole,
+    desiredSize:    eksDefaultSettings.DEFAULT_NODE_GROUP_CONFIG.desiredSize,
+    maxSize:        eksDefaultSettings.DEFAULT_NODE_GROUP_CONFIG.maxSize,
+    minSize:        eksDefaultSettings.DEFAULT_NODE_GROUP_CONFIG.minSize,
+    diskSize:       eksDefaultSettings.DEFAULT_NODE_GROUP_CONFIG.diskSize,
+    instanceType:   eksDefaultSettings.DEFAULT_NODE_GROUP_CONFIG.instanceType,
+    publicAccess:   eksDefaultSettings.DEFAULT_EKS_CONFIG.publicAccess,
+    privateAccess:  eksDefaultSettings.DEFAULT_EKS_CONFIG.privateAccess,
+    launchTemplate: 'Default (One will be created automatically)'
+  };
 
   const createEKSClusterPage = new ClusterManagerCreateEKSPagePo();
   const cloudCredForm = createEKSClusterPage.cloudCredentialsForm();
 
-  before(() => {
+  before( 'add cloud credentials', () => {
     cy.login();
     HomePagePo.goTo();
 
@@ -51,10 +52,6 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
         });
       }
     });
-  });
-
-  beforeEach(() => {
-    cy.createE2EResourceName('ekscluster').as('eksClusterName');
 
     // create cluster
     ClusterManagerListPagePo.navTo();
@@ -78,12 +75,16 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     cy.intercept('GET', '/v1/management.cattle.io.users?exclude=metadata.managedFields').as('pageLoad');
     cloudCredForm.saveCreateForm().cruResource().saveAndWaitForRequests('POST', '/v3/cloudcredentials').then((req) => {
       expect(req.response?.statusCode).to.equal(201);
-      cloudcredentialId = req.response?.body.id.replace(':', '%3A');
     });
 
     cy.wait('@pageLoad').its('response.statusCode').should('eq', 200);
     loadingPo.checkNotExists();
     createEKSClusterPage.waitForPage('type=amazoneks&rkeType=rke2#group1%200');
+  });
+
+  beforeEach( () => {
+    cy.createE2EResourceName('ekscluster').as('eksClusterName');
+    cy.createE2EResourceName('ekscluster2').as('eksClusterName2');
   });
 
   it('can create an Amazon EKS cluster by just filling in the mandatory fields', function() {
@@ -107,20 +108,60 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
   });
 
   it('can create an Amazon EKS cluster with default values', function() {
+    // create cluster
+    ClusterManagerListPagePo.navTo();
+    clusterList.waitForPage();
+    clusterList.createCluster();
+    createEKSClusterPage.selectKubeProvider(0);
+    loadingPo.checkNotExists();
+    createEKSClusterPage.rke2PageTitle().should('include', 'Create Amazon EKS');
+    createEKSClusterPage.waitForPage('type=amazoneks&rkeType=rke2#group1%200');
+
     // Verify that eks-zone-select dropdown is set to the default zone
-    createEKSClusterPage.getEKSzoneSelect().checkOptionSelected(eksSettings.eksRegion);
+    createEKSClusterPage.getRegion().checkOptionSelected(eksSettings.eksRegion);
 
     // Get latest EKS kubernetes version and verify that eks-version-select dropdown is set to the default version as defined in CruEKS.vue
     const latestEKSversion = createEKSClusterPage.getLatestEKSversion();
 
-    createEKSClusterPage.getEKSversionSelect().checkOptionSelected(latestEKSversion);
+    createEKSClusterPage.getVersion().checkOptionSelected(latestEKSversion);
 
     // Check the node group name is set to the default name
-    createEKSClusterPage.getEKSnodeGroup().checkOptionSelected(eksSettings.nodegroupName);
+    createEKSClusterPage.getNodeGroup().shouldHaveValue(eksSettings.nodegroupName);
+
+    // Check the node role is set to the default role
+    createEKSClusterPage.getNodeRole().checkOptionSelected(eksSettings.nodeRole);
+
+    // Check the default ASG Sizes
+    createEKSClusterPage.getDesiredASGSize().shouldHaveValue(eksSettings.desiredSize);
+    createEKSClusterPage.getMinASGSize().shouldHaveValue(eksSettings.minSize);
+    createEKSClusterPage.getMaxASGSize().shouldHaveValue(eksSettings.maxSize);
+
+    // Check the default Launch template
+    createEKSClusterPage.getLauchTemplate().checkOptionSelected(eksSettings.launchTemplate);
+
+    // Check the default instance type
+    // createEKSClusterPage.getInstanceType().checkContainsOptionSelected(eksSettings.instanceType);
+
+    // Check the default volume Size
+    createEKSClusterPage.getDiskSize().shouldHaveValue(eksSettings.diskSize);
+
+    // Check that standard role is selected
+    const serviceRolebuttonGroup = new RadioGroupInputPo('[data-testid= "eks-service-role-radio"]');
+
+    serviceRolebuttonGroup.isChecked(0);
+
+    // Check that standard Networking access
+    createEKSClusterPage.getPublicAccess().isChecked();
+    createEKSClusterPage.getPrivateAccess().isUnchecked();
+
+    // Check that default VPC and subnets are set
+    const vpcButtonGroup = new RadioGroupInputPo('[aria-label="VPCs and Subnets"]');
+
+    vpcButtonGroup.isChecked(0);
 
     // Set the cluster name and description in the Create EKS Page
-    createEKSClusterPage.getClusterName().set(this.eksClusterName);
-    createEKSClusterPage.getClusterDescription().set(`${ this.eksClusterName }-description`);
+    createEKSClusterPage.getClusterName().set(this.eksClusterName2);
+    createEKSClusterPage.getClusterDescription().set(`${ this.eksClusterName2 }-description`);
 
     // Create EKS Cluster and verify that the properties posted to the server match the expected settings
     cy.intercept('POST', 'v3/clusters').as('createEKSCluster');
@@ -128,9 +169,18 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     cy.wait('@createEKSCluster').then(({ response }) => {
       expect(response?.statusCode).to.eq(201);
       expect(response?.body).to.have.property('type', 'cluster');
-      expect(response?.body).to.have.property('name', this.eksClusterName);
-      expect(response?.body).to.have.property('description', `${ this.eksClusterName }-description`);
-      expect(response?.body.spec).to.have.property('kubernetesVersion').contains(latestEKSversion);
+      expect(response?.body).to.have.property('name', this.eksClusterName2);
+      expect(response?.body).to.have.property('description', `${ this.eksClusterName2 }-description`);
+      expect(response?.body.eksConfig).to.have.property('kubernetesVersion').contains(latestEKSversion);
+      expect(response?.body.eksConfig).to.have.property('region', eksSettings.eksRegion);
+      expect(response?.body.eksConfig).to.have.property('privateAccess', eksSettings.privateAccess);
+      expect(response?.body.eksConfig).to.have.property('publicAccess', eksSettings.publicAccess);
+      expect(response?.body.eksConfig.nodeGroups[0]).to.have.property('nodegroupName', eksSettings.nodegroupName);
+      expect(response?.body.eksConfig.nodeGroups[0]).to.have.property('desiredSize', Number(eksSettings.desiredSize));
+      expect(response?.body.eksConfig.nodeGroups[0]).to.have.property('minSize', Number(eksSettings.minSize));
+      expect(response?.body.eksConfig.nodeGroups[0]).to.have.property('maxSize', Number(eksSettings.maxSize));
+      expect(response?.body.eksConfig.nodeGroups[0]).to.have.property('instanceType', eksSettings.instanceType);
+      expect(response?.body.eksConfig.nodeGroups[0]).to.have.property('diskSize', Number(eksSettings.diskSize));
       clusterId = response?.body.id;
     });
 
@@ -138,7 +188,7 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     clusterList.list().state(this.eksClusterName).should('contain.text', 'Provisioning');
   });
 
-  afterEach('clean up', () => {
+  after('clean up', () => {
     // delete cluster
     cy.deleteRancherResource('v1', 'provisioning.cattle.io.clusters', `fleet-default/${ clusterId }`, false);
 

--- a/cypress/e2e/tests/pages/manager/eks-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/eks-cluster-provisioning.spec.ts
@@ -1,0 +1,138 @@
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import ClusterManagerCreateRke2AmazonPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-amazon.po';
+import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
+import ClusterManagerDetailRke2AmazonEc2PagePo from '@/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-rke2-amazon.po';
+import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
+import LoadingPo from '@/cypress/e2e/po/components/loading.po';
+import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
+import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import ClusterManagerCreateEKSPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po';
+
+/******
+ *  Running this test will delete all Amazon cloud credentials from the target cluster
+ ******/
+
+describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@adminUser', '@jenkins'] }, () => {
+  const clusterList = new ClusterManagerListPagePo();
+  const loadingPo = new LoadingPo('.loading-indicator');
+
+  let removeCloudCred = false;
+  let cloudcredentialId = '';
+  let k8sVersion = '';
+  let clusterId = '';
+  const eksDefaultRegion = 'us-west-2';
+
+  before(() => {
+    cy.login();
+    HomePagePo.goTo();
+
+    // clean up amazon cloud credentials
+    cy.getRancherResource('v3', 'cloudcredentials', null, null).then((resp: Cypress.Response<any>) => {
+      const body = resp.body;
+
+      if (body.pagination['total'] > 0) {
+        body.data.forEach((item: any) => {
+          if (item.amazonec2credentialConfig) {
+            const id = item.id;
+
+            cy.deleteRancherResource('v3', 'cloudcredentials', id);
+          } else {
+            cy.log('There are no existing amazon cloud credentials to delete');
+          }
+        });
+      }
+    });
+  });
+
+  beforeEach(() => {
+    cy.createE2EResourceName('ekscluster').as('eksClusterName');
+    cy.createE2EResourceName('ekscloudcredential').as('eksCloudCredentialName');
+  });
+
+  it('can create an Amazon EKS cluster with default values', function() {
+    const createEKSClusterPage = new ClusterManagerCreateEKSPagePo();
+    const cloudCredForm = createEKSClusterPage.cloudCredentialsForm();
+
+    // create cluster
+    ClusterManagerListPagePo.navTo();
+    clusterList.waitForPage();
+    clusterList.createCluster();
+    createEKSClusterPage.selectKubeProvider(0);
+    loadingPo.checkNotExists();
+    createEKSClusterPage.rke2PageTitle().should('include', 'Create Amazon EKS');
+    createEKSClusterPage.waitForPage('type=amazoneks&rkeType=rke2');
+
+    // create amazon cloud credential
+    cloudCredForm.saveButton().expectToBeDisabled();
+    cloudCredForm.nameNsDescription().name().set(this.eksCloudCredentialName);
+    cloudCredForm.accessKey().set(Cypress.env('awsAccessKey'));
+    cloudCredForm.secretKey().set(Cypress.env('awsSecretKey'), true);
+    cloudCredForm.defaultRegion().toggle();
+    cloudCredForm.defaultRegion().clickOptionWithLabel(eksDefaultRegion);
+    cloudCredForm.region().toggle();
+    cloudCredForm.region().clickOptionWithLabel(eksDefaultRegion);
+    cloudCredForm.saveButton().expectToBeEnabled();
+
+    cy.intercept('GET', '/v1/management.cattle.io.users?exclude=metadata.managedFields').as('pageLoad');
+    cloudCredForm.saveCreateForm().cruResource().saveAndWaitForRequests('POST', '/v3/cloudcredentials').then((req) => {
+      expect(req.response?.statusCode).to.equal(201);
+      cloudcredentialId = req.response?.body.id.replace(':', '%3A');
+      // removeCloudCred = true;
+    });
+
+    //
+    cy.wait('@pageLoad').its('response.statusCode').should('eq', 200);
+    loadingPo.checkNotExists();
+    createEKSClusterPage.waitForPage('type=amazoneks&rkeType=rke2#group1%200');
+    createEKSClusterPage.getClusterName().set(this.eksClusterName);
+    createEKSClusterPage.nameNsDescription().description().set(`${ this.eksClusterName }-description`);
+
+    // Get latest kubernetes version
+    // cy.wait('@getRke2Releases').then(({ response }) => {
+    //   expect(response.statusCode).to.eq(200);
+    //   const length = response.body.data.length - 1;
+
+    //   k8sVersion = response.body.data[length].id;
+    //   cy.wrap(k8sVersion).as('k8sVersion');
+    // });
+
+    // cy.get<string>('@k8sVersion').then((version) => {
+    //   createEKSClusterPage.basicsTab().kubernetesVersions().toggle();
+    //   createEKSClusterPage.basicsTab().kubernetesVersions().clickOptionWithLabel(version);
+
+    cy.intercept('POST', 'v3/clusters').as('createEKSCluster');
+    createEKSClusterPage.create();
+    cy.wait('@createEKSCluster').then(({ response }) => {
+      expect(response?.statusCode).to.eq(201);
+      expect(response?.body).to.have.property('kind', 'Cluster');
+      expect(response?.body.metadata).to.have.property('name', this.eksClusterName);
+      // expect(response?.body.spec).to.have.property('kubernetesVersion').contains(version);
+      clusterId = response?.body.id;
+    });
+
+    clusterList.waitForPage();
+    clusterList.list().state(this.eksClusterName).should('contain.text', 'Provisioning');
+  });
+
+  after('clean up', () => {
+    // delete cluster
+    cy.deleteRancherResource('v1', 'provisioning.cattle.io.clusters', `fleet-default/${ clusterId }`, false);
+
+    // clean up Amazon cloud credentials
+    cy.getRancherResource('v3', 'cloudcredentials', null, null).then((resp: Cypress.Response<any>) => {
+      const body = resp.body;
+
+      if (body.pagination['total'] > 0) {
+        body.data.forEach((item: any) => {
+          if (item.amazonec2credentialConfig) {
+            const id = item.id;
+
+            cy.deleteRancherResource('v3', 'cloudcredentials', id);
+          } else {
+            cy.log('There are no existing Amazon cloud credentials to delete');
+          }
+        });
+      }
+    });
+  });
+});

--- a/pkg/eks/components/AccountAccess.vue
+++ b/pkg/eks/components/AccountAccess.vue
@@ -117,6 +117,7 @@ export default defineComponent({
       <LabeledSelect
         :disabled="mode!=='create'"
         :value="region"
+        data-testid="eks_region"
         label-key="eks.region.label"
         :options="regionOptions"
         @update:value="$emit('update-region', $event)"

--- a/pkg/eks/components/NodeGroup.vue
+++ b/pkg/eks/components/NodeGroup.vue
@@ -561,6 +561,7 @@ export default defineComponent({
         <LabeledSelect
           v-model:value="displayNodeRole"
           :mode="mode"
+          data-testid="eks-noderole"
           label-key="eks.nodeGroups.nodeRole.label"
           :options="[defaultNodeRoleOption, ...ec2Roles]"
           option-label="RoleName"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1572
This e2e test suite comprises eks cluster provisioning tests that create a cluster by filling the mandatory fields and create a cluster with default values.
 
### Occurred changes and/or fixed issues

- Added PO for eks Create cluster Page.
- Added `data-testid` for the NodeRole field
- Added supporting function `checkContainsOptionSelected()` in `Labeled-Select.po` that matches partially/contains the expected value
- Created blueprint file that contains all the default eks config values from `CruEKS.vue`

### Areas or cases that should be tested
- EKS cluster provisioning
- cluster provisioning for other hosted providers

### Areas which could experience regressions
- e2e tests for other providers (amazon ec2, azure, gke, rke2/rke1, etc)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
