### PR TITLE
Adding the new Secret detail page to the application

### DIFF
--- a/cypress/e2e/po/pages/explorer/config-map.po.ts
+++ b/cypress/e2e/po/pages/explorer/config-map.po.ts
@@ -44,6 +44,6 @@ export class ConfigMapPagePo extends PagePo {
   }
 
   title() {
-    return this.self().get('.title h1').invoke('text');
+    return this.self().get('.title-bar .title').invoke('text');
   }
 }

--- a/cypress/e2e/po/pages/explorer/config-map.po.ts
+++ b/cypress/e2e/po/pages/explorer/config-map.po.ts
@@ -44,6 +44,6 @@ export class ConfigMapPagePo extends PagePo {
   }
 
   title() {
-    return this.self().get('.title-bar .title').invoke('text');
+    return this.self().get('.title h1').invoke('text');
   }
 }

--- a/cypress/e2e/po/pages/explorer/secrets.po.ts
+++ b/cypress/e2e/po/pages/explorer/secrets.po.ts
@@ -36,7 +36,7 @@ export class SecretsListPagePo extends BaseListPagePo {
   }
 
   title() {
-    return this.self().get('.title-bar .title').invoke('text');
+    return this.self().get('.title h1').invoke('text');
   }
 
   createButton() {

--- a/cypress/e2e/po/pages/explorer/secrets.po.ts
+++ b/cypress/e2e/po/pages/explorer/secrets.po.ts
@@ -36,7 +36,7 @@ export class SecretsListPagePo extends BaseListPagePo {
   }
 
   title() {
-    return this.self().get('.title h1').invoke('text');
+    return this.self().get('.title-bar .title').invoke('text');
   }
 
   createButton() {

--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -227,7 +227,7 @@ export default {
     },
 
     onFocus() {
-      this.isCodeMirrorFocused = !this.isDisabled;
+      this.isCodeMirrorFocused = true;
       this.$emit('onFocus', this.isCodeMirrorFocused);
     },
 

--- a/shell/components/DetailText.vue
+++ b/shell/components/DetailText.vue
@@ -187,6 +187,7 @@ export default {
       :options="{mode:{name:'javascript', json:true}, lineNumbers:false, foldGutter:false, readOnly:true}"
       :value="jsonStr"
       :class="{'conceal': concealed}"
+      aria-live="polite"
     />
 
     <span
@@ -194,6 +195,7 @@ export default {
       v-clean-html="bodyHtml"
       data-testid="detail-top_html"
       :class="{'conceal': concealed, 'monospace': monospace && !isBinary}"
+      aria-live="polite"
     />
 
     <template v-if="!isBinary && !jsonStr && isLong && !expanded">

--- a/shell/components/Drawer/Chrome.vue
+++ b/shell/components/Drawer/Chrome.vue
@@ -82,11 +82,13 @@ const ariaLabel = computed(() => i18n.t('component.drawer.chrome.ariaLabel.close
 
       & > .actions {
         button {
-          display: inline-block;
+          display: inline-flex;
           $size: 24px;
           width: $size;
           height: $size;
           color: var(--body-text);
+
+          justify-content: center;
         }
       }
     }

--- a/shell/components/Drawer/ResourceDetailDrawer/YamlTab.vue
+++ b/shell/components/Drawer/ResourceDetailDrawer/YamlTab.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import ResourceYaml from '@shell/components/ResourceYaml.vue';
+import CodeMirror from '@shell/components/CodeMirror.vue';
 import { useI18n } from '@shell/composables/useI18n';
 import { _VIEW } from '@shell/config/query-params';
 import { useStore } from 'vuex';
@@ -24,10 +24,9 @@ const yamlComponent: any = useTemplateRef('yaml');
     :label="i18n.t('component.drawer.resourceDetailDrawer.yamlTab.title')"
     @active="() => yamlComponent?.refresh()"
   >
-    <ResourceYaml
+    <CodeMirror
       ref="yaml"
-      :value="props.resource"
-      :yaml="props.yaml"
+      :value="props.yaml"
       :mode="_VIEW"
     />
   </Tab>
@@ -35,7 +34,7 @@ const yamlComponent: any = useTemplateRef('yaml');
 
 <style lang="scss" scoped>
 .yaml-tab {
-  :deep() .yaml-editor .codemirror-container {
+  :deep() .codemirror-container {
     background-color: var(--body-bg);
     border-radius: var(--border-radius-md);
     padding: 16px;

--- a/shell/components/Drawer/ResourceDetailDrawer/__tests__/YamlTab.test.ts
+++ b/shell/components/Drawer/ResourceDetailDrawer/__tests__/YamlTab.test.ts
@@ -4,17 +4,13 @@ import { createStore } from 'vuex';
 
 import Tab from '@shell/components/Tabbed/Tab.vue';
 import { _VIEW } from '@shell/config/query-params';
-import ResourceYaml from '@shell/components/ResourceYaml.vue';
+import CodeMirror from '@shell/components/CodeMirror.vue';
 import { nextTick } from 'vue';
 
-jest.mock('@shell/components/ResourceYaml.vue', () => ({
-  template: `<div>ResourceYaml</div>`,
+jest.mock('@shell/components/CodeMirror.vue', () => ({
+  template: `<div>CodeMirror</div>`,
   props:    {
     value: {
-      type:     Object,
-      required: true
-    },
-    yaml: {
       type:     String,
       required: true
     },
@@ -50,17 +46,16 @@ describe('component: ResourceDetailDrawer/ConfigTab', () => {
     expect(component.props('name')).toStrictEqual('yaml-tab');
   });
 
-  it('should render a ResourceYaml component and pass the correct props', () => {
+  it('should render a CodeMirror component and pass the correct props', () => {
     const wrapper = mount(YamlTab, {
       props: { resource, yaml },
       global
     });
 
-    const component = wrapper.getComponent(ResourceYaml);
+    const component = wrapper.getComponent(CodeMirror);
 
-    expect(component.props('value')).toStrictEqual(resource);
+    expect(component.props('value')).toStrictEqual(yaml);
     expect(component.props('mode')).toStrictEqual(_VIEW);
-    expect(component.props('yaml')).toStrictEqual(yaml);
   });
 
   it('should refresh yaml editor when tab is activated', async() => {
@@ -71,10 +66,10 @@ describe('component: ResourceDetailDrawer/ConfigTab', () => {
 
     const tabComponent = wrapper.getComponent(Tab);
 
-    expect(ResourceYaml.methods?.refresh).toHaveBeenCalledTimes(0);
+    expect(CodeMirror.methods?.refresh).toHaveBeenCalledTimes(0);
     tabComponent.vm.$emit('active');
     await nextTick();
 
-    expect(ResourceYaml.methods?.refresh).toHaveBeenCalledTimes(1);
+    expect(CodeMirror.methods?.refresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/shell/components/Drawer/ResourceDetailDrawer/__tests__/composables.test.ts
+++ b/shell/components/Drawer/ResourceDetailDrawer/__tests__/composables.test.ts
@@ -60,21 +60,21 @@ describe('composables: ResourceDetailDrawer', () => {
     it('should create a wrapper that passes that appropriate properties to the drawer methods', () => {
       const openSpy = jest.fn();
       const closeSpy = jest.fn();
-
+      const selector = '.selector';
       const useDrawerSpy = jest.spyOn(drawer, 'useDrawer').mockImplementation(() => ({ open: openSpy, close: closeSpy }));
       const resourceDetailDrawer = useResourceDetailDrawer();
 
-      resourceDetailDrawer.openResourceDetailDrawer(resource);
+      resourceDetailDrawer.openResourceDetailDrawer(resource, selector);
 
       expect(useDrawerSpy).toHaveBeenCalledTimes(1);
-      expect(openSpy).toHaveBeenCalledWith({ name: 'ResourceDetailDrawer' }, {
+      expect(openSpy).toHaveBeenCalledWith({ name: 'ResourceDetailDrawer' }, selector, {
         resource,
         onClose:   closeSpy,
         width:     '73%',
         // We want this to be full viewport height top to bottom
         height:    '100vh',
         top:       '0',
-        'z-index': 101 // We want this to be above the main side menu
+        'z-index': 101, // We want this to be above the main side menu
       });
     });
   });

--- a/shell/components/Drawer/ResourceDetailDrawer/composables.ts
+++ b/shell/components/Drawer/ResourceDetailDrawer/composables.ts
@@ -8,16 +8,18 @@ import { getYaml } from '@shell/components/Drawer/ResourceDetailDrawer/helpers';
 export function useResourceDetailDrawer() {
   const { open, close } = useDrawer();
 
-  const openResourceDetailDrawer = (resource: any) => {
-    open(ResourceDetailDrawer, {
-      resource,
-      onClose:   close,
-      width:     '73%',
-      // We want this to be full viewport height top to bottom
-      height:    '100vh',
-      top:       '0',
-      'z-index': 101 // We want this to be above the main side menu
-    });
+  const openResourceDetailDrawer = (resource: any, returnFocusSelector: string) => {
+    open(ResourceDetailDrawer,
+      returnFocusSelector,
+      {
+        resource,
+        onClose:   close,
+        width:     '73%',
+        // We want this to be full viewport height top to bottom
+        height:    '100vh',
+        top:       '0',
+        'z-index': 101 // We want this to be above the main side menu
+      });
   };
 
   return { openResourceDetailDrawer };

--- a/shell/components/Resource/Detail/Metadata/Annotations/index.vue
+++ b/shell/components/Resource/Detail/Metadata/Annotations/index.vue
@@ -8,7 +8,7 @@ export type Annotation = Row;
 export interface AnnotationsProps {
   annotations: Annotation[];
 
-  onShowConfiguration?: () => void;
+  onShowConfiguration?: (returnFocusSelector: string) => void;
 }
 
 </script>
@@ -26,6 +26,6 @@ const i18n = useI18n(store);
     :rows="annotations"
     :outline="true"
 
-    @show-configuration="() => emit('show-configuration')"
+    @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector)"
   />
 </template>

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/composable.ts
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/composable.ts
@@ -1,35 +1,58 @@
-import { useI18n } from '@shell/composables/useI18n';
-import { computed, ComputedRef, markRaw, toValue } from 'vue';
-import LiveDate from '@shell/components/formatter/LiveDate.vue';
-import { useStore } from 'vuex';
+import { computed, ComputedRef, toValue } from 'vue';
 import { Row } from '@shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue';
-
-export const useLiveDate = (resource: any): ComputedRef<Row> => {
-  const store = useStore();
-  const i18n = useI18n(store);
-  const resourceValue = toValue(resource);
-
-  return computed(() => ({
-    label:         i18n.t('component.resource.detail.metadata.identifyingInformation.age'),
-    valueOverride: {
-      component: markRaw(LiveDate),
-      props:     { value: resourceValue.creationTimestamp }
-    },
-    value: resourceValue.age,
-  }));
-};
+import {
+  useCertificate,
+  useExpires,
+  useImage, useIssuer, useLiveDate, useNamespace, useReady, useSecretType,
+  useServiceAccount
+} from '@shell/components/Resource/Detail/Metadata/IdentifyingInformation/identifying-fields';
+import { useStore } from 'vuex';
+import { useI18n } from '@shell/composables/useI18n';
 
 export const useDefaultIdentifyingInformation = (resource: any): ComputedRef<Row[]> => {
+  return computed(() => {
+    const namespace = useNamespace(resource);
+    const liveDate = useLiveDate(resource);
+
+    return [
+      namespace.value,
+      liveDate.value
+    ];
+  });
+};
+
+export const useSecretIdentifyingInformation = (resource: any): ComputedRef<Row[]> => {
+  return computed(() => {
+    const rows = [
+      useSecretType(resource),
+      useServiceAccount(resource),
+      useCertificate(resource),
+      useIssuer(resource),
+      useExpires(resource),
+    ];
+
+    return rows
+      .filter((r) => typeof r !== 'undefined')
+      .map((r) => r.value);
+  });
+};
+
+export const useDefaultWorkloadIdentifyingInformation = (resource: any): ComputedRef<Row[]> => {
   const store = useStore();
   const i18n = useI18n(store);
+
   const resourceValue = toValue(resource);
-  const liveDate = useLiveDate(resource);
 
   return computed(() => [
+    useImage(resource).value,
+    useReady(resource).value,
     {
-      label: i18n.t('component.resource.detail.metadata.identifyingInformation.namespace'),
-      value: resourceValue.namespace,
+      label: i18n.t('component.resource.detail.metadata.identifyingInformation.up-to-date'),
+      value: resourceValue.upToDate,
     },
-    liveDate.value
+    {
+      label: i18n.t('component.resource.detail.metadata.identifyingInformation.available'),
+      value: resourceValue.available,
+    },
   ]);
 };

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/composable.ts
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/composable.ts
@@ -10,30 +10,34 @@ import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
 
 export const useDefaultIdentifyingInformation = (resource: any): ComputedRef<Row[]> => {
-  return computed(() => {
-    const namespace = useNamespace(resource);
-    const liveDate = useLiveDate(resource);
+  const namespace = useNamespace(resource);
+  const liveDate = useLiveDate(resource);
 
+  return computed(() => {
     return [
-      namespace.value,
-      liveDate.value
-    ];
+      namespace?.value,
+      liveDate?.value
+    ].filter((info) => typeof info !== 'undefined');
   });
 };
 
 export const useSecretIdentifyingInformation = (resource: any): ComputedRef<Row[]> => {
+  const secretType = useSecretType(resource);
+  const serviceAccount = useServiceAccount(resource);
+  const certificate = useCertificate(resource);
+  const issuer = useIssuer(resource);
+  const expires = useExpires(resource);
+
   return computed(() => {
     const rows = [
-      useSecretType(resource),
-      useServiceAccount(resource),
-      useCertificate(resource),
-      useIssuer(resource),
-      useExpires(resource),
+      secretType?.value,
+      serviceAccount?.value,
+      certificate?.value,
+      issuer?.value,
+      expires?.value,
     ];
 
-    return rows
-      .filter((r) => typeof r !== 'undefined')
-      .map((r) => r.value);
+    return rows.filter((r) => typeof r !== 'undefined');
   });
 };
 
@@ -42,10 +46,12 @@ export const useDefaultWorkloadIdentifyingInformation = (resource: any): Compute
   const i18n = useI18n(store);
 
   const resourceValue = toValue(resource);
+  const image = useImage(resource);
+  const ready = useReady(resource);
 
   return computed(() => [
-    useImage(resource).value,
-    useReady(resource).value,
+    image.value,
+    ready.value,
     {
       label: i18n.t('component.resource.detail.metadata.identifyingInformation.up-to-date'),
       value: resourceValue.upToDate,

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
@@ -21,6 +21,8 @@ export interface MetadataProps {
 
 <script setup lang="ts">
 const { rows } = defineProps<MetadataProps>();
+
+const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`.toLowerCase().replaceAll(' ', '');
 </script>
 
 <template>
@@ -31,11 +33,15 @@ const { rows } = defineProps<MetadataProps>();
       class="row"
       :data-testid="row.dataTestid"
     >
-      <div class="label text-muted">
+      <label
+        class="label text-muted"
+        :for="getRowValueId(row)"
+      >
         {{ row.label }}
-      </div>
+      </label>
       <div
         v-if="row.valueOverride?.component && row.value"
+        :id="getRowValueId(row)"
         class="value"
       >
         <component
@@ -47,6 +53,7 @@ const { rows } = defineProps<MetadataProps>();
       </div>
       <div
         v-else
+        :id="getRowValueId(row)"
         class="value"
       >
         <div
@@ -62,8 +69,14 @@ const { rows } = defineProps<MetadataProps>();
         </router-link>
         <span
           v-else-if="row.value"
+          <<<<<<<
+          HEAD
           :data-testid="row.valueDataTestid"
-        >{{ row.value }}</span>
+          =="====="
+          tabindex="0"
+          :aria-label="row.value"
+        >>>>>>> Switched to labels and made use of the :for attribute
+          >{{ row.value }}</span>
         <span
           v-else
           class="text-muted"

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
@@ -69,14 +69,10 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
         </router-link>
         <span
           v-else-if="row.value"
-          <<<<<<<
-          HEAD
           :data-testid="row.valueDataTestid"
-          =="====="
           tabindex="0"
           :aria-label="row.value"
-        >>>>>>> Switched to labels and made use of the :for attribute
-          >{{ row.value }}</span>
+        >{{ row.value }}</span>
         <span
           v-else
           class="text-muted"

--- a/shell/components/Resource/Detail/Metadata/KeyValue.vue
+++ b/shell/components/Resource/Detail/Metadata/KeyValue.vue
@@ -16,13 +16,17 @@ export interface KeyValueProps {
     rows: Row[];
     maxRows?: number;
     outline?: boolean;
+
+    onShowConfiguration?: (returnFocusSelector: string) => void;
 }
 </script>
 
 <script setup lang="ts">
 const props = withDefaults(
   defineProps<KeyValueProps>(),
-  { outline: false, maxRows: 4 }
+  {
+    outline: false, maxRows: 4, onShowConfiguration: undefined
+  }
 );
 const {
   propertyName, rows, maxRows, outline
@@ -41,6 +45,10 @@ const showShowAllButton = computed(() => rows.value.length > maxRows.value);
 const showAllLabel = computed(() => `Show all ${ lowercasePropertyName.value }`);
 
 const displayValue = (row: Row) => `${ row.key }: ${ row.value }`;
+const showConfigurationEmptyDataTestId = computed(() => `empty-show-configuration_${ propertyName.value.replaceAll(' ', '').toLowerCase() }`);
+const showConfigurationEmptyFocusSelector = computed(() => `[data-testid="${ showConfigurationEmptyDataTestId.value }"]`);
+const showConfigurationMoreDataTestId = computed(() => `more-show-configuration_${ propertyName.value.replaceAll(' ', '').toLowerCase() }`);
+const showConfigurationMoreFocusSelector = computed(() => `[data-testid="${ showConfigurationMoreDataTestId.value }"]`);
 </script>
 
 <template>
@@ -58,9 +66,10 @@ const displayValue = (row: Row) => `${ row.key }: ${ row.value }`;
       </div>
       <div class="show-configuration mmt-1">
         <a
+          :data-testid="showConfigurationEmptyDataTestId"
           class="secondary text-muted"
           href="#"
-          @click="(ev: MouseEvent) => {ev.preventDefault(); emit('show-configuration');}"
+          @click="(ev: MouseEvent) => {ev.preventDefault(); emit('show-configuration', showConfigurationEmptyFocusSelector);}"
         >
           {{ i18n.t('component.resource.detail.metadata.keyValue.showConfiguration') }}
         </a>
@@ -80,9 +89,10 @@ const displayValue = (row: Row) => `${ row.key }: ${ row.value }`;
     </div>
     <a
       v-if="showShowAllButton"
+      :data-testid="showConfigurationMoreDataTestId"
       href="#"
       class="show-all secondary"
-      @click="(ev: MouseEvent) => {ev.preventDefault(); emit('show-configuration');}"
+      @click="(ev: MouseEvent) => {ev.preventDefault(); emit('show-configuration', showConfigurationMoreFocusSelector);}"
     >
       {{ showAllLabel }}
     </a>

--- a/shell/components/Resource/Detail/Metadata/Labels/index.vue
+++ b/shell/components/Resource/Detail/Metadata/Labels/index.vue
@@ -8,7 +8,7 @@ export type Label = Row;
 export interface LabelsProps {
     labels: Label[];
 
-    onShowConfiguration?: () => void;
+    onShowConfiguration?: (returnFocusSelector: string) => void;
 }
 
 </script>
@@ -26,6 +26,6 @@ const i18n = useI18n(store);
   <KeyValue
     :propertyName="i18n.t('component.resource.detail.metadata.labels.title')"
     :rows="labels"
-    @show-configuration="() => emit('show-configuration')"
+    @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector)"
   />
 </template>

--- a/shell/components/Resource/Detail/Metadata/composables.ts
+++ b/shell/components/Resource/Detail/Metadata/composables.ts
@@ -18,7 +18,7 @@ export const useBasicMetadata = (resource: any) => {
     return {
       labels:              labels.value,
       annotations:         annotations.value,
-      onShowConfiguration: () => openResourceDetailDrawer(resource)
+      onShowConfiguration: (returnFocusSelector: string) => openResourceDetailDrawer(resource, returnFocusSelector)
     };
   });
 };
@@ -36,7 +36,7 @@ export const useDefaultMetadataProps = (resource: any, additionalIdentifyingInfo
       identifyingInformation: identifyingInformation.value,
       labels:                 basicMetaData.value.labels,
       annotations:            basicMetaData.value.annotations,
-      onShowConfiguration:    () => openResourceDetailDrawer(resource)
+      onShowConfiguration:    (returnFocusSelector: string) => openResourceDetailDrawer(resource, returnFocusSelector)
     };
   });
 };

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -12,7 +12,7 @@ export interface MetadataProps {
   identifyingInformation: IdentifyingInformationRow[],
   labels: Label[],
   annotations: Annotation[],
-  onShowConfiguration?: () => void;
+  onShowConfiguration?: (returnFocusSelector: string) => void;
 }
 
 const { identifyingInformation, labels, annotations } = defineProps<MetadataProps>();

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -39,7 +39,7 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
       <KeyValue
         :rows="[]"
         :propertyName="i18n.t('component.resource.detail.metadata.labelsAndAnnotations')"
-        @show-configuration="() => emit('show-configuration')"
+        @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector)"
       />
     </div>
     <!-- I'm not using v-else here so I can maintain the spacing correctly with the other columns in other rows. -->
@@ -49,7 +49,7 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
     >
       <Labels
         :labels="labels"
-        @show-configuration="() => emit('show-configuration')"
+        @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector)"
       />
     </div>
     <div
@@ -58,7 +58,7 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
     >
       <Annotations
         :annotations="annotations"
-        @show-configuration="() => emit('show-configuration')"
+        @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector)"
       />
     </div>
   </SpacedRow>

--- a/shell/components/Resource/Detail/ResourceTabs/KnownHostsTab/__tests__/composables.test.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/KnownHostsTab/__tests__/composables.test.ts
@@ -1,0 +1,66 @@
+import * as composables from '@shell/components/Resource/Detail/ResourceTabs/KnownHostsTab/composables';
+import { SECRET_TYPES } from '@shell/config/secret';
+import * as crypto from '@shell/utils/crypto';
+
+jest.mock('@shell/utils/crypto');
+
+describe('composables: KnownHostsTab/composables', () => {
+  const base64DecodeSpy = jest.spyOn(crypto, 'base64Decode');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('useGetKnownHostsTabProps', () => {
+    it('should return undefined if not the ssh type but supportsSshKnownHosts is true', () => {
+      const resource = {
+        supportsSshKnownHosts: true,
+        _type:                 SECRET_TYPES.BASIC
+      };
+
+      const props = composables.useGetKnownHostsTabProps(resource);
+
+      expect(props.value).toBeUndefined();
+    });
+
+    it('should return undefined if the ssh type but supportsSshKnownHosts is false', () => {
+      const resource = {
+        supportsSshKnownHosts: false,
+        _type:                 SECRET_TYPES.SSH
+      };
+
+      const props = composables.useGetKnownHostsTabProps(resource);
+
+      expect(props.value).toBeUndefined();
+    });
+
+    it('should return empty knownHosts if known_hosts is falsy', () => {
+      const resource = {
+        supportsSshKnownHosts: true,
+        _type:                 SECRET_TYPES.SSH,
+        data:                  {}
+      };
+
+      const props = composables.useGetKnownHostsTabProps(resource);
+
+      expect(props.value?.knownHosts).toStrictEqual('');
+    });
+
+    it('should return base64decoded knownHosts if known_hosts has a value', () => {
+      const knownHosts = 'KNOWN_HOSTS';
+      const knowHostsDecoded = 'KNOWN_HOSTS_DECODED';
+      const resource = {
+        supportsSshKnownHosts: true,
+        _type:                 SECRET_TYPES.SSH,
+        data:                  { known_hosts: knownHosts }
+      };
+
+      base64DecodeSpy.mockReturnValue(knowHostsDecoded);
+
+      const props = composables.useGetKnownHostsTabProps(resource);
+
+      expect(props.value?.knownHosts).toStrictEqual(knowHostsDecoded);
+      expect(base64DecodeSpy).toHaveBeenCalledWith(knownHosts);
+    });
+  });
+});

--- a/shell/components/Resource/Detail/ResourceTabs/KnownHostsTab/composables.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/KnownHostsTab/composables.ts
@@ -1,0 +1,21 @@
+import { Props } from '@shell/components/Resource/Detail/ResourceTabs/KnownHostsTab/index.vue';
+import { computed, Ref, toValue } from 'vue';
+import { base64Decode } from '@shell/utils/crypto';
+import { SECRET_TYPES } from '@shell/config/secret';
+
+export const useGetKnownHostsTabProps = (resource: any): Ref<Props | undefined> => {
+  const resourceValue = toValue(resource);
+
+  return computed(() => {
+    const isSsh = resourceValue._type === SECRET_TYPES.SSH;
+    const showKnownHosts = isSsh && resourceValue.supportsSshKnownHosts;
+
+    if (!showKnownHosts) {
+      return undefined;
+    }
+
+    const { data = {} } = resourceValue;
+
+    return { knownHosts: data.known_hosts ? base64Decode(data.known_hosts) : '' };
+  });
+};

--- a/shell/components/Resource/Detail/ResourceTabs/KnownHostsTab/index.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/KnownHostsTab/index.vue
@@ -1,0 +1,31 @@
+<script lang="ts">
+import Tab from '@shell/components/Tabbed/Tab.vue';
+import DetailText from '@shell/components/DetailText.vue';
+
+export interface Props {
+  knownHosts: string;
+  weight?: number;
+}
+</script>
+
+<script lang="ts" setup>
+const { knownHosts, weight } = defineProps<Props>();
+</script>
+
+<template>
+  <Tab
+    name="known_hosts"
+    label-key="secret.ssh.knownHosts"
+    :weight="weight"
+  >
+    <div class="row">
+      <div class="col span-12">
+        <DetailText
+          :value="knownHosts"
+          label-key="secret.ssh.knownHosts"
+          :conceal="false"
+        />
+      </div>
+    </div>
+  </Tab>
+</template>

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Basic.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Basic.vue
@@ -1,0 +1,45 @@
+<script lang="ts">
+import DetailText from '@shell/components/DetailText.vue';
+import { useI18n } from '@shell/composables/useI18n';
+import { useStore } from 'vuex';
+
+export interface Row {
+    key: string;
+    value: string;
+}
+
+export interface Props {
+    rows: Row[];
+}
+</script>
+
+<script setup lang="ts">
+
+const store = useStore();
+const i18n = useI18n(store);
+
+const props = defineProps<Props>();
+</script>
+<template>
+  <div class="secret-data-tab-basic">
+    <div
+      v-for="(row, idx) in props.rows"
+      :key="idx"
+      class="entry"
+    >
+      <DetailText
+        :value="row.value"
+        :label="row.key"
+        :conceal="true"
+        :conceal-stand-alone="true"
+      />
+    </div>
+    <div v-if="!rows.length">
+      <div
+        class="m-20 text-center no-rows"
+      >
+        {{ i18n.t('sortableTable.noRows') }}
+      </div>
+    </div>
+  </div>
+</template>

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/BasicAuth.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/BasicAuth.vue
@@ -1,0 +1,31 @@
+<script lang="ts">
+import DetailText from '@shell/components/DetailText.vue';
+
+export interface Props {
+    username: string;
+    password: string;
+}
+</script>
+
+<script setup lang="ts">
+const props = defineProps<Props>();
+</script>
+
+<template>
+  <div class="row mt-20 secret-data-basic-auth">
+    <div class="col span-6 username">
+      <DetailText
+        :value="props.username"
+        label-key="secret.registry.username"
+      />
+    </div>
+    <div class="col span-6 password">
+      <DetailText
+        :value="props.password"
+        label-key="secret.registry.password"
+        :conceal="true"
+        :conceal-stand-alone="true"
+      />
+    </div>
+  </div>
+</template>

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Certificate.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Certificate.vue
@@ -1,0 +1,31 @@
+<script lang="ts">
+import DetailText from '@shell/components/DetailText.vue';
+
+export interface Props {
+    crt?: string;
+    token?: string;
+}
+</script>
+
+<script setup lang="ts">
+const props = defineProps<Props>();
+</script>
+
+<template>
+  <div class="row secret-data-certificate">
+    <div class="col span-6 token">
+      <DetailText
+        :value="props.token"
+        label-key="secret.certificate.privateKey"
+        :conceal="true"
+        :conceal-stand-alone="true"
+      />
+    </div>
+    <div class="col span-6 crt">
+      <DetailText
+        :value="props.crt"
+        label-key="secret.certificate.certificate"
+      />
+    </div>
+  </div>
+</template>

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Registry.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Registry.vue
@@ -1,0 +1,22 @@
+<script lang="ts">
+import DetailText from '@shell/components/DetailText.vue';
+
+export interface Props {
+  registryUrl?: string;
+}
+</script>
+
+<script setup lang="ts">
+const props = defineProps<Props>();
+</script>
+
+<template>
+  <div class="row secret-data-registry">
+    <div class="col span-12 registry-url">
+      <DetailText
+        :value="props.registryUrl"
+        label-key="secret.registry.domainName"
+      />
+    </div>
+  </div>
+</template>

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/ServiceAccountToken.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/ServiceAccountToken.vue
@@ -1,0 +1,31 @@
+<script lang="ts">
+import DetailText from '@shell/components/DetailText.vue';
+
+export interface Props {
+    crt: string;
+    token: string;
+}
+</script>
+
+<script setup lang="ts">
+const props = defineProps<Props>();
+</script>
+
+<template>
+  <div class="row secret-data-service-account-token">
+    <div class="col span-6 crt">
+      <DetailText
+        :value="props.crt"
+        label-key="secret.serviceAcct.ca"
+      />
+    </div>
+    <div class="col span-6 token">
+      <DetailText
+        :value="props.token"
+        label-key="secret.serviceAcct.token"
+        :conceal="true"
+        :conceal-stand-alone="true"
+      />
+    </div>
+  </div>
+</template>

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Ssh.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Ssh.vue
@@ -1,0 +1,32 @@
+<script lang="ts">
+import DetailText from '@shell/components/DetailText.vue';
+
+export interface Props {
+    username: string;
+    password: string;
+}
+</script>
+
+<script setup lang="ts">
+const props = defineProps<Props>();
+
+</script>
+
+<template>
+  <div class="row secret-data-ssh">
+    <div class="col span-6 username">
+      <DetailText
+        :value="props.username"
+        label-key="secret.ssh.public"
+      />
+    </div>
+    <div class="col span-6 password">
+      <DetailText
+        :value="props.password"
+        label-key="secret.ssh.private"
+        :conceal="true"
+        :conceal-stand-alone="true"
+      />
+    </div>
+  </div>
+</template>

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/Basic.test.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/Basic.test.ts
@@ -1,0 +1,40 @@
+import { mount } from '@vue/test-utils';
+import Basic from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Basic.vue';
+
+jest.mock('@shell/components/DetailText.vue', () => ({
+  name:     'DetailText',
+  template: `<div class="detail-text">DetailText</div>`,
+  props:    ['value', 'label', 'conceal']
+}));
+
+jest.mock('vuex', () => ({ useStore: jest.fn() }));
+
+describe('component: SecretDataTab/Basic', () => {
+  const rows = [
+    {
+      key:   'KEY',
+      value: 'VALUE'
+    }
+  ];
+
+  it('should render container with class secret-data-tab-basic', async() => {
+    const wrapper = mount(Basic, { props: { rows: [] } });
+
+    expect(wrapper.find('.secret-data-tab-basic').exists()).toBeTruthy();
+  });
+
+  it('should render no rows message if empty rows are passed', async() => {
+    const wrapper = mount(Basic, { props: { rows: [] } });
+
+    expect(wrapper.find('.no-rows').text()).toStrictEqual('sortableTable.noRows');
+  });
+
+  it('should render row of DetailText with appropriate props', async() => {
+    const wrapper = mount(Basic, { props: { rows } });
+
+    const detailTextComponent = wrapper.findComponent({ name: 'DetailText' });
+
+    expect(detailTextComponent.props('label')).toStrictEqual(rows[0].key);
+    expect(detailTextComponent.props('value')).toStrictEqual(rows[0].value);
+  });
+});

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/BasicAuth.test.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/BasicAuth.test.ts
@@ -1,0 +1,33 @@
+import { mount } from '@vue/test-utils';
+import BasicAuth from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/BasicAuth.vue';
+
+jest.mock('@shell/components/DetailText.vue', () => ({
+  name:     'DetailText',
+  template: `<div class="detail-text">DetailText</div>`,
+  props:    ['value', 'label-key', 'conceal']
+}));
+
+describe('component: SecretDataTab/BasicAuth', () => {
+  const username = 'USERNAME';
+  const password = 'PASSWORD';
+
+  it('should render container with class secret-data-basic-auth', async() => {
+    const wrapper = mount(BasicAuth, { props: { username, password } });
+
+    expect(wrapper.find('.secret-data-basic-auth').exists()).toBeTruthy();
+  });
+
+  it('should render DetailText with username and password props passed correctly', async() => {
+    const wrapper = mount(BasicAuth, { props: { username, password } });
+
+    const usernameDetailTextComponent = wrapper.find('.username').findComponent({ name: 'DetailText' });
+    const passwordDetailTextComponent = wrapper.find('.password').findComponent({ name: 'DetailText' });
+
+    expect(usernameDetailTextComponent.props('value')).toStrictEqual(username);
+    expect(usernameDetailTextComponent.props('labelKey')).toStrictEqual('secret.registry.username');
+
+    expect(passwordDetailTextComponent.props('value')).toStrictEqual(password);
+    expect(passwordDetailTextComponent.props('labelKey')).toStrictEqual('secret.registry.password');
+    expect(passwordDetailTextComponent.props('conceal')).toStrictEqual(true);
+  });
+});

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/Certificate.test.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/Certificate.test.ts
@@ -1,0 +1,33 @@
+import { mount } from '@vue/test-utils';
+import Certificate from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Certificate.vue';
+
+jest.mock('@shell/components/DetailText.vue', () => ({
+  name:     'DetailText',
+  template: `<div class="detail-text">DetailText</div>`,
+  props:    ['value', 'label-key', 'conceal']
+}));
+
+describe('component: SecretDataTab/Certificate', () => {
+  const crt = 'CRT';
+  const token = 'TOKEN';
+
+  it('should render container with class secret-data-basic-auth', async() => {
+    const wrapper = mount(Certificate, { props: { crt, token } });
+
+    expect(wrapper.find('.secret-data-certificate').exists()).toBeTruthy();
+  });
+
+  it('should render DetailText with crt and token props passed correctly', async() => {
+    const wrapper = mount(Certificate, { props: { crt, token } });
+
+    const crtDetailTextComponent = wrapper.find('.crt').findComponent({ name: 'DetailText' });
+    const tokenDetailTextComponent = wrapper.find('.token').findComponent({ name: 'DetailText' });
+
+    expect(crtDetailTextComponent.props('value')).toStrictEqual(crt);
+    expect(crtDetailTextComponent.props('labelKey')).toStrictEqual('secret.certificate.certificate');
+
+    expect(tokenDetailTextComponent.props('value')).toStrictEqual(token);
+    expect(tokenDetailTextComponent.props('labelKey')).toStrictEqual('secret.certificate.privateKey');
+    expect(tokenDetailTextComponent.props('conceal')).toStrictEqual(true);
+  });
+});

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/Registry.test.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/Registry.test.ts
@@ -1,0 +1,27 @@
+import { mount } from '@vue/test-utils';
+import Registry from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Registry.vue';
+
+jest.mock('@shell/components/DetailText.vue', () => ({
+  name:     'DetailText',
+  template: `<div class="detail-text">DetailText</div>`,
+  props:    ['value', 'label-key']
+}));
+
+describe('component: SecretDataTab/Registry', () => {
+  const registryUrl = 'url';
+
+  it('should render container with class secret-data-registry', async() => {
+    const wrapper = mount(Registry, { props: { registryUrl } });
+
+    expect(wrapper.find('.secret-data-registry').exists()).toBeTruthy();
+  });
+
+  it('should render DetailText with crt and token props passed correctly', async() => {
+    const wrapper = mount(Registry, { props: { registryUrl } });
+
+    const registryUrlDetailTextComponent = wrapper.find('.registry-url').findComponent({ name: 'DetailText' });
+
+    expect(registryUrlDetailTextComponent.props('value')).toStrictEqual(registryUrl);
+    expect(registryUrlDetailTextComponent.props('labelKey')).toStrictEqual('secret.registry.domainName');
+  });
+});

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/ServiceAccountToken.test.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/ServiceAccountToken.test.ts
@@ -1,0 +1,33 @@
+import { mount } from '@vue/test-utils';
+import ServiceAccountToken from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/ServiceAccountToken.vue';
+
+jest.mock('@shell/components/DetailText.vue', () => ({
+  name:     'DetailText',
+  template: `<div class="detail-text">DetailText</div>`,
+  props:    ['value', 'label-key', 'conceal']
+}));
+
+describe('component: SecretDataTab/ServiceAccountToken', () => {
+  const crt = 'CRT';
+  const token = 'TOKEN';
+
+  it('should render container with class secret-data-service-account-token', async() => {
+    const wrapper = mount(ServiceAccountToken, { props: { crt, token } });
+
+    expect(wrapper.find('.secret-data-service-account-token').exists()).toBeTruthy();
+  });
+
+  it('should render DetailText with ca and token props passed correctly', async() => {
+    const wrapper = mount(ServiceAccountToken, { props: { crt, token } });
+
+    const caDetailTextComponent = wrapper.find('.crt').findComponent({ name: 'DetailText' });
+    const tokenDetailTextComponent = wrapper.find('.token').findComponent({ name: 'DetailText' });
+
+    expect(caDetailTextComponent.props('value')).toStrictEqual(crt);
+    expect(caDetailTextComponent.props('labelKey')).toStrictEqual('secret.serviceAcct.ca');
+
+    expect(tokenDetailTextComponent.props('value')).toStrictEqual(token);
+    expect(tokenDetailTextComponent.props('labelKey')).toStrictEqual('secret.serviceAcct.token');
+    expect(tokenDetailTextComponent.props('conceal')).toStrictEqual(true);
+  });
+});

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/Ssh.test.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/Ssh.test.ts
@@ -1,0 +1,33 @@
+import { mount } from '@vue/test-utils';
+import Ssh from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Ssh.vue';
+
+jest.mock('@shell/components/DetailText.vue', () => ({
+  name:     'DetailText',
+  template: `<div class="detail-text">DetailText</div>`,
+  props:    ['value', 'label-key', 'conceal']
+}));
+
+describe('component: SecretDataTab/BasicAuth', () => {
+  const username = 'USERNAME';
+  const password = 'PASSWORD';
+
+  it('should render container with class secret-data-ssh', async() => {
+    const wrapper = mount(Ssh, { props: { username, password } });
+
+    expect(wrapper.find('.secret-data-ssh').exists()).toBeTruthy();
+  });
+
+  it('should render DetailText with username and password props passed correctly', async() => {
+    const wrapper = mount(Ssh, { props: { username, password } });
+
+    const usernameDetailTextComponent = wrapper.find('.username').findComponent({ name: 'DetailText' });
+    const passwordDetailTextComponent = wrapper.find('.password').findComponent({ name: 'DetailText' });
+
+    expect(usernameDetailTextComponent.props('value')).toStrictEqual(username);
+    expect(usernameDetailTextComponent.props('labelKey')).toStrictEqual('secret.ssh.public');
+
+    expect(passwordDetailTextComponent.props('value')).toStrictEqual(password);
+    expect(passwordDetailTextComponent.props('labelKey')).toStrictEqual('secret.ssh.private');
+    expect(passwordDetailTextComponent.props('conceal')).toStrictEqual(true);
+  });
+});

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/auth-types.test.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/auth-types.test.ts
@@ -1,0 +1,186 @@
+import * as authTypes from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/auth-types';
+import * as crypto from '@shell/utils/crypto';
+
+jest.mock('@shell/utils/crypto');
+jest.mock('vuex', () => ({ useStore: jest.fn() }));
+
+describe('composables: SecretDataTab/auth-types', () => {
+  const resource = { _type: 'RESOURCE', data: { type: 'data' } };
+  const base64 = '64 decoded string';
+  const base64DecodeSpy = jest.spyOn(crypto, 'base64Decode');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('useSecretInfo', () => {
+    it('should return the secret type and data set in resource', () => {
+      const info = authTypes.useSecretInfo(resource);
+
+      expect(info.value.secretType).toStrictEqual(resource._type);
+      expect(info.value.secretData).toStrictEqual(resource.data);
+    });
+
+    it('should return the an empty object for secretData if not set on resource', () => {
+      const info = authTypes.useSecretInfo({ _type: 'RESOURCE' });
+
+      expect(info.value.secretType).toStrictEqual(resource._type);
+      expect(info.value.secretData).toStrictEqual({});
+    });
+  });
+
+  describe('useSecretRows', () => {
+    it('should return empty array if data is not set', () => {
+      const rows = authTypes.useSecretRows({});
+
+      expect(rows.value).toStrictEqual([]);
+    });
+
+    it('should return a base64Decoded key/value if data is set', () => {
+      base64DecodeSpy.mockReturnValue(base64);
+      const row = { mockKey: 'value' };
+      const rows = authTypes.useSecretRows({ data: row });
+
+      expect(rows.value[0].key).toStrictEqual('mockKey');
+      expect(rows.value[0].value).toStrictEqual(base64);
+      expect(base64DecodeSpy).toHaveBeenCalledWith(row.mockKey);
+    });
+  });
+
+  describe('useDockerAuths', () => {
+    it('should return the auths field from a base64decoded json object in the `.dockerconfigjson` data field', () => {
+      const data = { '.dockerconfigjson': 'base64Json' };
+      const json = { auths: 'AUTHS' };
+
+      base64DecodeSpy.mockReturnValue(JSON.stringify(json));
+      const dockerAuths = authTypes.useDockerAuths({ data });
+
+      expect(dockerAuths.value).toStrictEqual(json.auths);
+      expect(base64DecodeSpy).toHaveBeenCalledWith(data['.dockerconfigjson']);
+    });
+  });
+
+  describe('useDockerRegistry', () => {
+    it('should return the first value from the docker auths', () => {
+      const data = { '.dockerconfigjson': 'base64Json' };
+      const registryUrl = 'registry-url.com';
+      const json = { auths: { [registryUrl]: { something: 'test' } } };
+
+      base64DecodeSpy.mockReturnValue(JSON.stringify(json));
+      const registry = authTypes.useDockerRegistry({ data });
+
+      expect(registry.value.registryUrl).toStrictEqual(registryUrl);
+      expect(base64DecodeSpy).toHaveBeenCalledWith(data['.dockerconfigjson']);
+    });
+  });
+
+  describe('useDockerBasic', () => {
+    it('should return the username and password from the docker auths', () => {
+      const data = { '.dockerconfigjson': 'base64Json' };
+      const registryUrl = 'registry-url.com';
+      const username = 'USERNAME';
+      const password = 'PASSWORD';
+      const json = { auths: { [registryUrl]: { username, password } } };
+
+      base64DecodeSpy.mockReturnValue(JSON.stringify(json));
+      const dockerBasic = authTypes.useDockerBasic({ data });
+
+      expect(dockerBasic.value.username).toStrictEqual(username);
+      expect(dockerBasic.value.password).toStrictEqual(password);
+      expect(base64DecodeSpy).toHaveBeenCalledWith(data['.dockerconfigjson']);
+    });
+  });
+
+  describe('useBasic', () => {
+    it('should return the username, password, rows from the docker auths', () => {
+      const username = 'USERNAME';
+      const password = 'PASSWORD';
+      const data = { username, password };
+
+      base64DecodeSpy
+        .mockReturnValueOnce(username)
+        .mockReturnValueOnce(password)
+        .mockReturnValueOnce(username)
+        .mockReturnValueOnce(password);
+
+      const basic = authTypes.useBasic({ data });
+
+      expect(basic.value.username).toStrictEqual(username);
+      expect(basic.value.password).toStrictEqual(password);
+      expect(basic.value.rows).toStrictEqual([{ key: 'username', value: username }, { key: 'password', value: password }]);
+      expect(base64DecodeSpy).toHaveBeenCalledWith(username);
+      expect(base64DecodeSpy).toHaveBeenCalledWith(password);
+      expect(base64DecodeSpy).toHaveBeenCalledWith(username);
+      expect(base64DecodeSpy).toHaveBeenCalledWith(password);
+    });
+  });
+
+  describe('useSsh', () => {
+    it('should return the username, password from data fields ssh-publickey/privatekey', () => {
+      const username = 'USERNAME';
+      const password = 'PASSWORD';
+      const data = {
+        'ssh-publickey':  username,
+        'ssh-privatekey': password
+      };
+
+      base64DecodeSpy
+        .mockReturnValueOnce(username)
+        .mockReturnValueOnce(password);
+
+      const ssh = authTypes.useSsh({ data });
+
+      expect(ssh.value.username).toStrictEqual(username);
+      expect(ssh.value.password).toStrictEqual(password);
+
+      expect(base64DecodeSpy).toHaveBeenCalledWith(username);
+      expect(base64DecodeSpy).toHaveBeenCalledWith(password);
+    });
+  });
+
+  describe('useServiceAccount', () => {
+    it('should return the token, crt from data fields token, ca.crt', () => {
+      const token = 'TOKEN';
+      const crt = 'CRT';
+      const data = {
+        token,
+        'ca.crt': crt
+      };
+
+      base64DecodeSpy
+        .mockReturnValueOnce(token)
+        .mockReturnValueOnce(crt);
+
+      const serviceAccount = authTypes.useServiceAccount({ data });
+
+      expect(serviceAccount.value.token).toStrictEqual(token);
+      expect(serviceAccount.value.crt).toStrictEqual(crt);
+
+      expect(base64DecodeSpy).toHaveBeenCalledWith(token);
+      expect(base64DecodeSpy).toHaveBeenCalledWith(crt);
+    });
+  });
+
+  describe('useTls', () => {
+    it('should return the token, crt from data fields token, ca.crt', () => {
+      const token = 'TOKEN';
+      const crt = 'CRT';
+      const data = {
+        'tls.key': token,
+        'tls.crt': crt
+      };
+
+      base64DecodeSpy
+        .mockReturnValueOnce(token)
+        .mockReturnValueOnce(crt);
+
+      const serviceAccount = authTypes.useTls({ data });
+
+      expect(serviceAccount.value.token).toStrictEqual(token);
+      expect(serviceAccount.value.crt).toStrictEqual(crt);
+
+      expect(base64DecodeSpy).toHaveBeenCalledWith(token);
+      expect(base64DecodeSpy).toHaveBeenCalledWith(crt);
+    });
+  });
+});

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/composables.test.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/composables.test.ts
@@ -1,0 +1,102 @@
+import * as authTypes from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/auth-types';
+import { useSecretDataTabDefaultProps } from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/composeables';
+import { SECRET_TYPES } from '@shell/config/secret';
+
+jest.mock('@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/auth-types');
+jest.mock('vuex', () => ({ useStore: jest.fn() }));
+
+describe('composables: SecretDataTab/composables', () => {
+  describe('useSecretDataTabDefaultProps', () => {
+    const useSecretInfoSpy = jest.spyOn(authTypes, 'useSecretInfo');
+    const resource = { type: 'Resource' };
+
+    it('should return the appropriate props when secret type is DOCKER_JSON', () => {
+      const dockerRegistry = { type: 'DockerRegistry' };
+      const dockerBasic = { type: 'DockerBasic' };
+      const useDockerRegistrySpy = jest.spyOn(authTypes, 'useDockerRegistry');
+      const useDockerBasic = jest.spyOn(authTypes, 'useDockerBasic');
+
+      useSecretInfoSpy.mockImplementation((): any => ({ value: { secretType: SECRET_TYPES.DOCKER_JSON } }));
+      useDockerRegistrySpy.mockImplementation((): any => ({ value: dockerRegistry }));
+      useDockerBasic.mockImplementation((): any => ({ value: dockerBasic }));
+
+      const props = useSecretDataTabDefaultProps(resource);
+
+      expect(props.value.tabLabel).toStrictEqual('secret.data');
+      expect(useDockerRegistrySpy).toHaveBeenCalledWith(resource);
+      expect(useDockerBasic).toHaveBeenCalledWith(resource);
+      expect(props.value.secretData.registry).toStrictEqual(dockerRegistry);
+      expect(props.value.secretData.basicAuth).toStrictEqual(dockerBasic);
+    });
+
+    it('should return the appropriate props when secret type is TLS', () => {
+      const tls = { type: 'TLS' };
+      const useTlsSpy = jest.spyOn(authTypes, 'useTls');
+
+      useSecretInfoSpy.mockImplementation((): any => ({ value: { secretType: SECRET_TYPES.TLS } }));
+      useTlsSpy.mockImplementation((): any => ({ value: tls }));
+
+      const props = useSecretDataTabDefaultProps(resource);
+
+      expect(props.value.tabLabel).toStrictEqual('secret.certificate.certificate');
+      expect(useTlsSpy).toHaveBeenCalledWith(resource);
+      expect(props.value.secretData.certificate).toStrictEqual(tls);
+    });
+
+    it('should return the appropriate props when secret type is SERVICE_ACCT', () => {
+      const serviceAccount = { type: 'serviceAccount' };
+      const useServiceAccountSpy = jest.spyOn(authTypes, 'useServiceAccount');
+
+      useSecretInfoSpy.mockImplementation((): any => ({ value: { secretType: SECRET_TYPES.SERVICE_ACCT } }));
+      useServiceAccountSpy.mockImplementation((): any => ({ value: serviceAccount }));
+
+      const props = useSecretDataTabDefaultProps(resource);
+
+      expect(props.value.tabLabel).toStrictEqual('secret.data');
+      expect(useServiceAccountSpy).toHaveBeenCalledWith(resource);
+      expect(props.value.secretData.serviceAccount).toStrictEqual(serviceAccount);
+    });
+
+    it('should return the appropriate props when secret type is SSH', () => {
+      const ssh = { type: 'SSH' };
+      const useSshSpy = jest.spyOn(authTypes, 'useSsh');
+
+      useSecretInfoSpy.mockImplementation((): any => ({ value: { secretType: SECRET_TYPES.SSH } }));
+      useSshSpy.mockImplementation((): any => ({ value: ssh }));
+
+      const props = useSecretDataTabDefaultProps(resource);
+
+      expect(props.value.tabLabel).toStrictEqual('secret.ssh.keys');
+      expect(useSshSpy).toHaveBeenCalledWith(resource);
+      expect(props.value.secretData.ssh).toStrictEqual(ssh);
+    });
+
+    it('should return the appropriate props when secret type is BASIC', () => {
+      const basic = { type: 'basic' };
+      const useBasicSpy = jest.spyOn(authTypes, 'useBasic');
+
+      useSecretInfoSpy.mockImplementation((): any => ({ value: { secretType: SECRET_TYPES.BASIC } }));
+      useBasicSpy.mockImplementation((): any => ({ value: basic }));
+
+      const props = useSecretDataTabDefaultProps(resource);
+
+      expect(props.value.tabLabel).toStrictEqual('secret.data');
+      expect(useBasicSpy).toHaveBeenCalledWith(resource);
+      expect(props.value.secretData.basicAuth).toStrictEqual(basic);
+    });
+
+    it('should return the appropriate props when secret type is anything else', () => {
+      const basic = { type: 'basic' };
+      const useBasicSpy = jest.spyOn(authTypes, 'useBasic');
+
+      useSecretInfoSpy.mockImplementation((): any => ({ value: { secretType: SECRET_TYPES.FLEET_CLUSTER } }));
+      useBasicSpy.mockImplementation((): any => ({ value: basic }));
+
+      const props = useSecretDataTabDefaultProps(resource);
+
+      expect(props.value.tabLabel).toStrictEqual('secret.data');
+      expect(useBasicSpy).toHaveBeenCalledWith(resource);
+      expect(props.value.secretData.basic).toStrictEqual(basic);
+    });
+  });
+});

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/auth-types.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/auth-types.ts
@@ -1,0 +1,109 @@
+import { computed, toValue } from 'vue';
+import { base64Decode } from '@shell/utils/crypto';
+
+export const useSecretInfo = (resource: any) => {
+  return computed(() => {
+    const resourceValue = toValue(resource);
+
+    return {
+      secretType: resourceValue._type,
+      secretData: resourceValue.data || {}
+    };
+  });
+};
+
+export const useSecretRows = (resource: any) => {
+  return computed(() => {
+    const resourceValue = toValue(resource);
+
+    const rows: any[] = [];
+    const { data = {} } = resourceValue;
+
+    Object.keys(data).forEach((key) => {
+      const value = base64Decode(data[key]);
+
+      rows.push({
+        key,
+        value
+      });
+    });
+
+    return rows;
+  });
+};
+
+export const useDockerAuths = (resource: any) => {
+  const secretInfo = useSecretInfo(resource);
+
+  return computed(() => {
+    const json = base64Decode(secretInfo.value.secretData['.dockerconfigjson']);
+
+    return JSON.parse(json).auths;
+  });
+};
+
+export const useDockerRegistry = (resource: any) => {
+  const dockerAuths = useDockerAuths(resource);
+
+  return computed(() => {
+    return { registryUrl: Object.keys(dockerAuths.value)[0] };
+  });
+};
+
+export const useDockerBasic = (resource: any) => {
+  const dockerAuths = useDockerAuths(resource);
+  const dockerRegistry = useDockerRegistry(resource);
+
+  return computed(() => {
+    return {
+      username: dockerAuths.value[dockerRegistry.value.registryUrl].username,
+      password: dockerAuths.value[dockerRegistry.value.registryUrl].password,
+    };
+  });
+};
+
+export const useBasic = (resource: any) => {
+  const rows = useSecretRows(resource);
+  const secretInfo = useSecretInfo(resource);
+
+  return computed(() => {
+    return {
+      username: base64Decode(secretInfo.value.secretData.username || ''),
+      password: base64Decode(secretInfo.value.secretData.password || ''),
+      rows:     rows.value
+    };
+  });
+};
+
+export const useSsh = (resource: any) => {
+  const secretInfo = useSecretInfo(resource);
+
+  return computed(() => {
+    return {
+      username: base64Decode(secretInfo.value.secretData['ssh-publickey'] || ''),
+      password: base64Decode(secretInfo.value.secretData['ssh-privatekey'] || ''),
+    };
+  });
+};
+
+export const useServiceAccount = (resource: any) => {
+  const secretInfo = useSecretInfo(resource);
+
+  return computed(() => {
+    return {
+      token: base64Decode(secretInfo.value.secretData['token']),
+      crt:   base64Decode(secretInfo.value.secretData['ca.crt']),
+    };
+  });
+};
+
+export const useTls = (resource: any) => {
+  const secretInfo = useSecretInfo(resource);
+
+  return computed(() => {
+    return {
+      token: base64Decode(secretInfo.value.secretData['tls.key']),
+      crt:   base64Decode(secretInfo.value.secretData['tls.crt']),
+    };
+  });
+};

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/composeables.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/composeables.ts
@@ -1,0 +1,52 @@
+import { computed, ComputedRef } from 'vue';
+import { Props } from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/index.vue';
+import { SECRET_TYPES } from '@shell/config/secret';
+import { useStore } from 'vuex';
+import { useI18n } from '@shell/composables/useI18n';
+import {
+  useBasic, useSsh, useTls, useSecretInfo, useDockerRegistry, useServiceAccount, useDockerBasic
+} from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/auth-types';
+
+export const useSecretDataTabDefaultProps = (resource: any): ComputedRef<Props> => {
+  const store = useStore();
+  const i18n = useI18n(store);
+  const secretInfo = useSecretInfo(resource);
+
+  return computed(() => {
+    switch (secretInfo.value.secretType) {
+    case SECRET_TYPES.DOCKER_JSON:
+      return {
+        tabLabel:   i18n.t('secret.data'),
+        secretData: {
+          registry:  useDockerRegistry(resource).value,
+          basicAuth: useDockerBasic(resource).value
+        }
+      };
+    case SECRET_TYPES.TLS:
+      return {
+        tabLabel:   i18n.t('secret.certificate.certificate'),
+        secretData: { certificate: useTls(resource).value }
+      };
+    case SECRET_TYPES.SERVICE_ACCT:
+      return {
+        tabLabel:   i18n.t('secret.data'),
+        secretData: { serviceAccount: useServiceAccount(resource).value }
+      };
+    case SECRET_TYPES.SSH:
+      return {
+        tabLabel:   i18n.t('secret.ssh.keys'),
+        secretData: { ssh: useSsh(resource).value }
+      };
+    case SECRET_TYPES.BASIC:
+      return {
+        tabLabel:   i18n.t('secret.data'),
+        secretData: { basicAuth: useBasic(resource).value }
+      };
+    default:
+      return {
+        tabLabel:   i18n.t('secret.data'),
+        secretData: { basic: useBasic(resource).value }
+      };
+    }
+  });
+};

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/index.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/index.vue
@@ -1,0 +1,71 @@
+<script lang="ts">
+import Tab from '@shell/components/Tabbed/Tab.vue';
+import Basic, { Props as BasicProps } from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Basic.vue';
+import Ssh, { Props as SshProps } from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Ssh.vue';
+import ServiceAccountToken, { Props as ServiceAccountTokenProps } from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/ServiceAccountToken.vue';
+import Certificate, { Props as CertificateProps } from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Certificate.vue';
+import BasicAuth, { Props as BasicAuthProps } from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/BasicAuth.vue';
+import Registry, { Props as RegistryProps } from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Registry.vue';
+
+export interface SecretData {
+  basic?: BasicProps;
+  basicAuth?: BasicAuthProps;
+  ssh?: SshProps;
+  serviceAccount?: ServiceAccountTokenProps;
+  certificate?: CertificateProps;
+  registry?: RegistryProps;
+}
+
+export interface Props {
+  tabLabel: string;
+  secretData: SecretData;
+
+  weight?: number;
+}
+</script>
+
+<script lang="ts" setup>
+const props = defineProps<Props>();
+</script>
+
+<template>
+  <Tab
+    class="secret-data-tab"
+    name="data"
+    :label="props.tabLabel"
+    :weight="props.weight"
+  >
+    <Registry
+      v-if="props.secretData.registry"
+      v-bind="props.secretData.registry"
+    />
+    <BasicAuth
+      v-if="props.secretData.basicAuth"
+      v-bind="props.secretData.basicAuth"
+    />
+    <Certificate
+      v-else-if="props.secretData.certificate"
+      v-bind="props.secretData.certificate"
+    />
+    <ServiceAccountToken
+      v-if="props.secretData.serviceAccount"
+      v-bind="props.secretData.serviceAccount"
+    />
+    <Ssh
+      v-if="props.secretData.ssh"
+      v-bind="props.secretData.ssh"
+    />
+    <Basic
+      v-if="props.secretData.basic"
+      v-bind="props.secretData.basic"
+    />
+  </Tab>
+</template>
+
+<style lang="scss" scoped>
+.secret-data-tab {
+  :deep() .entry:not(:first-of-type) {
+    margin-top: 16px;
+  }
+}
+</style>

--- a/shell/components/Resource/Detail/TitleBar/composables.ts
+++ b/shell/components/Resource/Detail/TitleBar/composables.ts
@@ -35,7 +35,7 @@ export const useDefaultTitleBarProps = (resource: any, resourceSubtype?: Ref<str
         label: resourceValue.stateDisplay
       },
       description:         resourceValue.description,
-      onShowConfiguration: () => openResourceDetailDrawer(resourceValue)
+      onShowConfiguration: (returnFocusSelector: string) => openResourceDetailDrawer(resourceValue, returnFocusSelector)
     };
   });
 };

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -49,7 +49,7 @@ const showConfigurationReturnFocusSelector = computed(() => `[data-testid="${ sh
 <template>
   <div class="title-bar">
     <Top>
-      <Title>
+      <Title class="title">
         <TabTitle :show-child="false">
           {{ resourceTypeLabel }}
         </TabTitle>
@@ -71,6 +71,7 @@ const showConfigurationReturnFocusSelector = computed(() => `[data-testid="${ sh
         </span>
         <BadgeState
           v-if="badge"
+          class="badge-state"
           :color="badge.color"
           :label="badge.label"
         />
@@ -112,7 +113,7 @@ const showConfigurationReturnFocusSelector = computed(() => `[data-testid="${ sh
 <style lang="scss" scoped>
 .title-bar {
 
-  &:deep() .badge-state {
+  .badge-state {
     font-size: 16px;
     margin-left: 4px;
     position: relative;
@@ -135,7 +136,7 @@ const showConfigurationReturnFocusSelector = computed(() => `[data-testid="${ sh
   }
 
   // This prevents the title from overlapping with the actions
-  :deep().title {
+  .title {
     max-width: calc(100% - 260px);
   }
 

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -87,6 +87,7 @@ const showConfigurationReturnFocusSelector = computed(() => `[data-testid="${ sh
           <img
             :src="showConfigurationIcon"
             class="mmr-3"
+            aria-hidden="true"
           >
           {{ i18n.t('component.resource.detail.titleBar.showConfiguration') }}
         </RcButton>

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -8,6 +8,7 @@ import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
 import RcButton from '@components/RcButton/RcButton.vue';
 import TabTitle from '@shell/components/TabTitle';
+import { computed } from 'vue';
 
 export interface Badge {
   color: 'bg-success' | 'bg-error' | 'bg-warning' | 'bg-info';
@@ -26,7 +27,7 @@ export interface TitleBarProps {
   // I don't have the time right now to swap this out though.
   actionMenuResource?: any;
 
-  onShowConfiguration?: () => void;
+  onShowConfiguration?: (returnFocusSelector: string) => void;
 }
 
 const showConfigurationIcon = require(`@shell/assets/images/icons/document.svg`);
@@ -41,6 +42,8 @@ const store = useStore();
 const i18n = useI18n(store);
 
 const emit = defineEmits(['show-configuration']);
+const showConfigurationDataTestId = 'show-configuration-cta';
+const showConfigurationReturnFocusSelector = computed(() => `[data-testid="${ showConfigurationDataTestId }"]`);
 </script>
 
 <template>
@@ -75,10 +78,11 @@ const emit = defineEmits(['show-configuration']);
       <div class="actions">
         <RcButton
           v-if="onShowConfiguration"
+          :data-testid="showConfigurationDataTestId"
           class="show-configuration"
           :primary="true"
           :aria-label="i18n.t('component.resource.detail.titleBar.ariaLabel.showConfiguration', { resource: resourceName })"
-          @click="emit('show-configuration')"
+          @click="() => emit('show-configuration', showConfigurationReturnFocusSelector)"
         >
           <img
             :src="showConfigurationIcon"

--- a/shell/components/ResourceDetail/__tests__/index.test.ts
+++ b/shell/components/ResourceDetail/__tests__/index.test.ts
@@ -117,6 +117,7 @@ describe('component: ResourceDetail/index', () => {
 
   it('should render new component if useIsNewDetailPageEnabledSpy is true', async() => {
     mockParams.resource = resourceName;
+    mockParams.id = 'ID';
     mockQuery[MODE] = _VIEW;
     mockQuery[LEGACY] = 'false';
 

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -29,10 +29,10 @@ const resourceToPage: any = {
   // 'batch.cronjob':    defineAsyncComponent(() => import('@shell/pages/explorer/resource/detail/batch.cronjob.vue')),
   // 'batch.job':        defineAsyncComponent(() => import('@shell/pages/explorer/resource/detail/batch.job.vue')),
   configmap: defineAsyncComponent(() => import('@shell/pages/explorer/resource/detail/configmap.vue')),
-  // namespace:          defineAsyncComponent(() => import('@shell/pages/explorer/resource/detail/namespace.vue')),
-  // node:               defineAsyncComponent(() => import('@shell/pages/explorer/resource/detail/node.vue')),
-  // pod:                defineAsyncComponent(() => import('@shell/pages/explorer/resource/detail/pod.vue')),
-  // secret:             defineAsyncComponent(() => import('@shell/pages/explorer/resource/detail/secret.vue')),
+  // namespace:           defineAsyncComponent(() => import('@shell/pages/explorer/resource/detail/namespace.vue')),
+  // node:                defineAsyncComponent(() => import('@shell/pages/explorer/resource/detail/node.vue')),
+  // pod:                 defineAsyncComponent(() => import('@shell/pages/explorer/resource/detail/pod.vue')),
+  secret:    defineAsyncComponent(() => import('@shell/pages/explorer/resource/detail/secret.vue')),
 };
 
 const route = useRoute();

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -62,7 +62,7 @@ const currentResourceName = computed(() => {
   return resource[0];
 });
 const mode = computed(() => route?.query?.[MODE]);
-const isView = computed(() => !mode.value || mode.value === _VIEW);
+const isView = computed(() => route?.params?.id && (!mode.value || mode.value === _VIEW));
 // We're defaulting to legacy being on, we'll switch this once we want to enable the new detail page by default
 const iseNewDetailPageEnabled = useIsNewDetailPageEnabled();
 const page = computed(() => currentResourceName.value ? resourceToPage[currentResourceName.value] : undefined);

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -35,6 +35,8 @@ const resourceToPage: any = {
   secret:    defineAsyncComponent(() => import('@shell/pages/explorer/resource/detail/secret.vue')),
 };
 
+defineOptions({ inheritAttrs: false });
+
 const route = useRoute();
 const props = withDefaults(defineProps<Props>(), {
   flexContent:         false,
@@ -60,7 +62,7 @@ const currentResourceName = computed(() => {
   return resource[0];
 });
 const mode = computed(() => route?.query?.[MODE]);
-const isView = computed(() => mode.value === _VIEW);
+const isView = computed(() => !mode.value || mode.value === _VIEW);
 // We're defaulting to legacy being on, we'll switch this once we want to enable the new detail page by default
 const iseNewDetailPageEnabled = useIsNewDetailPageEnabled();
 const page = computed(() => currentResourceName.value ? resourceToPage[currentResourceName.value] : undefined);
@@ -78,6 +80,6 @@ const useLatest = computed(() => !!(iseNewDetailPageEnabled && isView.value && p
   </Suspense>
   <Legacy
     v-else
-    v-bind="props"
+    v-bind="{...$attrs, ...props}"
   />
 </template>

--- a/shell/composables/drawer.ts
+++ b/shell/composables/drawer.ts
@@ -4,10 +4,14 @@ import { useStore } from 'vuex';
 export const useDrawer = () => {
   const store = useStore();
 
-  const open = (component: Component, options?: Record<string, any>) => {
+  const open = (component: Component, returnFocusSelector: string, options?: Record<string, any>) => {
     store.commit('slideInPanel/open', {
       component,
-      componentProps: options || {}
+      componentProps: {
+        ...(options || {}),
+        triggerFocusTrap: true,
+        returnFocusSelector
+      }
     });
   };
 

--- a/shell/pages/explorer/resource/detail/secret.vue
+++ b/shell/pages/explorer/resource/detail/secret.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import DetailPage from '@shell/components/Resource/Detail/Page.vue';
+import TitleBar from '@shell/components/Resource/Detail/TitleBar/index.vue';
+import { useDefaultTitleBarProps } from '@shell/components/Resource/Detail/TitleBar/composables';
+import Metadata from '@shell/components/Resource/Detail/Metadata/index.vue';
+import { useDefaultMetadataProps } from '@shell/components/Resource/Detail/Metadata/composables';
+import { SECRET } from '@shell/config/types';
+import { useFetchResourceWithId, useResourceIdentifiers } from '@shell/composables/resources';
+import ResourceTabs from '@shell/components/form/ResourceTabs/index.vue';
+import SecretDataTab from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/index.vue';
+import KnownHostsTab from '@shell/components/Resource/Detail/ResourceTabs/KnownHostsTab/index.vue';
+import { useGetKnownHostsTabProps } from '@shell/components/Resource/Detail/ResourceTabs/KnownHostsTab/composables';
+import { useSecretDataTabDefaultProps } from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/composeables';
+import { useSecretIdentifyingInformation } from '@shell/components/Resource/Detail/Metadata/IdentifyingInformation/composable';
+
+const { id, schema } = useResourceIdentifiers(SECRET);
+const secret = await useFetchResourceWithId(SECRET, id);
+const titleBarProps = useDefaultTitleBarProps(secret);
+const additionalIdentifyingInformation = useSecretIdentifyingInformation(secret);
+const metaDataProps = useDefaultMetadataProps(secret, additionalIdentifyingInformation);
+const knownHostsTabProps = useGetKnownHostsTabProps(secret);
+const secretDataTabProps = useSecretDataTabDefaultProps(secret);
+</script>
+<template>
+  <DetailPage>
+    <template #top-area>
+      <TitleBar v-bind="titleBarProps" />
+      <Metadata
+        class="mmt-6"
+        v-bind="metaDataProps"
+      />
+    </template>
+    <template #bottom-area>
+      <ResourceTabs
+        :value="secret"
+        :schema="schema"
+      >
+        <SecretDataTab
+          v-bind="secretDataTabProps"
+          :weight="1"
+        />
+        <KnownHostsTab
+          v-if="knownHostsTabProps"
+          v-bind="knownHostsTabProps"
+          :weight="0"
+        />
+      </ResourceTabs>
+    </template>
+  </DetailPage>
+</template>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
<ins>By default this will render the old detail page. You'll need to add the `legacy=false` query parameter to the url to see the new page. I demonstrate this in the video below.</ins>

Implements the new detail page design for Secrets. The new design is defined [here](https://confluence.suse.com/pages/viewpage.action?spaceKey=CU&title=Resource+page+redesign).

I think it's easiest to digest this code you start on the [secret.vue](https://github.com/rancher/dashboard/pull/14554/files#diff-04392b91d07b7bdd9f163c9d9440e58336e86df4131aefa6e5a08b07fc00e44b)

fixes #13325
fixes #14544
fixes #14580
<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
Each secret type should be tested to verify that we render the same content consistently between the new and legacy tabs.

To test the Known Hosts tab you can create a secret with the following yaml:
![image](https://github.com/user-attachments/assets/072a440a-3dc3-4d5c-8706-79563bf68dc7)
```
data:
  known_hosts: J2dvb2Jlcic=
  ssh-privatekey: cHJpdmF0ZXByaXZhdGU=
  ssh-publickey: cHVibGljcHVibGlj
```

### Areas which could experience regressions
DetailtText

We no longer want to have the global show/hide sensitive data control so I added  a control local to the DetailText component. The DetailText component should behave exactly as normal unless `:concealStandAlone="true"` is used. 

### Screenshot/Video
https://github.com/user-attachments/assets/6bee6921-8617-4b88-860c-1b3d733c45b5

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
