### PR TITLE
GH Workflow: Add back in GitHub fixes notation check

### DIFF
--- a/.github/workflows/scripts/pr-gh-project.js
+++ b/.github/workflows/scripts/pr-gh-project.js
@@ -15,6 +15,9 @@ const GH_PRJ_TO_TEST = 'To Test';
 const GH_PRJ_QA_REVIEW = 'QA Review';
 const GH_PRJ_IN_REVIEW = 'Review';
 
+// This label is used so that PRs from dependabot don't fail the check for 'fixes' notation
+const GH_DEPENDENCIES_LABEL = 'area/dependencies';
+
 function parseOrgAndRepo(repoUrl) {
   const parts = repoUrl.split('/');
 
@@ -267,6 +270,14 @@ async function processOpenOrEditAction() {
     console.log('+ This PR fixes issues: #' + issues.join(', '));
   } else {
     console.log("+ This PR does not fix any issues");
+
+    // PRs must fix an issue or have the label 'QA/None'
+    if (!hasLabel(pr, QA_NONE_LABEL) && !hasLabel(pr, GH_DEPENDENCIES_LABEL)) {
+      console.log('Error: A PR MUST either declare which issues it fixes OR must have the QA/None label');
+      process.exit(1);
+    }
+
+    console.log('Allowing PR to proceed without being linked to an issue because of the labels on the PR');    
   }
 
   const milestones = {};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Re-adds back https://github.com/rancher/dashboard/pull/14010

This was removed as we thought it was causing workload approvals, but does not seem to be, so adding back.

I have decided to only add this for PR open/edit and not on close - this does not make sense to fail the workflow when a PR is closed.

Marking as QA/None since this was previously reviewed and merged.
### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
