### PR TITLE
[2.11.2]Use management cluster status.version.gitVersion to filter upgrade options when AKS cluster configs are missing a patch number

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -152,8 +152,7 @@ export default defineComponent({
       }
 
       // track original version on edit to ensure we don't offer k8s downgrades
-      // const kubernetesVersion = semver.coerce(this.normanCluster?.aksConfig?.kubernetesVersion)?.version;
-      const kubernetesVersion = this.normanCluster?.aksConfig?.kubernetesVersion;
+      const kubernetesVersion = semver.coerce(this.normanCluster?.aksConfig?.kubernetesVersion)?.version;
 
       this.originalVersion = kubernetesVersion || '';
       // cluster spec version may not include a patch version if the cluster was created via terraform

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -152,9 +152,24 @@ export default defineComponent({
       }
 
       // track original version on edit to ensure we don't offer k8s downgrades
-      const kubernetesVersion = semver.coerce(this.normanCluster?.aksConfig?.kubernetesVersion)?.version;
+      // const kubernetesVersion = semver.coerce(this.normanCluster?.aksConfig?.kubernetesVersion)?.version;
+      const kubernetesVersion = this.normanCluster?.aksConfig?.kubernetesVersion;
 
       this.originalVersion = kubernetesVersion || '';
+      // cluster spec version may not include a patch version if the cluster was created via terraform
+      // use the more specific version in the cluster status to filter the list of upgrade choices
+      // this will NOT automatically alter the cluster spec - if the user does not select a new k8s version the patch-less version in the cluster's spec will be preserved
+      if (!semver.valid(this.normanCluster?.aksConfig?.kubernetesVersion)) {
+        await this.value.waitForMgmt();
+
+        const mgmtCluster = this.value.mgmt;
+
+        const statusVersion = mgmtCluster?.status?.version?.gitVersion;
+
+        if (statusVersion) {
+          this.originalVersion = statusVersion;
+        }
+      }
     } else {
       this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...defaultCluster }, { root: true });
 
@@ -189,7 +204,6 @@ export default defineComponent({
     const supportedVersionRange = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_SUPPORTED_K8S_VERSIONS)?.value;
 
     return {
-
       NETWORKING_AUTH_MODES,
       normanCluster:    { name: '' } as any,
       nodePools:        [] as AKSNodePool[],

--- a/pkg/aks/util/__mocks__/aks.ts
+++ b/pkg/aks/util/__mocks__/aks.ts
@@ -1,8 +1,8 @@
 export const mockRegions = [{ name: 'a' }, { name: 'b' }];
 
-export const mockVersions = ['1.25.0', '1.26.0', '1.27.0', '1.24.0'];
+export const mockVersions = ['1.25.0', '1.26.0', '1.27.0', '1.24.0', '1.26.1', '1.26.3', '1.26.5'];
 
-export const mockVersionsSorted = ['1.27.0', '1.26.0', '1.25.0', '1.24.0'];
+export const mockVersionsSorted = ['1.27.0', '1.26.5', '1.26.3', '1.26.1', '1.26.0', '1.25.0', '1.24.0'];
 
 export const mockSizes = ['size1', 'size2', 'size3'];
 


### PR DESCRIPTION
Backport of #14280 

fixes #13721 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
