### PR TITLE
Switched how we display editing Harvester clusters in Cluster management

### DIFF
--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -196,9 +196,12 @@ export default defineComponent({
     isRke2() {
       return !!this.value.isRke2;
     },
+    isHarvester() {
+      return !!this.value.isHarvester;
+    },
     enableNetworkPolicySupported() {
       // https://github.com/rancher/rancher/pull/33070/files
-      return !this.isK3s && !this.isRke2;
+      return !this.isK3s && !this.isRke2 && !this.isHarvester;
     },
     isLocal() {
       return !!this.value.isLocal;
@@ -580,7 +583,7 @@ export default defineComponent({
         />
       </Accordion>
       <Accordion
-        v-if="!isRKE1"
+        v-if="!isRKE1 & !isHarvester"
         class="mb-20 accordion"
         title-key="imported.accordions.advanced"
         :open-initially="false"

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -456,7 +456,7 @@ export default defineComponent({
           :versions="allVersions"
           :default-version="defaultVersion"
           :loading-versions="loadingVersions"
-          :show-version-management="!isRKE1"
+          :show-version-management="!isRKE1 && !isHarvester"
           :is-local="isLocal"
           :version-management-global-setting="versionManagementGlobalSetting"
           :version-management="versionManagement"
@@ -553,7 +553,7 @@ export default defineComponent({
         />
       </Accordion>
       <Accordion
-        v-if="!isRKE1"
+        v-if="!isRKE1 && !isHarvester"
         class="mb-20 accordion"
         title-key="imported.accordions.registries"
         data-testid="registries-accordion"

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -37,6 +37,7 @@ const SORT_GROUPS = {
 const PROXY_ENDPOINT = '/meta/proxy';
 const IMPORTED = 'imported';
 const LOCAL = 'local';
+const HARVESTER = 'harvester';
 
 export default {
   name: 'CruCluster',
@@ -176,9 +177,10 @@ export default {
     let subType = null;
 
     subType = this.$route.query[SUB_TYPE] || null;
+
     if ( this.$route.query[SUB_TYPE]) {
       subType = this.$route.query[SUB_TYPE];
-    } else if (this.value.isImported) {
+    } else if (this.value.isImported || this.value.machineProvider === HARVESTER) {
       subType = IMPORTED;
     } else if (this.value.isLocal) {
       subType = LOCAL;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14285 
<!-- Define findings related to the feature or bug issue. -->
Switched Harvester editing in Cluster Management to use Generic imported cluster edit

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Adding e2e tests seem to be disproportionate to the changes required, so this would require manual validation
1. Import Harvester cluster
2. Global settings -> feature flags -> "harvester-baremetal-container-workload" -> enable
3. Cluster Management -> Edit Harvester cluster
4. Generic imported cluster edit page should open

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

Uploading Screen Recording 2025-05-27 at 2.15.07 PM.mov…

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
