### PR TITLE
replace `mergeWithReplace` and `merge` with `handleConflict` function on machine pools sync mechanism

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1233,7 +1233,7 @@ export default {
           out.push(poolData);
 
           // but we also store the initial data so that we can handle conflicts
-          const poolDataClone = Object.assign({}, poolData);
+          const poolDataClone = structuredClone(poolData);
 
           this.initialMachinePoolsValues.push(poolDataClone);
         }
@@ -1301,7 +1301,7 @@ export default {
 
       this.machinePools.push(pool);
 
-      const poolDataClone = Object.assign({}, pool);
+      const poolDataClone = structuredClone(pool);
 
       this.initialMachinePoolsValues.push(poolDataClone);
 

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -6,11 +6,8 @@ import merge from 'lodash/merge';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import FormValidation from '@shell/mixins/form-validation';
 import { normalizeName } from '@shell/utils/kube';
-<<<<<<< HEAD
 import AccountAccess from '@shell/components/google/AccountAccess.vue';
-=======
 import { handleConflict } from '@shell/plugins/dashboard-store/normalize';
->>>>>>> c272e49089 (replace mergeWithReplace and merge with handleConflict function on machine pools sync mechanism)
 
 import {
   CAPI,

--- a/shell/plugins/dashboard-store/__tests__/normalize.test.ts
+++ b/shell/plugins/dashboard-store/__tests__/normalize.test.ts
@@ -1,0 +1,35 @@
+import { handleConflict } from '@shell/plugins/dashboard-store/normalize';
+import { usecases } from '@shell/plugins/dashboard-store/__tests__/utils/normalize-usecases';
+import actions from '@shell/plugins/steve/actions.js';
+
+describe('fx: handleConflict', () => {
+  it.each([
+    ['two keys same, another different', usecases.usecase1, false],
+    ['two different keys', usecases.usecase2, false],
+    ['only one left', usecases.usecase3, false],
+    ['with conflict', usecases.usecase4, 1],
+  ])('should handleConflict correctly for usecase ::: %s', async(text, usecaseData, res) => {
+    const storeName = 'management';
+
+    const mocks = {
+      storeName,
+      dispatch: async(arg1: any, arg2: any) => {
+        return Promise.resolve(actions.cleanForDiff({}, arg2));
+      },
+      rootGetters: { 'i18n/t': () => jest.fn().mockReturnValue('some-conflicts') }
+    };
+
+    const initialValue = usecaseData.initialConfig as any;
+    const currUserValue = usecaseData.currentConfig as any;
+    const serverValue = usecaseData.latestConfig as any;
+
+    initialValue.toJSON = () => Object.assign({}, initialValue);
+    currUserValue.toJSON = () => Object.assign({}, currUserValue);
+    serverValue.toJSON = () => Object.assign({}, serverValue);
+
+    // export async function handleConflict(initialValueJSON, value, liveValue, rootGetters, store, storeNamespace) {
+    const result = await handleConflict(initialValue, currUserValue, serverValue, mocks.rootGetters, mocks, storeName);
+
+    expect(typeof res !== 'boolean' ? result?.length : result).toStrictEqual(res);
+  });
+});

--- a/shell/plugins/dashboard-store/__tests__/normalize.test.ts
+++ b/shell/plugins/dashboard-store/__tests__/normalize.test.ts
@@ -1,14 +1,12 @@
 import { handleConflict } from '@shell/plugins/dashboard-store/normalize';
-import { usecases } from '@shell/plugins/dashboard-store/__tests__/utils/normalize-usecases';
+import { handleConflictUseCases } from '@shell/plugins/dashboard-store/__tests__/utils/normalize-usecases';
 import actions from '@shell/plugins/steve/actions.js';
+import cloneDeep from 'lodash/cloneDeep';
 
 describe('fx: handleConflict', () => {
-  it.each([
-    ['two keys same, another different', usecases.usecase1, false],
-    ['two different keys', usecases.usecase2, false],
-    ['only one left', usecases.usecase3, false],
-    ['with conflict', usecases.usecase4, 1],
-  ])('should handleConflict correctly for usecase ::: %s', async(text, usecaseData, res) => {
+  const testArr = handleConflictUseCases.map((usecase: any) => [usecase.description, usecase.data, usecase.result, usecase.outputValidation]);
+
+  it.each(testArr)('should handleConflict correctly for usecase ::: %s', async(text, usecaseData, res, validationData) => {
     const storeName = 'management';
 
     const mocks = {
@@ -19,9 +17,9 @@ describe('fx: handleConflict', () => {
       rootGetters: { 'i18n/t': () => jest.fn().mockReturnValue('some-conflicts') }
     };
 
-    const initialValue = usecaseData.initialConfig as any;
-    const currUserValue = usecaseData.currentConfig as any;
-    const serverValue = usecaseData.latestConfig as any;
+    const initialValue = cloneDeep(usecaseData.initialConfig as any);
+    const currUserValue = cloneDeep(usecaseData.currentConfig as any);
+    const serverValue = cloneDeep(usecaseData.latestConfig as any);
 
     initialValue.toJSON = () => Object.assign({}, initialValue);
     currUserValue.toJSON = () => Object.assign({}, currUserValue);
@@ -31,5 +29,6 @@ describe('fx: handleConflict', () => {
     const result = await handleConflict(initialValue, currUserValue, serverValue, mocks.rootGetters, mocks, storeName);
 
     expect(typeof res !== 'boolean' ? result?.length : result).toStrictEqual(res);
+    expect(currUserValue).toStrictEqual(expect.objectContaining(validationData));
   });
 });

--- a/shell/plugins/dashboard-store/__tests__/utils/normalize-usecases.ts
+++ b/shell/plugins/dashboard-store/__tests__/utils/normalize-usecases.ts
@@ -1,4 +1,666 @@
 export const handleConflictUseCases = [
+  // mergeWithReplace - merging arrays - usecase 1
+  {
+    description: 'mergeWithReplace usecase 1 - merge arrays',
+    data:        {
+      currentConfig: {
+        metadata: { resourceVersion: '3961358' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { a: ['one'] }
+              }
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        metadata: { resourceVersion: '3960953' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { a: [] }
+              }
+            }
+          }
+        }
+      },
+      initialConfig: {
+        metadata: { resourceVersion: '3960910' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {}
+              }
+            }
+          }
+        },
+        __clone: true
+      }
+    },
+    result:           1,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      { a: [] }
+            }
+          }
+        }
+      },
+    }
+  },
+  // mergeWithReplace - merging arrays - usecase 2
+  {
+    description: 'mergeWithReplace usecase 2 - merge arrays',
+    data:        {
+      currentConfig: {
+        metadata: { resourceVersion: '3961358' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { a: ['one', 'two'] }
+              }
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        metadata: { resourceVersion: '3960953' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { a: ['one', 'two', 'three'] }
+              }
+            }
+          }
+        }
+      },
+      initialConfig: {
+        metadata: { resourceVersion: '3960910' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {}
+              }
+            }
+          }
+        },
+        __clone: true
+      }
+    },
+    result:           1,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      { a: ['one', 'two', 'three'] }
+            }
+          }
+        }
+      },
+    }
+  },
+  // mergeWithReplace - merging arrays - usecase 3
+  {
+    description: 'mergeWithReplace usecase 3 - merge arrays',
+    data:        {
+      currentConfig: {
+        metadata: { resourceVersion: '3961358' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { a: ['one', 'two'], b: ['three', 'four'] }
+              }
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        metadata: { resourceVersion: '3960953' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { a: ['one'], b: [] }
+              }
+            }
+          }
+        }
+      },
+      initialConfig: {
+        metadata: { resourceVersion: '3960910' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {}
+              }
+            }
+          }
+        },
+        __clone: true
+      }
+    },
+    result:           1,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      { a: ['one'], b: [] }
+            }
+          }
+        }
+      },
+    }
+  },
+  // mergeWithReplace - merging arrays - usecase 4
+  {
+    description: 'mergeWithReplace usecase 4 - merge arrays',
+    data:        {
+      currentConfig: {
+        metadata: { resourceVersion: '3961358' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {
+                  a: ['one', 'two'], b: ['three', 'four'], c: 'five'
+                }
+              }
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        metadata: { resourceVersion: '3960953' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { a: ['one'], b: [] }
+              }
+            }
+          }
+        }
+      },
+      initialConfig: {
+        metadata: { resourceVersion: '3960910' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {}
+              }
+            }
+          }
+        },
+        __clone: true
+      }
+    },
+    result:           1,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      {
+                a: ['one'], b: [], c: 'five'
+              }
+            }
+          }
+        }
+      },
+    }
+  },
+  // mergeWithReplace - merging arrays - usecase 5
+  {
+    description: 'mergeWithReplace usecase 5 - merge arrays',
+    data:        {
+      currentConfig: {
+        metadata: { resourceVersion: '3961358' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { a: 'one' }
+              }
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        metadata: { resourceVersion: '3960953' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { b: 'two' }
+              }
+            }
+          }
+        }
+      },
+      initialConfig: {
+        metadata: { resourceVersion: '3960910' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {}
+              }
+            }
+          }
+        },
+        __clone: true
+      }
+    },
+    result:           false,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      { a: 'one', b: 'two' }
+            }
+          }
+        }
+      },
+    }
+  },
+  // mergeWithReplace - merging arrays - usecase 6
+  {
+    description: 'mergeWithReplace usecase 6 - merge arrays',
+    data:        {
+      currentConfig: {
+        metadata: { resourceVersion: '3961358' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { a: 'one' }
+              }
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        metadata: { resourceVersion: '3960953' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { a: '', b: 'two' }
+              }
+            }
+          }
+        }
+      },
+      initialConfig: {
+        metadata: { resourceVersion: '3960910' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {}
+              }
+            }
+          }
+        },
+        __clone: true
+      }
+    },
+    result:           1,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      { a: '', b: 'two' }
+            }
+          }
+        }
+      },
+    }
+  },
+  // mergeWithReplace - merging arrays - usecase 7
+  {
+    description: 'mergeWithReplace usecase 7 - merge arrays',
+    data:        {
+      currentConfig: {
+        metadata: { resourceVersion: '3961358' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { a: 'one', b: 'two' }
+              }
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        metadata: { resourceVersion: '3960953' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { a: 1, c: { d: null } }
+              }
+            }
+          }
+        }
+      },
+      initialConfig: {
+        metadata: { resourceVersion: '3960910' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {}
+              }
+            }
+          }
+        },
+        __clone: true
+      }
+    },
+    result:           1,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      {
+                a: 1, b: 'two', c: { d: null }
+              }
+            }
+          }
+        }
+      },
+    }
+  },
+  // mergeWithReplace - merging objects - usecase 1
+  {
+    description: 'mergeWithReplace usecase 1 - merge objects',
+    data:        {
+      currentConfig: {
+        metadata: { resourceVersion: '3961358' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { a: { b: false, c: false } }
+              }
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        metadata: { resourceVersion: '3960953' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { a: { b: true, c: null } }
+              }
+            }
+          }
+        }
+      },
+      initialConfig: {
+        metadata: { resourceVersion: '3960910' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {}
+              }
+            }
+          }
+        },
+        __clone: true
+      }
+    },
+    result:           1,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      { a: { b: true, c: null } }
+            }
+          }
+        }
+      },
+    }
+  },
+  // mergeWithReplace - merging objects - usecase 2
+  {
+    description: 'mergeWithReplace usecase 2 - merge objects',
+    data:        {
+      currentConfig: {
+        metadata: { resourceVersion: '3961358' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {
+                  a: [{
+                    b: 'test', c: 'test', value: true
+                  }]
+                }
+              }
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        metadata: { resourceVersion: '3960953' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {
+                  a: [{
+                    b: 'test', c: 'test', operator: 'exists'
+                  }]
+                }
+              }
+            }
+          }
+        }
+      },
+      initialConfig: {
+        metadata: { resourceVersion: '3960910' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {}
+              }
+            }
+          }
+        },
+        __clone: true
+      }
+    },
+    result:           1,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      {
+                a: [{
+                  b: 'test', c: 'test', operator: 'exists'
+                }]
+              }
+            }
+          }
+        }
+      },
+    }
+  },
+  // mergeWithReplace - merging objects - usecase 3
+  {
+    description: 'mergeWithReplace usecase 3 - merge objects',
+    data:        {
+      currentConfig: {
+        metadata: { resourceVersion: '3961358' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {
+                  a: { enabled: false }, b: { enabled: false }, c: { enabled: false }
+                }
+              }
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        metadata: { resourceVersion: '3960953' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { c: { enabled: true, stripUnderscores: true } }
+              }
+            }
+          }
+        }
+      },
+      initialConfig: {
+        metadata: { resourceVersion: '3960910' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {}
+              }
+            }
+          }
+        },
+        __clone: true
+      }
+    },
+    result:           1,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      {
+                a: { enabled: false }, b: { enabled: false }, c: { enabled: true, stripUnderscores: true }
+              }
+            }
+          }
+        }
+      },
+    }
+  },
   // 2 same keys entries but with different values, 1 different key, removing one of the same keys
   // remove from array
   // covers https://github.com/rancher/dashboard/issues/14397

