### PR TITLE
Revert custom object merge behavior

### DIFF
--- a/shell/detail/catalog.cattle.io.app.vue
+++ b/shell/detail/catalog.cattle.io.app.vue
@@ -56,7 +56,6 @@ export default {
       const combined = mergeWithReplace(
         merge({}, this.value?.chartValues || {}),
         this.value?.values || {},
-        { replaceObjectProps: true }
       );
 
       return jsyaml.dump(combined);

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -333,7 +333,6 @@ export default {
       this.chartValues = mergeWithReplace(
         merge({}, this.versionInfo?.values || {}),
         userValues,
-        { replaceObjectProps: true }
       );
 
       if (this.showCustomRegistry) {

--- a/shell/utils/object.js
+++ b/shell/utils/object.js
@@ -510,10 +510,6 @@ export function deepToRaw(obj, cache = new WeakSet()) {
  *                  with arrays in obj2 when both properties are arrays
  *                  false: default lodash merge behavior - recursively merges
  *                  array members
- * @param {boolean} [options.replaceObjectProps=false] - true: merges objects in
- *                  obj1 with objects in obj2, overwriting duplicate props
- *                  false: default lodash merge behavior - recursively merges
- *                  object props
  */
 export function mergeWithReplace(
   obj1 = {},
@@ -521,7 +517,6 @@ export function mergeWithReplace(
   {
     mutateOriginal = false,
     replaceArray = true,
-    replaceObjectProps = false,
   } = {}
 ) {
   const destination = mutateOriginal ? obj1 : {};
@@ -529,13 +524,6 @@ export function mergeWithReplace(
   return mergeWith(destination, obj1, obj2, (obj1Value, obj2Value) => {
     if (replaceArray && Array.isArray(obj1Value) && Array.isArray(obj2Value)) {
       return obj2Value;
-    }
-
-    if (replaceObjectProps && isObject(obj1Value) && isObject(obj2Value)) {
-      return {
-        ...obj1Value,
-        ...obj2Value,
-      };
     }
   });
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/rancher#50291

<!-- Define findings related to the feature or bug issue. -->

This reverts changes to object merge behavior because the existing behavior is destructive when merging deeply nested user values. 

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Revert changes to object merge behavior

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

For example, a default object contains the value:

```js
a: {
  b: true,
  c: true,
  d: {
    e: true,
    f: {
      g: true,
      e: { },
      f: [ ],
    },
  },
}
```

and a user value modifies `g`, which is stored as:

```js
a: {
  d: {
    f: {
      g: false,
    },
  },
}
```

When the object is merged, deeply nested values will only be taken from the user values, causing properties to be lost. Furthermore, default properties for `f` can also be dropped. This operation is too destructive, and it's better to merge user-supplied properties with defaults than to drastically alter YAML altogether.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

See associated issue for details. We will also need to retest #13980. This should still work with the updated array behavior, but object properties will use the default merge.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Charts install - Logging, Monitoring, etc..

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
