### PR TITLE
Set CodeMirror `readonly` flag to `true` to enable copy

### DIFF
--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -88,7 +88,7 @@ export default {
 
       // fixes https://github.com/rancher/dashboard/issues/13653
       // we can't use the inert HTML prop on the parent because it disables all interaction
-      out.readOnly = this.isDisabled ? 'nocursor' : false;
+      out.readOnly = !!this.isDisabled;
 
       return out;
     },
@@ -227,8 +227,8 @@ export default {
     },
 
     onFocus() {
-      this.isCodeMirrorFocused = true;
-      this.$emit('onFocus', true);
+      this.isCodeMirrorFocused = !this.isDisabled;
+      this.$emit('onFocus', this.isCodeMirrorFocused);
     },
 
     onBlur() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates the `readonly` flag to `true` instead of `nocursor` when the CodeMirror component is in View mode. 

Fixes #14243 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Set `readonly` to `true` when yaml editor is in view mode
- Set `isCodeMirrorFocused` to `false` when yaml editor is in view mode

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

🗒️ NOTE: VIM and Emacs modes behave inconsistently for copy and paste. We might need to consider the behavior of the view mode with different keybinds for a more comprehensive fix.

The copy event will not fire when type `ctrl + C` or `Command + C`; this stems from the fact that the editor never receives focus when `nocursor` is used.

To resolve this issue, we can use a boolean value for `readonly` and ensure that the container focus is not set to true when in View mode to prevent help text from rendering.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Editors used throughout dashboard should allow copying contents when in View mode

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Expand/collapse of sections when editor is in view mode
- Toggle of focus states when editor is in view mode

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
