### PR TITLE
Fixed error message when recieved from Norman

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -8167,13 +8167,35 @@ networkAttachmentDefinition:
 
 errors:
   actionNotAvailable: This action is not currently available
-  failedInApi: "Validation failed in API:"
-  missingRequired: "  is required"
-  notUnique: " is not unique"
-  notNullable: " must be set"
-  invalidOption: " is not a valid option"
-  invalidCharacters: " contains invalid characters"
-  minLengthExceeded: " is not long enough"
-  maxLengthExceeded: " is too long"
-  minLimitExceeded: " is too small"
-  maxLimitExceded: " is too big"
+  missingRequired: is required
+  notUnique: is not unique
+  notNullable: must be set
+  invalidOption: is not a valid option
+  invalidCharacters: contains invalid characters
+  minLengthExceeded: is not long enough
+  maxLengthExceeded: is too long
+  minLimitExceeded: is too small
+  maxLimitExceded: is too big
+  messageAndDetail: '{message} ({detail})'
+  messageOrDetail: '{val}'
+  failedInApi: 
+    withName:
+      withCodeExplanation:
+        withMessageDetail: 'Validation failed in API: {name} {codeExplanation}: {messageDetail}'
+        withoutMessageDetail: 'Validation failed in API: {name} {codeExplanation}'
+      withMessageDetail: 'Validation failed in API: {name} {messageDetail}'
+      withoutAnythingElse: 'Validation failed in API: {name} '
+    withoutName:
+      withMessageDetail: 
+        withCodeExplanation: 'Validation failed in API: {codeExplanation}: {messageDetail}'
+        withoutCodeExplanation: 'Validation failed in API: {messageDetail}'
+      withCode:
+        withCodeExplanation: 'Validation failed in API: {code} {codeExplanation}'
+        withoutCodeExplanation: 'Validation failed in API: {code}'
+    withoutAnything: Validation failed in API.
+  notFound:
+    withUrl: '{msg}: {url}'
+    withoutUrl: '{msg}'
+
+
+

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -433,77 +433,88 @@ export default {
       if ( typeof err === 'string') {
         return err;
       }
-      let str = '';
-      const msg = !!err?.message ? ` ${ err?.message }` : '';
 
       if ( err?.code === 'ActionNotAvailable' ) {
-        str = this.t('errors.actionNotAvailable');
-      } else if ( err?.status === 422 ) {
-        str = this.t('errors.failedInApi');
-        let something = false;
+        return this.t('errors.actionNotAvailable');
+      }
+      const msg = !!err?.message ? err.message : '';
+      let messageDetail = '';
 
-        if ( err?.fieldName ) {
-          str += ` '${ err?.fieldName }'${ msg }`;
-          something = true;
-        }
-        if ( err?.detail ) {
-          str += ` (${ err?.detail })`;
-          something = true;
-        }
-        if ( !something && !!msg) {
-          str += msg;
-          something = true;
-        }
-        if ( !something ) {
-          str += ` (${ err?.code })`;
-        }
-        switch ( err?.code ) {
-        case 'MissingRequired':
-          str += this.t('errors.missingRequired'); break;
-        case 'NotUnique':
-          str += this.t('errors.notUnique'); break;
-        case 'NotNullable':
-          str += this.t('errors.notNullable'); break;
-        case 'InvalidOption':
-          str += this.t('errors.invalidOption'); break;
-        case 'InvalidCharacters':
-          str += this.t('errors.invalidCharacters'); break;
-        case 'MinLengthExceeded':
-          str += this.t('errors.minLengthExceeded'); break;
-        case 'MaxLengthExceeded':
-          str += this.t('errors.maxLengthExceeded'); break;
-        case 'MinLimitExceeded':
-          str += this.t('errors.minLimitExceeded'); break;
-        case 'MaxLimitExceded':
-          str += this.t('errors.maxLimitExceded'); break;
-        }
-      } else if ( err?.status === 404 ) {
-        str = `${ msg }`;
-        if (!!err?.opt?.url) {
-          str += `: ${ err.opt.url }`;
-        }
-      } else {
-        if (!!msg || !!err.detail) {
-          let str = '';
+      if (!!err?.message && !!err.detail) {
+        messageDetail = this.t('errors.messageAndDetail', { message: err.message, detail: err.detail });
+      } else if (!!err?.message || !!err.detail) {
+        const val = err.message ? err.message : err.detail;
 
-          if ( msg ) {
-            str = msg;
-            if ( err.detail ) {
-              if ( str ) {
-                str += ` (${ err.detail })`;
-              } else {
-                str = err.detail;
-              }
-            }
-          } else if ( err.detail ) {
-            str = err.detail;
-          }
-
-          return str;
-        }
+        messageDetail = this.t('errors.messageOrDetail', { val });
       }
 
-      return str.length > 0 ? str : err;
+      if ( err?.status === 422 ) {
+        const name = err?.fieldName;
+        const code = err?.code;
+        let codeExplanation = '';
+
+        switch ( err?.code ) {
+        case 'MissingRequired':
+          codeExplanation = this.t('errors.missingRequired'); break;
+        case 'NotUnique':
+          codeExplanation = this.t('errors.notUnique'); break;
+        case 'NotNullable':
+          codeExplanation = this.t('errors.notNullable'); break;
+        case 'InvalidOption':
+          codeExplanation = this.t('errors.invalidOption'); break;
+        case 'InvalidCharacters':
+          codeExplanation = this.t('errors.invalidCharacters'); break;
+        case 'MinLengthExceeded':
+          codeExplanation = this.t('errors.minLengthExceeded'); break;
+        case 'MaxLengthExceeded':
+          codeExplanation = this.t('errors.maxLengthExceeded'); break;
+        case 'MinLimitExceeded':
+          codeExplanation = this.t('errors.minLimitExceeded'); break;
+        case 'MaxLimitExceded':
+          codeExplanation = this.t('errors.maxLimitExceded'); break;
+        }
+
+        if (!!name) {
+          if (!!codeExplanation) {
+            if (!!messageDetail) {
+              return this.t('errors.failedInApi.withName.withCodeExplanation.withMessageDetail', {
+                name, codeExplanation, messageDetail
+              });
+            }
+
+            return this.t('errors.failedInApi.withName.withCodeExplanation.withoutMessageDetail', { name, codeExplanation });
+          }
+          if (!!messageDetail) {
+            return this.t('errors.failedInApi.withName.withMessageDetail', { name, messageDetail });
+          }
+
+          return this.t('errors.failedInApi.withName.withoutAnythingElse', { name });
+        } else {
+          if (!!messageDetail) {
+            if (!!codeExplanation) {
+              return this.t('errors.failedInApi.withoutName.withMessageDetail.withCodeExplanation', { codeExplanation, messageDetail });
+            }
+
+            return this.t('errors.failedInApi.withoutName.withMessageDetail.withoutCodeExplanation', { messageDetail });
+          } else if (!!code) {
+            if (!!codeExplanation) {
+              return this.t('errors.failedInApi.withoutName.withCode.withCodeExplanation', { code, codeExplanation });
+            }
+
+            return this.t('errors.failedInApi.withoutName.withCode.withoutCodeExplanation', { code });
+          }
+
+          return this.t('errors.failedInApi.withoutAnything');
+        }
+      } else if ( err?.status === 404 ) {
+        if (!!err?.opt?.url) {
+          return this.t('errors.notFound.withUrl', { msg, url: err.opt.url });
+        }
+
+        return this.t('errors.notFound.withoutUrl', { msg });
+      }
+
+      return messageDetail.length > 0 ? messageDetail : err;
     }
   },
 

