### PR TITLE
Ensure ns filter selection is updated when stale entries are removed

### DIFF
--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -63,6 +63,9 @@ export default {
       return this.$store.getters[`${ this.currentProduct.inStore }/paginationEnabled`](this.$route.params?.resource) ? paginationUtils.validNsProjectFilters : null;
     },
 
+    /**
+     * Create visible options (filtered version of `options`)
+     */
     filtered() {
       let out = this.options;
 
@@ -142,6 +145,9 @@ export default {
       return createNamespaceFilterKey(this.$store.getters['clusterId'], this.currentProduct);
     },
 
+    /**
+     * Create options (see `filtered` for visible collection)
+     */
     options() {
       const t = this.$store.getters['i18n/t'];
       let out = [];
@@ -341,6 +347,11 @@ export default {
           })
           .filter((x) => !!x);
 
+        if (filters.length !== values.length) {
+          // filter has changed, ensure we persist these to store
+          this.value = filters;
+        }
+
         return filters;
       },
 
@@ -401,7 +412,7 @@ export default {
      *
      * This is caused by churn of the filtered and options computed properties causing multiple renders for each action.
      *
-     * To break this multiple-render per cycle behaviour detatch `filtered` from the value used in `v-for`.
+     * To break this multiple-render per cycle behaviour detach `filtered` from the value used in `v-for`.
      *
      */
     filtered(neu) {

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -412,6 +412,7 @@ export default {
   async findPage(ctx, { type, opt }) {
     const { getters, commit, dispatch } = ctx;
 
+    // of type @ActionFindPageArgs
     opt = opt || {};
 
     if (!opt.pagination) {
@@ -443,7 +444,7 @@ export default {
       return findAllGetter(getters, type, opt);
     }
 
-    console.log(`Find Page: [${ ctx.state.config.namespace }] ${ type }. Page: ${ opt.pagination.page }. Size: ${ opt.pagination.pageSize }`); // eslint-disable-line no-console
+    console.log(`Find Page: [${ ctx.state.config.namespace }] ${ type }. Page: ${ opt.pagination.page }. Size: ${ opt.pagination.pageSize }. Sort: ${ opt.pagination.sort.map((s) => s.field).join(', ') }`); // eslint-disable-line no-console
     opt = opt || {};
     opt.url = getters.urlFor(type, null, opt);
 

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -752,6 +752,7 @@ const defaultActions = {
       if (mode === STEVE_WATCH_MODE.RESOURCE_CHANGES) {
         // Other findX use options (id/ns/selector) from the messages received over socket.
         // However paginated requests have more complex params so grab them from store from the store.
+        // of type @StorePagination
         const storePagination = getters['havePage'](resourceType);
 
         if (!!storePagination) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14659
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- when we calculate the value of a filter we remove entries that no longer exist
- ensure that this new version of the filter is persisted
- this means whilst on vai supported lists it correctly kicks off a http request
  - this also avoids removed namespaces being used in filters if the list changes

Also
- improved some comments

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
- tab 1 - create a namespace
- tab 1 - in the header select the namespace
- tab 1 - go to pods list
- tab 2 - delete the namespace that was created
- tab 1 - should show the namespace filter change back to `Only User Namespaces` (the default) and a new http request kicked off to populate the table given the filter change

### Areas which could experience regressions
vai off world

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
