### PR TITLE
set harvester chart values in before save hook instead of saveOverride

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1654,6 +1654,9 @@ cluster:
       sshUser:
         placeholder: e.g. ubuntu
         toolTip: SSH user to login with the selected OS image.
+    kubeconfigSecret:
+        nameRequired: Cluster name is required.
+        error: 'Error generating Harvester kubeconfig secret: {err}'
   haveOneOwner: There must be at least one member with the Owner role.
   import:
     warningBanner: 'You should not import a cluster which has already been connected to another instance of Rancher as it will lead to data corruption.'

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -247,7 +247,7 @@ describe('component: rke2', () => {
 
     const cloudConfigPath = get(wrapper.vm.userChartValues, `${ chartKey }.cloudConfigPath`);
 
-    expect(cloudConfigPath).toStrictEqual('my-k8s-distro-path/var/lib/rancher/rke2/etc/config-files/cloud-provider-config');
+    expect(cloudConfigPath).toStrictEqual('my-k8s-distro-path/etc/config-files/cloud-provider-config');
   });
 
   // TODO: Complete test after implementing fetch https://github.com/rancher/dashboard/issues/9322

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -240,13 +240,14 @@ describe('component: rke2', () => {
 
     // we need to mock the "save" method from the create-edit-view-mixin
     // otherwise we get console errors
-    jest.spyOn(wrapper.vm, 'save').mockImplementation();
+    // jest.spyOn(wrapper.vm, 'save').mockImplementation();
 
     await wrapper.vm._doSaveOverride(jest.fn());
+    const chartKey = wrapper.vm.chartVersionKey(HARVESTER_CLOUD_PROVIDER);
 
-    const cloudConfigPath = get(wrapper.vm.chartValues, `${ HARVESTER_CLOUD_PROVIDER }.cloudConfigPath`);
+    const cloudConfigPath = get(wrapper.vm.userChartValues, `${ chartKey }.cloudConfigPath`);
 
-    expect(cloudConfigPath).toStrictEqual('my-k8s-distro-path/etc/config-files/cloud-provider-config');
+    expect(cloudConfigPath).toStrictEqual('my-k8s-distro-path/var/lib/rancher/rke2/etc/config-files/cloud-provider-config');
   });
 
   // TODO: Complete test after implementing fetch https://github.com/rancher/dashboard/issues/9322

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1596,10 +1596,8 @@ export default {
 
         if (!this.value?.metadata?.name) {
           const err = this.t('cluster.harvester.kubeconfigSecret.nameRequired');
-          const msg = this.t('cluster.harvester.kubeconfigSecret.error', { err });
 
-          this.errors.push(msg);
-          throw new Error(msg);
+          throw new Error(err);
         }
 
         if (clusterId && (this.isCreate || isUpgrade)) {
@@ -1634,7 +1632,8 @@ export default {
           set(this.userChartValues, `'${ harvesterCloudProviderKey }'.cloudConfigPath`, `${ distroRoot }/etc/config-files/cloud-provider-config`);
         }
       } catch (e) {
-        const msg = this.t('cluster.harvester.kubeconfigSecret.error', { err: [e?.errors || []].join('; ') });
+        const cause = e.errors ? e.errors.join('; ') : e?.message;
+        const msg = this.t('cluster.harvester.kubeconfigSecret.error', { err: cause });
 
         this.errors.push(msg);
         throw new Error(msg);

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1585,18 +1585,24 @@ export default {
     },
 
     async setHarvesterChartValues() {
-      if (!this.value?.metadata?.name) {
-        const err = this.t('cluster.harvester.kubeconfigSecret.nameRequired');
-        const msg = this.t('cluster.harvester.kubeconfigSecret.error', { err });
+      const isHarvester = this.agentConfig?.['cloud-provider-name'] === HARVESTER;
 
-        this.errors.push(msg);
-        throw new Error(msg);
+      if (!isHarvester) {
+        return;
       }
       try {
         const clusterId = get(this.credential, 'decodedData.clusterId') || '';
         const isUpgrade = this.isEdit && this.liveValue?.spec?.kubernetesVersion !== this.value?.spec?.kubernetesVersion;
 
-        if (this.agentConfig?.['cloud-provider-name'] === HARVESTER && clusterId && (this.isCreate || isUpgrade)) {
+        if (!this.value?.metadata?.name) {
+          const err = this.t('cluster.harvester.kubeconfigSecret.nameRequired');
+          const msg = this.t('cluster.harvester.kubeconfigSecret.error', { err });
+
+          this.errors.push(msg);
+          throw new Error(msg);
+        }
+
+        if (clusterId && (this.isCreate || isUpgrade)) {
           const namespace = this.machinePools?.[0]?.config?.vmNamespace;
 
           const res = await this.$store.dispatch('management/request', {

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1625,7 +1625,7 @@ export default {
           const distroSubdir = this.value?.spec?.kubernetesVersion?.includes('k3s') ? DEFAULT_SUBDIRS.K8S_DISTRO_K3S : DEFAULT_SUBDIRS.K8S_DISTRO_RKE2;
           const distroRoot = this.value?.spec?.rkeConfig?.dataDirectories?.k8sDistro?.length ? this.value?.spec?.rkeConfig?.dataDirectories?.k8sDistro : `${ DEFAULT_COMMON_BASE_PATH }/${ distroSubdir }`;
 
-          set(this.userChartValues, `'${ harvesterCloudProviderKey }'.cloudConfigPath`, `${ distroRoot }/var/lib/rancher/rke2/etc/config-files/cloud-provider-config`);
+          set(this.userChartValues, `'${ harvesterCloudProviderKey }'.cloudConfigPath`, `${ distroRoot }/etc/config-files/cloud-provider-config`);
         }
       } catch (e) {
         const msg = this.t('cluster.harvester.kubeconfigSecret.error', { err: [e?.errors || []].join('; ') });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13894 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
This PR moves the logic to generate a kubeconfig secret and set that as well as other chart values from saveOverride into a before save hook, so that the code runs before switching to the yaml view.  

### Areas or cases that should be tested
1. Navigate to the cluster manager cluster list view and click create
2. Select the harvester rke2 option
3. Select a cloud credential and fill all required fields in the machine config section
4. Open browser dev tools network tab and watch network requests
5. Click edit as yaml
6. Verify that a secret was created and referenced in the cluster yaml


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