--- a/shell/plugins/dashboard-store/__tests__/utils/normalize-usecases.ts
+++ b/shell/plugins/dashboard-store/__tests__/utils/normalize-usecases.ts
@@ -1,0 +1,1018 @@
+export const usecases = {
+  // 2 same keys entries but with different values, 1 different key, removing one of the same keys
+  usecase1: {
+    currentConfig: {
+      id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
+      type:  'elemental.cattle.io.machineinventoryselectortemplate',
+      links: {
+        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
+      },
+      apiVersion: 'elemental.cattle.io/v1beta1',
+      kind:       'MachineInventorySelectorTemplate',
+      metadata:   {
+        creationTimestamp: '2025-06-16T10:30:24Z',
+        fields:            [
+          'nc-test-final-1-pool1-mnwmd',
+          '51m'
+        ],
+        generateName:    'nc-test-final-1-pool1-',
+        generation:      2,
+        name:            'nc-test-final-1-pool1-mnwmd',
+        namespace:       'fleet-default',
+        ownerReferences: [
+          {
+            apiVersion: 'cluster.x-k8s.io/v1beta1',
+            kind:       'Cluster',
+            name:       'test-final-1',
+            uid:        'ed1e8c73-bd86-4a19-966a-cb9c4249e7cf'
+          }
+        ],
+        relationships: [
+          {
+            fromId:   'fleet-default/test-final-1',
+            fromType: 'cluster.x-k8s.io.cluster',
+            rel:      'owner',
+            state:    'provisioned'
+          }
+        ],
+        resourceVersion: '3961358',
+        state:           {
+          error:         false,
+          message:       'Resource is current',
+          name:          'active',
+          transitioning: false
+        },
+        uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
+      },
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [
+                {
+                  key:      'key',
+                  operator: 'In',
+                  values:   [
+                    'aaa'
+                  ]
+                },
+                {
+                  key:      'key',
+                  operator: 'In',
+                  values:   [
+                    'bbb'
+                  ]
+                },
+                {
+                  key:      'create-cluster-selector',
+                  operator: 'In',
+                  values:   [
+                    'cccc'
+                  ]
+                }
+              ],
+              matchLabels: { 'create-cluster-selector': 'cccc' }
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      },
+      __clone: true
+    },
+    latestConfig: {
+      id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
+      type:  'elemental.cattle.io.machineinventoryselectortemplate',
+      links: {
+        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
+      },
+      apiVersion: 'elemental.cattle.io/v1beta1',
+      kind:       'MachineInventorySelectorTemplate',
+      metadata:   {
+        creationTimestamp: '2025-06-16T10:30:24Z',
+        fields:            [
+          'nc-test-final-1-pool1-mnwmd',
+          '34s'
+        ],
+        generateName:  'nc-test-final-1-pool1-',
+        generation:    1,
+        managedFields: [
+          {
+            apiVersion: 'elemental.cattle.io/v1beta1',
+            fieldsType: 'FieldsV1',
+            fieldsV1:   {
+              'f:metadata': {
+                'f:ownerReferences': {
+                  '.':                                                {},
+                  'k:{"uid":"ed1e8c73-bd86-4a19-966a-cb9c4249e7cf"}': {}
+                }
+              }
+            },
+            manager:   'manager',
+            operation: 'Update',
+            time:      '2025-06-16T10:30:24Z'
+          },
+          {
+            apiVersion: 'elemental.cattle.io/v1beta1',
+            fieldsType: 'FieldsV1',
+            fieldsV1:   {
+              'f:metadata': { 'f:generateName': {} },
+              'f:spec':     {
+                '.':          {},
+                'f:template': {
+                  '.':          {},
+                  'f:metadata': {},
+                  'f:spec':     {
+                    '.':          {},
+                    'f:selector': {}
+                  },
+                  'f:status': {
+                    '.':                     {},
+                    'f:addresses':           {},
+                    'f:conditions':          {},
+                    'f:machineInventoryRef': {}
+                  }
+                }
+              }
+            },
+            manager:   'rancher',
+            operation: 'Update',
+            time:      '2025-06-16T10:30:24Z'
+          }
+        ],
+        name:            'nc-test-final-1-pool1-mnwmd',
+        namespace:       'fleet-default',
+        ownerReferences: [
+          {
+            apiVersion: 'cluster.x-k8s.io/v1beta1',
+            kind:       'Cluster',
+            name:       'test-final-1',
+            uid:        'ed1e8c73-bd86-4a19-966a-cb9c4249e7cf'
+          }
+        ],
+        relationships: [
+          {
+            fromId:   'fleet-default/test-final-1',
+            fromType: 'cluster.x-k8s.io.cluster',
+            rel:      'owner',
+            state:    'provisioned'
+          }
+        ],
+        resourceVersion: '3960953',
+        state:           {
+          error:         false,
+          message:       'Resource is current',
+          name:          'active',
+          transitioning: false
+        },
+        uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
+      },
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [
+                {
+                  key:      'key',
+                  operator: 'In',
+                  values:   [
+                    'aaa'
+                  ]
+                },
+                {
+                  key:      'key',
+                  operator: 'In',
+                  values:   [
+                    'bbb'
+                  ]
+                }
+              ],
+              matchLabels: { 'create-cluster-selector': 'cccc' }
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      }
+    },
+    initialConfig: {
+      id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
+      type:  'elemental.cattle.io.machineinventoryselectortemplate',
+      links: {
+        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
+      },
+      apiVersion: 'elemental.cattle.io/v1beta1',
+      kind:       'MachineInventorySelectorTemplate',
+      metadata:   {
+        creationTimestamp: '2025-06-16T10:30:24Z',
+        fields:            [
+          'nc-test-final-1-pool1-mnwmd',
+          '0s'
+        ],
+        generateName:  'nc-test-final-1-pool1-',
+        generation:    1,
+        managedFields: [
+          {
+            apiVersion: 'elemental.cattle.io/v1beta1',
+            fieldsType: 'FieldsV1',
+            fieldsV1:   {
+              'f:metadata': { 'f:generateName': {} },
+              'f:spec':     {
+                '.':          {},
+                'f:template': {
+                  '.':          {},
+                  'f:metadata': {},
+                  'f:spec':     {
+                    '.':          {},
+                    'f:selector': {}
+                  },
+                  'f:status': {
+                    '.':                     {},
+                    'f:addresses':           {},
+                    'f:conditions':          {},
+                    'f:machineInventoryRef': {}
+                  }
+                }
+              }
+            },
+            manager:   'rancher',
+            operation: 'Update',
+            time:      '2025-06-16T10:30:24Z'
+          }
+        ],
+        name:            'nc-test-final-1-pool1-mnwmd',
+        namespace:       'fleet-default',
+        relationships:   null,
+        resourceVersion: '3960910',
+        state:           {
+          error:         false,
+          message:       'Resource is current',
+          name:          'active',
+          transitioning: false
+        },
+        uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
+      },
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [
+                {
+                  key:      'key',
+                  operator: 'In',
+                  values:   [
+                    'aaa'
+                  ]
+                },
+                {
+                  key:      'key',
+                  operator: 'In',
+                  values:   [
+                    'bbb'
+                  ]
+                }
+              ],
+              matchLabels: { 'create-cluster-selector': 'cccc' }
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      },
+      __clone: true
+    }
+  },
+  // 2 different keys, removing one of them
+  usecase2: {
+    currentConfig: {
+      id:    'fleet-default/nc-final-test-pool1-7rw9q',
+      type:  'elemental.cattle.io.machineinventoryselectortemplate',
+      links: {
+        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
+      },
+      apiVersion: 'elemental.cattle.io/v1beta1',
+      kind:       'MachineInventorySelectorTemplate',
+      metadata:   {
+        creationTimestamp: '2025-05-30T09:03:40Z',
+        fields:            [
+          'nc-final-test-pool1-7rw9q',
+          '12m'
+        ],
+        generateName:    'nc-final-test-pool1-',
+        generation:      2,
+        name:            'nc-final-test-pool1-7rw9q',
+        namespace:       'fleet-default',
+        ownerReferences: [
+          {
+            apiVersion: 'cluster.x-k8s.io/v1beta1',
+            kind:       'Cluster',
+            name:       'final-test',
+            uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+          }
+        ],
+        relationships: [
+          {
+            fromId:   'fleet-default/final-test',
+            fromType: 'cluster.x-k8s.io.cluster',
+            rel:      'owner',
+            state:    'provisioned'
+          }
+        ],
+        resourceVersion: '970275',
+        state:           {
+          error:         false,
+          message:       'Resource is current',
+          name:          'active',
+          transitioning: false
+        },
+        uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+      },
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      {
+                'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC',
+                key:                       'key1'
+              }
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      },
+      __clone: true
+    },
+    latestConfig: {
+      id:    'fleet-default/nc-final-test-pool1-7rw9q',
+      type:  'elemental.cattle.io.machineinventoryselectortemplate',
+      links: {
+        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
+      },
+      apiVersion: 'elemental.cattle.io/v1beta1',
+      kind:       'MachineInventorySelectorTemplate',
+      metadata:   {
+        creationTimestamp: '2025-05-30T09:03:40Z',
+        fields:            [
+          'nc-final-test-pool1-7rw9q',
+          '12m'
+        ],
+        generateName:  'nc-final-test-pool1-',
+        generation:    2,
+        managedFields: [
+          {
+            apiVersion: 'elemental.cattle.io/v1beta1',
+            fieldsType: 'FieldsV1',
+            fieldsV1:   {
+              'f:metadata': {
+                'f:ownerReferences': {
+                  '.':                                                {},
+                  'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
+                }
+              }
+            },
+            manager:   'manager',
+            operation: 'Update',
+            time:      '2025-05-30T09:03:41Z'
+          },
+          {
+            apiVersion: 'elemental.cattle.io/v1beta1',
+            fieldsType: 'FieldsV1',
+            fieldsV1:   {
+              'f:metadata': { 'f:generateName': {} },
+              'f:spec':     {
+                '.':          {},
+                'f:template': {
+                  '.':          {},
+                  'f:metadata': {},
+                  'f:spec':     {
+                    '.':          {},
+                    'f:selector': {}
+                  },
+                  'f:status': {
+                    '.':                     {},
+                    'f:addresses':           {},
+                    'f:conditions':          {},
+                    'f:machineInventoryRef': {}
+                  }
+                }
+              }
+            },
+            manager:   'rancher',
+            operation: 'Update',
+            time:      '2025-05-30T09:15:58Z'
+          }
+        ],
+        name:            'nc-final-test-pool1-7rw9q',
+        namespace:       'fleet-default',
+        ownerReferences: [
+          {
+            apiVersion: 'cluster.x-k8s.io/v1beta1',
+            kind:       'Cluster',
+            name:       'final-test',
+            uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+          }
+        ],
+        relationships: [
+          {
+            fromId:   'fleet-default/final-test',
+            fromType: 'cluster.x-k8s.io.cluster',
+            rel:      'owner',
+            state:    'provisioned'
+          }
+        ],
+        resourceVersion: '970275',
+        state:           {
+          error:         false,
+          message:       'Resource is current',
+          name:          'active',
+          transitioning: false
+        },
+        uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+      },
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      {
+                'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC',
+                key:                       'key1'
+              }
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      },
+      __clone: true
+    },
+    initialConfig: {
+      id:         'fleet-default/nc-final-test-pool1-7rw9q',
+      type:       'elemental.cattle.io.machineinventoryselectortemplate',
+      apiVersion: 'elemental.cattle.io/v1beta1',
+      kind:       'MachineInventorySelectorTemplate',
+      metadata:   {
+        generateName:    'nc-final-test-pool1-',
+        name:            'nc-final-test-pool1-7rw9q',
+        namespace:       'fleet-default',
+        uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
+        labels:          {},
+        annotations:     {},
+        resourceVersion: '970275'
+      },
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      }
+    }
+  },
+  // 1 key left, removing it (no selectors)
+  usecase3: {
+    currentConfig: {
+      id:    'fleet-default/nc-final-test-pool1-7rw9q',
+      type:  'elemental.cattle.io.machineinventoryselectortemplate',
+      links: {
+        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
+      },
+      apiVersion: 'elemental.cattle.io/v1beta1',
+      kind:       'MachineInventorySelectorTemplate',
+      metadata:   {
+        creationTimestamp: '2025-05-30T09:03:40Z',
+        fields:            [
+          'nc-final-test-pool1-7rw9q',
+          '12m'
+        ],
+        generateName:  'nc-final-test-pool1-',
+        generation:    3,
+        managedFields: [
+          {
+            apiVersion: 'elemental.cattle.io/v1beta1',
+            fieldsType: 'FieldsV1',
+            fieldsV1:   {
+              'f:metadata': {
+                'f:ownerReferences': {
+                  '.':                                                {},
+                  'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
+                }
+              }
+            },
+            manager:   'manager',
+            operation: 'Update',
+            time:      '2025-05-30T09:03:41Z'
+          },
+          {
+            apiVersion: 'elemental.cattle.io/v1beta1',
+            fieldsType: 'FieldsV1',
+            fieldsV1:   {
+              'f:metadata': { 'f:generateName': {} },
+              'f:spec':     {
+                '.':          {},
+                'f:template': {
+                  '.':          {},
+                  'f:metadata': {},
+                  'f:spec':     {
+                    '.':          {},
+                    'f:selector': {}
+                  },
+                  'f:status': {
+                    '.':                     {},
+                    'f:addresses':           {},
+                    'f:conditions':          {},
+                    'f:machineInventoryRef': {}
+                  }
+                }
+              }
+            },
+            manager:   'rancher',
+            operation: 'Update',
+            time:      '2025-05-30T09:16:20Z'
+          }
+        ],
+        name:            'nc-final-test-pool1-7rw9q',
+        namespace:       'fleet-default',
+        ownerReferences: [
+          {
+            apiVersion: 'cluster.x-k8s.io/v1beta1',
+            kind:       'Cluster',
+            name:       'final-test',
+            uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+          }
+        ],
+        relationships: [
+          {
+            fromId:   'fleet-default/final-test',
+            fromType: 'cluster.x-k8s.io.cluster',
+            rel:      'owner',
+            state:    'provisioned'
+          }
+        ],
+        resourceVersion: '970343',
+        state:           {
+          error:         false,
+          message:       'Resource is current',
+          name:          'active',
+          transitioning: false
+        },
+        uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+      },
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      },
+      __clone: true
+    },
+    latestConfig: {
+      id:    'fleet-default/nc-final-test-pool1-7rw9q',
+      type:  'elemental.cattle.io.machineinventoryselectortemplate',
+      links: {
+        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
+      },
+      apiVersion: 'elemental.cattle.io/v1beta1',
+      kind:       'MachineInventorySelectorTemplate',
+      metadata:   {
+        creationTimestamp: '2025-05-30T09:03:40Z',
+        fields:            [
+          'nc-final-test-pool1-7rw9q',
+          '13m'
+        ],
+        generateName:  'nc-final-test-pool1-',
+        generation:    3,
+        managedFields: [
+          {
+            apiVersion: 'elemental.cattle.io/v1beta1',
+            fieldsType: 'FieldsV1',
+            fieldsV1:   {
+              'f:metadata': {
+                'f:ownerReferences': {
+                  '.':                                                {},
+                  'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
+                }
+              }
+            },
+            manager:   'manager',
+            operation: 'Update',
+            time:      '2025-05-30T09:03:41Z'
+          },
+          {
+            apiVersion: 'elemental.cattle.io/v1beta1',
+            fieldsType: 'FieldsV1',
+            fieldsV1:   {
+              'f:metadata': { 'f:generateName': {} },
+              'f:spec':     {
+                '.':          {},
+                'f:template': {
+                  '.':          {},
+                  'f:metadata': {},
+                  'f:spec':     {
+                    '.':          {},
+                    'f:selector': {}
+                  },
+                  'f:status': {
+                    '.':                     {},
+                    'f:addresses':           {},
+                    'f:conditions':          {},
+                    'f:machineInventoryRef': {}
+                  }
+                }
+              }
+            },
+            manager:   'rancher',
+            operation: 'Update',
+            time:      '2025-05-30T09:16:20Z'
+          }
+        ],
+        name:            'nc-final-test-pool1-7rw9q',
+        namespace:       'fleet-default',
+        ownerReferences: [
+          {
+            apiVersion: 'cluster.x-k8s.io/v1beta1',
+            kind:       'Cluster',
+            name:       'final-test',
+            uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+          }
+        ],
+        relationships: [
+          {
+            fromId:   'fleet-default/final-test',
+            fromType: 'cluster.x-k8s.io.cluster',
+            rel:      'owner',
+            state:    'provisioned'
+          }
+        ],
+        resourceVersion: '970343',
+        state:           {
+          error:         false,
+          message:       'Resource is current',
+          name:          'active',
+          transitioning: false
+        },
+        uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+      },
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      },
+      __clone: true
+    },
+    initialConfig: {
+      id:         'fleet-default/nc-final-test-pool1-7rw9q',
+      type:       'elemental.cattle.io.machineinventoryselectortemplate',
+      apiVersion: 'elemental.cattle.io/v1beta1',
+      kind:       'MachineInventorySelectorTemplate',
+      metadata:   {
+        generateName:    'nc-final-test-pool1-',
+        name:            'nc-final-test-pool1-7rw9q',
+        namespace:       'fleet-default',
+        uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
+        labels:          {},
+        annotations:     {},
+        resourceVersion: '970343'
+      },
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      {}
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      }
+    }
+  },
+  // FAIL!!! - matchLabels changed on both latest and current + resourceVersion on latest
+  usecase4: {
+    currentConfig: {
+      id:    'fleet-default/nc-final-test-pool1-7rw9q',
+      type:  'elemental.cattle.io.machineinventoryselectortemplate',
+      links: {
+        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
+      },
+      apiVersion: 'elemental.cattle.io/v1beta1',
+      kind:       'MachineInventorySelectorTemplate',
+      metadata:   {
+        creationTimestamp: '2025-05-30T09:03:40Z',
+        fields:            [
+          'nc-final-test-pool1-7rw9q',
+          '12m'
+        ],
+        generateName:  'nc-final-test-pool1-',
+        generation:    3,
+        managedFields: [
+          {
+            apiVersion: 'elemental.cattle.io/v1beta1',
+            fieldsType: 'FieldsV1',
+            fieldsV1:   {
+              'f:metadata': {
+                'f:ownerReferences': {
+                  '.':                                                {},
+                  'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
+                }
+              }
+            },
+            manager:   'manager',
+            operation: 'Update',
+            time:      '2025-05-30T09:03:41Z'
+          },
+          {
+            apiVersion: 'elemental.cattle.io/v1beta1',
+            fieldsType: 'FieldsV1',
+            fieldsV1:   {
+              'f:metadata': { 'f:generateName': {} },
+              'f:spec':     {
+                '.':          {},
+                'f:template': {
+                  '.':          {},
+                  'f:metadata': {},
+                  'f:spec':     {
+                    '.':          {},
+                    'f:selector': {}
+                  },
+                  'f:status': {
+                    '.':                     {},
+                    'f:addresses':           {},
+                    'f:conditions':          {},
+                    'f:machineInventoryRef': {}
+                  }
+                }
+              }
+            },
+            manager:   'rancher',
+            operation: 'Update',
+            time:      '2025-05-30T09:16:20Z'
+          }
+        ],
+        name:            'nc-final-test-pool1-7rw9q',
+        namespace:       'fleet-default',
+        ownerReferences: [
+          {
+            apiVersion: 'cluster.x-k8s.io/v1beta1',
+            kind:       'Cluster',
+            name:       'final-test',
+            uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+          }
+        ],
+        relationships: [
+          {
+            fromId:   'fleet-default/final-test',
+            fromType: 'cluster.x-k8s.io.cluster',
+            rel:      'owner',
+            state:    'provisioned'
+          }
+        ],
+        resourceVersion: '970343',
+        state:           {
+          error:         false,
+          message:       'Resource is current',
+          name:          'active',
+          transitioning: false
+        },
+        uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+      },
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxCbbbbbbbbb' }
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      },
+      __clone: true
+    },
+    latestConfig: {
+      id:    'fleet-default/nc-final-test-pool1-7rw9q',
+      type:  'elemental.cattle.io.machineinventoryselectortemplate',
+      links: {
+        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
+      },
+      apiVersion: 'elemental.cattle.io/v1beta1',
+      kind:       'MachineInventorySelectorTemplate',
+      metadata:   {
+        creationTimestamp: '2025-05-30T09:03:40Z',
+        fields:            [
+          'nc-final-test-pool1-7rw9q',
+          '13m'
+        ],
+        generateName:  'nc-final-test-pool1-',
+        generation:    3,
+        managedFields: [
+          {
+            apiVersion: 'elemental.cattle.io/v1beta1',
+            fieldsType: 'FieldsV1',
+            fieldsV1:   {
+              'f:metadata': {
+                'f:ownerReferences': {
+                  '.':                                                {},
+                  'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
+                }
+              }
+            },
+            manager:   'manager',
+            operation: 'Update',
+            time:      '2025-05-30T09:03:41Z'
+          },
+          {
+            apiVersion: 'elemental.cattle.io/v1beta1',
+            fieldsType: 'FieldsV1',
+            fieldsV1:   {
+              'f:metadata': { 'f:generateName': {} },
+              'f:spec':     {
+                '.':          {},
+                'f:template': {
+                  '.':          {},
+                  'f:metadata': {},
+                  'f:spec':     {
+                    '.':          {},
+                    'f:selector': {}
+                  },
+                  'f:status': {
+                    '.':                     {},
+                    'f:addresses':           {},
+                    'f:conditions':          {},
+                    'f:machineInventoryRef': {}
+                  }
+                }
+              }
+            },
+            manager:   'rancher',
+            operation: 'Update',
+            time:      '2025-05-30T09:16:20Z'
+          }
+        ],
+        name:            'nc-final-test-pool1-7rw9q',
+        namespace:       'fleet-default',
+        ownerReferences: [
+          {
+            apiVersion: 'cluster.x-k8s.io/v1beta1',
+            kind:       'Cluster',
+            name:       'final-test',
+            uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+          }
+        ],
+        relationships: [
+          {
+            fromId:   'fleet-default/final-test',
+            fromType: 'cluster.x-k8s.io.cluster',
+            rel:      'owner',
+            state:    'provisioned'
+          }
+        ],
+        resourceVersion: '970344',
+        state:           {
+          error:         false,
+          message:       'Resource is current',
+          name:          'active',
+          transitioning: false
+        },
+        uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+      },
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxCaaaa' }
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      },
+      __clone: true
+    },
+    initialConfig: {
+      id:         'fleet-default/nc-final-test-pool1-7rw9q',
+      type:       'elemental.cattle.io.machineinventoryselectortemplate',
+      apiVersion: 'elemental.cattle.io/v1beta1',
+      kind:       'MachineInventorySelectorTemplate',
+      metadata:   {
+        generateName:    'nc-final-test-pool1-',
+        name:            'nc-final-test-pool1-7rw9q',
+        namespace:       'fleet-default',
+        uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
+        labels:          {},
+        annotations:     {},
+        resourceVersion: '970343'
+      },
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      {}
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      }
+    }
+  }
+};

