### PR TITLE
adding validation on compare for sec min hour days

### DIFF
--- a/shell/components/SortableTable/grouping.js
+++ b/shell/components/SortableTable/grouping.js
@@ -1,4 +1,5 @@
 import { get } from '@shell/utils/object';
+import { sortBy } from '@shell/utils/sort';
 
 export default {
   computed: {
@@ -12,19 +13,28 @@ export default {
     groupedRows() {
       const groupKey = this.groupBy;
       const refKey = this.groupRef || this.selectedGroupOption?.groupLabelKey || groupKey;
+      let rowsToProcess = [];
+
+      if (this.pagedRows.length > 0 ) {
+        rowsToProcess = [...this.pagedRows];
+      }
+      // else{
+      //  rowsToProcess = [...this.rows];
+      // }
+      const outRows = sortBy(rowsToProcess, this.sortFields, this.descending);
 
       if ( !groupKey) {
         return [{
           key:  'default',
           ref:  'default',
-          rows: this.pagedRows,
+          rows: outRows,
         }];
       }
 
       const out = [];
       const map = {};
 
-      for ( const obj of this.pagedRows ) {
+      for ( const obj of outRows ) {
         const key = get(obj, groupKey) || '';
         const ref = get(obj, refKey);
         let entry = map[key];

--- a/shell/components/SortableTable/sorting.js
+++ b/shell/components/SortableTable/sorting.js
@@ -37,6 +37,12 @@ export default {
         return;
       }
 
+      let rowsToProcess = [];
+
+      if (this.cachedRows) {
+        rowsToProcess = this.cachedRows;
+      }
+
       let key;
 
       // Why is sortGeneration needed when we have sortGenerationFn?
@@ -51,18 +57,20 @@ export default {
       if ( sortGenerationKey) {
         key = `${ sortGenerationKey }/${ this.rows.length }/${ this.descending }/${ this.sortFields.join(',') }`;
         if ( this.cacheKey === key ) {
-          return this.cachedRows;
+          const outRowsCached = sortBy(rowsToProcess, this.sortFields, this.descending);
+
+          return outRowsCached;
         }
       }
 
-      const out = sortBy(this.rows, this.sortFields, this.descending);
+      const outRows = sortBy(this.rows, this.sortFields, this.descending);
 
       if ( key ) {
         this.cacheKey = key;
-        this.cachedRows = out;
+        this.cachedRows = outRows; // new cached rows
       }
 
-      return out;
+      return outRows;
     },
   },
 

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -520,6 +520,7 @@ export const LAST_SEEN_TIME = {
 
 export const EVENT_LAST_SEEN_TIME = {
   ...LAST_SEEN_TIME,
+  sort:        'metadata.fields.0',
   defaultSort: true,
 };
 

--- a/shell/utils/sort.js
+++ b/shell/utils/sort.js
@@ -127,6 +127,10 @@ const TYPE_ORDER = {
   date:      10,
 };
 
+function isDurationString(str) {
+  return typeof str === 'string' && /(\d+)([dhms])/i.test(str);
+}
+
 export function compare(a, b) {
   const typeA = typeOf(a);
   const typeB = typeOf(b);
@@ -135,6 +139,16 @@ export function compare(a, b) {
 
   if ( res ) {
     return res;
+  }
+
+  const aIsDuration = isDurationString(a);
+  const bIsDuration = isDurationString(b);
+
+  if (aIsDuration && bIsDuration) {
+    const msA = parseDurationToMilliseconds(a);
+    const msB = parseDurationToMilliseconds(b);
+
+    return spaceship(msA, msB);
   }
 
   switch (typeA) {
@@ -222,4 +236,40 @@ export function sortableNumericSuffix(str) {
 
 export function isNumeric(num) {
   return !!`${ num }`.match(notNumericRegex);
+}
+
+export function parseDurationToMilliseconds(durationStr) {
+  let totalMilliseconds = 0;
+
+  if (typeof durationStr !== 'string') {
+    return 0;
+  }
+  const regex = /(\d+)([dhms])/gi;
+  let match;
+
+  while ((match = regex.exec(durationStr)) !== null) {
+    const value = parseInt(match[1], 10);
+    const unit = match[2].toLowerCase();
+
+    if (isNaN(value)) {
+      return 0;
+    }
+
+    switch (unit) {
+    case 'd':
+      totalMilliseconds += value * 24 * 60 * 60 * 1000;
+      break;
+    case 'h':
+      totalMilliseconds += value * 60 * 60 * 1000;
+      break;
+    case 'm':
+      totalMilliseconds += value * 60 * 1000;
+      break;
+    case 's':
+      totalMilliseconds += value * 1000;
+      break;
+    }
+  }
+
+  return totalMilliseconds;
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The core problem was that duration strings (e.g., '10h', '47m', '8h4s') were being sorted alphabetically instead of by their actual time value (milliseconds). This was due to the compare function in @shell/utils/sort treating these strings as regular text and using _localeCompare_.
Fixes #8669
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
**Incorrect Duration String Sorting**: The primary issue of duration strings (e.g., "10h", "47m", "6s", "7m", "8h4s") being sorted incorrectly (alphabetically) is now addressed. They will now be sorted based on their total millisecond value (e.g., 6s, 7m, 47m, 8h4s, 10h).

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Modifying the compare function in @shell/utils/sort to explicitly detect duration strings using a _isDurationString_ helper and then converting them to milliseconds using _parseDurationToMilliseconds_ before comparison. This ensures that when the _sortBy_ utility calls compare, duration strings are numerically ordered.

_compare_ Function (@shell/utils/sort):

A new helper isDurationString(str) was added to identify strings conforming to the duration pattern (e.g., "10h", "5m").

A conditional block was added at the beginning of compare that checks if both a and b are duration strings. If they are, _parseDurationToMilliseconds_ is used to convert them to milliseconds, and then the spaceship function compares these numerical values.

The existing case 'string' within the switch statement will now only handle non-duration strings, ensuring they are still sorted alphabetically.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Cases to be tested:
- Simple Duration Sort: Test a list of items where the sort field contains simple duration strings (e.g., ['5s', '1m', '10s', '30m', '1h']) to ensure they sort correctly (e.g., 5s, 10s, 1m, 30m, 1h).
- Complex Duration Sort: Test with duration strings containing multiple units (e.g., ['1d2h3m', '2h1d', '3m2s']) to ensure _parseDurationToMilliseconds_ correctly sums them up for comparison.
- Descending Sort: Verify that descending order correctly reverses the duration sort.
- Mixed Unit Durations: Test with values like '8h4s' vs '8h' or '7m' vs '60s'.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
NA

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
NA

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