--- a/shell/components/__tests__/CruResource.test.ts
+++ b/shell/components/__tests__/CruResource.test.ts
@@ -73,16 +73,34 @@ describe('component: CruResource', () => {
     [{
       code: 'ActionNotAvailable', status: 500, message: 'error'
     }, 'errors.actionNotAvailable'],
-    [{ status: 422, message: 'error' }, 'errors.failedInApi error'],
-    [{ status: 404, message: 'message' }, 'message'],
+    [{
+      status: 422, fieldName: 'Name', code: 'NotUnique', message: 'error'
+    }, 'errors.failedInApi.withName.withCodeExplanation.withMessageDetail'],
+    [{
+      status: 422, fieldName: 'Name', code: 'NotUnique'
+    }, 'errors.failedInApi.withName.withCodeExplanation.withoutMessageDetail'],
+    [{
+      status: 422, fieldName: 'Name', code: 'Brr', message: 'error'
+    }, 'errors.failedInApi.withName.withMessageDetail'],
+    [{
+      status: 422, fieldName: 'Name', code: 'Brr'
+    }, 'errors.failedInApi.withName.withoutAnythingElse'],
+    [{
+      status: 422, code: 'NotUnique', message: 'error'
+    }, 'errors.failedInApi.withoutName.withMessageDetail.withCodeExplanation'],
+    [{ status: 422, message: 'error' }, 'errors.failedInApi.withoutName.withMessageDetail.withoutCodeExplanation'],
+    [{ status: 422, code: 'NotUnique' }, 'errors.failedInApi.withoutName.withCode.withCodeExplanation'],
+    [{ status: 422, code: 'Brr' }, 'errors.failedInApi.withoutName.withCode.withoutCodeExplanation'],
+    [{ status: 422 }, 'errors.failedInApi.withoutAnything'],
+    [{ status: 404, message: 'message' }, 'errors.notFound.withoutUrl'],
     [{
       status: 404, message: 'message', opt: { url: 'test' }
-    }, 'message: test'],
-    [{ status: 500, message: 'message' }, 'message'],
+    }, 'errors.notFound.withUrl'],
+    [{ status: 500, message: 'message' }, 'errors.messageOrDetail'],
     [{
       status: 500, message: 'message', detail: 'detail'
-    }, 'message (detail)'],
-    [{ status: 500, detail: 'detail' }, 'detail'],
+    }, 'errors.messageAndDetail'],
+    [{ status: 500, detail: 'detail' }, 'errors.messageOrDetail'],
   ])('should display correct error', (err, res) => {
     const wrapper = mount(CruResource, {
       props: {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14427
<!-- Define findings related to the feature or bug issue. -->
Currently, we do not format errors received from Norman. This has been adjusted to match what we did in Ember more closely.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Import a cluster and name it 'a'
Attempt to import another cluster named 'a'
The error returned should correctly inform of the issue

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Any component that displays errors from responses

### Screenshot/Video
<!-- Attach scre
<img width="1184" alt="Screenshot 2025-05-29 at 12 22 36 AM" src="https://github.com/user-attachments/assets/ead9ffb9-823d-4587-8e73-d0c39b311265" />
enshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
