### PR TITLE
Add a button to quickly install helm charts outside the apps and marketplace

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1141,6 +1141,7 @@ catalog:
           error: Error installing {chart}
       viewLogs: View Installation Logs
       customizeInstall: Customize Install Options
+      waitForLogs: Installation initialized; waiting for logs...
     chart: Chart
     warning:
       managed:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1144,7 +1144,7 @@ catalog:
         installChart:
           action: Install {chart}
           waiting: Installing {chart}...
-          success: '{chart} installation  started'
+          success: '{chart} installation started'
           error: Error installing {chart}
         waitForLogs:
           action: View installation logs

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1122,6 +1122,25 @@ catalog:
       goToUpgrade: Edit/Upgrade
     appReadmeMissing: This chart doesn't have any additional chart information.
     appReadmeTitle: Chart Information (Helm README)
+    button:
+      stages:
+        addRepo:
+          action: Add the {repo} repository
+          waiting: Adding {repo} repository...
+          success: Repository added
+          error: Error adding {repo} repository
+        loadCharts:
+          action:  Fetch {repo} repository chart(s)
+          waiting: Fetching {repo} repository chart(s)...
+          success: '{chart} found'
+          error: '{chart} chart not found - Try again?'
+        installChart:
+          action: Install {chart}
+          waiting: Installing {chart}...
+          success: '{chart} installation  initialized'
+          error: Error installing {chart}
+      viewLogs: View Installation Logs
+      customizeInstall: Customize Install Options
     chart: Chart
     warning:
       managed:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1123,6 +1123,13 @@ catalog:
     appReadmeMissing: This chart doesn't have any additional chart information.
     appReadmeTitle: Chart Information (Helm README)
     button:
+      alreadyInstalled: '{chart} version {version} is already installed.'
+      viewDetails: View chart details
+      customizeInstall: Customize Install Options
+      viewLogs: View Installation Logs
+      waitForLogs: Installation initialized; waiting for logs...
+      canNotCreateRepos: It looks like you don't have permission to add repositories and install helm charts. 
+      canNotInstallApps: The {repo} repository has been added, but you don't have permission to install charts from it.
       stages:
         addRepo:
           action: Add the {repo} repository
@@ -1137,11 +1144,16 @@ catalog:
         installChart:
           action: Install {chart}
           waiting: Installing {chart}...
-          success: '{chart} installation  initialized'
+          success: '{chart} installation  started'
           error: Error installing {chart}
