### PR TITLE
RichTranslation component for embedding components in translations and fix repositories causing refresh

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1069,10 +1069,7 @@ catalog:
     header: Charts
     noCharts:
       title: No charts to show
-      messagePart1: <b>Tips:</b> undo the last filter you applied or
-      messagePart2: clear all filters
-      messagePart3: ', and ensure you have the right <a tabindex="0" href={repositoriesUrl} rel="noopener noreferrer nofollow">repositories</a> in place.'
-      messagePart4: 'Want to learn more about Helm Charts and Apps? Read our <a tabindex="0" href="{docsBase}/how-to-guides/new-user-guides/helm-charts-in-rancher" target="_blank" class="secondary-text-link">documentation <i class="icon icon-external-link"></i></a>.'
+      message: '<b>Tips:</b> undo the last filter you applied or <resetAllFilters>clear all filters</resetAllFilters>, and ensure you have the right <repositoriesUrl>repositories</repositoriesUrl> in place. Want to learn more about Helm Charts and Apps? Read our <documentationUrl>documentation</documentationUrl>.'
     noWindows: Your repos do not contain any charts capable of being deployed on a cluster with Windows nodes.
     noWindowsAndLinux: Your repos do not contain any charts capable of being deployed on a cluster with both Windows and Linux worker nodes.
     operatingSystems:

--- a/shell/components/RichTranslation.vue
+++ b/shell/components/RichTranslation.vue
@@ -3,6 +3,8 @@ import { defineComponent, h, VNode } from 'vue';
 import { useStore } from 'vuex';
 import { escapeHtml } from '@shell/utils/string';
 
+const ALLOWED_TAGS = ['b', 'i', 'span', 'a']; // Add more as needed
+
 /**
  * A component for rendering translated strings with embedded HTML and custom Vue components.
  *
@@ -61,7 +63,7 @@ export default defineComponent({
       while ((match = regex.exec(rawStr)) !== null) {
       // Add the text before the current match as a plain text node.
         if (match.index > lastIndex) {
-          children.push(h('span', { innerHTML: rawStr.substring(lastIndex, match.index) }));
+          children.push(h('span', { innerHTML: escapeHtml(rawStr.substring(lastIndex, match.index)) }));
         }
 
         const selfClosingTagName = match[3]; // Captures the tag name for self-closing tags (e.g., 'anotherTag' from <anotherTag/>)
@@ -75,6 +77,9 @@ export default defineComponent({
           if (slots[tagName]) {
           // If a slot is provided for this tag, render the slot with the content.
             children.push(slots[tagName]({ content }));
+          } else if (ALLOWED_TAGS.includes(tagName.toLowerCase())) {
+          // If it's an allowed HTML tag, render it directly.
+            children.push(h(tagName, { innerHTML: content }));
           } else {
           // Otherwise, render the tag and its content as plain HTML.
             children.push(h('span', { innerHTML: escapeHtml(match[0]) }));
@@ -86,6 +91,9 @@ export default defineComponent({
           if (slots[tagName]) {
           // If a slot is provided for this tag, render the slot.
             children.push(slots[tagName]({ content: '' }));
+          } else if (ALLOWED_TAGS.includes(tagName.toLowerCase())) {
+          // If it's an allowed HTML tag, render it directly.
+            children.push(h(tagName));
           } else {
           // Otherwise, render the tag as plain HTML.
             children.push(h('span', { innerHTML: escapeHtml(match[0]) }));
@@ -98,7 +106,7 @@ export default defineComponent({
 
       // Add any remaining text after the last match.
       if (lastIndex < rawStr.length) {
-        children.push(h('span', { innerHTML: rawStr.substring(lastIndex) }));
+        children.push(h('span', { innerHTML: escapeHtml(rawStr.substring(lastIndex)) }));
       }
 
       // Render the root element with the processed children.

--- a/shell/components/RichTranslation.vue
+++ b/shell/components/RichTranslation.vue
@@ -1,0 +1,102 @@
+<script lang="ts">
+import { defineComponent, h, VNode } from 'vue';
+
+/**
+ * A component for rendering translated strings with embedded HTML and custom Vue components.
+ *
+ * This component allows you to use a single translation key for a message that contains
+ * both standard HTML tags (like <b>, <i>, etc.) and custom Vue components (like <router-link>).
+ *
+ * @example
+ * // In your translation file (e.g., en-us.yaml):
+ * my:
+ *   translation:
+ *     key: 'This is a <b>bold</b> statement with a <customLink>link</customLink>.'
+ *
+ * // In your Vue component:
+ * <RichTranslation k="my.translation.key">
+ *   <template #customLink="{ content }">
+ *     <router-link to="/some/path">{{ content }}</router-link>
+ *   </template>
+ * </RichTranslation>
+ */
+export default defineComponent({
+  name: 'RichTranslation',
+  props: {
+    /**
+     * The translation key for the message.
+     */
+    k: {
+      type:     String,
+      required: true,
+    },
+    /**
+     * The HTML tag to use for the root element.
+     */
+    tag: {
+      type:    [String, Object],
+      default: 'span'
+    },
+  },
+  render() {
+    // Get the raw translation string, without any processing.
+    const rawStr = this.$store.getters['i18n/t'](this.k, {}, true);
+
+    if (!rawStr || typeof rawStr !== 'string') {
+      return h(this.tag as string, {}, [rawStr]);
+    }
+
+    // This regex splits the string by the custom tags, keeping the tags in the resulting array.
+    const regex = /<([a-zA-Z0-9]+)>(.*?)<\/\1>|<([a-zA-Z0-9]+)\/>/g;
+    const children: (VNode | string)[] = [];
+    let lastIndex = 0;
+    let match;
+
+    // Iterate over all matches of the regex.
+    while ((match = regex.exec(rawStr)) !== null) {
+      // Add the text before the current match as a plain text node.
+      if (match.index > lastIndex) {
+        children.push(h('span', { innerHTML: rawStr.substring(lastIndex, match.index) }));
+      }
+
+      const selfClosingTagName = match[3];
+      const enclosingTagName = match[1];
+
+      if (enclosingTagName) {
+        // This is an enclosing tag, like <tag>content</tag>.
+        const tagName = enclosingTagName;
+        const content = match[2];
+
+        if (this.$slots[tagName]) {
+          // If a slot is provided for this tag, render the slot with the content.
+          children.push(this.$slots[tagName]({ content }));
+        } else {
+          // Otherwise, render the tag and its content as plain HTML.
+          children.push(h('span', { innerHTML: match[0] }));
+        }
+      } else if (selfClosingTagName) {
+        // This is a self-closing tag, like <tag/>.
+        const tagName = selfClosingTagName;
+
+        if (this.$slots[tagName]) {
+          // If a slot is provided for this tag, render the slot.
+          children.push(this.$slots[tagName]({ content: '' }));
+        } else {
+          // Otherwise, render the tag as plain HTML.
+          children.push(h('span', { innerHTML: match[0] }));
+        }
+      }
+      
+      lastIndex = regex.lastIndex;
+    }
+
+    // Add any remaining text after the last match.
+    if (lastIndex < rawStr.length) {
+      children.push(h('span', { innerHTML: rawStr.substring(lastIndex) }));
+    }
+
+    // Render the root element with the processed children.
+    return h(this.tag as string, {}, children);
+  }
+});
+</script>

