### PR TITLE
Ensure correct syntax is used with SSP and the secret selectors

### DIFF
--- a/shell/components/form/SecretSelector.vue
+++ b/shell/components/form/SecretSelector.vue
@@ -173,11 +173,18 @@ export default {
     paginatePageOptions(opts) {
       const { opts: { filter } } = opts;
 
-      const filters = !!filter ? [PaginationParamFilter.createSingleField({ field: 'metadata.name', value: filter })] : [];
+      const filters = !!filter ? [PaginationParamFilter.createSingleField({
+        field: 'metadata.name', value: filter, exact: false, equals: true
+      })] : [];
 
       filters.push(
         PaginationParamFilter.createSingleField({ field: 'metadata.namespace', value: this.namespace }),
-        PaginationParamFilter.createSingleField({ field: 'metadata.fields.1', value: this.types.join(',') })
+        PaginationParamFilter.createMultipleFields(this.types.map((t) => ({
+          field:  'metadata.fields.1',
+          equals: true,
+          exact:  true,
+          value:  t
+        })))
       );
 
       return {

--- a/shell/components/form/SimpleSecretSelector.vue
+++ b/shell/components/form/SimpleSecretSelector.vue
@@ -156,11 +156,18 @@ export default {
     paginatePageOptions(opts) {
       const { opts: { filter } } = opts;
 
-      const filters = !!filter ? [PaginationParamFilter.createSingleField({ field: 'metadata.name', value: filter })] : [];
+      const filters = !!filter ? [PaginationParamFilter.createSingleField({
+        field: 'metadata.name', value: filter, exact: false, equals: true
+      })] : [];
 
       filters.push(
         PaginationParamFilter.createSingleField({ field: 'metadata.namespace', value: this.namespace }),
-        PaginationParamFilter.createSingleField({ field: 'metadata.fields.1', value: this.types.join(',') })
+        PaginationParamFilter.createMultipleFields(this.types.map((t) => ({
+          field:  'metadata.fields.1',
+          equals: true,
+          exact:  true,
+          value:  t
+        })))
       );
 
       return {


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14474
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- two fixes, two places
- Fix - ensure filter=x=1,x=2 format is used and not filter=x=1,2
  - this must have worked at some point...
- Fix - ensure partial filter is used when searching secrets by name
  - same here...
- SimpleSecretSelector is only used in monitoring alertmanager receive config
  - See issue for repro steps
  - whoever created it should have used SecretSelector instead
- SecretSelector is only used in logging output providers
  - Logging --> Outputs --> Create --> Outputs tab --> Access secret fields

### Areas or cases that should be tested
as per issue, plus SecretSelector via steps above

### Areas which could experience regressions
localised changes, shouldn't cause regressions elsewhere

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
