### PR TITLE
backport pr 14277 - 2.10.6

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/DirectoryConfig.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/DirectoryConfig.test.ts
@@ -1,7 +1,7 @@
 import { nextTick } from 'vue';
 /* eslint-disable jest/no-hooks */
 import { mount, Wrapper } from '@vue/test-utils';
-import DirectoryConfig, { DATA_DIR_RADIO_OPTIONS, DEFAULT_SUBDIRS } from '@shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue';
+import DirectoryConfig, { DATA_DIR_RADIO_OPTIONS, DEFAULT_SUBDIRS, DEFAULT_COMMON_BASE_PATH } from '@shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue';
 import { _EDIT, _CREATE } from '@shell/config/query-params';
 import { clone } from '@shell/utils/object';
 
@@ -54,7 +54,7 @@ describe('component: DirectoryConfig', () => {
     expect(k8sDistroInput.exists()).toBe(false);
   });
 
-  it('updating common base directory should set the correct values on each data dir variable', async() => {
+  it('setting the radio option to "common" should set the correct values on each data dir variable', async() => {
     const newMountOptions = clone(mountOptions);
 
     wrapper = mount(
@@ -68,17 +68,12 @@ describe('component: DirectoryConfig', () => {
       }
     );
 
-    const inputPath = 'some-data-dir';
-    const commonInput = wrapper.find('[data-testid="rke2-directory-config-common-data-dir"]');
+    // update radio to the "common" option
+    await wrapper.vm.handleRadioInput(DATA_DIR_RADIO_OPTIONS.COMMON);
 
-    // update base dir value
-    expect(commonInput.exists()).toBe(true);
-    commonInput.setValue(inputPath);
-    await nextTick();
-
-    expect(wrapper.vm.value.systemAgent).toStrictEqual(`${ inputPath }/${ DEFAULT_SUBDIRS.AGENT }`);
-    expect(wrapper.vm.value.provisioning).toStrictEqual(`${ inputPath }/${ DEFAULT_SUBDIRS.PROVISIONING }`);
-    expect(wrapper.vm.value.k8sDistro).toStrictEqual(`${ inputPath }/${ DEFAULT_SUBDIRS.K8S_DISTRO_K3S }`);
+    expect(wrapper.vm.value.systemAgent).toStrictEqual(`${ DEFAULT_COMMON_BASE_PATH }/${ DEFAULT_SUBDIRS.AGENT }`);
+    expect(wrapper.vm.value.provisioning).toStrictEqual(`${ DEFAULT_COMMON_BASE_PATH }/${ DEFAULT_SUBDIRS.PROVISIONING }`);
+    expect(wrapper.vm.value.k8sDistro).toStrictEqual(`${ DEFAULT_COMMON_BASE_PATH }/${ DEFAULT_SUBDIRS.K8S_DISTRO_K3S }`);
   });
 
   it('updating each individual data dir should set the correct values on each data dir variable', async() => {
@@ -178,5 +173,24 @@ describe('component: DirectoryConfig', () => {
     expect(wrapper.vm.value.systemAgent).toStrictEqual(`${ inputPath }/${ DEFAULT_SUBDIRS.AGENT }`);
     expect(wrapper.vm.value.provisioning).toStrictEqual(`${ inputPath }/${ DEFAULT_SUBDIRS.PROVISIONING }`);
     expect(wrapper.vm.value.k8sDistro).toStrictEqual(`${ inputPath }/${ DEFAULT_SUBDIRS.K8S_DISTRO_K3S }`);
+  });
+
+  it('updating the k8s version for the "common" config should only update the sub dir for the k8sDistro value', async() => {
+    wrapper = mount(
+      DirectoryConfig,
+      mountOptions
+    );
+
+    // update radio to the "common" option
+    await wrapper.vm.handleRadioInput(DATA_DIR_RADIO_OPTIONS.COMMON);
+
+    expect(wrapper.vm.value.systemAgent).toStrictEqual(`${ DEFAULT_COMMON_BASE_PATH }/${ DEFAULT_SUBDIRS.AGENT }`);
+    expect(wrapper.vm.value.provisioning).toStrictEqual(`${ DEFAULT_COMMON_BASE_PATH }/${ DEFAULT_SUBDIRS.PROVISIONING }`);
+    expect(wrapper.vm.value.k8sDistro).toStrictEqual(`${ DEFAULT_COMMON_BASE_PATH }/${ DEFAULT_SUBDIRS.K8S_DISTRO_K3S }`);
+
+    // let's update the k8s version
+    await wrapper.setProps({ k8sVersion: 'v1.32.4+rke2r1' });
+
+    expect(wrapper.vm.value.k8sDistro).toStrictEqual(`${ DEFAULT_COMMON_BASE_PATH }/${ DEFAULT_SUBDIRS.K8S_DISTRO_RKE2 }`);
   });
 });

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
@@ -78,8 +78,8 @@ export default {
           this.k8sDistroSubDir = DEFAULT_SUBDIRS.K8S_DISTRO_RKE2;
         }
 
-        if (this.value.k8sDistro) {
-          this.value.k8sDistro = `${ neu }/${ this.k8sDistroSubDir }`;
+        if (this.dataConfigRadioValue === DATA_DIR_RADIO_OPTIONS.COMMON && this.commonConfig) {
+          this.value.k8sDistro = `${ this.commonConfig }/${ this.k8sDistroSubDir }`;
         }
       }
     }
@@ -129,9 +129,11 @@ export default {
         this.commonConfig = DEFAULT_COMMON_BASE_PATH;
 
         this.dataConfigRadioValue = DATA_DIR_RADIO_OPTIONS.COMMON;
+
+        // individual data for each field is set on the watcher for commonConfig a bit further above
         break;
-      // default is custom config
       default:
+        // switch "default" is for the "custom" config
         if (this.mode === _CREATE) {
           this.commonConfig = '';
         }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14291
<!-- Define findings related to the feature or bug issue. -->

Original kudos to @khushalchandak17 for the fix in https://github.com/rancher/dashboard/pull/14262. 
Backport of https://github.com/rancher/dashboard/pull/14267

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- address issue with common config and updating k8s version
- updates unit tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Test creating and editing clusters with all three directory configuration options (Default, Common, Custom) and changing the Kubernetes version during and after creation to ensure the directory settings behave as described.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
