### PR TITLE
Disable VAI on test for CRD resource

### DIFF
--- a/cypress/e2e/tests/pages/explorer/more-resources/api/custom-resource-definitions.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/more-resources/api/custom-resource-definitions.spec.ts
@@ -14,7 +14,7 @@ describe('CustomResourceDefinitions', { testIsolation: 'off', tags: ['@explorer'
     cy.login();
   });
 
-  describe('List', { tags: ['@vai', '@adminUser'] }, () => {
+  describe('List', { tags: ['@adminUser'] }, () => {
     before(() => {
       ClusterDashboardPagePo.goToAndWait(cluster); // Ensure we're at a solid state before messing with preferences (given login/load might change them)
       cy.tableRowsPerPageAndNamespaceFilter(10, cluster, 'none', '{\"local\":[]}');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Temporarily disable CRD tests for vai given https://github.com/rancher/rancher/issues/50687

### Technical notes summary
- issue to revert https://github.com/rancher/dashboard/issues/14533

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
