### PR TITLE
fix problem with space key on searchable selects

### DIFF
--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -157,9 +157,16 @@ export default {
 
   methods: {
     // resizeHandler = in mixin
-    focusSearch() {
+    focusSearch(ev) {
       if (this.isView || this.disabled || this.loading) {
         return;
+      }
+
+      const searchBox = document.querySelector('.vs__search');
+
+      // added to mitigate https://github.com/rancher/dashboard/issues/14361
+      if (!this.isSearchable || (searchBox && document.activeElement && !searchBox.contains(document.activeElement))) {
+        ev.preventDefault();
       }
 
       this.$refs['select-input'].open = true;
@@ -293,7 +300,7 @@ export default {
     @click="focusSearch"
     @keydown.enter="focusSearch"
     @keydown.down.prevent="focusSearch"
-    @keydown.space.prevent="focusSearch"
+    @keydown.space="focusSearch"
   >
     <div
       :class="{ 'labeled-container': true, raised, empty, [mode]: true }"

--- a/shell/components/form/Select.vue
+++ b/shell/components/form/Select.vue
@@ -124,7 +124,14 @@ export default {
       calculatePosition(dropdownList, component, width, this.placement);
     },
 
-    focusSearch() {
+    focusSearch(ev) {
+      const searchBox = document.querySelector('.vs__search');
+
+      // added to mitigate https://github.com/rancher/dashboard/issues/14361
+      if (!this.isSearchable || (searchBox && document.activeElement && !searchBox.contains(document.activeElement))) {
+        ev.preventDefault();
+      }
+
       this.$refs['select-input'].open = true;
 
       this.$nextTick(() => {
@@ -269,7 +276,7 @@ export default {
     @click="focusSearch"
     @keydown.enter="focusSearch"
     @keydown.down.prevent="focusSearch"
-    @keydown.space.prevent="focusSearch"
+    @keydown.space="focusSearch"
   >
     <v-select
       ref="select-input"

--- a/shell/components/form/__tests__/LabeledSelect.test.ts
+++ b/shell/components/form/__tests__/LabeledSelect.test.ts
@@ -283,6 +283,7 @@ describe('component: LabeledSelect', () => {
     // mimic pressing space on search box inside v-select
     await input.trigger('keydown.space', mockEvent);
 
+    // eslint-disable-next-line
     expect(spyFocus).toHaveBeenCalled();
     expect(spyPreventDefault).not.toHaveBeenCalled();
   });

--- a/shell/components/form/__tests__/LabeledSelect.test.ts
+++ b/shell/components/form/__tests__/LabeledSelect.test.ts
@@ -254,4 +254,36 @@ describe('component: LabeledSelect', () => {
     // from the library
     expect(vSelectInput.attributes('aria-label')).toBe('-');
   });
+
+  it('pressing space key while focused on search should not prevent event propagation', async() => {
+    const value = 'value-1';
+    const options = [
+      { label: 'label-1', value: 'value-1' },
+      { label: 'label-2', value: 'value-2' },
+    ];
+
+    const wrapper = mount(LabeledSelect, {
+      props: {
+        value,
+        label:      'some-label',
+        options,
+        searchable: true
+      }
+    });
+
+    const mockEvent = { preventDefault: jest.fn() };
+    const spyFocus = jest.spyOn(wrapper.vm, 'focusSearch');
+    const spyPreventDefault = jest.spyOn(mockEvent, 'preventDefault');
+
+    const input = wrapper.find('.labeled-select');
+
+    // open labeled-select first
+    await input.trigger('keydown.enter');
+
+    // mimic pressing space on search box inside v-select
+    await input.trigger('keydown.space', mockEvent);
+
+    expect(spyFocus).toHaveBeenCalled();
+    expect(spyPreventDefault).not.toHaveBeenCalled();
+  });
 });

--- a/shell/components/form/__tests__/Select.test.ts
+++ b/shell/components/form/__tests__/Select.test.ts
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, mount } from '@vue/test-utils';
 import { defineComponent } from 'vue';
 import Select from '@shell/components/form/Select.vue';
 
@@ -63,5 +63,37 @@ describe('select.vue', () => {
     // screen readers won't pick up the default "Select option" aria-label
     // from the library
     expect(vSelectInput.attributes('aria-label')).toBe('-');
+  });
+
+  it('pressing space key while focused on search should not prevent event propagation', async() => {
+    const value = 'value-1';
+    const options = [
+      { label: 'label-1', value: 'value-1' },
+      { label: 'label-2', value: 'value-2' },
+    ];
+
+    const wrapper = mount(SelectComponent, {
+      props: {
+        value,
+        label:      'some-label',
+        options,
+        searchable: true
+      }
+    });
+
+    const mockEvent = { preventDefault: jest.fn() };
+    const spyFocus = jest.spyOn(wrapper.vm, 'focusSearch');
+    const spyPreventDefault = jest.spyOn(mockEvent, 'preventDefault');
+
+    const input = wrapper.find('.unlabeled-select');
+
+    // open unlabeled-select first
+    await input.trigger('keydown.enter');
+
+    // mimic pressing space on search box inside v-select
+    await input.trigger('keydown.space', mockEvent);
+
+    expect(spyFocus).toHaveBeenCalled();
+    expect(spyPreventDefault).not.toHaveBeenCalled();
   });
 });

--- a/shell/components/form/__tests__/Select.test.ts
+++ b/shell/components/form/__tests__/Select.test.ts
@@ -93,6 +93,7 @@ describe('select.vue', () => {
     // mimic pressing space on search box inside v-select
     await input.trigger('keydown.space', mockEvent);
 
+    // eslint-disable-next-line
     expect(spyFocus).toHaveBeenCalled();
     expect(spyPreventDefault).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14361 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix problem with `space` key on searchable selects 
- add unit tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- test both `LabeledSelect` and `Select` components, both `searchable` or not

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- possible regression on https://github.com/rancher/dashboard/issues/13252#issuecomment-2672428059

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
