### PR TITLE
Implementation of Visual Test with Percy for Machine sets page #14386

### DIFF
--- a/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
@@ -3,6 +3,28 @@ import MachineSetsPagePo from '@/cypress/e2e/po/pages/cluster-manager/machine-se
 import * as path from 'path';
 import * as jsyaml from 'js-yaml';
 
+describe('Visual Testing', { testIsolation: 'off', tags: ['@manager', '@adminUser'] }, () => {
+  before(() => {
+    cy.login();
+  });
+  it('validating empty machine sets page with percy', () => {
+    const machineSetsPage = new MachineSetsPagePo();
+
+    MachineSetsPagePo.goTo();
+    machineSetsPage.waitForPage();
+
+    machineSetsPage.list().resourceTable().sortableTable().checkVisible();
+    machineSetsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+    machineSetsPage.waitForPage();
+
+    // Ignoring the user profile picture
+    cy.hideElementBySelector('[data-testid="nav_header_showUserMenu"]');
+    // Ignoring the side navbar counters
+    cy.hideElementBySelector("[data-testid='type-count']");
+    // takes percy snapshot.
+    cy.percySnapshot('machineSets Page');
+  });
+});
 describe('MachineSets', { testIsolation: 'off', tags: ['@manager', '@adminUser'] }, () => {
   const machineSetsPage = new MachineSetsPagePo();
   const nsName = 'default';


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
A visual test has been created using Percy to verify the machine sets screen within Rancher. The goal of this test is to ensure that the user interface is displayed correctly and detect any unexpected visual changes

Page route:
`qa.rancher.space/dashboard/c/_/manager/cluster.x-k8s.io.machineset`
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