--- a/shell/plugins/dashboard-store/__tests__/utils/normalize-usecases.ts
+++ b/shell/plugins/dashboard-store/__tests__/utils/normalize-usecases.ts
@@ -6,52 +6,8 @@ export const handleConflictUseCases = [
     description: 'delete from array',
     data:        {
       currentConfig: {
-        id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-06-16T10:30:24Z',
-          fields:            [
-            'nc-test-final-1-pool1-mnwmd',
-            '51m'
-          ],
-          generateName:    'nc-test-final-1-pool1-',
-          generation:      2,
-          name:            'nc-test-final-1-pool1-mnwmd',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'test-final-1',
-              uid:        'ed1e8c73-bd86-4a19-966a-cb9c4249e7cf'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/test-final-1',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '3961358',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
-        },
-        spec: {
+        metadata: { resourceVersion: '3961358' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -74,107 +30,14 @@ export const handleConflictUseCases = [
                 ],
                 matchLabels: { 'create-cluster-selector': 'cccc' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
         __clone: true
       },
       latestConfig: {
-        id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-06-16T10:30:24Z',
-          fields:            [
-            'nc-test-final-1-pool1-mnwmd',
-            '34s'
-          ],
-          generateName:  'nc-test-final-1-pool1-',
-          generation:    1,
-          managedFields: [
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': {
-                  'f:ownerReferences': {
-                    '.':                                                {},
-                    'k:{"uid":"ed1e8c73-bd86-4a19-966a-cb9c4249e7cf"}': {}
-                  }
-                }
-              },
-              manager:   'manager',
-              operation: 'Update',
-              time:      '2025-06-16T10:30:24Z'
-            },
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': { 'f:generateName': {} },
-                'f:spec':     {
-                  '.':          {},
-                  'f:template': {
-                    '.':          {},
-                    'f:metadata': {},
-                    'f:spec':     {
-                      '.':          {},
-                      'f:selector': {}
-                    },
-                    'f:status': {
-                      '.':                     {},
-                      'f:addresses':           {},
-                      'f:conditions':          {},
-                      'f:machineInventoryRef': {}
-                    }
-                  }
-                }
-              },
-              manager:   'rancher',
-              operation: 'Update',
-              time:      '2025-06-16T10:30:24Z'
-            }
-          ],
-          name:            'nc-test-final-1-pool1-mnwmd',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'test-final-1',
-              uid:        'ed1e8c73-bd86-4a19-966a-cb9c4249e7cf'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/test-final-1',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '3960953',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
-        },
-        spec: {
+        metadata: { resourceVersion: '3960953' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -197,76 +60,13 @@ export const handleConflictUseCases = [
                 ],
                 matchLabels: { 'create-cluster-selector': 'cccc' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         }
       },
       initialConfig: {
-        id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-06-16T10:30:24Z',
-          fields:            [
-            'nc-test-final-1-pool1-mnwmd',
-            '0s'
-          ],
-          generateName:  'nc-test-final-1-pool1-',
-          generation:    1,
-          managedFields: [
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': { 'f:generateName': {} },
-                'f:spec':     {
-                  '.':          {},
-                  'f:template': {
-                    '.':          {},
-                    'f:metadata': {},
-                    'f:spec':     {
-                      '.':          {},
-                      'f:selector': {}
-                    },
-                    'f:status': {
-                      '.':                     {},
-                      'f:addresses':           {},
-                      'f:conditions':          {},
-                      'f:machineInventoryRef': {}
-                    }
-                  }
-                }
-              },
-              manager:   'rancher',
-              operation: 'Update',
-              time:      '2025-06-16T10:30:24Z'
-            }
-          ],
-          name:            'nc-test-final-1-pool1-mnwmd',
-          namespace:       'fleet-default',
-          relationships:   null,
-          resourceVersion: '3960910',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
-        },
-        spec: {
+        metadata: { resourceVersion: '3960910' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -289,11 +89,6 @@ export const handleConflictUseCases = [
                 ],
                 matchLabels: { 'create-cluster-selector': 'cccc' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
@@ -325,11 +120,6 @@ export const handleConflictUseCases = [
               ],
               matchLabels: { 'create-cluster-selector': 'cccc' }
             }
-          },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
           }
         }
       },
@@ -342,52 +132,8 @@ export const handleConflictUseCases = [
     description: 'emptying array',
     data:        {
       currentConfig: {
-        id:    'fleet-default/nc-final-test-pool1-7rw9q',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-05-30T09:03:40Z',
-          fields:            [
-            'nc-final-test-pool1-7rw9q',
-            '12m'
-          ],
-          generateName:    'nc-final-test-pool1-',
-          generation:      2,
-          name:            'nc-final-test-pool1-7rw9q',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'final-test',
-              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/final-test',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '970275',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-        },
-        spec: {
+        metadata: { resourceVersion: '970275' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -395,107 +141,14 @@ export const handleConflictUseCases = [
                 matchExpressions: [],
                 matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
         __clone: true
       },
       latestConfig: {
-        id:    'fleet-default/nc-final-test-pool1-7rw9q',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-05-30T09:03:40Z',
-          fields:            [
-            'nc-final-test-pool1-7rw9q',
-            '12m'
-          ],
-          generateName:  'nc-final-test-pool1-',
-          generation:    2,
-          managedFields: [
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': {
-                  'f:ownerReferences': {
-                    '.':                                                {},
-                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
-                  }
-                }
-              },
-              manager:   'manager',
-              operation: 'Update',
-              time:      '2025-05-30T09:03:41Z'
-            },
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': { 'f:generateName': {} },
-                'f:spec':     {
-                  '.':          {},
-                  'f:template': {
-                    '.':          {},
-                    'f:metadata': {},
-                    'f:spec':     {
-                      '.':          {},
-                      'f:selector': {}
-                    },
-                    'f:status': {
-                      '.':                     {},
-                      'f:addresses':           {},
-                      'f:conditions':          {},
-                      'f:machineInventoryRef': {}
-                    }
-                  }
-                }
-              },
-              manager:   'rancher',
-              operation: 'Update',
-              time:      '2025-05-30T09:15:58Z'
-            }
-          ],
-          name:            'nc-final-test-pool1-7rw9q',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'final-test',
-              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/final-test',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '970275',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-        },
-        spec: {
+        metadata: { resourceVersion: '970275' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -506,31 +159,14 @@ export const handleConflictUseCases = [
                   key:                       'key1'
                 }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
         __clone: true
       },
       initialConfig: {
-        id:         'fleet-default/nc-final-test-pool1-7rw9q',
-        type:       'elemental.cattle.io.machineinventoryselectortemplate',
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          generateName:    'nc-final-test-pool1-',
-          name:            'nc-final-test-pool1-7rw9q',
-          namespace:       'fleet-default',
-          uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
-          labels:          {},
-          annotations:     {},
-          resourceVersion: '970275'
-        },
-        spec: {
+        metadata: { resourceVersion: '970275' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -541,11 +177,6 @@ export const handleConflictUseCases = [
                   key:                       'key1'
                 }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         }
@@ -561,11 +192,6 @@ export const handleConflictUseCases = [
               matchExpressions: [],
               matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
             }
-          },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
           }
         }
       },
@@ -578,96 +204,8 @@ export const handleConflictUseCases = [
     description: 'emptying object',
     data:        {
       currentConfig: {
-        id:    'fleet-default/nc-final-test-pool1-7rw9q',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-05-30T09:03:40Z',
-          fields:            [
-            'nc-final-test-pool1-7rw9q',
-            '12m'
-          ],
-          generateName:  'nc-final-test-pool1-',
-          generation:    3,
-          managedFields: [
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': {
-                  'f:ownerReferences': {
-                    '.':                                                {},
-                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
-                  }
-                }
-              },
-              manager:   'manager',
-              operation: 'Update',
-              time:      '2025-05-30T09:03:41Z'
-            },
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': { 'f:generateName': {} },
-                'f:spec':     {
-                  '.':          {},
-                  'f:template': {
-                    '.':          {},
-                    'f:metadata': {},
-                    'f:spec':     {
-                      '.':          {},
-                      'f:selector': {}
-                    },
-                    'f:status': {
-                      '.':                     {},
-                      'f:addresses':           {},
-                      'f:conditions':          {},
-                      'f:machineInventoryRef': {}
-                    }
-                  }
-                }
-              },
-              manager:   'rancher',
-              operation: 'Update',
-              time:      '2025-05-30T09:16:20Z'
-            }
-          ],
-          name:            'nc-final-test-pool1-7rw9q',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'final-test',
-              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/final-test',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '970343',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-        },
-        spec: {
+        metadata: { resourceVersion: '970343' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -675,107 +213,14 @@ export const handleConflictUseCases = [
                 matchExpressions: [],
                 matchLabels:      {}
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
         __clone: true
       },
       latestConfig: {
-        id:    'fleet-default/nc-final-test-pool1-7rw9q',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-05-30T09:03:40Z',
-          fields:            [
-            'nc-final-test-pool1-7rw9q',
-            '13m'
-          ],
-          generateName:  'nc-final-test-pool1-',
-          generation:    3,
-          managedFields: [
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': {
-                  'f:ownerReferences': {
-                    '.':                                                {},
-                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
-                  }
-                }
-              },
-              manager:   'manager',
-              operation: 'Update',
-              time:      '2025-05-30T09:03:41Z'
-            },
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': { 'f:generateName': {} },
-                'f:spec':     {
-                  '.':          {},
-                  'f:template': {
-                    '.':          {},
-                    'f:metadata': {},
-                    'f:spec':     {
-                      '.':          {},
-                      'f:selector': {}
-                    },
-                    'f:status': {
-                      '.':                     {},
-                      'f:addresses':           {},
-                      'f:conditions':          {},
-                      'f:machineInventoryRef': {}
-                    }
-                  }
-                }
-              },
-              manager:   'rancher',
-              operation: 'Update',
-              time:      '2025-05-30T09:16:20Z'
-            }
-          ],
-          name:            'nc-final-test-pool1-7rw9q',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'final-test',
-              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/final-test',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '970343',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-        },
-        spec: {
+        metadata: { resourceVersion: '970343' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -783,31 +228,14 @@ export const handleConflictUseCases = [
                 matchExpressions: [],
                 matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
         __clone: true
       },
       initialConfig: {
-        id:         'fleet-default/nc-final-test-pool1-7rw9q',
-        type:       'elemental.cattle.io.machineinventoryselectortemplate',
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          generateName:    'nc-final-test-pool1-',
-          name:            'nc-final-test-pool1-7rw9q',
-          namespace:       'fleet-default',
-          uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
-          labels:          {},
-          annotations:     {},
-          resourceVersion: '970343'
-        },
-        spec: {
+        metadata: { resourceVersion: '970343' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -815,11 +243,6 @@ export const handleConflictUseCases = [
                 matchExpressions: [],
                 matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         }
@@ -835,11 +258,6 @@ export const handleConflictUseCases = [
               matchExpressions: [],
               matchLabels:      {}
             }
-          },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
           }
         }
       }
