### PR TITLE
Ensure selection of secret key when configuring alert manager configs

### DIFF
--- a/shell/components/form/SimpleSecretSelector.vue
+++ b/shell/components/form/SimpleSecretSelector.vue
@@ -75,8 +75,11 @@ export default {
       key:                props.initialKey,
       none:               NONE,
       SECRET,
+      /**
+       * Of type @ResourceLabeledSelectSettings
+       */
       allSecretsSettings: {
-        mapResult: (secrets) => {
+        updateResources: (secrets) => {
           const allSecretsInNamespace = secrets.filter((secret) => this.types.includes(secret._type) && secret.namespace === this.namespace);
           const mappedSecrets = this.mapSecrets(allSecretsInNamespace.sort((a, b) => a.name.localeCompare(b.name)));
 
@@ -85,9 +88,12 @@ export default {
           return mappedSecrets;
         }
       },
+      /**
+       * Of type @ResourceLabeledSelectPaginateSettings
+       */
       paginateSecretsSetting: {
         requestSettings: this.paginatePageOptions,
-        mapResult:       (secrets) => {
+        updateResources: (secrets) => {
           const mappedSecrets = this.mapSecrets(secrets);
 
           this.secrets = secrets; // We need the key from the selected secret. When paginating we won't touch the store, so just pass back here


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14474
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Regression introduced in v2.11.0
- wrong map fn name was used for SimpleSecretSelector
- SimpleSecretSelector is only used when managing alert manager configs


### Areas or cases that should be tested
- Creating alert manager config for all types
  - Install monitoring
  - Monitoring --> Alerting --> AlertmanagerConfigs --> Create --> enter name --> Create
  - Create a secret in the same namespace the AlertmanagerConfig was created it
  - Edit the AlertmanagerConfigs --> Add Receiver --> Slack -->
  - Select a secret --> select a key from that secret

### Areas which could experience regressions
Recieves other than slack

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
