### PR TITLE
Use management cluster status.version.gitVersion to filter upgrade options when AKS cluster configs are missing a patch number

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -152,8 +152,7 @@ export default defineComponent({
       }
 
       // track original version on edit to ensure we don't offer k8s downgrades
-      // const kubernetesVersion = semver.coerce(this.normanCluster?.aksConfig?.kubernetesVersion)?.version;
-      const kubernetesVersion = this.normanCluster?.aksConfig?.kubernetesVersion;
+      const kubernetesVersion = semver.coerce(this.normanCluster?.aksConfig?.kubernetesVersion)?.version;
 
       this.originalVersion = kubernetesVersion || '';
       // cluster spec version may not include a patch version if the cluster was created via terraform

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -152,9 +152,24 @@ export default defineComponent({
       }
 
       // track original version on edit to ensure we don't offer k8s downgrades
-      const kubernetesVersion = semver.coerce(this.normanCluster?.aksConfig?.kubernetesVersion)?.version;
+      // const kubernetesVersion = semver.coerce(this.normanCluster?.aksConfig?.kubernetesVersion)?.version;
+      const kubernetesVersion = this.normanCluster?.aksConfig?.kubernetesVersion;
 
       this.originalVersion = kubernetesVersion || '';
+      // cluster spec version may not include a patch version if the cluster was created via terraform
+      // use the more specific version in the cluster status to filter the list of upgrade choices
+      // this will NOT automatically alter the cluster spec - if the user does not select a new k8s version the patch-less version in the cluster's spec will be preserved
+      if (!semver.valid(this.normanCluster?.aksConfig?.kubernetesVersion)) {
+        await this.value.waitForMgmt();
+
+        const mgmtCluster = this.value.mgmt;
+
+        const statusVersion = mgmtCluster?.status?.version?.gitVersion;
+
+        if (statusVersion) {
+          this.originalVersion = statusVersion;
+        }
+      }
     } else {
       this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...defaultCluster }, { root: true });
 
@@ -189,7 +204,6 @@ export default defineComponent({
     const supportedVersionRange = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_SUPPORTED_K8S_VERSIONS)?.value;
 
     return {
-
       NETWORKING_AUTH_MODES,
       normanCluster:    { name: '' } as any,
       nodePools:        [] as AKSNodePool[],

--- a/pkg/aks/components/__tests__/Config.test.ts
+++ b/pkg/aks/components/__tests__/Config.test.ts
@@ -120,10 +120,10 @@ describe('aks provisioning form', () => {
 
   it.each([[
     '1.26.0',
-    mockVersionsSorted.filter((v: string) => semver.lte(v, '1.27.0') && semver.gte(v, '1.26.0'))
+    mockVersionsSorted.filter((v: string) => semver.lt(v, '1.28.0') && semver.gte(v, '1.26.0'))
   ],
   ['1.25.0',
-    mockVersionsSorted.filter((v: string) => semver.lte(v, '1.26.0') && semver.gte(v, '1.25.0'))
+    mockVersionsSorted.filter((v: string) => semver.lt(v, '1.27.0') && semver.gte(v, '1.25.0'))
   ],
   ])('should only allow upgrading one minor version at a time', async(originalVersion, validVersions) => {
     const wrapper = shallowMount(Config, {

--- a/pkg/aks/util/__mocks__/aks.ts
+++ b/pkg/aks/util/__mocks__/aks.ts
@@ -1,8 +1,8 @@
 export const mockRegions = [{ name: 'a' }, { name: 'b' }];
 
-export const mockVersions = ['1.25.0', '1.26.0', '1.27.0', '1.24.0'];
+export const mockVersions = ['1.25.0', '1.26.0', '1.27.0', '1.24.0', '1.26.1', '1.26.3', '1.26.5'];
 
-export const mockVersionsSorted = ['1.27.0', '1.26.0', '1.25.0', '1.24.0'];
+export const mockVersionsSorted = ['1.27.0', '1.26.5', '1.26.3', '1.26.1', '1.26.0', '1.25.0', '1.24.0'];
 
 export const mockSizes = ['size1', 'size2', 'size3'];
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12535 - see https://github.com/rancher/dashboard/issues/12535#issuecomment-2736071342
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the AKS provisioning form to use the management cluster's status.gitVersion to filter the list of available upgrade versions when the cluster config is missing a patch version, which may happen when provisioning through terraform.


### Areas or cases that should be tested
1. Create a new AKS cluster with an older k8s version (eg 1.30.1)
2. Edit the cluster and just verify that the form has loaded correctly, the kubernetes version dropdown shows '1.30.1', and the dropdown options no longer include 1.30.0
3. Edit the cluster to update the k8s version to one without a patch number. I did this through the norman api ui: 
     a) navigate to `<rancher url>/v3/clusters`, look through the list, and click the id of the AKS cluster you just created
     b) click 'edit' in the upper right
     c) modify the `aksConfig` value to change `kubernetesVersion` from `"1.30.1"` to `"1.31"`
     d) scroll down and click preview request
     e) scroll down and click send request
4. Return to the rancher ui cluster management list view and wait for the cluster to finish upgrading. Note the new kubernetes version displayed for your AKS cluster in the cluster list. It should be 1.31.<something>
5. Edit the cluster
Verify that:
  a) The Kubernetes Version dropdown has '1.31' selected
  b) There are no versions lower than the full version displayed in the cluster management list view
In this example, that means there should be no versions lower than 1.31.7 displayed. Here's what the list looks like in this PR:

![Screenshot 2025-05-07 at 12 26 20 PM](https://github.com/user-attachments/assets/2cabcee1-eb15-40c2-bd9e-230f145f264a)


and here is the same cluster being edited in master:
![Screenshot 2025-05-07 at 12 26 25 PM](https://github.com/user-attachments/assets/c6b104ea-5f48-4519-9196-4ae6a2bf3648)




### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
