### PR TITLE
re-enable color contrast tests

### DIFF
--- a/cypress/support/commands/accessiblity.ts
+++ b/cypress/support/commands/accessiblity.ts
@@ -7,9 +7,6 @@ const severityIndicators = {
   critical: '🔴',
 };
 
-// Ignore color contrast for now
-const RULES = { rules: { 'color-contrast': { enabled: false } } };
-
 // Used to track where multiple checks are done in a test to ensure we save
 // the screenshots for them to unique filenames
 const screenshotIndexes: {[key: string]: number} = {};
@@ -134,7 +131,7 @@ function getAccessibilityViolationsCallback(description?: string) {
  */
 // skipFailures = true will not fail the test when there are accessibility failures
 Cypress.Commands.add('checkPageAccessibility', (description?: string) => {
-  cy.checkA11y(undefined, RULES, getAccessibilityViolationsCallback(description), true);
+  cy.checkA11y(undefined, {}, getAccessibilityViolationsCallback(description), true);
 });
 
 /**
@@ -146,5 +143,5 @@ Cypress.Commands.add('checkElementAccessibility', (subject: any, description?: s
     cy.log(`✅ Found ${ $el.length } elements matching`);
   });
 
-  cy.checkA11y(subject, RULES, getAccessibilityViolationsCallback(description), true);
+  cy.checkA11y(subject, {}, getAccessibilityViolationsCallback(description), true);
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14297 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- re-enable color contrast tests for a11y

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
