### PR TITLE
Resolving an issue when DetailText receives undefined/null value

### DIFF
--- a/shell/components/DetailText.vue
+++ b/shell/components/DetailText.vue
@@ -22,7 +22,7 @@ export default {
 
     value: {
       type:    String,
-      default: null,
+      default: '',
     },
 
     maxLength: {

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Basic.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Basic.vue
@@ -4,8 +4,8 @@ import { useI18n } from '@shell/composables/useI18n';
 import { useStore } from 'vuex';
 
 export interface Row {
-    key: string;
-    value: string;
+    key?: string;
+    value?: string;
 }
 
 export interface Props {

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/BasicAuth.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/BasicAuth.vue
@@ -2,8 +2,8 @@
 import DetailText from '@shell/components/DetailText.vue';
 
 export interface Props {
-    username: string;
-    password: string;
+    username?: string;
+    password?: string;
 }
 </script>
 

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/ServiceAccountToken.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/ServiceAccountToken.vue
@@ -2,8 +2,8 @@
 import DetailText from '@shell/components/DetailText.vue';
 
 export interface Props {
-    crt: string;
-    token: string;
+    crt?: string;
+    token?: string;
 }
 </script>
 

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Ssh.vue
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/Ssh.vue
@@ -2,8 +2,8 @@
 import DetailText from '@shell/components/DetailText.vue';
 
 export interface Props {
-    username: string;
-    password: string;
+    username?: string;
+    password?: string;
 }
 </script>
 

--- a/shell/composables/resources.test.ts
+++ b/shell/composables/resources.test.ts
@@ -1,0 +1,63 @@
+import { useResourceIdentifiers, useFetchResourceWithId } from '@shell/composables/resources';
+
+const mockStore: any = {
+  getters:  { 'cluster/schemaFor': jest.fn(() => ({ id: 'test-schema' })) },
+  dispatch: jest.fn()
+};
+const mockRoute: any = {
+  params: {
+    cluster:   'test-cluster',
+    namespace: 'test-namespace',
+    id:        'test-id',
+  },
+};
+
+jest.mock('vuex', () => ({ useStore: () => mockStore }));
+jest.mock('vue-router', () => ({ useRoute: () => mockRoute }));
+
+describe('resources', () => {
+  describe('useResourceIdentifiers', () => {
+    it('should return the correct value for a route with a namespace', async() => {
+      const { clusterId, id, schema } = useResourceIdentifiers('test-type');
+
+      expect(clusterId).toBe('test-cluster');
+      expect(id).toBe('test-namespace/test-id');
+      expect(schema).toStrictEqual({ id: 'test-schema' });
+    });
+
+    it('should return the correct value for a route without a namespace', async() => {
+      mockRoute.params.namespace = undefined;
+      const { clusterId, id, schema } = useResourceIdentifiers('test-type');
+
+      expect(clusterId).toBe('test-cluster');
+      expect(id).toBe('test-id');
+      expect(schema).toStrictEqual({ id: 'test-schema' });
+    });
+  });
+
+  describe('useFetchResourceWithId', () => {
+    it('should return the correct value given the correct arguments are passed to the dispatch method', async() => {
+      mockStore.dispatch.mockImplementation(() => Promise.resolve({ id: 'test-resource' }));
+      const resource = await useFetchResourceWithId('test-type', 'test-id');
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith('cluster/find', { type: 'test-type', id: 'test-id' });
+      expect(resource).toStrictEqual({ id: 'test-resource' });
+    });
+
+    it('should dispatch a loadingError if a 404 occurs', async() => {
+      // eslint-disable-next-line prefer-promise-reject-errors
+      mockStore.dispatch.mockImplementationOnce(() => Promise.reject({ status: 404 }));
+      await useFetchResourceWithId('test-type', 'test-id');
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith('loadingError', new Error('nav.failWhale.resourceIdNotFound-{"resource":"test-type","fqid":"test-id"}'));
+    });
+
+    it('should dispatch a loadingError if a 403 occurs', async() => {
+      // eslint-disable-next-line prefer-promise-reject-errors
+      mockStore.dispatch.mockImplementationOnce(() => Promise.reject({ status: 403 }));
+      await useFetchResourceWithId('test-type', 'test-id');
+
+      expect(mockStore.dispatch).toHaveBeenCalledWith('loadingError', new Error('nav.failWhale.resourceIdNotFound-{"resource":"test-type","fqid":"test-id"}'));
+    });
+  });
+});

--- a/shell/composables/resources.ts
+++ b/shell/composables/resources.ts
@@ -1,3 +1,4 @@
+import { useI18n } from '@shell/composables/useI18n';
 import { computed, Ref, toValue } from 'vue';
 import { useRoute } from 'vue-router';
 import { useStore } from 'vuex';
@@ -22,9 +23,16 @@ export const useResourceIdentifiers = (type: ResourceType) => {
 
 export const useFetchResourceWithId = async(type: ResourceType, id: IdType) => {
   const store = useStore();
+  const i18n = useI18n(store);
 
   const typeValue = toValue(type);
   const idValue = toValue(id);
 
-  return await store.dispatch('cluster/find', { type: typeValue, id: idValue });
+  try {
+    return await store.dispatch('cluster/find', { type: typeValue, id: idValue });
+  } catch (ex: any) {
+    if (ex.status === 404 || ex.status === 403) {
+      store.dispatch('loadingError', new Error(i18n.t('nav.failWhale.resourceIdNotFound', { resource: type, fqid: id }, true)));
+    }
+  }
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13547

_The repro steps outlined in the original issue are a little finicky. The secret gets immediately deleted from the backend so you only see on the same page load as doing the yaml import. If you refresh you'll need to import again._

### Occurred changes and/or fixed issues
We now default to an empty string which allows the rest of the component to run as expected.

I also made the auth type components props optional since they can come back undefined. This resolves some console warnings.

While testing this it also became apparent we weren't properly redirecting to failwhale when a resource didn't exist. I added that functionality as well.

### Areas or cases that should be tested
Anywhere that has `<DetailText />`. I think verifying in the secret detail page is sufficient.

### Areas which could experience regressions
Same as above

### Screenshot/Video


https://github.com/user-attachments/assets/d1c9d03b-f9cc-4919-8925-6f48b71f429d


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
