### PR TITLE
Fix an issue where some detail pages wouldn't render the ConfigTab

### DIFF
--- a/shell/components/Drawer/ResourceDetailDrawer/ConfigTab.vue
+++ b/shell/components/Drawer/ResourceDetailDrawer/ConfigTab.vue
@@ -31,6 +31,7 @@ const i18n = useI18n(store);
         :real-mode="_VIEW"
         :initial-value="props.resource"
         :use-tabbed-hash="false /* Have to disable hashing on child components or it modifies the url and closes the drawer */"
+        as="config"
       />
     </div>
   </Tab>
@@ -44,6 +45,13 @@ const i18n = useI18n(store);
     padding: 16px;
     max-width: 100%;
     width: 100%;
+    position: relative;
+  }
+
+  // Handle the loading indicator
+  :deep() .overlay-content-mode {
+    left: 0;
+    top: 0;
   }
 
   :deep() .cru-resource-footer {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
We needed to pass the `as` prop to the components
Also fixed a rendering issue with the loading component

### Areas or cases that should be tested
Cluster detail page config tab

### Areas which could experience regressions
Cluster detail page config tab

### Screenshot/Video

https://github.com/user-attachments/assets/9d39c15c-7944-4eab-8b1d-5a7f3b4b3305



### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
