### PR TITLE
Fleet add Cluster targets Match Expressions

### DIFF
--- a/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po.ts
+++ b/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po.ts
@@ -8,6 +8,7 @@ import SelectOrCreateAuthPo from '@/cypress/e2e/po/components/select-or-create-a
 import { BaseListPagePo } from '@/cypress/e2e/po/pages/base/base-list-page.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import ResourceTablePo from '@/cypress/e2e/po/components/resource-table.po';
+import RadioGroupInputPo from '@/cypress/e2e/po/components/radio-group-input.po';
 
 export class FleetApplicationListPagePo extends BaseListPagePo {
   static url = `/c/_/fleet/application`;
@@ -83,8 +84,12 @@ export class FleetGitRepoCreateEditPo extends BaseDetailPagePo {
     return this.gitRepoPaths().setValueAtIndex(path, index);
   }
 
+  targetClusterOptions(): RadioGroupInputPo {
+    return new RadioGroupInputPo('[data-testid="fleet-target-cluster-radio-button"]');
+  }
+
   targetCluster(): LabeledSelectPo {
-    return new LabeledSelectPo('[data-testid="fleet-gitrepo-target-cluster"]');
+    return new LabeledSelectPo('[data-testid="fleet-target-cluster-name-selector"]');
   }
 
   gitRepoPaths() {

--- a/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
@@ -84,9 +84,10 @@ describe('Git Repo', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] }, (
 
       gitRepoCreatePage.resourceDetail().createEditView().nextPage();
 
-      // Target info step
+      // Target selection step
+      gitRepoCreatePage.targetClusterOptions().set(2);
       gitRepoCreatePage.targetCluster().toggle();
-      gitRepoCreatePage.targetCluster().clickOption(6);
+      gitRepoCreatePage.targetCluster().clickLabel(fakeProvClusterId);
 
       gitRepoCreatePage.resourceDetail().createEditView().nextPage();
 

--- a/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
@@ -85,6 +85,7 @@ describe('Git Repo', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] }, (
       gitRepoCreatePage.resourceDetail().createEditView().nextPage();
 
       // Target selection step
+      gitRepoCreatePage.targetClusterOptions().set(1);
       gitRepoCreatePage.targetClusterOptions().set(2);
       gitRepoCreatePage.targetCluster().toggle();
       gitRepoCreatePage.targetCluster().clickLabel(fakeProvClusterId);

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2591,6 +2591,11 @@ fleet:
         title: Selected clusters
         placeholder: Select clusters by name or labels
         empty: No clusters in the workspace
+        plusMore: |-
+          {n, plural,
+            =1 {+ 1 more cluster}
+            other {+ {n, number} more clusters}
+          }
   application:
     pageTitle: App Bundles
     menuLabel: App Bundles
@@ -2725,7 +2730,7 @@ fleet:
       additionalOptions: Additional settings
     targetDisplay:
       advanced: Advanced
-      clusters: "Clusters"
+      clusters: Clusters
       all: All
       none: None
       local: Local
@@ -2857,7 +2862,7 @@ fleet:
       additionalOptions: Additional Options
     targetDisplay:
       advanced: Advanced
-      clusters: "Clusters"
+      clusters: Clusters
       all: All
       none: None
       local: Local

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2722,8 +2722,7 @@ fleet:
       additionalOptions: Additional Options
     targetDisplay:
       advanced: Advanced
-      cluster: "Cluster"
-      clusterGroup: "Group"
+      clusters: "Clusters"
       all: All
       none: None
       local: Local
@@ -2855,8 +2854,7 @@ fleet:
       additionalOptions: Additional Options
     targetDisplay:
       advanced: Advanced
-      cluster: "Cluster"
-      clusterGroup: "Group"
+      clusters: "Clusters"
       all: All
       none: None
       local: Local

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2578,6 +2578,16 @@ fleet:
       unknown: 'Unknown'
       notReady: Not Ready
       waitApplied: Wait Applied
+  clusterTargets:
+    label: Clusters
+    advancedConfigs: Advanced target configurations are defined, check the YAML file for further details.
+    placeholders:
+      selectMultiple: Select Multiple Clusters
+    rules:
+      title: Labels matching rules
+      description: Add rules to select clusters with matching labels
+      addSelector: Add cluster selector
+      matching: Target Clusters
   application:
     pageTitle: App Bundles
     menuLabel: App Bundles
@@ -2709,6 +2719,7 @@ fleet:
       clusterGroup: Cluster Group
       label: Deploy To
       labelLocal: Deploy With
+      additionalOptions: Additional Options
     targetDisplay:
       advanced: Advanced
       cluster: "Cluster"
@@ -2841,6 +2852,7 @@ fleet:
       clusterGroup: Cluster Group
       label: Deploy To
       labelLocal: Deploy With
+      additionalOptions: Additional Options
     targetDisplay:
       advanced: Advanced
       cluster: "Cluster"

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2579,15 +2579,18 @@ fleet:
       notReady: Not Ready
       waitApplied: Wait Applied
   clusterTargets:
+    title: Select by name
     label: Clusters
     advancedConfigs: Advanced target configurations are defined, check the YAML file for further details.
     placeholders:
       selectMultiple: Select Multiple Clusters
     rules:
-      title: Labels matching rules
-      description: Add rules to select clusters with matching labels
+      title: Select by labels
       addSelector: Add cluster selector
-      matching: Target Clusters
+      matching:
+        title: Selected clusters
+        placeholder: Select clusters by name or labels
+        empty: No clusters in the workspace
   application:
     pageTitle: App Bundles
     menuLabel: App Bundles
@@ -2719,7 +2722,7 @@ fleet:
       clusterGroup: Cluster Group
       label: Deploy To
       labelLocal: Deploy With
-      additionalOptions: Additional Options
+      additionalOptions: Additional settings
     targetDisplay:
       advanced: Advanced
       clusters: "Clusters"

--- a/shell/components/fleet/FleetClusterTargets/TargetsList.vue
+++ b/shell/components/fleet/FleetClusterTargets/TargetsList.vue
@@ -1,0 +1,54 @@
+<script lang="ts">
+import { PropType } from 'vue';
+
+export default {
+  name: 'FleetTargetsList',
+
+  props: {
+    clusters: {
+      type:    Array as PropType<{ name: string }[]>,
+      default: () => [],
+    },
+  },
+
+  computed: {
+    names() {
+      const names = this.clusters.map(({ name }) => name);
+      const max = 10;
+
+      const remaining = names.length - max;
+
+      if (remaining > 0) {
+        return [
+          ...names.filter((_, i) => i < max),
+          `... and ${ remaining } other clusters`
+        ];
+      }
+
+      return names;
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="targets-list">
+    <h3>{{ t('fleet.clusterTargets.rules.matching') }}</h3>
+    <span
+      v-for="(name, i) in names"
+      :key="i"
+      class="row"
+    >
+      {{ name }}
+    </span>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .targets-list {
+    border: 1px solid var(--border);
+    padding: 15px;
+    border-radius: 5px;
+    height: 100%;
+  }
+</style>

--- a/shell/components/fleet/FleetClusterTargets/TargetsList.vue
+++ b/shell/components/fleet/FleetClusterTargets/TargetsList.vue
@@ -9,6 +9,11 @@ export default {
       type:    Array as PropType<{ name: string }[]>,
       default: () => [],
     },
+
+    emptyLabel: {
+      type:    String,
+      default: ''
+    }
   },
 
   computed: {
@@ -33,22 +38,25 @@ export default {
 
 <template>
   <div class="targets-list">
-    <h3>{{ t('fleet.clusterTargets.rules.matching') }}</h3>
+    <h3>{{ t('fleet.clusterTargets.rules.matching.title') }}</h3>
     <span
       v-for="(name, i) in names"
       :key="i"
-      class="row"
+      class="row mt-5"
     >
       {{ name }}
+    </span>
+    <span
+      v-if="!names.length"
+      class="text-muted"
+    >
+      {{ emptyLabel || t('fleet.clusterTargets.rules.matching.empty') }}
     </span>
   </div>
 </template>
 
 <style lang="scss" scoped>
   .targets-list {
-    border: 1px solid var(--border);
-    padding: 15px;
-    border-radius: 5px;
     height: 100%;
   }
 </style>

--- a/shell/components/fleet/FleetClusterTargets/TargetsList.vue
+++ b/shell/components/fleet/FleetClusterTargets/TargetsList.vue
@@ -26,7 +26,7 @@ export default {
       if (remaining > 0) {
         return [
           ...names.filter((_, i) => i < max),
-          `... and ${ remaining } other clusters`
+          this.t('fleet.clusterTargets.rules.matching.plusMore', { n: remaining }, true),
         ];
       }
 

--- a/shell/components/fleet/FleetClusterTargets/index.vue
+++ b/shell/components/fleet/FleetClusterTargets/index.vue
@@ -28,7 +28,7 @@ export default {
 
   name: 'FleetClusterTargets',
 
-  emits: ['update:value'],
+  emits: ['update:value', 'created'],
 
   components: {
     Banner,
@@ -58,7 +58,12 @@ export default {
     mode: {
       type:    String,
       default: _EDIT
-    }
+    },
+
+    created: {
+      type:    String as PropType<TargetMode>,
+      default: '',
+    },
   },
 
   async fetch() {
@@ -85,7 +90,14 @@ export default {
   mounted() {
     this.fromTargets();
 
-    this.update();
+    if (this.mode === _CREATE) {
+      this.update();
+
+      // Restore the targetMode from parent component; this is the case of edit targets in CREATE mode, go to YAML editor and come back to the form
+      this.targetMode = this.created || 'all';
+    } else {
+      this.targetMode = FleetUtils.Application.getTargetMode(this.targets || [], this.namespace);
+    }
   },
 
   watch: {
@@ -149,6 +161,9 @@ export default {
     selectTargetMode(value: TargetMode) {
       this.targetMode = value;
 
+      // Save the current targetMode in parent component
+      this.$emit('created', this.targetMode);
+
       this.update();
     },
 
@@ -186,8 +201,6 @@ export default {
       if (!this.targets?.length) {
         return;
       }
-
-      this.targetMode = FleetUtils.Application.getTargetMode(this.targets || [], this.namespace);
 
       for (const target of this.targets) {
         const {

--- a/shell/components/fleet/FleetClusterTargets/index.vue
+++ b/shell/components/fleet/FleetClusterTargets/index.vue
@@ -353,6 +353,7 @@ export default {
             :mode="mode"
             :initial-empty-row="true"
             :add-icon="'icon-plus'"
+            :add-class="'btn-sm'"
             @update:value="updateMatchExpressions(i, $event, selector.key)"
           />
           <RcButton

--- a/shell/components/fleet/FleetClusterTargets/index.vue
+++ b/shell/components/fleet/FleetClusterTargets/index.vue
@@ -184,7 +184,7 @@ export default {
     },
 
     fromTargets() {
-      this.targetMode = 'all';
+      this.targetMode = FleetUtils.Application.getTargetMode(this.targets || []);
 
       if (!this.targets?.length) {
         return;

--- a/shell/components/fleet/FleetClusterTargets/index.vue
+++ b/shell/components/fleet/FleetClusterTargets/index.vue
@@ -384,11 +384,12 @@ export default {
 
   <div
     v-if="targetMode === 'all' && !isLocal"
-    class="row mt-20"
+    class="row"
   >
     <div class="col span-6">
       <TargetsList
-        class="target-list"
+        v-if="matching.length"
+        class="target-list mt-20"
         :clusters="matching"
       />
     </div>

--- a/shell/components/fleet/FleetClusterTargets/index.vue
+++ b/shell/components/fleet/FleetClusterTargets/index.vue
@@ -210,6 +210,7 @@ export default {
           clusterGroupSelector,
         } = target;
 
+        // If clusterGroup or clusterGroupSelector are defined, targets are marked as complex and won't handle by the UI
         if (clusterGroup || clusterGroupSelector) {
           return;
         }

--- a/shell/components/fleet/FleetClusterTargets/index.vue
+++ b/shell/components/fleet/FleetClusterTargets/index.vue
@@ -111,18 +111,18 @@ export default {
 
       const out: { label: string, value: TargetMode }[] = [
         {
-          label: 'All Clusters in the Workspace',
+          label: 'All Clusters in the workspace',
           value: 'all',
         },
         {
-          label: 'No Clusters',
+          label: 'No clusters',
           value: 'none'
         },
       ];
 
       if (this.clustersOptions.length) {
         out.push({
-          label: 'Manually select clusters',
+          label: 'Manually selected clusters',
           value: 'clusters'
         });
       }
@@ -326,7 +326,9 @@ export default {
     class="row mt-20"
   >
     <div class="col span-8">
+      <h3> {{ t('fleet.clusterTargets.title') }} </h3>
       <LabeledSelect
+        class="mt-20"
         :value="selectedClusters"
         :label="t('fleet.clusterTargets.label')"
         :options="clustersOptions"
@@ -337,15 +339,12 @@ export default {
         :placeholder="t('fleet.clusterTargets.placeholders.selectMultiple')"
         @update:value="selectClusters"
       />
-      <div class="mt-20">
+      <div class="mt-30">
         <h3> {{ t('fleet.clusterTargets.rules.title') }} </h3>
-        <p class="text-muted">
-          {{ t('fleet.clusterTargets.rules.description') }}
-        </p>
         <div
           v-for="(selector, i) in clusterSelectors"
           :key="selector.key"
-          class="match-expressions-container mt-10"
+          class="match-expressions-container mt-20"
         >
           <MatchExpressions
             class="body"
@@ -382,6 +381,7 @@ export default {
       <TargetsList
         class="target-list"
         :clusters="matching"
+        :empty-label="t('fleet.clusterTargets.rules.matching.placeholder')"
       />
     </div>
   </div>

--- a/shell/components/fleet/FleetClusterTargets/index.vue
+++ b/shell/components/fleet/FleetClusterTargets/index.vue
@@ -306,6 +306,7 @@ export default {
   >
     <RadioGroup
       name="targetMode"
+      data-testid="fleet-target-cluster-radio-button"
       :value="isLocal ? 'local' : targetMode"
       :mode="mode"
       :options="targetModeOptions"
@@ -329,6 +330,7 @@ export default {
       <h3> {{ t('fleet.clusterTargets.title') }} </h3>
       <LabeledSelect
         class="mt-20"
+        data-testid="fleet-target-cluster-name-selector"
         :value="selectedClusters"
         :label="t('fleet.clusterTargets.label')"
         :options="clustersOptions"

--- a/shell/components/fleet/FleetClusterTargets/index.vue
+++ b/shell/components/fleet/FleetClusterTargets/index.vue
@@ -184,11 +184,11 @@ export default {
     },
 
     fromTargets() {
-      this.targetMode = FleetUtils.Application.getTargetMode(this.targets || []);
-
       if (!this.targets?.length) {
         return;
       }
+
+      this.targetMode = FleetUtils.Application.getTargetMode(this.targets || [], this.namespace);
 
       for (const target of this.targets) {
         const {

--- a/shell/components/fleet/FleetClusterTargets/index.vue
+++ b/shell/components/fleet/FleetClusterTargets/index.vue
@@ -407,7 +407,6 @@ export default {
   >
     <div class="col span-6">
       <TargetsList
-        v-if="matching.length"
         class="target-list mt-20"
         :clusters="matching"
       />

--- a/shell/components/fleet/FleetClusterTargets/index.vue
+++ b/shell/components/fleet/FleetClusterTargets/index.vue
@@ -78,7 +78,7 @@ export default {
       allClusters:      [],
       selectedClusters: [],
       clusterSelectors: [],
-      key:              0
+      key:              0 // Generates a unique key to handle Targets
     };
   },
 
@@ -91,7 +91,6 @@ export default {
   watch: {
     namespace() {
       if (this.mode === _CREATE) {
-        // TO TEST on edit
         this.reset();
       }
 
@@ -207,11 +206,15 @@ export default {
         }
 
         if (!isEmpty(clusterSelector)) {
-          this.clusterSelectors.push({
+          const neu = {
             key:              this.key++,
             matchLabels:      clusterSelector.matchLabels,
             matchExpressions: clusterSelector.matchExpressions?.filter((f) => f.key !== excludeHarvesterRule.clusterSelector.matchExpressions[0].key)
-          });
+          };
+
+          if (neu.matchLabels || neu.matchExpressions?.length) {
+            this.clusterSelectors.push(neu);
+          }
         }
       }
     },

--- a/shell/components/fleet/FleetRepos.vue
+++ b/shell/components/fleet/FleetRepos.vue
@@ -112,11 +112,6 @@ export default {
       return this.showIntro && !this.filteredRows.length;
     },
   },
-  methods: {
-    parseTargetMode(row) {
-      return row.targetInfo?.mode === 'clusterGroup' ? this.t('fleet.gitRepo.warningTooltip.clusterGroup') : this.t('fleet.gitRepo.warningTooltip.cluster');
-    },
-  },
 };
 </script>
 

--- a/shell/components/fleet/__tests__/FleetClusterTargets.test.ts
+++ b/shell/components/fleet/__tests__/FleetClusterTargets.test.ts
@@ -1,0 +1,323 @@
+import { mount } from '@vue/test-utils';
+import FleetClusterTargets from '@shell/components/fleet/FleetClusterTargets/index.vue';
+import { _CREATE } from '@shell/config/query-params';
+import { Selector } from '@shell/types/fleet';
+
+describe('component: FleetClusterTargets', () => {
+  describe('mode: create', () => {
+    const mode = _CREATE;
+
+    describe('targets', () => {
+      it('should build form source data from target with clusterName and clusterSelector', () => {
+        const target1 = {
+          clusterName:     'fleet-5-france',
+          clusterSelector: { matchLabels: { foo: 'true' } }
+        };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('clusters');
+        expect(selectedClusters).toStrictEqual([target1.clusterName]);
+        expect(clusterSelectors[0].matchLabels).toStrictEqual(target1.clusterSelector.matchLabels);
+        expect(clusterSelectors[0].matchExpressions).toBeUndefined();
+      });
+
+      it('should set targetMode to "all" and correctly filter clusterSelector for harvester rule', () => {
+        const target1 = {
+          clusterSelector: {
+            matchExpressions: [{
+              key:      'provider.cattle.io',
+              operator: 'NotIn',
+              values:   ['harvester']
+            }]
+          }
+        };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('all');
+        expect(clusterSelectors).toStrictEqual([]); // Harvester rule should be filtered out
+        expect(selectedClusters).toStrictEqual([]);
+      });
+
+      it('should set targetMode to "clusters" and populate selectedClusters and clusterSelectors', () => {
+        const target1 = { clusterName: 'fleet-5-france' };
+
+        const target2 = { clusterSelector: { matchLabels: { foo: 'true' } } };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1, target2],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('clusters');
+        expect(selectedClusters).toStrictEqual(['fleet-5-france']);
+        expect(clusterSelectors).toStrictEqual([{
+          key:              0,
+          matchLabels:      { foo: 'true' },
+          matchExpressions: undefined
+        }]);
+      });
+
+      it('should set targetMode to "clusters" and populate clusterSelectors with multiple entries', () => {
+        const target1 = { clusterSelector: { matchLabels: { foo: 'true' } } };
+        const target2 = { clusterSelector: { matchLabels: { hci: 'true' } } };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1, target2],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('clusters');
+        expect(selectedClusters).toStrictEqual([]);
+        expect(clusterSelectors).toStrictEqual([{
+          key:              0,
+          matchLabels:      { foo: 'true' },
+          matchExpressions: undefined
+        }, {
+          key:              1,
+          matchLabels:      { hci: 'true' },
+          matchExpressions: undefined
+        }]);
+      });
+
+      it('should set targetMode to "advanced" and return early if clusterGroupSelector is present', () => {
+        const target1 = { clusterGroupSelector: {} };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('advanced');
+        // Expect no further processing for selectedClusters or clusterSelectors due to early return
+        expect(selectedClusters).toStrictEqual([]);
+        expect(clusterSelectors).toStrictEqual([]);
+      });
+
+      it('should set targetMode to "advanced" and return early if clusterGroup is present', () => {
+        const target1 = {
+          clusterGroup:         'cg1',
+          clusterGroupSelector: {
+            matchExpressions: [{
+              key:      'string',
+              operator: 'string',
+              values:   ['string']
+            }],
+            matchLabels: { foo: 'bar' }
+          },
+          clusterName:     'pippo',
+          clusterSelector: {
+            matchExpressions: [{
+              key:      'string',
+              operator: 'string',
+              values:   ['vvv']
+            }],
+            matchLabels: { foo: 'bar' }
+          },
+          name: 'tt1',
+        };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('advanced');
+        // Expect no further processing for selectedClusters or clusterSelectors due to early return
+        expect(selectedClusters).toStrictEqual([]);
+        expect(clusterSelectors).toStrictEqual([]);
+      });
+
+      it('should return early and not modify state if targets is empty', () => {
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('all'); // getTargetMode is not called
+        expect(selectedClusters).toStrictEqual([]);
+        expect(clusterSelectors).toStrictEqual([]);
+      });
+
+      it('should return targetMode local if namespace is fleet-local', () => {
+        const target1 = { clusterSelector: { matchLabels: { foo: 'true' } } };
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-local',
+            mode,
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+
+        expect(targetMode).toBe('local');
+      });
+
+      it('should handle targets with multiple clusterName', () => {
+        const target1 = { clusterName: 'prod-cluster' };
+        const target2 = { clusterName: 'test-cluster' };
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1, target2],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('clusters');
+        expect(selectedClusters).toStrictEqual(['prod-cluster', 'test-cluster']);
+        expect(clusterSelectors).toStrictEqual([]);
+      });
+
+      it('should filter out harvester rule and leave others', () => {
+        const target1 = {
+          clusterSelector: {
+            matchExpressions: [{
+              key:      'provider.cattle.io',
+              operator: 'NotIn',
+              values:   ['harvester']
+            }, {
+              key:      'foo',
+              operator: 'In',
+              values:   ['bar']
+            }]
+          }
+        };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('clusters');
+        expect(selectedClusters).toStrictEqual([]);
+        expect(clusterSelectors).toStrictEqual([{
+          key:              0,
+          matchLabels:      undefined,
+          matchExpressions: [{
+            key:      'foo',
+            operator: 'In',
+            values:   ['bar']
+          }]
+        }]);
+      });
+
+      it('should correctly process targets when targetMode is "all" and no clusterName or clusterSelector is present', () => {
+        const target1 = { name: 'simple-target' };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('all');
+        expect(selectedClusters).toStrictEqual([]);
+        expect(clusterSelectors).toStrictEqual([]);
+      });
+
+      it('should correctly process targets when targetMode is "all", name is defined and harvester rule is present', () => {
+        const target1 = {
+          clusterSelector: {
+            matchExpressions: [{
+              key:      'provider.cattle.io',
+              operator: 'NotIn',
+              values:   ['harvester']
+            }]
+          },
+          name: 'simple-target'
+        };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('all');
+        expect(selectedClusters).toStrictEqual([]);
+        expect(clusterSelectors).toStrictEqual([]); // Harvester rule should be filtered out
+      });
+    });
+  });
+});

--- a/shell/components/fleet/__tests__/FleetClusterTargets.test.ts
+++ b/shell/components/fleet/__tests__/FleetClusterTargets.test.ts
@@ -5,10 +5,9 @@ import { _CREATE, _EDIT } from '@shell/config/query-params';
 import { Selector } from '@shell/types/fleet';
 
 describe('component: FleetClusterTargets', () => {
-  describe.each([
-    _EDIT,
-    _CREATE
-  ])('mode: %p', (mode) => {
+  describe('mode: edit', () => {
+    const mode = _EDIT;
+
     describe('decode spec.targets and set form data', () => {
       it('should build form source data from target with clusterName and clusterSelector', () => {
         const target1 = {
@@ -19,7 +18,7 @@ describe('component: FleetClusterTargets', () => {
           props: {
             targets:   [target1],
             namespace: 'fleet-default',
-            mode,
+            mode
           },
         });
 
@@ -69,7 +68,7 @@ describe('component: FleetClusterTargets', () => {
           props: {
             targets:   [target1, target2],
             namespace: 'fleet-default',
-            mode,
+            mode
           },
         });
 
@@ -94,7 +93,7 @@ describe('component: FleetClusterTargets', () => {
           props: {
             targets:   [target1, target2],
             namespace: 'fleet-default',
-            mode,
+            mode
           },
         });
 
@@ -122,7 +121,7 @@ describe('component: FleetClusterTargets', () => {
           props: {
             targets:   [target1],
             namespace: 'fleet-default',
-            mode,
+            mode
           },
         });
 
@@ -163,7 +162,7 @@ describe('component: FleetClusterTargets', () => {
           props: {
             targets:   [target1],
             namespace: 'fleet-default',
-            mode,
+            mode
           },
         });
 
@@ -182,7 +181,7 @@ describe('component: FleetClusterTargets', () => {
           props: {
             targets:   [],
             namespace: 'fleet-default',
-            mode,
+            mode
           },
         });
 
@@ -190,7 +189,7 @@ describe('component: FleetClusterTargets', () => {
         const selectedClusters = wrapper.vm.selectedClusters;
         const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
 
-        expect(targetMode).toBe('all'); // getTargetMode is not called
+        expect(targetMode).toBe('none');
         expect(selectedClusters).toStrictEqual([]);
         expect(clusterSelectors).toStrictEqual([]);
       });
@@ -201,7 +200,7 @@ describe('component: FleetClusterTargets', () => {
           props: {
             targets:   [target1],
             namespace: 'fleet-local',
-            mode,
+            mode
           },
         });
 
@@ -217,7 +216,7 @@ describe('component: FleetClusterTargets', () => {
           props: {
             targets:   [target1, target2],
             namespace: 'fleet-default',
-            mode,
+            mode
           },
         });
 
@@ -249,7 +248,7 @@ describe('component: FleetClusterTargets', () => {
           props: {
             targets:   [target1],
             namespace: 'fleet-default',
-            mode,
+            mode
           },
         });
 
@@ -334,6 +333,8 @@ describe('component: FleetClusterTargets', () => {
           },
         });
 
+        wrapper.vm.update();
+
         await flushPromises();
 
         expect(wrapper.emitted('update:value')?.[0][0]).toStrictEqual([{ clusterName: 'fleet-5-france' }, { clusterSelector: { matchLabels: { foo: 'true' } } }]);
@@ -357,6 +358,7 @@ describe('component: FleetClusterTargets', () => {
           },
         });
 
+        wrapper.vm.update();
         await flushPromises();
 
         expect(wrapper.emitted('update:value')?.[0][0]).toStrictEqual([{
@@ -381,6 +383,7 @@ describe('component: FleetClusterTargets', () => {
           },
         });
 
+        wrapper.vm.update();
         await flushPromises();
 
         expect(wrapper.emitted('update:value')?.[0][0]).toStrictEqual([{ clusterName: 'fleet-5-france' }, { clusterSelector: { matchLabels: { foo: 'true' } } }]);
@@ -398,6 +401,7 @@ describe('component: FleetClusterTargets', () => {
           },
         });
 
+        wrapper.vm.update();
         await flushPromises();
 
         expect(wrapper.emitted('update:value')?.[0][0]).toStrictEqual([{ clusterSelector: { matchLabels: { foo: 'true' } } }, { clusterSelector: { matchLabels: { hci: 'true' } } }]);
@@ -414,6 +418,7 @@ describe('component: FleetClusterTargets', () => {
           },
         });
 
+        wrapper.vm.update();
         await flushPromises();
 
         expect(wrapper.emitted('update:value')?.[0][0]).toStrictEqual([{ clusterGroupSelector: {} }]);
@@ -450,6 +455,7 @@ describe('component: FleetClusterTargets', () => {
           },
         });
 
+        wrapper.vm.update();
         await flushPromises();
 
         expect(wrapper.emitted('update:value')?.[0][0]).toStrictEqual([{
@@ -474,21 +480,16 @@ describe('component: FleetClusterTargets', () => {
       it('should emit harvester rule from empty targets source', async() => {
         const wrapper = mount(FleetClusterTargets, {
           props: {
-            targets:   [],
+            targets:   [], // targetMode === 'none'
             namespace: 'fleet-default',
             mode,
           },
         });
 
+        wrapper.vm.update();
         await flushPromises();
 
-        expect(wrapper.emitted('update:value')?.[0][0]).toStrictEqual([{
-          clusterSelector: {
-            matchExpressions: [{
-              key: 'provider.cattle.io', operator: 'NotIn', values: ['harvester']
-            }]
-          }
-        }]);
+        expect(wrapper.emitted('update:value')?.[0][0]).toBeUndefined();
       });
 
       it('should emit untouched targets from source when operating in fleet-local workspace', async() => {
@@ -502,6 +503,7 @@ describe('component: FleetClusterTargets', () => {
           },
         });
 
+        wrapper.vm.update();
         await flushPromises();
 
         expect(wrapper.emitted('update:value')?.[0][0]).toStrictEqual([{ clusterSelector: { matchLabels: { foo: 'true' } } }]);
@@ -530,6 +532,7 @@ describe('component: FleetClusterTargets', () => {
           },
         });
 
+        wrapper.vm.update();
         await flushPromises();
 
         expect(wrapper.emitted('update:value')?.[0][0]).toStrictEqual([{
@@ -552,6 +555,7 @@ describe('component: FleetClusterTargets', () => {
           },
         });
 
+        wrapper.vm.update();
         await flushPromises();
 
         expect(wrapper.emitted('update:value')?.[0][0]).toStrictEqual([{
@@ -583,6 +587,628 @@ describe('component: FleetClusterTargets', () => {
           },
         });
 
+        wrapper.vm.update();
+        await flushPromises();
+
+        expect(wrapper.emitted('update:value')?.[0][0]).toStrictEqual([{
+          clusterSelector: {
+            matchExpressions: [{
+              key: 'provider.cattle.io', operator: 'NotIn', values: ['harvester']
+            }]
+          }
+        }]);
+      });
+    });
+  });
+
+  describe('mode: create', () => {
+    const mode = _CREATE;
+
+    describe('decode spec.targets and set form data', () => {
+      it('should build form source data from target with clusterName and clusterSelector', () => {
+        const target1 = {
+          clusterName:     'fleet-5-france',
+          clusterSelector: { matchLabels: { foo: 'true' } }
+        };
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+            created:   'clusters'
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('clusters');
+        expect(selectedClusters).toStrictEqual([target1.clusterName]);
+        expect(clusterSelectors[0].matchLabels).toStrictEqual(target1.clusterSelector.matchLabels);
+        expect(clusterSelectors[0].matchExpressions).toBeUndefined();
+      });
+
+      it('should set targetMode to "all" and correctly filter clusterSelector for harvester rule', () => {
+        const target1 = {
+          clusterSelector: {
+            matchExpressions: [{
+              key:      'provider.cattle.io',
+              operator: 'NotIn',
+              values:   ['harvester']
+            }]
+          }
+        };
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('all');
+        expect(clusterSelectors).toStrictEqual([]); // Harvester rule should be filtered out
+        expect(selectedClusters).toStrictEqual([]);
+      });
+
+      it('should set targetMode to "clusters" and populate selectedClusters and clusterSelectors', () => {
+        const target1 = { clusterName: 'fleet-5-france' };
+
+        const target2 = { clusterSelector: { matchLabels: { foo: 'true' } } };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1, target2],
+            namespace: 'fleet-default',
+            mode,
+            created:   'clusters'
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('clusters');
+        expect(selectedClusters).toStrictEqual(['fleet-5-france']);
+        expect(clusterSelectors).toStrictEqual([{
+          key:              0,
+          matchLabels:      { foo: 'true' },
+          matchExpressions: undefined
+        }]);
+      });
+
+      it('should set targetMode to "clusters" and populate clusterSelectors with multiple entries', () => {
+        const target1 = { clusterSelector: { matchLabels: { foo: 'true' } } };
+        const target2 = { clusterSelector: { matchLabels: { hci: 'true' } } };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1, target2],
+            namespace: 'fleet-default',
+            mode,
+            created:   'clusters'
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('clusters');
+        expect(selectedClusters).toStrictEqual([]);
+        expect(clusterSelectors).toStrictEqual([{
+          key:              0,
+          matchLabels:      { foo: 'true' },
+          matchExpressions: undefined
+        }, {
+          key:              1,
+          matchLabels:      { hci: 'true' },
+          matchExpressions: undefined
+        }]);
+      });
+
+      it('should set targetMode to "advanced" and return early if clusterGroupSelector is present', () => {
+        const target1 = { clusterGroupSelector: {} };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+            created:   'advanced'
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('advanced');
+        // Expect no further processing for selectedClusters or clusterSelectors due to early return
+        expect(selectedClusters).toStrictEqual([]);
+        expect(clusterSelectors).toStrictEqual([]);
+      });
+
+      it('should set targetMode to "advanced" and return early if clusterGroup is present', () => {
+        const target1 = {
+          clusterGroup:         'cg1',
+          clusterGroupSelector: {
+            matchExpressions: [{
+              key:      'string',
+              operator: 'string',
+              values:   ['string']
+            }],
+            matchLabels: { foo: 'bar' }
+          },
+          clusterName:     'pippo',
+          clusterSelector: {
+            matchExpressions: [{
+              key:      'string',
+              operator: 'string',
+              values:   ['vvv']
+            }],
+            matchLabels: { foo: 'bar' }
+          },
+          name: 'tt1',
+        };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+            created:   'advanced'
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('advanced');
+        // Expect no further processing for selectedClusters or clusterSelectors due to early return
+        expect(selectedClusters).toStrictEqual([]);
+        expect(clusterSelectors).toStrictEqual([]);
+      });
+
+      it('should return early and not modify state if targets is empty', () => {
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [],
+            namespace: 'fleet-default',
+            mode,
+            created:   'none'
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('none');
+        expect(selectedClusters).toStrictEqual([]);
+        expect(clusterSelectors).toStrictEqual([]);
+      });
+
+      it('should return targetMode local if namespace is fleet-local', () => {
+        const target1 = { clusterSelector: { matchLabels: { foo: 'true' } } };
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-local',
+            mode,
+            created:   'local'
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+
+        expect(targetMode).toBe('local');
+      });
+
+      it('should handle targets with multiple clusterName', () => {
+        const target1 = { clusterName: 'prod-cluster' };
+        const target2 = { clusterName: 'test-cluster' };
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1, target2],
+            namespace: 'fleet-default',
+            mode,
+            created:   'clusters'
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('clusters');
+        expect(selectedClusters).toStrictEqual(['prod-cluster', 'test-cluster']);
+        expect(clusterSelectors).toStrictEqual([]);
+      });
+
+      it('should filter out harvester rule and leave others', () => {
+        const target1 = {
+          clusterSelector: {
+            matchExpressions: [{
+              key:      'provider.cattle.io',
+              operator: 'NotIn',
+              values:   ['harvester']
+            }, {
+              key:      'foo',
+              operator: 'In',
+              values:   ['bar']
+            }]
+          }
+        };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+            created:   'clusters'
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('clusters');
+        expect(selectedClusters).toStrictEqual([]);
+        expect(clusterSelectors).toStrictEqual([{
+          key:              0,
+          matchLabels:      undefined,
+          matchExpressions: [{
+            key:      'foo',
+            operator: 'In',
+            values:   ['bar']
+          }]
+        }]);
+      });
+
+      it('should correctly process targets when targetMode is "all" and no clusterName or clusterSelector is present', () => {
+        const target1 = { name: 'simple-target' };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('all');
+        expect(selectedClusters).toStrictEqual([]);
+        expect(clusterSelectors).toStrictEqual([]);
+      });
+
+      it('should correctly process targets when targetMode is "all", name is defined and harvester rule is present', () => {
+        const target1 = {
+          clusterSelector: {
+            matchExpressions: [{
+              key:      'provider.cattle.io',
+              operator: 'NotIn',
+              values:   ['harvester']
+            }]
+          },
+          name: 'simple-target'
+        };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        const targetMode = wrapper.vm.targetMode;
+        const selectedClusters = wrapper.vm.selectedClusters;
+        const clusterSelectors = wrapper.vm.clusterSelectors as Selector[];
+
+        expect(targetMode).toBe('all');
+        expect(selectedClusters).toStrictEqual([]);
+        expect(clusterSelectors).toStrictEqual([]); // Harvester rule should be filtered out
+      });
+    });
+
+    describe('decode form data and emit to spec.targets', () => {
+      it('should emit target with clusterName and clusterSelector', async() => {
+        const target1 = {
+          clusterName:     'fleet-5-france',
+          clusterSelector: { matchLabels: { foo: 'true' } }
+        };
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        wrapper.setData({ targetMode: 'clusters' });
+
+        wrapper.vm.update();
+
+        await flushPromises();
+
+        expect(wrapper.emitted('update:value')?.[1][0]).toStrictEqual([{ clusterName: 'fleet-5-france' }, { clusterSelector: { matchLabels: { foo: 'true' } } }]);
+      });
+
+      it('should emit harvester exclude rule', async() => {
+        const target1 = {
+          clusterSelector: {
+            matchExpressions: [{
+              key:      'provider.cattle.io',
+              operator: 'NotIn',
+              values:   ['harvester']
+            }]
+          }
+        };
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        wrapper.vm.update();
+        await flushPromises();
+
+        expect(wrapper.emitted('update:value')?.[0][0]).toStrictEqual([{
+          clusterSelector: {
+            matchExpressions: [{
+              key: 'provider.cattle.io', operator: 'NotIn', values: ['harvester']
+            }]
+          }
+        }]);
+      });
+
+      it('should emit multiple targets with clusterName and clusterSelector', async() => {
+        const target1 = { clusterName: 'fleet-5-france' };
+
+        const target2 = { clusterSelector: { matchLabels: { foo: 'true' } } };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1, target2],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        wrapper.setData({ targetMode: 'clusters' });
+
+        wrapper.vm.update();
+        await flushPromises();
+
+        expect(wrapper.emitted('update:value')?.[1][0]).toStrictEqual([{ clusterName: 'fleet-5-france' }, { clusterSelector: { matchLabels: { foo: 'true' } } }]);
+      });
+
+      it('should emit multiple targets containing both clusterSelector fields', async() => {
+        const target1 = { clusterSelector: { matchLabels: { foo: 'true' } } };
+        const target2 = { clusterSelector: { matchLabels: { hci: 'true' } } };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1, target2],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        wrapper.setData({ targetMode: 'clusters' });
+
+        wrapper.vm.update();
+        await flushPromises();
+
+        expect(wrapper.emitted('update:value')?.[1][0]).toStrictEqual([{ clusterSelector: { matchLabels: { foo: 'true' } } }, { clusterSelector: { matchLabels: { hci: 'true' } } }]);
+      });
+
+      it('should emit advanced cases untouched', async() => {
+        const target1 = { clusterGroupSelector: {} };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        wrapper.setData({ targetMode: 'advanced' });
+
+        wrapper.vm.update();
+        await flushPromises();
+
+        expect(wrapper.emitted('update:value')?.[1][0]).toStrictEqual([{ clusterGroupSelector: {} }]);
+      });
+
+      it('should emit full target definition', async() => {
+        const target1 = {
+          clusterGroup:         'cg1',
+          clusterGroupSelector: {
+            matchExpressions: [{
+              key:      'string',
+              operator: 'string',
+              values:   ['string']
+            }],
+            matchLabels: { foo: 'bar' }
+          },
+          clusterName:     'pippo',
+          clusterSelector: {
+            matchExpressions: [{
+              key:      'string',
+              operator: 'string',
+              values:   ['vvv']
+            }],
+            matchLabels: { foo: 'bar' }
+          },
+          name: 'tt1',
+        };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        wrapper.setData({ targetMode: 'advanced' });
+
+        wrapper.vm.update();
+        await flushPromises();
+
+        expect(wrapper.emitted('update:value')?.[1][0]).toStrictEqual([{
+          clusterGroup:         'cg1',
+          clusterGroupSelector: {
+            matchExpressions: [{
+              key: 'string', operator: 'string', values: ['string']
+            }],
+            matchLabels: { foo: 'bar' }
+          },
+          clusterName:     'pippo',
+          clusterSelector: {
+            matchExpressions: [{
+              key: 'string', operator: 'string', values: ['vvv']
+            }],
+            matchLabels: { foo: 'bar' }
+          },
+          name: 'tt1'
+        }]);
+      });
+
+      it('should emit harvester rule from empty targets source', async() => {
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [], // targetMode === 'none'
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        wrapper.setData({ targetMode: 'none' });
+
+        wrapper.vm.update();
+        await flushPromises();
+
+        expect(wrapper.emitted('update:value')?.[1][0]).toBeUndefined();
+      });
+
+      it('should emit untouched targets from source when operating in fleet-local workspace', async() => {
+        const target1 = { clusterSelector: { matchLabels: { foo: 'true' } } };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-local',
+            mode,
+          },
+        });
+
+        wrapper.setData({ targetMode: 'clusters' });
+
+        wrapper.vm.update();
+        await flushPromises();
+
+        expect(wrapper.emitted('update:value')?.[1][0]).toStrictEqual([{ clusterSelector: { matchLabels: { foo: 'true' } } }]);
+      });
+
+      it('should emit custom targets filtering out harvester rule', async() => {
+        const target1 = {
+          clusterSelector: {
+            matchExpressions: [{
+              key:      'provider.cattle.io',
+              operator: 'NotIn',
+              values:   ['harvester']
+            }, {
+              key:      'foo',
+              operator: 'In',
+              values:   ['bar']
+            }]
+          }
+        };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        wrapper.setData({ targetMode: 'clusters' });
+
+        wrapper.vm.update();
+        await flushPromises();
+
+        expect(wrapper.emitted('update:value')?.[1][0]).toStrictEqual([{
+          clusterSelector: {
+            matchExpressions: [{
+              key: 'foo', operator: 'In', values: ['bar']
+            }]
+          }
+        }]);
+      });
+
+      it('should emit targets excluding target names and adding harvester rule', async() => {
+        const target1 = { name: 'simple-target' };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        wrapper.vm.update();
+        await flushPromises();
+
+        expect(wrapper.emitted('update:value')?.[0][0]).toStrictEqual([{
+          clusterSelector: {
+            matchExpressions: [{
+              key: 'provider.cattle.io', operator: 'NotIn', values: ['harvester']
+            }]
+          }
+        }]);
+      });
+
+      it('should emit targets excluding target names and harvester rule if present in source targets', async() => {
+        const target1 = {
+          clusterSelector: {
+            matchExpressions: [{
+              key:      'provider.cattle.io',
+              operator: 'NotIn',
+              values:   ['harvester']
+            }]
+          },
+          name: 'simple-target'
+        };
+
+        const wrapper = mount(FleetClusterTargets, {
+          props: {
+            targets:   [target1],
+            namespace: 'fleet-default',
+            mode,
+          },
+        });
+
+        wrapper.vm.update();
         await flushPromises();
 
         expect(wrapper.emitted('update:value')?.[0][0]).toStrictEqual([{

--- a/shell/components/fleet/__tests__/FleetOCIStorageSecret.test.ts
+++ b/shell/components/fleet/__tests__/FleetOCIStorageSecret.test.ts
@@ -79,11 +79,11 @@ describe('component: FleetOCIStorageSecret', () => {
       const wrapper = mount(FleetOCIStorageSecret, {
         props: {
           workspace: 'fleet-local',
-          secret:    null,
+          secret:    '',
           mode,
         },
         data() {
-          return { secrets: [], workspaces };
+          return { secrets: [], workspaces } as any;
         },
       });
 
@@ -95,11 +95,11 @@ describe('component: FleetOCIStorageSecret', () => {
       const wrapper = mount(FleetOCIStorageSecret, {
         props: {
           workspace: 'fleet-local',
-          secret:    null,
+          secret:    '',
           mode,
         },
         data() {
-          return { secrets, workspaces };
+          return { secrets, workspaces } as any;
         },
       });
 
@@ -114,11 +114,11 @@ describe('component: FleetOCIStorageSecret', () => {
       const wrapper = mount(FleetOCIStorageSecret, {
         props: {
           workspace: 'fleet-default',
-          secret:    null,
+          secret:    '',
           mode,
         },
         data() {
-          return { secrets, workspaces };
+          return { secrets, workspaces } as any;
         },
       });
 
@@ -134,11 +134,11 @@ describe('component: FleetOCIStorageSecret', () => {
       const wrapper = mount(FleetOCIStorageSecret, {
         props: {
           workspace: 'fleet-custom-workspace',
-          secret:    null,
+          secret:    '',
           mode,
         },
         data() {
-          return { secrets, workspaces };
+          return { secrets, workspaces } as any;
         },
       });
 
@@ -156,11 +156,11 @@ describe('component: FleetOCIStorageSecret', () => {
       const wrapper = mount(FleetOCIStorageSecret, {
         props: {
           workspace: '',
-          secret:    null,
+          secret:    '',
           mode,
         },
         data() {
-          return { secrets, workspaces };
+          return { secrets, workspaces } as any;
         },
       });
 
@@ -174,11 +174,11 @@ describe('component: FleetOCIStorageSecret', () => {
       const wrapper = mount(FleetOCIStorageSecret, {
         props: {
           workspace: '',
-          secret:    null,
+          secret:    '',
           mode,
         },
         data() {
-          return { secrets, workspaces };
+          return { secrets, workspaces } as any;
         },
       });
 
@@ -200,7 +200,7 @@ describe('component: FleetOCIStorageSecret', () => {
           mode,
         },
         data() {
-          return { secrets, workspaces };
+          return { secrets, workspaces } as any;
         },
       });
 

--- a/shell/components/fleet/dashboard/ResourceDetails.vue
+++ b/shell/components/fleet/dashboard/ResourceDetails.vue
@@ -136,7 +136,7 @@ export default {
           <div class="col span-10">
             <LabeledSelect
               v-model:value="clusterId"
-              :label="'Cluster'"
+              :label="t('fleet.cluster.label')"
               :options="clusters"
               :mode="'edit'"
               :disabled="workspace.id === 'fleet-local'"

--- a/shell/components/form/MatchExpressions.vue
+++ b/shell/components/form/MatchExpressions.vue
@@ -54,6 +54,16 @@ export default {
       default: true
     },
 
+    addLabel: {
+      type:    String,
+      default: '',
+    },
+
+    addIcon: {
+      type:    String,
+      default: '',
+    },
+
     // whether or not to show remove rule button right side of the rule
     showRemoveButton: {
       type:    Boolean,
@@ -144,6 +154,10 @@ export default {
   computed: {
     isView() {
       return this.mode === 'view';
+    },
+
+    _addLabel() {
+      return this.addLabel || this.t('workload.scheduling.affinity.matchExpressions.addRule');
     },
 
     node() {
@@ -397,7 +411,11 @@ export default {
         :data-testid="`input-match-expression-add-rule`"
         @click="addRule"
       >
-        <t k="workload.scheduling.affinity.matchExpressions.addRule" />
+        <i
+          v-if="addIcon"
+          class="mr-5 icon"
+          :class="[addIcon]"
+        /> {{ _addLabel }}
       </button>
     </div>
   </div>

--- a/shell/components/form/MatchExpressions.vue
+++ b/shell/components/form/MatchExpressions.vue
@@ -414,7 +414,7 @@ export default {
         type="button"
         class="btn role-tertiary add"
         :class="[addClass]"
-        :data-testid="`input-match-expression-add-rule`"
+        data-testid="input-match-expression-add-rule"
         @click="addRule"
       >
         <i

--- a/shell/components/form/MatchExpressions.vue
+++ b/shell/components/form/MatchExpressions.vue
@@ -64,6 +64,11 @@ export default {
       default: '',
     },
 
+    addClass: {
+      type:    String,
+      default: '',
+    },
+
     // whether or not to show remove rule button right side of the rule
     showRemoveButton: {
       type:    Boolean,
@@ -408,6 +413,7 @@ export default {
       <button
         type="button"
         class="btn role-tertiary add"
+        :class="[addClass]"
         :data-testid="`input-match-expression-add-rule`"
         @click="addRule"
       >

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -784,7 +784,7 @@ export const FLEET_APPLICATION_TARGET = {
   name:     'applicationTarget',
   labelKey: 'fleet.tableHeaders.applicationTarget',
   value:    'targetInfo.modeDisplay',
-  sort:     ['targetInfo.modeDisplay', 'targetInfo.cluster', 'targetInfo.clusterGroup'],
+  sort:     ['targetInfo.modeDisplay'],
 };
 
 export const FLEET_APPLICATION_CLUSTERS_READY = {
@@ -1102,7 +1102,7 @@ export const FLEET_REPO_TARGET = {
   name:     'target',
   labelKey: 'tableHeaders.target',
   value:    'targetInfo.modeDisplay',
-  sort:     ['targetInfo.modeDisplay', 'targetInfo.cluster', 'targetInfo.clusterGroup'],
+  sort:     ['targetInfo.modeDisplay'],
 };
 
 export const FLEET_REPO = {

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -1,32 +1,26 @@
 <script>
-import { exceptionToErrorsArray } from '@shell/utils/error';
 import { mapGetters } from 'vuex';
-import {
-  AUTH_TYPE, FLEET, NORMAN, SECRET, VIRTUAL_HARVESTER_PROVIDER
-} from '@shell/config/types';
+import { AUTH_TYPE, NORMAN, SECRET } from '@shell/config/types';
 import { set } from '@shell/utils/object';
 import ArrayList from '@shell/components/form/ArrayList';
 import { Banner } from '@components/Banner';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import CruResource from '@shell/components/CruResource';
 import InputWithSelect from '@shell/components/form/InputWithSelect';
-import jsyaml from 'js-yaml';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import Labels from '@shell/components/form/Labels';
 import Loading from '@shell/components/Loading';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
-import YamlEditor from '@shell/components/YamlEditor';
 import { base64Decode, base64Encode } from '@shell/utils/crypto';
 import SelectOrCreateAuthSecret from '@shell/components/form/SelectOrCreateAuthSecret';
 import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
-import { isHarvesterCluster } from '@shell/utils/cluster';
-import { CAPI, CATALOG, FLEET as FLEET_LABELS } from '@shell/config/labels-annotations';
+import { CATALOG, FLEET as FLEET_LABELS } from '@shell/config/labels-annotations';
 import { SECRET_TYPES } from '@shell/config/secret';
-import { checkSchemasForFindAllHash } from '@shell/utils/auth';
 import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 import FormValidation from '@shell/mixins/form-validation';
 import UnitInput from '@shell/components/form/UnitInput';
+import FleetClusterTargets from '@shell/components/fleet/FleetClusterTargets/index.vue';
 import { toSeconds } from '@shell/utils/duration';
 import FleetOCIStorageSecret from '@shell/components/fleet/FleetOCIStorageSecret.vue';
 import { DEFAULT_POLLING_INTERVAL, MINIMUM_POLLING_INTERVAL } from '@shell/models/fleet-application';
@@ -54,29 +48,14 @@ export default {
     LabeledSelect,
     Loading,
     NameNsDescription,
-    YamlEditor,
     SelectOrCreateAuthSecret,
+    FleetClusterTargets,
     UnitInput,
   },
 
   mixins: [CreateEditView, FormValidation],
 
   async fetch() {
-    const hash = await checkSchemasForFindAllHash({
-      allClusters: {
-        inStoreType: 'management',
-        type:        FLEET.CLUSTER
-      },
-
-      allClusterGroups: {
-        inStoreType: 'management',
-        type:        FLEET.CLUSTER_GROUP
-      }
-    }, this.$store);
-
-    this.allClusters = hash.allClusters || [];
-    this.allClusterGroups = hash.allClusterGroups || [];
-
     let tls = _VERIFY;
 
     if ( this.value.spec.insecureSkipTLSVerify ) {
@@ -93,8 +72,6 @@ export default {
     this.tlsMode = tls;
 
     this.correctDriftEnabled = this.value.spec?.correctDrift?.enabled || false;
-
-    this.updateTargets();
   },
 
   data() {
@@ -109,27 +86,10 @@ export default {
       }
     }
 
-    const targetInfo = this.value.targetInfo;
-    const targetCluster = targetInfo.cluster;
-    const targetClusterGroup = targetInfo.clusterGroup;
-    const targetAdvanced = targetInfo.advanced;
-
     const ref = ( this.value.spec?.revision ? 'revision' : 'branch' );
     const refValue = this.value.spec?.[ref] || '';
 
-    let targetMode = targetInfo.mode;
-
-    if ( this.realMode === _CREATE ) {
-      targetMode = 'all';
-    } else if ( targetMode === 'cluster' ) {
-      targetMode = `cluster://${ targetCluster }`;
-    } else if ( targetMode === 'clusterGroup' ) {
-      targetMode = `group://${ targetClusterGroup }`;
-    }
-
     return {
-      allClusters:             [],
-      allClusterGroups:        [],
       tempCachedValues:        {},
       username:                null,
       password:                null,
@@ -138,15 +98,9 @@ export default {
       tlsMode:                 null,
       caBundle:                null,
       correctDriftEnabled:     false,
-      targetAdvancedErrors:    null,
-      matchingClusters:        null,
       pollingInterval,
       ref,
       refValue,
-      targetMode,
-      targetCluster,
-      targetClusterGroup,
-      targetAdvanced,
       displayHelmRepoURLRegex: false,
       fvFormRuleSets:          [{
         path:  'spec.repo',
@@ -206,68 +160,8 @@ export default {
       ];
     },
 
-    isLocal() {
-      return this.value.metadata.namespace === 'fleet-local';
-    },
-
     isTls() {
       return !(this.value?.spec?.repo || '').startsWith('http://');
-    },
-
-    targetOptions() {
-      const out = [
-        {
-          label: 'No Clusters',
-          value: 'none'
-        },
-        {
-          label: 'All Clusters in the Workspace',
-          value: 'all',
-        },
-        {
-          label: 'Advanced',
-          value: 'advanced'
-        },
-      ];
-
-      const clusters = this.allClusters
-        .filter((x) => {
-          return x.metadata.namespace === this.value.metadata.namespace;
-        })
-        .filter((x) => !isHarvesterCluster(x))
-        .map((x) => {
-          return { label: x.nameDisplay, value: `cluster://${ x.metadata.name }` };
-        });
-
-      if ( clusters.length ) {
-        out.push({ kind: 'divider', disabled: true });
-        out.push({
-          kind:     'title',
-          label:    'Clusters',
-          disabled: true,
-        });
-
-        out.push(...clusters);
-      }
-
-      const groups = this.allClusterGroups
-        .filter((x) => x.metadata.namespace === this.value.metadata.namespace)
-        .map((x) => {
-          return { label: x.nameDisplay, value: `group://${ x.metadata.name }` };
-        });
-
-      if ( groups.length ) {
-        out.push({ kind: 'divider', disabled: true });
-        out.push({
-          kind:     'title',
-          label:    'Cluster Groups',
-          disabled: true
-        });
-
-        out.push(...groups);
-      }
-
-      return out;
     },
 
     tlsOptions() {
@@ -284,13 +178,8 @@ export default {
   },
 
   watch: {
-    'value.metadata.namespace': 'updateTargets',
-    targetMode:                 'updateTargets',
-    targetCluster:              'updateTargets',
-    targetClusterGroup:         'updateTargets',
-    targetAdvanced:             'updateTargets',
-    tlsMode:                    'updateTls',
-    caBundle:                   'updateTls',
+    tlsMode:  'updateTls',
+    caBundle: 'updateTls',
 
     workspace(neu) {
       if ( this.isCreate ) {
@@ -339,59 +228,15 @@ export default {
       this.updateCachedAuthVal(val, key);
     },
 
+    updateTargets(value) {
+      this.value.spec.targets = value;
+    },
+
     toggleHelmRepoURLRegex(active) {
       this.displayHelmRepoURLRegex = active;
 
       if (!active) {
         delete this.value.spec?.helmRepoURLRegex;
-      }
-    },
-
-    updateTargets() {
-      const spec = this.value.spec;
-      const mode = this.targetMode;
-
-      let kind, value;
-      const match = mode.match(/([^:]+)(:\/\/(.*))?$/);
-
-      if ( match ) {
-        kind = match[1];
-        value = match[3];
-      }
-
-      if ( kind === 'all' ) {
-        spec.targets = [{
-          clusterSelector: {
-            matchExpressions: [{
-              key:      CAPI.PROVIDER,
-              operator: 'NotIn',
-              values:   [
-                VIRTUAL_HARVESTER_PROVIDER
-              ],
-            }],
-          },
-        }];
-      } else if ( kind === 'none' ) {
-        spec.targets = [];
-      } else if ( kind === 'cluster' ) {
-        spec.targets = [
-          { clusterName: value },
-        ];
-      } else if ( kind === 'group' ) {
-        spec.targets = [
-          { clusterGroup: value }
-        ];
-      } else if ( kind === 'advanced' ) {
-        try {
-          const parsed = jsyaml.load(this.targetAdvanced);
-
-          spec.targets = parsed;
-          this.targetAdvancedErrors = null;
-        } catch (e) {
-          this.targetAdvancedErrors = exceptionToErrorsArray(e);
-        }
-      } else {
-        spec.targets = [];
       }
     },
 
@@ -811,50 +656,19 @@ export default {
     </template>
 
     <template #stepTarget>
-      <h2 v-t="isLocal ? 'fleet.gitRepo.target.labelLocal' : 'fleet.gitRepo.target.label'" />
+      <h2 v-t="'fleet.gitRepo.target.label'" />
 
-      <template v-if="!isLocal">
-        <div class="row">
-          <div class="col span-6">
-            <LabeledSelect
-              v-model:value="targetMode"
-              :options="targetOptions"
-              option-key="value"
-              :mode="mode"
-              :selectable="option => !option.disabled"
-              :label="t('fleet.gitRepo.target.selectLabel')"
-              data-testid="fleet-gitrepo-target-cluster"
-            >
-              <template v-slot:option="opt">
-                <hr v-if="opt.kind === 'divider'">
-                <div v-else-if="opt.kind === 'title'">
-                  {{ opt.label }}
-                </div>
-                <div v-else>
-                  {{ opt.label }}
-                </div>
-              </template>
-            </LabeledSelect>
-          </div>
-        </div>
+      <FleetClusterTargets
+        :targets="value.spec.targets"
+        :matching="value.targetClusters"
+        :namespace="value.metadata.namespace"
+        :mode="realMode"
+        @update:value="updateTargets"
+      />
 
-        <div
-          v-if="targetMode === 'advanced'"
-          class="row mt-10"
-        >
-          <div class="col span-12">
-            <YamlEditor v-model:value="targetAdvanced" />
-          </div>
-        </div>
-
-        <Banner
-          v-for="(err, i) in targetAdvancedErrors"
-          :key="i"
-          color="error"
-          :label="err"
-        />
-      </template>
-
+      <h3 class="mt-30">
+        {{ t('fleet.gitRepo.target.additionalOptions') }}
+      </h3>
       <div class="row mt-20">
         <div class="col span-6">
           <LabeledInput

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -127,7 +127,7 @@ export default {
           label:          this.t('fleet.gitRepo.add.steps.metadata.label'),
           subtext:        this.t('fleet.gitRepo.add.steps.metadata.subtext'),
           descriptionKey: 'fleet.gitRepo.add.steps.metadata.description',
-          ready:          this.isView || !!this.value.metadata.name,
+          ready:          true,
           weight:         1
         },
         {
@@ -136,7 +136,7 @@ export default {
           label:          this.t('fleet.gitRepo.add.steps.repo.label'),
           subtext:        this.t('fleet.gitRepo.add.steps.repo.subtext'),
           descriptionKey: 'fleet.gitRepo.add.steps.repo.description',
-          ready:          this.isView || (!!this.refValue && !!this.fvFormIsValid),
+          ready:          true,
           weight:         1
         },
         {
@@ -657,7 +657,6 @@ export default {
 
     <template #stepTarget>
       <h2 v-t="'fleet.gitRepo.target.label'" />
-
       <FleetClusterTargets
         :targets="value.spec.targets"
         :matching="value.targetClusters"
@@ -666,7 +665,7 @@ export default {
         @update:value="updateTargets"
       />
 
-      <h3 class="mt-30">
+      <h3 class="mt-40">
         {{ t('fleet.gitRepo.target.additionalOptions') }}
       </h3>
       <div class="row mt-20">

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -102,6 +102,7 @@ export default {
       ref,
       refValue,
       displayHelmRepoURLRegex: false,
+      targetsCreated:          '',
       fvFormRuleSets:          [{
         path:  'spec.repo',
         rules: [
@@ -662,7 +663,9 @@ export default {
         :matching="value.targetClusters"
         :namespace="value.metadata.namespace"
         :mode="realMode"
+        :created="targetsCreated"
         @update:value="updateTargets"
+        @created="targetsCreated=$event"
       />
 
       <h3 class="mt-40">

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -127,7 +127,7 @@ export default {
           label:          this.t('fleet.gitRepo.add.steps.metadata.label'),
           subtext:        this.t('fleet.gitRepo.add.steps.metadata.subtext'),
           descriptionKey: 'fleet.gitRepo.add.steps.metadata.description',
-          ready:          true,
+          ready:          this.isView || !!this.value.metadata.name,
           weight:         1
         },
         {
@@ -136,7 +136,7 @@ export default {
           label:          this.t('fleet.gitRepo.add.steps.repo.label'),
           subtext:        this.t('fleet.gitRepo.add.steps.repo.subtext'),
           descriptionKey: 'fleet.gitRepo.add.steps.repo.description',
-          ready:          true,
+          ready:          this.isView || (!!this.refValue && !!this.fvFormIsValid),
           weight:         1
         },
         {

--- a/shell/edit/fleet.cattle.io.helmop.vue
+++ b/shell/edit/fleet.cattle.io.helmop.vue
@@ -673,7 +673,6 @@ export default {
 
     <template #target>
       <h2 v-t="'fleet.helmOp.target.label'" />
-
       <FleetClusterTargets
         :targets="value.spec.targets"
         :matching="value.targetClusters"
@@ -682,7 +681,7 @@ export default {
         @update:value="updateTargets"
       />
 
-      <h3 class="mt-30">
+      <h3 class="mt-40">
         {{ t('fleet.helmOp.target.additionalOptions') }}
       </h3>
       <div class="row mt-20">

--- a/shell/edit/fleet.cattle.io.helmop.vue
+++ b/shell/edit/fleet.cattle.io.helmop.vue
@@ -415,7 +415,7 @@ export default {
     },
 
     updateBeforeSave() {
-this.value.spec.helm.valuesFrom = FleetUtils.HelmOp.toValuesFrom(this.valuesFrom, this.workspace);
+      this.value.spec.helm.valuesFrom = FleetUtils.HelmOp.toValuesFrom(this.valuesFrom, this.workspace);
       this.value.spec['correctDrift'] = { enabled: this.correctDriftEnabled };
     },
 
@@ -697,7 +697,7 @@ this.value.spec.helm.valuesFrom = FleetUtils.HelmOp.toValuesFrom(this.valuesFrom
         </div>
         <div class="col span-6">
           <LabeledInput
-            v-model:value="value.spec.targetNamespace"
+            v-model:value="value.spec.namespace"
             :mode="mode"
             label-key="fleet.helmOp.targetNamespace.label"
             placeholder-key="fleet.helmOp.targetNamespace.placeholder"

--- a/shell/edit/fleet.cattle.io.helmop.vue
+++ b/shell/edit/fleet.cattle.io.helmop.vue
@@ -408,8 +408,6 @@ export default {
 
     updateValueFrom(index, value) {
       this.valuesFrom[index] = value;
-
-      this.value.spec.helm.valuesFrom = FleetUtils.HelmOp.toValuesFrom(this.valuesFrom, this.workspace);
     },
 
     removeValueFrom(index) {
@@ -417,6 +415,7 @@ export default {
     },
 
     updateBeforeSave() {
+this.value.spec.helm.valuesFrom = FleetUtils.HelmOp.toValuesFrom(this.valuesFrom, this.workspace);
       this.value.spec['correctDrift'] = { enabled: this.correctDriftEnabled };
     },
 
@@ -647,7 +646,7 @@ export default {
         <h2 v-t="'fleet.helmOp.values.valuesFrom.selectLabel'" />
         <div
           v-for="(row, i) in valuesFrom"
-          :key="i"
+          :key="row.name"
         >
           <ValueFromResource
             :value="row"

--- a/shell/edit/fleet.cattle.io.helmop.vue
+++ b/shell/edit/fleet.cattle.io.helmop.vue
@@ -4,14 +4,11 @@ import jsyaml from 'js-yaml';
 import { saferDump } from '@shell/utils/create-yaml';
 import { mapGetters } from 'vuex';
 import { base64Encode } from '@shell/utils/crypto';
-import { exceptionToErrorsArray } from '@shell/utils/error';
 import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
 import { checkSchemasForFindAllHash } from '@shell/utils/auth';
 import FleetUtils from '@shell/utils/fleet';
-import {
-  AUTH_TYPE, CONFIG_MAP, FLEET, NORMAN, SECRET, VIRTUAL_HARVESTER_PROVIDER
-} from '@shell/config/types';
-import { CAPI, CATALOG, FLEET as FLEET_LABELS } from '@shell/config/labels-annotations';
+import { AUTH_TYPE, CONFIG_MAP, NORMAN, SECRET } from '@shell/config/types';
+import { CATALOG, FLEET as FLEET_LABELS } from '@shell/config/labels-annotations';
 import { SOURCE_TYPE } from '@shell/config/product/fleet';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import CruResource from '@shell/components/CruResource';
@@ -28,9 +25,9 @@ import YamlEditor, { EDITOR_MODES } from '@shell/components/YamlEditor';
 import SelectOrCreateAuthSecret from '@shell/components/form/SelectOrCreateAuthSecret';
 import ValueFromResource from '@shell/components/form/ValueFromResource';
 import { mapPref, DIFF } from '@shell/store/prefs';
-import { isHarvesterCluster } from '@shell/utils/cluster';
 import { SECRET_TYPES } from '@shell/config/secret';
 import UnitInput from '@shell/components/form/UnitInput';
+import FleetClusterTargets from '@shell/components/fleet/FleetClusterTargets/index.vue';
 import { toSeconds } from '@shell/utils/duration';
 import { DEFAULT_POLLING_INTERVAL, MINIMUM_POLLING_INTERVAL } from '@shell/models/fleet-application';
 
@@ -51,6 +48,7 @@ export default {
     ButtonGroup,
     Checkbox,
     CruResource,
+    FleetClusterTargets,
     YamlEditor,
     LabeledInput,
     LabeledSelect,
@@ -66,16 +64,6 @@ export default {
 
   async fetch() {
     const hash = await checkSchemasForFindAllHash({
-      allClusters: {
-        inStoreType: 'management',
-        type:        FLEET.CLUSTER
-      },
-
-      allClusterGroups: {
-        inStoreType: 'management',
-        type:        FLEET.CLUSTER_GROUP
-      },
-
       allSecrets: {
         inStoreType: 'management',
         type:        SECRET
@@ -87,12 +75,8 @@ export default {
       }
     }, this.$store);
 
-    this.allClusters = hash.allClusters || [];
-    this.allClusterGroups = hash.allClusterGroups || [];
     this.allSecrets = hash.allSecrets || [];
     this.allConfigMaps = hash.allConfigMaps || [];
-
-    this.updateTargets();
   },
 
   data() {
@@ -107,21 +91,6 @@ export default {
       }
     }
 
-    const targetInfo = this.value.targetInfo;
-    const targetCluster = targetInfo.cluster;
-    const targetClusterGroup = targetInfo.clusterGroup;
-    const targetAdvanced = targetInfo.advanced;
-
-    let targetMode = targetInfo.mode;
-
-    if ( this.realMode === _CREATE ) {
-      targetMode = 'all';
-    } else if ( targetMode === 'cluster' ) {
-      targetMode = `cluster://${ targetCluster }`;
-    } else if ( targetMode === 'clusterGroup' ) {
-      targetMode = `group://${ targetClusterGroup }`;
-    }
-
     const correctDriftEnabled = this.value.spec?.correctDrift?.enabled || false;
 
     const chartValues = saferDump(clone(this.value.spec.helm.values));
@@ -129,27 +98,22 @@ export default {
     return {
       VALUES_STATE,
       SOURCE_TYPE,
-      allClusters:          [],
-      allClusterGroups:     [],
-      allSecrets:           [],
-      allConfigMaps:        [],
-      allWorkspaces:        [],
+      allSecrets:       [],
+      allConfigMaps:    [],
+      allWorkspaces:    [],
       pollingInterval,
-      targetMode,
-      targetAdvanced,
-      targetAdvancedErrors: null,
-      sourceTypeInit:       this.value.sourceType,
-      sourceType:           this.value.sourceType || SOURCE_TYPE.REPO,
-      helmSpecInit:         clone(this.value.spec.helm),
-      yamlForm:             VALUES_STATE.YAML,
+      sourceTypeInit:   this.value.sourceType,
+      sourceType:       this.value.sourceType || SOURCE_TYPE.REPO,
+      helmSpecInit:     clone(this.value.spec.helm),
+      yamlForm:         VALUES_STATE.YAML,
       chartValues,
-      chartValuesInit:      chartValues,
-      valuesFrom:           FleetUtils.HelmOp.fromValuesFrom(this.value.spec.helm.valuesFrom),
+      chartValuesInit:  chartValues,
+      valuesFrom:       FleetUtils.HelmOp.fromValuesFrom(this.value.spec.helm.valuesFrom),
       correctDriftEnabled,
-      tempCachedValues:     {},
-      doneRouteList:        'c-cluster-fleet-application',
-      isRealModeEdit:       this.realMode === _EDIT,
-      fvFormRuleSets:       []
+      tempCachedValues: {},
+      doneRouteList:    'c-cluster-fleet-application',
+      isRealModeEdit:   this.realMode === _EDIT,
+      fvFormRuleSets:   []
     };
   },
 
@@ -220,10 +184,6 @@ export default {
       ];
     },
 
-    isLocal() {
-      return this.value.metadata.namespace === 'fleet-local';
-    },
-
     sourceTypeOptions() {
       return Object.values(SOURCE_TYPE).map((value) => ({
         value,
@@ -277,74 +237,12 @@ export default {
       return EDITOR_MODES.EDIT_CODE;
     },
 
-    targetOptions() {
-      const out = [
-        {
-          label: 'No Clusters',
-          value: 'none'
-        },
-        {
-          label: 'All Clusters in the Workspace',
-          value: 'all',
-        },
-        {
-          label: 'Advanced',
-          value: 'advanced'
-        },
-      ];
-
-      const clusters = this.allClusters
-        .filter((x) => {
-          return x.metadata.namespace === this.value.metadata.namespace;
-        })
-        .filter((x) => !isHarvesterCluster(x))
-        .map((x) => {
-          return { label: x.nameDisplay, value: `cluster://${ x.metadata.name }` };
-        });
-
-      if ( clusters.length ) {
-        out.push({ kind: 'divider', disabled: true });
-        out.push({
-          kind:     'title',
-          label:    'Clusters',
-          disabled: true,
-        });
-
-        out.push(...clusters);
-      }
-
-      const groups = this.allClusterGroups
-        .filter((x) => x.metadata.namespace === this.value.metadata.namespace)
-        .map((x) => {
-          return { label: x.nameDisplay, value: `group://${ x.metadata.name }` };
-        });
-
-      if ( groups.length ) {
-        out.push({ kind: 'divider', disabled: true });
-        out.push({
-          kind:     'title',
-          label:    'Cluster Groups',
-          disabled: true
-        });
-
-        out.push(...groups);
-      }
-
-      return out;
-    },
-
     showPollingIntervalWarning() {
       return !this.isView && this.value.isPollingEnabled && this.pollingInterval < MINIMUM_POLLING_INTERVAL;
     },
   },
 
   watch: {
-    'value.metadata.namespace': 'updateTargets',
-    targetMode:                 'updateTargets',
-    targetCluster:              'updateTargets',
-    targetClusterGroup:         'updateTargets',
-    targetAdvanced:             'updateTargets',
-
     workspace(neu) {
       if (this.isCreate) {
         set(this.value, 'metadata.namespace', neu);
@@ -369,52 +267,8 @@ export default {
       this.updateValidationRules(type);
     },
 
-    updateTargets() {
-      const spec = this.value.spec;
-      const mode = this.targetMode;
-
-      let kind, value;
-      const match = mode.match(/([^:]+)(:\/\/(.*))?$/);
-
-      if ( match ) {
-        kind = match[1];
-        value = match[3];
-      }
-
-      if ( kind === 'all' ) {
-        spec.targets = [{
-          clusterSelector: {
-            matchExpressions: [{
-              key:      CAPI.PROVIDER,
-              operator: 'NotIn',
-              values:   [
-                VIRTUAL_HARVESTER_PROVIDER
-              ],
-            }],
-          },
-        }];
-      } else if ( kind === 'none' ) {
-        spec.targets = [];
-      } else if ( kind === 'cluster' ) {
-        spec.targets = [
-          { clusterName: value },
-        ];
-      } else if ( kind === 'group' ) {
-        spec.targets = [
-          { clusterGroup: value }
-        ];
-      } else if ( kind === 'advanced' ) {
-        try {
-          const parsed = jsyaml.load(this.targetAdvanced);
-
-          spec.targets = parsed;
-          this.targetAdvancedErrors = null;
-        } catch (e) {
-          this.targetAdvancedErrors = exceptionToErrorsArray(e);
-        }
-      } else {
-        spec.targets = [];
-      }
+    updateTargets(value) {
+      this.value.spec.targets = value;
     },
 
     enablePolling(value) {
@@ -818,49 +672,19 @@ export default {
     </template>
 
     <template #target>
-      <h2 v-t="isLocal ? 'fleet.helmOp.target.labelLocal' : 'fleet.helmOp.target.label'" />
+      <h2 v-t="'fleet.helmOp.target.label'" />
 
-      <template v-if="!isLocal">
-        <div class="row">
-          <div class="col span-6">
-            <LabeledSelect
-              v-model:value="targetMode"
-              :options="targetOptions"
-              option-key="value"
-              :mode="mode"
-              :selectable="option => !option.disabled"
-              :label="t('fleet.helmOp.target.selectLabel')"
-            >
-              <template v-slot:option="opt">
-                <hr v-if="opt.kind === 'divider'">
-                <div v-else-if="opt.kind === 'title'">
-                  {{ opt.label }}
-                </div>
-                <div v-else>
-                  {{ opt.label }}
-                </div>
-              </template>
-            </LabeledSelect>
-          </div>
-        </div>
+      <FleetClusterTargets
+        :targets="value.spec.targets"
+        :matching="value.targetClusters"
+        :namespace="value.metadata.namespace"
+        :mode="realMode"
+        @update:value="updateTargets"
+      />
 
-        <div
-          v-if="targetMode === 'advanced'"
-          class="row mt-10"
-        >
-          <div class="col span-12">
-            <YamlEditor v-model:value="targetAdvanced" />
-          </div>
-        </div>
-
-        <Banner
-          v-for="(err, i) in targetAdvancedErrors"
-          :key="i"
-          color="error"
-          :label="err"
-        />
-      </template>
-
+      <h3 class="mt-30">
+        {{ t('fleet.helmOp.target.additionalOptions') }}
+      </h3>
       <div class="row mt-20">
         <div class="col span-6">
           <LabeledInput

--- a/shell/edit/fleet.cattle.io.helmop.vue
+++ b/shell/edit/fleet.cattle.io.helmop.vue
@@ -113,7 +113,8 @@ export default {
       tempCachedValues: {},
       doneRouteList:    'c-cluster-fleet-application',
       isRealModeEdit:   this.realMode === _EDIT,
-      fvFormRuleSets:   []
+      targetsCreated:   '',
+      fvFormRuleSets:   [],
     };
   },
 
@@ -678,7 +679,9 @@ export default {
         :matching="value.targetClusters"
         :namespace="value.metadata.namespace"
         :mode="realMode"
+        :created="targetsCreated"
         @update:value="updateTargets"
+        @created="targetsCreated=$event"
       />
 
       <h3 class="mt-40">

--- a/shell/models/fleet-application.js
+++ b/shell/models/fleet-application.js
@@ -138,7 +138,7 @@ export default class FleetApplication extends SteveModel {
   }
 
   get targetInfo() {
-    const mode = FleetUtils.Application.getTargetMode(this.spec.targets || []);
+    const mode = FleetUtils.Application.getTargetMode(this.spec.targets || [], this.metadata.namespace);
 
     return {
       mode,

--- a/shell/types/fleet.d.ts
+++ b/shell/types/fleet.d.ts
@@ -34,3 +34,27 @@ export interface Application {
     name: string
   }
 }
+
+export type TargetMode = 'none' | 'all' | 'clusters' | 'local' | 'advanced';
+
+export type MatchLabels = Record<string, string>;
+
+export interface Expression {
+  key: string,
+  operator: string,
+  values: string[]
+}
+
+export interface Selector {
+  key?: number,
+  matchLabels?: MatchLabels,
+  matchExpressions?: Expression[]
+}
+
+export interface Target {
+  name?: string,
+  clusterName?: string,
+  clusterSelector?: Selector,
+  clusterGroup?: string,
+  clusterGroupSelector?: Selector
+}

--- a/shell/utils/__tests__/fleet.test.ts
+++ b/shell/utils/__tests__/fleet.test.ts
@@ -1,0 +1,148 @@
+import { Target } from '@shell/types/fleet';
+import FleetUtils from '@shell/utils/fleet';
+
+describe('fx: util.getTargetMode', () => {
+  const util = FleetUtils.Application;
+
+  it('should return "all" when targets contain excludeHarvesterRule and namespace is not fleet-local', () => {
+    const targets = [{
+      clusterSelector: {
+        matchExpressions: [{
+          key:      'provider.cattle.io',
+          operator: 'NotIn',
+          values:   ['harvester'],
+        }],
+      },
+    }];
+    const namespace = 'ws1';
+
+    expect(util.getTargetMode(targets, namespace)).toBe('all');
+  });
+
+  it('should return "clusters" when targets include clusterName and clusterSelector', () => {
+    const targets = [{ clusterName: 'fleet-5-france' }, { clusterSelector: { matchLabels: { foo: 'true' } } }];
+    const namespace = 'ws1';
+
+    expect(util.getTargetMode(targets, namespace)).toBe('clusters');
+  });
+
+  it('should return "clusters" when targets only include multiple clusterSelectors', () => {
+    const targets: Target[] = [{ clusterSelector: { matchLabels: { foo: 'true' } } }, { clusterSelector: { matchLabels: { hci: 'true' } } }];
+    const namespace = 'ws1';
+
+    expect(util.getTargetMode(targets, namespace)).toBe('clusters');
+  });
+
+  it('should return "advanced" when a target contains clusterGroupSelector', () => {
+    const targets = [{ clusterGroupSelector: {} }];
+    const namespace = 'ws1';
+
+    expect(util.getTargetMode(targets, namespace)).toBe('advanced');
+  });
+
+  it('should return "advanced" when any target contains clusterGroup or clusterGroupSelector', () => {
+    const targets = [{
+      clusterGroup:         'cg1',
+      clusterGroupSelector: {
+        matchExpressions: [{
+          key:      'string',
+          operator: 'string',
+          values:   ['string']
+        }],
+        matchLabels: { foo: 'bar' }
+      },
+      clusterName:     'pippo',
+      clusterSelector: {
+        matchExpressions: [{
+          key:      'string',
+          operator: 'string',
+          values:   ['vvv']
+        }],
+        matchLabels: { foo: 'bar' }
+      },
+      name: 'tt1',
+    }, {
+      clusterGroup:         'cg2',
+      clusterGroupSelector: {
+        matchExpressions: [{
+          key:      'string',
+          operator: 'string',
+          values:   ['string']
+        }],
+        matchLabels: { foo: 'bar' }
+      },
+      clusterName:     'pippo',
+      clusterSelector: {
+        matchExpressions: [{
+          key:      'string',
+          operator: 'string',
+          values:   ['vvv']
+        }],
+        matchLabels: { foo: 'bar' }
+      },
+      name: 'tt1',
+    }];
+    const namespace = 'ws1';
+
+    expect(util.getTargetMode(targets, namespace)).toBe('advanced');
+  });
+
+  it('should return "none" when targets is an empty array', () => {
+    const targets: Target[] = [];
+    const namespace = 'ws1';
+
+    expect(util.getTargetMode(targets, namespace)).toBe('none');
+  });
+
+  it('should return "local" when namespace is "fleet-local" regardless of targets', () => {
+    const targets: Target[] = [{ clusterSelector: { matchLabels: { foo: 'true' } } }, { clusterSelector: { matchLabels: { hci: 'true' } } }];
+    const namespace = 'fleet-local';
+
+    expect(util.getTargetMode(targets, namespace)).toBe('local');
+  });
+
+  it('should return "all" if no specific target type (clusterName, clusterSelector, clusterGroup, clusterGroupSelector) is present', () => {
+    const targets = [{ name: 'target1' }];
+    const namespace = 'ws1';
+
+    expect(util.getTargetMode(targets, namespace)).toBe('all');
+  });
+
+  it('should return "clusters" if multiple targets include only clusterName', () => {
+    const targets = [{ clusterName: 'cluster-a' }, { clusterName: 'cluster-b' }];
+    const namespace = 'ws1';
+
+    expect(util.getTargetMode(targets, namespace)).toBe('clusters');
+  });
+
+  it('should return "clusters" if a mix of clusterName and empty clusterSelector is present', () => {
+    const targets = [{ clusterName: 'cluster-c' }, { clusterSelector: {} },
+    ];
+    const namespace = 'ws1';
+
+    expect(util.getTargetMode(targets, namespace)).toBe('clusters');
+  });
+
+  it('should return "advanced" if one target has clusterGroup but others have clusterName or clusterSelector', () => {
+    const targets = [{ clusterName: 'cluster-x' }, { clusterGroup: 'my-group' }, { clusterSelector: { matchLabels: { env: 'prod' } } }];
+    const namespace = 'ws1';
+
+    expect(util.getTargetMode(targets, namespace)).toBe('advanced');
+  });
+
+  it('should return "all" when targets contain excludeHarvesterRule along with other irrelevant properties', () => {
+    const targets = [{
+      clusterSelector: {
+        matchExpressions: [{
+          key:      'provider.cattle.io',
+          operator: 'NotIn',
+          values:   ['harvester'],
+        }],
+      },
+      name: 'some-other-name'
+    }];
+    const namespace = 'ws1';
+
+    expect(util.getTargetMode(targets, namespace)).toBe('all');
+  });
+});

--- a/shell/utils/fleet.ts
+++ b/shell/utils/fleet.ts
@@ -61,7 +61,7 @@ class Application {
       return 'local';
     }
 
-    if (!targets?.length) {
+    if (!targets.length) {
       return 'none';
     }
 
@@ -88,7 +88,14 @@ class Application {
       }
     }
 
-    if (isEqual(targets, [this.excludeHarvesterRule])) {
+    const normalized = [...targets].map((target) => {
+      delete target.name;
+
+      return target;
+    });
+
+    // Check if targets contains only harvester rule after name normalizing
+    if (isEqual(normalized, [this.excludeHarvesterRule])) {
       mode = 'all';
     }
 

--- a/shell/utils/fleet.ts
+++ b/shell/utils/fleet.ts
@@ -1,3 +1,4 @@
+import { isEmpty, isEqual } from 'lodash';
 import {
   BundleDeploymentResource,
   BundleResourceKey,
@@ -6,10 +7,10 @@ import {
   Condition,
 } from '@shell/types/resources/fleet';
 import { mapStateToEnum, STATES_ENUM, STATES } from '@shell/plugins/dashboard-store/resource-class';
-import { FLEET as FLEET_LABELS } from '@shell/config/labels-annotations';
+import { FLEET as FLEET_LABELS, CAPI } from '@shell/config/labels-annotations';
 import { NAME as EXPLORER_NAME } from '@shell/config/product/explorer';
-import { FleetDashboardState, FleetResourceState } from '@shell/types/fleet';
-import { FLEET } from '@shell/config/types';
+import { FleetDashboardState, FleetResourceState, Target, TargetMode } from '@shell/types/fleet';
+import { FLEET, VIRTUAL_HARVESTER_PROVIDER } from '@shell/config/types';
 
 interface Resource extends BundleDeploymentResource {
   state: string,
@@ -40,6 +41,55 @@ function conditionIsTrue(conditions: Condition[] | undefined, type: string): boo
   }
 
   return !!conditions.find((c) => c.type === type && c.status.toLowerCase() === 'true');
+}
+
+class Application {
+  excludeHarvesterRule = {
+    clusterSelector: {
+      matchExpressions: [{
+        key:      CAPI.PROVIDER,
+        operator: 'NotIn',
+        values:   [
+          VIRTUAL_HARVESTER_PROVIDER
+        ],
+      }],
+    },
+  };
+
+  getTargetMode(targets: Target[]) {
+    if (!targets?.length) {
+      return 'none';
+    }
+
+    let mode: TargetMode = 'all';
+
+    for (const target of targets) {
+      const {
+        clusterName,
+        clusterSelector,
+        clusterGroup,
+        clusterGroupSelector,
+      } = target;
+
+      if (clusterGroup || clusterGroupSelector) {
+        return 'advanced';
+      }
+
+      if (clusterName) {
+        mode = 'clusters';
+      }
+
+      if (!isEmpty(clusterSelector)) {
+        mode = 'clusters';
+      }
+    }
+
+    if (isEqual(targets, [this.excludeHarvesterRule])) {
+      mode = 'all';
+    }
+
+    return mode;
+  }
 }
 
 class HelmOp {
@@ -149,6 +199,7 @@ class Fleet {
     },
   ];
 
+  Application = new Application();
   HelmOp = new HelmOp();
 
   GIT_HTTPS_REGEX = /^https?:\/\/github\.com\/(.*?)(\.git)?\/*$/;

--- a/shell/utils/fleet.ts
+++ b/shell/utils/fleet.ts
@@ -56,7 +56,11 @@ class Application {
     },
   };
 
-  getTargetMode(targets: Target[]) {
+  getTargetMode(targets: Target[], namespace: string): TargetMode {
+    if (namespace === 'fleet-local') {
+      return 'local';
+    }
+
     if (!targets?.length) {
       return 'none';
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13924
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

We want to improve the Cluster targets functionalities in GitRepos and HelmOps wizards.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- YAML editor for advanced scenarios has been removed
-  The new form can handle the following use cases:
  - No clusters
  - All Clusters
  - Select multiple clusters and/or matching expressions
- We don't want to handle clusterGroups and clusterGroupsExpressions; These 2 scenarions are considered complex and can be handled directly in the YAML editor.
- We display a warning message to inform the users to handle complex scenarios using the YAML editor.
- default target in flett-local workspace will be local cluster.
- We changed the 'Target' column in each GitRepos and HelmOps tables to be consistent with the new scenarios (remove ClusterGroups values)

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Create/Edit GitRepos and HelmOps
- Assign targets

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- GitRepos & HelmOps wizard
- GitRepos & HelmOps list

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

Targets selector

[Screencast from 2025-06-18 14-00-06.webm](https://github.com/user-attachments/assets/ce920d5f-3401-41ba-9b4e-c312ed21bd02)

Target column

![image](https://github.com/user-attachments/assets/f9f58f5f-fea6-4d3f-9fc5-9ebeba147bff)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
