### PR TITLE
Automation - Adding a test to check the Resource UI elements in the Chart Wizard

### DIFF
--- a/cypress/e2e/po/pages/explorer/charts/install-charts.po.ts
+++ b/cypress/e2e/po/pages/explorer/charts/install-charts.po.ts
@@ -51,6 +51,10 @@ export class InstallChartPage extends PagePo {
     return this;
   }
 
+  chartName() {
+    return this.self().get('[data-testid="NameNsDescriptionNameInput"]');
+  }
+
   tabsCountOnInstallQuestions() {
     return new TabbedPo().allTabs();
   }

--- a/cypress/e2e/tests/pages/charts/chart-install-wizard.spec.ts
+++ b/cypress/e2e/tests/pages/charts/chart-install-wizard.spec.ts
@@ -1,0 +1,70 @@
+import { ChartPage } from '@/cypress/e2e/po/pages/explorer/charts/chart.po';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import { InstallChartPage } from '@/cypress/e2e/po/pages/explorer/charts/install-charts.po';
+import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
+import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+
+const configMapPayload = {
+  apiVersion: 'v1',
+  kind:       'ConfigMap',
+  metadata:   {
+    name:        `e2e-test-${ +new Date() }`,
+    annotations: {},
+    labels:      {},
+    namespace:   'default'
+  },
+  data:    { foo: 'bar' },
+  __clone: true
+};
+
+describe('Charts Wizard', { testIsolation: 'off', tags: ['@charts', '@adminUser', '@vai'] }, () => {
+  const testChartsRepoName = 'test-charts';
+  const testChartsGitRepoUrl = 'https://github.com/richard-cox/rodeo';
+  const testChartsBranchName = 'master';
+
+  before(() => {
+    cy.login();
+    HomePagePo.goTo();
+  });
+
+  describe('Check resources are selectable in the chart install wizard', () => {
+    const installChartPage = new InstallChartPage();
+    const chartPage = new ChartPage();
+    const tabbedPo = new TabbedPo('[data-testid="tabbed-block"]');
+
+    before(() => {
+      cy.createRancherResource('v1', 'catalog.cattle.io.clusterrepos', {
+        type:     'catalog.cattle.io.clusterrepo',
+        metadata: { name: testChartsRepoName },
+        spec:     {
+          clientSecret: null, gitRepo: testChartsGitRepoUrl, gitBranch: testChartsBranchName
+        }
+      });
+
+      cy.createRancherResource('v1', 'configmaps', configMapPayload);
+    });
+
+    it('Resource dropdown picker has ConfigMaps listed', () => {
+      ChartPage.navTo(null, 'rancher-demo');
+      chartPage.waitForChartHeader('rancher-demo', MEDIUM_TIMEOUT_OPT);
+      chartPage.goToInstall();
+      installChartPage.chartName().type('rancher-demo');
+      installChartPage.nextPage();
+      tabbedPo.allTabs().should('have.length', 4);
+      installChartPage.selectTab(tabbedPo, 'Other Demo Fields');
+
+      const labeledSelect = new LabeledSelectPo('section[id="Other Demo Fields"] [type="search"]');
+
+      labeledSelect.self().scrollIntoView();
+      labeledSelect.toggle();
+      labeledSelect.clickLabel(`${ configMapPayload.metadata.name }`);
+    });
+
+    after('clean up', () => {
+      cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', testChartsRepoName);
+      cy.deleteRancherResource('v1', 'configmaps', `${ configMapPayload.metadata.namespace }/${ configMapPayload.metadata.name }` );
+      cy.updateNamespaceFilter('local', 'none', '{"local":["all://user"]}');
+    });
+  });
+});


### PR DESCRIPTION
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1795

### Occurred changes and/or fixed issues
Adding a basic validation for a Resource UI element LabeledSelector that let the user pick existing resources during the Chart Wizard.

### Technical notes summary
In this case the test chart has a ConfigMaps selector. 
The repo URL is suggested in the EPIC linked in the task for reproducibility.

### Areas or cases that should be tested
N/A

### Areas which could experience regressions
N/A

### Checklist
- [X] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [X] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [X] The PR template has been filled out
- [X] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [X] The PR has a reviewer assigned
- [X] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [X] ~The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes~
- [X] ~The PR has been reviewed in terms of Accessibility~
