### PR TITLE
SSP: Disable SSP for side nav and home page cluster list

### DIFF
--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -658,18 +658,19 @@ export const PAGINATION_SETTINGS_STORE_DEFAULTS: PaginationSettingsStore = {
       }
     }
   },
-  management: {
-    resources: {
-      enableAll:  false,
-      enableSome: {
-        enabled: [
-          { resource: CAPI.RANCHER_CLUSTER, context: ['home', 'side-bar'] },
-          { resource: MANAGEMENT.CLUSTER, context: ['side-bar'] },
-        ],
-        generic: false,
-      }
-    }
-  }
+  // Disabled due to https://github.com/rancher/dashboard/issues/14493
+  // management: {
+  //   resources: {
+  //     enableAll:  false,
+  //     enableSome: {
+  //       enabled: [
+  //         { resource: CAPI.RANCHER_CLUSTER, context: ['home', 'side-bar'] },
+  //         { resource: MANAGEMENT.CLUSTER, context: ['side-bar'] },
+  //       ],
+  //       generic: false,
+  //     }
+  //   }
+  // }
 };
 
 export default new StevePaginationUtils();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Updates to the cluster lists in the side nav are not updating correctly when clusters are created or deleted. This is one of the final hurdles to enabling SSP by default, so disable ssp for those cases to unblock a lot of activity

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Remove locations from allow list
- Will be reverted as part of https://github.com/rancher/dashboard/issues/14493

### Areas or cases that should be tested
- side nav updates when a cluster is created/deleted 
  - when on the home page
  - when on the cluster manager cluster list
  - when clusters are created/deleted in another browser

### Areas which could experience regressions
- none

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
