### PR TITLE
Use `defaultNamespace` prop as a default value

### DIFF
--- a/shell/dialog/ImportDialog.vue
+++ b/shell/dialog/ImportDialog.vue
@@ -38,11 +38,12 @@ export default {
 
   data() {
     return {
-      currentYaml:   '',
-      allNamespaces: [],
-      errors:        null,
-      rows:          null,
-      done:          false,
+      currentYaml:       '',
+      allNamespaces:     [],
+      errors:            null,
+      rows:              null,
+      done:              false,
+      selectedNamespace: this.defaultNamespace,
     };
   },
 
@@ -90,7 +91,7 @@ export default {
 
         const res = await this.currentCluster.doAction('apply', {
           yaml:             this.currentYaml,
-          defaultNamespace: this.defaultNamespace,
+          defaultNamespace: this.selectedNamespace,
         });
 
         btnCb(true);
@@ -143,11 +144,10 @@ export default {
             </div>
             <div class="col span-6">
               <LabeledSelect
-                :value="defaultNamespace"
+                v-model:value="selectedNamespace"
                 :options="namespaceOptions"
                 label-key="import.defaultNamespace.label"
                 mode="edit"
-                @update:value="newValue => defaultNamespace = newValue"
               />
             </div>
           </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This stops `ImportDialog.vue` from attempting to mutate the `defaultNamespace` prop and uses it as a default value for a `selectedNamespace` data prop instead.

Fixes #14644 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Use `defaultNamespace` prop as default value for `selectedNamespace` data prop

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Mutating props is heavily discouraged in Vue - using `defaultNamespace` as a default value for a data prop helps to avoid the issue of mutating props altogether. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Import YAML dialog

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Import YAML dialog

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
