### PR TITLE
[2.11.4] Fix protected Labels

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3130,6 +3130,7 @@ labels:
   addTag: Add Tag
   addTaint: Add Taint
   addAnnotation: Add Annotation
+  protectedWarning: This key is protected and will be discarded
   labels:
     title: Labels
     description: Key/value pairs that are attached to objects which specify identifying attributes.

--- a/shell/components/form/Labels.vue
+++ b/shell/components/form/Labels.vue
@@ -1,6 +1,74 @@
-<script>
-import KeyValue from '@shell/components/form/KeyValue';
+<script lang="ts">
+import { pickBy, omitBy, mapValues } from 'lodash';
+import { matchesSomeRegex } from '@shell/utils/string';
+import { LABELS_TO_IGNORE_REGEX, ANNOTATIONS_TO_IGNORE_REGEX } from '@shell/config/labels-annotations';
+import KeyValue from '@shell/components/form/KeyValue.vue';
 import { ToggleSwitch } from '@components/Form/ToggleSwitch';
+import { _VIEW } from '@shell/config/query-params';
+
+export class Factory {
+  private protectedKeys: string[] = [];
+  private protectedRegexes: RegExp[] = [];
+  private protectedWarning = '';
+
+  private isProtected(key: string) {
+    return this.protectedKeys.includes(key) || matchesSomeRegex(key, this.protectedRegexes);
+  }
+
+  private omitProtected(obj: object) {
+    return omitBy(obj, (_, key) => this.isProtected(key));
+  }
+
+  private pickProtected(obj: object) {
+    return pickBy(obj, (_, key) => this.isProtected(key));
+  }
+
+  private keyErrorMap(elems: object) {
+    return mapValues(this.pickProtected(elems), () => this.protectedWarning);
+  }
+
+  constructor(protectedKeys: string[], protectedRegexes: RegExp[], msg: string, initValue: object) {
+    // Init privates
+    this.protectedKeys = protectedKeys || [];
+    this.protectedRegexes = protectedRegexes || [];
+    this.protectedWarning = msg || '';
+
+    this.initValue = initValue || {};
+    this.value = this.omitProtected(this.initValue);
+    this.keyErrors = this.keyErrorMap(this.value);
+    this.hasProtectedKeys = Object.keys(this.pickProtected(this.initValue)).length > 0;
+  }
+
+  initValue: object = {};
+  value: object = {};
+  keyErrors: object = {};
+  hasProtectedKeys = false;
+
+  /**
+   * Updates resource's model and discard new protected keys
+   * Old protected keys remain untouched on edit
+   *
+   * @param value edited labels/annotations
+   * @param callbackFn function to set model's labels/annotations
+   */
+  update(value: Record<string, string>, callbackFn: (value: object) => void) {
+    const neu = value || {};
+
+    callbackFn({
+      ...this.omitProtected(neu),
+      ...this.pickProtected(this.initValue),
+    });
+
+    this.value = neu;
+    this.keyErrors = this.keyErrorMap(neu);
+  }
+}
+
+interface DataType {
+  labels: Factory,
+  annotations: Factory,
+  toggler: boolean,
+}
 
 export default {
   components: {
@@ -60,8 +128,14 @@ export default {
     },
   },
 
-  data() {
-    return { toggler: false };
+  data(): DataType {
+    const protectedWarning = this.t('labels.protectedWarning');
+
+    return {
+      labels:      new Factory(this.value.systemLabels, LABELS_TO_IGNORE_REGEX, protectedWarning, this.value.labels),
+      annotations: new Factory(this.value.systemAnnotations, ANNOTATIONS_TO_IGNORE_REGEX, protectedWarning, this.value.annotations),
+      toggler:     false
+    };
   },
 
   computed: {
@@ -75,6 +149,10 @@ export default {
 
     columnsClass() {
       return `${ this.displaySideBySide ? 'col span-6' : 'row' }`.trim();
+    },
+
+    showToggler() {
+      return this.mode === _VIEW && (this.labels.hasProtectedKeys || this.annotations.hasProtectedKeys);
     }
   }
 };
@@ -88,7 +166,7 @@ export default {
             <t k="labels.labels.title" />
           </h3>
           <ToggleSwitch
-            v-if="value.hasSystemLabels"
+            v-if="showToggler"
             v-model:value="toggler"
             name="label-system-toggle"
             :on-label="t('labels.labels.show')"
@@ -98,21 +176,17 @@ export default {
           <t k="labels.labels.description" />
         </p>
         <div :class="columnsClass">
-          <slot
-            name="labels"
-            :toggler="toggler"
-          >
+          <slot name="labels">
             <KeyValue
               key="labels"
-              :value="value.labels"
-              :protected-keys="value.systemLabels || []"
-              :toggle-filter="toggler"
+              :value="toggler ? labels.initValue : labels.value"
               :add-label="t('labels.addLabel')"
               :add-icon="addIcon"
               :mode="mode"
               :read-allowed="false"
               :value-can-be-empty="true"
-              @update:value="value.setLabels($event)"
+              :key-errors="labels.keyErrors"
+              @update:value="labels.update($event, (x) => value.setLabels(x))"
             />
           </slot>
         </div>
@@ -125,17 +199,16 @@ export default {
     >
       <KeyValue
         key="annotations"
-        :value="value.annotations"
+        :value="toggler ? annotations.initValue : annotations.value"
         :add-label="t('labels.addAnnotation')"
         :add-icon="addIcon"
         :mode="mode"
-        :protected-keys="value.systemAnnotations || []"
-        :toggle-filter="toggler"
         :title="t('labels.annotations.title')"
         :title-protip="annotationTitleTooltip"
         :read-allowed="false"
         :value-can-be-empty="true"
-        @update:value="value.setAnnotations($event)"
+        :key-errors="annotations.keyErrors"
+        @update:value="annotations.update($event, (x) => value.setAnnotations(x))"
       />
     </div>
   </div>

--- a/shell/components/form/__tests__/Labels.test.ts
+++ b/shell/components/form/__tests__/Labels.test.ts
@@ -1,0 +1,360 @@
+import { mount } from '@vue/test-utils';
+import Labels, { Factory } from '@shell/components/form/Labels.vue';
+import KeyValue from '@shell/components/form/KeyValue.vue';
+import { ToggleSwitch } from '@components/Form/ToggleSwitch';
+import { _EDIT, _VIEW } from '@shell/config/query-params';
+
+const mockT = jest.fn((key: string) => key);
+
+describe('class: Factory', () => {
+  const mockProtectedWarning = 'Protected Key';
+
+  it('should correctly initialize with no protected keys or regexes', () => {
+    const factory = new Factory([], [], mockProtectedWarning, { a: '1', b: '2' });
+
+    expect((factory as any).protectedKeys).toStrictEqual([]);
+    expect((factory as any).protectedRegexes).toStrictEqual([]);
+    expect((factory as any).protectedWarning).toBe(mockProtectedWarning);
+    expect(factory.initValue).toStrictEqual({ a: '1', b: '2' });
+    expect(factory.value).toStrictEqual({ a: '1', b: '2' });
+    expect(factory.keyErrors).toStrictEqual({});
+    expect(factory.hasProtectedKeys).toBe(false);
+  });
+
+  it('should correctly initialize with protected keys', () => {
+    const factory = new Factory(['key1'], [], mockProtectedWarning, { key1: 'value1', key2: 'value2' });
+
+    expect((factory as any).protectedKeys).toStrictEqual(['key1']);
+    expect(factory.value).toStrictEqual({ key2: 'value2' });
+    expect(factory.hasProtectedKeys).toBe(true);
+  });
+
+  it('should correctly initialize with protected regexes', () => {
+    const factory = new Factory([], [/^key/], mockProtectedWarning, { key1: 'value1', other: 'value2' });
+
+    expect((factory as any).protectedRegexes.map((r: RegExp) => r.source)).toStrictEqual(['^key']);
+    expect(factory.value).toStrictEqual({ other: 'value2' });
+    expect(factory.hasProtectedKeys).toBe(true);
+  });
+
+  it('should omit protected keys from value but keep them in initValue', () => {
+    const factory = new Factory(['protected'], [], mockProtectedWarning, { protected: 'pVal', normal: 'nVal' });
+
+    expect(factory.initValue).toStrictEqual({ protected: 'pVal', normal: 'nVal' });
+    expect(factory.value).toStrictEqual({ normal: 'nVal' });
+  });
+
+  it('should update value and call callbackFn, preserving initial protected keys', () => {
+    const initialValue = {
+      system: 'sysVal', user: 'userVal', system2: 'sysVal'
+    };
+    const factory = new Factory(['system', 'system2'], [], mockProtectedWarning, initialValue);
+    const callback = jest.fn();
+
+    const newValue = {
+      newUser: 'newUVal', user: 'updatedUserVal', newProtected: 'newPVal', system: 'foo'
+    };
+
+    factory.update(newValue, callback);
+
+    // The internal factory.value is just the new set
+    expect(factory.value).toStrictEqual(newValue);
+
+    // The callback should receive the mix of new unprotected values and initial protected values
+    expect(callback).toHaveBeenCalledWith({
+      newProtected: 'newPVal',
+      newUser:      'newUVal',
+      user:         'updatedUserVal',
+      system:       'sysVal', // 'system' is the original protected from initialValue, sysVal is the original value
+      system2:      'sysVal' // 'system2' is the original protected from initialValue
+    });
+  });
+
+  it('should handle null/undefined update value gracefully', () => {
+    const initialValue = { system: 'sysVal', user: 'userVal' };
+    const factory = new Factory(['system'], [], mockProtectedWarning, initialValue);
+    const callback = jest.fn();
+
+    factory.update({}, callback);
+
+    expect(factory.value).toStrictEqual({});
+    expect(factory.keyErrors).toStrictEqual({});
+    expect(callback).toHaveBeenCalledWith({ system: 'sysVal' }); // Only the original protected values
+  });
+
+  it('should correctly identify protected keys based on both array and regex', () => {
+    const factory = new Factory(['staticKey'], [/^dynamic/], mockProtectedWarning, {});
+
+    expect((factory as any).isProtected('staticKey')).toBe(true);
+    expect((factory as any).isProtected('dynamicKey')).toBe(true);
+    expect((factory as any).isProtected('otherKey')).toBe(false);
+  });
+});
+
+describe('component: Labels', () => {
+  const mockValue = {
+    labels: {
+      'kubernetes.io/hostname': 'test-app',
+      'my-label':               'my-value'
+    },
+    systemLabels: ['kubernetes.io/hostname'],
+    annotations:  {
+      'cattle.io/system': 'user',
+      'my-annotation':    'my-annotation'
+    },
+    systemAnnotations: ['cattle.io/system'],
+    setLabels:         jest.fn(),
+    setAnnotations:    jest.fn(),
+  };
+
+  it('should initialize with correct data properties', () => {
+    const wrapper = mount(Labels, {
+      props: {
+        value: mockValue,
+        mode:  'create',
+      },
+      global: { mocks: { t: mockT } },
+    });
+
+    const data = (wrapper.vm as any).$data;
+
+    expect(data.labels).toBeDefined();
+    expect(data.labels.initValue).toStrictEqual(mockValue.labels);
+    expect(data.labels.protectedKeys).toStrictEqual(mockValue.systemLabels);
+    expect(data.labels.value).toStrictEqual({ 'my-label': 'my-value' });
+    expect(data.labels.hasProtectedKeys).toBe(true);
+    expect(data.labels.keyErrors).toStrictEqual({}); // only when manually update
+
+    expect(data.annotations).toBeDefined();
+    expect(data.annotations.initValue).toStrictEqual(mockValue.annotations);
+    expect(data.annotations.protectedKeys).toStrictEqual(mockValue.systemAnnotations);
+    expect(data.annotations.value).toStrictEqual({ 'my-annotation': 'my-annotation' });
+    expect(data.annotations.hasProtectedKeys).toBe(true);
+    expect(data.annotations.keyErrors).toStrictEqual({}); // only when manually update
+
+    expect(data.toggler).toBe(false);
+  });
+
+  it('should render KeyValue for labels', () => {
+    const wrapper = mount(Labels, {
+      props: {
+        value: mockValue,
+        mode:  'create',
+      },
+      global: { mocks: { t: mockT } },
+    });
+
+    const labelsKeyValue = wrapper.findComponent(KeyValue);
+
+    expect(labelsKeyValue.exists()).toBe(true);
+    expect(labelsKeyValue.props('value')).toStrictEqual({ 'my-label': 'my-value' });
+    expect(labelsKeyValue.props('addLabel')).toBe('labels.addLabel');
+    expect(labelsKeyValue.props('mode')).toBe('create');
+    expect(labelsKeyValue.props('keyErrors')).toStrictEqual({});
+  });
+
+  it('should render KeyValue for annotations if showAnnotations is true', () => {
+    const wrapper = mount(Labels, {
+      props: {
+        value:           mockValue,
+        mode:            'create',
+        showAnnotations: true,
+      },
+      global: { mocks: { t: mockT } },
+    });
+
+    const keyValueComponents = wrapper.findAllComponents(KeyValue);
+
+    expect(keyValueComponents).toHaveLength(2);
+    const annotationsKeyValue = keyValueComponents[1]; // The second KeyValue is for annotations
+
+    expect(annotationsKeyValue.exists()).toBe(true);
+    expect(annotationsKeyValue.props('value')).toStrictEqual({ 'my-annotation': 'my-annotation' });
+    expect(annotationsKeyValue.props('addLabel')).toBe('labels.addAnnotation');
+    expect(annotationsKeyValue.props('mode')).toBe('create');
+    expect(annotationsKeyValue.props('keyErrors')).toStrictEqual({});
+  });
+
+  it('should not render KeyValue for annotations if showAnnotations is false', () => {
+    const wrapper = mount(Labels, {
+      props: {
+        value:           mockValue,
+        mode:            'create',
+        showAnnotations: false,
+      },
+      global: { mocks: { t: mockT } },
+    });
+
+    const keyValueComponents = wrapper.findAllComponents(KeyValue);
+
+    expect(keyValueComponents).toHaveLength(1); // Only the KeyValue for labels
+  });
+
+  it('should show ToggleSwitch in VIEW mode if there are protected keys', async() => {
+    const wrapper = mount(Labels, {
+      props: {
+        value: mockValue,
+        mode:  _VIEW,
+      },
+      global: { mocks: { t: mockT } },
+    });
+
+    expect((wrapper.vm as any).showToggler).toBe(true);
+    const toggleSwitch = wrapper.findComponent(ToggleSwitch);
+
+    expect(toggleSwitch.exists()).toBe(true);
+    expect(toggleSwitch.props('onLabel')).toBe('labels.labels.show');
+  });
+
+  it('should not show ToggleSwitch in non-VIEW mode', () => {
+    const wrapper = mount(Labels, {
+      props: {
+        value: mockValue,
+        mode:  _EDIT,
+      },
+      global: { mocks: { t: mockT } },
+    });
+
+    expect((wrapper.vm as any).showToggler).toBe(false);
+    expect(wrapper.findComponent(ToggleSwitch).exists()).toBe(false);
+  });
+
+  it('should not show ToggleSwitch in VIEW mode if no protected keys', () => {
+    const mockValueNoProtected = {
+      labels:            { 'my-label': 'my-value' },
+      systemLabels:      [],
+      annotations:       { 'my-annotation': 'my-annotation' },
+      systemAnnotations: [],
+      setLabels:         jest.fn(),
+      setAnnotations:    jest.fn(),
+    };
+
+    const wrapper = mount(Labels, {
+      props: {
+        value: mockValueNoProtected,
+        mode:  _VIEW,
+      },
+      global: { mocks: { t: mockT } },
+    });
+
+    expect((wrapper.vm as any).showToggler).toBe(false);
+    expect(wrapper.findComponent(ToggleSwitch).exists()).toBe(false);
+  });
+
+  it('should toggle label values when ToggleSwitch is activated', async() => {
+    const wrapper = mount(Labels, {
+      props: {
+        value: mockValue,
+        mode:  _VIEW,
+      },
+      global: { mocks: { t: mockT } },
+    });
+
+    const labelsKeyValue = wrapper.findComponent(KeyValue);
+
+    expect(labelsKeyValue.props('value')).toStrictEqual({ 'my-label': 'my-value' }); // Initial: hidden protected
+
+    // Activate the toggle
+    await wrapper.findComponent(ToggleSwitch).vm.$emit('update:value', true);
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as any).toggler).toBe(true);
+    expect(labelsKeyValue.props('value')).toStrictEqual(mockValue.labels); // Should show all labels including protected
+  });
+
+  it('should toggle annotation values when ToggleSwitch is activated', async() => {
+    const wrapper = mount(Labels, {
+      props: {
+        value: mockValue,
+        mode:  _VIEW,
+      },
+      global: { mocks: { t: mockT } },
+    });
+
+    const annotationsKeyValue = wrapper.findAllComponents(KeyValue)[1];
+
+    expect(annotationsKeyValue.props('value')).toStrictEqual({ 'my-annotation': 'my-annotation' }); // Initial: hidden protected
+
+    // Activate the toggle
+    await wrapper.findComponent(ToggleSwitch).vm.$emit('update:value', true);
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as any).toggler).toBe(true);
+    expect(annotationsKeyValue.props('value')).toStrictEqual(mockValue.annotations); // Should show all annotations including protected
+  });
+
+  it('should call setLabels when labels KeyValue emits update:value', async() => {
+    const wrapper = mount(Labels, {
+      props: {
+        value: mockValue,
+        mode:  'create',
+      },
+      global: { mocks: { t: mockT } },
+    });
+
+    const labelsKeyValue = wrapper.findComponent(KeyValue);
+    const newLabels = { 'new-label': 'new-value', 'my-label': 'my-value' };
+
+    await labelsKeyValue.vm.$emit('update:value', newLabels);
+
+    // We expect setLabels to be called with the new values, preserving initial protected ones
+    expect(mockValue.setLabels).toHaveBeenCalledWith({
+      'new-label':              'new-value',
+      'my-label':               'my-value',
+      'kubernetes.io/hostname': 'test-app'
+    });
+  });
+
+  it('should call setAnnotations when annotations KeyValue emits update:value', async() => {
+    const wrapper = mount(Labels, {
+      props: {
+        value:           mockValue,
+        mode:            'create',
+        showAnnotations: true,
+      },
+      global: { mocks: { t: mockT } },
+    });
+
+    const annotationsKeyValue = wrapper.findAllComponents(KeyValue)[1];
+    const newAnnotations = { 'new-anno': 'new-value', 'my-annotation': 'my-annotation' };
+
+    await annotationsKeyValue.vm.$emit('update:value', newAnnotations);
+
+    // We expect setAnnotations to be called with the new values, preserving initial protected ones
+    expect(mockValue.setAnnotations).toHaveBeenCalledWith({
+      'new-anno':         'new-value',
+      'my-annotation':    'my-annotation',
+      'cattle.io/system': 'user'
+    });
+  });
+
+  it('should add newly entered protected keys to keyErrors', async() => {
+    const wrapper = mount(Labels, {
+      props: {
+        value: mockValue,
+        mode:  'create',
+      },
+      global: { mocks: { t: mockT } },
+    });
+
+    // Insert new protected key
+    const newLabels = {
+      'my-label':               'my-value',
+      'kubernetes.io/hostname': 'new-protected-value',
+      'non-protected':          'value'
+    };
+
+    await wrapper.vm.labels.update(newLabels, () => {});
+    await wrapper.vm.$nextTick();
+
+    // Expect to add protected labels in keyErrors
+    expect((wrapper.vm as any).labels.keyErrors).toStrictEqual({ 'kubernetes.io/hostname': 'labels.protectedWarning' });
+
+    // On edit, should key the protected label in the list
+    expect((wrapper.vm as any).labels.value).toStrictEqual({
+      'my-label':               'my-value',
+      'kubernetes.io/hostname': 'new-protected-value',
+      'non-protected':          'value'
+    });
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14682
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