-      viewLogs: View Installation Logs
-      customizeInstall: Customize Install Options
-      waitForLogs: Installation initialized; waiting for logs...
+        waitForLogs:
+          action: View installation logs
+          waiting: Waiting for installation logs...
+          error: Unable to load installation logs
+      errors:
+        fetchChart: Error retrieving chart from repository
+        alreadyInstalled: Chart already installed
+        timeoutWaiting: Timed out waiting for logs
     chart: Chart
     warning:
       managed:

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -265,7 +265,7 @@ export default {
       return !this.errors ? {} : this.errorsMap || this.errors.reduce((acc, error) => ({
         ...acc,
         [error]: {
-          message: this.formatError(error),
+          message: error,
           icon:    null
         }
       }), {});
@@ -426,94 +426,6 @@ export default {
 
     shouldProvideSlot(slot) {
       return slot !== 'default' && typeof this.$slots[slot] === 'function';
-    },
-
-    formatError(err) {
-      if ( typeof err === 'string') {
-        return err;
-      }
-
-      if ( err?.code === 'ActionNotAvailable' ) {
-        return this.t('errors.actionNotAvailable');
-      }
-      const msg = !!err?.message ? err.message : '';
-      let messageDetail = '';
-
-      if (!!err?.message && !!err.detail) {
-        messageDetail = this.t('errors.messageAndDetail', { message: err.message, detail: err.detail });
-      } else if (!!err?.message || !!err.detail) {
-        const val = err.message ? err.message : err.detail;
-
-        messageDetail = this.t('errors.messageOrDetail', { val });
-      }
-
-      if ( err?.status === 422 ) {
-        const name = err?.fieldName;
-        const code = err?.code;
-        let codeExplanation = '';
-
-        switch ( err?.code ) {
-        case 'MissingRequired':
-          codeExplanation = this.t('errors.missingRequired'); break;
-        case 'NotUnique':
-          codeExplanation = this.t('errors.notUnique'); break;
-        case 'NotNullable':
-          codeExplanation = this.t('errors.notNullable'); break;
-        case 'InvalidOption':
-          codeExplanation = this.t('errors.invalidOption'); break;
-        case 'InvalidCharacters':
-          codeExplanation = this.t('errors.invalidCharacters'); break;
-        case 'MinLengthExceeded':
-          codeExplanation = this.t('errors.minLengthExceeded'); break;
-        case 'MaxLengthExceeded':
-          codeExplanation = this.t('errors.maxLengthExceeded'); break;
-        case 'MinLimitExceeded':
-          codeExplanation = this.t('errors.minLimitExceeded'); break;
-        case 'MaxLimitExceded':
-          codeExplanation = this.t('errors.maxLimitExceded'); break;
-        }
-
-        if (!!name) {
-          if (!!codeExplanation) {
-            if (!!messageDetail) {
-              return this.t('errors.failedInApi.withName.withCodeExplanation.withMessageDetail', {
-                name, codeExplanation, messageDetail
-              });
-            }
-
-            return this.t('errors.failedInApi.withName.withCodeExplanation.withoutMessageDetail', { name, codeExplanation });
-          }
-          if (!!messageDetail) {
-            return this.t('errors.failedInApi.withName.withMessageDetail', { name, messageDetail });
-          }
-
-          return this.t('errors.failedInApi.withName.withoutAnythingElse', { name });
-        } else {
-          if (!!messageDetail) {
-            if (!!codeExplanation) {
-              return this.t('errors.failedInApi.withoutName.withMessageDetail.withCodeExplanation', { codeExplanation, messageDetail });
-            }
-
-            return this.t('errors.failedInApi.withoutName.withMessageDetail.withoutCodeExplanation', { messageDetail });
-          } else if (!!code) {
-            if (!!codeExplanation) {
-              return this.t('errors.failedInApi.withoutName.withCode.withCodeExplanation', { code, codeExplanation });
-            }
-
-            return this.t('errors.failedInApi.withoutName.withCode.withoutCodeExplanation', { code });
-          }
-
-          return this.t('errors.failedInApi.withoutAnything');
-        }
-      } else if ( err?.status === 404 ) {
-        if (!!err?.opt?.url) {
-          return this.t('errors.notFound.withUrl', { msg, url: err.opt.url });
-        }
-
-        return this.t('errors.notFound.withoutUrl', { msg });
-      }
-
-      return messageDetail.length > 0 ? messageDetail : err;
     }
   },
 

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -265,7 +265,7 @@ export default {
       return !this.errors ? {} : this.errorsMap || this.errors.reduce((acc, error) => ({
         ...acc,
         [error]: {
-          message: error,
+          message: this.formatError(error),
           icon:    null
         }
       }), {});
@@ -426,6 +426,94 @@ export default {
 
     shouldProvideSlot(slot) {
       return slot !== 'default' && typeof this.$slots[slot] === 'function';
+    },
+
+    formatError(err) {
+      if ( typeof err === 'string') {
+        return err;
+      }
+
+      if ( err?.code === 'ActionNotAvailable' ) {
+        return this.t('errors.actionNotAvailable');
+      }
+      const msg = !!err?.message ? err.message : '';
+      let messageDetail = '';
+
+      if (!!err?.message && !!err.detail) {
+        messageDetail = this.t('errors.messageAndDetail', { message: err.message, detail: err.detail });
+      } else if (!!err?.message || !!err.detail) {
+        const val = err.message ? err.message : err.detail;
+
+        messageDetail = this.t('errors.messageOrDetail', { val });
+      }
+
+      if ( err?.status === 422 ) {
+        const name = err?.fieldName;
+        const code = err?.code;
+        let codeExplanation = '';
+
+        switch ( err?.code ) {
+        case 'MissingRequired':
+          codeExplanation = this.t('errors.missingRequired'); break;
+        case 'NotUnique':
+          codeExplanation = this.t('errors.notUnique'); break;
+        case 'NotNullable':
+          codeExplanation = this.t('errors.notNullable'); break;
+        case 'InvalidOption':
+          codeExplanation = this.t('errors.invalidOption'); break;
+        case 'InvalidCharacters':
+          codeExplanation = this.t('errors.invalidCharacters'); break;
+        case 'MinLengthExceeded':
+          codeExplanation = this.t('errors.minLengthExceeded'); break;
+        case 'MaxLengthExceeded':
+          codeExplanation = this.t('errors.maxLengthExceeded'); break;
+        case 'MinLimitExceeded':
+          codeExplanation = this.t('errors.minLimitExceeded'); break;
+        case 'MaxLimitExceded':
+          codeExplanation = this.t('errors.maxLimitExceded'); break;
+        }
+
+        if (!!name) {
+          if (!!codeExplanation) {
+            if (!!messageDetail) {
+              return this.t('errors.failedInApi.withName.withCodeExplanation.withMessageDetail', {
+                name, codeExplanation, messageDetail
+              });
+            }
+
+            return this.t('errors.failedInApi.withName.withCodeExplanation.withoutMessageDetail', { name, codeExplanation });
+          }
+          if (!!messageDetail) {
+            return this.t('errors.failedInApi.withName.withMessageDetail', { name, messageDetail });
+          }
+
+          return this.t('errors.failedInApi.withName.withoutAnythingElse', { name });
+        } else {
+          if (!!messageDetail) {
+            if (!!codeExplanation) {
+              return this.t('errors.failedInApi.withoutName.withMessageDetail.withCodeExplanation', { codeExplanation, messageDetail });
+            }
+
+            return this.t('errors.failedInApi.withoutName.withMessageDetail.withoutCodeExplanation', { messageDetail });
+          } else if (!!code) {
+            if (!!codeExplanation) {
+              return this.t('errors.failedInApi.withoutName.withCode.withCodeExplanation', { code, codeExplanation });
+            }
+
+            return this.t('errors.failedInApi.withoutName.withCode.withoutCodeExplanation', { code });
+          }
+
+          return this.t('errors.failedInApi.withoutAnything');
+        }
+      } else if ( err?.status === 404 ) {
+        if (!!err?.opt?.url) {
+          return this.t('errors.notFound.withUrl', { msg, url: err.opt.url });
+        }
+
+        return this.t('errors.notFound.withoutUrl', { msg });
+      }
+
+      return messageDetail.length > 0 ? messageDetail : err;
     }
   },
 

--- a/shell/components/InstallHelmCharts.vue
+++ b/shell/components/InstallHelmCharts.vue
@@ -123,7 +123,7 @@ export default {
           id:   SETTING.SERVER_URL,
         });
       } catch (e) {
-        console.error('Unable to fetch `server-url` setting: ', e); // eslint-disable-line no-console
+        this.$store.dispatch('growl/fromError', { err: e });
       }
 
       await this.$store.dispatch(`${ this.store }/findAll`, { type: MANAGEMENT.PROJECT });
