### PR TITLE
Revert changes to enforce PR linking

### DIFF
--- a/.github/workflows/scripts/pr-gh-project.js
+++ b/.github/workflows/scripts/pr-gh-project.js
@@ -15,9 +15,6 @@ const GH_PRJ_TO_TEST = 'To Test';
 const GH_PRJ_QA_REVIEW = 'QA Review';
 const GH_PRJ_IN_REVIEW = 'Review';
 
-// This label is used so that PRs from dependabot don't fail the check for 'fixes' notation
-const GH_DEPENDENCIES_LABEL = 'area/dependencies';
-
 function parseOrgAndRepo(repoUrl) {
   const parts = repoUrl.split('/');
 
@@ -136,14 +133,6 @@ async function processClosedAction() {
     console.log('  This PR fixes issues: ' + issues.join(', '));
   } else {
     console.log("  This PR does not fix any issues");
-
-    // PRs must fix an issue or have the label 'QA/None'
-    if (!hasLabel(pr, QA_NONE_LABEL) && !hasLabel(pr, GH_DEPENDENCIES_LABEL)) {
-      console.log('Error: A PR MUST either declare which issues it fixes OR must have the QA/None label');
-      process.exit(1);
-    }
-
-    console.log('Allowing PR to proceed without being linked to an issue because of the labels on the PR');
   }
 
   // Need to get all open PRs to see if any other references the same issues that this PR says it fixes
@@ -278,14 +267,6 @@ async function processOpenOrEditAction() {
     console.log('+ This PR fixes issues: #' + issues.join(', '));
   } else {
     console.log("+ This PR does not fix any issues");
-
-    // PRs must fix an issue or have the label 'QA/None'
-    if (!hasLabel(pr, QA_NONE_LABEL) && !hasLabel(pr, GH_DEPENDENCIES_LABEL)) {
-      console.log('Error: A PR MUST either declare which issues it fixes OR must have the QA/None label');
-      process.exit(1);
-    }
-
-    console.log('Allowing PR to proceed without being linked to an issue because of the labels on the PR');
   }
 
   const milestones = {};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14010

Reverts the previous fix for this issue, since this may be causing workflow approval issues.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
