### PR TITLE
[Automation] Workload: Add redeploy dialog tests

### DIFF
--- a/cypress/e2e/po/components/workloads/redeploy-dialog.po.ts
+++ b/cypress/e2e/po/components/workloads/redeploy-dialog.po.ts
@@ -1,0 +1,68 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
+
+export default class RedeployDialogPo extends ComponentPo {
+  constructor(selector = '#modal-container-element') {
+    super(selector);
+  }
+
+  shouldBeVisible(): this {
+    this.self().should('be.visible');
+
+    return this;
+  }
+
+  shouldBeClosed(): this {
+    this.self().should('not.exist');
+
+    return this;
+  }
+
+  cancel(): this {
+    this.cancelButton().click();
+
+    return this;
+  }
+
+  private cancelButton(): Cypress.Chainable {
+    return this.self().find('button').contains(/cancel/i);
+  }
+
+  expectCancelButtonLabel(expectedText: string): this {
+    this.cancelButton().should('contain.text', expectedText);
+
+    return this;
+  }
+
+  private applyButton(): AsyncButtonPo {
+    return new AsyncButtonPo('[data-testid="action-button-async-button"]', this.self());
+  }
+
+  expectApplyButtonLabel(expectedText: string): this {
+    this.applyButton().self().should('contain.text', expectedText);
+
+    return this;
+  }
+
+  confirmRedeploy(endpoint: string): void {
+    const alias = 'redeploySuccess';
+
+    cy.intercept('PUT', endpoint, { statusCode: 200 }).as(alias);
+
+    this.applyButton().click();
+    cy.wait(`@${ alias }`).its('response.statusCode').should('eq', 200);
+  }
+
+  simulateRedeployError(endpoint: string): void {
+    const alias = 'redeployError';
+
+    cy.intercept('PUT', endpoint, {
+      statusCode: 500,
+      body:       { message: 'Simulated failure' },
+    }).as(alias);
+
+    this.applyButton().click();
+    cy.wait(`@${ alias }`);
+    cy.get('[data-testid="banner-content"]').should('be.visible');
+  }
+}

--- a/cypress/e2e/po/pages/explorer/workloads-daemonsets.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads-daemonsets.po.ts
@@ -5,6 +5,7 @@ import { BaseDetailPagePo } from '@/cypress/e2e/po/pages/base/base-detail-page.p
 import { BaseListPagePo } from '@/cypress/e2e/po/pages/base/base-list-page.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+import RedeployDialogPo from '@/cypress/e2e/po/components/workloads/redeploy-dialog.po';
 
 export class WorkloadsDaemonsetsListPagePo extends BaseListPagePo {
   private static createPath(clusterId: string) {
@@ -26,6 +27,10 @@ export class WorkloadsDaemonsetsListPagePo extends BaseListPagePo {
     burgerMenu.goToCluster(clusterId);
     sideNav.navToSideMenuGroupByLabel('Workloads');
     sideNav.navToSideMenuEntryByLabel('DaemonSets');
+  }
+
+  redeployDialog(): RedeployDialogPo {
+    return new RedeployDialogPo();
   }
 }
 

--- a/cypress/e2e/po/pages/explorer/workloads-statefulsets.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads-statefulsets.po.ts
@@ -1,6 +1,7 @@
 import { BaseListPagePo } from '@/cypress/e2e/po/pages/base/base-list-page.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+import RedeployDialogPo from '@/cypress/e2e/po/components/workloads/redeploy-dialog.po';
 
 export class WorkloadsStatefulSetsListPagePo extends BaseListPagePo {
   private static createPath(clusterId: string) {
@@ -22,5 +23,9 @@ export class WorkloadsStatefulSetsListPagePo extends BaseListPagePo {
     burgerMenu.goToCluster(clusterId);
     sideNav.navToSideMenuGroupByLabel('Workloads');
     sideNav.navToSideMenuEntryByLabel('StatefulSets');
+  }
+
+  redeployDialog(): RedeployDialogPo {
+    return new RedeployDialogPo();
   }
 }

--- a/cypress/e2e/po/pages/explorer/workloads/workloads-deployments.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads/workloads-deployments.po.ts
@@ -1,6 +1,8 @@
 import { WorkloadsListPageBasePo, WorkloadsCreatePageBasePo, workloadDetailsPageBasePo } from '@/cypress/e2e/po/pages/explorer/workloads/workloads.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
+import RedeployDialogPo from '@/cypress/e2e/po/components/workloads/redeploy-dialog.po';
+
 export class WorkloadsDeploymentsDetailsPagePo extends workloadDetailsPageBasePo {
   constructor(workloadId: string, protected clusterId: string = 'local', workloadType = 'apps.deployment', namespaceId = 'default', queryParams?: Record<string, string>) {
     super(workloadId, clusterId, workloadType, queryParams, namespaceId);
@@ -19,6 +21,10 @@ export class WorkloadsDeploymentsListPagePo extends WorkloadsListPageBasePo {
     burgerMenu.goToCluster(clusterId);
     sideNav.navToSideMenuGroupByLabel('Workloads');
     sideNav.navToSideMenuEntryByLabel('Deployments');
+  }
+
+  redeployDialog(): RedeployDialogPo {
+    return new RedeployDialogPo();
   }
 }
 

--- a/cypress/e2e/tests/pages/explorer2/workloads/daemonsets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/daemonsets.spec.ts
@@ -347,4 +347,50 @@ describe('DaemonSets', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'
       cy.deleteRancherResource('v1', 'namespaces', nsName2);
     });
   });
