### PR TITLE
Explicitly pass `undefined` when closing MoveNamespaceDialog.vue

### DIFF
--- a/shell/dialog/MoveNamespaceDialog.vue
+++ b/shell/dialog/MoveNamespaceDialog.vue
@@ -121,7 +121,7 @@ export default {
     <template #actions>
       <button
         class="btn role-secondary"
-        @click="close"
+        @click="close(undefined)"
       >
         {{ t('generic.cancel') }}
       </button>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This explicitly sets data to `undefined` for when cancelling `MoveNamespaceDialog.vue` to fix an issue with the cancel button preventing the modal from raising again. 

Fixes #14392
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- pass undefined to close event in `MoveNamespaceDialog.vue`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The `click` event was implicitly passed to close when clicking on the cancel button. This can cause issues in `togglePromptModal` in `shell/store/action-menu.js`. `data` is defined, but it doesn't have a value for `performCallback`; `showModal` will default to true, but the modal will no longer and the `modalData` will become malformed. Making sure that we don't provided any data resolves the issues.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

See issue for details.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This should only affect the `MoveNamespaceDialog`.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
