### PR TITLE
Fleet paths refinements

### DIFF
--- a/shell/components/fleet/FleetGitRepoPaths.vue
+++ b/shell/components/fleet/FleetGitRepoPaths.vue
@@ -336,7 +336,7 @@ export default {
             <RcButton
               v-if="!isView"
               small
-              tertiary
+              link
               @click="removePaths(i)"
             >
               <i class="icon icon-x" />
@@ -403,6 +403,9 @@ export default {
   .row-container {
     display: flex;
     flex-direction: column;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius);
 
     .header {
       display: flex;
@@ -457,7 +460,7 @@ export default {
 
         // Customize Remove rows button
         :deep(.footer) {
-          margin-top: 5px !important;
+          margin-top: 0px !important;
           margin-left: 30px;
         }
       }


### PR DESCRIPTION
### Summary
Final refinements.
- Paths boxed with a border to keep them consistent with cluster selectors. This will probably be changed globally in 2.13, for now we keep all of them consistent.
- Close button in role `link`, role `tertiary` without the new themes is not right.
- Top margin for `Add subpath` button fixed.

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
