### PR TITLE
Fix lint issue

### DIFF
--- a/shell/components/nav/NotificationCenter/index.vue
+++ b/shell/components/nav/NotificationCenter/index.vue
@@ -2,7 +2,6 @@
 import {
   computed,
   onMounted,
-  onUnmounted,
   ref,
   watch
 } from 'vue';
@@ -16,7 +15,6 @@ import {
 } from '@components/RcDropdown';
 import { StoredNotification } from '@shell/types/notifications';
 import { encrypt } from '@shell/utils/crypto/encryption';
-import { loadFromString } from '@shell/utils/notifications';
 import { onExtensionsReady } from '@shell/utils/uiplugins';
 
 const store = useStore();
@@ -38,18 +36,6 @@ const open = (opened: boolean) => {
 const localStorageKey = store.getters['notifications/localStorageKey'];
 const encryptionKey = store.getters['notifications/encryptionKey'];
 
-const localStorageEventHandler = async(ev: any) => {
-  if (ev.key === localStorageKey) {
-    try {
-      const data = await loadFromString(ev.newValue || '{}', encryptionKey);
-
-      store.dispatch('notifications/load', data);
-    } catch (e) {
-      console.error('Error parsing notifications from storage event', e); // eslint-disable-line no-console
-    }
-  }
-};
-
 /**
  * When notifications are updated, write to local storage
  */
@@ -65,14 +51,7 @@ watch(allNotifications, async(newData: StoredNotification[]) => {
 }, { deep: true });
 
 onMounted(async() => {
-  // Listen to storage events, so if the UI is open in multiple tabs, notifications in one tab will be sync'ed across all tabs
-  window.addEventListener('storage', localStorageEventHandler);
-
   await onExtensionsReady(store);
-});
-
-onUnmounted(() => {
-  window.removeEventListener('storage', localStorageEventHandler);
 });
 </script>
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14512

### Occurred changes and/or fixed issues

This is one round of improvements to the Notification Centre.

This improves the way we sync notifications across tabs.

### Technical notes summary

We use a broadcast channel in place of the local storage notification event and manage this ourselves - sending on only the changes, and crucially, sending the unencrypted data across tabs - this results in significant performance improvements and avoid the needs to use `load` everytime there is a chance.

Note: This is one part of some additional changes - this is, however, standalone, and improves performance.

### Areas or cases that should be tested

Open two browsers and check notifications in one appear in the other

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