@@ -850,52 +268,8 @@ export const handleConflictUseCases = [
     description: 'add to array',
     data:        {
       currentConfig: {
-        id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-06-16T10:30:24Z',
-          fields:            [
-            'nc-test-final-1-pool1-mnwmd',
-            '51m'
-          ],
-          generateName:    'nc-test-final-1-pool1-',
-          generation:      2,
-          name:            'nc-test-final-1-pool1-mnwmd',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'test-final-1',
-              uid:        'ed1e8c73-bd86-4a19-966a-cb9c4249e7cf'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/test-final-1',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '3961358',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
-        },
-        spec: {
+        metadata: { resourceVersion: '3961358' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -932,107 +306,14 @@ export const handleConflictUseCases = [
                 ],
                 matchLabels: { 'create-cluster-selector': 'cccc' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
         __clone: true
       },
       latestConfig: {
-        id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-06-16T10:30:24Z',
-          fields:            [
-            'nc-test-final-1-pool1-mnwmd',
-            '34s'
-          ],
-          generateName:  'nc-test-final-1-pool1-',
-          generation:    1,
-          managedFields: [
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': {
-                  'f:ownerReferences': {
-                    '.':                                                {},
-                    'k:{"uid":"ed1e8c73-bd86-4a19-966a-cb9c4249e7cf"}': {}
-                  }
-                }
-              },
-              manager:   'manager',
-              operation: 'Update',
-              time:      '2025-06-16T10:30:24Z'
-            },
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': { 'f:generateName': {} },
-                'f:spec':     {
-                  '.':          {},
-                  'f:template': {
-                    '.':          {},
-                    'f:metadata': {},
-                    'f:spec':     {
-                      '.':          {},
-                      'f:selector': {}
-                    },
-                    'f:status': {
-                      '.':                     {},
-                      'f:addresses':           {},
-                      'f:conditions':          {},
-                      'f:machineInventoryRef': {}
-                    }
-                  }
-                }
-              },
-              manager:   'rancher',
-              operation: 'Update',
-              time:      '2025-06-16T10:30:24Z'
-            }
-          ],
-          name:            'nc-test-final-1-pool1-mnwmd',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'test-final-1',
-              uid:        'ed1e8c73-bd86-4a19-966a-cb9c4249e7cf'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/test-final-1',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '3960953',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
-        },
-        spec: {
+        metadata: { resourceVersion: '3960953' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -1055,76 +336,13 @@ export const handleConflictUseCases = [
                 ],
                 matchLabels: { 'create-cluster-selector': 'cccc' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         }
       },
       initialConfig: {
-        id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-06-16T10:30:24Z',
-          fields:            [
-            'nc-test-final-1-pool1-mnwmd',
-            '0s'
-          ],
-          generateName:  'nc-test-final-1-pool1-',
-          generation:    1,
-          managedFields: [
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': { 'f:generateName': {} },
-                'f:spec':     {
-                  '.':          {},
-                  'f:template': {
-                    '.':          {},
-                    'f:metadata': {},
-                    'f:spec':     {
-                      '.':          {},
-                      'f:selector': {}
-                    },
-                    'f:status': {
-                      '.':                     {},
-                      'f:addresses':           {},
-                      'f:conditions':          {},
-                      'f:machineInventoryRef': {}
-                    }
-                  }
-                }
-              },
-              manager:   'rancher',
-              operation: 'Update',
-              time:      '2025-06-16T10:30:24Z'
-            }
-          ],
-          name:            'nc-test-final-1-pool1-mnwmd',
-          namespace:       'fleet-default',
-          relationships:   null,
-          resourceVersion: '3960910',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
-        },
-        spec: {
+        metadata: { resourceVersion: '3960910' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -1147,11 +365,6 @@ export const handleConflictUseCases = [
                 ],
                 matchLabels: { 'create-cluster-selector': 'cccc' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
@@ -1197,11 +410,6 @@ export const handleConflictUseCases = [
               ],
               matchLabels: { 'create-cluster-selector': 'cccc' }
             }
-          },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
           }
         }
       },
@@ -1212,52 +420,8 @@ export const handleConflictUseCases = [
     description: 'edit an array',
     data:        {
       currentConfig: {
-        id:    'fleet-default/nc-final-test-pool1-7rw9q',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-05-30T09:03:40Z',
-          fields:            [
-            'nc-final-test-pool1-7rw9q',
-            '12m'
-          ],
-          generateName:    'nc-final-test-pool1-',
-          generation:      2,
-          name:            'nc-final-test-pool1-7rw9q',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'final-test',
-              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/final-test',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '970275',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-        },
-        spec: {
+        metadata: { resourceVersion: '970275' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -1280,107 +444,14 @@ export const handleConflictUseCases = [
                 ],
                 matchLabels: { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
         __clone: true
       },
       latestConfig: {
-        id:    'fleet-default/nc-final-test-pool1-7rw9q',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-05-30T09:03:40Z',
-          fields:            [
-            'nc-final-test-pool1-7rw9q',
-            '12m'
-          ],
-          generateName:  'nc-final-test-pool1-',
-          generation:    2,
-          managedFields: [
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': {
-                  'f:ownerReferences': {
-                    '.':                                                {},
-                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
-                  }
-                }
-              },
-              manager:   'manager',
-              operation: 'Update',
-              time:      '2025-05-30T09:03:41Z'
-            },
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': { 'f:generateName': {} },
-                'f:spec':     {
-                  '.':          {},
-                  'f:template': {
-                    '.':          {},
-                    'f:metadata': {},
-                    'f:spec':     {
-                      '.':          {},
-                      'f:selector': {}
-                    },
-                    'f:status': {
-                      '.':                     {},
-                      'f:addresses':           {},
-                      'f:conditions':          {},
-                      'f:machineInventoryRef': {}
-                    }
-                  }
-                }
-              },
-              manager:   'rancher',
-              operation: 'Update',
-              time:      '2025-05-30T09:15:58Z'
-            }
-          ],
-          name:            'nc-final-test-pool1-7rw9q',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'final-test',
-              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/final-test',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '970275',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-        },
-        spec: {
+        metadata: { resourceVersion: '970275' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -1403,31 +474,14 @@ export const handleConflictUseCases = [
                 ],
                 matchLabels: { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
         __clone: true
       },
       initialConfig: {
-        id:         'fleet-default/nc-final-test-pool1-7rw9q',
-        type:       'elemental.cattle.io.machineinventoryselectortemplate',
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          generateName:    'nc-final-test-pool1-',
-          name:            'nc-final-test-pool1-7rw9q',
-          namespace:       'fleet-default',
-          uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
-          labels:          {},
-          annotations:     {},
-          resourceVersion: '970275'
-        },
-        spec: {
+        metadata: { resourceVersion: '970275' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -1450,11 +504,6 @@ export const handleConflictUseCases = [
                 ],
                 matchLabels: { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         }
@@ -1485,11 +534,6 @@ export const handleConflictUseCases = [
               ],
               matchLabels: { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
             }
-          },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
           }
         }
       },
@@ -1500,96 +544,8 @@ export const handleConflictUseCases = [
     description: 'add key to object',
     data:        {
       currentConfig: {
-        id:    'fleet-default/nc-final-test-pool1-7rw9q',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-05-30T09:03:40Z',
-          fields:            [
-            'nc-final-test-pool1-7rw9q',
-            '12m'
-          ],
-          generateName:  'nc-final-test-pool1-',
-          generation:    3,
-          managedFields: [
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': {
-                  'f:ownerReferences': {
-                    '.':                                                {},
-                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
-                  }
-                }
-              },
-              manager:   'manager',
-              operation: 'Update',
-              time:      '2025-05-30T09:03:41Z'
-            },
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': { 'f:generateName': {} },
-                'f:spec':     {
-                  '.':          {},
-                  'f:template': {
-                    '.':          {},
-                    'f:metadata': {},
-                    'f:spec':     {
-                      '.':          {},
-                      'f:selector': {}
-                    },
-                    'f:status': {
-                      '.':                     {},
-                      'f:addresses':           {},
-                      'f:conditions':          {},
-                      'f:machineInventoryRef': {}
-                    }
-                  }
-                }
-              },
-              manager:   'rancher',
-              operation: 'Update',
-              time:      '2025-05-30T09:16:20Z'
-            }
-          ],
-          name:            'nc-final-test-pool1-7rw9q',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'final-test',
-              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/final-test',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '970343',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-        },
-        spec: {
+        metadata: { resourceVersion: '970343' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -1597,107 +553,14 @@ export const handleConflictUseCases = [
                 matchExpressions: [],
                 matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC', 'new-key': 'new-value' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
         __clone: true
       },
       latestConfig: {
-        id:    'fleet-default/nc-final-test-pool1-7rw9q',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-05-30T09:03:40Z',
-          fields:            [
-            'nc-final-test-pool1-7rw9q',
-            '13m'
-          ],
-          generateName:  'nc-final-test-pool1-',
-          generation:    3,
-          managedFields: [
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': {
-                  'f:ownerReferences': {
-                    '.':                                                {},
-                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
-                  }
-                }
-              },
-              manager:   'manager',
-              operation: 'Update',
-              time:      '2025-05-30T09:03:41Z'
-            },
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': { 'f:generateName': {} },
-                'f:spec':     {
-                  '.':          {},
-                  'f:template': {
-                    '.':          {},
-                    'f:metadata': {},
-                    'f:spec':     {
-                      '.':          {},
-                      'f:selector': {}
-                    },
-                    'f:status': {
-                      '.':                     {},
-                      'f:addresses':           {},
-                      'f:conditions':          {},
-                      'f:machineInventoryRef': {}
-                    }
-                  }
-                }
-              },
-              manager:   'rancher',
-              operation: 'Update',
-              time:      '2025-05-30T09:16:20Z'
-            }
-          ],
-          name:            'nc-final-test-pool1-7rw9q',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'final-test',
-              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/final-test',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '970343',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-        },
-        spec: {
+        metadata: { resourceVersion: '970343' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -1705,31 +568,14 @@ export const handleConflictUseCases = [
                 matchExpressions: [],
                 matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
         __clone: true
       },
       initialConfig: {
-        id:         'fleet-default/nc-final-test-pool1-7rw9q',
-        type:       'elemental.cattle.io.machineinventoryselectortemplate',
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          generateName:    'nc-final-test-pool1-',
-          name:            'nc-final-test-pool1-7rw9q',
-          namespace:       'fleet-default',
-          uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
-          labels:          {},
-          annotations:     {},
-          resourceVersion: '970343'
-        },
-        spec: {
+        metadata: { resourceVersion: '970343' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -1737,11 +583,6 @@ export const handleConflictUseCases = [
                 matchExpressions: [],
                 matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         }
@@ -1757,11 +598,6 @@ export const handleConflictUseCases = [
               matchExpressions: [],
               matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC', 'new-key': 'new-value' }
             }
-          },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
           }
         }
       }
@@ -1772,96 +608,8 @@ export const handleConflictUseCases = [
     description: 'edit object key-value',
     data:        {
       currentConfig: {
-        id:    'fleet-default/nc-final-test-pool1-7rw9q',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-05-30T09:03:40Z',
-          fields:            [
-            'nc-final-test-pool1-7rw9q',
-            '12m'
-          ],
-          generateName:  'nc-final-test-pool1-',
-          generation:    3,
-          managedFields: [
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': {
-                  'f:ownerReferences': {
-                    '.':                                                {},
-                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
-                  }
-                }
-              },
-              manager:   'manager',
-              operation: 'Update',
-              time:      '2025-05-30T09:03:41Z'
-            },
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': { 'f:generateName': {} },
-                'f:spec':     {
-                  '.':          {},
-                  'f:template': {
-                    '.':          {},
-                    'f:metadata': {},
-                    'f:spec':     {
-                      '.':          {},
-                      'f:selector': {}
-                    },
-                    'f:status': {
-                      '.':                     {},
-                      'f:addresses':           {},
-                      'f:conditions':          {},
-                      'f:machineInventoryRef': {}
-                    }
-                  }
-                }
-              },
-              manager:   'rancher',
-              operation: 'Update',
-              time:      '2025-05-30T09:16:20Z'
-            }
-          ],
-          name:            'nc-final-test-pool1-7rw9q',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'final-test',
-              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/final-test',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '970343',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-        },
-        spec: {
+        metadata: { resourceVersion: '970343' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -1869,107 +617,14 @@ export const handleConflictUseCases = [
                 matchExpressions: [],
                 matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC-edited' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
         __clone: true
       },
       latestConfig: {
-        id:    'fleet-default/nc-final-test-pool1-7rw9q',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-05-30T09:03:40Z',
-          fields:            [
-            'nc-final-test-pool1-7rw9q',
-            '13m'
-          ],
-          generateName:  'nc-final-test-pool1-',
-          generation:    3,
-          managedFields: [
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': {
-                  'f:ownerReferences': {
-                    '.':                                                {},
-                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
-                  }
-                }
-              },
-              manager:   'manager',
-              operation: 'Update',
-              time:      '2025-05-30T09:03:41Z'
-            },
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': { 'f:generateName': {} },
-                'f:spec':     {
-                  '.':          {},
-                  'f:template': {
-                    '.':          {},
-                    'f:metadata': {},
-                    'f:spec':     {
-                      '.':          {},
-                      'f:selector': {}
-                    },
-                    'f:status': {
-                      '.':                     {},
-                      'f:addresses':           {},
-                      'f:conditions':          {},
-                      'f:machineInventoryRef': {}
-                    }
-                  }
-                }
-              },
-              manager:   'rancher',
-              operation: 'Update',
-              time:      '2025-05-30T09:16:20Z'
-            }
-          ],
-          name:            'nc-final-test-pool1-7rw9q',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'final-test',
-              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/final-test',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '970343',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-        },
-        spec: {
+        metadata: { resourceVersion: '970343' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -1977,31 +632,14 @@ export const handleConflictUseCases = [
                 matchExpressions: [],
                 matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
         __clone: true
       },
       initialConfig: {
-        id:         'fleet-default/nc-final-test-pool1-7rw9q',
-        type:       'elemental.cattle.io.machineinventoryselectortemplate',
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          generateName:    'nc-final-test-pool1-',
-          name:            'nc-final-test-pool1-7rw9q',
-          namespace:       'fleet-default',
-          uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
-          labels:          {},
-          annotations:     {},
-          resourceVersion: '970343'
-        },
-        spec: {
+        metadata: { resourceVersion: '970343' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -2009,11 +647,6 @@ export const handleConflictUseCases = [
                 matchExpressions: [],
                 matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         }
@@ -2029,11 +662,6 @@ export const handleConflictUseCases = [
               matchExpressions: [],
               matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC-edited' }
             }
-          },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
           }
         }
       }
@@ -2045,96 +673,8 @@ export const handleConflictUseCases = [
     description: 'with basic conflict',
     data:        {
       currentConfig: {
-        id:    'fleet-default/nc-final-test-pool1-7rw9q1111',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q1111',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q1111',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q1111',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q1111'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-05-30T09:03:40Z',
-          fields:            [
-            'nc-final-test-pool1-7rw9q1111',
-            '12m'
-          ],
-          generateName:  'nc-final-test-pool1-',
-          generation:    3,
-          managedFields: [
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': {
-                  'f:ownerReferences': {
-                    '.':                                                {},
-                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
-                  }
-                }
-              },
-              manager:   'manager',
-              operation: 'Update',
-              time:      '2025-05-30T09:03:41Z'
-            },
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': { 'f:generateName': {} },
-                'f:spec':     {
-                  '.':          {},
-                  'f:template': {
-                    '.':          {},
-                    'f:metadata': {},
-                    'f:spec':     {
-                      '.':          {},
-                      'f:selector': {}
-                    },
-                    'f:status': {
-                      '.':                     {},
-                      'f:addresses':           {},
-                      'f:conditions':          {},
-                      'f:machineInventoryRef': {}
-                    }
-                  }
-                }
-              },
-              manager:   'rancher',
-              operation: 'Update',
-              time:      '2025-05-30T09:16:20Z'
-            }
-          ],
-          name:            'nc-final-test-pool1-7rw9q1111',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'final-test',
-              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/final-test',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '970343',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-        },
-        spec: {
+        metadata: { resourceVersion: '970343' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -2142,107 +682,14 @@ export const handleConflictUseCases = [
                 matchExpressions: ['current_user_update_exp'],
                 matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC_current_user_update' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
         __clone: true
       },
       latestConfig: {
-        id:    'fleet-default/nc-final-test-pool1-7rw9q1111',
-        type:  'elemental.cattle.io.machineinventoryselectortemplate',
-        links: {
-          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q1111',
-          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q1111',
-          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q1111',
-          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q1111'
-        },
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          creationTimestamp: '2025-05-30T09:03:40Z',
-          fields:            [
-            'nc-final-test-pool1-7rw9q1111',
-            '13m'
-          ],
-          generateName:  'nc-final-test-pool1-',
-          generation:    3,
-          managedFields: [
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': {
-                  'f:ownerReferences': {
-                    '.':                                                {},
-                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
-                  }
-                }
-              },
-              manager:   'manager',
-              operation: 'Update',
-              time:      '2025-05-30T09:03:41Z'
-            },
-            {
-              apiVersion: 'elemental.cattle.io/v1beta1',
-              fieldsType: 'FieldsV1',
-              fieldsV1:   {
-                'f:metadata': { 'f:generateName': {} },
-                'f:spec':     {
-                  '.':          {},
-                  'f:template': {
-                    '.':          {},
-                    'f:metadata': {},
-                    'f:spec':     {
-                      '.':          {},
-                      'f:selector': {}
-                    },
-                    'f:status': {
-                      '.':                     {},
-                      'f:addresses':           {},
-                      'f:conditions':          {},
-                      'f:machineInventoryRef': {}
-                    }
-                  }
-                }
-              },
-              manager:   'rancher',
-              operation: 'Update',
-              time:      '2025-05-30T09:16:20Z'
-            }
-          ],
-          name:            'nc-final-test-pool1-7rw9q1111',
-          namespace:       'fleet-default',
-          ownerReferences: [
-            {
-              apiVersion: 'cluster.x-k8s.io/v1beta1',
-              kind:       'Cluster',
-              name:       'final-test',
-              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-            }
-          ],
-          relationships: [
-            {
-              fromId:   'fleet-default/final-test',
-              fromType: 'cluster.x-k8s.io.cluster',
-              rel:      'owner',
-              state:    'provisioned'
-            }
-          ],
-          resourceVersion: '970344',
-          state:           {
-            error:         false,
-            message:       'Resource is current',
-            name:          'active',
-            transitioning: false
-          },
-          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-        },
-        spec: {
+        metadata: { resourceVersion: '970344' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -2250,31 +697,14 @@ export const handleConflictUseCases = [
                 matchExpressions: ['live_server_value'],
                 matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxClive_server_value' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         },
         __clone: true
       },
       initialConfig: {
-        id:         'fleet-default/nc-final-test-pool1-7rw9q1111',
-        type:       'elemental.cattle.io.machineinventoryselectortemplate',
-        apiVersion: 'elemental.cattle.io/v1beta1',
-        kind:       'MachineInventorySelectorTemplate',
-        metadata:   {
-          generateName:    'nc-final-test-pool1-',
-          name:            'nc-final-test-pool1-7rw9q1111',
-          namespace:       'fleet-default',
-          uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
-          labels:          {},
-          annotations:     {},
-          resourceVersion: '970343'
-        },
-        spec: {
+        metadata: { resourceVersion: '970343' },
+        spec:     {
           template: {
             metadata: {},
             spec:     {
@@ -2282,11 +712,6 @@ export const handleConflictUseCases = [
                 matchExpressions: ['some-exp'],
                 matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
               }
-            },
-            status: {
-              addresses:           [],
-              conditions:          [],
-              machineInventoryRef: {}
             }
           }
         }
@@ -2302,11 +727,6 @@ export const handleConflictUseCases = [
               matchExpressions: ['live_server_value'],
               matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxClive_server_value' }
             }
-          },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
           }
         }
       },

