### PR TITLE
add visual snapshots to pages inside cluster management

### DIFF
--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -5,14 +5,11 @@ import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/clu
 import ClusterManagerImportGenericPagePo from '@/cypress/e2e/po/extensions/imported/cluster-import-generic.po';
 import { PARTIAL_SETTING_THRESHOLD } from '@/cypress/support/utils/settings-utils';
 import { RANCHER_PAGE_EXCEPTIONS, catchTargetPageException } from '~/cypress/support/utils/exception-utils';
-import ClusterManagerDetailPagePo from '@/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po';
-import KontainerDriversPagePo from '@/cypress/e2e/po/pages/cluster-manager/kontainer-drivers.po';
 
 const homePage = new HomePagePo();
 const homeClusterList = homePage.list();
 const provClusterList = new ClusterManagerListPagePo('local');
 const longClusterDescription = 'this-is-some-really-really-really-really-really-really-long-description';
-const driversPage = new KontainerDriversPagePo();
 
 // Reset the home page card prefs, go the home page and ensure the page is fully loaded
 function goToHomePageAndSettle() {

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -5,11 +5,14 @@ import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/clu
 import ClusterManagerImportGenericPagePo from '@/cypress/e2e/po/extensions/imported/cluster-import-generic.po';
 import { PARTIAL_SETTING_THRESHOLD } from '@/cypress/support/utils/settings-utils';
 import { RANCHER_PAGE_EXCEPTIONS, catchTargetPageException } from '~/cypress/support/utils/exception-utils';
+import ClusterManagerDetailPagePo from '@/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po';
+import KontainerDriversPagePo from '@/cypress/e2e/po/pages/cluster-manager/kontainer-drivers.po';
 
 const homePage = new HomePagePo();
 const homeClusterList = homePage.list();
 const provClusterList = new ClusterManagerListPagePo('local');
 const longClusterDescription = 'this-is-some-really-really-really-really-really-really-long-description';
+const driversPage = new KontainerDriversPagePo();
 
 // Reset the home page card prefs, go the home page and ensure the page is fully loaded
 function goToHomePageAndSettle() {
@@ -83,6 +86,9 @@ describe('Home Page', () => {
 
       provClusterList.goTo();
       provClusterList.waitForPage();
+
+      // #takes percy snapshot.
+      cy.percySnapshot('cluster management Page');
 
       cy.get('@stateText').then((state) => {
         provClusterList.list().details(clusterName, 1).should('contain.text', state);

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -84,6 +84,12 @@ describe('Home Page', () => {
       provClusterList.goTo();
       provClusterList.waitForPage();
 
+      provClusterList.list().resourceTable().sortableTable().checkVisible();
+      provClusterList.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+
+      cy.get('[data-testid="sortable-table-downloadKubeConfig"]').should('be.visible');
+      cy.get('[data-testid="sortable-table-download"]').should('be.visible');
+
       // takes percy snapshot.
       cy.percySnapshot('cluster management Page');
 

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -84,7 +84,7 @@ describe('Home Page', () => {
       provClusterList.goTo();
       provClusterList.waitForPage();
 
-      // #takes percy snapshot.
+      // takes percy snapshot.
       cy.percySnapshot('cluster management Page');
 
       cy.get('@stateText').then((state) => {

--- a/cypress/e2e/tests/pages/manager/cloud-credentials.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credentials.spec.ts
@@ -41,7 +41,7 @@ describe('Cloud Credentials', { testIsolation: 'off', tags: ['@manager', '@jenki
   it('can create aws cloud credentials', function() {
     CloudCredentialsPagePo.navTo();
 
-    // #takes percy snapshot.
+    // takes percy snapshot.
     cy.percySnapshot('empty cloud credentials Page');
 
     cloudCredentialsPage.create();

--- a/cypress/e2e/tests/pages/manager/cloud-credentials.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credentials.spec.ts
@@ -40,6 +40,10 @@ describe('Cloud Credentials', { testIsolation: 'off', tags: ['@manager', '@jenki
 
   it('can create aws cloud credentials', function() {
     CloudCredentialsPagePo.navTo();
+
+    // #takes percy snapshot.
+    cy.percySnapshot('empty cloud credentials Page');
+
     cloudCredentialsPage.create();
     cloudCredentialsPage.createEditCloudCreds().waitForPage();
     cloudCredentialsPage.createEditCloudCreds().cloudServiceOptions().selectSubTypeByIndex(0).click();

--- a/cypress/e2e/tests/pages/manager/cloud-credentials.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credentials.spec.ts
@@ -38,12 +38,19 @@ describe('Cloud Credentials', { testIsolation: 'off', tags: ['@manager', '@jenki
     cy.contains('Authentication test failed, please check your credentials').should('be.visible');
   });
 
-  it('can create aws cloud credentials', function() {
+  it.only('can take percy snapshot of empty cloud credentials page', () => {
     CloudCredentialsPagePo.navTo();
+    cloudCredentialsPage.waitForPage();
+    cloudCredentialsPage.list().resourceTable().sortableTable().checkVisible();
+    cloudCredentialsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
 
     // takes percy snapshot.
     cy.percySnapshot('empty cloud credentials Page');
+  });
 
+  it('can create aws cloud credentials', function() {
+    CloudCredentialsPagePo.navTo();
+    cloudCredentialsPage.waitForPage();
     cloudCredentialsPage.create();
     cloudCredentialsPage.createEditCloudCreds().waitForPage();
     cloudCredentialsPage.createEditCloudCreds().cloudServiceOptions().selectSubTypeByIndex(0).click();

--- a/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
+++ b/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
@@ -4,6 +4,36 @@ import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import JWTAuthenticationPagePo from '@/cypress/e2e/po/pages/cluster-manager/jwt-authentication.po';
 
+// describe('JWT Authentication visual testing', { testIsolation: 'off', tags: ['@manager', '@adminUser', '@jenkins'] }, () => {
+//   const jwtAuthenticationPage = new JWTAuthenticationPagePo();
+//   before('clean up', () => {
+//     if (removeCluster0) {
+//       //  delete cluster
+//       cy.deleteRancherResource('v1', `provisioning.cattle.io.clusters/${ namespace }`, instance0);
+//     }
+
+//     if (removeCluster1) {
+//       //  delete cluster
+//       cy.deleteRancherResource('v1', `provisioning.cattle.io.clusters/${ namespace }`, instance1);
+
+//     }
+//   });
+//   it('should take snapshot of JWT Authentication page', () => {
+//     cy.login();
+//     HomePagePo.goTo();
+
+//     JWTAuthenticationPagePo.navTo();
+//     jwtAuthenticationPage.waitForPage();
+
+//     jwtAuthenticationPage.title().should('be.visible');
+//     jwtAuthenticationPage.list().resourceTable().sortableTable().checkVisible();
+//     jwtAuthenticationPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+
+//     // takes percy snapshot.
+//     cy.percySnapshot('JWT Authentication list Page');
+//   });
+// });
+
 describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@adminUser', '@jenkins'] }, () => {
   const jwtAuthenticationPage = new JWTAuthenticationPagePo();
 
@@ -64,12 +94,19 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
     JWTAuthenticationPagePo.navTo();
     jwtAuthenticationPage.waitForPage();
 
-    // takes percy snapshot.
-    cy.percySnapshot('JWT Authentication Page');
-
     jwtAuthenticationPage.title().should('be.visible');
     jwtAuthenticationPage.list().resourceTable().sortableTable().checkVisible();
     jwtAuthenticationPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+
+    // takes percy snapshot.
+    cy.percySnapshot('JWT Authentication list Page', {
+      percyCSS: `
+        [data-testid^="sortable-table-"] {
+          display: none !important;
+        }
+      `
+    });
+
     jwtAuthenticationPage.list().state(instance0).should('contain', 'Disabled');
     jwtAuthenticationPage.list().state(instance1).should('contain', 'Disabled');
   });
@@ -153,7 +190,6 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
     }
   });
 });
-
 describe('JWT Authentication (Standard User)', { testIsolation: 'off', tags: ['@manager', '@standardUser', '@jenkins'] }, () => {
   before(() => {
     cy.login();

--- a/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
+++ b/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
@@ -63,6 +63,10 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
   it('should show the JWT Authentication list page', () => {
     JWTAuthenticationPagePo.navTo();
     jwtAuthenticationPage.waitForPage();
+
+    // #takes percy snapshot.
+    cy.percySnapshot('JWT Authentication Page');
+
     jwtAuthenticationPage.title().should('be.visible');
     jwtAuthenticationPage.list().resourceTable().sortableTable().checkVisible();
     jwtAuthenticationPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();

--- a/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
+++ b/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
@@ -64,7 +64,7 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
     JWTAuthenticationPagePo.navTo();
     jwtAuthenticationPage.waitForPage();
 
-    // #takes percy snapshot.
+    // takes percy snapshot.
     cy.percySnapshot('JWT Authentication Page');
 
     jwtAuthenticationPage.title().should('be.visible');

--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -35,7 +35,7 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     driversPage.list().resourceTable().sortableTable().checkVisible();
     driversPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
 
-    // #takes percy snapshot.
+    // takes percy snapshot.
     cy.percySnapshot('cluster drivers Page');
   });
 

--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -36,7 +36,13 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     driversPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
 
     // takes percy snapshot.
-    cy.percySnapshot('cluster drivers Page');
+    cy.percySnapshot('cluster drivers Page', {
+      percyCSS: `
+        [data-testid^="sortable-table-"] {
+          display: none !important;
+        }
+      `
+    });
   });
 
   it('can refresh kubernetes metadata', () => {

--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -34,6 +34,9 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     driversPage.title().should('be.visible');
     driversPage.list().resourceTable().sortableTable().checkVisible();
     driversPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+
+    // #takes percy snapshot.
+    cy.percySnapshot('cluster drivers Page');
   });
 
   it('can refresh kubernetes metadata', () => {

--- a/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
@@ -25,7 +25,7 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
     MachineDeploymentsPagePo.goTo();
     machineDeploymentsPage.waitForPage();
 
-    // #takes percy snapshot.
+    // takes percy snapshot.
     cy.percySnapshot('machine deployments Page');
 
     machineDeploymentsPage.create();

--- a/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
@@ -25,6 +25,9 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
     MachineDeploymentsPagePo.goTo();
     machineDeploymentsPage.waitForPage();
 
+    // #takes percy snapshot.
+    cy.percySnapshot('machine deployments Page');
+
     machineDeploymentsPage.create();
 
     machineDeploymentsPage.createEditMachineDeployment().waitForPage('as=yaml');

--- a/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
@@ -25,9 +25,19 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
     MachineDeploymentsPagePo.goTo();
     machineDeploymentsPage.waitForPage();
 
-    // takes percy snapshot.
-    cy.percySnapshot('machine deployments Page');
+    machineDeploymentsPage.list().resourceTable().sortableTable().checkVisible();
+    machineDeploymentsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
 
+    // takes percy snapshot.
+    cy.percySnapshot('machineSets deployments Page');
+
+    // cy.percySnapshot('machine deployments Page', {
+    //   percyCSS: `
+    //     [data-testid^="sortable-table-"] {
+    //       display: none !important;
+    //     }
+    //   `
+    // });
     machineDeploymentsPage.create();
 
     machineDeploymentsPage.createEditMachineDeployment().waitForPage('as=yaml');

--- a/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
@@ -25,7 +25,7 @@ describe('MachineSets', { testIsolation: 'off', tags: ['@manager', '@adminUser']
     MachineSetsPagePo.goTo();
     machineSetsPage.waitForPage();
 
-    // #takes percy snapshot.
+    // takes percy snapshot.
     cy.percySnapshot('machineSets Page');
 
     machineSetsPage.create();

--- a/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
@@ -24,6 +24,10 @@ describe('MachineSets', { testIsolation: 'off', tags: ['@manager', '@adminUser']
   it('can create a MachineSet', function() {
     MachineSetsPagePo.goTo();
     machineSetsPage.waitForPage();
+
+    // #takes percy snapshot.
+    cy.percySnapshot('machineSets Page');
+
     machineSetsPage.create();
 
     machineSetsPage.createEditMachineSet().waitForPage('as=yaml');

--- a/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
@@ -25,6 +25,9 @@ describe('MachineSets', { testIsolation: 'off', tags: ['@manager', '@adminUser']
     MachineSetsPagePo.goTo();
     machineSetsPage.waitForPage();
 
+    machineSetsPage.list().resourceTable().sortableTable().checkVisible();
+    machineSetsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+
     // takes percy snapshot.
     cy.percySnapshot('machineSets Page');
 

--- a/cypress/e2e/tests/pages/manager/node-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/node-drivers.spec.ts
@@ -35,6 +35,9 @@ describe.skip('Node Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     driversPage.title().should('be.visible');
     driversPage.list().resourceTable().sortableTable().checkVisible();
     driversPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+
+    // #takes percy snapshot.
+    cy.percySnapshot('node drivers Page');
   });
 
   it('can delete an existing node driver', () => {

--- a/cypress/e2e/tests/pages/manager/node-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/node-drivers.spec.ts
@@ -36,7 +36,7 @@ describe.skip('Node Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     driversPage.list().resourceTable().sortableTable().checkVisible();
     driversPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
 
-    // #takes percy snapshot.
+    // takes percy snapshot.
     cy.percySnapshot('node drivers Page');
   });
 

--- a/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
+++ b/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
@@ -21,6 +21,10 @@ describe('Pod Security Admissions', { testIsolation: 'off', tags: ['@manager', '
   it('can open "Edit as YAML"', () => {
     PodSecurityAdmissionsPagePo.navTo();
     podSecurityAdmissionsPage.waitForPage();
+
+    // #takes percy snapshot.
+    cy.percySnapshot('pod security Page');
+
     podSecurityAdmissionsPage.create();
     podSecurityAdmissionsPage.createPodSecurityAdmissionForm().editAsYaml().click();
     podSecurityAdmissionsPage.createPodSecurityAdmissionForm().yamlEditor().checkExists();

--- a/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
+++ b/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
@@ -22,6 +22,9 @@ describe('Pod Security Admissions', { testIsolation: 'off', tags: ['@manager', '
     PodSecurityAdmissionsPagePo.navTo();
     podSecurityAdmissionsPage.waitForPage();
 
+    podSecurityAdmissionsPage.list().resourceTable().sortableTable().checkVisible();
+    podSecurityAdmissionsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+
     // takes percy snapshot.
     cy.percySnapshot('pod security Page');
 

--- a/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
+++ b/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
@@ -22,7 +22,7 @@ describe('Pod Security Admissions', { testIsolation: 'off', tags: ['@manager', '
     PodSecurityAdmissionsPagePo.navTo();
     podSecurityAdmissionsPage.waitForPage();
 
-    // #takes percy snapshot.
+    // takes percy snapshot.
     cy.percySnapshot('pod security Page');
 
     podSecurityAdmissionsPage.create();

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -25,7 +25,7 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     ChartRepositoriesPagePo.navTo();
     repositoriesPage.waitForPage();
 
-    // #takes percy snapshot.
+    // takes percy snapshot.
     cy.percySnapshot('repository Page');
 
     repositoriesPage.create();

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -25,10 +25,21 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     ChartRepositoriesPagePo.navTo();
     repositoriesPage.waitForPage();
 
-    // takes percy snapshot.
-    cy.percySnapshot('repository Page');
-
+    repositoriesPage.list().resourceTable().sortableTable().checkVisible();
+    repositoriesPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
     repositoriesPage.create();
+
+    // takes percy snapshot.
+    cy.percySnapshot('repository Page', {
+      percyCSS: `
+        *:contains("e2e-test"),
+        *:contains("day"), *:contains("hour"), *:contains("min"),
+        *:contains("days"), *:contains("hours"), *:contains("minutes") {
+          color: transparent;
+        }
+      `,
+    });
+
     repositoriesPage.createEditRepositories().waitForPage();
     repositoriesPage.createEditRepositories().nameNsDescription().name().set(this.repoName);
     repositoriesPage.createEditRepositories().nameNsDescription().description().set(`${ this.repoName }-description`);

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -21,7 +21,7 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     cy.createE2EResourceName('repo').as('repoName');
   });
 
-  it.only('can create a repository', function() {
+  it('can create a repository', function() {
     ChartRepositoriesPagePo.navTo();
     repositoriesPage.waitForPage();
 

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -21,9 +21,13 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     cy.createE2EResourceName('repo').as('repoName');
   });
 
-  it('can create a repository', function() {
+  it.only('can create a repository', function() {
     ChartRepositoriesPagePo.navTo();
     repositoriesPage.waitForPage();
+
+    // #takes percy snapshot.
+    cy.percySnapshot('repository Page');
+
     repositoriesPage.create();
     repositoriesPage.createEditRepositories().waitForPage();
     repositoriesPage.createEditRepositories().nameNsDescription().name().set(this.repoName);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
increase visual test coverage for areas mentioned on:
https://github.com/rancher/qa-tasks/issues/1782
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