@@ -144,9 +144,8 @@ export default {
       throttledRefreshCharts: null,
 
       // check the cluster repo schema
-      canCreateRepos:   false,
-      // once the target repo is created/found, we'll check that the user can perform the install action with that specific repo
-      // canInstallChart:  true,
+      canCreateRepos: false,
+
       serverUrlSetting: null,
       versionInfo:      null,
       userValues:       {},

--- a/shell/components/InstallHelmCharts.vue
+++ b/shell/components/InstallHelmCharts.vue
@@ -278,7 +278,6 @@ export default {
           return;
         }
 
-        await nextTick();
         this.throttledRefreshCharts();
       } catch (e) {
         this.$store.dispatch('growl/fromError', { err: e });
@@ -323,9 +322,6 @@ export default {
 
     // once a chart is located fetch installation info from the repo
     async fetchVersionInfo() {
-      if (!this.doingButtonAction) {
-        return;
-      }
       try {
         // assume we want the latest non-prerelease version
         const targetVersion = (this.chart?.versions || []).find((v) => v.version && !isPrerelease(v.version))?.version;
@@ -399,12 +395,13 @@ export default {
         this.installCmd.charts[0].values = {
           ...this.getGlobalValues(), ...this.extraValues, ...this.userValues
         };
-
         res = await this.targetRepo.doAction('install', this.installCmd);
       } catch (err) {
         this.btnCb(false);
         this.errors.push(err);
         this.doingButtonAction = false;
+
+        return;
       }
 
       this.installOperationName = res.operationName;

--- a/shell/components/InstallHelmCharts.vue
+++ b/shell/components/InstallHelmCharts.vue
@@ -281,8 +281,7 @@ export default {
         } catch (err) {
           // some errors here are expected
           // we only show error state when while block finishes and still no chart found
-          // eslint-disable-next-line no-console
-          console.error(err);
+          console.error(err); // eslint-disable-line no-console
         }
       }
 
@@ -379,8 +378,7 @@ export default {
 
         res = await this.targetRepo.doAction('install', this.installCmd);
       } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error(err);
+        console.error(err); // eslint-disable-line no-console
         this.btnCb(false);
 
         this.stages.installChart.loading = false;

--- a/shell/components/InstallHelmCharts.vue
+++ b/shell/components/InstallHelmCharts.vue
@@ -83,7 +83,12 @@ export default {
       default: 1000
     },
 
-    displayName: {
+    chartDisplayName: {
+      type:    String,
+      default: null
+    },
+
+    repoDisplayName: {
       type:    String,
       default: null
     }
@@ -133,37 +138,37 @@ export default {
 
       stages: {
         addRepo: {
-          actionLabel:  this.t('catalog.install.button.stages.addRepo.action', { repo: this.repoName }),
-          waitingLabel: this.t('catalog.install.button.stages.addRepo.waiting', { repo: this.repoName }),
-          successLabel: this.t('catalog.install.button.stages.addRepo.success', { repo: this.repoName }),
-          errorLabel:   this.t('catalog.install.button.stages.addRepo.error', { repo: this.repoName }),
+          actionLabel:  this.t('catalog.install.button.stages.addRepo.action', { repo: this.repoDisplayName || this.repoName }),
+          waitingLabel: this.t('catalog.install.button.stages.addRepo.waiting', { repo: this.repoDisplayName || this.repoName }),
+          successLabel: this.t('catalog.install.button.stages.addRepo.success', { repo: this.repoDisplayName || this.repoName }),
+          errorLabel:   this.t('catalog.install.button.stages.addRepo.error', { repo: this.repoDisplayName || this.repoName }),
           loading:      false,
           done:         false,
           errors:       []
         },
         loadCharts: {
-          actionLabel:  this.t('catalog.install.button.stages.loadCharts.action', { repo: this.repoName }),
-          waitingLabel: this.t('catalog.install.button.stages.loadCharts.waiting', { repo: this.repoName }),
-          successLabel: this.t('catalog.install.button.stages.loadCharts.success', { chart: this.displayName || this.chartName }),
-          errorLabel:   this.t('catalog.install.button.stages.loadCharts.error', { chart: this.displayName || this.chartName }),
+          actionLabel:  this.t('catalog.install.button.stages.loadCharts.action', { repo: this.repoDisplayName || this.repoName }),
+          waitingLabel: this.t('catalog.install.button.stages.loadCharts.waiting', { repo: this.repoDisplayName || this.repoName }),
+          successLabel: this.t('catalog.install.button.stages.loadCharts.success', { chart: this.chartDisplayName || this.chartName }),
+          errorLabel:   this.t('catalog.install.button.stages.loadCharts.error', { chart: this.chartDisplayName || this.chartName }),
           loading:      false,
           done:         false,
           errors:       []
         },
         configureChart: {
-          actionLabel:  this.t('catalog.install.button.stages.installChart.action', { chart: this.displayName || this.chartName }),
-          waitingLabel: this.t('catalog.install.button.stages.installChart.waiting', { chart: this.displayName || this.chartName }),
-          successLabel: this.t('catalog.install.button.stages.installChart.success', { chart: this.displayName || this.chartName }),
-          errorLabel:   this.t('catalog.install.button.stages.installChart.error', { chart: this.displayName || this.chartName }),
+          actionLabel:  this.t('catalog.install.button.stages.installChart.action', { chart: this.chartDisplayName || this.chartName }),
+          waitingLabel: this.t('catalog.install.button.stages.installChart.waiting', { chart: this.chartDisplayName || this.chartName }),
+          successLabel: this.t('catalog.install.button.stages.installChart.success', { chart: this.chartDisplayName || this.chartName }),
+          errorLabel:   this.t('catalog.install.button.stages.installChart.error', { chart: this.chartDisplayName || this.chartName }),
           loading:      false,
           done:         false,
           errors:       []
         },
         installChart: {
-          actionLabel:  this.t('catalog.install.button.stages.installChart.action', { chart: this.displayName || this.chartName }),
-          waitingLabel: this.t('catalog.install.button.stages.installChart.waiting', { chart: this.displayName || this.chartName }),
-          successLabel: this.t('catalog.install.button.stages.installChart.success', { chart: this.displayName || this.chartName }),
-          errorLabel:   this.t('catalog.install.button.stages.installChart.error', { chart: this.displayName || this.chartName }),
+          actionLabel:  this.t('catalog.install.button.stages.installChart.action', { chart: this.chartDisplayName || this.chartName }),
+          waitingLabel: this.t('catalog.install.button.stages.installChart.waiting', { chart: this.chartDisplayName || this.chartName }),
+          successLabel: this.t('catalog.install.button.stages.installChart.success', { chart: this.chartDisplayName || this.chartName }),
+          errorLabel:   this.t('catalog.install.button.stages.installChart.error', { chart: this.chartDisplayName || this.chartName }),
           loading:      false,
           done:         false,
           errors:       []
@@ -330,7 +335,7 @@ export default {
 
       const projects = this.$store.getters[`${ this.store }/all`](MANAGEMENT.PROJECT);
 
-      const systemProjectId = projects.find((p) => p.spec?.displayName === 'System')?.id?.split('/')?.[1] || '';
+      const systemProjectId = projects.find((p) => p.spec?.chartDisplayName === 'System')?.id?.split('/')?.[1] || '';
 
       const values = {
         global: {
@@ -401,10 +406,8 @@ export default {
       const { installOperationName, installOperationNamespace } = this;
       const operationId = `${ installOperationNamespace }/${ installOperationName }`;
 
-      // Non-admins without a cluster won't be able to fetch operations immediately
       await this.targetRepo.waitForOperation(operationId);
 
-      // Dynamically use store decided when loading catalog (covers standard user case when there's not cluster)
       this.operation = await this.$store.dispatch(`${ this.store }/find`, {
         type: CATALOG.OPERATION,
         id:   operationId
@@ -592,7 +595,7 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
-  <div v-if=" stages.installChart.done">
+  <div v-if="stages.installChart.done && logsReady">
     <button
       class="btn btn-sm role-secondary"
       type="button"
@@ -626,6 +629,7 @@ export default {
     <!-- click event's callback function is stored in a data prop to be triggerd by different component methods -->
     <!-- 'current phase' sets color, enabled/disabled, spinner -->
     <AsyncButton
+      v-if="!stages.installChart.done"
       :current-phase="buttonLabel.phase"
       :action-label="buttonLabel.actionLabel"
       :waiting-label="buttonLabel.waitingLabel"

--- a/shell/components/InstallHelmCharts.vue
+++ b/shell/components/InstallHelmCharts.vue
@@ -11,7 +11,6 @@ import AsyncButton from '@shell/components/AsyncButton';
 import Loading from '@shell/components/Loading';
 
 import { isPrerelease } from '@shell/utils/version';
-import { nextTick } from 'vue';
 import { set } from '@shell/utils/object';
 import { defaultCmdOpts as defaultOpts } from '@shell/pages/c/_cluster/apps/charts/install.vue';
 

--- a/shell/components/InstallHelmCharts.vue
+++ b/shell/components/InstallHelmCharts.vue
@@ -595,14 +595,16 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
-  <div v-if="stages.installChart.done && logsReady">
+  <div v-if="stages.installChart.done">
     <button
+      v-if="logsReady"
       class="btn btn-sm role-secondary"
       type="button"
       @click="openLogs"
     >
       {{ t('catalog.install.button.viewLogs') }}
     </button>
+    <span v-else><i class="icon icon-spinner icon-spin" />{{ t('catalog.install.button.waitForLogs') }} </span>
   </div>
   <div v-else>
     <div

--- a/shell/components/InstallHelmCharts.vue
+++ b/shell/components/InstallHelmCharts.vue
@@ -120,7 +120,6 @@ export default {
       serverUrlSetting:          null,
       debouncedRefreshCharts:    null,
       versionInfo:               null,
-      versionInfoError:          null,
       userValues:                {},
       // payload for 'install' action on clusterrepo resource
       // contains array of chart install info as well as some helm install opts that are set by default in the regular chart install ui
@@ -308,10 +307,7 @@ export default {
           versionName: targetVersion
         });
       } catch (e) {
-        // TODO nb growl?
-        this.versionInfoError = e;
-
-        console.error('Unable to fetch VersionInfo: ', e); // eslint-disable-line no-console
+        this.stages.configureChart.errors = e;
       }
     },
 
@@ -357,6 +353,7 @@ export default {
     },
 
     async installChart() {
+      this.stages.configureChart.errors = '';
       this.stages.installChart.loading = true;
 
       if (this.stages.installChart.done) {

--- a/shell/components/InstallHelmCharts.vue
+++ b/shell/components/InstallHelmCharts.vue
@@ -281,6 +281,7 @@ export default {
         } catch (err) {
           // some errors here are expected
           // we only show error state when while block finishes and still no chart found
+          // eslint-disable-next-line no-console
           console.error(err);
         }
       }
@@ -378,6 +379,7 @@ export default {
 
         res = await this.targetRepo.doAction('install', this.installCmd);
       } catch (err) {
+        // eslint-disable-next-line no-console
         console.error(err);
         this.btnCb(false);
 
@@ -468,24 +470,7 @@ export default {
     },
 
     // label the async button depending on form stage
-    /** set button currentPhase to one of xLabel
-     *   actionLabel: {
-      type:    String,
-      default: null,
-    },
-    waitingLabel: {
-      type:    String,
-      default: null,
-    },
-    successLabel: {
-      type:    String,
-      default: null,
-    },
-    errorLabel: {
-      type:    String,
-      default: null,
-    },
-
+    /** set button currentPhase to one of actionLabel, waitingLabel, successLabel, or errorLabel
      */
     buttonLabel() {
       const {

--- a/shell/components/InstallHelmCharts.vue
+++ b/shell/components/InstallHelmCharts.vue
@@ -281,7 +281,6 @@ export default {
         } catch (err) {
           // some errors here are expected
           // we only show error state when while block finishes and still no chart found
-          console.error(err); // eslint-disable-line no-console
         }
       }
 
@@ -378,7 +377,6 @@ export default {
 
         res = await this.targetRepo.doAction('install', this.installCmd);
       } catch (err) {
-        console.error(err); // eslint-disable-line no-console
         this.btnCb(false);
 
         this.stages.installChart.loading = false;

--- a/shell/components/InstallHelmCharts.vue
+++ b/shell/components/InstallHelmCharts.vue
@@ -1,0 +1,640 @@
+<script>
+import { mapGetters } from 'vuex';
+import debounce from 'lodash/debounce';
+
+import { CATALOG, MANAGEMENT } from '@shell/config/types';
+import { SETTING } from '@shell/config/settings';
+import { WINDOWS } from '@shell/store/catalog';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
+import Banner from '@components/Banner/Banner.vue';
+
+import AsyncButton from '@shell/components/AsyncButton';
+import { isPrerelease } from '@shell/utils/version';
+import { nextTick } from 'vue';
+import { set } from '@shell/utils/object';
+import { defaultCmdOpts } from '@shell/pages/c/_cluster/apps/charts/install.vue';
+
+/**
+ * Assumptions made by this component
+ * If not in a cluster context, you want to install things in the mgmt cluster
+ * You want to use the latest non-pre-release version of the chart
+ * You want global values (rancher values) configured just as they would be when using the full install experience
+ * Consuming component is responsible for determining:
+ *  - if the app is already installed
+ *  - if the user has permission to install apps
+ */
+
+const MAX_TRIES = 5;
+const RETRY_WAIT = 500;
+
+export default {
+  name: 'InstallHelmCharts',
+
+  components: { AsyncButton, Banner },
+
+  emits: ['done'],
+
+  props: {
+    // vuex store  management or cluster
+    store: {
+      type:    String,
+      default: 'cluster'
+    },
+
+    chartName: {
+      type:     String,
+      required: true
+    },
+
+    repoUrl: {
+      type:     String,
+      required: true
+    },
+
+    repoName: {
+      type:     String,
+      required: true
+    },
+
+    repoType: {
+      type:    String,
+      default: 'cluster'
+    },
+
+    // if not set will use chart targetNamespace. If neither this prop nor chart's targetNamespace are defined, will use default
+    targetNamespace: {
+      type:    String,
+      default: null
+    },
+
+    // consuming component can supply some values to merge with chart values
+    extraValues: {
+      type:    Object,
+      default: () => {
+        return {};
+      }
+    },
+
+    // how long in ms to show a done/success label between each step
+    delay: {
+      type:    Number,
+      default: 1000
+    },
+
+    displayName: {
+      type:    String,
+      default: null
+    }
+
+  },
+
+  async fetch() {
+    this.debouncedRefreshCharts = debounce((init = false) => {
+      try {
+        this.$store.dispatch('catalog/load', { force: true });
+      } catch (e) {
+        this.$store.dispatch('growl/fromError', { err: e });
+      }
+    }, 500);
+
+    if (!this.targetRepo || !this.chart) {
+      this.debouncedRefreshCharts(true);
+    }
+
+    try {
+      this.serverUrlSetting = await this.$store.dispatch(`${ this.store }/find`, {
+        type: MANAGEMENT.SETTING,
+        id:   SETTING.SERVER_URL,
+      });
+    } catch (e) {
+      console.error('Unable to fetch `server-url` setting: ', e); // eslint-disable-line no-console
+    }
+
+    await this.$store.dispatch(`${ this.store }/findAll`, { type: MANAGEMENT.PROJECT });
+  },
+
+  data() {
+    return {
+      serverUrlSetting:          null,
+      debouncedRefreshCharts:    null,
+      versionInfo:               null,
+      versionInfoError:          null,
+      userValues:                {},
+      // payload for 'install' action on clusterrepo resource
+      // contains array of chart install info as well as some helm install opts that are set by default in the regular chart install ui
+      installCmd:                { charts: [], ...defaultCmdOpts },
+      // 'operation' is crd used to view helm install logs
+      // name and ns returned from 'install' api call
+      installOperationName:      '',
+      installOperationNamespace: '',
+      operation:                 {},
+      logsReady:                 false,
+
+      // TODO nb localize
+      stages: {
+        addRepo: {
+          actionLabel:  `Install ${ this.displayName || this.chartName }`,
+          waitingLabel: `Adding ${ this.repoName } repository...`,
+          successLabel: 'Repository Added',
+          errorLabel:   `Error Adding ${ this.repoName } repository`,
+          loading:      false,
+          done:         false,
+          errors:       []
+        },
+        loadCharts: {
+          actionLabel:  `Fetch ${ this.repoName } repository chart(s)`,
+          waitingLabel: `Fetching ${ this.repoName } respository chart(s)...`,
+          successLabel: 'Charts found',
+          errorLabel:   'Chart not found - Try Again',
+          loading:      false,
+          done:         false,
+          errors:       []
+        },
+        configureChart: {
+          actionLabel:  `Install ${ this.displayName || this.chartName }`,
+          waitingLabel: `Installing ${ this.displayName || this.chartName }...`,
+          successLabel: 'Installed',
+          errorLabel:   'Error Installing Chart',
+          loading:      false,
+          done:         false,
+          errors:       []
+        },
+        installChart: {
+          actionLabel:  `Install ${ this.displayName || this.chartName }`,
+          waitingLabel: `Installing ${ this.displayName || this.chartName }...`,
+          successLabel: `${ this.displayName || this.chartName } Installation Initialized`,
+          errorLabel:   `Error Installing ${ this.displayName || this.chartName }...`,
+          loading:      false,
+          done:         false,
+          errors:       []
+        }
+      },
+      btnCb: () => {}
+    };
+  },
+
+  watch: {
+    targetRepo: {
+      handler(neu) {
+        if (neu) {
+          this.stages.addRepo.done = true;
+          this.stages.addRepo.errors = '';
+
+          if (!this.chart) {
+            this.fetchRepoCharts();
+          }
+        }
+      },
+      immediate: true
+    },
+
+    chart: {
+      handler(neu) {
+        if (neu) {
+          this.stages.loadCharts.done = true;
+          this.stages.loadCharts.errors = '';
+          this.fetchVersionInfo();
+        }
+      },
+      immediate: true
+    },
+
+    versionInfo(neu) {
+      const { chart: chartInfo } = neu;
+
+      this.installCmd.charts[0] = {
+        chartName:   this.chartName,
+        releaseName: chartInfo.name,
+        version:     chartInfo.version,
+        annotations: {
+          [CATALOG_ANNOTATIONS.SOURCE_REPO_TYPE]: this.repoType,
+          [CATALOG_ANNOTATIONS.SOURCE_REPO_NAME]: this.repoName
+        },
+        // this only needs to be values that differ from the default
+        values: {
+          ...this.getGlobalValues(), ...this.extraValues, ...this.userValues
+        }
+      };
+
+      this.installCmd.namespace = this.targetNamespace || this.chart?.targetNamespace || 'default';
+    }
+  },
+
+  methods: {
+    async addRepository() {
+      this.stages.addRepo.loading = true;
+      this.stages.addRepo.error = null;
+
+      try {
+        const repoObj = await this.$store.dispatch(`${ this.store }/create`, {
+          type:     CATALOG.CLUSTER_REPO,
+          metadata: { name: this.repoName },
+          spec:     { url: this.repoUrl },
+        });
+
+        try {
+          await repoObj.save();
+        } catch (e) {
+          this.$store.dispatch('growl/fromError', { err: e });
+          this.stages.addRepo.loading = false;
+
+          this.stages.addRepo.error = e;
+
+          this.btnCb(false);
+
+          return;
+        }
+
+        this.stages.addRepo.loading = false;
+        this.stages.addRepo.done = true;
+        this.stages.loadCharts.loading = true;
+        this.stages.loadCharts.error = '';
+        await nextTick();
+        this.debouncedRefreshCharts();
+      } catch (e) {
+        this.$store.dispatch('growl/fromError', { err: e });
+        this.stages.addRepo.loading = false;
+
+        this.stages.addRepo.error = e;
+        this.btnCb(false);
+      }
+    },
+
+    // it takes time to fetch a repo's charts when the repo resource is created
+    // so we retry loading the chart info using the "refresh" clusterrepo model action
+    async fetchRepoCharts() {
+      this.stages.loadCharts.loading = true;
+      this.stages.loadCharts.error = '';
+
+      let tries = 0;
+
+      while (tries < MAX_TRIES) {
+        try {
+          tries++;
+          await this.targetRepo.refresh();
+          if (this.chart) {
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, RETRY_WAIT));
+        } catch (err) {
+          // some errors here are expected
+          // we only show error state when while block finishes and still no chart found
+          console.error(err);
+        }
+      }
+
+      this.stages.loadCharts.loading = false;
+
+      // tried all our tries and the chart still isn't found - tell users something has gone wrong
+      if (!this.chart) {
+        this.btnCb(false);
+
+        this.stages.loadCharts.error = `Unable to locate the ${ this.chartName } chart in the ${ this.repoName } repository`;
+      } else {
+        this.btnCb(true);
+
+        this.stages.loadCharts.done = true;
+      }
+    },
+
+    async fetchVersionInfo() {
+      try {
+        // assume we want the latest non-prerelease version
+        const targetVersion = (this.chart?.versions || []).find((v) => v.version && !isPrerelease(v.version))?.version;
+
+        if (!targetVersion) {
+          return;
+        }
+        this.versionInfo = await this.$store.dispatch('catalog/getVersionInfo', {
+          repoType:    this.repoType,
+          repoName:    this.repoName,
+          chartName:   this.chartName,
+          versionName: targetVersion
+        });
+      } catch (e) {
+        // TODO nb growl?
+        this.versionInfoError = e;
+
+        console.error('Unable to fetch VersionInfo: ', e); // eslint-disable-line no-console
+      }
+    },
+
+    getGlobalValues() {
+      let clusterId = '';
+      let clusterName = '';
+
+      if (this.currentCluster) {
+        clusterId = this.currentCluster?.id;
+        clusterName = this.currentCluster.nameDisplay;
+      } else {
+        clusterId = 'local';
+        clusterName = 'local';
+      }
+
+      const serverUrl = this.serverUrlSetting?.value || '';
+      const rkePathPrefix = this.currentCluster?.spec?.rancherKubernetesEngineConfig?.prefixPath || '';
+      const rkeWindowsPathPrefix = this.currentCluster?.spec?.rancherKubernetesEngineConfig?.winPrefixPath || '';
+      const isWindows = (this.currentCluster?.workerOSs || []).includes(WINDOWS);
+
+      const projects = this.$store.getters[`${ this.store }/all`](MANAGEMENT.PROJECT);
+
+      const systemProjectId = projects.find((p) => p.spec?.displayName === 'System')?.id?.split('/')?.[1] || '';
+
+      const values = {
+        global: {
+          cattle: {
+            clusterName,
+            clusterId,
+            url: serverUrl,
+            rkePathPrefix,
+            rkeWindowsPathPrefix,
+            systemProjectId
+          }
+        }
+      };
+
+      if (isWindows) {
+        values.global.cattle.windows = { enabled: true };
+      }
+
+      return values;
+    },
+
+    async installChart(btnCb = () => {}) {
+      this.stages.installChart.loading = true;
+
+      if (this.stages.installChart.done) {
+        this.stages.installChart.loading = false;
+
+        this.stages.installChart.error = 'Chart already installed';
+
+        return;
+      }
+      let res;
+
+      try {
+        res = await this.targetRepo.doAction('install', this.installCmd);
+      } catch (err) {
+        // TODO nb growl?
+        console.error(err);
+        this.btnCb(false);
+
+        this.stages.installChart.loading = false;
+
+        this.stages.installChart.error = err;
+      }
+
+      // this.btnCb(true);
+      this.stages.installChart.loading = false;
+      this.stages.installChart.done = true;
+      this.installOperationName = res.operationName;
+      this.installOperationNamespace = res.operationNamespace;
+
+      await this.waitForLogs();
+      this.btnCb(true);
+
+      setTimeout(() => this.$emit('done', { namespace: res.operationNamespace, name: res.operationName }), this.delay);
+    },
+
+    setValue(key, val) {
+      set(this.userValues, key, val);
+    },
+
+    // find the helm operation and check if logs  are available
+    async waitForLogs() {
+      const { installOperationName, installOperationNamespace } = this;
+      const operationId = `${ installOperationNamespace }/${ installOperationName }`;
+
+      // Non-admins without a cluster won't be able to fetch operations immediately
+      await this.targetRepo.waitForOperation(operationId);
+
+      // Dynamically use store decided when loading catalog (covers standard user case when there's not cluster)
+      this.operation = await this.$store.dispatch(`${ this.store }/find`, {
+        type: CATALOG.OPERATION,
+        id:   operationId
+      });
+
+      try {
+        await this.operation.waitForLink('logs');
+        this.logsReady = true;
+      } catch (e) {
+        // The wait times out eventually, move on...
+      }
+    },
+
+    openLogs() {
+      this.operation.openLogs();
+    },
+  },
+
+  computed: {
+    // ...mapGetters(['currentCluster']),
+    ...mapGetters({
+      charts: 'catalog/charts',
+      repos:  'catalog/repos',
+      t:      'i18n/t'
+    }),
+
+    currentCluster() {
+      const storeCluster = this.$store.getters['currentCluster'];
+
+      if (storeCluster) {
+        return storeCluster;
+      }
+
+      return this.$store.getters[`management/byId`](MANAGEMENT.CLUSTER, 'local' );
+    },
+
+    /**
+       * [!IMPORTANT]
+       * TODO:
+       * THIS IS BROKEN
+       * When installing, if you add the repo and leave the page
+       * then come back, the controllerChart will be null, but so will
+       * the targetRepo. This is because the repo is not saved to the store?
+       * TODO nb
+       */
+    chart() {
+      if (this.targetRepo) {
+        return this.$store.getters['catalog/chart']({
+          repoName:  this.repoName,
+          repoType:  this.repoType,
+          chartName: this.chartName
+        });
+      }
+
+      return null;
+    },
+
+    targetRepo() {
+      return this.$store.getters['catalog/repo']({ repoType: this.repoType, repoName: this.repoName });
+    },
+
+    // label the async button depending on form stage
+    /** set button currentPhase to one of xLabel
+     *   actionLabel: {
+      type:    String,
+      default: null,
+    },
+    waitingLabel: {
+      type:    String,
+      default: null,
+    },
+    successLabel: {
+      type:    String,
+      default: null,
+    },
+    errorLabel: {
+      type:    String,
+      default: null,
+    },
+
+     */
+    buttonLabel() {
+      const {
+        addRepo, loadCharts, configureChart, installChart
+      } = this.stages;
+
+      const pStages = [installChart, configureChart, loadCharts, addRepo];
+
+      // start w/ add repo label
+      const out = {
+        actionLabel:  addRepo.actionLabel,
+        waitingLabel: addRepo.waitingLabel,
+        successLabel: addRepo.successLabel,
+        errorLabel:   addRepo.errorLabel,
+        phase:        'action',
+        action:       this.addRepository
+
+      };
+
+      const errorStage = pStages.find((s) => s?.error && s?.error?.length);
+
+      if (errorStage) {
+        out.phase = 'error';
+        out.waitingLabel = errorStage.errorLabel;
+        out.errorLabel = errorStage.errorLabel;
+        out.error = errorStage.error;
+
+        if (errorStage === loadCharts) {
+          out.action = () => {
+            if (!this.chart) {
+              this.fetchRepoCharts();
+            } else {
+              this.fetchVersionInfo();
+            }
+          };
+        }
+
+        return out;
+      }
+
+      // Find latest loading stage
+      const loadingStage = pStages.find((s) => s?.loading);
+
+      if (loadingStage) {
+        out.phase = 'waiting';
+        out.waitingLabel = loadingStage.waitingLabel;
+        out.actionLabel = loadingStage.waitingLabel;
+        out.successLabel = loadingStage.successLabel;
+
+        return out;
+      }
+
+      const nextStageI = pStages.findIndex((s) => s?.done) - 1;
+
+      if (nextStageI >= 0 && pStages[nextStageI]) {
+        const nextStage = pStages[nextStageI];
+
+        out.phase = 'action';
+        out.actionLabel = nextStage.actionLabel;
+        out.waitingLabel = nextStage.waitingLabel;
+        out.successLabel = nextStage.successLabel;
+
+        if (nextStage === configureChart || nextStage === installChart) {
+          out.action = this.installChart;
+
+          return out;
+        }
+        if (nextStage === loadCharts) {
+          out.phase = 'waiting';
+          out.action = () => {
+            if (!this.chart) {
+              this.fetchRepoCharts();
+            } else {
+              this.fetchVersionInfo();
+            }
+          };
+        }
+
+        return out;
+        // nothing is in error, nothing is loading, nothing is done - show first step
+      } else {
+        return {
+          actionLabel:  addRepo.actionLabel,
+          waitingLabel: addRepo.waitingLabel,
+          successLabel: addRepo.successLabel,
+          errorLabel:   addRepo.errorLabel,
+          phase:        'action',
+          action:       this.addRepository
+
+        };
+      }
+    },
+
+    errors() {
+      return this.buttonLabel.errors;
+    },
+
+  },
+
+}
+;
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" />
+  <div v-if=" stages.installChart.done">
+    <button
+      class="btn btn-sm role-secondary"
+      type="button"
+      @click="openLogs"
+    >
+      view helm logs
+    </button>
+  </div>
+  <div v-else>
+    <div v-if="stages.loadCharts.done && chart && !( stages.installChart.loading || stages.installChart.done )">
+      <!-- shown when a chart is ready to be installed, and installation has not yet begun -->
+      <slot
+        :set-value="setValue"
+        :values="userValues"
+        name="values"
+      />
+    </div>
+    <div v-if="errors">
+      <slot
+        :errors="errors"
+        name="errors"
+      >
+        <Banner
+          color="error"
+          :label="errors"
+        />
+      </slot>
+    </div>
+    <!-- click event's callback function is stored in a data prop to be triggerd by different component methods -->
+    <!-- 'current phase' sets color, enabled/disabled, spinner -->
+    <AsyncButton
+      :current-phase="buttonLabel.phase"
+      :action-label="buttonLabel.actionLabel"
+      :waiting-label="buttonLabel.waitingLabel"
+      :success-label="buttonLabel.successLabel"
+      :error-label="buttonLabel.errorLabel"
+      :delay="delay"
+      type="button"
+      class="btn role-primary"
+      @click="cb=>{btnCb=cb;buttonLabel.action()}"
+    />
+  </div>
+</template>

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -51,7 +51,7 @@ const VALUES_STATE = {
  * Helm CLI options that are not persisted on the back end,
  * but are used for the final install/upgrade operation.
  */
-const defaultCmdOpts = {
+export const defaultCmdOpts = {
   cleanupOnFail: false,
   crds:          true,
   hooks:         true,

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -59,7 +59,7 @@ export const defaultCmdOpts = {
   resetValues:   false,
   openApi:       true,
   wait:          true,
-  timeout:       '600',
+  timeout:       600,
   historyMax:    5,
 };
 

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -59,7 +59,7 @@ export const defaultCmdOpts = {
   resetValues:   false,
   openApi:       true,
   wait:          true,
-  timeout:       600,
+  timeout:       '600',
   historyMax:    5,
 };
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13105 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR adds a component to install charts outside the apps and marketplace with minimal configuration. 

### Areas or cases that should be tested
Test using https://github.com/rancher/capi-ui-extension/pull/169

### Areas which could experience regressions
none

### Screenshot/Video


https://github.com/user-attachments/assets/748bdf28-80e7-4dff-8f6c-f18696f17662


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
