### PR TITLE
Add back RKE Metadata configuration setting

### DIFF
--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -50,6 +50,7 @@ export const SETTING = {
   FIRST_LOGIN:                                   'first-login',
   INGRESS_IP_DOMAIN:                             'ingress-ip-domain',
   SERVER_URL:                                    'server-url',
+  RKE_METADATA_CONFIG:                           'rke-metadata-config',
   EULA_AGREED:                                   'eula-agreed',
   AUTH_USER_INFO_MAX_AGE_SECONDS:                'auth-user-info-max-age-seconds',
   AUTH_USER_SESSION_TTL_MINUTES:                 'auth-user-session-ttl-minutes',
@@ -146,6 +147,7 @@ export const ALLOWED_SETTINGS: GlobalSetting = {
   [SETTING.KUBECONFIG_DEFAULT_TOKEN_TTL_MINUTES]: { kind: 'integer' },
   [SETTING.AUTH_USER_INFO_RESYNC_CRON]:           {},
   [SETTING.SERVER_URL]:                           { kind: 'url', canReset: true },
+  [SETTING.RKE_METADATA_CONFIG]:                  { kind: 'json' },
   [SETTING.SYSTEM_DEFAULT_REGISTRY]:              {},
   [SETTING.UI_INDEX]:                             {},
   [SETTING.UI_DASHBOARD_INDEX]:                   {},
@@ -170,7 +172,15 @@ export const ALLOWED_SETTINGS: GlobalSetting = {
 
 };
 
-export const PROVISIONING_SETTINGS = ['engine-iso-url', 'engine-install-url', 'imported-cluster-version-management', 'cluster-agent-default-priority-class', 'cluster-agent-default-pod-disruption-budget'];
+export const PROVISIONING_SETTINGS = [
+  'engine-iso-url',
+  'engine-install-url',
+  SETTING.RKE_METADATA_CONFIG,
+  'imported-cluster-version-management',
+  'cluster-agent-default-priority-class',
+  'cluster-agent-default-pod-disruption-budget'
+];
+
 /**
  * Settings on how to handle warnings returning in api responses, specifically which to show as growls
  */


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14612

### Occurred changes and/or fixed issues

Reverts removal of a setting as part of RKE1 removal (https://github.com/rancher/dashboard/pull/14226/files)

This setting is still required for RKE2/k3s

### Technical notes summary

Reverted lines to add back in the setting.

Note: I moved the setting into the `Cluster Provisioning` section as part of this PR.
 
### Areas or cases that should be tested

Go settings, scroll down and check that the `rke-metadata-config` setting is now shown.

### Screenshot/Video

![image](https://github.com/user-attachments/assets/0bcc04b0-7eb7-432c-aa0b-b87d314cafed)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