--- a/shell/plugins/dashboard-store/__tests__/utils/normalize-usecases.ts
+++ b/shell/plugins/dashboard-store/__tests__/utils/normalize-usecases.ts
@@ -453,6 +453,135 @@ export const handleConflictUseCases = [
       },
     }
   },
+  // mergeWithReplace - merging arrays - usecase 8
+  {
+    description: 'mergeWithReplace usecase 8 - merge arrays',
+    data:        {
+      currentConfig: {
+        metadata: { resourceVersion: '3961358' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      undefined
+              }
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        metadata: { resourceVersion: '3960953' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {}
+              }
+            }
+          }
+        }
+      },
+      initialConfig: {
+        metadata: { resourceVersion: '3960910' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      undefined
+              }
+            }
+          }
+        },
+        __clone: true
+      }
+    },
+    result:           false,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      {}
+            }
+          }
+        }
+      },
+    }
+  },
+  // mergeWithReplace - merging arrays - usecase 9
+  {
+    description: 'mergeWithReplace usecase 9 - merge arrays',
+    data:        {
+      currentConfig: {
+        metadata: { resourceVersion: '3961358' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {}
+              }
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        metadata: { resourceVersion: '3960953' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      undefined
+              }
+            }
+          }
+        }
+      },
+      initialConfig: {
+        metadata: { resourceVersion: '3960910' },
+        spec:     {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      undefined
+              }
+            }
+          }
+        },
+        __clone: true
+      }
+    },
+    result:           false,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      {}
+            }
+          }
+        }
+      },
+    }
+  },
+
   // mergeWithReplace - merging objects - usecase 1
   {
     description: 'mergeWithReplace usecase 1 - merge objects',

--- a/shell/plugins/dashboard-store/__tests__/utils/normalize-usecases.ts
+++ b/shell/plugins/dashboard-store/__tests__/utils/normalize-usecases.ts
@@ -1,52 +1,307 @@
-export const usecases = {
+export const handleConflictUseCases = [
   // 2 same keys entries but with different values, 1 different key, removing one of the same keys
-  usecase1: {
-    currentConfig: {
-      id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
-      type:  'elemental.cattle.io.machineinventoryselectortemplate',
-      links: {
-        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
-      },
-      apiVersion: 'elemental.cattle.io/v1beta1',
-      kind:       'MachineInventorySelectorTemplate',
-      metadata:   {
-        creationTimestamp: '2025-06-16T10:30:24Z',
-        fields:            [
-          'nc-test-final-1-pool1-mnwmd',
-          '51m'
-        ],
-        generateName:    'nc-test-final-1-pool1-',
-        generation:      2,
-        name:            'nc-test-final-1-pool1-mnwmd',
-        namespace:       'fleet-default',
-        ownerReferences: [
-          {
-            apiVersion: 'cluster.x-k8s.io/v1beta1',
-            kind:       'Cluster',
-            name:       'test-final-1',
-            uid:        'ed1e8c73-bd86-4a19-966a-cb9c4249e7cf'
-          }
-        ],
-        relationships: [
-          {
-            fromId:   'fleet-default/test-final-1',
-            fromType: 'cluster.x-k8s.io.cluster',
-            rel:      'owner',
-            state:    'provisioned'
-          }
-        ],
-        resourceVersion: '3961358',
-        state:           {
-          error:         false,
-          message:       'Resource is current',
-          name:          'active',
-          transitioning: false
+  // remove from array
+  // covers https://github.com/rancher/dashboard/issues/14397
+  {
+    description: 'delete from array',
+    data:        {
+      currentConfig: {
+        id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
         },
-        uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-06-16T10:30:24Z',
+          fields:            [
+            'nc-test-final-1-pool1-mnwmd',
+            '51m'
+          ],
+          generateName:    'nc-test-final-1-pool1-',
+          generation:      2,
+          name:            'nc-test-final-1-pool1-mnwmd',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'test-final-1',
+              uid:        'ed1e8c73-bd86-4a19-966a-cb9c4249e7cf'
+            }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/test-final-1',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '3961358',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
+          },
+          uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [
+                  {
+                    key:      'key',
+                    operator: 'In',
+                    values:   [
+                      'aaa'
+                    ]
+                  },
+                  {
+                    key:      'create-cluster-selector',
+                    operator: 'In',
+                    values:   [
+                      'cccc'
+                    ]
+                  }
+                ],
+                matchLabels: { 'create-cluster-selector': 'cccc' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        },
+        __clone: true
       },
+      latestConfig: {
+        id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-06-16T10:30:24Z',
+          fields:            [
+            'nc-test-final-1-pool1-mnwmd',
+            '34s'
+          ],
+          generateName:  'nc-test-final-1-pool1-',
+          generation:    1,
+          managedFields: [
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': {
+                  'f:ownerReferences': {
+                    '.':                                                {},
+                    'k:{"uid":"ed1e8c73-bd86-4a19-966a-cb9c4249e7cf"}': {}
+                  }
+                }
+              },
+              manager:   'manager',
+              operation: 'Update',
+              time:      '2025-06-16T10:30:24Z'
+            },
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': { 'f:generateName': {} },
+                'f:spec':     {
+                  '.':          {},
+                  'f:template': {
+                    '.':          {},
+                    'f:metadata': {},
+                    'f:spec':     {
+                      '.':          {},
+                      'f:selector': {}
+                    },
+                    'f:status': {
+                      '.':                     {},
+                      'f:addresses':           {},
+                      'f:conditions':          {},
+                      'f:machineInventoryRef': {}
+                    }
+                  }
+                }
+              },
+              manager:   'rancher',
+              operation: 'Update',
+              time:      '2025-06-16T10:30:24Z'
+            }
+          ],
+          name:            'nc-test-final-1-pool1-mnwmd',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'test-final-1',
+              uid:        'ed1e8c73-bd86-4a19-966a-cb9c4249e7cf'
+            }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/test-final-1',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '3960953',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
+          },
+          uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [
+                  {
+                    key:      'key',
+                    operator: 'In',
+                    values:   [
+                      'aaa'
+                    ]
+                  },
+                  {
+                    key:      'key',
+                    operator: 'In',
+                    values:   [
+                      'bbb'
+                    ]
+                  }
+                ],
+                matchLabels: { 'create-cluster-selector': 'cccc' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        }
+      },
+      initialConfig: {
+        id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-06-16T10:30:24Z',
+          fields:            [
+            'nc-test-final-1-pool1-mnwmd',
+            '0s'
+          ],
+          generateName:  'nc-test-final-1-pool1-',
+          generation:    1,
+          managedFields: [
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': { 'f:generateName': {} },
+                'f:spec':     {
+                  '.':          {},
+                  'f:template': {
+                    '.':          {},
+                    'f:metadata': {},
+                    'f:spec':     {
+                      '.':          {},
+                      'f:selector': {}
+                    },
+                    'f:status': {
+                      '.':                     {},
+                      'f:addresses':           {},
+                      'f:conditions':          {},
+                      'f:machineInventoryRef': {}
+                    }
+                  }
+                }
+              },
+              manager:   'rancher',
+              operation: 'Update',
+              time:      '2025-06-16T10:30:24Z'
+            }
+          ],
+          name:            'nc-test-final-1-pool1-mnwmd',
+          namespace:       'fleet-default',
+          relationships:   null,
+          resourceVersion: '3960910',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
+          },
+          uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [
+                  {
+                    key:      'key',
+                    operator: 'In',
+                    values:   [
+                      'aaa'
+                    ]
+                  },
+                  {
+                    key:      'key',
+                    operator: 'In',
+                    values:   [
+                      'bbb'
+                    ]
+                  }
+                ],
+                matchLabels: { 'create-cluster-selector': 'cccc' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        },
+        __clone: true
+      }
+    },
+    result:           false,
+    outputValidation: {
       spec: {
         template: {
           metadata: {},
@@ -58,13 +313,6 @@ export const usecases = {
                   operator: 'In',
                   values:   [
                     'aaa'
-                  ]
-                },
-                {
-                  key:      'key',
-                  operator: 'In',
-                  values:   [
-                    'bbb'
                   ]
                 },
                 {
@@ -85,668 +333,500 @@ export const usecases = {
           }
         }
       },
-      __clone: true
-    },
-    latestConfig: {
-      id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
-      type:  'elemental.cattle.io.machineinventoryselectortemplate',
-      links: {
-        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
-      },
-      apiVersion: 'elemental.cattle.io/v1beta1',
-      kind:       'MachineInventorySelectorTemplate',
-      metadata:   {
-        creationTimestamp: '2025-06-16T10:30:24Z',
-        fields:            [
-          'nc-test-final-1-pool1-mnwmd',
-          '34s'
-        ],
-        generateName:  'nc-test-final-1-pool1-',
-        generation:    1,
-        managedFields: [
-          {
-            apiVersion: 'elemental.cattle.io/v1beta1',
-            fieldsType: 'FieldsV1',
-            fieldsV1:   {
-              'f:metadata': {
-                'f:ownerReferences': {
-                  '.':                                                {},
-                  'k:{"uid":"ed1e8c73-bd86-4a19-966a-cb9c4249e7cf"}': {}
-                }
-              }
-            },
-            manager:   'manager',
-            operation: 'Update',
-            time:      '2025-06-16T10:30:24Z'
-          },
-          {
-            apiVersion: 'elemental.cattle.io/v1beta1',
-            fieldsType: 'FieldsV1',
-            fieldsV1:   {
-              'f:metadata': { 'f:generateName': {} },
-              'f:spec':     {
-                '.':          {},
-                'f:template': {
-                  '.':          {},
-                  'f:metadata': {},
-                  'f:spec':     {
-                    '.':          {},
-                    'f:selector': {}
-                  },
-                  'f:status': {
-                    '.':                     {},
-                    'f:addresses':           {},
-                    'f:conditions':          {},
-                    'f:machineInventoryRef': {}
-                  }
-                }
-              }
-            },
-            manager:   'rancher',
-            operation: 'Update',
-            time:      '2025-06-16T10:30:24Z'
-          }
-        ],
-        name:            'nc-test-final-1-pool1-mnwmd',
-        namespace:       'fleet-default',
-        ownerReferences: [
-          {
-            apiVersion: 'cluster.x-k8s.io/v1beta1',
-            kind:       'Cluster',
-            name:       'test-final-1',
-            uid:        'ed1e8c73-bd86-4a19-966a-cb9c4249e7cf'
-          }
-        ],
-        relationships: [
-          {
-            fromId:   'fleet-default/test-final-1',
-            fromType: 'cluster.x-k8s.io.cluster',
-            rel:      'owner',
-            state:    'provisioned'
-          }
-        ],
-        resourceVersion: '3960953',
-        state:           {
-          error:         false,
-          message:       'Resource is current',
-          name:          'active',
-          transitioning: false
-        },
-        uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
-      },
-      spec: {
-        template: {
-          metadata: {},
-          spec:     {
-            selector: {
-              matchExpressions: [
-                {
-                  key:      'key',
-                  operator: 'In',
-                  values:   [
-                    'aaa'
-                  ]
-                },
-                {
-                  key:      'key',
-                  operator: 'In',
-                  values:   [
-                    'bbb'
-                  ]
-                }
-              ],
-              matchLabels: { 'create-cluster-selector': 'cccc' }
-            }
-          },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
-          }
-        }
-      }
-    },
-    initialConfig: {
-      id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
-      type:  'elemental.cattle.io.machineinventoryselectortemplate',
-      links: {
-        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
-        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
-      },
-      apiVersion: 'elemental.cattle.io/v1beta1',
-      kind:       'MachineInventorySelectorTemplate',
-      metadata:   {
-        creationTimestamp: '2025-06-16T10:30:24Z',
-        fields:            [
-          'nc-test-final-1-pool1-mnwmd',
-          '0s'
-        ],
-        generateName:  'nc-test-final-1-pool1-',
-        generation:    1,
-        managedFields: [
-          {
-            apiVersion: 'elemental.cattle.io/v1beta1',
-            fieldsType: 'FieldsV1',
-            fieldsV1:   {
-              'f:metadata': { 'f:generateName': {} },
-              'f:spec':     {
-                '.':          {},
-                'f:template': {
-                  '.':          {},
-                  'f:metadata': {},
-                  'f:spec':     {
-                    '.':          {},
-                    'f:selector': {}
-                  },
-                  'f:status': {
-                    '.':                     {},
-                    'f:addresses':           {},
-                    'f:conditions':          {},
-                    'f:machineInventoryRef': {}
-                  }
-                }
-              }
-            },
-            manager:   'rancher',
-            operation: 'Update',
-            time:      '2025-06-16T10:30:24Z'
-          }
-        ],
-        name:            'nc-test-final-1-pool1-mnwmd',
-        namespace:       'fleet-default',
-        relationships:   null,
-        resourceVersion: '3960910',
-        state:           {
-          error:         false,
-          message:       'Resource is current',
-          name:          'active',
-          transitioning: false
-        },
-        uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
-      },
-      spec: {
-        template: {
-          metadata: {},
-          spec:     {
-            selector: {
-              matchExpressions: [
-                {
-                  key:      'key',
-                  operator: 'In',
-                  values:   [
-                    'aaa'
-                  ]
-                },
-                {
-                  key:      'key',
-                  operator: 'In',
-                  values:   [
-                    'bbb'
-                  ]
-                }
-              ],
-              matchLabels: { 'create-cluster-selector': 'cccc' }
-            }
-          },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
-          }
-        }
-      },
-      __clone: true
     }
   },
   // 2 different keys, removing one of them
