### PR TITLE
Adding a quick fix to allow showing graph view option for fleet

### DIFF
--- a/shell/components/Resource/Detail/TitleBar/__tests__/composables.test.ts
+++ b/shell/components/Resource/Detail/TitleBar/__tests__/composables.test.ts
@@ -4,7 +4,10 @@ import { useRoute } from 'vue-router';
 
 const mockStore = {
   getters: {
-    'type-map/labelFor': jest.fn(), currentStore: jest.fn(), 'cluster/schemaFor': jest.fn()
+    'type-map/labelFor': jest.fn(),
+    'type-map/hasGraph': jest.fn(),
+    currentStore:        jest.fn(),
+    'cluster/schemaFor': jest.fn()
   }
 };
 const mockRoute = { params: { cluster: 'CLUSTER' } };
@@ -25,6 +28,7 @@ describe('composables: TitleBar', () => {
   };
   const labelFor = 'LABEL_FOR';
   const schema = { type: 'SCHEMA' };
+  const hasGraph = true;
 
   it('should return the appropriate values based on input', async() => {
     const route = useRoute();
@@ -32,11 +36,13 @@ describe('composables: TitleBar', () => {
     mockStore.getters['currentStore'].mockImplementation(() => 'cluster');
     mockStore.getters['cluster/schemaFor'].mockImplementation(() => schema);
     mockStore.getters['type-map/labelFor'].mockImplementation(() => labelFor);
+    mockStore.getters['type-map/hasGraph'].mockImplementation(() => hasGraph);
 
     const props = useDefaultTitleBarProps(resource, ref(undefined));
 
     expect(props.value.resourceTypeLabel).toStrictEqual(labelFor);
     expect(mockStore.getters['type-map/labelFor']).toHaveBeenLastCalledWith(schema);
+    expect(mockStore.getters['type-map/hasGraph']).toHaveBeenLastCalledWith(resource.type);
     expect(mockStore.getters['currentStore']).toHaveBeenLastCalledWith(resource.type);
     expect(mockStore.getters['cluster/schemaFor']).toHaveBeenLastCalledWith(resource.type);
     expect(props.value.resourceTo?.params.product).toStrictEqual('explorer');
@@ -49,8 +55,9 @@ describe('composables: TitleBar', () => {
     expect(props.value.badge?.color).toStrictEqual(resource.stateBackground);
     expect(props.value.badge?.label).toStrictEqual(resource.stateDisplay);
     expect(props.value.description).toStrictEqual(resource.description);
+    expect(props.value.showViewOptions).toStrictEqual(hasGraph);
 
-    props.value.onShowConfiguration?.();
+    props.value.onShowConfiguration?.('callback');
     expect(mockDrawer.openResourceDetailDrawer).toHaveBeenCalledTimes(1);
   });
 });

--- a/shell/components/Resource/Detail/TitleBar/composables.ts
+++ b/shell/components/Resource/Detail/TitleBar/composables.ts
@@ -25,6 +25,7 @@ export const useDefaultTitleBarProps = (resource: any, resourceSubtype?: Ref<str
         resource:  resourceValue.type
       }
     };
+    const hasGraph = !!store.getters['type-map/hasGraph'](resourceValue.type);
 
     return {
       resourceTypeLabel,
@@ -36,6 +37,7 @@ export const useDefaultTitleBarProps = (resource: any, resourceSubtype?: Ref<str
         label: resourceValue.stateDisplay
       },
       description:         resourceValue.description,
+      showViewOptions:     hasGraph,
       onShowConfiguration: (returnFocusSelector: string) => openResourceDetailDrawer(resourceValue, returnFocusSelector)
     };
   });

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import BadgeState from '@components/BadgeState/BadgeState.vue';
-import { RouteLocationRaw } from 'vue-router';
+import { RouteLocationRaw, useRouter } from 'vue-router';
 import Title from '@shell/components/Resource/Detail/TitleBar/Title.vue';
 import Top from '@shell/components/Resource/Detail/TitleBar/Top.vue';
 import ActionMenu from '@shell/components/ActionMenuShell.vue';
@@ -8,7 +8,9 @@ import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
 import RcButton from '@components/RcButton/RcButton.vue';
 import TabTitle from '@shell/components/TabTitle';
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
+import { _CONFIG, _GRAPH, AS } from '@shell/config/query-params';
+import ButtonGroup from '@shell/components/ButtonGroup';
 
 export interface Badge {
   color: 'bg-success' | 'bg-error' | 'bg-warning' | 'bg-info';
@@ -27,6 +29,9 @@ export interface TitleBarProps {
   // I don't have the time right now to swap this out though.
   actionMenuResource?: any;
 
+  // Please don't expand this pattern, this was a quick fix to resolve a conflict between the new masthead and fleet.
+  showViewOptions?: boolean;
+
   onShowConfiguration?: (returnFocusSelector: string) => void;
 }
 
@@ -35,15 +40,41 @@ const showConfigurationIcon = require(`@shell/assets/images/icons/document.svg`)
 
 <script setup lang="ts">
 const {
-  resourceTypeLabel, resourceTo, resourceName, description, badge, onShowConfiguration
+  resourceTypeLabel, resourceTo, resourceName, description, badge, showViewOptions, onShowConfiguration,
 } = defineProps<TitleBarProps>();
 
 const store = useStore();
 const i18n = useI18n(store);
+const router = useRouter();
 
 const emit = defineEmits(['show-configuration']);
 const showConfigurationDataTestId = 'show-configuration-cta';
 const showConfigurationReturnFocusSelector = computed(() => `[data-testid="${ showConfigurationDataTestId }"]`);
+
+const currentView = ref(router?.currentRoute?.value?.query?.as || _CONFIG);
+const viewOptions = computed(() => {
+  if (!showViewOptions) {
+    return;
+  }
+
+  return [
+    {
+      labelKey: 'resourceDetail.masthead.config',
+      value:    _CONFIG,
+    },
+    {
+      labelKey: 'resourceDetail.masthead.graph',
+      value:    _GRAPH,
+    }
+  ];
+});
+
+watch(
+  () => currentView.value,
+  () => {
+    router.push({ query: { [AS]: currentView.value } });
+  }
+);
 </script>
 
 <template>
@@ -77,6 +108,12 @@ const showConfigurationReturnFocusSelector = computed(() => `[data-testid="${ sh
         />
       </Title>
       <div class="actions">
+        <!-- Please don't expand this pattern, this was a quick fix to resolve a conflict between the new masthead and fleet. -->
+        <ButtonGroup
+          v-if="viewOptions"
+          v-model:value="currentView"
+          :options="viewOptions"
+        />
         <RcButton
           v-if="onShowConfiguration"
           :data-testid="showConfigurationDataTestId"
@@ -112,11 +149,16 @@ const showConfigurationReturnFocusSelector = computed(() => `[data-testid="${ sh
 
 <style lang="scss" scoped>
 .title-bar {
+  min-width: 740px;
 
   .badge-state {
     font-size: 16px;
     margin-left: 4px;
     position: relative;
+  }
+
+  .show-configuration {
+    margin-left: 16px;
   }
 
   &:deep() button[data-testid="masthead-action-menu"] {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Adding a quick fix to allow showing graph view option for fleet

### Areas or cases that should be tested
Masthead on a page that should have the view options and a page that shouldn't

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/2eebb04e-b99a-4dfd-b54f-3eea0316c800



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
