### PR TITLE
[Automation] Vai: Add workloads tests

### DIFF
--- a/cypress/e2e/blueprints/explorer/workloads/cronjobs/cronjobs-get.ts
+++ b/cypress/e2e/blueprints/explorer/workloads/cronjobs/cronjobs-get.ts
@@ -1,0 +1,74 @@
+import { CYPRESS_SAFE_RESOURCE_REVISION } from '../../../blueprint.utils';
+
+const cronJobsGetResponseSmallSet = {
+  type:         'collection',
+  links:        { self: 'https://localhost:8005/v1/batch.cronjobs' },
+  createTypes:  { 'batch.cronjob': 'https://localhost:8005/v1/batch.cronjobs' },
+  actions:      {},
+  resourceType: 'batch.cronjob',
+  revision:     CYPRESS_SAFE_RESOURCE_REVISION,
+  count:        1,
+  data:         [{
+    id:    'default/test1',
+    type:  'batch.cronjob',
+    links: {
+      remove: 'https://localhost:8005/v1/batch.cronjobs/default/test1',
+      self:   'https://localhost:8005/v1/batch.cronjobs/default/test1',
+      update: 'https://localhost:8005/v1/batch.cronjobs/default/test1',
+      view:   'https://localhost:8005/apis/batch/v1/namespaces/default/cronjobs/test1'
+    },
+    apiVersion: 'batch/v1',
+    kind:       'CronJob',
+    metadata:   {
+      creationTimestamp: '2024-08-07T23:58:10Z',
+      name:              'test1',
+      namespace:         'default',
+      resourceVersion:   CYPRESS_SAFE_RESOURCE_REVISION,
+      state:             {
+        error:         false,
+        message:       '',
+        name:          'active',
+        transitioning: false
+      }
+    },
+    spec: {
+      schedule:                   '*/1 * * * *',
+      concurrencyPolicy:          'Allow',
+      failedJobsHistoryLimit:     1,
+      successfulJobsHistoryLimit: 3,
+      suspend:                    false,
+      jobTemplate:                {
+        spec: {
+          template: {
+            spec: {
+              containers: [
+                {
+                  image: 'nginx:latest',
+                  name:  'container-0'
+                }
+              ],
+              restartPolicy: 'OnFailure'
+            }
+          }
+        }
+      }
+    },
+    status: {
+      active:           [],
+      lastScheduleTime: '2024-08-07T23:58:00Z'
+    }
+  }]
+};
+
+function reply(statusCode: number, body: any) {
+  return (req) => {
+    req.reply({
+      statusCode,
+      body
+    });
+  };
+}
+
+export function generateCronJobsDataSmall(): Cypress.Chainable<Response> {
+  return cy.intercept('GET', '/v1/batch.cronjobs?*', reply(200, cronJobsGetResponseSmallSet)).as('cronJobsDataSmall');
+}

--- a/cypress/e2e/blueprints/explorer/workloads/daemonsets/daemonsets-get.ts
+++ b/cypress/e2e/blueprints/explorer/workloads/daemonsets/daemonsets-get.ts
@@ -1,0 +1,67 @@
+import { CYPRESS_SAFE_RESOURCE_REVISION } from '../../../blueprint.utils';
+
+const daemonSetsGetResponseSmallSet = {
+  type:         'collection',
+  links:        { self: 'https://localhost:8005/v1/apps.daemonsets' },
+  createTypes:  { 'apps.daemonset': 'https://localhost:8005/v1/apps.daemonsets' },
+  actions:      {},
+  resourceType: 'apps.daemonset',
+  revision:     CYPRESS_SAFE_RESOURCE_REVISION,
+  count:        1,
+  data:         [{
+    id:    'default/test1',
+    type:  'apps.daemonset',
+    links: {
+      remove: 'https://localhost:8005/v1/apps.daemonsets/default/test1',
+      self:   'https://localhost:8005/v1/apps.daemonsets/default/test1',
+      update: 'https://localhost:8005/v1/apps.daemonsets/default/test1',
+      view:   'https://localhost:8005/apis/apps/v1/namespaces/default/daemonsets/test1'
+    },
+    apiVersion: 'apps/v1',
+    kind:       'DaemonSet',
+    metadata:   {
+      creationTimestamp: '2024-08-07T23:58:10Z',
+      name:              'test1',
+      namespace:         'default',
+      resourceVersion:   CYPRESS_SAFE_RESOURCE_REVISION,
+      state:             {
+        error:         false,
+        message:       '',
+        name:          'active',
+        transitioning: false
+      }
+    },
+    spec: {
+      selector: { matchLabels: { app: 'test1' } },
+      template: {
+        metadata: { labels: { app: 'test1' } },
+        spec:     {
+          containers: [
+            {
+              image: 'nginx:latest',
+              name:  'container-0'
+            }
+          ]
+        }
+      }
+    },
+    status: {
+      currentNumberScheduled: 1,
+      desiredNumberScheduled: 1,
+      numberReady:            1
+    }
+  }]
+};
+
+function reply(statusCode: number, body: any) {
+  return (req) => {
+    req.reply({
+      statusCode,
+      body
+    });
+  };
+}
+
+export function generateDaemonSetsDataSmall(): Cypress.Chainable<Response> {
+  return cy.intercept('GET', '/v1/apps.daemonsets?*', reply(200, daemonSetsGetResponseSmallSet)).as('daemonSetsDataSmall');
+}

--- a/cypress/e2e/blueprints/explorer/workloads/deployments/deployments-get.ts
+++ b/cypress/e2e/blueprints/explorer/workloads/deployments/deployments-get.ts
@@ -1,0 +1,66 @@
+import { CYPRESS_SAFE_RESOURCE_REVISION } from '../../../blueprint.utils';
+
+const deploymentsGetResponseSmallSet = {
+  type:         'collection',
+  links:        { self: 'https://localhost:8005/v1/apps.deployments' },
+  createTypes:  { 'apps.deployment': 'https://localhost:8005/v1/apps.deployments' },
+  actions:      {},
+  resourceType: 'apps.deployment',
+  revision:     CYPRESS_SAFE_RESOURCE_REVISION,
+  count:        1,
+  data:         [{
+    id:    'default/test1',
+    type:  'apps.deployment',
+    links: {
+      remove: 'https://localhost:8005/v1/apps.deployments/default/test1',
+      self:   'https://localhost:8005/v1/apps.deployments/default/test1',
+      update: 'https://localhost:8005/v1/apps.deployments/default/test1',
+      view:   'https://localhost:8005/apis/apps/v1/namespaces/default/deployments/test1'
+    },
+    apiVersion: 'apps/v1',
+    kind:       'Deployment',
+    metadata:   {
+      creationTimestamp: '2024-08-07T23:58:10Z',
+      name:              'test1',
+      namespace:         'default',
+      resourceVersion:   CYPRESS_SAFE_RESOURCE_REVISION,
+      state:             {
+        error:         false,
+        message:       '',
+        name:          'active',
+        transitioning: false
+      }
+    },
+    spec: {
+      replicas: 1,
+      template: {
+        spec: {
+          containers: [
+            {
+              image: 'nginx:latest',
+              name:  'container-0'
+            }
+          ]
+        }
+      }
+    },
+    status: {
+      availableReplicas: 1,
+      readyReplicas:     1,
+      replicas:          1
+    }
+  }]
+};
+
+function reply(statusCode: number, body: any) {
+  return (req) => {
+    req.reply({
+      statusCode,
+      body
+    });
+  };
+}
+
+export function generateDeploymentsDataSmall(): Cypress.Chainable<Response> {
+  return cy.intercept('GET', '/v1/apps.deployments?*', reply(200, deploymentsGetResponseSmallSet)).as('deploymentsDataSmall');
+}

--- a/cypress/e2e/blueprints/explorer/workloads/jobs/jobs-get.ts
+++ b/cypress/e2e/blueprints/explorer/workloads/jobs/jobs-get.ts
@@ -1,0 +1,71 @@
+import { CYPRESS_SAFE_RESOURCE_REVISION } from '../../../blueprint.utils';
+
+const jobsGetResponseSmallSet = {
+  type:         'collection',
+  links:        { self: 'https://localhost:8005/v1/batch.jobs' },
+  createTypes:  { 'batch.job': 'https://localhost:8005/v1/batch.jobs' },
+  actions:      {},
+  resourceType: 'batch.job',
+  revision:     CYPRESS_SAFE_RESOURCE_REVISION,
+  count:        1,
+  data:         [{
+    id:    'default/test1',
+    type:  'batch.job',
+    links: {
+      remove: 'https://localhost:8005/v1/batch.jobs/default/test1',
+      self:   'https://localhost:8005/v1/batch.jobs/default/test1',
+      update: 'https://localhost:8005/v1/batch.jobs/default/test1',
+      view:   'https://localhost:8005/apis/batch/v1/namespaces/default/jobs/test1'
+    },
+    apiVersion: 'batch/v1',
+    kind:       'Job',
+    metadata:   {
+      creationTimestamp: '2024-08-07T23:58:10Z',
+      name:              'test1',
+      namespace:         'default',
+      resourceVersion:   CYPRESS_SAFE_RESOURCE_REVISION,
+      state:             {
+        error:         false,
+        message:       '',
+        name:          'active',
+        transitioning: false
+      }
+    },
+    spec: {
+      backoffLimit: 6,
+      completions:  1,
+      parallelism:  1,
+      selector:     { matchLabels: { 'job-name': 'test1' } },
+      template:     {
+        metadata: { labels: { 'job-name': 'test1' } },
+        spec:     {
+          containers: [
+            {
+              image: 'nginx:latest',
+              name:  'container-0'
+            }
+          ],
+          restartPolicy: 'Never'
+        }
+      }
+    },
+    status: {
+      active:    1,
+      succeeded: 0,
+      failed:    0
+    }
+  }]
+};
+
+function reply(statusCode: number, body: any) {
+  return (req) => {
+    req.reply({
+      statusCode,
+      body
+    });
+  };
+}
+
+export function generateJobsDataSmall(): Cypress.Chainable<Response> {
+  return cy.intercept('GET', '/v1/batch.jobs?*', reply(200, jobsGetResponseSmallSet)).as('jobsDataSmall');
+}

--- a/cypress/e2e/blueprints/explorer/workloads/statefulsets/statefulsets-get.ts
+++ b/cypress/e2e/blueprints/explorer/workloads/statefulsets/statefulsets-get.ts
@@ -1,0 +1,72 @@
+import { CYPRESS_SAFE_RESOURCE_REVISION } from '../../../blueprint.utils';
+
+const statefulSetsGetResponseSmallSet = {
+  type:         'collection',
+  links:        { self: 'https://localhost:8005/v1/apps.statefulsets' },
+  createTypes:  { 'apps.statefulset': 'https://localhost:8005/v1/apps.statefulsets' },
+  actions:      {},
+  resourceType: 'apps.statefulset',
+  revision:     CYPRESS_SAFE_RESOURCE_REVISION,
+  count:        1,
+  data:         [{
+    id:    'default/test1',
+    type:  'apps.statefulset',
+    links: {
+      remove: 'https://localhost:8005/v1/apps.statefulsets/default/test1',
+      self:   'https://localhost:8005/v1/apps.statefulsets/default/test1',
+      update: 'https://localhost:8005/v1/apps.statefulsets/default/test1',
+      view:   'https://localhost:8005/apis/apps/v1/namespaces/default/statefulsets/test1'
+    },
+    apiVersion: 'apps/v1',
+    kind:       'StatefulSet',
+    metadata:   {
+      creationTimestamp: '2024-08-07T23:58:10Z',
+      name:              'test1',
+      namespace:         'default',
+      resourceVersion:   CYPRESS_SAFE_RESOURCE_REVISION,
+      state:             {
+        error:         false,
+        message:       '',
+        name:          'active',
+        transitioning: false
+      }
+    },
+    spec: {
+      replicas:            1,
+      serviceName:         'test1',
+      podManagementPolicy: 'OrderedReady',
+      updateStrategy:      { type: 'RollingUpdate' },
+      selector:            { matchLabels: { app: 'test1' } },
+      template:            {
+        metadata: { labels: { app: 'test1' } },
+        spec:     {
+          containers: [
+            {
+              image: 'nginx:latest',
+              name:  'container-0'
+            }
+          ]
+        }
+      }
+    },
+    status: {
+      replicas:        1,
+      readyReplicas:   1,
+      currentReplicas: 1,
+      updatedReplicas: 1
+    }
+  }]
+};
+
+function reply(statusCode: number, body: any) {
+  return (req) => {
+    req.reply({
+      statusCode,
+      body
+    });
+  };
+}
+
+export function generateStatefulSetsDataSmall(): Cypress.Chainable<Response> {
+  return cy.intercept('GET', '/v1/apps.statefulsets?*', reply(200, statefulSetsGetResponseSmallSet)).as('statefulSetsDataSmall');
+}

--- a/cypress/e2e/po/lists/pods-list.po.ts
+++ b/cypress/e2e/po/lists/pods-list.po.ts
@@ -1,7 +1,0 @@
-import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
-
-/**
- * List component for pods resources
- */
-export default class PodsListPo extends BaseResourceList {
-}

