### PR TITLE
Add SCC registration notification

### DIFF
--- a/pkg/rancher-prime/index.ts
+++ b/pkg/rancher-prime/index.ts
@@ -3,6 +3,7 @@ import { IPlugin, PanelLocation } from '@shell/core/types';
 import { installDocHandler } from './docs';
 
 import routing from './routing/index';
+import { useI18n } from '@shell/composables/useI18n';
 
 // Init the package
 export default function(plugin: IPlugin) {
@@ -30,4 +31,24 @@ export default function(plugin: IPlugin) {
 
   // About page panel
   plugin.addPanel(PanelLocation.ABOUT_TOP, {}, { component: () => import('./components/AboutPanel.vue') });
+
+  plugin.addNavHooks({
+    onLogin: async(store: any) => {
+      const { t } = useI18n(store);
+      const notification = {
+        level:         'error',
+        title:         t('registration.notification.title'),
+        message:       t('registration.notification.message'),
+        progress:      0,
+        primaryAction: {
+          label:  t('registration.notification.button.primary.label'),
+          action: { route: '/c/local/settings/registration' }
+        },
+        id:         'rancher-prime-registration',
+        preference: 'rancher-prime-registration'
+      };
+
+      await store.dispatch('notifications/add', notification);
+    }
+  });
 }

--- a/pkg/rancher-prime/index.ts
+++ b/pkg/rancher-prime/index.ts
@@ -4,6 +4,7 @@ import { installDocHandler } from './docs';
 
 import routing from './routing/index';
 import { useI18n } from '@shell/composables/useI18n';
+import { usePrimeRegistration } from './pages/registration.composable';
 
 // Init the package
 export default function(plugin: IPlugin) {
@@ -34,21 +35,30 @@ export default function(plugin: IPlugin) {
 
   plugin.addNavHooks({
     onLogin: async(store: any) => {
-      const { t } = useI18n(store);
-      const notification = {
-        level:         'error',
-        title:         t('registration.notification.title'),
-        message:       t('registration.notification.message'),
-        progress:      0,
-        primaryAction: {
-          label: t('registration.notification.button.primary.label'),
-          route: '/c/local/settings/registration'
-        },
-        id:         'rancher-prime-registration',
-        preference: 'rancher-prime-registration'
-      };
+      const {
+        registrationStatus,
+        initRegistration,
+      } = usePrimeRegistration(store);
 
-      await store.dispatch('notifications/add', notification);
+      initRegistration().then(() => {
+        if (registrationStatus.value === null) {
+          const { t } = useI18n(store);
+          const notification = {
+            level:         'error',
+            title:         t('registration.notification.title'),
+            message:       t('registration.notification.message'),
+            progress:      0,
+            primaryAction: {
+              label: t('registration.notification.button.primary.label'),
+              route: '/c/local/settings/registration'
+            },
+            id:         'rancher-prime-registration',
+            preference: 'rancher-prime-registration'
+          };
+
+          store.dispatch('notifications/add', notification);
+        }
+      });
     }
   });
 }

--- a/pkg/rancher-prime/index.ts
+++ b/pkg/rancher-prime/index.ts
@@ -41,8 +41,8 @@ export default function(plugin: IPlugin) {
         message:       t('registration.notification.message'),
         progress:      0,
         primaryAction: {
-          label:  t('registration.notification.button.primary.label'),
-          action: { route: '/c/local/settings/registration' }
+          label: t('registration.notification.button.primary.label'),
+          route: '/c/local/settings/registration'
         },
         id:         'rancher-prime-registration',
         preference: 'rancher-prime-registration'

--- a/pkg/rancher-prime/l10n/en-us.yaml
+++ b/pkg/rancher-prime/l10n/en-us.yaml
@@ -2,6 +2,15 @@ registration:
   navigation:
     label: Registration
 
+  notification:
+    title: Rancher Prime Registration
+    message: Register your SUSE Rancher Manager Prime Suite to receive the latest updates and support.
+    button:
+      primary:
+        label: Register SUSE Rancher Manager Prime
+      secondary:
+        label: Dismiss
+
   title: Product Registration
   banner:
     status:

--- a/pkg/rancher-prime/l10n/en-us.yaml
+++ b/pkg/rancher-prime/l10n/en-us.yaml
@@ -7,9 +7,7 @@ registration:
     message: Register your SUSE Rancher Manager Prime Suite to receive the latest updates and support.
     button:
       primary:
-        label: Register SUSE Rancher Manager Prime
-      secondary:
-        label: Dismiss
+        label: Register Now
 
   title: Product Registration
   banner:

--- a/pkg/rancher-prime/pages/Registration.vue
+++ b/pkg/rancher-prime/pages/Registration.vue
@@ -2,7 +2,6 @@
 import { onMounted, computed } from 'vue';
 import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
-import { useRouter } from 'vue-router';
 
 import Tab from '@shell/components/Tabbed/Tab';
 import Tabbed from '@shell/components/Tabbed';
@@ -15,7 +14,6 @@ import { usePrimeRegistration } from './registration.composable';
 import Loading from '@shell/components/Loading.vue';
 
 const store = useStore();
-const router = useRouter();
 const { t } = useI18n(store);
 const {
   downloadOfflineRequest,

--- a/pkg/rancher-prime/pages/Registration.vue
+++ b/pkg/rancher-prime/pages/Registration.vue
@@ -2,6 +2,7 @@
 import { onMounted, computed } from 'vue';
 import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
+import { useRouter } from 'vue-router';
 
 import Tab from '@shell/components/Tabbed/Tab';
 import Tabbed from '@shell/components/Tabbed';
@@ -14,6 +15,7 @@ import { usePrimeRegistration } from './registration.composable';
 import Loading from '@shell/components/Loading.vue';
 
 const store = useStore();
+const router = useRouter();
 const { t } = useI18n(store);
 const {
   downloadOfflineRequest,

--- a/pkg/rancher-prime/pages/registration.composable.test.ts
+++ b/pkg/rancher-prime/pages/registration.composable.test.ts
@@ -19,7 +19,7 @@ describe('registration composable', () => {
 
       await registerOnline((val: boolean) => true);
 
-      expect(dispatchSpy).toHaveBeenCalledWith('cluster/find', namespaceRequest);
+      expect(dispatchSpy).toHaveBeenCalledWith('management/find', namespaceRequest);
     });
 
     it('should create a new namespace if missing', async() => {
@@ -31,7 +31,7 @@ describe('registration composable', () => {
       await registerOnline((val: boolean) => true);
 
       expect(dispatchSpy).toHaveBeenCalledTimes(2);
-      expect(dispatchSpy).toHaveBeenCalledWith('cluster/find', namespaceRequest);
+      expect(dispatchSpy).toHaveBeenCalledWith('management/find', namespaceRequest);
     });
 
     it('should delete any existing secret', async() => {
@@ -39,7 +39,7 @@ describe('registration composable', () => {
 
       await registerOnline((val: boolean) => true);
 
-      expect(dispatchSpy).toHaveBeenCalledWith('cluster/find', namespaceRequest);
+      expect(dispatchSpy).toHaveBeenCalledWith('management/find', namespaceRequest);
     });
   });
 
@@ -96,8 +96,8 @@ describe('registration composable', () => {
 
       await registerOnline((val: boolean) => true);
 
-      expect(dispatchSpy).toHaveBeenCalledWith('cluster/find', namespaceRequest);
-      expect(dispatchSpy).toHaveBeenCalledWith('cluster/create', secret);
+      expect(dispatchSpy).toHaveBeenCalledWith('management/find', namespaceRequest);
+      expect(dispatchSpy).toHaveBeenCalledWith('management/create', secret);
       expect(registration.value).toStrictEqual(expectation);
     });
   });

--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -205,14 +205,14 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
    */
   const ensureNamespace = async() => {
     try {
-      await store.dispatch('cluster/find', {
+      await store.dispatch('management/find', {
         type: 'namespace',
         id:   REGISTRATION_NAMESPACE,
         opt:  { force: true }
       });
     } catch (error) {
       try {
-        const newNamespace = await store.dispatch('cluster/create', {
+        const newNamespace = await store.dispatch('management/create', {
           type:     'namespace',
           metadata: { name: REGISTRATION_NAMESPACE }
         });
@@ -334,7 +334,7 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
    * Get unique secret code with hardcoded namespace and name
    */
   const getSecret = async(): Promise<PartialSecret | null> => {
-    const secrets: PartialSecret[] = await store.dispatch('cluster/findAll', { type: SECRET });
+    const secrets: PartialSecret[] = await store.dispatch('management/findAll', { type: SECRET });
 
     return secrets.find((secret) => secret.metadata?.namespace === REGISTRATION_NAMESPACE &&
       secret.metadata?.name === REGISTRATION_SECRET) ?? null;
@@ -359,7 +359,7 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
    */
   const createSecret = async(type: string, code: string): Promise<PartialSecret | null> => {
     try {
-      const secret = await store.dispatch('cluster/create', {
+      const secret = await store.dispatch('management/create', {
         type:     SECRET,
         metadata: {
           namespace: REGISTRATION_NAMESPACE,

--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -1,5 +1,5 @@
 import { computed, ref, Ref } from 'vue';
-import { useStore } from 'vuex';
+import { type Store, useStore } from 'vuex';
 
 import { downloadFile } from '@shell/utils/download';
 import { REGISTRATION_NAMESPACE, REGISTRATION_SECRET, REGISTRATION_RESOURCE_NAME, REGISTRATION_LABEL } from '../config/constants';
@@ -91,8 +91,8 @@ const registrationBannerCases = {
   }
 };
 
-export const usePrimeRegistration = () => {
-  const store = useStore();
+export const usePrimeRegistration = (storeArg?: Store<any>) => {
+  const store = storeArg ?? useStore();
 
   /**
    * Registration from CRD


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13400

Notification is displayed if rancher registration status is not active.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary

- Corrected getters to use `manager` instead of `cluster`
- Allowed `store` to be passed by the registration composable

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video


https://github.com/user-attachments/assets/3ec7d787-9c06-4b43-a80b-256139f5da87




### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
