### PR TITLE
Separated creating new namespace from createNamespace check

### DIFF
--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -371,8 +371,6 @@ export default {
     },
 
     async clickSave(buttonDone) {
-      let errorOccurred = false;
-
       if (this.createNamespace) {
         try {
           await this.createNamespaceIfNeeded();
@@ -381,16 +379,15 @@ export default {
         // show any applicable errors if the namespace is
         // invalid.
           this.$emit('error', exceptionToErrorsArray(err.message));
-          errorOccurred = true;
           buttonDone(false);
+
+          return;
         }
       }
 
       // If the attempt to create the new namespace
       // was successful or no ns needs to be created, save the resource.
-      if (!errorOccurred) {
-        this.$emit('finish', buttonDone);
-      }
+      this.$emit('finish', buttonDone);
     },
 
     save() {

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -371,19 +371,21 @@ export default {
     },
 
     async clickSave(buttonDone) {
-      try {
-        await this.createNamespaceIfNeeded();
-
-        // If the attempt to create the new namespace
-        // is successful, save the resource.
-        this.$emit('finish', buttonDone);
-      } catch (err) {
+      if (this.createNamespace) {
+        try {
+          await this.createNamespaceIfNeeded();
+        } catch (err) {
         // After the attempt to create the namespace,
         // show any applicable errors if the namespace is
         // invalid.
-        this.$emit('error', exceptionToErrorsArray(err.message));
-        buttonDone(false);
+          this.$emit('error', exceptionToErrorsArray(err.message));
+          buttonDone(false);
+        }
       }
+
+      // If the attempt to create the new namespace
+      // was successful or no ns needs to be created, save the resource.
+      this.$emit('finish', buttonDone);
     },
 
     save() {
@@ -395,17 +397,13 @@ export default {
       const newNamespaceName = get(this.resource, this.namespaceKey);
       let namespaceAlreadyExists = false;
 
-      if (!this.createNamespace) {
-        return;
-      }
-
       try {
         // This is in a try-catch block because the call to fetch
         // a namespace throws an error if the namespace is not found.
         namespaceAlreadyExists = !!(await this.$store.dispatch(`${ inStore }/find`, { type: NAMESPACE, id: newNamespaceName }));
       } catch {}
 
-      if (this.createNamespace && !namespaceAlreadyExists) {
+      if (!namespaceAlreadyExists) {
         try {
           const newNamespace = await this.$store.dispatch(`${ inStore }/createNamespace`, { name: newNamespaceName }, { root: true });
 

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -371,6 +371,8 @@ export default {
     },
 
     async clickSave(buttonDone) {
+      let errorOccurred = false;
+
       if (this.createNamespace) {
         try {
           await this.createNamespaceIfNeeded();
@@ -379,13 +381,16 @@ export default {
         // show any applicable errors if the namespace is
         // invalid.
           this.$emit('error', exceptionToErrorsArray(err.message));
+          errorOccurred = true;
           buttonDone(false);
         }
       }
 
       // If the attempt to create the new namespace
       // was successful or no ns needs to be created, save the resource.
-      this.$emit('finish', buttonDone);
+      if (!errorOccurred) {
+        this.$emit('finish', buttonDone);
+      }
     },
 
     save() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14462 
<!-- Define findings related to the feature or bug issue. -->
Separated new namespace creation logic from a check to see if CruResource should create a new namespace.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
CAPI providers usually have pre-defined namespaces they are supposed to be created at. Those namespaces usually do not exist if provider has not been installed before. Without this change, it is impossible to pre-set the namespace we want to create and we would have to rely on users to know the correct namespace name and create it using 'Create New Namespace' functionality of the NameNsDescription control, which would set createNamespace state to true. We want to avoid having to rely on the user to do this, however, there was no other way to overwrite the value of createNamespace check. With this change, other components can call createNamespaceIfNeeded method directly, sidestepping createNamespace check if needed.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Make sure that NameNsDescription functionality hasn't changed:
- You can create a new namespace if 'Create a New Namespace' is selected. 
- For components that do not allow in-line creation of a new namespace, no new namespace is created

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
This could technically affect any component that utilizes CruResource

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
