### PR TITLE
Update backport bot to use issue URL rather than issue Number

### DIFF
--- a/.github/workflows/port-issue.yaml
+++ b/.github/workflows/port-issue.yaml
@@ -52,6 +52,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORIGINAL_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ORIGINAL_ISSUE_URL: ${{ github.event.issue.html_url }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           declare -a additional_cmd
@@ -95,7 +96,7 @@ jobs:
               fi
           fi
           if [ -n "$MILESTONE" ]; then
-              echo -e "This is a ${TYPE} issue for #${ORIGINAL_ISSUE_NUMBER}, automatically created via [GitHub Actions workflow]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) initiated by @${GITHUB_ACTOR}\n" > $BODY
+              echo -e "This is a ${TYPE} issue for ${ORIGINAL_ISSUE_URL}, automatically created via [GitHub Actions workflow]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) initiated by @${GITHUB_ACTOR}\n" > $BODY
               echo -e "\nOriginal issue body:\n" >> $BODY
               echo "${ORIGINAL_ISSUE}" | jq -r '.body[0:65536]' >> $BODY
               NEW_ISSUE=$(gh issue create -R "${GITHUB_REPOSITORY}" --title "${NEW_TITLE}" --body-file "${BODY}" -m "${MILESTONE}" "${additional_cmd[@]}")

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2150,7 +2150,7 @@ export default {
       :showing-form="showForm"
       :default-on-cancel="true"
       data-testid="select-credential"
-      class="mt-20"
+      class="mt-20 span-4"
     />
 
     <div

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2150,7 +2150,7 @@ export default {
       :showing-form="showForm"
       :default-on-cancel="true"
       data-testid="select-credential"
-      class="mt-20 span-4"
+      class="mt-20"
     />
 
     <div


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14355

### Occurred changes and/or fixed issues

Updates issue backport bot to use full URL rather than the issue number.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
