### PR TITLE
backport PR 14357

### DIFF
--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -61,6 +61,11 @@ export default {
     tabsOnly: {
       type:    Boolean,
       default: false,
+    },
+
+    resource: {
+      type:    Object,
+      default: () => {}
     }
   },
 
@@ -355,6 +360,7 @@ export default {
       >
         <component
           :is="tab.component"
+          :resource="resource"
         />
       </Tab>
     </div>

--- a/shell/components/form/ResourceTabs/index.vue
+++ b/shell/components/form/ResourceTabs/index.vue
@@ -232,6 +232,7 @@ export default {
   <Tabbed
     v-bind="$attrs"
     :default-tab="defaultTab"
+    :resource="value"
     @changed="tabChange"
   >
     <slot />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14380
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Reconnect `resource` to `Tabbed` component via `ResourceTabs`

**NOTE: Observability environments are very short-lived, so this requires some urgency to review while the env is still up**

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
A bug was introduced via https://github.com/rancher/dashboard/pull/12886 where I incorrectly "disconnected" the `resource` prop from being passed to the `Tab` component, causing a problem on the `Observability` extension, reproducible on the extension version `2.0.1`.

This won't catch all the use cases for `Tabbed`, but at least it assures it's wired in where `Tabbed` is used via `ResourceTabs` (that's covering 16 different detail views on the UI), where this particular extension is applied.

Mitigation has already been done on the extension side via https://github.com/StackVista/rancher-extension-stackstate/pull/73.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Needs an `Observability` environment set up. My Rancher env has one already setup, just DM me for credentials to access it.

In the original problem, a network request failed with the following url:
`<base-url>/meta/proxy/<SO url>/api/components?identifier=urn:kubernetes:/local:undefined/undefined`, where `undefined` is the namespace+name of the given resource. Also a console warning would appear because the Observability component `MonitorTab` "requires" the `resource` prop being passed and it's was not connected

<img width="2192" alt="Screenshot 2025-05-15 at 09 42 55" src="https://github.com/user-attachments/assets/55da1697-aff2-455c-b96a-2265e506edad" />

If you run my environment without running this branch, you should see the error above.

To validate, just run this branch/PR against my env and verify that there are no more `undefined` on the URL, despite being a 404 (that's just because there's no data).

PS: `MonitorTab` is being used in the following areas: 
https://github.com/StackVista/rancher-extension-stackstate/blob/main/pkg/observability/index.ts#L118-L133

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
