### PR TITLE
Fix missing Elemental cluster creation tile

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -343,12 +343,9 @@ export default {
           });
         });
 
+        // If Elemental is installed, then add the elemental cluster provider
         if (isElementalActive) {
-          // !this.subType means we are on the /create screen - we only want to show for rke2
-          // if a subType is selected, always add the ELEMENTAL_CLUSTER_PROVIDER type to cover edit scenarios
-          if ((!this.subType && this.isRke2) || this.subType) {
-            addType(this.$plugin, ELEMENTAL_CLUSTER_PROVIDER, 'custom2', false);
-          }
+          addType(this.$plugin, ELEMENTAL_CLUSTER_PROVIDER, 'custom2', false);
         }
 
         // Only add the RKE2 options if RKE2 is enabled


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Follow-on work for https://github.com/rancher/dashboard/issues/14088

Fixes an issue where the cluster tile for Elemental no longer appears.

### Technical notes summary

See code - the logic was broken by the RKE1 removal.

### Areas or cases that should be tested

Marked as QA/None - expectation is that reviewer will validate that the Elemental tile is back - this should be sufficient.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
