### PR TITLE
Ensure refresh button correctly clears table selection

### DIFF
--- a/shell/components/PaginatedResourceTable.vue
+++ b/shell/components/PaginatedResourceTable.vue
@@ -95,6 +95,12 @@ export default defineComponent({
 
       return customHeaders || this.$store.getters['type-map/headersFor'](this.schema, this.canPaginate);
     }
+  },
+
+  methods: {
+    clearSelection() {
+      this.$refs.table.clearSelection();
+    },
   }
 });
 
@@ -103,6 +109,7 @@ export default defineComponent({
 <template>
   <div>
     <ResourceTable
+      ref="table"
       v-bind="$attrs"
       :schema="schema"
       :rows="rows"

--- a/shell/components/SortableTable/selection.js
+++ b/shell/components/SortableTable/selection.js
@@ -531,7 +531,7 @@ export default {
     },
 
     clearSelection() {
-      this.update([], this.selectedRows);
+      this.update([], [...this.selectedRows]);
     },
 
   }

--- a/shell/mixins/resource-fetch.js
+++ b/shell/mixins/resource-fetch.js
@@ -124,6 +124,9 @@ export default {
       // this is where the data assignment will trigger the update of the list view...
       if (this.init && neu) {
         await this.$fetch();
+        if (this.clearSelection) {
+          this.clearSelection();
+        }
         if (this.canPaginate && this.fetchPageSecondaryResources) {
           this.fetchPageSecondaryResources({
             canPaginate: this.canPaginate, force: true, page: this.rows, pagResult: this.paginationResult


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14448
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- On manul refresh with vai on ensure that the table's selection state (row highlighting, checkbox, total count at top) is reset once the user has clicked refresh

### Technical notes summary
- need to understand how this should / will work when resource's are automatically updated

### Areas or cases that should be tested
- vai on, any list, make a few selections hit refresh

### Areas which could experience regressions
- projects/namespace list `move` namespace (though this looks already broken)

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