-  usecase2: {
-    currentConfig: {
-      id:    'fleet-default/nc-final-test-pool1-7rw9q',
-      type:  'elemental.cattle.io.machineinventoryselectortemplate',
-      links: {
-        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-      },
-      apiVersion: 'elemental.cattle.io/v1beta1',
-      kind:       'MachineInventorySelectorTemplate',
-      metadata:   {
-        creationTimestamp: '2025-05-30T09:03:40Z',
-        fields:            [
-          'nc-final-test-pool1-7rw9q',
-          '12m'
-        ],
-        generateName:    'nc-final-test-pool1-',
-        generation:      2,
-        name:            'nc-final-test-pool1-7rw9q',
-        namespace:       'fleet-default',
-        ownerReferences: [
-          {
-            apiVersion: 'cluster.x-k8s.io/v1beta1',
-            kind:       'Cluster',
-            name:       'final-test',
-            uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-          }
-        ],
-        relationships: [
-          {
-            fromId:   'fleet-default/final-test',
-            fromType: 'cluster.x-k8s.io.cluster',
-            rel:      'owner',
-            state:    'provisioned'
-          }
-        ],
-        resourceVersion: '970275',
-        state:           {
-          error:         false,
-          message:       'Resource is current',
-          name:          'active',
-          transitioning: false
+  // remove from array
+  // covers https://github.com/rancher/dashboard/issues/14397
+  {
+    description: 'emptying array',
+    data:        {
+      currentConfig: {
+        id:    'fleet-default/nc-final-test-pool1-7rw9q',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
         },
-        uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-      },
-      spec: {
-        template: {
-          metadata: {},
-          spec:     {
-            selector: {
-              matchExpressions: [],
-              matchLabels:      {
-                'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC',
-                key:                       'key1'
-              }
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-05-30T09:03:40Z',
+          fields:            [
+            'nc-final-test-pool1-7rw9q',
+            '12m'
+          ],
+          generateName:    'nc-final-test-pool1-',
+          generation:      2,
+          name:            'nc-final-test-pool1-7rw9q',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'final-test',
+              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
             }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/final-test',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '970275',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
           },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
-          }
-        }
-      },
-      __clone: true
-    },
-    latestConfig: {
-      id:    'fleet-default/nc-final-test-pool1-7rw9q',
-      type:  'elemental.cattle.io.machineinventoryselectortemplate',
-      links: {
-        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-      },
-      apiVersion: 'elemental.cattle.io/v1beta1',
-      kind:       'MachineInventorySelectorTemplate',
-      metadata:   {
-        creationTimestamp: '2025-05-30T09:03:40Z',
-        fields:            [
-          'nc-final-test-pool1-7rw9q',
-          '12m'
-        ],
-        generateName:  'nc-final-test-pool1-',
-        generation:    2,
-        managedFields: [
-          {
-            apiVersion: 'elemental.cattle.io/v1beta1',
-            fieldsType: 'FieldsV1',
-            fieldsV1:   {
-              'f:metadata': {
-                'f:ownerReferences': {
-                  '.':                                                {},
-                  'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
-                }
+          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
               }
             },
-            manager:   'manager',
-            operation: 'Update',
-            time:      '2025-05-30T09:03:41Z'
-          },
-          {
-            apiVersion: 'elemental.cattle.io/v1beta1',
-            fieldsType: 'FieldsV1',
-            fieldsV1:   {
-              'f:metadata': { 'f:generateName': {} },
-              'f:spec':     {
-                '.':          {},
-                'f:template': {
-                  '.':          {},
-                  'f:metadata': {},
-                  'f:spec':     {
-                    '.':          {},
-                    'f:selector': {}
-                  },
-                  'f:status': {
-                    '.':                     {},
-                    'f:addresses':           {},
-                    'f:conditions':          {},
-                    'f:machineInventoryRef': {}
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        id:    'fleet-default/nc-final-test-pool1-7rw9q',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-05-30T09:03:40Z',
+          fields:            [
+            'nc-final-test-pool1-7rw9q',
+            '12m'
+          ],
+          generateName:  'nc-final-test-pool1-',
+          generation:    2,
+          managedFields: [
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': {
+                  'f:ownerReferences': {
+                    '.':                                                {},
+                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
                   }
                 }
+              },
+              manager:   'manager',
+              operation: 'Update',
+              time:      '2025-05-30T09:03:41Z'
+            },
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': { 'f:generateName': {} },
+                'f:spec':     {
+                  '.':          {},
+                  'f:template': {
+                    '.':          {},
+                    'f:metadata': {},
+                    'f:spec':     {
+                      '.':          {},
+                      'f:selector': {}
+                    },
+                    'f:status': {
+                      '.':                     {},
+                      'f:addresses':           {},
+                      'f:conditions':          {},
+                      'f:machineInventoryRef': {}
+                    }
+                  }
+                }
+              },
+              manager:   'rancher',
+              operation: 'Update',
+              time:      '2025-05-30T09:15:58Z'
+            }
+          ],
+          name:            'nc-final-test-pool1-7rw9q',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'final-test',
+              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+            }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/final-test',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '970275',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
+          },
+          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {
+                  'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC',
+                  key:                       'key1'
+                }
               }
             },
-            manager:   'rancher',
-            operation: 'Update',
-            time:      '2025-05-30T09:15:58Z'
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
           }
-        ],
-        name:            'nc-final-test-pool1-7rw9q',
-        namespace:       'fleet-default',
-        ownerReferences: [
-          {
-            apiVersion: 'cluster.x-k8s.io/v1beta1',
-            kind:       'Cluster',
-            name:       'final-test',
-            uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-          }
-        ],
-        relationships: [
-          {
-            fromId:   'fleet-default/final-test',
-            fromType: 'cluster.x-k8s.io.cluster',
-            rel:      'owner',
-            state:    'provisioned'
-          }
-        ],
-        resourceVersion: '970275',
-        state:           {
-          error:         false,
-          message:       'Resource is current',
-          name:          'active',
-          transitioning: false
         },
-        uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+        __clone: true
       },
-      spec: {
-        template: {
-          metadata: {},
-          spec:     {
-            selector: {
-              matchExpressions: [],
-              matchLabels:      {
-                'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC',
-                key:                       'key1'
+      initialConfig: {
+        id:         'fleet-default/nc-final-test-pool1-7rw9q',
+        type:       'elemental.cattle.io.machineinventoryselectortemplate',
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          generateName:    'nc-final-test-pool1-',
+          name:            'nc-final-test-pool1-7rw9q',
+          namespace:       'fleet-default',
+          uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
+          labels:          {},
+          annotations:     {},
+          resourceVersion: '970275'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {
+                  'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC',
+                  key:                       'key1'
+                }
               }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
             }
-          },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
-          }
-        }
-      },
-      __clone: true
-    },
-    initialConfig: {
-      id:         'fleet-default/nc-final-test-pool1-7rw9q',
-      type:       'elemental.cattle.io.machineinventoryselectortemplate',
-      apiVersion: 'elemental.cattle.io/v1beta1',
-      kind:       'MachineInventorySelectorTemplate',
-      metadata:   {
-        generateName:    'nc-final-test-pool1-',
-        name:            'nc-final-test-pool1-7rw9q',
-        namespace:       'fleet-default',
-        uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
-        labels:          {},
-        annotations:     {},
-        resourceVersion: '970275'
-      },
-      spec: {
-        template: {
-          metadata: {},
-          spec:     {
-            selector: {
-              matchExpressions: [],
-              matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
-            }
-          },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
           }
         }
       }
+    },
+    result:           false,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      },
     }
   },
   // 1 key left, removing it (no selectors)
-  usecase3: {
-    currentConfig: {
-      id:    'fleet-default/nc-final-test-pool1-7rw9q',
-      type:  'elemental.cattle.io.machineinventoryselectortemplate',
-      links: {
-        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-      },
-      apiVersion: 'elemental.cattle.io/v1beta1',
-      kind:       'MachineInventorySelectorTemplate',
-      metadata:   {
-        creationTimestamp: '2025-05-30T09:03:40Z',
-        fields:            [
-          'nc-final-test-pool1-7rw9q',
-          '12m'
-        ],
-        generateName:  'nc-final-test-pool1-',
-        generation:    3,
-        managedFields: [
-          {
-            apiVersion: 'elemental.cattle.io/v1beta1',
-            fieldsType: 'FieldsV1',
-            fieldsV1:   {
-              'f:metadata': {
-                'f:ownerReferences': {
-                  '.':                                                {},
-                  'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
-                }
-              }
-            },
-            manager:   'manager',
-            operation: 'Update',
-            time:      '2025-05-30T09:03:41Z'
-          },
-          {
-            apiVersion: 'elemental.cattle.io/v1beta1',
-            fieldsType: 'FieldsV1',
-            fieldsV1:   {
-              'f:metadata': { 'f:generateName': {} },
-              'f:spec':     {
-                '.':          {},
-                'f:template': {
-                  '.':          {},
-                  'f:metadata': {},
-                  'f:spec':     {
-                    '.':          {},
-                    'f:selector': {}
-                  },
-                  'f:status': {
-                    '.':                     {},
-                    'f:addresses':           {},
-                    'f:conditions':          {},
-                    'f:machineInventoryRef': {}
+  // covers https://github.com/rancher/dashboard/issues/14397
+  // remove from object
+  {
+    description: 'emptying object',
+    data:        {
+      currentConfig: {
+        id:    'fleet-default/nc-final-test-pool1-7rw9q',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-05-30T09:03:40Z',
+          fields:            [
+            'nc-final-test-pool1-7rw9q',
+            '12m'
+          ],
+          generateName:  'nc-final-test-pool1-',
+          generation:    3,
+          managedFields: [
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': {
+                  'f:ownerReferences': {
+                    '.':                                                {},
+                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
                   }
                 }
-              }
+              },
+              manager:   'manager',
+              operation: 'Update',
+              time:      '2025-05-30T09:03:41Z'
             },
-            manager:   'rancher',
-            operation: 'Update',
-            time:      '2025-05-30T09:16:20Z'
-          }
-        ],
-        name:            'nc-final-test-pool1-7rw9q',
-        namespace:       'fleet-default',
-        ownerReferences: [
-          {
-            apiVersion: 'cluster.x-k8s.io/v1beta1',
-            kind:       'Cluster',
-            name:       'final-test',
-            uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-          }
-        ],
-        relationships: [
-          {
-            fromId:   'fleet-default/final-test',
-            fromType: 'cluster.x-k8s.io.cluster',
-            rel:      'owner',
-            state:    'provisioned'
-          }
-        ],
-        resourceVersion: '970343',
-        state:           {
-          error:         false,
-          message:       'Resource is current',
-          name:          'active',
-          transitioning: false
-        },
-        uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-      },
-      spec: {
-        template: {
-          metadata: {},
-          spec:     {
-            selector: {
-              matchExpressions: [],
-              matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
-            }
-          },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
-          }
-        }
-      },
-      __clone: true
-    },
-    latestConfig: {
-      id:    'fleet-default/nc-final-test-pool1-7rw9q',
-      type:  'elemental.cattle.io.machineinventoryselectortemplate',
-      links: {
-        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-      },
-      apiVersion: 'elemental.cattle.io/v1beta1',
-      kind:       'MachineInventorySelectorTemplate',
-      metadata:   {
-        creationTimestamp: '2025-05-30T09:03:40Z',
-        fields:            [
-          'nc-final-test-pool1-7rw9q',
-          '13m'
-        ],
-        generateName:  'nc-final-test-pool1-',
-        generation:    3,
-        managedFields: [
-          {
-            apiVersion: 'elemental.cattle.io/v1beta1',
-            fieldsType: 'FieldsV1',
-            fieldsV1:   {
-              'f:metadata': {
-                'f:ownerReferences': {
-                  '.':                                                {},
-                  'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
-                }
-              }
-            },
-            manager:   'manager',
-            operation: 'Update',
-            time:      '2025-05-30T09:03:41Z'
-          },
-          {
-            apiVersion: 'elemental.cattle.io/v1beta1',
-            fieldsType: 'FieldsV1',
-            fieldsV1:   {
-              'f:metadata': { 'f:generateName': {} },
-              'f:spec':     {
-                '.':          {},
-                'f:template': {
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': { 'f:generateName': {} },
+                'f:spec':     {
                   '.':          {},
-                  'f:metadata': {},
-                  'f:spec':     {
+                  'f:template': {
                     '.':          {},
-                    'f:selector': {}
-                  },
-                  'f:status': {
-                    '.':                     {},
-                    'f:addresses':           {},
-                    'f:conditions':          {},
-                    'f:machineInventoryRef': {}
+                    'f:metadata': {},
+                    'f:spec':     {
+                      '.':          {},
+                      'f:selector': {}
+                    },
+                    'f:status': {
+                      '.':                     {},
+                      'f:addresses':           {},
+                      'f:conditions':          {},
+                      'f:machineInventoryRef': {}
+                    }
                   }
                 }
+              },
+              manager:   'rancher',
+              operation: 'Update',
+              time:      '2025-05-30T09:16:20Z'
+            }
+          ],
+          name:            'nc-final-test-pool1-7rw9q',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'final-test',
+              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+            }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/final-test',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '970343',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
+          },
+          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      {}
               }
             },
-            manager:   'rancher',
-            operation: 'Update',
-            time:      '2025-05-30T09:16:20Z'
-          }
-        ],
-        name:            'nc-final-test-pool1-7rw9q',
-        namespace:       'fleet-default',
-        ownerReferences: [
-          {
-            apiVersion: 'cluster.x-k8s.io/v1beta1',
-            kind:       'Cluster',
-            name:       'final-test',
-            uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-          }
-        ],
-        relationships: [
-          {
-            fromId:   'fleet-default/final-test',
-            fromType: 'cluster.x-k8s.io.cluster',
-            rel:      'owner',
-            state:    'provisioned'
-          }
-        ],
-        resourceVersion: '970343',
-        state:           {
-          error:         false,
-          message:       'Resource is current',
-          name:          'active',
-          transitioning: false
-        },
-        uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-      },
-      spec: {
-        template: {
-          metadata: {},
-          spec:     {
-            selector: {
-              matchExpressions: [],
-              matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
             }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        id:    'fleet-default/nc-final-test-pool1-7rw9q',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-05-30T09:03:40Z',
+          fields:            [
+            'nc-final-test-pool1-7rw9q',
+            '13m'
+          ],
+          generateName:  'nc-final-test-pool1-',
+          generation:    3,
+          managedFields: [
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': {
+                  'f:ownerReferences': {
+                    '.':                                                {},
+                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
+                  }
+                }
+              },
+              manager:   'manager',
+              operation: 'Update',
+              time:      '2025-05-30T09:03:41Z'
+            },
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': { 'f:generateName': {} },
+                'f:spec':     {
+                  '.':          {},
+                  'f:template': {
+                    '.':          {},
+                    'f:metadata': {},
+                    'f:spec':     {
+                      '.':          {},
+                      'f:selector': {}
+                    },
+                    'f:status': {
+                      '.':                     {},
+                      'f:addresses':           {},
+                      'f:conditions':          {},
+                      'f:machineInventoryRef': {}
+                    }
+                  }
+                }
+              },
+              manager:   'rancher',
+              operation: 'Update',
+              time:      '2025-05-30T09:16:20Z'
+            }
+          ],
+          name:            'nc-final-test-pool1-7rw9q',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'final-test',
+              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+            }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/final-test',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '970343',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
           },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
+          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        },
+        __clone: true
+      },
+      initialConfig: {
+        id:         'fleet-default/nc-final-test-pool1-7rw9q',
+        type:       'elemental.cattle.io.machineinventoryselectortemplate',
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          generateName:    'nc-final-test-pool1-',
+          name:            'nc-final-test-pool1-7rw9q',
+          namespace:       'fleet-default',
+          uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
+          labels:          {},
+          annotations:     {},
+          resourceVersion: '970343'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
           }
         }
-      },
-      __clone: true
+      }
     },
