### PR TITLE
Add support for HTML page banners

### DIFF
--- a/cypress/e2e/po/pages/global-settings/banners.po.ts
+++ b/cypress/e2e/po/pages/global-settings/banners.po.ts
@@ -7,6 +7,7 @@ import RootClusterPage from '@/cypress/e2e/po/pages/root-cluster-page';
 import RadioGroupInputPo from '@/cypress/e2e/po/components/radio-group-input.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+import ToggleSwitchPo from '@/cypress/e2e/po/components/toggle-switch.po';
 
 export class BannersPagePo extends RootClusterPage {
   static url = '/c/_/settings/banners';
@@ -59,6 +60,35 @@ export class BannersPagePo extends RootClusterPage {
     return CheckboxInputPo.byLabel(this.self(), 'Show custom login error');
   }
 
+  consentBannerShowAsDialogCheckbox(): CheckboxInputPo {
+    return CheckboxInputPo.byLabel(this.self(), 'Show Login Consent as a modal dialog');
+  }
+
+  /**
+   * Get content type toggle switch
+   */
+  contentTypeToggle(bannerType: string) {
+    return new ToggleSwitchPo(`[data-testid="banner_content_type_toggle${ bannerType }"]`, this.self());
+  }
+
+  /**
+   * HTML Input box
+   * @param bannerType Banner Type
+   * @returns Input Box
+   */
+  htmlTextArea(bannerType: string) {
+    return new LabeledInputPo(`[data-testid="banner_html${ bannerType }"]`, this.self());
+  }
+
+  /**
+   * Accept Button Input box
+   * @param bannerType Banner Type
+   * @returns Input Box
+   */
+  acceptButtonInput(bannerType: string) {
+    return new LabeledInputPo(`[data-testid="banner_accept_button${ bannerType }"]`, this.self());
+  }
+
   /**
    * Get text alignment radio buttons
    * @param bannerType
@@ -105,6 +135,14 @@ export class BannersPagePo extends RootClusterPage {
    */
   banner(): Cypress.Chainable {
     return cy.getId('fixed__banner');
+  }
+
+  /**
+   * Get the login confirmation dialog (login confirmation banner shown as a dialog)
+   * @returns
+   */
+  loadingConfirmationDialog(): Cypress.Chainable {
+    return cy.get('#banner-consent .banner-dialog-frame');
   }
 
   /**

--- a/cypress/e2e/po/pages/login-page.po.ts
+++ b/cypress/e2e/po/pages/login-page.po.ts
@@ -2,6 +2,7 @@ import PagePo from '@/cypress/e2e/po/pages/page.po';
 import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import PasswordPo from '@/cypress/e2e/po/components/password.po';
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
 
 export class LoginPagePo extends PagePo {
   static url = '/auth/login'
@@ -46,6 +47,10 @@ export class LoginPagePo extends PagePo {
 
   submitButton(): AsyncButtonPo {
     return new AsyncButtonPo('[data-testid="login-submit"]', this.self());
+  }
+
+  confirmationAcceptButton(): ComponentPo {
+    return new ComponentPo('[data-testid="login-confirmation-accept-button"]', this.self());
   }
 
   /**

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -73,7 +73,7 @@ declare global {
 
       state(state: any): any;
 
-      login(username?: string, password?: string, cacheSession?: boolean, skipNavigation?: boolean): Chainable<Element>;
+      login(username?: string, password?: string, cacheSession?: boolean, skipNavigation?: boolean, acceptConfirmation?: string): Chainable<Element>;
       logout(): Chainable;
       byLabel(label: string): Chainable<Element>;
       getRootE2EResourceName(): Chainable<string>;

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -15,6 +15,7 @@ Cypress.Commands.add('login', (
   password = Cypress.env('password'),
   cacheSession = true,
   skipNavigation = false,
+  acceptConfirmation = '', // Use when we expect the confirmation dialog to be present (expected button text)
 ) => {
   const login = () => {
     cy.intercept('POST', '/v3-public/localProviders/local*').as('loginReq');
@@ -26,6 +27,11 @@ Cypress.Commands.add('login', (
 
     loginPage
       .checkIsCurrentPage(!skipNavigation);
+
+    if (!!acceptConfirmation) {
+      loginPage.confirmationAcceptButton().shouldContainText(acceptConfirmation);
+      loginPage.confirmationAcceptButton().self().click();
+    }
 
     loginPage.switchToLocal();
 

--- a/pkg/rancher-components/src/components/Banner/Banner.vue
+++ b/pkg/rancher-components/src/components/Banner/Banner.vue
@@ -47,7 +47,14 @@ export default defineComponent({
     stacked: {
       type:    Boolean,
       default: false
-    }
+    },
+    /**
+     * Disabled banner - banner is shown greyed out
+     */
+    disabled: {
+      type:    Boolean,
+      default: false
+    },
   },
   emits:    ['close'],
   computed: {
@@ -56,7 +63,7 @@ export default defineComponent({
      */
     messageLabel(): string | void {
       return !(typeof this.label === 'string') ? stringify(this.label) : undefined;
-    }
+    },
   },
   methods: { nlToBr }
 });