--- a/shell/components/__tests__/RichTranslation.test.ts
+++ b/shell/components/__tests__/RichTranslation.test.ts
@@ -1,0 +1,129 @@
+import { mount } from '@vue/test-utils';
+import RichTranslation from '../RichTranslation.vue';
+import { createStore } from 'vuex';
+import { h } from 'vue';
+
+// Mock the i18n store getter
+const mockI18nStore = createStore({
+  getters: {
+    'i18n/t': () => (key: string, args: any, noMarkup: boolean) => {
+      const translations: Record<string, string> = {
+        'test.simple':   'Hello World',
+        'test.html':     'This is <b>bold</b> and <i>italic</i>.',
+        'test.custom':   'This has a <customLink>link</customLink> and <anotherTag/>.',
+        'test.mixed':    'Text before <tag1>content1</tag1> text in middle <tag2/> text after.',
+        'test.noString': 123,
+      };
+
+      return translations[key] || key;
+    },
+  },
+});
+
+describe('richTranslation', () => {
+  it('renders a simple translation correctly', () => {
+    const wrapper = mount(RichTranslation, {
+      props:  { k: 'test.simple' },
+      global: { plugins: [mockI18nStore] },
+    });
+
+    expect(wrapper.text()).toBe('Hello World');
+    expect(wrapper.html()).toContain('<span>Hello World</span>');
+  });
+
+  it('renders HTML tags correctly', () => {
+    const wrapper = mount(RichTranslation, {
+      props:  { k: 'test.html' },
+      global: { plugins: [mockI18nStore] },
+    });
+
+    expect(wrapper.html()).toContain('<span>This is </span><span><b>bold</b></span><span> and </span><span><i>italic</i></span><span>.</span>');
+    expect(wrapper.find('b').exists()).toBe(true);
+    expect(wrapper.find('i').exists()).toBe(true);
+  });
+
+  it('renders custom components via slots (enclosing tag)', () => {
+    const wrapper = mount(RichTranslation, {
+      props:  { k: 'test.custom' },
+      slots:  { customLink: ({ content }: { content: string }) => h('a', { href: '/test' }, content) },
+      global: { plugins: [mockI18nStore] },
+    });
+
+    expect(wrapper.html()).toContain('<a href="/test">link</a>');
+    expect(wrapper.find('a').text()).toBe('link');
+  });
+
+  it('renders custom components via slots (self-closing tag)', () => {
+    const wrapper = mount(RichTranslation, {
+      props:  { k: 'test.custom' },
+      slots:  { anotherTag: () => h('span', { class: 'self-closed' }, 'Self-closed content') },
+      global: { plugins: [mockI18nStore] },
+    });
+
+    expect(wrapper.html()).toContain('<span class="self-closed">Self-closed content</span>');
+    expect(wrapper.find('.self-closed').text()).toBe('Self-closed content');
+  });
+
+  it('handles mixed content with multiple custom components', () => {
+    const wrapper = mount(RichTranslation, {
+      props: { k: 'test.mixed' },
+      slots: {
+        tag1: ({ content }: { content: string }) => h('strong', {}, content),
+        tag2: () => h('em', {}, 'emphasized'),
+      },
+      global: { plugins: [mockI18nStore] },
+    });
+
+    expect(wrapper.html()).toContain('<span>Text before </span><strong>content1</strong><span> text in middle </span><em>emphasized</em><span> text after.</span>');
+    expect(wrapper.find('strong').text()).toBe('content1');
+    expect(wrapper.find('em').text()).toBe('emphasized');
+  });
+
+  it('renders correctly when translation is not a string', () => {
+    const wrapper = mount(RichTranslation, {
+      props:  { k: 'test.noString' },
+      global: { plugins: [mockI18nStore] },
+    });
+
+    expect(wrapper.text()).toBe('123');
+    expect(wrapper.html()).toContain('<span>123</span>');
+  });
+
+  it('uses the specified root tag', () => {
+    const wrapper = mount(RichTranslation, {
+      props: {
+        k:   'test.simple',
+        tag: 'div',
+      },
+      global: { plugins: [mockI18nStore] },
+    });
+
+    expect(wrapper.html()).toContain('<div><span>Hello World</span></div>');
+    expect(wrapper.find('div').exists()).toBe(true);
+    expect(wrapper.find('span').exists()).toBe(true); // Inner span for content
+  });
+
+  it('falls back to raw tag content if slot is not provided for enclosing tag', () => {
+    const wrapper = mount(RichTranslation, {
+      props: { k: 'test.custom', // Contains <customLink> and <anotherTag/>
+      },
+      // No slots provided
+      global: { plugins: [mockI18nStore] },
+    });
+
+    expect(wrapper.html()).toContain('<span>This has a </span><span>&lt;customLink&gt;link&lt;/customLink&gt;</span><span> and </span><span>&lt;anotherTag/&gt;</span><span>.</span>');
+    expect(wrapper.find('a').exists()).toBe(false); // Should not render as <a>
+  });
+
+  it('falls back to raw tag content if slot is not provided for self-closing tag', () => {
+    const wrapper = mount(RichTranslation, {
+      props: { k: 'test.custom', // Contains <customLink> and <anotherTag/>
+      },
+      // No slots provided
+      global: { plugins: [mockI18nStore] },
+    });
+
+    expect(wrapper.html()).toContain('<span>&lt;anotherTag/&gt;</span>');
+    expect(wrapper.find('.self-closed').exists()).toBe(false); // Should not render with custom class
+  });
+});