-    initialConfig: {
-      id:         'fleet-default/nc-final-test-pool1-7rw9q',
-      type:       'elemental.cattle.io.machineinventoryselectortemplate',
-      apiVersion: 'elemental.cattle.io/v1beta1',
-      kind:       'MachineInventorySelectorTemplate',
-      metadata:   {
-        generateName:    'nc-final-test-pool1-',
-        name:            'nc-final-test-pool1-7rw9q',
-        namespace:       'fleet-default',
-        uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
-        labels:          {},
-        annotations:     {},
-        resourceVersion: '970343'
-      },
+    result:           false,
+    outputValidation: {
       spec: {
         template: {
           metadata: {},
@@ -754,6 +834,1200 @@ export const usecases = {
             selector: {
               matchExpressions: [],
               matchLabels:      {}
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      }
+    }
+  },
+  // add to array
+  {
+    description: 'add to array',
+    data:        {
+      currentConfig: {
+        id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-06-16T10:30:24Z',
+          fields:            [
+            'nc-test-final-1-pool1-mnwmd',
+            '51m'
+          ],
+          generateName:    'nc-test-final-1-pool1-',
+          generation:      2,
+          name:            'nc-test-final-1-pool1-mnwmd',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'test-final-1',
+              uid:        'ed1e8c73-bd86-4a19-966a-cb9c4249e7cf'
+            }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/test-final-1',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '3961358',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
+          },
+          uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [
+                  {
+                    key:      'key',
+                    operator: 'In',
+                    values:   [
+                      'aaa'
+                    ]
+                  },
+                  {
+                    key:      'key',
+                    operator: 'In',
+                    values:   [
+                      'bbb'
+                    ]
+                  },
+                  {
+                    key:      'key',
+                    operator: 'In',
+                    values:   [
+                      'ccc'
+                    ]
+                  },
+                  {
+                    key:      'create-cluster-selector',
+                    operator: 'In',
+                    values:   [
+                      'cccc'
+                    ]
+                  }
+                ],
+                matchLabels: { 'create-cluster-selector': 'cccc' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-06-16T10:30:24Z',
+          fields:            [
+            'nc-test-final-1-pool1-mnwmd',
+            '34s'
+          ],
+          generateName:  'nc-test-final-1-pool1-',
+          generation:    1,
+          managedFields: [
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': {
+                  'f:ownerReferences': {
+                    '.':                                                {},
+                    'k:{"uid":"ed1e8c73-bd86-4a19-966a-cb9c4249e7cf"}': {}
+                  }
+                }
+              },
+              manager:   'manager',
+              operation: 'Update',
+              time:      '2025-06-16T10:30:24Z'
+            },
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': { 'f:generateName': {} },
+                'f:spec':     {
+                  '.':          {},
+                  'f:template': {
+                    '.':          {},
+                    'f:metadata': {},
+                    'f:spec':     {
+                      '.':          {},
+                      'f:selector': {}
+                    },
+                    'f:status': {
+                      '.':                     {},
+                      'f:addresses':           {},
+                      'f:conditions':          {},
+                      'f:machineInventoryRef': {}
+                    }
+                  }
+                }
+              },
+              manager:   'rancher',
+              operation: 'Update',
+              time:      '2025-06-16T10:30:24Z'
+            }
+          ],
+          name:            'nc-test-final-1-pool1-mnwmd',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'test-final-1',
+              uid:        'ed1e8c73-bd86-4a19-966a-cb9c4249e7cf'
+            }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/test-final-1',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '3960953',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
+          },
+          uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [
+                  {
+                    key:      'key',
+                    operator: 'In',
+                    values:   [
+                      'aaa'
+                    ]
+                  },
+                  {
+                    key:      'key',
+                    operator: 'In',
+                    values:   [
+                      'bbb'
+                    ]
+                  }
+                ],
+                matchLabels: { 'create-cluster-selector': 'cccc' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        }
+      },
+      initialConfig: {
+        id:    'fleet-default/nc-test-final-1-pool1-mnwmd',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-test-final-1-pool1-mnwmd',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-test-final-1-pool1-mnwmd'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-06-16T10:30:24Z',
+          fields:            [
+            'nc-test-final-1-pool1-mnwmd',
+            '0s'
+          ],
+          generateName:  'nc-test-final-1-pool1-',
+          generation:    1,
+          managedFields: [
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': { 'f:generateName': {} },
+                'f:spec':     {
+                  '.':          {},
+                  'f:template': {
+                    '.':          {},
+                    'f:metadata': {},
+                    'f:spec':     {
+                      '.':          {},
+                      'f:selector': {}
+                    },
+                    'f:status': {
+                      '.':                     {},
+                      'f:addresses':           {},
+                      'f:conditions':          {},
+                      'f:machineInventoryRef': {}
+                    }
+                  }
+                }
+              },
+              manager:   'rancher',
+              operation: 'Update',
+              time:      '2025-06-16T10:30:24Z'
+            }
+          ],
+          name:            'nc-test-final-1-pool1-mnwmd',
+          namespace:       'fleet-default',
+          relationships:   null,
+          resourceVersion: '3960910',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
+          },
+          uid: 'bcf115a9-cfb3-416f-8622-98753b9d3081'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [
+                  {
+                    key:      'key',
+                    operator: 'In',
+                    values:   [
+                      'aaa'
+                    ]
+                  },
+                  {
+                    key:      'key',
+                    operator: 'In',
+                    values:   [
+                      'bbb'
+                    ]
+                  }
+                ],
+                matchLabels: { 'create-cluster-selector': 'cccc' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        },
+        __clone: true
+      }
+    },
+    result:           false,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [
+                {
+                  key:      'key',
+                  operator: 'In',
+                  values:   [
+                    'aaa'
+                  ]
+                },
+                {
+                  key:      'key',
+                  operator: 'In',
+                  values:   [
+                    'bbb'
+                  ]
+                },
+                {
+                  key:      'key',
+                  operator: 'In',
+                  values:   [
+                    'ccc'
+                  ]
+                },
+                {
+                  key:      'create-cluster-selector',
+                  operator: 'In',
+                  values:   [
+                    'cccc'
+                  ]
+                }
+              ],
+              matchLabels: { 'create-cluster-selector': 'cccc' }
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      },
+    }
+  },
+  // edit an array
+  {
+    description: 'edit an array',
+    data:        {
+      currentConfig: {
+        id:    'fleet-default/nc-final-test-pool1-7rw9q',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-05-30T09:03:40Z',
+          fields:            [
+            'nc-final-test-pool1-7rw9q',
+            '12m'
+          ],
+          generateName:    'nc-final-test-pool1-',
+          generation:      2,
+          name:            'nc-final-test-pool1-7rw9q',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'final-test',
+              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+            }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/final-test',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '970275',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
+          },
+          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [
+                  {
+                    key:      'key',
+                    operator: 'In',
+                    values:   [
+                      'aaa-edited'
+                    ]
+                  },
+                  {
+                    key:      'create-cluster-selector',
+                    operator: 'In',
+                    values:   [
+                      'cccc'
+                    ]
+                  }
+                ],
+                matchLabels: { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        id:    'fleet-default/nc-final-test-pool1-7rw9q',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-05-30T09:03:40Z',
+          fields:            [
+            'nc-final-test-pool1-7rw9q',
+            '12m'
+          ],
+          generateName:  'nc-final-test-pool1-',
+          generation:    2,
+          managedFields: [
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': {
+                  'f:ownerReferences': {
+                    '.':                                                {},
+                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
+                  }
+                }
+              },
+              manager:   'manager',
+              operation: 'Update',
+              time:      '2025-05-30T09:03:41Z'
+            },
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': { 'f:generateName': {} },
+                'f:spec':     {
+                  '.':          {},
+                  'f:template': {
+                    '.':          {},
+                    'f:metadata': {},
+                    'f:spec':     {
+                      '.':          {},
+                      'f:selector': {}
+                    },
+                    'f:status': {
+                      '.':                     {},
+                      'f:addresses':           {},
+                      'f:conditions':          {},
+                      'f:machineInventoryRef': {}
+                    }
+                  }
+                }
+              },
+              manager:   'rancher',
+              operation: 'Update',
+              time:      '2025-05-30T09:15:58Z'
+            }
+          ],
+          name:            'nc-final-test-pool1-7rw9q',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'final-test',
+              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+            }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/final-test',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '970275',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
+          },
+          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [
+                  {
+                    key:      'key',
+                    operator: 'In',
+                    values:   [
+                      'aaa'
+                    ]
+                  },
+                  {
+                    key:      'create-cluster-selector',
+                    operator: 'In',
+                    values:   [
+                      'cccc'
+                    ]
+                  }
+                ],
+                matchLabels: { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        },
+        __clone: true
+      },
+      initialConfig: {
+        id:         'fleet-default/nc-final-test-pool1-7rw9q',
+        type:       'elemental.cattle.io.machineinventoryselectortemplate',
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          generateName:    'nc-final-test-pool1-',
+          name:            'nc-final-test-pool1-7rw9q',
+          namespace:       'fleet-default',
+          uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
+          labels:          {},
+          annotations:     {},
+          resourceVersion: '970275'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [
+                  {
+                    key:      'key',
+                    operator: 'In',
+                    values:   [
+                      'aaa'
+                    ]
+                  },
+                  {
+                    key:      'create-cluster-selector',
+                    operator: 'In',
+                    values:   [
+                      'cccc'
+                    ]
+                  }
+                ],
+                matchLabels: { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        }
+      }
+    },
+    result:           false,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [
+                {
+                  key:      'key',
+                  operator: 'In',
+                  values:   [
+                    'aaa-edited'
+                  ]
+                },
+                {
+                  key:      'create-cluster-selector',
+                  operator: 'In',
+                  values:   [
+                    'cccc'
+                  ]
+                }
+              ],
+              matchLabels: { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      },
+    }
+  },
+  // add key to object
+  {
+    description: 'add key to object',
+    data:        {
+      currentConfig: {
+        id:    'fleet-default/nc-final-test-pool1-7rw9q',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-05-30T09:03:40Z',
+          fields:            [
+            'nc-final-test-pool1-7rw9q',
+            '12m'
+          ],
+          generateName:  'nc-final-test-pool1-',
+          generation:    3,
+          managedFields: [
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': {
+                  'f:ownerReferences': {
+                    '.':                                                {},
+                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
+                  }
+                }
+              },
+              manager:   'manager',
+              operation: 'Update',
+              time:      '2025-05-30T09:03:41Z'
+            },
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': { 'f:generateName': {} },
+                'f:spec':     {
+                  '.':          {},
+                  'f:template': {
+                    '.':          {},
+                    'f:metadata': {},
+                    'f:spec':     {
+                      '.':          {},
+                      'f:selector': {}
+                    },
+                    'f:status': {
+                      '.':                     {},
+                      'f:addresses':           {},
+                      'f:conditions':          {},
+                      'f:machineInventoryRef': {}
+                    }
+                  }
+                }
+              },
+              manager:   'rancher',
+              operation: 'Update',
+              time:      '2025-05-30T09:16:20Z'
+            }
+          ],
+          name:            'nc-final-test-pool1-7rw9q',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'final-test',
+              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+            }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/final-test',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '970343',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
+          },
+          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC', 'new-key': 'new-value' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        id:    'fleet-default/nc-final-test-pool1-7rw9q',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-05-30T09:03:40Z',
+          fields:            [
+            'nc-final-test-pool1-7rw9q',
+            '13m'
+          ],
+          generateName:  'nc-final-test-pool1-',
+          generation:    3,
+          managedFields: [
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': {
+                  'f:ownerReferences': {
+                    '.':                                                {},
+                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
+                  }
+                }
+              },
+              manager:   'manager',
+              operation: 'Update',
+              time:      '2025-05-30T09:03:41Z'
+            },
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': { 'f:generateName': {} },
+                'f:spec':     {
+                  '.':          {},
+                  'f:template': {
+                    '.':          {},
+                    'f:metadata': {},
+                    'f:spec':     {
+                      '.':          {},
+                      'f:selector': {}
+                    },
+                    'f:status': {
+                      '.':                     {},
+                      'f:addresses':           {},
+                      'f:conditions':          {},
+                      'f:machineInventoryRef': {}
+                    }
+                  }
+                }
+              },
+              manager:   'rancher',
+              operation: 'Update',
+              time:      '2025-05-30T09:16:20Z'
+            }
+          ],
+          name:            'nc-final-test-pool1-7rw9q',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'final-test',
+              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+            }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/final-test',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '970343',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
+          },
+          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        },
+        __clone: true
+      },
+      initialConfig: {
+        id:         'fleet-default/nc-final-test-pool1-7rw9q',
+        type:       'elemental.cattle.io.machineinventoryselectortemplate',
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          generateName:    'nc-final-test-pool1-',
+          name:            'nc-final-test-pool1-7rw9q',
+          namespace:       'fleet-default',
+          uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
+          labels:          {},
+          annotations:     {},
+          resourceVersion: '970343'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        }
+      }
+    },
+    result:           false,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC', 'new-key': 'new-value' }
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      }
+    }
+  },
+  // edit an object key value
+  {
+    description: 'edit object key-value',
+    data:        {
+      currentConfig: {
+        id:    'fleet-default/nc-final-test-pool1-7rw9q',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-05-30T09:03:40Z',
+          fields:            [
+            'nc-final-test-pool1-7rw9q',
+            '12m'
+          ],
+          generateName:  'nc-final-test-pool1-',
+          generation:    3,
+          managedFields: [
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': {
+                  'f:ownerReferences': {
+                    '.':                                                {},
+                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
+                  }
+                }
+              },
+              manager:   'manager',
+              operation: 'Update',
+              time:      '2025-05-30T09:03:41Z'
+            },
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': { 'f:generateName': {} },
+                'f:spec':     {
+                  '.':          {},
+                  'f:template': {
+                    '.':          {},
+                    'f:metadata': {},
+                    'f:spec':     {
+                      '.':          {},
+                      'f:selector': {}
+                    },
+                    'f:status': {
+                      '.':                     {},
+                      'f:addresses':           {},
+                      'f:conditions':          {},
+                      'f:machineInventoryRef': {}
+                    }
+                  }
+                }
+              },
+              manager:   'rancher',
+              operation: 'Update',
+              time:      '2025-05-30T09:16:20Z'
+            }
+          ],
+          name:            'nc-final-test-pool1-7rw9q',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'final-test',
+              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+            }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/final-test',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '970343',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
+          },
+          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC-edited' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        },
+        __clone: true
+      },
+      latestConfig: {
+        id:    'fleet-default/nc-final-test-pool1-7rw9q',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-05-30T09:03:40Z',
+          fields:            [
+            'nc-final-test-pool1-7rw9q',
+            '13m'
+          ],
+          generateName:  'nc-final-test-pool1-',
+          generation:    3,
+          managedFields: [
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': {
+                  'f:ownerReferences': {
+                    '.':                                                {},
+                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
+                  }
+                }
+              },
+              manager:   'manager',
+              operation: 'Update',
+              time:      '2025-05-30T09:03:41Z'
+            },
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': { 'f:generateName': {} },
+                'f:spec':     {
+                  '.':          {},
+                  'f:template': {
+                    '.':          {},
+                    'f:metadata': {},
+                    'f:spec':     {
+                      '.':          {},
+                      'f:selector': {}
+                    },
+                    'f:status': {
+                      '.':                     {},
+                      'f:addresses':           {},
+                      'f:conditions':          {},
+                      'f:machineInventoryRef': {}
+                    }
+                  }
+                }
+              },
+              manager:   'rancher',
+              operation: 'Update',
+              time:      '2025-05-30T09:16:20Z'
+            }
+          ],
+          name:            'nc-final-test-pool1-7rw9q',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'final-test',
+              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+            }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/final-test',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '970343',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
+          },
+          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        },
+        __clone: true
+      },
+      initialConfig: {
+        id:         'fleet-default/nc-final-test-pool1-7rw9q',
+        type:       'elemental.cattle.io.machineinventoryselectortemplate',
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          generateName:    'nc-final-test-pool1-',
+          name:            'nc-final-test-pool1-7rw9q',
+          namespace:       'fleet-default',
+          uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
+          labels:          {},
+          annotations:     {},
+          resourceVersion: '970343'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: [],
+                matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
+          }
+        }
+      }
+    },
+    result:           false,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: [],
+              matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC-edited' }
             }
           },
           status: {
@@ -766,253 +2040,276 @@ export const usecases = {
     }
   },
   // FAIL!!! - matchLabels changed on both latest and current + resourceVersion on latest
