### PR TITLE
Change location for encryption-provider-config.yaml

### DIFF
--- a/shell/utils/formatter.js
+++ b/shell/utils/formatter.js
@@ -3,7 +3,7 @@ import { SECRET_TYPES } from '@shell/config/secret';
 
 export function formatEncryptionSecretNames(secrets, chartNamespace) {
   return secrets
-    .filter((secret) => (secret.data || {})['encryption-provider-config.yaml'] &&
+    .filter((secret) => (secret.data || {})['/encryption/encryption-provider-config.yaml'] &&
       secret.metadata.namespace === chartNamespace &&
       !secret.metadata?.state?.error &&
       secret._type === SECRET_TYPES.OPAQUE


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/rancher/issues/50872
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
A bug was found in the v2.12 pre-release version of BRO consisting of a lack of access to the directory where encryption provider files were created. The solution was to move those files to a different directory. We need this UI to look for those encryption providers in their new location.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Creating an encrypted backup.
- From that backup, create a restore via UI. Make sure the Rancher dashboard is able to find encryption providers without issues.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Encrypted Rancher backups (backup-restore-operator)


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
