### PR TITLE
Disabled editing Harvester cluster from Cluster management

### DIFF
--- a/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
+++ b/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
@@ -88,6 +88,8 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
       harvesterPo.harvesterLogo().should('not.exist');
       harvesterPo.harvesterTagline().should('not.exist');
 
+      // #14285: Should be able to edit cluster here
+      harvesterPo.list().actionMenu(harvesterClusterName).getMenuItem('Edit Config').should('exist');
       // delete cluster
       cy.deleteRancherResource('v1', 'provisioning.cattle.io.clusters', `fleet-default/${ harvesterClusterId }`);
     });

--- a/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
+++ b/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
@@ -41,6 +41,16 @@ export default class HciCluster extends ProvCluster {
     return false;
   }
 
+  // We do not allow users to edit Harvester clusters from Cluster Management, so we need to re-enable that action here.
+  get _availableActions() {
+    const out = super._availableActions;
+    const edit = out.find((action) => action.action === 'goToEdit');
+
+    edit.enabled = true;
+
+    return out;
+  }
+
   get stateColor() {
     if (!this.isSupportedHarvester) {
       return colorForState(STATES_ENUM.DENIED);

--- a/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
+++ b/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
@@ -46,7 +46,9 @@ export default class HciCluster extends ProvCluster {
     const out = super._availableActions;
     const edit = out.find((action) => action.action === 'goToEdit');
 
-    edit.enabled = this.canCustomEdit;
+    if (edit) {
+      edit.enabled = this.canCustomEdit;
+    }
 
     return out;
   }

--- a/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
+++ b/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
@@ -46,7 +46,7 @@ export default class HciCluster extends ProvCluster {
     const out = super._availableActions;
     const edit = out.find((action) => action.action === 'goToEdit');
 
-    edit.enabled = true;
+    edit.enabled = this.canCustomEdit;
 
     return out;
   }

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -162,8 +162,8 @@ export default class ProvCluster extends SteveModel {
 
     const all = actions.concat(out);
 
-    // If the cluster is a KEV1 cluster then prevent edit
-    if (this.isKev1) {
+    // If the cluster is a KEV1 cluster or Harvester cluster then prevent edit
+    if (this.isKev1 || this.isHarvester) {
       const edit = all.find((action) => action.action === 'goToEdit');
 
       if (edit) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14285 
<!-- Define findings related to the feature or bug issue. -->
Disabled editing Harvester clusters from Cluster Management.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
When we enable harvester-baremetal-container-workload feature flag, Harvester clusters become available in Cluster Management. Users should not be able to edit Harvester clusters from there, so editing action has been removed and is only added when access through Harvester Clusters

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Import Harvester cluster
Global settings -> feature flags -> "harvester-baremetal-container-workload" -> enable
Cluster Management -> Harvester cluster -> action menu should NOT have an option to edit a cluster
Cluster Management -> non-Harvester cluster -> action menu should have an option to edit a cluster
Virtualization Management -> Harvester cluster -> action menu should have an option to edit a cluster

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
List of actions available to Harvester clusters under Virtualization management could be impacted

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1167" alt="Screenshot 2025-06-16 at 1 02 26 PM" src="https://github.com/user-attachments/assets/c8786a98-60aa-425d-8af5-8ee6503c1789" />
<img width="1181" alt="Screenshot 2025-06-16 at 1 03 06 PM" src="https://github.com/user-attachments/assets/b37fca75-9bce-4c0f-87f1-230c2e79d465" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
