### PR TITLE
SSP: Fix two harvester related bugs

### DIFF
--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -303,6 +303,7 @@ export default {
       this.update();
     } catch (e) {
       this.errors = exceptionToErrorsArray(e);
+      console.error('Failed to initialize harvester machine config data', e); // eslint-disable-line no-console
     }
   },
 

--- a/shell/plugins/dashboard-store/getters.js
+++ b/shell/plugins/dashboard-store/getters.js
@@ -11,6 +11,9 @@ import garbageCollect from '@shell/utils/gc/gc';
 import paginationUtils from '@shell/utils/pagination-utils';
 import { labelSelectorToSelector } from '@shell/utils/selector-typed';
 
+/**
+ * opt: ActionFindPageArgs
+ */
 export const urlFor = (state, getters) => (type, id, opt) => {
   opt = opt || {};
   type = getters.normalizeType(type);

--- a/shell/plugins/steve/getters.js
+++ b/shell/plugins/steve/getters.js
@@ -50,12 +50,15 @@ export default {
    */
   isSteveCacheUrl: (state, getters, rootState, rootGetters) => (urlPath) => getters.isSteveUrl(urlPath) && paginationUtils.isSteveCacheEnabled({ rootGetters }),
 
+  /**
+   * opt: ActionFindPageArgs
+   */
   urlOptions: (state, getters) => (url, opt, schema) => {
     opt = opt || {};
     const parsedUrl = parse(url || '');
 
     const isSteveUrl = getters.isSteveUrl(parsedUrl.path);
-    const stevePagination = stevePaginationUtils.createParamsForPagination(schema, opt);
+    const stevePagination = stevePaginationUtils.createParamsForPagination({ schema, opt });
 
     if (stevePagination) {
       url += `${ (url.includes('?') ? '&' : '?') + stevePagination }`;

--- a/shell/types/store/dashboard-store.types.ts
+++ b/shell/types/store/dashboard-store.types.ts
@@ -4,6 +4,7 @@ import { PaginationArgs } from '@shell/types/store/pagination.types';
  * Properties on all findX actions
  */
 export type ActionCoreFindArgs = {
+  url?: string,
   force?: boolean,
 }
 

--- a/shell/utils/cluster.js
+++ b/shell/utils/cluster.js
@@ -6,7 +6,7 @@ import { SETTING } from '@shell/config/settings';
 import { PaginationFilterField, PaginationParamFilter } from '@shell/types/store/pagination.types';
 import { compare, sortable } from '@shell/utils/version';
 import { sortBy } from '@shell/utils/sort';
-import { SCHEDULING_CUSTOMIZATION } from '@shell/store/features';
+import { HARVESTER_CONTAINER, SCHEDULING_CUSTOMIZATION } from '@shell/store/features';
 import { _CREATE, _EDIT } from '@shell/config/query-params';
 import isEmpty from 'lodash/isEmpty';
 import { set } from '@shell/utils/object';
@@ -20,14 +20,12 @@ import { set } from '@shell/utils/object';
 export function paginationFilterClusters(store, filterMgmtCluster = true) {
   const paginationRequestFilters = [];
 
-  // Commenting out for the moment. This is broken for non-paginated world
-  // filterOnlyKubernetesClusters expects a mgmt cluster, however in the home page it's given a prov cluster
-  // note - filterHiddenLocalCluster works because it uses model isLocal which is on both cluster types
-  // const pFilterOnlyKubernetesClusters = paginationFilterOnlyKubernetesClusters(store);
-  // if (pFilterOnlyKubernetesClusters) {
-  //   paginationRequestFilters.push(pFilterOnlyKubernetesClusters);
-  // }
+  const pFilterOnlyKubernetesClusters = paginationFilterOnlyKubernetesClusters(store);
   const pFilterHiddenLocalCluster = paginationFilterHiddenLocalCluster(store, filterMgmtCluster);
+
+  if (pFilterOnlyKubernetesClusters) {
+    paginationRequestFilters.push(...pFilterOnlyKubernetesClusters);
+  }
 
   if (pFilterHiddenLocalCluster) {
     paginationRequestFilters.push(pFilterHiddenLocalCluster);
@@ -77,37 +75,43 @@ export function paginationFilterHiddenLocalCluster(store, filterMgmtCluster = tr
  * @returns PaginationParam | null
  */
 export function paginationFilterOnlyKubernetesClusters(store) {
-  const openHarvesterContainerWorkload = store.getters['features/get']('harvester-baremetal-container-workload');
+  const openHarvesterContainerWorkload = store.getters['features/get'](HARVESTER_CONTAINER);
 
-  if (!openHarvesterContainerWorkload) {
+  if (openHarvesterContainerWorkload) {
+    // Show harvester clusters
     return null;
   }
 
-  return PaginationParamFilter.createMultipleFields([
-    new PaginationFilterField({
+  // Filter out harvester clusters
+  return [
+    PaginationParamFilter.createSingleField(new PaginationFilterField({
       field:  `metadata.labels[${ CAPI.PROVIDER }]`,
       equals: false,
       value:  VIRTUAL_HARVESTER_PROVIDER,
       exact:  true
-    }),
-    new PaginationFilterField({
+    })),
+    PaginationParamFilter.createSingleField(new PaginationFilterField({
       field:  `status.provider`,
       equals: false,
       value:  VIRTUAL_HARVESTER_PROVIDER,
       exact:  true
-    }),
-  ]);
+    }))
+  ];
 }
 
 /**
  * Filter out any clusters that are not Kubernetes Clusters
  **/
 export function filterOnlyKubernetesClusters(mgmtClusters, store) {
-  const openHarvesterContainerWorkload = store.getters['features/get']('harvester-baremetal-container-workload');
+  const openHarvesterContainerWorkload = store.getters['features/get'](HARVESTER_CONTAINER);
 
-  return mgmtClusters?.filter((c) => {
-    return openHarvesterContainerWorkload ? true : !isHarvesterCluster(c);
-  });
+  if (openHarvesterContainerWorkload) {
+    // Show harvester clusters
+    return mgmtClusters;
+  }
+
+  // Filter out harvester clusters
+  return mgmtClusters?.filter((c) => !isHarvesterCluster(c));
 }
 
 export function isHarvesterCluster(mgmtCluster) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14420
Fixes #11549
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
I've combined two bug fixes as they both require a harvester instance to validate, and are small


Bug 1 - #14420 - Ensure harvester clusters are filtered out from side nav and cluster home page
- with FF `harvester-baremetal-container-workload` disabled (which is the default) harvester clusters should be hidden from normal cluster lists
- this was happened as before for cluster management (unchanged), but was broken in side nav and home page cluster list
- the code for this was written but not wired in

Bug 2 - #11549 - Ensure harvester machine config options are correctly presented
- once a downstream harvester cluster is imported, users can provisioned rancher instances into it (cluster management --> create --> harvester)
- this requires make http requests to that downstream cluster. harvester machine config component does this by hand crafting url's and directly fetching data (as there's no `cluster` store in cluster management)
- bug was that these requests were never made as an initial fn to determine vai on filter params failed
  - pkg/harvester-manager/machine-config/harvester.vue --> fetch --> vai on? then call special fn
- fix is to make sure those fn work in this context

### Areas or cases that should be tested
- bug 1 and 2 - as per issue

### Areas which could experience regressions
- bug 1 - vai off side nav, home page cluster list, cluster management cluster list
- bug 2 - requests made to support vai backed lists 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
