### PR TITLE
Don't show agent status when API calls fail

### DIFF
--- a/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
@@ -9,6 +9,7 @@ import { NodesPagePo } from '@/cypress/e2e/po/pages/explorer/nodes.po';
 import { EventsPageListPo } from '@/cypress/e2e/po/pages/explorer/events.po';
 import * as path from 'path';
 import { eventsNoDataset } from '@/cypress/e2e/blueprints/explorer/cluster/events';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 
 const configMapYaml = `apiVersion: v1
 kind: ConfigMap
@@ -375,6 +376,50 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
       });
     });
   });
+
+  function reply(statusCode: number, body: any) {
+    return (req) => { req.reply({ statusCode, body }); };
+  }
+
+  const forbiddenResponse = {
+    "type": "error",
+    "links": {},
+    "code": "Forbidden",
+    "message": "deployments.apps is forbidden",
+    "status": 403,
+  };
+
+  describe('Cluster dashboard - Fleet agent', () => {
+    it('does not show fleet controller status if a 403 is returned by the API', () => {
+      cy.intercept('GET', '/v1/apps.deployments/cattle-fleet-system/fleet-controller?*', reply(403, forbiddenResponse));
+      cy.intercept('GET', '/v1/apps.deployments/cattle-fleet-local-system/fleet-agent?*', reply(403, forbiddenResponse));
+
+      HomePagePo.goToAndWaitForGet();
+      ClusterDashboardPagePo.navTo();
+      clusterDashboard.waitForPage();
+
+      clusterDashboard.fleetStatus().should('exist');
+      clusterDashboard.fleetStatus().should('be.hidden');
+      clusterDashboard.etcdStatus().should('exist');
+      clusterDashboard.schedulerStatus().should('exist');
+      clusterDashboard.controllerManagerStatus().should('exist');
+    });
+
+    it('does not show fleet controller status if a 404 is returned by the API', () => {
+      cy.intercept('GET', '/v1/apps.deployments/cattle-fleet-system/fleet-controller?*', reply(404, {}));
+      cy.intercept('GET', '/v1/apps.deployments/cattle-fleet-local-system/fleet-agent?*', reply(404, {}));
+
+      HomePagePo.goToAndWaitForGet();
+      ClusterDashboardPagePo.navTo();
+      clusterDashboard.waitForPage();
+
+      clusterDashboard.fleetStatus().should('exist');
+      clusterDashboard.fleetStatus().should('be.hidden');
+      clusterDashboard.etcdStatus().should('exist');
+      clusterDashboard.schedulerStatus().should('exist');
+      clusterDashboard.controllerManagerStatus().should('exist');
+    });
+  });  
 
   after(function() {
     if (removePod) {

--- a/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
@@ -378,15 +378,17 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
   });
 
   function reply(statusCode: number, body: any) {
-    return (req) => { req.reply({ statusCode, body }); };
+    return (req) => {
+      req.reply({ statusCode, body });
+    };
   }
 
   const forbiddenResponse = {
-    "type": "error",
-    "links": {},
-    "code": "Forbidden",
-    "message": "deployments.apps is forbidden",
-    "status": 403,
+    type:    'error',
+    links:   {},
+    code:    'Forbidden',
+    message: 'deployments.apps is forbidden',
+    status:  403,
   };
 
   describe('Cluster dashboard - Fleet agent', () => {
@@ -419,7 +421,7 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
       clusterDashboard.schedulerStatus().should('exist');
       clusterDashboard.controllerManagerStatus().should('exist');
     });
-  });  
+  });
 
   after(function() {
     if (removePod) {

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -515,7 +515,7 @@ export default {
     getAgentStatus(resources, opt = { checkDisconnected: false }) {
       // If there is a single resource that is null, then there was an error fetching the status, which
       // is most likely because the user does not have permission, so we should hide the agent status
-      // as we can not determine what it is 
+      // as we can not determine what it is
       if (resources.length === 1 && resources[0] === null) {
         return { state: STATES_ENUM.OFF };
       }

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -513,6 +513,13 @@ export default {
     },
 
     getAgentStatus(resources, opt = { checkDisconnected: false }) {
+      // If there is a single resource that is null, then there was an error fetching the status, which
+      // is most likely because the user does not have permission, so we should hide the agent status
+      // as we can not determine what it is 
+      if (resources.length === 1 && resources[0] === null) {
+        return { state: STATES_ENUM.OFF };
+      }
+
       if (resources.find((resource) => resource === 'loading')) {
         return { state: STATES_ENUM.IN_PROGRESS };
       }
@@ -999,6 +1006,10 @@ export default {
     > I {
       color: var(--success)
     }
+  }
+
+  &.off {
+    display: none;
   }
 }
 </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14394

### Occurred changes and/or fixed issues

This PR fixes the issue above.

The existing code does handle the case where the backend API returns an error code, but does not then use this correctly.

This PR is a relatively small fix, which ensures we hide the boxes when we get errors from the APIs, since these indicate that the user does not have permission. 

### Areas or cases that should be tested

Automated tests are extended to cover the gap - I believe they are sufficient to cover the use cases given the code paths that we have.

### Screenshot/Video

Before:

![image](https://github.com/user-attachments/assets/50d1da6d-438d-445e-91a2-3be122e3adb0)

After:

![image](https://github.com/user-attachments/assets/0c9b8624-d4e2-4013-bbc3-17c4a05d9200)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
