### PR TITLE
Hide the newly added timepicker/refresh controls from grafana dashboard

### DIFF
--- a/shell/utils/grafana.js
+++ b/shell/utils/grafana.js
@@ -24,6 +24,7 @@ export function computeDashboardUrl(monitoringVersion, embedUrl, clusterId, para
   }
   newUrl = addParam(newUrl, 'orgId', url.query.orgId);
   newUrl = addParam(newUrl, 'kiosk', null);
+  newUrl = addParam(newUrl, '_dash.hideTimePicker', 'true');
 
   Object.entries(params).forEach((entry) => {
     newUrl = addParam(newUrl, entry[0], entry[1]);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14374
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
We now hide the timepicker and refresh buttons on all grafana dashboards in the app.

### Technical notes summary
We just had to add the newly added `_dash.hideTimePicker=true` query param to the urls. [docs](https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v11-3/#scenes-powered-dashboards-are-generally-available)

It's a pain to actually test this in a local cluster. You won't see actual data because of a same origin issue. This goes back a long way https://github.com/rancher/rancher/issues/31891. For testing this locally I think it's sufficient to verify that the widgets are no longer present even if data is missing.

I validated on all of the pages listed below and verified that the new parameter doesn't break old versions of the grafana dashboard.
 

### Areas or cases that should be tested
There are the locations of all the grafana dashboards
![image](https://github.com/user-attachments/assets/00a1fdc6-2136-4adb-baae-66c739010bea)


### Areas which could experience regressions
See above

### Screenshot/Video
![no-controls](https://github.com/user-attachments/assets/6ae78975-84be-4e39-8cdf-911373b002e1)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