--- a/cypress/e2e/po/pages/explorer/service-accounts.po.ts
+++ b/cypress/e2e/po/pages/explorer/service-accounts.po.ts
@@ -23,7 +23,7 @@ export class ServiceAccountsPagePo extends PagePo {
     burgerMenu.goToCluster(clusterId);
     sideNav.navToSideMenuGroupByLabel('More Resources');
     sideNav.navToSideMenuGroupByLabel('Core');
-    sideNav.navToSideMenuEntryByLabel('ServiceAccount');
+    sideNav.navToSideMenuEntryByLabel('ServiceAccounts');
   }
 
   constructor(clusterId = 'local') {

--- a/cypress/e2e/po/pages/explorer/services.po.ts
+++ b/cypress/e2e/po/pages/explorer/services.po.ts
@@ -23,7 +23,7 @@ export class ServicesPagePo extends PagePo {
 
     burgerMenu.goToCluster(clusterId);
     sideNav.navToSideMenuGroupByLabel('Service Discovery');
-    sideNav.navToSideMenuEntryByLabel('Service');
+    sideNav.navToSideMenuEntryByLabel('Services');
   }
 
   constructor(private clusterId = 'local') {

--- a/cypress/e2e/po/pages/explorer/workloads-cronjobs.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads-cronjobs.po.ts
@@ -1,0 +1,26 @@
+import { BaseListPagePo } from '@/cypress/e2e/po/pages/base/base-list-page.po';
+import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+
+export class WorkloadsCronJobsListPagePo extends BaseListPagePo {
+  private static createPath(clusterId: string) {
+    return `/c/${ clusterId }/explorer/batch.cronjob`;
+  }
+
+  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(WorkloadsCronJobsListPagePo.createPath(clusterId));
+  }
+
+  constructor(clusterId = 'local') {
+    super(WorkloadsCronJobsListPagePo.createPath(clusterId));
+  }
+
+  static navTo(clusterId = 'local') {
+    const burgerMenu = new BurgerMenuPo();
+    const sideNav = new ProductNavPo();
+
+    burgerMenu.goToCluster(clusterId);
+    sideNav.navToSideMenuGroupByLabel('Workloads');
+    sideNav.navToSideMenuEntryByLabel('CronJobs');
+  }
+}

--- a/cypress/e2e/po/pages/explorer/workloads-daemonsets.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads-daemonsets.po.ts
@@ -3,6 +3,8 @@ import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 import { BaseDetailPagePo } from '@/cypress/e2e/po/pages/base/base-detail-page.po';
 import { BaseListPagePo } from '@/cypress/e2e/po/pages/base/base-list-page.po';
+import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 
 export class WorkloadsDaemonsetsListPagePo extends BaseListPagePo {
   private static createPath(clusterId: string) {
@@ -15,6 +17,15 @@ export class WorkloadsDaemonsetsListPagePo extends BaseListPagePo {
 
   constructor(clusterId = 'local') {
     super(WorkloadsDaemonsetsListPagePo.createPath(clusterId));
+  }
+
+  static navTo(clusterId = 'local') {
+    const burgerMenu = new BurgerMenuPo();
+    const sideNav = new ProductNavPo();
+
+    burgerMenu.goToCluster(clusterId);
+    sideNav.navToSideMenuGroupByLabel('Workloads');
+    sideNav.navToSideMenuEntryByLabel('DaemonSets');
   }
 }
 

--- a/cypress/e2e/po/pages/explorer/workloads-jobs.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads-jobs.po.ts
@@ -1,10 +1,11 @@
-import PagePo from '@/cypress/e2e/po/pages/page.po';
-import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
+import { BaseListPagePo } from '@/cypress/e2e/po/pages/base/base-list-page.po';
+import { BaseDetailPagePo } from '~/cypress/e2e/po/pages/base/base-detail-page.po';
 import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
-import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 
-export class WorkloadsJobsListPagePo extends PagePo {
+export class WorkloadsJobsListPagePo extends BaseListPagePo {
   private static createPath(clusterId: string) {
     return `/c/${ clusterId }/explorer/batch.job`;
   }
@@ -17,21 +18,17 @@ export class WorkloadsJobsListPagePo extends PagePo {
     super(WorkloadsJobsListPagePo.createPath(clusterId));
   }
 
-  list() {
-    return new BaseResourceList(this.self());
-  }
+  static navTo(clusterId = 'local') {
+    const burgerMenu = new BurgerMenuPo();
+    const sideNav = new ProductNavPo();
 
-  listCreate() {
-    return this.list().masthead().actions().eq(0)
-      .click();
-  }
-
-  listElementWithName(name:string) {
-    return this.list().resourceTable().sortableTable().rowElementWithName(name);
+    burgerMenu.goToCluster(clusterId);
+    sideNav.navToSideMenuGroupByLabel('Workloads');
+    sideNav.navToSideMenuEntryByLabel('Jobs');
   }
 }
 
-export class WorkLoadsJobDetailsPagePo extends PagePo {
+export class WorkLoadsJobDetailsPagePo extends BaseDetailPagePo {
   static url: string;
 
   private static createPath(jobId: string, clusterId: string, namespaceId: string, queryParams?: Record<string, string>) {
@@ -67,16 +64,8 @@ export class WorkLoadsJobDetailsPagePo extends PagePo {
     return LabeledInputPo.byLabel(this.self(), 'Namespace');
   }
 
-  name() {
-    return LabeledInputPo.bySelector(this.self(), '[data-testid="name-ns-description-name"]');
-  }
-
   containerImage(): LabeledInputPo {
     return LabeledInputPo.byLabel(this.self(), 'Container Image');
-  }
-
-  saveCreateForm(): AsyncButtonPo {
-    return new AsyncButtonPo('[data-testid="form-save"]', this.self());
   }
 
   errorBanner() {

--- a/cypress/e2e/po/pages/explorer/workloads-pods.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads-pods.po.ts
@@ -1,11 +1,10 @@
-import PagePo from '@/cypress/e2e/po/pages/page.po';
-import PodsListPo from '@/cypress/e2e/po/lists/pods-list.po';
+import { BaseListPagePo } from '@/cypress/e2e/po/pages/base/base-list-page.po';
+import { BaseDetailPagePo } from '@/cypress/e2e/po/pages/base/base-detail-page.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import { WorkloadsCreatePageBasePo } from '@/cypress/e2e/po/pages/explorer/workloads/workloads.po';
-import ResourceDetailPo from '@/cypress/e2e/po/edit/resource-detail.po';
 
-export class WorkloadsPodsListPagePo extends PagePo {
+export class WorkloadsPodsListPagePo extends BaseListPagePo {
   private static createPath(clusterId: string) {
     return `/c/${ clusterId }/explorer/pod`;
   }
@@ -27,21 +26,13 @@ export class WorkloadsPodsListPagePo extends PagePo {
     sideNav.navToSideMenuEntryByLabel('Pods');
   }
 
-  list(): PodsListPo {
-    return new PodsListPo('[data-testid="sortable-table-list-container"]');
-  }
-
-  sortableTable() {
-    return this.list().resourceTable().sortableTable();
-  }
-
   createPod() {
     return this.list().masthead().actions().eq(0)
       .click();
   }
 }
 
-export class WorkLoadsPodDetailsPagePo extends PagePo {
+export class WorkLoadsPodDetailsPagePo extends BaseDetailPagePo {
   static url: string;
 
   private static createPath(podId: string, clusterId: string, namespaceId: string, queryParams?: Record<string, string>) {
@@ -71,7 +62,7 @@ export class WorkloadsPodsCreatePagePo extends WorkloadsCreatePageBasePo {
     super(clusterId, workloadType, queryParams);
   }
 }
-export class WorkLoadsPodEditPagePo extends PagePo {
+export class WorkLoadsPodEditPagePo extends BaseDetailPagePo {
   private static createPath(podId: string, clusterId: string, namespaceId: string) {
     return `/c/${ clusterId }/explorer/pod/${ namespaceId }/${ podId }`;
   }
@@ -86,9 +77,5 @@ export class WorkLoadsPodEditPagePo extends PagePo {
 
   constructor(podId: string, clusterId = 'local', namespaceId = 'default') {
     super(WorkLoadsPodEditPagePo.createPath(podId, clusterId, namespaceId));
-  }
-
-  saveCreateForm(): ResourceDetailPo {
-    return new ResourceDetailPo(this.self());
   }
 }

--- a/cypress/e2e/po/pages/explorer/workloads-replicasets.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads-replicasets.po.ts
@@ -1,12 +1,8 @@
-import PagePo from '@/cypress/e2e/po/pages/page.po';
-import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
-import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
-import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
-import ResourceListMastheadPo from '@/cypress/e2e/po/components/ResourceList/resource-list-masthead.po';
-import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
+import { BaseListPagePo } from '@/cypress/e2e/po/pages/base/base-list-page.po';
+import { BaseDetailPagePo } from '@/cypress/e2e/po/pages/base/base-detail-page.po';
 import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 
-export class WorkloadsReplicasetsListPagePo extends PagePo {
+export class WorkloadsReplicasetsListPagePo extends BaseListPagePo {
   private static createPath(clusterId: string) {
     return `/c/${ clusterId }/explorer/apps.replicaset`;
   }
@@ -18,39 +14,9 @@ export class WorkloadsReplicasetsListPagePo extends PagePo {
   constructor(clusterId = 'local') {
     super(WorkloadsReplicasetsListPagePo.createPath(clusterId));
   }
-
-  masthead() {
-    return new ResourceListMastheadPo(this.self());
-  }
-
-  createReplicaset() {
-    return this.masthead().create();
-  }
-
-  goToeditItemWithName(name:string) {
-    const baseResourceList = new BaseResourceList(this.self());
-
-    return baseResourceList.actionMenu(name).getMenuItem('Edit Config').click();
-  }
-
-  baseResourceList() {
-    return new BaseResourceList(this.self());
-  }
-
-  listElementWithName(name:string) {
-    const baseResourceList = new BaseResourceList(this.self());
-
-    return baseResourceList.resourceTable().sortableTable().rowElementWithName(name);
-  }
-
-  sortableTable() {
-    const baseResourceList = new BaseResourceList(this.self());
-
-    return baseResourceList.resourceTable().sortableTable();
-  }
 }
 
-export class WorkloadsReplicasetsEditPagePo extends PagePo {
+export class WorkloadsReplicasetsEditPagePo extends BaseDetailPagePo {
   static url: string;
 
   private static createPath(daemonsetId: string, clusterId: string, namespaceId: string, queryParams?: Record<string, string>) {
@@ -75,19 +41,7 @@ export class WorkloadsReplicasetsEditPagePo extends PagePo {
     WorkloadsReplicasetsEditPagePo.url = WorkloadsReplicasetsEditPagePo.createPath(daemonsetId, clusterId, namespaceId, queryParams);
   }
 
-  nameNsDescription() {
-    return new NameNsDescription(this.self());
-  }
-
   containerImageInput(): LabeledInputPo {
     return LabeledInputPo.byLabel(this.self(), 'Container Image');
-  }
-
-  clickTab(selector: string) {
-    return new TabbedPo().clickTabWithSelector(selector);
-  }
-
-  saveCreateForm(): AsyncButtonPo {
-    return new AsyncButtonPo('[data-testid="form-save"]', this.self());
   }
 }

--- a/cypress/e2e/po/pages/explorer/workloads-statefulsets.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads-statefulsets.po.ts
@@ -1,0 +1,26 @@
+import { BaseListPagePo } from '@/cypress/e2e/po/pages/base/base-list-page.po';
+import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+
+export class WorkloadsStatefulSetsListPagePo extends BaseListPagePo {
+  private static createPath(clusterId: string) {
+    return `/c/${ clusterId }/explorer/apps.statefulset`;
+  }
+
+  static goTo(clusterId: string): Cypress.Chainable<Cypress.AUTWindow> {
+    return super.goTo(WorkloadsStatefulSetsListPagePo.createPath(clusterId));
+  }
+
+  constructor(clusterId = 'local') {
+    super(WorkloadsStatefulSetsListPagePo.createPath(clusterId));
+  }
+
+  static navTo(clusterId = 'local') {
+    const burgerMenu = new BurgerMenuPo();
+    const sideNav = new ProductNavPo();
+
+    burgerMenu.goToCluster(clusterId);
+    sideNav.navToSideMenuGroupByLabel('Workloads');
+    sideNav.navToSideMenuEntryByLabel('StatefulSets');
+  }
+}

--- a/cypress/e2e/po/pages/explorer/workloads/workloads-deployments.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads/workloads-deployments.po.ts
@@ -1,5 +1,6 @@
 import { WorkloadsListPageBasePo, WorkloadsCreatePageBasePo, workloadDetailsPageBasePo } from '@/cypress/e2e/po/pages/explorer/workloads/workloads.po';
-
+import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 export class WorkloadsDeploymentsDetailsPagePo extends workloadDetailsPageBasePo {
   constructor(workloadId: string, protected clusterId: string = 'local', workloadType = 'apps.deployment', namespaceId = 'default', queryParams?: Record<string, string>) {
     super(workloadId, clusterId, workloadType, queryParams, namespaceId);
@@ -9,6 +10,15 @@ export class WorkloadsDeploymentsDetailsPagePo extends workloadDetailsPageBasePo
 export class WorkloadsDeploymentsListPagePo extends WorkloadsListPageBasePo {
   constructor(protected clusterId: string = 'local', workloadType = 'apps.deployment', queryParams?: Record<string, string>) {
     super(clusterId, workloadType, queryParams);
+  }
+
+  static navTo(clusterId = 'local') {
+    const burgerMenu = new BurgerMenuPo();
+    const sideNav = new ProductNavPo();
+
+    burgerMenu.goToCluster(clusterId);
+    sideNav.navToSideMenuGroupByLabel('Workloads');
+    sideNav.navToSideMenuEntryByLabel('Deployments');
   }
 }
 

--- a/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
@@ -1,7 +1,7 @@
-import PagePo from '@/cypress/e2e/po/pages/page.po';
+import { BaseDetailPagePo } from '@/cypress/e2e/po/pages/base/base-detail-page.po';
+import { BaseListPagePo } from '@/cypress/e2e/po/pages/base/base-list-page.po';
 import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
 import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
-import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import WorkloadPagePo from '@/cypress/e2e/po/pages/explorer/workloads.po';
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
@@ -11,7 +11,7 @@ import ContainerMountPathPo from '@/cypress/e2e/po/components/workloads/containe
 import { WorkloadType } from '@shell/types/fleet';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 
-export class workloadDetailsPageBasePo extends PagePo {
+export class workloadDetailsPageBasePo extends BaseDetailPagePo {
   static url: string;
 
   private static createPath(
@@ -77,7 +77,7 @@ export class workloadDetailsPageBasePo extends PagePo {
   }
 }
 
-export class WorkloadsListPageBasePo extends PagePo {
+export class WorkloadsListPageBasePo extends BaseListPagePo {
   static createPath(clusterId: string, workloadType: WorkloadType, queryParams?: Record<string, string>) {
     const urlStr = `/c/${ clusterId }/explorer/${ workloadType }`;
 
@@ -163,7 +163,7 @@ export class WorkloadsListPageBasePo extends PagePo {
   }
 }
 
-export class WorkloadsCreatePageBasePo extends PagePo {
+export class WorkloadsCreatePageBasePo extends BaseDetailPagePo {
   static createPath(clusterId: string, workloadType: WorkloadType, queryParams?: Record<string, string>) {
     const urlStr = `/c/${ clusterId }/explorer/${ workloadType }/create`;
 
@@ -191,16 +191,8 @@ export class WorkloadsCreatePageBasePo extends PagePo {
     return LabeledInputPo.byLabel(this.self(), 'Namespace');
   }
 
-  name() {
-    return LabeledInputPo.bySelector(this.self(), '[data-testid="name-ns-description-name"]');
-  }
-
   containerImage(): LabeledInputPo {
     return LabeledInputPo.byLabel(this.self(), 'Container Image');
-  }
-
-  saveCreateForm(): AsyncButtonPo {
-    return new AsyncButtonPo('[data-testid="form-save"]', this.self());
   }
 
   addEnvironmentVariable() {
@@ -265,9 +257,10 @@ export class WorkloadsCreatePageBasePo extends PagePo {
   createWithUI(name: string, containerImage: string, namespace = 'default') {
     // NB: namespace is already selected by default
     this.selectNamespace(namespace);
-    this.name().set(name);
+    this.resourceDetail().createEditView().nameNsDescription().name()
+      .set(name);
     this.containerImage().set(containerImage);
-    this.saveCreateForm().click();
+    this.resourceDetail().createEditView().save();
   }
 
   private workload() {

--- a/cypress/e2e/po/side-bars/product-side-nav.po.ts
+++ b/cypress/e2e/po/side-bars/product-side-nav.po.ts
@@ -43,7 +43,13 @@ export default class ProductNavPo extends ComponentPo {
   }
 
   sideMenuEntryByLabel(label: string): Cypress.Chainable {
-    return this.self().should('exist', LONG_TIMEOUT_OPT).find('.child.nav-type a .label').contains(label);
+    return this.self().should('exist', LONG_TIMEOUT_OPT)
+      .find('.child.nav-type a .label')
+      .filter(`:contains("${ label }")`)
+      .filter((index, element) => {
+        // Only match exact text, not partial matches
+        return element.textContent.trim() === label;
+      });
   }
 
   /**

--- a/cypress/e2e/tests/pages/explorer2/namespace-picker.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/namespace-picker.spec.ts
@@ -52,9 +52,10 @@ describe('Namespace picker', { testIsolation: 'off' }, () => {
     namespacePicker.clickOptionByLabel('cattle-fleet-system');
     namespacePicker.isChecked('cattle-fleet-system');
     namespacePicker.closeDropdown();
-    workloadsPodPage.sortableTable()
+    workloadsPodPage.list().resourceTable().sortableTable()
       .groupElementWithName('cattle-fleet-system')
-      .scrollIntoView().should('be.visible')
+      .scrollIntoView()
+      .should('be.visible')
       .and('have.length', 1);
 
     // clear selection: from dropdown controller
@@ -67,8 +68,12 @@ describe('Namespace picker', { testIsolation: 'off' }, () => {
     namespacePicker.clickOptionByLabel('Project: System');
     namespacePicker.isChecked('Project: System');
     namespacePicker.closeDropdown();
-    workloadsPodPage.sortableTable().groupElementWithName('kube-system').scrollIntoView().should('be.visible');
-    workloadsPodPage.sortableTable().groupElementWithName('cattle-fleet-system').scrollIntoView().should('be.visible');
+    workloadsPodPage.list().resourceTable().sortableTable().groupElementWithName('kube-system')
+      .scrollIntoView()
+      .should('be.visible');
+    workloadsPodPage.list().resourceTable().sortableTable().groupElementWithName('cattle-fleet-system')
+      .scrollIntoView()
+      .should('be.visible');
   });
 
   it('can select only one of the top 5 resource filters at a time', { tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {

--- a/cypress/e2e/tests/pages/explorer2/workloads/cronjobs.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/cronjobs.spec.ts
@@ -1,0 +1,313 @@
+import { WorkloadsCronJobsListPagePo } from '@/cypress/e2e/po/pages/explorer/workloads-cronjobs.po';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import SortableTablePo from '@/cypress/e2e/po/components/sortable-table.po';
+import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dashboard.po';
+import { generateCronJobsDataSmall } from '@/cypress/e2e/blueprints/explorer/workloads/cronjobs/cronjobs-get';
+
+describe('CronJobs', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
+  const localCluster = 'local';
+  const cronJobListPage = new WorkloadsCronJobsListPagePo(localCluster);
+
+  before(() => {
+    cy.login();
+  });
+
+  describe('List', { tags: ['@vai', '@adminUser'] }, () => {
+    let uniqueCronJob = SortableTablePo.firstByDefaultName('cronjob');
+    const cronJobNamesList = [];
+    let nsName1: string;
+    let nsName2: string;
+    let rootResourceName: string;
+
+    before('set up', () => {
+      cy.getRootE2EResourceName().then((root) => {
+        rootResourceName = root;
+      });
+
+      cy.createE2EResourceName('ns1').then((ns1) => {
+        nsName1 = ns1;
+        // create namespace
+        cy.createNamespace(nsName1);
+
+        // create cronjobs
+        let i = 0;
+
+        while (i < 25) {
+          const cronJobName = Cypress._.uniqueId(Date.now().toString());
+
+          cy.createRancherResource('v1', 'batch.cronjob', JSON.stringify({
+            apiVersion: 'batch/v1',
+            kind:       'CronJob',
+            metadata:   {
+              name:      cronJobName,
+              namespace: nsName1
+            },
+            spec: {
+              schedule:                   '*/1 * * * *',
+              concurrencyPolicy:          'Allow',
+              failedJobsHistoryLimit:     1,
+              successfulJobsHistoryLimit: 3,
+              suspend:                    false,
+              jobTemplate:                {
+                spec: {
+                  template: {
+                    spec: {
+                      containers: [{
+                        name:  'nginx',
+                        image: 'nginx:alpine'
+                      }],
+                      restartPolicy: 'OnFailure'
+                    }
+                  }
+                }
+              }
+            }
+          })).then((resp) => {
+            cronJobNamesList.push(resp.body.metadata.name);
+          });
+
+          i++;
+        }
+
+        cy.createE2EResourceName('ns2').then((ns2) => {
+          nsName2 = ns2;
+
+          // create namespace
+          cy.createNamespace(nsName2);
+
+          // create unique cronjob for filtering/sorting test
+          cy.createRancherResource('v1', 'batch.cronjob', JSON.stringify({
+            apiVersion: 'batch/v1',
+            kind:       'CronJob',
+            metadata:   {
+              name:      uniqueCronJob,
+              namespace: nsName2
+            },
+            spec: {
+              schedule:                   '*/1 * * * *',
+              concurrencyPolicy:          'Allow',
+              failedJobsHistoryLimit:     1,
+              successfulJobsHistoryLimit: 3,
+              suspend:                    false,
+              jobTemplate:                {
+                spec: {
+                  template: {
+                    spec: {
+                      containers: [{
+                        name:  'nginx',
+                        image: 'nginx:alpine'
+                      }],
+                      restartPolicy: 'OnFailure'
+                    }
+                  }
+                }
+              }
+            }
+          })).then((resp) => {
+            uniqueCronJob = resp.body.metadata.name;
+          });
+
+          cy.tableRowsPerPageAndNamespaceFilter(10, localCluster, 'none', `{\"local\":[\"ns://${ nsName1 }\",\"ns://${ nsName2 }\"]}`);
+        });
+      });
+    });
+
+    it('pagination is visible and user is able to navigate through cronjobs data', () => {
+      ClusterDashboardPagePo.goToAndConfirmNsValues(localCluster, { nsProject: { values: [nsName1, nsName2] } });
+
+      WorkloadsCronJobsListPagePo.navTo();
+      cronJobListPage.waitForPage();
+
+      // check cronjobs count
+      const count = cronJobNamesList.length + 1;
+
+      cy.waitForRancherResources('v1', 'batch.cronjob', count - 1, true).then((resp: Cypress.Response<any>) => {
+        // pagination is visible
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .checkVisible();
+
+        // basic checks on navigation buttons
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isDisabled();
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isDisabled();
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .rightButton()
+          .isEnabled();
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .endButton()
+          .isEnabled();
+
+        // check text before navigation
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } CronJobs`);
+          });
+
+        // navigate to next page - right button
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .rightButton()
+          .click();
+
+        // check text and buttons after navigation
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`11 - 20 of ${ count } CronJobs`);
+          });
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isEnabled();
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isEnabled();
+
+        // navigate to first page - left button
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .click();
+
+        // check text and buttons after navigation
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } CronJobs`);
+          });
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isDisabled();
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isDisabled();
+
+        // navigate to last page - end button
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .endButton()
+          .scrollIntoView()
+          .click();
+
+        // row count on last page
+        let lastPageCount = count % 10;
+
+        if (lastPageCount === 0) {
+          lastPageCount = 10;
+        }
+
+        // check text after navigation
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } CronJobs`);
+          });
+
+        // navigate to first page - beginning button
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .click();
+
+        // check text and buttons after navigation
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } CronJobs`);
+          });
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isDisabled();
+        cronJobListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isDisabled();
+      });
+    });
+
+    it('sorting changes the order of paginated cronjobs data', () => {
+      WorkloadsCronJobsListPagePo.navTo();
+      cronJobListPage.waitForPage();
+      // use filter to only show test data
+      cronJobListPage.list().resourceTable().sortableTable().filter(rootResourceName);
+
+      // check table is sorted by name in ASC order by default
+      cronJobListPage.list().resourceTable().sortableTable().tableHeaderRow()
+        .checkSortOrder(2, 'down');
+
+      // cronjob name should be visible on first page (sorted in ASC order)
+      cronJobListPage.list().resourceTable().sortableTable().tableHeaderRow()
+        .self()
+        .scrollIntoView();
+      cronJobListPage.list().resourceTable().sortableTable().rowElementWithName(cronJobNamesList[0])
+        .scrollIntoView()
+        .should('be.visible');
+
+      // sort by name in DESC order
+      cronJobListPage.list().resourceTable().sortableTable().sort(2)
+        .click({ force: true });
+      cronJobListPage.list().resourceTable().sortableTable().tableHeaderRow()
+        .checkSortOrder(2, 'up');
+
+      // cronjob name should be NOT visible on first page (sorted in DESC order)
+      cronJobListPage.list().resourceTable().sortableTable().rowElementWithName(cronJobNamesList[0])
+        .should('not.exist');
+
+      // navigate to last page
+      cronJobListPage.list().resourceTable().sortableTable().pagination()
+        .endButton()
+        .scrollIntoView()
+        .click();
+
+      // cronjob name should be visible on last page (sorted in DESC order)
+      cronJobListPage.list().resourceTable().sortableTable().rowElementWithName(cronJobNamesList[0])
+        .scrollIntoView()
+        .should('be.visible');
+    });
+
+    it('filter cronjobs', () => {
+      WorkloadsCronJobsListPagePo.navTo();
+      cronJobListPage.waitForPage();
+
+      cronJobListPage.list().resourceTable().sortableTable().checkVisible();
+      cronJobListPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+      cronJobListPage.list().resourceTable().sortableTable().checkRowCount(false, 10);
+
+      // filter by name
+      cronJobListPage.list().resourceTable().sortableTable().filter(cronJobNamesList[0]);
+      cronJobListPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
+      cronJobListPage.list().resourceTable().sortableTable().rowElementWithName(cronJobNamesList[0])
+        .should('be.visible');
+
+      // filter by namespace
+      cronJobListPage.list().resourceTable().sortableTable().filter(nsName2);
+      cronJobListPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
+      cronJobListPage.list().resourceTable().sortableTable().rowElementWithName(uniqueCronJob)
+        .should('be.visible');
+    });
+
+    it('pagination is hidden', () => {
+      cy.tableRowsPerPageAndNamespaceFilter(10, localCluster, 'none', '{"local":[]}');
+
+      // generate small set of cronjobs data
+      generateCronJobsDataSmall();
+      HomePagePo.goTo(); // this is needed here for the intercept to work
+      WorkloadsCronJobsListPagePo.navTo();
+      cy.wait('@cronJobsDataSmall');
+      cronJobListPage.waitForPage();
+
+      cronJobListPage.list().resourceTable().sortableTable().checkVisible();
+      cronJobListPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+      cronJobListPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
+      cronJobListPage.list().resourceTable().sortableTable().pagination()
+        .checkNotExists();
+    });
+
+    after('clean up', () => {
+      // Ensure the default rows per page value is set after running the tests
+      cy.tableRowsPerPageAndNamespaceFilter(100, localCluster, 'none', '{"local":["all://user"]}');
+
+      // delete namespace (this will also delete all cronjobs in it)
+      cy.deleteRancherResource('v1', 'namespaces', nsName1);
+      cy.deleteRancherResource('v1', 'namespaces', nsName2);
+    });
+  });
+});

--- a/cypress/e2e/tests/pages/explorer2/workloads/daemonsets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/daemonsets.spec.ts
@@ -1,63 +1,350 @@
 import { WorkloadsDaemonsetsListPagePo, WorkLoadsDaemonsetsEditPagePo } from '@/cypress/e2e/po/pages/explorer/workloads-daemonsets.po';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import SortableTablePo from '@/cypress/e2e/po/components/sortable-table.po';
+import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dashboard.po';
+import { generateDaemonSetsDataSmall } from '@/cypress/e2e/blueprints/explorer/workloads/daemonsets/daemonsets-get';
 
-describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser'] }, () => {
-  beforeEach(() => {
+describe('DaemonSets', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
+  const localCluster = 'local';
+
+  before(() => {
     cy.login();
   });
 
-  describe('Workloads', () => {
-    describe('Daemonsets', () => {
-      it('modifying "Scaling and Upgrade Policy" to "On Delete" should use the correct property "OnDelete"', () => {
-        const daemonsetName = 'daemonset-test';
+  it('modifying "Scaling and Upgrade Policy" to "On Delete" should use the correct property "OnDelete"', () => {
+    const daemonsetName = 'daemonset-test';
 
-        // to test payload of https://github.com/rancher/dashboard/issues/9874
-        // we need to mock the PUT reply otherwise we get 409 conflict
-        cy.intercept('PUT', `/v1/apps.daemonsets/default/${ daemonsetName }`, (req: any) => {
-          req.reply({
-            statusCode: 200,
-            body:       {}
+    // to test payload of https://github.com/rancher/dashboard/issues/9874
+    // we need to mock the PUT reply otherwise we get 409 conflict
+    cy.intercept('PUT', `/v1/apps.daemonsets/default/${ daemonsetName }`, (req: any) => {
+      req.reply({
+        statusCode: 200,
+        body:       {}
+      });
+    }).as('daemonsetEdit');
+
+    // list view for daemonsets
+    const workloadsDaemonsetsListPage = new WorkloadsDaemonsetsListPagePo(localCluster);
+
+    workloadsDaemonsetsListPage.goTo();
+    workloadsDaemonsetsListPage.waitForPage();
+    workloadsDaemonsetsListPage.baseResourceList().masthead().create();
+
+    // create a new daemonset
+    const workloadsDaemonsetsEditPage = new WorkLoadsDaemonsetsEditPagePo(localCluster);
+
+    workloadsDaemonsetsEditPage.resourceDetail().createEditView().nameNsDescription()
+      .name()
+      .set(daemonsetName);
+    workloadsDaemonsetsEditPage.containerImageInput().set('nginx');
+    workloadsDaemonsetsEditPage.resourceDetail().cruResource().saveOrCreate()
+      .click();
+
+    workloadsDaemonsetsListPage.waitForPage();
+    workloadsDaemonsetsListPage.list().resourceTable().sortableTable()
+      .rowElementWithName(daemonsetName)
+      .should('be.visible');
+    workloadsDaemonsetsListPage.list().actionMenu(daemonsetName).getMenuItem('Edit Config')
+      .click();
+
+    // edit daemonset
+    workloadsDaemonsetsEditPage.clickTab('#DaemonSet');
+    workloadsDaemonsetsEditPage.clickTab('#upgrading');
+    workloadsDaemonsetsEditPage.ScalingUpgradePolicyRadioBtn().set(1);
+    workloadsDaemonsetsEditPage.resourceDetail().cruResource().saveOrCreate()
+      .click();
+
+    workloadsDaemonsetsListPage.baseResourceList().resourceTable().sortableTable()
+      .rowElementWithName(daemonsetName)
+      .should('be.visible');
+
+    cy.wait('@daemonsetEdit', { requestTimeout: 4000 }).then((req) => {
+      expect(req.request.body.spec.updateStrategy.type).to.equal('OnDelete');
+    });
+  });
+
+  describe('List', { tags: ['@vai', '@adminUser'] }, () => {
+    const daemonSetsListPage = new WorkloadsDaemonsetsListPagePo(localCluster);
+
+    let uniqueDaemonSet = SortableTablePo.firstByDefaultName('daemonset');
+    const daemonSetNamesList = [];
+    let nsName1: string;
+    let nsName2: string;
+    let rootResourceName: string;
+
+    before('set up', () => {
+      cy.getRootE2EResourceName().then((root) => {
+        rootResourceName = root;
+      });
+
+      cy.createE2EResourceName('ns1').then((ns1) => {
+        nsName1 = ns1;
+        // create namespace
+        cy.createNamespace(nsName1);
+
+        // create daemonsets
+        let i = 0;
+
+        while (i < 25) {
+          const daemonSetName = Cypress._.uniqueId(Date.now().toString());
+
+          cy.createRancherResource('v1', 'apps.daemonset', JSON.stringify({
+            apiVersion: 'apps/v1',
+            kind:       'DaemonSet',
+            metadata:   {
+              name:      daemonSetName,
+              namespace: nsName1
+            },
+            spec: {
+              selector: { matchLabels: { app: daemonSetName } },
+              template: {
+                metadata: { labels: { app: daemonSetName } },
+                spec:     {
+                  containers: [{
+                    name:  'nginx',
+                    image: 'nginx:alpine'
+                  }]
+                }
+              }
+            }
+          })).then((resp) => {
+            daemonSetNamesList.push(resp.body.metadata.name);
           });
-        }).as('daemonsetEdit');
 
-        // list view for daemonsets
-        const workloadsDaemonsetsListPage = new WorkloadsDaemonsetsListPagePo('local');
+          i++;
+        }
 
-        workloadsDaemonsetsListPage.goTo();
-        workloadsDaemonsetsListPage.waitForPage();
-        workloadsDaemonsetsListPage.baseResourceList().masthead().create();
+        cy.createE2EResourceName('ns2').then((ns2) => {
+          nsName2 = ns2;
 
-        // create a new daemonset
-        const workloadsDaemonsetsEditPage = new WorkLoadsDaemonsetsEditPagePo('local');
+          // create namespace
+          cy.createNamespace(nsName2);
 
-        workloadsDaemonsetsEditPage.resourceDetail().createEditView().nameNsDescription()
-          .name()
-          .set(daemonsetName);
-        workloadsDaemonsetsEditPage.containerImageInput().set('nginx');
-        workloadsDaemonsetsEditPage.resourceDetail().cruResource().saveOrCreate()
-          .click();
+          // create unique daemonset for filtering/sorting test
+          cy.createRancherResource('v1', 'apps.daemonset', JSON.stringify({
+            apiVersion: 'apps/v1',
+            kind:       'DaemonSet',
+            metadata:   {
+              name:      uniqueDaemonSet,
+              namespace: nsName2
+            },
+            spec: {
+              selector: { matchLabels: { app: uniqueDaemonSet } },
+              template: {
+                metadata: { labels: { app: uniqueDaemonSet } },
+                spec:     {
+                  containers: [{
+                    name:  'nginx',
+                    image: 'nginx:alpine'
+                  }]
+                }
+              }
+            }
+          })).then((resp) => {
+            uniqueDaemonSet = resp.body.metadata.name;
+          });
 
-        workloadsDaemonsetsListPage.waitForPage();
-        workloadsDaemonsetsListPage.list().resourceTable().sortableTable()
-          .rowElementWithName(daemonsetName)
-          .should('be.visible');
-        workloadsDaemonsetsListPage.list().actionMenu(daemonsetName).getMenuItem('Edit Config')
-          .click();
-
-        // edit daemonset
-        workloadsDaemonsetsEditPage.clickTab('#DaemonSet');
-        workloadsDaemonsetsEditPage.clickTab('#upgrading');
-        workloadsDaemonsetsEditPage.ScalingUpgradePolicyRadioBtn().set(1);
-        workloadsDaemonsetsEditPage.resourceDetail().cruResource().saveOrCreate()
-          .click();
-
-        workloadsDaemonsetsListPage.baseResourceList().resourceTable().sortableTable()
-          .rowElementWithName(daemonsetName)
-          .should('be.visible');
-
-        cy.wait('@daemonsetEdit', { requestTimeout: 4000 }).then((req) => {
-          expect(req.request.body.spec.updateStrategy.type).to.equal('OnDelete');
+          cy.tableRowsPerPageAndNamespaceFilter(10, localCluster, 'none', `{\"local\":[\"ns://${ nsName1 }\",\"ns://${ nsName2 }\"]}`);
         });
       });
+    });
+
+    it('pagination is visible and user is able to navigate through daemonsets data', () => {
+      ClusterDashboardPagePo.goToAndConfirmNsValues(localCluster, { nsProject: { values: [nsName1, nsName2] } });
+
+      WorkloadsDaemonsetsListPagePo.navTo();
+      daemonSetsListPage.waitForPage();
+
+      // check daemonsets count
+      const count = daemonSetNamesList.length + 1;
+
+      cy.waitForRancherResources('v1', 'apps.daemonset', count - 1, true).then((resp: Cypress.Response<any>) => {
+        // pagination is visible
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .checkVisible();
+
+        // basic checks on navigation buttons
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isDisabled();
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isDisabled();
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .rightButton()
+          .isEnabled();
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .endButton()
+          .isEnabled();
+
+        // check text before navigation
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } DaemonSets`);
+          });
+
+        // navigate to next page - right button
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .rightButton()
+          .click();
+
+        // check text and buttons after navigation
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`11 - 20 of ${ count } DaemonSets`);
+          });
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isEnabled();
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isEnabled();
+
+        // navigate to first page - left button
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .click();
+
+        // check text and buttons after navigation
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } DaemonSets`);
+          });
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isDisabled();
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isDisabled();
+
+        // navigate to last page - end button
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .endButton()
+          .scrollIntoView()
+          .click();
+
+        // row count on last page
+        let lastPageCount = count % 10;
+
+        if (lastPageCount === 0) {
+          lastPageCount = 10;
+        }
+
+        // check text after navigation
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } DaemonSets`);
+          });
+
+        // navigate to first page - beginning button
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .click();
+
+        // check text and buttons after navigation
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } DaemonSets`);
+          });
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isDisabled();
+        daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isDisabled();
+      });
+    });
+
+    it('sorting changes the order of paginated daemonsets data', () => {
+      WorkloadsDaemonsetsListPagePo.navTo();
+      daemonSetsListPage.waitForPage();
+      // use filter to only show test data
+      daemonSetsListPage.list().resourceTable().sortableTable().filter(rootResourceName);
+
+      // check table is sorted by name in ASC order by default
+      daemonSetsListPage.list().resourceTable().sortableTable().tableHeaderRow()
+        .checkSortOrder(2, 'down');
+
+      // daemonset name should be visible on first page (sorted in ASC order)
+      daemonSetsListPage.list().resourceTable().sortableTable().tableHeaderRow()
+        .self()
+        .scrollIntoView();
+      daemonSetsListPage.list().resourceTable().sortableTable().rowElementWithName(daemonSetNamesList[0])
+        .scrollIntoView()
+        .should('be.visible');
+
+      // sort by name in DESC order
+      daemonSetsListPage.list().resourceTable().sortableTable().sort(2)
+        .click({ force: true });
+      daemonSetsListPage.list().resourceTable().sortableTable().tableHeaderRow()
+        .checkSortOrder(2, 'up');
+
+      // daemonset name should be NOT visible on first page (sorted in DESC order)
+      daemonSetsListPage.list().resourceTable().sortableTable().rowElementWithName(daemonSetNamesList[0])
+        .should('not.exist');
+
+      // navigate to last page
+      daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+        .endButton()
+        .scrollIntoView()
+        .click();
+
+      // daemonset name should be visible on last page (sorted in DESC order)
+      daemonSetsListPage.list().resourceTable().sortableTable().rowElementWithName(daemonSetNamesList[0])
+        .scrollIntoView()
+        .should('be.visible');
+    });
+
+    it('filter daemonsets', () => {
+      WorkloadsDaemonsetsListPagePo.navTo();
+      daemonSetsListPage.waitForPage();
+
+      daemonSetsListPage.list().resourceTable().sortableTable().checkVisible();
+      daemonSetsListPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+      daemonSetsListPage.list().resourceTable().sortableTable().checkRowCount(false, 10);
+
+      // filter by name
+      daemonSetsListPage.list().resourceTable().sortableTable().filter(daemonSetNamesList[0]);
+      daemonSetsListPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
+      daemonSetsListPage.list().resourceTable().sortableTable().rowElementWithName(daemonSetNamesList[0])
+        .should('be.visible');
+
+      // filter by namespace
+      daemonSetsListPage.list().resourceTable().sortableTable().filter(nsName2);
+      daemonSetsListPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
+      daemonSetsListPage.list().resourceTable().sortableTable().rowElementWithName(uniqueDaemonSet)
+        .should('be.visible');
+    });
+
+    it('pagination is hidden', () => {
+      cy.tableRowsPerPageAndNamespaceFilter(10, localCluster, 'none', '{"local":[]}');
+
+      // generate small set of daemonsets data
+      generateDaemonSetsDataSmall();
+      HomePagePo.goTo(); // this is needed here for the intercept to work
+      WorkloadsDaemonsetsListPagePo.navTo();
+      cy.wait('@daemonSetsDataSmall');
+      daemonSetsListPage.waitForPage();
+
+      daemonSetsListPage.list().resourceTable().sortableTable().checkVisible();
+      daemonSetsListPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+      daemonSetsListPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
+      daemonSetsListPage.list().resourceTable().sortableTable().pagination()
+        .checkNotExists();
+    });
+
+    after('clean up', () => {
+      // Ensure the default rows per page value is set after running the tests
+      cy.tableRowsPerPageAndNamespaceFilter(100, localCluster, 'none', '{"local":["all://user"]}');
+
+      // delete namespace (this will also delete all daemonsets in it)
+      cy.deleteRancherResource('v1', 'namespaces', nsName1);
+      cy.deleteRancherResource('v1', 'namespaces', nsName2);
     });
   });
 });

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -1,258 +1,443 @@
 import { WorkloadsDeploymentsListPagePo, WorkloadsDeploymentsCreatePagePo, WorkloadsDeploymentsDetailsPagePo } from '@/cypress/e2e/po/pages/explorer/workloads/workloads-deployments.po';
 import { createDeploymentBlueprint, deploymentCreateRequest } from '@/cypress/e2e/blueprints/explorer/workloads/deployments/deployment-create';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import SortableTablePo from '@/cypress/e2e/po/components/sortable-table.po';
+import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dashboard.po';
+import { generateDeploymentsDataSmall } from '@/cypress/e2e/blueprints/explorer/workloads/deployments/deployments-get';
+import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 
-describe('Cluster Explorer', () => {
-  describe('Workloads', { tags: ['@explorer2', '@standardUser', '@adminUser'] }, () => {
-    let deploymentsListPage: WorkloadsDeploymentsListPagePo;
-    let deploymentsCreatePage: WorkloadsDeploymentsCreatePagePo;
+const localCluster = 'local';
 
-    beforeEach(() => {
-      cy.login();
-      deploymentsCreatePage = new WorkloadsDeploymentsCreatePagePo('local');
-      deploymentsListPage = new WorkloadsDeploymentsListPagePo('local');
+describe('Deployments', { testIsolation: 'off', tags: '@explorer2' }, () => {
+  before(() => {
+    cy.login();
+  });
+
+  describe('CRUD', { tags: ['@standardUser', '@adminUser'] }, () => {
+    const deploymentsListPage = new WorkloadsDeploymentsListPagePo(localCluster);
+    const deploymentsCreatePage = new WorkloadsDeploymentsCreatePagePo(localCluster);
+    const deploymentEditConfigPage = new WorkloadsDeploymentsCreatePagePo();
+    const { namespace } = createDeploymentBlueprint.metadata;
+    let deploymentId;
+    let volumeDeploymentId;
+
+    before(() => {
+      cy.createE2EResourceName('deployment').then((name) => {
+        deploymentId = name;
+      });
+
+      cy.createE2EResourceName('volume-deployment').then((name) => {
+        volumeDeploymentId = name;
+        // Create a deployment with volumes for the volume-related tests
+        const volumeDeployment = { ...createDeploymentBlueprint };
+
+        volumeDeployment.metadata.name = volumeDeploymentId;
+        cy.createRancherResource('v1', 'apps.deployment', JSON.stringify(volumeDeployment));
+      });
+
+      cy.intercept('POST', '/v1/apps.deployments').as('createDeployment');
     });
 
-    describe('Create: Deployments', () => {
-      let deploymentId;
+    it('should be able to create a new deployment with basic options', () => {
+      deploymentCreateRequest.metadata.name = deploymentId;
+      const { namespace } = deploymentCreateRequest.metadata;
+      const containerImage = 'nginx';
 
-      before(() => {
-        cy.intercept('POST', '/v1/apps.deployments').as('createDeployment');
-      });
+      deploymentsCreatePage.goTo();
+      deploymentsCreatePage.waitForPage();
 
-      it('should be able to create a new deployment with basic options', () => {
-        const name = `e2e-deployment-${ Math.random().toString(36).substr(2, 6) }`;
+      deploymentsCreatePage.createWithUI(deploymentId, containerImage, namespace);
 
-        deploymentCreateRequest.metadata.name = name;
-        const { namespace } = deploymentCreateRequest.metadata;
-        const containerImage = 'nginx';
-
-        deploymentsCreatePage.goTo();
-        deploymentsCreatePage.waitForPage();
-
-        deploymentsCreatePage.createWithUI(name, containerImage, namespace);
-
-        cy.wait('@createDeployment').then(({ request, response }) => {
-          // comparing pod spec instead of the entire request body to avoid needing to compare labels that include the dynamic test name
-          expect(request.body.spec.template.spec).to.deep.eq(deploymentCreateRequest.spec.template.spec);
-          expect(response.statusCode).to.eq(201);
-          expect(response.body.metadata.name).to.eq(name);
-          expect(response.body.metadata.namespace).to.eq(namespace);
-
-          deploymentId = response.body.id;
-        });
-      });
-
-      afterEach(() => {
-        cy.deleteRancherResource('v1', 'apps.deployment', deploymentId);
-      });
-    });
-
-    describe('Update: Deployments', () => {
-      let workloadName;
-      let workloadDetailsPage;
-      let updatedDeploymentId;
-
-      const { namespace } = createDeploymentBlueprint.metadata;
-      let deploymentEditConfigPage;
-
-      beforeEach(() => {
-        workloadName = `e2e-deployment-${ Math.random().toString(36).substr(2, 6) }`;
-        const testDeployment = { ...createDeploymentBlueprint };
-
-        workloadDetailsPage = new WorkloadsDeploymentsDetailsPagePo(workloadName);
-        deploymentEditConfigPage = new WorkloadsDeploymentsCreatePagePo();
-
-        testDeployment.metadata.name = workloadName;
-
-        cy.createRancherResource('v1', 'apps.deployment', JSON.stringify(testDeployment)).then((resp: Cypress.Response<any>) => {
-          updatedDeploymentId = resp.body.id;
-        });
-      });
-
-      afterEach(() => {
-        cy.deleteRancherResource('v1', 'apps.deployment', updatedDeploymentId);
-      });
-
-      it('Should be able to scale the number of pods', () => {
-        workloadDetailsPage.goTo();
-        workloadDetailsPage.waitForPage();
-        workloadDetailsPage.mastheadTitle().should('contain', workloadName);
-        workloadDetailsPage.podsRunningTotal().should('contain', '1');
-        workloadDetailsPage.podScaleUp().click();
-        workloadDetailsPage.gaugesPods().should('contain', 'Containercreating');
-        workloadDetailsPage.gaugesPods().should('contain', 'Running');
-        workloadDetailsPage.podsRunningTotal().should('contain', '2');
-        workloadDetailsPage.podScaleDown().click();
-        workloadDetailsPage.podsRunningTotal().should('contain', '1');
-      });
-
-      it('Should be able to view and edit configuration of pod volumes with no custom component', () => {
-        cy.intercept('PUT', `/v1/apps.deployments/${ namespace }/${ workloadName }`).as('editDeployment');
-
-        deploymentsListPage.goTo();
-        deploymentsListPage.waitForPage();
-        deploymentsListPage.goToEditConfigPage(workloadName);
-
-        // open the pod tab
-        deploymentEditConfigPage.horizontalTabs().clickTabWithSelector('li#pod');
-
-        // open the pod storage tab
-        deploymentEditConfigPage.podTabs().clickTabWithSelector('li#storage-pod');
-
-        // check that there is a component rendered for each workload volume and that that component has rendered some information about the volume
-        deploymentEditConfigPage.podStorage().nthVolumeComponent(0).yamlEditor().value()
-          .should('contain', 'name: test-vol');
-        deploymentEditConfigPage.podStorage().nthVolumeComponent(1).yamlEditor().value()
-          .should('contain', 'name: test-vol1');
-
-        // now try editing
-        deploymentEditConfigPage.podStorage().nthVolumeComponent(0).yamlEditor().set('name: test-vol-changed\nprojected:\n    defaultMode: 420');
-
-        // verify that the list of volumes in the container tab has updated
-        deploymentEditConfigPage.nthContainerTabs(0).clickTabWithSelector('li#storage');
-        deploymentEditConfigPage.containerStorage().addVolumeButton().toggle();
-        deploymentEditConfigPage.containerStorage().addVolumeButton().getOptions().should('contain', 'test-vol-changed (projected)');
-        deploymentEditConfigPage.containerStorage().addVolumeButton().getOptions().should('not.contain', 'test-vol (projected)');
-
-        deploymentEditConfigPage.saveCreateForm().click();
-
-        cy.wait('@editDeployment').then(({ request, response }) => {
-          expect(response.statusCode).to.eq(200);
-          expect(request.body.spec.template.spec.volumes[0]).to.deep.eq({ name: 'test-vol-changed', projected: { defaultMode: 420 } });
-          expect(response.body.spec.template.spec.volumes[0]).to.deep.eq({ name: 'test-vol-changed', projected: { defaultMode: 420, sources: null } });
-        });
-      });
-
-      it('should be able to add and remove container volume mounts', () => {
-        cy.intercept('PUT', `/v1/apps.deployments/${ namespace }/${ workloadName }`).as('editDeployment');
-
-        deploymentsListPage.goTo();
-        deploymentsListPage.waitForPage();
-        deploymentsListPage.goToEditConfigPage(workloadName);
-        deploymentEditConfigPage.nthContainerTabs(0).clickTabWithSelector('li#storage');
-
-        deploymentEditConfigPage.containerStorage().addVolume('test-vol1');
-
-        deploymentEditConfigPage.containerStorage().nthVolumeMount(0).nthMountPoint(0).set('test-123');
-
-        deploymentEditConfigPage.saveCreateForm().click();
-
-        cy.wait('@editDeployment').then(({ request, response }) => {
-          expect(request.body.spec.template.spec.containers[0].volumeMounts).to.deep.eq([{ mountPath: 'test-123', name: 'test-vol1' }]);
-          expect(response.body.spec.template.spec.containers[0].volumeMounts).to.deep.eq([{ mountPath: 'test-123', name: 'test-vol1' }]);
-        });
-
-        cy.intercept('PUT', `/v1/apps.deployments/${ namespace }/${ workloadName }`).as('editDeployment');
-
-        deploymentsListPage.goTo();
-        deploymentsListPage.waitForPage();
-        deploymentsListPage.goToEditConfigPage(workloadName);
-        deploymentEditConfigPage.nthContainerTabs(0).clickTabWithSelector('li#storage');
-        deploymentEditConfigPage.containerStorage().removeVolume(0);
-        deploymentEditConfigPage.saveCreateForm().click();
-
-        cy.wait('@editDeployment').then(({ request, response }) => {
-          expect(request.body.spec.template.spec.containers[0].volumeMounts).to.deep.eq([]);
-          expect(response.body.spec.template.spec.containers[0].volumeMounts).to.eq(undefined);
-        });
-      });
-
-      it('should be able to add and remove EnvVars', () => {
-        // The viewport needs to be a little larger for cypress to consider the key value input components to be visible
-        cy.viewport(1440, 900);
-
-        deploymentsCreatePage.goTo();
-        deploymentsCreatePage.waitForPage();
-
-        deploymentsCreatePage.horizontalTabs().clickTabWithSelector('li#container-0');
-
-        deploymentsCreatePage.addEnvironmentVariable();
-        deploymentsCreatePage.addEnvironmentVariable();
-        deploymentsCreatePage.addEnvironmentVariable();
-
-        // // Ensure the default key and value are empty as expected
-        deploymentsCreatePage.environmentVariableKeyInput(0).value().should('eq', '');
-        deploymentsCreatePage.environmentVariableValueInput(0).value().should('eq', '');
-
-        deploymentsCreatePage.environmentVariableKeyInput(0).set('a');
-        deploymentsCreatePage.environmentVariableValueInput(0).set('a');
-        deploymentsCreatePage.environmentVariableKeyInput(1).set('b');
-        deploymentsCreatePage.environmentVariableValueInput(1).set('b');
-        deploymentsCreatePage.environmentVariableKeyInput(2).set('c');
-        deploymentsCreatePage.environmentVariableValueInput(2).set('c');
-
-        // Ensure when we remove the variable we remove the correct row
-        deploymentsCreatePage.removeEnvironmentVariable(1);
-        deploymentEditConfigPage.environmentVariableKeyInput(1).value().should('eq', 'c');
-      });
-
-      it('should be able to select Pod CSI storage option', () => {
-        deploymentsCreatePage.goTo();
-        deploymentsCreatePage.waitForPage();
-
-        // open the pod tab
-        deploymentsCreatePage.horizontalTabs().clickTabWithSelector('li#pod');
-
-        // open the pod storage tab
-        deploymentsCreatePage.podTabs().clickTabWithSelector('li#storage-pod');
-
-        deploymentsCreatePage.podStorage().addVolumeButton().toggle();
-        deploymentsCreatePage.podStorage().addVolumeButton().getOptions().should('contain', 'CSI');
-
-        deploymentsCreatePage.podStorage().addVolumeButton().clickOptionWithLabel('CSI');
-
-        // open the driver input
-        deploymentsCreatePage.podStorage().driverInput().toggle();
-        deploymentsCreatePage.podStorage().driverInput().getOptions().should('contain', 'Longhorn');
-
-        // select the Longhorn option from the driver input
-        deploymentsCreatePage.podStorage().driverInput().clickOptionWithLabel('Longhorn');
+      cy.wait('@createDeployment').then(({ request, response }) => {
+        // comparing pod spec instead of the entire request body to avoid needing to compare labels that include the dynamic test name
+        expect(request.body.spec.template.spec).to.deep.eq(deploymentCreateRequest.spec.template.spec);
+        expect(response.statusCode).to.eq(201);
+        expect(response.body.metadata.name).to.eq(deploymentId);
+        expect(response.body.metadata.namespace).to.eq(namespace);
       });
     });
 
-    describe('List: Deployments', () => {
-      let listedDeploymentName1Id;
-      let listedDeploymentName2Id;
+    it('Should be able to scale the number of pods', () => {
+      const workloadDetailsPage = new WorkloadsDeploymentsDetailsPagePo(deploymentId);
 
-      it('Should list the workloads', () => {
-        const listedWorkloadName1 = Cypress._.uniqueId(Date.now().toString());
-        const listedWorkloadName2 = Cypress._.uniqueId(Date.now().toString());
-        const testDeployment = { ...createDeploymentBlueprint };
+      workloadDetailsPage.goTo();
+      workloadDetailsPage.waitForPage();
+      workloadDetailsPage.mastheadTitle().should('contain', deploymentId);
+      workloadDetailsPage.podsRunningTotal().should('contain', '1');
+      workloadDetailsPage.podScaleUp().click();
+      workloadDetailsPage.gaugesPods().should('contain', 'Containercreating');
+      workloadDetailsPage.gaugesPods().should('contain', 'Running');
+      workloadDetailsPage.podsRunningTotal().should('contain', '2', MEDIUM_TIMEOUT_OPT);
+      workloadDetailsPage.podScaleDown().click();
+      workloadDetailsPage.podsRunningTotal().should('contain', '1', MEDIUM_TIMEOUT_OPT);
+    });
 
-        testDeployment.metadata.name = listedWorkloadName1;
-        cy.createRancherResource('v1', 'apps.deployment', JSON.stringify(testDeployment)).then((resp: Cypress.Response<any>) => {
-          listedDeploymentName1Id = resp.body.id;
-        });
+    it('Should be able to view and edit configuration of pod volumes with no custom component', () => {
+      cy.intercept('PUT', `/v1/apps.deployments/${ namespace }/${ volumeDeploymentId }`).as('editDeployment');
 
-        testDeployment.metadata.name = listedWorkloadName2;
-        cy.createRancherResource('v1', 'apps.deployment', JSON.stringify(testDeployment)).then((resp: Cypress.Response<any>) => {
-          listedDeploymentName2Id = resp.body.id;
-        });
-        deploymentsListPage.goTo();
-        deploymentsListPage.waitForPage();
-        deploymentsListPage.listElementWithName(listedWorkloadName1).should('exist');
-        deploymentsListPage.listElementWithName(listedWorkloadName2).should('exist');
-      });
+      deploymentsListPage.goTo();
+      deploymentsListPage.waitForPage();
+      deploymentsListPage.goToEditConfigPage(volumeDeploymentId);
 
-      after(() => {
-        cy.deleteRancherResource('v1', 'apps.deployment', listedDeploymentName1Id);
-        cy.deleteRancherResource('v1', 'apps.deployment', listedDeploymentName2Id);
+      // open the pod tab
+      deploymentEditConfigPage.horizontalTabs().clickTabWithSelector('li#pod');
+
+      // open the pod storage tab
+      deploymentEditConfigPage.podTabs().clickTabWithSelector('li#storage-pod');
+
+      // check that there is a component rendered for each workload volume and that that component has rendered some information about the volume
+      deploymentEditConfigPage.podStorage().nthVolumeComponent(0).yamlEditor().value()
+        .should('contain', 'name: test-vol');
+      deploymentEditConfigPage.podStorage().nthVolumeComponent(1).yamlEditor().value()
+        .should('contain', 'name: test-vol1');
+
+      // now try editing
+      deploymentEditConfigPage.podStorage().nthVolumeComponent(0).yamlEditor().set('name: test-vol-changed\nprojected:\n    defaultMode: 420');
+
+      // verify that the list of volumes in the container tab has updated
+      deploymentEditConfigPage.nthContainerTabs(0).clickTabWithSelector('li#storage');
+      deploymentEditConfigPage.containerStorage().addVolumeButton().toggle();
+      deploymentEditConfigPage.containerStorage().addVolumeButton().getOptions().should('contain', 'test-vol-changed (projected)');
+      deploymentEditConfigPage.containerStorage().addVolumeButton().getOptions().should('not.contain', 'test-vol (projected)');
+
+      deploymentEditConfigPage.resourceDetail().cruResource().saveOrCreate().click();
+
+      cy.wait('@editDeployment').then(({ request, response }) => {
+        expect(response.statusCode).to.eq(200);
+        expect(request.body.spec.template.spec.volumes[0]).to.deep.eq({ name: 'test-vol-changed', projected: { defaultMode: 420 } });
+        expect(response.body.spec.template.spec.volumes[0]).to.deep.eq({ name: 'test-vol-changed', projected: { defaultMode: 420, sources: null } });
       });
     });
 
-    describe('Delete: Deployments', () => {
-      it('Should be able to delete a workload', () => {
-        const workloadName = Cypress._.uniqueId(Date.now().toString());
-        const testDeployment = { ...createDeploymentBlueprint };
+    it('should be able to add and remove container volume mounts', () => {
+      cy.intercept('PUT', `/v1/apps.deployments/${ namespace }/${ volumeDeploymentId }`).as('editDeployment');
 
-        testDeployment.metadata.name = workloadName;
-        cy.createRancherResource('v1', 'apps.deployment', JSON.stringify(testDeployment));
-        deploymentsListPage.goTo();
-        deploymentsListPage.waitForPage();
-        deploymentsListPage.listElementWithName(workloadName).should('exist');
-        deploymentsListPage.deleteAndWaitForRequest(workloadName);
-        deploymentsListPage.listElementWithName(workloadName).should('not.exist');
+      deploymentsListPage.goTo();
+      deploymentsListPage.waitForPage();
+      deploymentsListPage.goToEditConfigPage(volumeDeploymentId);
+      deploymentEditConfigPage.nthContainerTabs(0).clickTabWithSelector('li#storage');
+
+      deploymentEditConfigPage.containerStorage().addVolume('test-vol1');
+
+      deploymentEditConfigPage.containerStorage().nthVolumeMount(0).nthMountPoint(0).set('test-123');
+
+      deploymentEditConfigPage.resourceDetail().cruResource().saveOrCreate().click();
+
+      cy.wait('@editDeployment').then(({ request, response }) => {
+        expect(request.body.spec.template.spec.containers[0].volumeMounts).to.deep.eq([{ mountPath: 'test-123', name: 'test-vol1' }]);
+        expect(response.body.spec.template.spec.containers[0].volumeMounts).to.deep.eq([{ mountPath: 'test-123', name: 'test-vol1' }]);
       });
+
+      cy.intercept('PUT', `/v1/apps.deployments/${ namespace }/${ volumeDeploymentId }`).as('editDeployment');
+
+      deploymentsListPage.goTo();
+      deploymentsListPage.waitForPage();
+      deploymentsListPage.goToEditConfigPage(volumeDeploymentId);
+      deploymentEditConfigPage.nthContainerTabs(0).clickTabWithSelector('li#storage');
+      deploymentEditConfigPage.containerStorage().removeVolume(0);
+      deploymentEditConfigPage.resourceDetail().cruResource().saveOrCreate().click();
+
+      cy.wait('@editDeployment').then(({ request, response }) => {
+        expect(request.body.spec.template.spec.containers[0].volumeMounts).to.deep.eq([]);
+        expect(response.body.spec.template.spec.containers[0].volumeMounts).to.eq(undefined);
+      });
+    });
+
+    it('should be able to add and remove EnvVars', () => {
+      // The viewport needs to be a little larger for cypress to consider the key value input components to be visible
+      cy.viewport(1440, 900);
+
+      deploymentsCreatePage.goTo();
+      deploymentsCreatePage.waitForPage();
+
+      deploymentsCreatePage.horizontalTabs().clickTabWithSelector('li#container-0');
+
+      deploymentsCreatePage.addEnvironmentVariable();
+      deploymentsCreatePage.addEnvironmentVariable();
+      deploymentsCreatePage.addEnvironmentVariable();
+
+      // Ensure the default key and value are empty as expected
+      deploymentsCreatePage.environmentVariableKeyInput(0).value().should('eq', '');
+      deploymentsCreatePage.environmentVariableValueInput(0).value().should('eq', '');
+
+      deploymentsCreatePage.environmentVariableKeyInput(0).set('a');
+      deploymentsCreatePage.environmentVariableValueInput(0).set('a');
+      deploymentsCreatePage.environmentVariableKeyInput(1).set('b');
+      deploymentsCreatePage.environmentVariableValueInput(1).set('b');
+      deploymentsCreatePage.environmentVariableKeyInput(2).set('c');
+      deploymentsCreatePage.environmentVariableValueInput(2).set('c');
+
+      // Ensure when we remove the variable we remove the correct row
+      deploymentsCreatePage.removeEnvironmentVariable(1);
+      deploymentEditConfigPage.environmentVariableKeyInput(1).value().should('eq', 'c');
+    });
+
+    it('should be able to select Pod CSI storage option', () => {
+      deploymentsCreatePage.goTo();
+      deploymentsCreatePage.waitForPage();
+
+      // open the pod tab
+      deploymentsCreatePage.horizontalTabs().clickTabWithSelector('li#pod');
+
+      // open the pod storage tab
+      deploymentsCreatePage.podTabs().clickTabWithSelector('li#storage-pod');
+
+      deploymentsCreatePage.podStorage().addVolumeButton().toggle();
+      deploymentsCreatePage.podStorage().addVolumeButton().getOptions().should('contain', 'CSI');
+
+      deploymentsCreatePage.podStorage().addVolumeButton().clickOptionWithLabel('CSI');
+
+      // open the driver input
+      deploymentsCreatePage.podStorage().driverInput().toggle();
+      deploymentsCreatePage.podStorage().driverInput().getOptions().should('contain', 'Longhorn');
+
+      // select the Longhorn option from the driver input
+      deploymentsCreatePage.podStorage().driverInput().clickOptionWithLabel('Longhorn');
+    });
+
+    it('Should be able to delete the workload', () => {
+      deploymentsListPage.goTo();
+      deploymentsListPage.waitForPage();
+      deploymentsListPage.listElementWithName(deploymentId).should('exist');
+      deploymentsListPage.deleteAndWaitForRequest(deploymentId);
+      deploymentsListPage.listElementWithName(deploymentId).should('not.exist');
+    });
+
+    after(() => {
+      cy.deleteRancherResource('v1', 'apps.deployment', `${ namespace }/${ volumeDeploymentId }`);
+    });
+  });
+
+  describe('List', { tags: ['@vai', '@adminUser'] }, () => {
+    const deploymentsListPage = new WorkloadsDeploymentsListPagePo(localCluster);
+
+    let uniqueDeployment = SortableTablePo.firstByDefaultName('deployment');
+    const deploymentNamesList = [];
+    let nsName1: string;
+    let nsName2: string;
+    let rootResourceName: string;
+
+    before('set up', () => {
+      cy.getRootE2EResourceName().then((root) => {
+        rootResourceName = root;
+      });
+
+      cy.createE2EResourceName('ns1').then((ns1) => {
+        nsName1 = ns1;
+        // create namespace
+        cy.createNamespace(nsName1);
+
+        // create deployments
+        let i = 0;
+
+        while (i < 25) {
+          const deploymentName = Cypress._.uniqueId(Date.now().toString());
+
+          cy.createRancherResource('v1', 'apps.deployment', JSON.stringify({
+            apiVersion: 'apps/v1',
+            kind:       'Deployment',
+            metadata:   {
+              name:      deploymentName,
+              namespace: nsName1
+            },
+            spec: {
+              replicas: 1,
+              selector: { matchLabels: { app: deploymentName } },
+              template: {
+                metadata: { labels: { app: deploymentName } },
+                spec:     {
+                  containers: [{
+                    name:  'nginx',
+                    image: 'nginx:alpine'
+                  }]
+                }
+              }
+            }
+          })).then((resp) => {
+            deploymentNamesList.push(resp.body.metadata.name);
+          });
+
+          i++;
+        }
+
+        cy.createE2EResourceName('ns2').then((ns2) => {
+          nsName2 = ns2;
+
+          // create namespace
+          cy.createNamespace(nsName2);
+
+          // create unique deployment for filtering/sorting test
+          cy.createRancherResource('v1', 'apps.deployment', JSON.stringify({
+            apiVersion: 'apps/v1',
+            kind:       'Deployment',
+            metadata:   {
+              name:      uniqueDeployment,
+              namespace: nsName2
+            },
+            spec: {
+              replicas: 1,
+              selector: { matchLabels: { app: uniqueDeployment } },
+              template: {
+                metadata: { labels: { app: uniqueDeployment } },
+                spec:     {
+                  containers: [{
+                    name:  'nginx',
+                    image: 'nginx:alpine'
+                  }]
+                }
+              }
+            }
+          })).then((resp) => {
+            uniqueDeployment = resp.body.metadata.name;
+          });
+
+          cy.tableRowsPerPageAndNamespaceFilter(10, localCluster, 'none', `{\"local\":[\"ns://${ nsName1 }\",\"ns://${ nsName2 }\"]}`);
+        });
+      });
+    });
+
+    it('pagination is visible and user is able to navigate through deployments data', () => {
+      ClusterDashboardPagePo.goToAndConfirmNsValues(localCluster, { nsProject: { values: [nsName1, nsName2] } });
+
+      WorkloadsDeploymentsListPagePo.navTo();
+      deploymentsListPage.waitForPage();
+
+      // check deployments count
+      const count = deploymentNamesList.length + 1;
+
+      cy.waitForRancherResources('v1', 'apps.deployment', count - 1, true).then((resp: Cypress.Response<any>) => {
+      // pagination is visible
+        deploymentsListPage.sortableTable().pagination().checkVisible();
+
+        // basic checks on navigation buttons
+        deploymentsListPage.sortableTable().pagination().beginningButton().isDisabled();
+        deploymentsListPage.sortableTable().pagination().leftButton().isDisabled();
+        deploymentsListPage.sortableTable().pagination().rightButton().isEnabled();
+        deploymentsListPage.sortableTable().pagination().endButton().isEnabled();
+
+        // check text before navigation
+        deploymentsListPage.sortableTable().pagination().paginationText().then((el) => {
+          expect(el.trim()).to.eq(`1 - 10 of ${ count } Deployments`);
+        });
+
+        // navigate to next page - right button
+        deploymentsListPage.sortableTable().pagination().rightButton().click();
+
+        // check text and buttons after navigation
+        deploymentsListPage.sortableTable().pagination().paginationText().then((el) => {
+          expect(el.trim()).to.eq(`11 - 20 of ${ count } Deployments`);
+        });
+        deploymentsListPage.sortableTable().pagination().beginningButton().isEnabled();
+        deploymentsListPage.sortableTable().pagination().leftButton().isEnabled();
+
+        // navigate to first page - left button
+        deploymentsListPage.sortableTable().pagination().leftButton().click();
+
+        // check text and buttons after navigation
+        deploymentsListPage.sortableTable().pagination().paginationText().then((el) => {
+          expect(el.trim()).to.eq(`1 - 10 of ${ count } Deployments`);
+        });
+        deploymentsListPage.sortableTable().pagination().beginningButton().isDisabled();
+        deploymentsListPage.sortableTable().pagination().leftButton().isDisabled();
+
+        // navigate to last page - end button
+        deploymentsListPage.sortableTable().pagination().endButton().scrollIntoView()
+          .click();
+
+        // row count on last page
+        let lastPageCount = count % 10;
+
+        if (lastPageCount === 0) {
+          lastPageCount = 10;
+        }
+
+        // check text after navigation
+        deploymentsListPage.sortableTable().pagination().paginationText().then((el) => {
+          expect(el.trim()).to.eq(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } Deployments`);
+        });
+
+        // navigate to first page - beginning button
+        deploymentsListPage.sortableTable().pagination().beginningButton().click();
+
+        // check text and buttons after navigation
+        deploymentsListPage.sortableTable().pagination().paginationText().then((el) => {
+          expect(el.trim()).to.eq(`1 - 10 of ${ count } Deployments`);
+        });
+        deploymentsListPage.sortableTable().pagination().beginningButton().isDisabled();
+        deploymentsListPage.sortableTable().pagination().leftButton().isDisabled();
+      });
+    });
+
+    it('sorting changes the order of paginated deployments data', () => {
+      WorkloadsDeploymentsListPagePo.navTo();
+      deploymentsListPage.waitForPage();
+      // use filter to only show test data
+      deploymentsListPage.sortableTable().filter(rootResourceName);
+
+      // check table is sorted by name in ASC order by default
+      deploymentsListPage.sortableTable().tableHeaderRow().checkSortOrder(2, 'down');
+
+      // deployment name should be visible on first page (sorted in ASC order)
+      deploymentsListPage.sortableTable().tableHeaderRow().self().scrollIntoView();
+      deploymentsListPage.sortableTable().rowElementWithName(deploymentNamesList[0]).scrollIntoView().should('be.visible');
+
+      // sort by name in DESC order
+      deploymentsListPage.sortableTable().sort(2).click({ force: true });
+      deploymentsListPage.sortableTable().tableHeaderRow().checkSortOrder(2, 'up');
+
+      // deployment name should be NOT visible on first page (sorted in DESC order)
+      deploymentsListPage.sortableTable().rowElementWithName(deploymentNamesList[0]).should('not.exist');
+
+      // navigate to last page
+      deploymentsListPage.sortableTable().pagination().endButton().scrollIntoView()
+        .click();
+
+      // deployment name should be visible on last page (sorted in DESC order)
+      deploymentsListPage.sortableTable().rowElementWithName(deploymentNamesList[0]).scrollIntoView().should('be.visible');
+    });
+
+    it('filter deployments', () => {
+      WorkloadsDeploymentsListPagePo.navTo();
+      deploymentsListPage.waitForPage();
+
+      deploymentsListPage.sortableTable().checkVisible();
+      deploymentsListPage.sortableTable().checkLoadingIndicatorNotVisible();
+      deploymentsListPage.sortableTable().checkRowCount(false, 10);
+
+      // filter by name
+      deploymentsListPage.sortableTable().filter(deploymentNamesList[0]);
+      deploymentsListPage.sortableTable().checkRowCount(false, 1);
+      deploymentsListPage.sortableTable().rowElementWithName(deploymentNamesList[0]).should('be.visible');
+
+      // filter by namespace
+      deploymentsListPage.sortableTable().filter(nsName2);
+      deploymentsListPage.sortableTable().checkRowCount(false, 1);
+      deploymentsListPage.sortableTable().rowElementWithName(uniqueDeployment).should('be.visible');
+    });
+
+    it('pagination is hidden', () => {
+      cy.tableRowsPerPageAndNamespaceFilter(10, localCluster, 'none', '{"local":[]}');
+
+      // generate small set of deployments data
+      generateDeploymentsDataSmall();
+      HomePagePo.goTo(); // this is needed here for the intercept to work
+      WorkloadsDeploymentsListPagePo.navTo();
+      cy.wait('@deploymentsDataSmall');
+      deploymentsListPage.waitForPage();
+
+      deploymentsListPage.sortableTable().checkVisible();
+      deploymentsListPage.sortableTable().checkLoadingIndicatorNotVisible();
+      deploymentsListPage.sortableTable().checkRowCount(false, 1);
+      deploymentsListPage.sortableTable().pagination().checkNotExists();
+    });
+
+    after('clean up', () => {
+    // Ensure the default rows per page value is set after running the tests
+      cy.tableRowsPerPageAndNamespaceFilter(100, localCluster, 'none', '{"local":["all://user"]}');
+
+      // delete namespace (this will also delete all deployments in it)
+      cy.deleteRancherResource('v1', 'namespaces', nsName1);
+      cy.deleteRancherResource('v1', 'namespaces', nsName2);
     });
   });
 });

--- a/cypress/e2e/tests/pages/explorer2/workloads/jobs.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/jobs.spec.ts
@@ -1,82 +1,384 @@
 import { WorkloadsJobsListPagePo, WorkLoadsJobDetailsPagePo } from '@/cypress/e2e/po/pages/explorer/workloads-jobs.po';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import SortableTablePo from '@/cypress/e2e/po/components/sortable-table.po';
+import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dashboard.po';
+import { generateJobsDataSmall } from '@/cypress/e2e/blueprints/explorer/workloads/jobs/jobs-get';
 
-describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser'] }, () => {
-  beforeEach(() => {
+describe('Jobs', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
+  const localCluster = 'local';
+
+  before(() => {
     cy.login();
   });
 
-  describe('Workloads', () => {
-    describe('Jobs', () => {
-      const namespaceName = 'custom-namespace';
-      const jobName = 'my-job-custom-name';
-      const containerImageName = 'nginx';
+  describe('CRUD', () => {
+    const namespaceName = 'custom-namespace';
+    const jobName = 'my-job-custom-name';
+    const containerImageName = 'nginx';
 
-      after(() => {
-        // Delete the namespace created after the tests run
-        cy.deleteRancherResource('v1', 'namespace', namespaceName);
+    it('Creating a job while creating a new namespace should succeed', () => {
+      cy.intercept('POST', 'v1/namespaces').as('createNamespace');
+      cy.intercept('POST', 'v1/batch.jobs').as('createJob');
+
+      // list view jobs
+      const workloadsJobsListPage = new WorkloadsJobsListPagePo(localCluster);
+
+      workloadsJobsListPage.goTo();
+      workloadsJobsListPage.baseResourceList().masthead().create();
+
+      // create view jobs
+      const workloadsJobDetailsPage = new WorkLoadsJobDetailsPagePo(localCluster);
+
+      workloadsJobDetailsPage.selectNamespaceOption(1);
+      workloadsJobDetailsPage.namespace().set(namespaceName);
+      workloadsJobDetailsPage.resourceDetail().createEditView().nameNsDescription().name()
+        .set(jobName);
+      workloadsJobDetailsPage.containerImage().set(containerImageName);
+      workloadsJobDetailsPage.resourceDetail().createEditView().save();
+      cy.wait('@createNamespace').its('response.statusCode').should('eq', 201);
+      cy.wait('@createJob').its('response.statusCode').should('eq', 201);
+
+      workloadsJobsListPage.list().resourceTable().sortableTable().rowElementWithName(jobName)
+        .should('exist');
+
+      // navigate to namespace and check existence of namespace
+      cy.visit('/c/local/explorer/projectsnamespaces');
+      workloadsJobsListPage.list().resourceTable().sortableTable().rowElementWithName(namespaceName)
+        .should('exist');
+    });
+
+    it('Should be able to clone a job', () => {
+      const jobName2 = `${ jobName }-2`;
+      const jobNameClone = `${ jobName }-3`;
+
+      // list view jobs
+      const workloadsJobsListPage = new WorkloadsJobsListPagePo('local');
+
+      workloadsJobsListPage.goTo();
+      workloadsJobsListPage.baseResourceList().masthead().create();
+
+      // create view jobs
+      const workloadsJobDetailsPage = new WorkLoadsJobDetailsPagePo('local');
+
+      workloadsJobDetailsPage.selectNamespaceOption(1);
+      workloadsJobDetailsPage.namespace().set(namespaceName);
+      workloadsJobDetailsPage.resourceDetail().createEditView().nameNsDescription().name()
+        .set(jobName2);
+      workloadsJobDetailsPage.containerImage().set(containerImageName);
+      workloadsJobDetailsPage.resourceDetail().createEditView().save();
+
+      workloadsJobsListPage.list().resourceTable().sortableTable().rowElementWithName(jobName2)
+        .should('exist');
+
+      // Clone the job
+      workloadsJobsListPage.list().actionMenu(jobName2).getMenuItem('Clone').click();
+
+      const cloneJobDetailsPage = new WorkLoadsJobDetailsPagePo(jobName2, {}, 'local', namespaceName);
+
+      cloneJobDetailsPage.waitForPage();
+      cloneJobDetailsPage.resourceDetail().createEditView().nameNsDescription().name()
+        .set(jobNameClone);
+      cloneJobDetailsPage.resourceDetail().createEditView().save();
+      cloneJobDetailsPage.errorBanner().should('not.exist');
+
+      workloadsJobsListPage.list().resourceTable().sortableTable().rowElementWithName(jobNameClone)
+        .should('exist');
+    });
+
+    after(() => {
+      // Delete the namespace created after the tests run
+      cy.deleteRancherResource('v1', 'namespace', namespaceName);
+    });
+  });
+
+  describe('List', { tags: ['@vai', '@adminUser'] }, () => {
+    const jobsListPage = new WorkloadsJobsListPagePo(localCluster);
+
+    let uniqueJob = SortableTablePo.firstByDefaultName('job');
+    const jobNamesList = [];
+    let nsName1: string;
+    let nsName2: string;
+    let rootResourceName: string;
+
+    before('set up', () => {
+      cy.getRootE2EResourceName().then((root) => {
+        rootResourceName = root;
       });
 
-      it('Creating a job while creating a new namespace should succeed', () => {
-        cy.intercept('POST', 'v1/namespaces').as('createNamespace');
-        cy.intercept('POST', 'v1/batch.jobs').as('createJob');
+      cy.createE2EResourceName('ns1').then((ns1) => {
+        nsName1 = ns1;
+        // create namespace
+        cy.createNamespace(nsName1);
 
-        // list view jobs
-        const workloadsJobsListPage = new WorkloadsJobsListPagePo('local');
+        // create jobs
+        let i = 0;
 
-        workloadsJobsListPage.goTo();
-        workloadsJobsListPage.listCreate();
+        while (i < 25) {
+          const jobName = Cypress._.uniqueId(Date.now().toString());
 
-        // create view jobs
-        const workloadsJobDetailsPage = new WorkLoadsJobDetailsPagePo('local');
+          cy.createRancherResource('v1', 'batch.job', JSON.stringify({
+            apiVersion: 'batch/v1',
+            kind:       'Job',
+            metadata:   {
+              name:      jobName,
+              namespace: nsName1
+            },
+            spec: {
+              backoffLimit: 6,
+              completions:  1,
+              parallelism:  1,
+              template:     {
+                metadata: { labels: { 'job-name': jobName } },
+                spec:     {
+                  containers: [{
+                    name:  'nginx',
+                    image: 'nginx:alpine'
+                  }],
+                  restartPolicy: 'Never'
+                }
+              }
+            }
+          })).then((resp) => {
+            jobNamesList.push(resp.body.metadata.name);
+          });
 
-        workloadsJobDetailsPage.selectNamespaceOption(1);
-        workloadsJobDetailsPage.namespace().set(namespaceName);
-        workloadsJobDetailsPage.name().set(jobName);
-        workloadsJobDetailsPage.containerImage().set(containerImageName);
-        workloadsJobDetailsPage.saveCreateForm().click();
-        cy.wait('@createNamespace').its('response.statusCode').should('eq', 201);
-        cy.wait('@createJob').its('response.statusCode').should('eq', 201);
+          i++;
+        }
 
-        workloadsJobsListPage.listElementWithName(jobName).should('exist');
+        cy.createE2EResourceName('ns2').then((ns2) => {
+          nsName2 = ns2;
 
-        // navigate to namespace and check existence of namespace
-        cy.visit('/c/local/explorer/projectsnamespaces');
-        workloadsJobsListPage.listElementWithName(namespaceName).should('exist');
+          // create namespace
+          cy.createNamespace(nsName2);
+
+          // create unique job for filtering/sorting test
+          cy.createRancherResource('v1', 'batch.job', JSON.stringify({
+            apiVersion: 'batch/v1',
+            kind:       'Job',
+            metadata:   {
+              name:      uniqueJob,
+              namespace: nsName2
+            },
+            spec: {
+              backoffLimit: 6,
+              completions:  1,
+              parallelism:  1,
+              template:     {
+                metadata: { labels: { 'job-name': uniqueJob } },
+                spec:     {
+                  containers: [{
+                    name:  'nginx',
+                    image: 'nginx:alpine'
+                  }],
+                  restartPolicy: 'Never'
+                }
+              }
+            }
+          })).then((resp) => {
+            uniqueJob = resp.body.metadata.name;
+          });
+
+          cy.tableRowsPerPageAndNamespaceFilter(10, localCluster, 'none', `{\"local\":[\"ns://${ nsName1 }\",\"ns://${ nsName2 }\"]}`);
+        });
       });
+    });
 
-      it('Should be able to clone a job', () => {
-        const jobName2 = `${ jobName }-2`;
-        const jobNameClone = `${ jobName }-3`;
+    it('pagination is visible and user is able to navigate through jobs data', () => {
+      ClusterDashboardPagePo.goToAndConfirmNsValues(localCluster, { nsProject: { values: [nsName1, nsName2] } });
 
-        // list view jobs
-        const workloadsJobsListPage = new WorkloadsJobsListPagePo('local');
+      WorkloadsJobsListPagePo.navTo();
+      jobsListPage.waitForPage();
 
-        workloadsJobsListPage.goTo();
-        workloadsJobsListPage.listCreate();
+      // check jobs count
+      const count = jobNamesList.length + 1;
 
-        // create view jobs
-        const workloadsJobDetailsPage = new WorkLoadsJobDetailsPagePo('local');
+      cy.waitForRancherResources('v1', 'batch.job', count - 1, true).then((resp: Cypress.Response<any>) => {
+        // pagination is visible
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .checkVisible();
 
-        workloadsJobDetailsPage.selectNamespaceOption(1);
-        workloadsJobDetailsPage.namespace().set(namespaceName);
-        workloadsJobDetailsPage.name().set(jobName2);
-        workloadsJobDetailsPage.containerImage().set(containerImageName);
-        workloadsJobDetailsPage.saveCreateForm().click();
+        // basic checks on navigation buttons
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isDisabled();
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isDisabled();
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .rightButton()
+          .isEnabled();
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .endButton()
+          .isEnabled();
 
-        workloadsJobsListPage.listElementWithName(jobName2).should('exist');
+        // check text before navigation
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } Jobs`);
+          });
 
-        // Clone the job
-        workloadsJobsListPage.list().actionMenu(jobName2).getMenuItem('Clone').click();
+        // navigate to next page - right button
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .rightButton()
+          .click();
 
-        const cloneJobDetailsPage = new WorkLoadsJobDetailsPagePo(jobName2, {}, 'local', namespaceName);
+        // check text and buttons after navigation
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`11 - 20 of ${ count } Jobs`);
+          });
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isEnabled();
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isEnabled();
 
-        cloneJobDetailsPage.waitForPage();
-        cloneJobDetailsPage.name().set(jobNameClone);
-        cloneJobDetailsPage.saveCreateForm().click();
-        cloneJobDetailsPage.errorBanner().should('not.exist');
+        // navigate to first page - left button
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .click();
 
-        workloadsJobsListPage.listElementWithName(jobNameClone).should('exist');
+        // check text and buttons after navigation
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } Jobs`);
+          });
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isDisabled();
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isDisabled();
+
+        // navigate to last page - end button
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .endButton()
+          .scrollIntoView()
+          .click();
+
+        // row count on last page
+        let lastPageCount = count % 10;
+
+        if (lastPageCount === 0) {
+          lastPageCount = 10;
+        }
+
+        // check text after navigation
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } Jobs`);
+          });
+
+        // navigate to first page - beginning button
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .click();
+
+        // check text and buttons after navigation
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } Jobs`);
+          });
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isDisabled();
+        jobsListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isDisabled();
       });
+    });
+
+    it('sorting changes the order of paginated jobs data', () => {
+      WorkloadsJobsListPagePo.navTo();
+      jobsListPage.waitForPage();
+      // use filter to only show test data
+      jobsListPage.list().resourceTable().sortableTable().filter(rootResourceName);
+
+      // check table is sorted by name in ASC order by default
+      jobsListPage.list().resourceTable().sortableTable().tableHeaderRow()
+        .checkSortOrder(2, 'down');
+
+      // job name should be visible on first page (sorted in ASC order)
+      jobsListPage.list().resourceTable().sortableTable().tableHeaderRow()
+        .self()
+        .scrollIntoView();
+      jobsListPage.list().resourceTable().sortableTable().rowElementWithName(jobNamesList[0])
+        .scrollIntoView()
+        .should('be.visible');
+
+      // sort by name in DESC order
+      jobsListPage.list().resourceTable().sortableTable().sort(2)
+        .click({ force: true });
+      jobsListPage.list().resourceTable().sortableTable().tableHeaderRow()
+        .checkSortOrder(2, 'up');
+
+      // job name should be NOT visible on first page (sorted in DESC order)
+      jobsListPage.list().resourceTable().sortableTable().rowElementWithName(jobNamesList[0])
+        .should('not.exist');
+
+      // navigate to last page
+      jobsListPage.list().resourceTable().sortableTable().pagination()
+        .endButton()
+        .scrollIntoView()
+        .click();
+
+      // job name should be visible on last page (sorted in DESC order)
+      jobsListPage.list().resourceTable().sortableTable().rowElementWithName(jobNamesList[0])
+        .scrollIntoView()
+        .should('be.visible');
+    });
+
+    it('filter jobs', () => {
+      WorkloadsJobsListPagePo.navTo();
+      jobsListPage.waitForPage();
+
+      jobsListPage.list().resourceTable().sortableTable().checkVisible();
+      jobsListPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+      jobsListPage.list().resourceTable().sortableTable().checkRowCount(false, 10);
+
+      // filter by name
+      jobsListPage.list().resourceTable().sortableTable().filter(jobNamesList[0]);
+      jobsListPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
+      jobsListPage.list().resourceTable().sortableTable().rowElementWithName(jobNamesList[0])
+        .should('be.visible');
+
+      // filter by namespace
+      jobsListPage.list().resourceTable().sortableTable().filter(nsName2);
+      jobsListPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
+      jobsListPage.list().resourceTable().sortableTable().rowElementWithName(uniqueJob)
+        .should('be.visible');
+    });
+
+    it('pagination is hidden', () => {
+      cy.tableRowsPerPageAndNamespaceFilter(10, localCluster, 'none', '{"local":[]}');
+
+      // generate small set of jobs data
+      generateJobsDataSmall();
+      HomePagePo.goTo(); // this is needed here for the intercept to work
+      WorkloadsJobsListPagePo.navTo();
+      cy.wait('@jobsDataSmall');
+      jobsListPage.waitForPage();
+
+      jobsListPage.list().resourceTable().sortableTable().checkVisible();
+      jobsListPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+      jobsListPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
+      jobsListPage.list().resourceTable().sortableTable().pagination()
+        .checkNotExists();
+    });
+
+    after('clean up', () => {
+      // Ensure the default rows per page value is set after running the tests
+      cy.tableRowsPerPageAndNamespaceFilter(100, localCluster, 'none', '{"local":["all://user"]}');
+
+      // delete namespace (this will also delete all jobs in it)
+      cy.deleteRancherResource('v1', 'namespaces', nsName1);
+      cy.deleteRancherResource('v1', 'namespaces', nsName2);
     });
   });
 });

--- a/cypress/e2e/tests/pages/explorer2/workloads/pods.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/pods.spec.ts
@@ -74,41 +74,70 @@ describe('Pods', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, (
 
       cy.waitForRancherResources('v1', 'pods', count - 1, true).then((resp: Cypress.Response<any>) => {
         // pagination is visible
-        workloadsPodPage.sortableTable().pagination().checkVisible();
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .checkVisible();
 
         // basic checks on navigation buttons
-        workloadsPodPage.sortableTable().pagination().beginningButton().isDisabled();
-        workloadsPodPage.sortableTable().pagination().leftButton().isDisabled();
-        workloadsPodPage.sortableTable().pagination().rightButton().isEnabled();
-        workloadsPodPage.sortableTable().pagination().endButton().isEnabled();
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isDisabled();
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isDisabled();
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .rightButton()
+          .isEnabled();
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .endButton()
+          .isEnabled();
 
         // check text before navigation
-        workloadsPodPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`1 - 10 of ${ count } Pods`);
-        });
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } Pods`);
+          });
 
         // navigate to next page - right button
-        workloadsPodPage.sortableTable().pagination().rightButton().click();
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .rightButton()
+          .click();
 
         // check text and buttons after navigation
-        workloadsPodPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`11 - 20 of ${ count } Pods`);
-        });
-        workloadsPodPage.sortableTable().pagination().beginningButton().isEnabled();
-        workloadsPodPage.sortableTable().pagination().leftButton().isEnabled();
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`11 - 20 of ${ count } Pods`);
+          });
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isEnabled();
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isEnabled();
 
         // navigate to first page - left button
-        workloadsPodPage.sortableTable().pagination().leftButton().click();
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .click();
 
         // check text and buttons after navigation
-        workloadsPodPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`1 - 10 of ${ count } Pods`);
-        });
-        workloadsPodPage.sortableTable().pagination().beginningButton().isDisabled();
-        workloadsPodPage.sortableTable().pagination().leftButton().isDisabled();
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } Pods`);
+          });
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isDisabled();
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isDisabled();
 
         // navigate to last page - end button
-        workloadsPodPage.sortableTable().pagination().endButton().scrollIntoView()
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .endButton()
+          .scrollIntoView()
           .click();
 
         // row count on last page
@@ -119,19 +148,29 @@ describe('Pods', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, (
         }
 
         // check text after navigation
-        workloadsPodPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } Pods`);
-        });
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } Pods`);
+          });
 
         // navigate to first page - beginning button
-        workloadsPodPage.sortableTable().pagination().beginningButton().click();
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .click();
 
         // check text and buttons after navigation
-        workloadsPodPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`1 - 10 of ${ count } Pods`);
-        });
-        workloadsPodPage.sortableTable().pagination().beginningButton().isDisabled();
-        workloadsPodPage.sortableTable().pagination().leftButton().isDisabled();
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } Pods`);
+          });
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isDisabled();
+        workloadsPodPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isDisabled();
       });
     });
 
@@ -139,47 +178,61 @@ describe('Pods', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, (
       WorkloadsPodsListPagePo.navTo();
       workloadsPodPage.waitForPage();
       // use filter to only show test data
-      workloadsPodPage.sortableTable().filter(rootResourceName);
+      workloadsPodPage.list().resourceTable().sortableTable().filter(rootResourceName);
 
       // check table is sorted by name in ASC order by default
-      workloadsPodPage.sortableTable().tableHeaderRow().checkSortOrder(2, 'down');
+      workloadsPodPage.list().resourceTable().sortableTable().tableHeaderRow()
+        .checkSortOrder(2, 'down');
 
       // pod name should be visible on first page (sorted in ASC order)
-      workloadsPodPage.sortableTable().tableHeaderRow().self().scrollIntoView();
-      workloadsPodPage.sortableTable().rowElementWithName(podNamesList[0]).scrollIntoView().should('be.visible');
+      workloadsPodPage.list().resourceTable().sortableTable().tableHeaderRow()
+        .self()
+        .scrollIntoView();
+      workloadsPodPage.list().resourceTable().sortableTable().rowElementWithName(podNamesList[0])
+        .scrollIntoView()
+        .should('be.visible');
 
       // sort by name in DESC order
-      workloadsPodPage.sortableTable().sort(2).click({ force: true });
-      workloadsPodPage.sortableTable().tableHeaderRow().checkSortOrder(2, 'up');
+      workloadsPodPage.list().resourceTable().sortableTable().sort(2)
+        .click({ force: true });
+      workloadsPodPage.list().resourceTable().sortableTable().tableHeaderRow()
+        .checkSortOrder(2, 'up');
 
       // pod name should be NOT visible on first page (sorted in DESC order)
-      workloadsPodPage.sortableTable().rowElementWithName(podNamesList[0]).should('not.exist');
+      workloadsPodPage.list().resourceTable().sortableTable().rowElementWithName(podNamesList[0])
+        .should('not.exist');
 
       // navigate to last page
-      workloadsPodPage.sortableTable().pagination().endButton().scrollIntoView()
+      workloadsPodPage.list().resourceTable().sortableTable().pagination()
+        .endButton()
+        .scrollIntoView()
         .click();
 
       // pod name should be visible on last page (sorted in DESC order)
-      workloadsPodPage.sortableTable().rowElementWithName(podNamesList[0]).scrollIntoView().should('be.visible');
+      workloadsPodPage.list().resourceTable().sortableTable().rowElementWithName(podNamesList[0])
+        .scrollIntoView()
+        .should('be.visible');
     });
 
     it('filter pods', () => {
       WorkloadsPodsListPagePo.navTo();
       workloadsPodPage.waitForPage();
 
-      workloadsPodPage.sortableTable().checkVisible();
-      workloadsPodPage.sortableTable().checkLoadingIndicatorNotVisible();
-      workloadsPodPage.sortableTable().checkRowCount(false, 10);
+      workloadsPodPage.list().resourceTable().sortableTable().checkVisible();
+      workloadsPodPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+      workloadsPodPage.list().resourceTable().sortableTable().checkRowCount(false, 10);
 
       // filter by name
-      workloadsPodPage.sortableTable().filter(podNamesList[0]);
-      workloadsPodPage.sortableTable().checkRowCount(false, 1);
-      workloadsPodPage.sortableTable().rowElementWithName(podNamesList[0]).should('be.visible');
+      workloadsPodPage.list().resourceTable().sortableTable().filter(podNamesList[0]);
+      workloadsPodPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
+      workloadsPodPage.list().resourceTable().sortableTable().rowElementWithName(podNamesList[0])
+        .should('be.visible');
 
       // filter by namespace
-      workloadsPodPage.sortableTable().filter(nsName2);
-      workloadsPodPage.sortableTable().checkRowCount(false, 1);
-      workloadsPodPage.sortableTable().rowElementWithName(uniquePod).should('be.visible');
+      workloadsPodPage.list().resourceTable().sortableTable().filter(nsName2);
+      workloadsPodPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
+      workloadsPodPage.list().resourceTable().sortableTable().rowElementWithName(uniquePod)
+        .should('be.visible');
     });
 
     it('pagination is hidden', () => {
@@ -192,10 +245,11 @@ describe('Pods', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, (
       cy.wait('@podsDataSmall');
       workloadsPodPage.waitForPage();
 
-      workloadsPodPage.sortableTable().checkVisible();
-      workloadsPodPage.sortableTable().checkLoadingIndicatorNotVisible();
-      workloadsPodPage.sortableTable().checkRowCount(false, 3);
-      workloadsPodPage.sortableTable().pagination().checkNotExists();
+      workloadsPodPage.list().resourceTable().sortableTable().checkVisible();
+      workloadsPodPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+      workloadsPodPage.list().resourceTable().sortableTable().checkRowCount(false, 3);
+      workloadsPodPage.list().resourceTable().sortableTable().pagination()
+        .checkNotExists();
     });
 
     after('clean up', () => {
@@ -317,7 +371,9 @@ describe('Pods', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, (
 
       podDetails.saveCreateForm().cruResource().saveOrCreate().click();
       workloadsPodPage.waitForPage();
-      workloadsPodPage.sortableTable().rowElementWithName(singlePodName).scrollIntoView().should('be.visible');
+      workloadsPodPage.list().resourceTable().sortableTable().rowElementWithName(singlePodName)
+        .scrollIntoView()
+        .should('be.visible');
     });
 
     it('Footer controls should stick to bottom in YAML Editor', () => {
@@ -328,16 +384,18 @@ describe('Pods', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, (
 
       workloadsPodPage.goTo();
       workloadsPodPage.waitForPage();
-      workloadsPodPage.sortableTable().rowElementWithName(singlePodName).scrollIntoView().should('be.visible');
+      workloadsPodPage.list().resourceTable().sortableTable().rowElementWithName(singlePodName)
+        .scrollIntoView()
+        .should('be.visible');
       workloadsPodPage.list().actionMenu(singlePodName).getMenuItem('Edit YAML').click();
       workloadsPodEditPage.waitForPage('mode=edit&as=yaml');
       cy.wait('@getPod');
 
       // clear the form
-      workloadsPodEditPage.saveCreateForm().resourceYaml().codeMirror().set('');
+      workloadsPodEditPage.resourceDetail().resourceYaml().codeMirror().set('');
 
       // footer should maintain its position on the page
-      workloadsPodEditPage.saveCreateForm().resourceYaml().footer().then(($el) => {
+      workloadsPodEditPage.resourceDetail().resourceYaml().footer().then(($el) => {
         const elementRect = $el[0].getBoundingClientRect();
         const viewportHeight = Cypress.config('viewportHeight');
         const pageHeight = Cypress.$(cy.state('window')).height();

--- a/cypress/e2e/tests/pages/explorer2/workloads/replicasets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/replicasets.spec.ts
@@ -16,20 +16,22 @@ describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser'] }, () => {
 
         workloadsReplicasetsListPage.goTo();
         workloadsReplicasetsListPage.waitForPage();
-        workloadsReplicasetsListPage.createReplicaset();
+        workloadsReplicasetsListPage.baseResourceList().masthead().create();
 
         // create a new replicaset
         const workloadsDaemonsetsEditPage = new WorkloadsReplicasetsEditPagePo('local');
 
-        workloadsDaemonsetsEditPage.nameNsDescription().name().set(replicasetName);
+        workloadsDaemonsetsEditPage.resourceDetail().createEditView().nameNsDescription().name()
+          .set(replicasetName);
         workloadsDaemonsetsEditPage.containerImageInput().set('nginx');
-        workloadsDaemonsetsEditPage.saveCreateForm().click();
+        workloadsDaemonsetsEditPage.resourceDetail().createEditView().save();
 
         ResourceSearchDialog.goToResource('ReplicaSets');
 
         workloadsReplicasetsListPage.waitForPage();
 
-        workloadsReplicasetsListPage.listElementWithName(replicasetName).should('be.visible');
+        workloadsReplicasetsListPage.list().resourceTable().sortableTable().rowElementWithName(replicasetName)
+          .should('be.visible');
         workloadsReplicasetsListPage.baseResourceList().actionMenu(replicasetName).menuItemNames().should('not.contain', 'Rollback');
 
         cy.deleteRancherResource('v1', 'apps.replicasets', `default/${ replicasetName }`);

--- a/cypress/e2e/tests/pages/explorer2/workloads/statefulsets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/statefulsets.spec.ts
@@ -1,0 +1,305 @@
+import { WorkloadsStatefulSetsListPagePo } from '@/cypress/e2e/po/pages/explorer/workloads-statefulsets.po';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import SortableTablePo from '@/cypress/e2e/po/components/sortable-table.po';
+import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dashboard.po';
+import { generateStatefulSetsDataSmall } from '@/cypress/e2e/blueprints/explorer/workloads/statefulsets/statefulsets-get';
+
+describe('StatefulSets', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
+  const localCluster = 'local';
+  const statefulSetListPage = new WorkloadsStatefulSetsListPagePo(localCluster);
+
+  before(() => {
+    cy.login();
+  });
+
+  describe('List', { tags: ['@vai', '@adminUser'] }, () => {
+    let uniqueStatefulSet = SortableTablePo.firstByDefaultName('statefulset');
+    const statefulSetNamesList = [];
+    let nsName1: string;
+    let nsName2: string;
+    let rootResourceName: string;
+
+    before('set up', () => {
+      cy.getRootE2EResourceName().then((root) => {
+        rootResourceName = root;
+      });
+
+      cy.createE2EResourceName('ns1').then((ns1) => {
+        nsName1 = ns1;
+        // create namespace
+        cy.createNamespace(nsName1);
+
+        // create statefulsets
+        let i = 0;
+
+        while (i < 25) {
+          const statefulSetName = Cypress._.uniqueId(Date.now().toString());
+
+          cy.createRancherResource('v1', 'apps.statefulset', JSON.stringify({
+            apiVersion: 'apps/v1',
+            kind:       'StatefulSet',
+            metadata:   {
+              name:      statefulSetName,
+              namespace: nsName1
+            },
+            spec: {
+              replicas:            1,
+              serviceName:         statefulSetName,
+              podManagementPolicy: 'OrderedReady',
+              updateStrategy:      { type: 'RollingUpdate' },
+              selector:            { matchLabels: { app: statefulSetName } },
+              template:            {
+                metadata: { labels: { app: statefulSetName } },
+                spec:     {
+                  containers: [{
+                    name:  'nginx',
+                    image: 'nginx:alpine'
+                  }]
+                }
+              }
+            }
+          })).then((resp) => {
+            statefulSetNamesList.push(resp.body.metadata.name);
+          });
+
+          i++;
+        }
+
+        cy.createE2EResourceName('ns2').then((ns2) => {
+          nsName2 = ns2;
+
+          // create namespace
+          cy.createNamespace(nsName2);
+
+          // create unique statefulset for filtering/sorting test
+          cy.createRancherResource('v1', 'apps.statefulset', JSON.stringify({
+            apiVersion: 'apps/v1',
+            kind:       'StatefulSet',
+            metadata:   {
+              name:      uniqueStatefulSet,
+              namespace: nsName2
+            },
+            spec: {
+              replicas:            1,
+              serviceName:         uniqueStatefulSet,
+              podManagementPolicy: 'OrderedReady',
+              updateStrategy:      { type: 'RollingUpdate' },
+              selector:            { matchLabels: { app: uniqueStatefulSet } },
+              template:            {
+                metadata: { labels: { app: uniqueStatefulSet } },
+                spec:     {
+                  containers: [{
+                    name:  'nginx',
+                    image: 'nginx:alpine'
+                  }]
+                }
+              }
+            }
+          })).then((resp) => {
+            uniqueStatefulSet = resp.body.metadata.name;
+          });
+
+          cy.tableRowsPerPageAndNamespaceFilter(10, localCluster, 'none', `{\"local\":[\"ns://${ nsName1 }\",\"ns://${ nsName2 }\"]}`);
+        });
+      });
+    });
+
+    it('pagination is visible and user is able to navigate through statefulsets data', () => {
+      ClusterDashboardPagePo.goToAndConfirmNsValues(localCluster, { nsProject: { values: [nsName1, nsName2] } });
+
+      WorkloadsStatefulSetsListPagePo.navTo();
+      statefulSetListPage.waitForPage();
+
+      // check statefulsets count
+      const count = statefulSetNamesList.length + 1;
+
+      cy.waitForRancherResources('v1', 'apps.statefulset', count - 1, true).then((resp: Cypress.Response<any>) => {
+        // pagination is visible
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .checkVisible();
+
+        // basic checks on navigation buttons
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isDisabled();
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isDisabled();
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .rightButton()
+          .isEnabled();
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .endButton()
+          .isEnabled();
+
+        // check text before navigation
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } StatefulSets`);
+          });
+
+        // navigate to next page - right button
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .rightButton()
+          .click();
+
+        // check text and buttons after navigation
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`11 - 20 of ${ count } StatefulSets`);
+          });
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isEnabled();
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isEnabled();
+
+        // navigate to first page - left button
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .click();
+
+        // check text and buttons after navigation
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } StatefulSets`);
+          });
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isDisabled();
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isDisabled();
+
+        // navigate to last page - end button
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .endButton()
+          .scrollIntoView()
+          .click();
+
+        // row count on last page
+        let lastPageCount = count % 10;
+
+        if (lastPageCount === 0) {
+          lastPageCount = 10;
+        }
+
+        // check text after navigation
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } StatefulSets`);
+          });
+
+        // navigate to first page - beginning button
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .click();
+
+        // check text and buttons after navigation
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .paginationText()
+          .then((el) => {
+            expect(el.trim()).to.eq(`1 - 10 of ${ count } StatefulSets`);
+          });
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .beginningButton()
+          .isDisabled();
+        statefulSetListPage.list().resourceTable().sortableTable().pagination()
+          .leftButton()
+          .isDisabled();
+      });
+    });
+
+    it('sorting changes the order of paginated statefulsets data', () => {
+      WorkloadsStatefulSetsListPagePo.navTo();
+      statefulSetListPage.waitForPage();
+      // use filter to only show test data
+      statefulSetListPage.list().resourceTable().sortableTable().filter(rootResourceName);
+
+      // check table is sorted by name in ASC order by default
+      statefulSetListPage.list().resourceTable().sortableTable().tableHeaderRow()
+        .checkSortOrder(2, 'down');
+
+      // statefulset name should be visible on first page (sorted in ASC order)
+      statefulSetListPage.list().resourceTable().sortableTable().tableHeaderRow()
+        .self()
+        .scrollIntoView();
+      statefulSetListPage.list().resourceTable().sortableTable().rowElementWithName(statefulSetNamesList[0])
+        .scrollIntoView()
+        .should('be.visible');
+
+      // sort by name in DESC order
+      statefulSetListPage.list().resourceTable().sortableTable().sort(2)
+        .click({ force: true });
+      statefulSetListPage.list().resourceTable().sortableTable().tableHeaderRow()
+        .checkSortOrder(2, 'up');
+
+      // statefulset name should be NOT visible on first page (sorted in DESC order)
+      statefulSetListPage.list().resourceTable().sortableTable().rowElementWithName(statefulSetNamesList[0])
+        .should('not.exist');
+
+      // navigate to last page
+      statefulSetListPage.list().resourceTable().sortableTable().pagination()
+        .endButton()
+        .scrollIntoView()
+        .click();
+
+      // statefulset name should be visible on last page (sorted in DESC order)
+      statefulSetListPage.list().resourceTable().sortableTable().rowElementWithName(statefulSetNamesList[0])
+        .scrollIntoView()
+        .should('be.visible');
+    });
+
+    it('filter statefulsets', () => {
+      WorkloadsStatefulSetsListPagePo.navTo();
+      statefulSetListPage.waitForPage();
+
+      statefulSetListPage.list().resourceTable().sortableTable().checkVisible();
+      statefulSetListPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+      statefulSetListPage.list().resourceTable().sortableTable().checkRowCount(false, 10);
+
+      // filter by name
+      statefulSetListPage.list().resourceTable().sortableTable().filter(statefulSetNamesList[0]);
+      statefulSetListPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
+      statefulSetListPage.list().resourceTable().sortableTable().rowElementWithName(statefulSetNamesList[0])
+        .should('be.visible');
+
+      // filter by namespace
+      statefulSetListPage.list().resourceTable().sortableTable().filter(nsName2);
+      statefulSetListPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
+      statefulSetListPage.list().resourceTable().sortableTable().rowElementWithName(uniqueStatefulSet)
+        .should('be.visible');
+    });
+
+    it('pagination is hidden', () => {
+      cy.tableRowsPerPageAndNamespaceFilter(10, localCluster, 'none', '{"local":[]}');
+
+      // generate small set of statefulsets data
+      generateStatefulSetsDataSmall();
+      HomePagePo.goTo(); // this is needed here for the intercept to work
+      WorkloadsStatefulSetsListPagePo.navTo();
+      cy.wait('@statefulSetsDataSmall');
+      statefulSetListPage.waitForPage();
+
+      statefulSetListPage.list().resourceTable().sortableTable().checkVisible();
+      statefulSetListPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+      statefulSetListPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
+      statefulSetListPage.list().resourceTable().sortableTable().pagination()
+        .checkNotExists();
+    });
+
+    after('clean up', () => {
+      // Ensure the default rows per page value is set after running the tests
+      cy.tableRowsPerPageAndNamespaceFilter(100, localCluster, 'none', '{"local":["all://user"]}');
+
+      // delete namespace (this will also delete all statefulsets in it)
+      cy.deleteRancherResource('v1', 'namespaces', nsName1);
+      cy.deleteRancherResource('v1', 'namespaces', nsName2);
+    });
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1794

This PR adds UI validations for the Cluster Workloads pages to ensure the resource table behaves as expected when Vai is enabled (pagination, sorting, filtering).
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