--- a/shell/components/__tests__/RichTranslation.test.ts
+++ b/shell/components/__tests__/RichTranslation.test.ts
@@ -37,7 +37,7 @@ describe('richTranslation', () => {
       global: { plugins: [mockI18nStore] },
     });
 
-    expect(wrapper.html()).toContain('<span>This is </span><span><b>bold</b></span><span> and </span><span><i>italic</i></span><span>.</span>');
+    expect(wrapper.html()).toContain('<span><span>This is </span><b>bold</b><span> and </span><i>italic</i><span>.</span></span>');
     expect(wrapper.find('b').exists()).toBe(true);
     expect(wrapper.find('i').exists()).toBe(true);
   });
@@ -105,8 +105,7 @@ describe('richTranslation', () => {
 
   it('falls back to raw tag content if slot is not provided for enclosing tag', () => {
     const wrapper = mount(RichTranslation, {
-      props: { k: 'test.custom', // Contains <customLink> and <anotherTag/>
-      },
+      props:  { k: 'test.custom' }, // Contains <customLink> and <anotherTag/>
       // No slots provided
       global: { plugins: [mockI18nStore] },
     });
@@ -117,8 +116,7 @@ describe('richTranslation', () => {
 
   it('falls back to raw tag content if slot is not provided for self-closing tag', () => {
     const wrapper = mount(RichTranslation, {
-      props: { k: 'test.custom', // Contains <customLink> and <anotherTag/>
-      },
+      props:  { k: 'test.custom' }, // Contains <customLink> and <anotherTag/>
       // No slots provided
       global: { plugins: [mockI18nStore] },
     });

--- a/shell/config/router/routes.js
+++ b/shell/config/router/routes.js
@@ -313,6 +313,20 @@ export default [
             component: () => interopDefault(import('@shell/pages/c/_cluster/apps/charts/install.vue')),
             name:      'c-cluster-apps-charts-install',
           },
+          {
+            path: '/c/:cluster/apps/catalog.cattle.io.clusterrepo',
+            name: 'c-cluster-apps-catalog-repo',
+            redirect(to) {
+              return {
+                name:   'c-cluster-product-resource',
+                params: {
+                  ...to.params,
+                  product:  APPS,
+                  resource: 'catalog.cattle.io.clusterrepo',
+                }
+              };
+            },
+          },
         ]
       },
       {

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -22,6 +22,7 @@ import AppChartCardSubHeader from '@shell/pages/c/_cluster/apps/charts/AppChartC
 import AppChartCardFooter from '@shell/pages/c/_cluster/apps/charts/AppChartCardFooter';
 import AddRepoLink from '@shell/pages/c/_cluster/apps/charts/AddRepoLink';
 import StatusLabel from '@shell/pages/c/_cluster/apps/charts/StatusLabel';
+import RichTranslation from '@shell/components/RichTranslation.vue';
 import Select from '@shell/components/form/Select';
 
 const createInitialFilters = () => ({
@@ -41,7 +42,8 @@ export default {
     FilterPanel,
     AppChartCardSubHeader,
     AppChartCardFooter,
-    Select
+    Select,
+    RichTranslation
   },
 
   async fetch() {
@@ -502,25 +504,39 @@ export default {
           {{ t('catalog.charts.noCharts.title') }}
         </h1>
         <div class="empty-state-tips">
-          <h4
-            v-clean-html="t('catalog.charts.noCharts.messagePart1', {}, true)"
-          />
-          <a
-            tabindex="0"
-            role="button"
-            class="empty-state-reset-filters link"
-            data-testid="charts-empty-state-reset-filters"
-            @click="resetAllFilters"
+          <RichTranslation
+            k="catalog.charts.noCharts.message"
+            :raw="true"
           >
-            {{ t('catalog.charts.noCharts.messagePart2') }}
-          </a>
-          <h4
-            v-clean-html="t('catalog.charts.noCharts.messagePart3', { repositoriesUrl: `/c/${clusterId}/apps/catalog.cattle.io.clusterrepo`}, true)"
-          />
+            <template #resetAllFilters="{ content }">
+              <a
+                tabindex="0"
+                role="button"
+                class="link"
+                data-testid="charts-empty-state-reset-filters"
+                @click="resetAllFilters"
+                @keyup.enter="resetAllFilters"
+                @keyup.space="resetAllFilters"
+              >{{ content }}</a>
+            </template>
+            <template #repositoriesUrl="{ content }">
+              <router-link :to="{ name: 'c-cluster-apps-catalog-repo'}">
+                {{ content }}
+              </router-link>
+            </template>
+            <template #documentationUrl="{ content }">
+              <a
+                tabindex="0"
+                :href="`${docsBase}/how-to-guides/new-user-guides/helm-charts-in-rancher`"
+                target="_blank"
+                rel="noopener noreferrer nofollow"
+                class="secondary-text-link"
+              >
+                {{ content }} <i class="icon icon-external-link" />
+              </a>
+            </template>
+          </RichTranslation>
         </div>
-        <h4
-          v-clean-html="t('catalog.charts.noCharts.messagePart4', {}, true)"
-        />
       </div>
       <div
         v-else
@@ -705,22 +721,8 @@ export default {
 
   .empty-state-tips {
     margin-bottom: 12px;
-
-    .empty-state-reset-filters {
-      font-size: 16px;
-    }
-
-    h4 {
-      display: inline;
-    }
-  }
-
-  :deep(h4 .icon-external-link) {
-    text-decoration: underline;
-  }
-
-  :deep(h4:hover .icon-external-link) {
-    text-decoration: none;
+    font-size: 16px;
+    line-height: 32px;
   }
 }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14532 
Fixes #14679 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- New component `RichTranslation.vue` created to support embedding vue components
- Empty state multiple messages replaced with `RichTranslation`
- Repositories link now uses `router-link`
- Unit tests

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Test all the functionalities in the empty message:

- clear all filters
- repositories link
- documentation link

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
The new component is used only for the empty state in charts/apps page, so no regression expected throughout the app 
### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
