### PR TITLE
Added private registry support when importing generic cluster

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -614,9 +614,9 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         importClusterPage.accordion(2, 'Basics').should('be.visible');
         importClusterPage.accordion(3, 'Member Roles').should('be.visible');
         importClusterPage.accordion(4, 'Labels and Annotations').scrollIntoView().should('be.visible');
-        importClusterPage.accordion(5, 'Advanced').scrollIntoView().should('be.visible');
+        importClusterPage.accordion(5, 'Registries').scrollIntoView().should('be.visible');
+        importClusterPage.accordion(6, 'Advanced').scrollIntoView().should('be.visible');
         importClusterPage.networkingAccordion().should('not.exist');
-        importClusterPage.registriesAccordion().should('not.exist');
 
         importClusterPage.nameNsDescription().name().checkVisible();
         importClusterPage.nameNsDescription().name().set(importGenericName);

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -550,7 +550,7 @@ export default defineComponent({
         />
       </Accordion>
       <Accordion
-        v-if="!isCreate && !isRKE1"
+        v-if="!isRKE1"
         class="mb-20 accordion"
         title-key="imported.accordions.registries"
         data-testid="registries-accordion"
@@ -573,7 +573,6 @@ export default defineComponent({
           v-if="showPrivateRegistryInput"
           v-model:value="normanCluster.importedConfig.privateRegistryURL"
           :mode="mode"
-          :disabled="!isEdit"
           :rules="fvGetAndReportPathRules('normanCluster.importedConfig.privateRegistryURL')"
           label-key="catalog.chart.registry.custom.inputLabel"
           data-testid="private-registry-url"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14335 
<!-- Define findings related to the feature or bug issue. -->
Enabled Private registry when importing a cluster

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Originally, we thought it should only be enabled on edit, but there is no technical reason to not support it on creation.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Import generic cluster -> Registries tab should be visible and should be configurable.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1583" alt="Screenshot 2025-05-26 at 5 25 21 PM" src="https://github.com/user-attachments/assets/ae3dfc7a-09fb-45b0-8b94-25724ba98153" />


### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