@@ -66,6 +73,7 @@ export default defineComponent({
     class="banner"
     :class="{
       [color]: true,
+      'banner-disabled': disabled
     }"
     role="banner"
   >
@@ -162,6 +170,10 @@ $icon-size: 24px;
       background: var(--error);
       color: var(--primary-text);
     }
+  }
+
+  &.banner-disabled {
+    filter: grayscale(1);
   }
 
   &__content {

--- a/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.vue
+++ b/pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.vue
@@ -29,6 +29,11 @@ export default defineComponent({
       type:    String,
       default: '',
     },
+
+    disabled: {
+      type:    Boolean,
+      default: false,
+    },
   },
 
   emits: ['update:value'],
@@ -84,7 +89,10 @@ export default defineComponent({
 </script>
 
 <template>
-  <span class="toggle-container">
+  <span
+    class="toggle-container"
+    :class="{'toggle-disabled': disabled}"
+  >
     <span
       class="label no-select hand"
       :class="{ active: !state}"
@@ -125,6 +133,18 @@ $toggle-height: 16px;
   }
   span:last-child {
     padding-left: 6px;
+  }
+
+  &.toggle-disabled {
+    pointer-events: none;
+
+    .slider {
+      background-color: var(--checkbox-disabled-bg);
+
+      &:before {
+        opacity: 0.6;
+      }
+    }
   }
 }
 /* The switch - the box around the slider */

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7866,6 +7866,10 @@ banner:
   consent: Consent Banner
   consentFootnote: "Tip: Use \\n character for line break"
   individualSetting: 'This banner is managed by the setting "{name}" and can not be modified in the UI'
+  type:
+    html: HTML
+    text: Text
+  htmlWarning: 'Not all HTML elements or attributes are permitted and the HTML entered here will be sanitized before display. For HTML anchor elements, it is recommended to use the target attribute to have links open in a blank tab.'
 
 branding:
   label: Branding

--- a/shell/components/FixedBanner.vue
+++ b/shell/components/FixedBanner.vue
@@ -210,13 +210,19 @@ export default {
               </div>
             </div>
             <div
-              v-else
+              v-else-if="banner.text"
               class="single-row"
             >
               {{ banner.text }}
             </div>
+            <div
+              v-else-if="banner.html"
+              v-clean-html="banner.html"
+              class="single-row"
+            />
           </div>
           <button
+            data-testid="login-confirmation-accept-button"
             class="btn role-primary"
             @click="hideDialog()"
           >
@@ -232,9 +238,9 @@ export default {
   .banner {
     line-height: 2em;
     width: 100%;
-    padding: 0 20px;
 
     &.banner-text {
+      padding: 0 20px;
       text-align: center;
     }
 

--- a/shell/components/FixedBanner.vue
+++ b/shell/components/FixedBanner.vue
@@ -164,7 +164,7 @@ export default {
       class="banner"
       data-testid="fixed__banner"
       :style="bannerStyle"
-      :class="{'banner-consent': consent}"
+      :class="{'banner-consent': consent, 'banner-text': !!banner.text}"
     >
       <!-- text as array to support line breaks programmatically rather than just exposing HTML -->
       <div v-if="isTextAnArray">
@@ -177,11 +177,16 @@ export default {
         </div>
       </div>
       <div
-        v-else
+        v-else-if="banner.text"
         class="single-row"
       >
         {{ banner.text }}
       </div>
+      <div
+        v-else-if="banner.html"
+        v-clean-html="banner.html"
+        class="single-row"
+      />
     </div>
     <div v-else-if="showDialog">
       <div class="banner-dialog-glass" />
@@ -225,10 +230,13 @@ export default {
 
 <style lang="scss" scoped>
   .banner {
-    text-align: center;
     line-height: 2em;
     width: 100%;
     padding: 0 20px;
+
+    &.banner-text {
+      text-align: center;
+    }
 
     &.banner-consent {
       height: unset;

--- a/shell/components/form/BannerSettings.vue
+++ b/shell/components/form/BannerSettings.vue
@@ -7,6 +7,7 @@ import { RadioGroup } from '@components/Form/Radio';
 import { _EDIT, _VIEW } from '@shell/config/query-params';
 import { ToggleSwitch } from '@components/Form/ToggleSwitch';
 import { TextAreaAutoGrow } from '@components/Form/TextArea';
+import { Banner } from '@components/Banner';
 
 export default ({
   name: 'BannerSettings',
@@ -30,7 +31,7 @@ export default ({
   },
 
   components: {
-    Checkbox, ColorInput, LabeledInput, LabeledSelect, RadioGroup, TextAreaAutoGrow, ToggleSwitch
+    Banner, Checkbox, ColorInput, LabeledInput, LabeledSelect, RadioGroup, TextAreaAutoGrow, ToggleSwitch
   },
 
   data() {
@@ -139,9 +140,10 @@ export default ({
     <div class="row pb-10">
       <ToggleSwitch
         v-model:value="isHtml"
+        :data-testid="`banner_content_type_toggle${bannerType}`"
         :disabled="isUiDisabled"
-        off-label="Text"
-        on-label="HTML"
+        :off-label="t('banner.type.text')"
+        :on-label="t('banner.type.html')"
       />
     </div>
     <div
@@ -215,10 +217,21 @@ export default ({
       v-else
       class="row"
     >
-      <TextAreaAutoGrow
-        v-model:value="value[bannerType].html"
-        :min-height="64"
-      />
+      <div class="col span-12">
+        <Banner
+          :disabled="isUiDisabled"
+          color="warning"
+        >
+          {{ t('banner.htmlWarning') }}
+        </Banner>
+        <TextAreaAutoGrow
+          v-model:value="value[bannerType].html"
+          :data-testid="`banner_html${bannerType}`"
+          :min-height="64"
+          :disabled="isUiDisabled"
+          :placeholder="t('banner.type.html')"
+        />
+      </div>
     </div>
     <div
       v-if="isConsentBanner"
@@ -228,8 +241,9 @@ export default ({
         <div class="mt-10">
           <Checkbox
             v-model:value="showAsDialog"
-            name="bannerDecoration"
+            name="bannerShowAsDialog"
             class="banner-decoration-checkbox"
+            :data-testid="`banner_show_as_dialog_checkbox${bannerType}`"
             :mode="mode"
             :label="t('banner.showAsDialog.label')"
             :tooltip="t('banner.showAsDialog.tooltip')"
@@ -237,6 +251,7 @@ export default ({
           />
           <LabeledInput
             v-model:value="buttonText"
+            :data-testid="`banner_accept_button${bannerType}`"
             :disabled="!showAsDialog || isUiDisabled"
             :label="t('banner.buttonText')"
             :aria-describedby="bannerTitleId"

--- a/shell/components/form/BannerSettings.vue
+++ b/shell/components/form/BannerSettings.vue
@@ -5,6 +5,8 @@ import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { RadioGroup } from '@components/Form/Radio';
 import { _EDIT, _VIEW } from '@shell/config/query-params';
+import { ToggleSwitch } from '@components/Form/ToggleSwitch';
+import { TextAreaAutoGrow } from '@components/Form/TextArea';
 
 export default ({
   name: 'BannerSettings',
@@ -28,12 +30,13 @@ export default ({
   },
 
   components: {
-    Checkbox, ColorInput, LabeledInput, LabeledSelect, RadioGroup
+    Checkbox, ColorInput, LabeledInput, LabeledSelect, RadioGroup, TextAreaAutoGrow, ToggleSwitch
   },
 
   data() {
     const showAsDialog = !!this.value[this.bannerType]?.button || false;
     const buttonText = this.value[this.bannerType]?.button || this.t('banner.showAsDialog.defaultButtonText');
+    const isHtml = !!this.value[this.bannerType]?.html; // HTML display if the 'html' field is set (otherwise default is text)
 
     return {
       showAsDialog,
@@ -43,7 +46,8 @@ export default ({
         bannerBgColor:   getComputedStyle(document.body).getPropertyValue('--default'),
         bannerTextColor: getComputedStyle(document.body).getPropertyValue('--banner-text-color')
       },
-      bannerTitleId: `describe-banners-${ this.bannerType }-id`
+      bannerTitleId: `describe-banners-${ this.bannerType }-id`,
+      isHtml,
     };
   },
 
@@ -59,6 +63,12 @@ export default ({
     buttonText(neu, old) {
       if (neu !== old) {
         this.value[this.bannerType].button = neu;
+      }
+    },
+
+    isHtml(neu, old) {
+      if (neu !== old) {
+        this.value[this.bannerType].isHtml = neu; // Keep track of the content type (this is not persisted)
       }
     }
   },
@@ -105,109 +115,131 @@ export default ({
 </script>
 
 <template>
-  <div class="row mb-20">
-    <div class="col span-12">
-      <div class="row">
+  <div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <ColorInput
+          v-model:value="value[bannerType].color"
+          :default-value="themeVars.bannerTextColor"
+          :label="t('banner.textColor')"
+          :mode="mode"
+          :aria-label="`${t(`banner.${bannerType}`)} ${t('banner.textColor')}`"
+        />
+      </div>
+      <div class="col span-6">
+        <ColorInput
+          v-model:value="value[bannerType].background"
+          :default-value="themeVars.bannerBgColor"
+          :label="t('banner.background')"
+          :mode="mode"
+          :aria-label="`${t(`banner.${bannerType}`)} ${t('banner.background')}`"
+        />
+      </div>
+    </div>
+    <div class="row pb-10">
+      <ToggleSwitch
+        v-model:value="isHtml"
+        :disabled="isUiDisabled"
+        off-label="Text"
+        on-label="HTML"
+      />
+    </div>
+    <div
+      v-if="!isHtml"
+      class="row"
+    >
+      <p
+        :id="bannerTitleId"
+        class="sr-only"
+      >
+        {{ t(`banner.${bannerType}`) }}
+      </p>
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="value[bannerType].text"
+          :disabled="isUiDisabled"
+          :label="t('banner.text')"
+          type="multiline"
+          :aria-describedby="bannerTitleId"
+        />
         <p
-          :id="bannerTitleId"
-          class="sr-only"
+          v-if="isConsentBanner"
+          class="banner-input-footnote mt-5 mb-20"
         >
-          {{ t(`banner.${bannerType}`) }}
+          {{ t('banner.consentFootnote') }}
         </p>
-        <div class="col span-6">
-          <LabeledInput
-            v-model:value="value[bannerType].text"
-            :disabled="isUiDisabled"
-            :label="t('banner.text')"
-            type="multiline"
-            :aria-describedby="bannerTitleId"
-          />
-          <p
-            v-if="isConsentBanner"
-            class="banner-input-footnote mt-5 mb-20"
-          >
-            {{ t('banner.consentFootnote') }}
-          </p>
-          <div
-            v-if="isConsentBanner"
-            class="mt-10"
-          >
-            <Checkbox
-              v-model:value="showAsDialog"
-              name="bannerDecoration"
-              class="banner-decoration-checkbox"
-              :mode="mode"
-              :label="t('banner.showAsDialog.label')"
-              :tooltip="t('banner.showAsDialog.tooltip')"
-              :aria-describedby="bannerTitleId"
-            />
-            <LabeledInput
-              v-model:value="buttonText"
-              :disabled="!showAsDialog || isUiDisabled"
-              :label="t('banner.buttonText')"
-              :aria-describedby="bannerTitleId"
-            />
-          </div>
-        </div>
-        <div class="col span-2">
-          <RadioGroup
-            v-model:value="value[bannerType].textAlignment"
-            name="bannerAlignment"
-            :data-testid="`banner_alignment_radio_options${bannerType}`"
-            :label="t('banner.bannerAlignment.label')"
-            :options="radioOptions.options"
-            :labels="radioOptions.labels"
+      </div>
+      <div class="col span-2">
+        <RadioGroup
+          v-model:value="value[bannerType].textAlignment"
+          name="bannerAlignment"
+          :data-testid="`banner_alignment_radio_options${bannerType}`"
+          :label="t('banner.bannerAlignment.label')"
+          :options="radioOptions.options"
+          :labels="radioOptions.labels"
+          :mode="mode"
+          :aria-label="`${t(`banner.${bannerType}`)} ${t('banner.bannerAlignment.label')}`"
+        />
+      </div>
+      <div class="col span-2">
+        <h3 id="decoration-banner-title-id">
+          {{ t('banner.bannerDecoration.label') }}
+        </h3>
+        <div
+          v-for="(o, i) in textDecorationOptions"
+          :key="i"
+        >
+          <Checkbox
+            v-model:value="value[bannerType][o.style]"
+            name="bannerDecoration"
+            :data-testid="`banner_decoration_checkbox${bannerType}${o.label}`"
+            class="banner-decoration-checkbox"
             :mode="mode"
-            :aria-label="`${t(`banner.${bannerType}`)} ${t('banner.bannerAlignment.label')}`"
-          />
-        </div>
-        <div class="col span-2">
-          <h3 id="decoration-banner-title-id">
-            {{ t('banner.bannerDecoration.label') }}
-          </h3>
-          <div
-            v-for="(o, i) in textDecorationOptions"
-            :key="i"
-          >
-            <Checkbox
-              v-model:value="value[bannerType][o.style]"
-              name="bannerDecoration"
-              :data-testid="`banner_decoration_checkbox${bannerType}${o.label}`"
-              class="banner-decoration-checkbox"
-              :mode="mode"
-              :label="o.label"
-              :aria-describedby="`${bannerTitleId} decoration-banner-title-id`"
-            />
-          </div>
-        </div>
-        <div class="col span-2">
-          <LabeledSelect
-            v-model:value="value[bannerType].fontSize"
-            :data-testid="`banner_font_size_options${bannerType}`"
-            :disabled="isUiDisabled"
-            :label="t('banner.bannerFontSize.label')"
-            :options="uiBannerFontSizeOptions"
-            :aria-describedby="bannerTitleId"
+            :label="o.label"
+            :aria-describedby="`${bannerTitleId} decoration-banner-title-id`"
           />
         </div>
       </div>
-      <div class="row mt-10">
-        <div class="col span-6">
-          <ColorInput
-            v-model:value="value[bannerType].color"
-            :default-value="themeVars.bannerTextColor"
-            :label="t('banner.textColor')"
+      <div class="col span-2">
+        <LabeledSelect
+          v-model:value="value[bannerType].fontSize"
+          :data-testid="`banner_font_size_options${bannerType}`"
+          :disabled="isUiDisabled"
+          :label="t('banner.bannerFontSize.label')"
+          :options="uiBannerFontSizeOptions"
+          :aria-describedby="bannerTitleId"
+        />
+      </div>
+    </div>
+    <div
+      v-else
+      class="row"
+    >
+      <TextAreaAutoGrow
+        v-model:value="value[bannerType].html"
+        :min-height="64"
+      />
+    </div>
+    <div
+      v-if="isConsentBanner"
+      class="row"
+    >
+      <div class="col span-6">
+        <div class="mt-10">
+          <Checkbox
+            v-model:value="showAsDialog"
+            name="bannerDecoration"
+            class="banner-decoration-checkbox"
             :mode="mode"
-            :aria-label="`${t(`banner.${bannerType}`)} ${t('banner.textColor')}`"
+            :label="t('banner.showAsDialog.label')"
+            :tooltip="t('banner.showAsDialog.tooltip')"
+            :aria-describedby="bannerTitleId"
           />
-        </div>
-        <div class="col span-6">
-          <ColorInput
-            v-model:value="value[bannerType].background"
-            :default-value="themeVars.bannerBgColor"
-            :label="t('banner.background')"
-            :mode="mode"
-            :aria-label="`${t(`banner.${bannerType}`)} ${t('banner.background')}`"
+          <LabeledInput
+            v-model:value="buttonText"
+            :disabled="!showAsDialog || isUiDisabled"
+            :label="t('banner.buttonText')"
+            :aria-describedby="bannerTitleId"
           />
         </div>
       </div>

--- a/shell/pages/c/_cluster/settings/banners.vue
+++ b/shell/pages/c/_cluster/settings/banners.vue
@@ -26,6 +26,7 @@ const DEFAULT_BANNER_SETTING = {
     fontSize:       '14px',
     textDecoration: null,
     text:           null,
+    html:           null,
   },
   bannerFooter: {
     background:     null,
@@ -35,7 +36,8 @@ const DEFAULT_BANNER_SETTING = {
     fontStyle:      null,
     fontSize:       '14px',
     textDecoration: null,
-    text:           null
+    text:           null,
+    html:           null,
   },
   bannerConsent: {
     background:     null,
@@ -47,6 +49,7 @@ const DEFAULT_BANNER_SETTING = {
     textDecoration: null,
     text:           null,
     button:         null,
+    html:           null,
   },
   showHeader:  'false',
   showFooter:  'false',
@@ -175,8 +178,43 @@ export default {
       return parsedBanner;
     },
 
+    tidy(val) {
+      Object.keys(val).forEach((k) => {
+        if (k.startsWith('banner')) {
+          const banner = val[k];
+          const isHtml = banner.isHtml === undefined ? !banner.text : banner.isHtml;
+
+          if (isHtml) {
+            delete banner.text;
+
+            // Remove all of the fields for text formatting (not needed for HTML)
+            delete banner.textAlignment;
+            delete banner.textDecoration;
+            delete banner.fontWeight;
+            delete banner.fontStyle;
+            delete banner.fontSize;
+          } else {
+            delete banner.html;
+          }
+
+          delete banner.isHtml;
+
+          Object.keys(banner).forEach((f) => {
+            if (banner[f] === null) {
+              delete banner[f];
+            }
+          });
+        }
+      });
+
+      return val;
+    },
+
     async save(btnCB) {
-      this.uiBannerSetting.value = JSON.stringify(this.bannerVal);
+      // Clone the value - we'll tidy it up before save, but want to keep the full value in case the save errors
+      const cpy = JSON.parse(JSON.stringify(this.bannerVal));
+
+      this.uiBannerSetting.value = JSON.stringify(this.tidy(cpy));
 
       this.errors = [];
 

--- a/shell/plugins/clean-html.js
+++ b/shell/plugins/clean-html.js
@@ -2,6 +2,7 @@ import DOMPurify from 'dompurify';
 import { uniq } from '@shell/utils/array';
 
 const ALLOWED_TAGS = [
+  'center',
   'code',
   'li',
   'a',
@@ -13,6 +14,7 @@ const ALLOWED_TAGS = [
   'span',
   'div',
   'i',
+  'img',
   'em',
   'strong',
   'h1',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13080

This PR updates the custom page/login banners feature to support HTML in addition to the option-based text banners that are currently supported.

### Occurred changes and/or fixed issues

A new `html` field is supported on the banner configuration that allows for an HTML block to be configured. This is only used if the existing `text` field is empty.

The `BannerSettings` component that supports this configuration has been updated with a toggle switch to switch between the existing text options or HTML. The color configuration has been moved to the top, as this can still be used in both cases and, for HTML, provides an easy way to set the background and foreground colors.

The HTML is sanitized before being rendered to ensure that `script` and other elements/tags are removed to prevent code execution etc.

HTML presentation is wired into the `FixedBanner` component - so everywhere we can show text, we now support HTML. It is also shown correctly on the login confirmation dialog, when configured this way.

Automated e2e tests are added:

- A normal banner case, checking that the new HTML option works correctly. This checks the banner setting and fixed banner component changes. We only test one banner use (header banner), but since these are common components and we have existing tests that test the different banners, that is considered enough.
- Login confirmation dialog case. Adds a test that the HTML is shown correctly when configured as a consent banner for the login screen.

### Areas or cases that should be tested

Automated test coverage should be sufficient.

### Screenshot/Video

**Banner settings:**

![image](https://github.com/user-attachments/assets/72053fb1-ea45-4f97-b3d7-ce5418127027)

![image](https://github.com/user-attachments/assets/6e42e150-aa82-45d5-a727-6777f5ab1f31)

**Regular Banner (header banner shown):**

![image](https://github.com/user-attachments/assets/db4d3a7c-b574-4f3f-83fd-60b88eb370f4)

**Login Screen Confirmation Dialog:**

![image](https://github.com/user-attachments/assets/c7fde520-3f95-4ddf-97e9-e1fb16a210b9)

### Test Data

For testing, the following HTML was used:

**Normal Banner**

```
<div style="display: flex; align-items: center; padding: 0 10px"><img onload="alert('hello');" src="https://www.rancher.com/assets/img/logos/rancher-logo-horiz-color.svg" height="24" style="margin-right: 10px; padding: 4px 0"/><p>Use of this system implies acceptance of <a target="_blank" href="https://www.suse.com">SUSE's Terms and Conditions</a></p></div>
```

**Login Confirmation Dialog Banner**

```
<div style="display: flex; flex-direction: column; align-items: center; padding: 0 10px"><img onload="alert('hello');" src="https://www.rancher.com/assets/img/logos/rancher-logo-horiz-color.svg" height="64" style="margin-right: 10px; padding: 10px 0"/><p style="margin-bottom: 20px">Use of this system is strictly for SUSE business use and implies acceptance of <a target="_blank" href="https://www.suse.com">SUSE's Terms and Conditions</a></p></div>
```

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