+
+  describe('Redeploy dialog', () => {
+    const daemonsetName = 'daemonset-test';
+    const apiResource = 'apps.daemonsets';
+    const redeployEndpoint = `/v1/${ apiResource }/default/${ daemonsetName }`;
+    const daemonSetsListPage = new WorkloadsDaemonsetsListPagePo(localCluster);
+
+    const openRedeployDialog = () => {
+      daemonSetsListPage.goTo();
+      daemonSetsListPage.waitForPage();
+
+      daemonSetsListPage
+        .list()
+        .actionMenu(daemonsetName)
+        .getMenuItem('Redeploy')
+        .click();
+
+      return daemonSetsListPage
+        .redeployDialog()
+        .shouldBeVisible()
+        .expectCancelButtonLabel('Cancel')
+        .expectApplyButtonLabel('Redeploy');
+    };
+
+    it('redeploys successfully after confirmation', () => {
+      const dialog = openRedeployDialog();
+
+      dialog.confirmRedeploy(redeployEndpoint);
+      dialog.shouldBeClosed();
+    });
+
+    it('does not send a request when cancelled', () => {
+      cy.intercept('PUT', redeployEndpoint).as('redeployCancelled');
+
+      const dialog = openRedeployDialog();
+
+      dialog.cancel().shouldBeClosed();
+      cy.get('@redeployCancelled.all').should('have.length', 0);
+    });
+
+    it('displays error banner on failure', () => {
+      const dialog = openRedeployDialog();
+
+      dialog.simulateRedeployError(redeployEndpoint);
+    });
+  });
 });

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -8,7 +8,7 @@ import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 
 const localCluster = 'local';
 
-describe('Deployments', { testIsolation: 'off', tags: '@explorer2' }, () => {
+describe('Deployments', { testIsolation: 'off', tags: ['@explorer2'] }, () => {
   before(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -440,4 +440,67 @@ describe('Deployments', { testIsolation: 'off', tags: '@explorer2' }, () => {
       cy.deleteRancherResource('v1', 'namespaces', nsName2);
     });
   });
+
+  describe('Redeploy Dialog', () => {
+    let volumeDeploymentId: string;
+    const { namespace } = createDeploymentBlueprint.metadata;
+    const apiResource = 'apps.deployments';
+    const deploymentsListPage = new WorkloadsDeploymentsListPagePo(localCluster);
+
+    const getRedeployEndpoint = () => `/v1/${ apiResource }/${ namespace }/${ volumeDeploymentId }`;
+    const openRedeployDialog = () => {
+      deploymentsListPage.goTo();
+      deploymentsListPage.waitForPage();
+
+      deploymentsListPage
+        .list()
+        .actionMenu(volumeDeploymentId)
+        .getMenuItem('Redeploy')
+        .click();
+
+      return deploymentsListPage
+        .redeployDialog()
+        .shouldBeVisible()
+        .expectCancelButtonLabel('Cancel')
+        .expectApplyButtonLabel('Redeploy');
+    };
+
+    before(() => {
+      cy.createE2EResourceName('volume-deployment').then((name) => {
+        volumeDeploymentId = name;
+
+        const volumeDeployment = { ...createDeploymentBlueprint };
+
+        volumeDeployment.metadata.name = name;
+
+        cy.createRancherResource('v1', apiResource, JSON.stringify(volumeDeployment));
+      });
+    });
+
+    it('redeploys successfully after confirmation', () => {
+      const dialog = openRedeployDialog();
+
+      dialog.confirmRedeploy(getRedeployEndpoint());
+      dialog.shouldBeClosed();
+    });
+
+    it('does not send a request when cancelled', () => {
+      cy.intercept('PUT', getRedeployEndpoint()).as('redeployCancelled');
+
+      const dialog = openRedeployDialog();
+
+      dialog.cancel().shouldBeClosed();
+      cy.get('@redeployCancelled.all').should('have.length', 0);
+    });
+
+    it('displays error banner on failure', () => {
+      const dialog = openRedeployDialog();
+
+      dialog.simulateRedeployError(getRedeployEndpoint());
+    });
+
+    after(() => {
+      cy.deleteRancherResource('v1', apiResource, `${ namespace }/${ volumeDeploymentId }`);
+    });
+  });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14455 
<!-- Define findings related to the feature or bug issue. -->
Add e2e coverage for the `Redeploy` action across all three workload types (DaemonSet, Deployment, StatefulSet).

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