-  usecase4: {
-    currentConfig: {
-      id:    'fleet-default/nc-final-test-pool1-7rw9q',
-      type:  'elemental.cattle.io.machineinventoryselectortemplate',
-      links: {
-        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-      },
-      apiVersion: 'elemental.cattle.io/v1beta1',
-      kind:       'MachineInventorySelectorTemplate',
-      metadata:   {
-        creationTimestamp: '2025-05-30T09:03:40Z',
-        fields:            [
-          'nc-final-test-pool1-7rw9q',
-          '12m'
-        ],
-        generateName:  'nc-final-test-pool1-',
-        generation:    3,
-        managedFields: [
-          {
-            apiVersion: 'elemental.cattle.io/v1beta1',
-            fieldsType: 'FieldsV1',
-            fieldsV1:   {
-              'f:metadata': {
-                'f:ownerReferences': {
-                  '.':                                                {},
-                  'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
-                }
-              }
-            },
-            manager:   'manager',
-            operation: 'Update',
-            time:      '2025-05-30T09:03:41Z'
-          },
-          {
-            apiVersion: 'elemental.cattle.io/v1beta1',
-            fieldsType: 'FieldsV1',
-            fieldsV1:   {
-              'f:metadata': { 'f:generateName': {} },
-              'f:spec':     {
-                '.':          {},
-                'f:template': {
-                  '.':          {},
-                  'f:metadata': {},
-                  'f:spec':     {
-                    '.':          {},
-                    'f:selector': {}
-                  },
-                  'f:status': {
-                    '.':                     {},
-                    'f:addresses':           {},
-                    'f:conditions':          {},
-                    'f:machineInventoryRef': {}
+  // basic fail usecase
+  {
+    description: 'with basic conflict',
+    data:        {
+      currentConfig: {
+        id:    'fleet-default/nc-final-test-pool1-7rw9q1111',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q1111',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q1111',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q1111',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q1111'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-05-30T09:03:40Z',
+          fields:            [
+            'nc-final-test-pool1-7rw9q1111',
+            '12m'
+          ],
+          generateName:  'nc-final-test-pool1-',
+          generation:    3,
+          managedFields: [
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': {
+                  'f:ownerReferences': {
+                    '.':                                                {},
+                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
                   }
                 }
-              }
+              },
+              manager:   'manager',
+              operation: 'Update',
+              time:      '2025-05-30T09:03:41Z'
             },
-            manager:   'rancher',
-            operation: 'Update',
-            time:      '2025-05-30T09:16:20Z'
-          }
-        ],
-        name:            'nc-final-test-pool1-7rw9q',
-        namespace:       'fleet-default',
-        ownerReferences: [
-          {
-            apiVersion: 'cluster.x-k8s.io/v1beta1',
-            kind:       'Cluster',
-            name:       'final-test',
-            uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-          }
-        ],
-        relationships: [
-          {
-            fromId:   'fleet-default/final-test',
-            fromType: 'cluster.x-k8s.io.cluster',
-            rel:      'owner',
-            state:    'provisioned'
-          }
-        ],
-        resourceVersion: '970343',
-        state:           {
-          error:         false,
-          message:       'Resource is current',
-          name:          'active',
-          transitioning: false
-        },
-        uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
-      },
-      spec: {
-        template: {
-          metadata: {},
-          spec:     {
-            selector: {
-              matchExpressions: [],
-              matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxCbbbbbbbbb' }
-            }
-          },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
-          }
-        }
-      },
-      __clone: true
-    },
-    latestConfig: {
-      id:    'fleet-default/nc-final-test-pool1-7rw9q',
-      type:  'elemental.cattle.io.machineinventoryselectortemplate',
-      links: {
-        remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q',
-        view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q'
-      },
-      apiVersion: 'elemental.cattle.io/v1beta1',
-      kind:       'MachineInventorySelectorTemplate',
-      metadata:   {
-        creationTimestamp: '2025-05-30T09:03:40Z',
-        fields:            [
-          'nc-final-test-pool1-7rw9q',
-          '13m'
-        ],
-        generateName:  'nc-final-test-pool1-',
-        generation:    3,
-        managedFields: [
-          {
-            apiVersion: 'elemental.cattle.io/v1beta1',
-            fieldsType: 'FieldsV1',
-            fieldsV1:   {
-              'f:metadata': {
-                'f:ownerReferences': {
-                  '.':                                                {},
-                  'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
-                }
-              }
-            },
-            manager:   'manager',
-            operation: 'Update',
-            time:      '2025-05-30T09:03:41Z'
-          },
-          {
-            apiVersion: 'elemental.cattle.io/v1beta1',
-            fieldsType: 'FieldsV1',
-            fieldsV1:   {
-              'f:metadata': { 'f:generateName': {} },
-              'f:spec':     {
-                '.':          {},
-                'f:template': {
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': { 'f:generateName': {} },
+                'f:spec':     {
                   '.':          {},
-                  'f:metadata': {},
-                  'f:spec':     {
+                  'f:template': {
                     '.':          {},
-                    'f:selector': {}
-                  },
-                  'f:status': {
-                    '.':                     {},
-                    'f:addresses':           {},
-                    'f:conditions':          {},
-                    'f:machineInventoryRef': {}
+                    'f:metadata': {},
+                    'f:spec':     {
+                      '.':          {},
+                      'f:selector': {}
+                    },
+                    'f:status': {
+                      '.':                     {},
+                      'f:addresses':           {},
+                      'f:conditions':          {},
+                      'f:machineInventoryRef': {}
+                    }
                   }
                 }
+              },
+              manager:   'rancher',
+              operation: 'Update',
+              time:      '2025-05-30T09:16:20Z'
+            }
+          ],
+          name:            'nc-final-test-pool1-7rw9q1111',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'final-test',
+              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+            }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/final-test',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '970343',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
+          },
+          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: ['current_user_update_exp'],
+                matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC_current_user_update' }
               }
             },
-            manager:   'rancher',
-            operation: 'Update',
-            time:      '2025-05-30T09:16:20Z'
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
           }
-        ],
-        name:            'nc-final-test-pool1-7rw9q',
-        namespace:       'fleet-default',
-        ownerReferences: [
-          {
-            apiVersion: 'cluster.x-k8s.io/v1beta1',
-            kind:       'Cluster',
-            name:       'final-test',
-            uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
-          }
-        ],
-        relationships: [
-          {
-            fromId:   'fleet-default/final-test',
-            fromType: 'cluster.x-k8s.io.cluster',
-            rel:      'owner',
-            state:    'provisioned'
-          }
-        ],
-        resourceVersion: '970344',
-        state:           {
-          error:         false,
-          message:       'Resource is current',
-          name:          'active',
-          transitioning: false
         },
-        uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+        __clone: true
       },
-      spec: {
-        template: {
-          metadata: {},
-          spec:     {
-            selector: {
-              matchExpressions: [],
-              matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxCaaaa' }
+      latestConfig: {
+        id:    'fleet-default/nc-final-test-pool1-7rw9q1111',
+        type:  'elemental.cattle.io.machineinventoryselectortemplate',
+        links: {
+          remove: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q1111',
+          self:   'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q1111',
+          update: 'https://localhost:8005/v1/elemental.cattle.io.machineinventoryselectortemplates/fleet-default/nc-final-test-pool1-7rw9q1111',
+          view:   'https://localhost:8005/apis/elemental.cattle.io/v1beta1/namespaces/fleet-default/machineinventoryselectortemplates/nc-final-test-pool1-7rw9q1111'
+        },
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          creationTimestamp: '2025-05-30T09:03:40Z',
+          fields:            [
+            'nc-final-test-pool1-7rw9q1111',
+            '13m'
+          ],
+          generateName:  'nc-final-test-pool1-',
+          generation:    3,
+          managedFields: [
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': {
+                  'f:ownerReferences': {
+                    '.':                                                {},
+                    'k:{"uid":"0f7602c5-cd8a-41b7-a4ff-30312f882df5"}': {}
+                  }
+                }
+              },
+              manager:   'manager',
+              operation: 'Update',
+              time:      '2025-05-30T09:03:41Z'
+            },
+            {
+              apiVersion: 'elemental.cattle.io/v1beta1',
+              fieldsType: 'FieldsV1',
+              fieldsV1:   {
+                'f:metadata': { 'f:generateName': {} },
+                'f:spec':     {
+                  '.':          {},
+                  'f:template': {
+                    '.':          {},
+                    'f:metadata': {},
+                    'f:spec':     {
+                      '.':          {},
+                      'f:selector': {}
+                    },
+                    'f:status': {
+                      '.':                     {},
+                      'f:addresses':           {},
+                      'f:conditions':          {},
+                      'f:machineInventoryRef': {}
+                    }
+                  }
+                }
+              },
+              manager:   'rancher',
+              operation: 'Update',
+              time:      '2025-05-30T09:16:20Z'
             }
+          ],
+          name:            'nc-final-test-pool1-7rw9q1111',
+          namespace:       'fleet-default',
+          ownerReferences: [
+            {
+              apiVersion: 'cluster.x-k8s.io/v1beta1',
+              kind:       'Cluster',
+              name:       'final-test',
+              uid:        '0f7602c5-cd8a-41b7-a4ff-30312f882df5'
+            }
+          ],
+          relationships: [
+            {
+              fromId:   'fleet-default/final-test',
+              fromType: 'cluster.x-k8s.io.cluster',
+              rel:      'owner',
+              state:    'provisioned'
+            }
+          ],
+          resourceVersion: '970344',
+          state:           {
+            error:         false,
+            message:       'Resource is current',
+            name:          'active',
+            transitioning: false
           },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
+          uid: '8f2ab229-3bcc-4412-a2d6-f8036dfc4769'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: ['live_server_value'],
+                matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxClive_server_value' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
+            }
           }
-        }
+        },
+        __clone: true
       },
-      __clone: true
-    },
-    initialConfig: {
-      id:         'fleet-default/nc-final-test-pool1-7rw9q',
-      type:       'elemental.cattle.io.machineinventoryselectortemplate',
-      apiVersion: 'elemental.cattle.io/v1beta1',
-      kind:       'MachineInventorySelectorTemplate',
-      metadata:   {
-        generateName:    'nc-final-test-pool1-',
-        name:            'nc-final-test-pool1-7rw9q',
-        namespace:       'fleet-default',
-        uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
-        labels:          {},
-        annotations:     {},
-        resourceVersion: '970343'
-      },
-      spec: {
-        template: {
-          metadata: {},
-          spec:     {
-            selector: {
-              matchExpressions: [],
-              matchLabels:      {}
+      initialConfig: {
+        id:         'fleet-default/nc-final-test-pool1-7rw9q1111',
+        type:       'elemental.cattle.io.machineinventoryselectortemplate',
+        apiVersion: 'elemental.cattle.io/v1beta1',
+        kind:       'MachineInventorySelectorTemplate',
+        metadata:   {
+          generateName:    'nc-final-test-pool1-',
+          name:            'nc-final-test-pool1-7rw9q1111',
+          namespace:       'fleet-default',
+          uid:             '8f2ab229-3bcc-4412-a2d6-f8036dfc4769',
+          labels:          {},
+          annotations:     {},
+          resourceVersion: '970343'
+        },
+        spec: {
+          template: {
+            metadata: {},
+            spec:     {
+              selector: {
+                matchExpressions: ['some-exp'],
+                matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxC' }
+              }
+            },
+            status: {
+              addresses:           [],
+              conditions:          [],
+              machineInventoryRef: {}
             }
-          },
-          status: {
-            addresses:           [],
-            conditions:          [],
-            machineInventoryRef: {}
           }
         }
       }
+    },
+    result:           1,
+    outputValidation: {
+      spec: {
+        template: {
+          metadata: {},
+          spec:     {
+            selector: {
+              matchExpressions: ['live_server_value'],
+              matchLabels:      { 'create-cluster-selector': 'Z3soEpn7z3OSoktiJsmVHuxClive_server_value' }
+            }
+          },
+          status: {
+            addresses:           [],
+            conditions:          [],
+            machineInventoryRef: {}
+          }
+        }
+      },
     }
   }
-};
+];

--- a/shell/plugins/dashboard-store/normalize.js
+++ b/shell/plugins/dashboard-store/normalize.js
@@ -17,24 +17,36 @@ export function normalizeType(type) {
   return type;
 }
 
-// Detect and resolve conflicts from a 409 response.
-// If they are resolved, return a false-y value
-// Else they can't be resolved, return an array of errors to show to the user.
-export async function handleConflict(initialValueJSON, value, liveValue, rootGetters, store, storeNamespace) {
-  const orig = await store.dispatch(`${ storeNamespace }/cleanForDiff`, initialValueJSON, { root: true });
-  const user = await store.dispatch(`${ storeNamespace }/cleanForDiff`, value.toJSON(), { root: true });
-  const cur = await store.dispatch(`${ storeNamespace }/cleanForDiff`, liveValue.toJSON(), { root: true });
+/**
+ * Detect and resolve conflicts from a 409 response.
+ *
+ * @param {*} initialValueJSON the initial value before changes
+ * @param {*} userValue the value containing the local changes. this function will intentionally mutate this to contain changes made from the server
+ * @param {*} serverValue the very latest value from the server
+ * @returns If `value` has been successfully updated return a false-y value. Else they can't be resolved, return an array of errors to show the user.
+ */
+export async function handleConflict(initialValueJSON, userValue, serverValue, rootGetters, store, storeNamespace) {
+  // initial value
+  const initial = await store.dispatch(`${ storeNamespace }/cleanForDiff`, initialValueJSON, { root: true });
+  // changed value (user edits)
+  const user = await store.dispatch(`${ storeNamespace }/cleanForDiff`, userValue.toJSON(), { root: true });
+  // server value
+  const server = await store.dispatch(`${ storeNamespace }/cleanForDiff`, serverValue.toJSON(), { root: true });
 
-  const bgChange = changeset(orig, cur);
-  const userChange = changeset(orig, user);
-  const actualConflicts = changesetConflicts(bgChange, userChange);
+  // changes made to the server value
+  const serverChanges = changeset(initial, server);
+  // changes made locally
+  const userChanges = changeset(initial, user);
+  // Any incompatibilities between changes made locally and the server?
+  const actualConflicts = changesetConflicts(serverChanges, userChanges);
 
-  console.log('Background Change', bgChange); // eslint-disable-line no-console
-  console.log('User Change', userChange); // eslint-disable-line no-console
+  console.log('Background Change', serverChanges); // eslint-disable-line no-console
+  console.log('User Change', userChanges); // eslint-disable-line no-console
   console.log('Conflicts', actualConflicts); // eslint-disable-line no-console
 
-  value.metadata.resourceVersion = liveValue.metadata.resourceVersion;
-  applyChangeset(value, bgChange);
+  userValue.metadata.resourceVersion = serverValue.metadata.resourceVersion;
+  // Apply changes made on the server to the changed (user) value
+  applyChangeset(userValue, serverChanges);
 
   if ( actualConflicts.length ) {
     // Stop the save and let the user inspect and continue editing


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14397 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- replace `mergeWithReplace` and `merge` with `handleConflict` function on machine pools sync mechanism

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- I've had a go at creating unit tests and hit a lot of barriers along the way because the `handleConflict` uses a lot of accessorial methods, but I just couldn't circumvent the problems I hit on `changeset` method, so this needs to be manually tested

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Install Elemental `3.x.x` along with the operator
- Go to `Elemental`, `Inventory of Machines` and create an instance of this resource via `create YAML` where you should:
   1) add any name
   2) on `metadata`, add the following label 
   ```
   labels:  
     key: 'some-string'
   ```
   having a label with key `key` is important
   
- On the list view of `Inventory of Machines`, select that row item and on the table actions (bulk) select `Create Elemental Cluster`
- On the `Inventory of Machines Selector Template` part, leave the `create-cluster-selector`
- add another selector (row) with key `key`, `in list`, value `value1`
- add another selector (row) with key `key`, `in list`, value `value2`
- Save

Scenarios to test:
- edit cluster, remove one of the rows for key `key` in `Inventory of Machines Selector Template` -> data should be cleared after save (check by going to edit again)
- edit cluster, delete the remaining row for key `key` in `Inventory of Machines Selector Template` -> data should be cleared after save (check by going to edit again) -> `mergeWithReplace` would definitely fail here
- edit cluster, delete the row for key `create-cluster-selector` (only row left) in `Inventory of Machines Selector Template` -> data should be cleared after save (check by going to edit again) -> `mergeWithReplace` would definitely fail here

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- make sure we don't regress in https://github.com/rancher/dashboard/pull/10741
- make sure we don't regress in https://github.com/rancher/dashboard/pull/14200

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
