### PR TITLE
Quick fixes to resolve issues in the ConfigDrawer when rendering fleet resources

### DIFF
--- a/shell/components/Drawer/ResourceDetailDrawer/ConfigTab.vue
+++ b/shell/components/Drawer/ResourceDetailDrawer/ConfigTab.vue
@@ -23,8 +23,10 @@ const i18n = useI18n(store);
     <div class="container">
       <component
         :is="props.component"
-        v-model:value="props.resource"
+        :value="props.resource"
+        :liveValue="props.resource"
         :mode="_VIEW"
+        :real-mode="_VIEW"
         :initial-value="props.resource"
         :use-tabbed-hash="false /* Have to disable hashing on child components or it modifies the url and closes the drawer */"
       />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
These resolves some undefined and missing realMode issues that were apparent in the fleet gitrepo when using the new Configuration Drawer

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
https://github.com/user-attachments/assets/1e81fb50-e3de-4f89-b96f-530a53765b84

### Checklist




- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
