### PR TITLE
aks networking validation fixes and user-defined-routing fixes

### DIFF
--- a/pkg/aks/components/Config.vue
+++ b/pkg/aks/components/Config.vue
@@ -117,7 +117,6 @@ export default defineComponent({
     const store = this.$store as Store<any>;
     // This setting is used by RKE1 AKS GKE and EKS - rke2/k3s have a different mechanism for fetching supported versions
     const supportedVersionRange = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.UI_SUPPORTED_K8S_VERSIONS)?.value;
-    const t = store.getters['i18n/t'];
 
     return {
 

--- a/pkg/aks/components/Config.vue
+++ b/pkg/aks/components/Config.vue
@@ -257,7 +257,7 @@ export default defineComponent({
         nodeResourceGroupLength: resourceGroupLength(this, 'aks.nodeResourceGroup.label', 'config.nodeResourceGroup'),
         resourceGroupEnd:        resourceGroupEnd(this, 'aks.clusterResourceGroup.label', 'config.resourceGroup'),
         nodeResourceGroupEnd:    resourceGroupEnd(this, 'aks.nodeResourceGroup.label', 'config.nodeResourceGroup'),
-        ipv4WithOrWithoutCidr:   ipv4WithOrWithoutCidr(this, 'aks.authorizedIpRanges.label', 'config.authorizedIpRanges'),
+        ipv4WithOrWithoutCidr:   ipv4WithOrWithoutCidr(this),
         serviceCidr:             ipv4WithCidr(this, 'aks.serviceCidr.label', 'config.serviceCidr'),
         podCidr:                 ipv4WithCidr(this, 'aks.podCidr.label', 'config.podCidr'),
         dockerBridgeCidr:        ipv4WithCidr(this, 'aks.dockerBridgeCidr.label', 'config.dockerBridgeCidr'),

--- a/pkg/aks/components/__tests__/Config.test.ts
+++ b/pkg/aks/components/__tests__/Config.test.ts
@@ -470,4 +470,53 @@ describe('aks provisioning form', () => {
 
     expect(nodePoolNames({ t: (str:string) => str })(nodeName)).toBeUndefined();
   });
+
+  it('should set the network plugin to azure when user defined routing is selected', async() => {
+    const config = {
+      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc'
+    };
+    const wrapper = shallowMount(Config, {
+      propsData: {
+        value: {}, mode: 'edit', config
+      },
+      ...requiredSetup()
+    });
+
+    await setCredential(wrapper, config);
+    const outboundTypeSelect = wrapper.findComponent('[data-testid="aks-outbound-type-select"]');
+    const outboundTypeOpts = outboundTypeSelect.props().options;
+
+    outboundTypeSelect.vm.$emit('update:value', outboundTypeOpts[1].value);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.config.networkPlugin).toBe('azure');
+    const networkPluginSelect = wrapper.findComponent('[data-testid="aks-network-plugin-select"]');
+
+    const kubeOption = networkPluginSelect.props().options.find((opt) => opt.value === 'kubenet');
+
+    expect(kubeOption.disabled).toBeTruthy();
+  });
+
+  it('should make virtual network required when user defined routing is selected', async() => {
+    const config = {
+      dnsPrefix: 'abc-123', resourceGroup: 'abc', clusterName: 'abc'
+    };
+    const wrapper = shallowMount(Config, {
+      propsData: {
+        value: {}, mode: 'edit', config
+      },
+      ...requiredSetup()
+    });
+
+    await setCredential(wrapper, config);
+    const outboundTypeSelect = wrapper.findComponent('[data-testid="aks-outbound-type-select"]');
+    const outboundTypeOpts = outboundTypeSelect.props().options;
+
+    outboundTypeSelect.vm.$emit('update:value', outboundTypeOpts[1].value);
+    await wrapper.vm.$nextTick();
+
+    const virtualNetworkSelect = wrapper.findComponent('[data-testid="aks-virtual-network-select"]');
+
+    expect(virtualNetworkSelect.props().required).toBe(true);
+  });
 });

--- a/pkg/aks/util/validators.ts
+++ b/pkg/aks/util/validators.ts
@@ -118,7 +118,7 @@ export const ipv4WithCidr = (ctx: any, labelKey: string, clusterPath: string) =>
 export const outboundTypeUserDefined = (ctx: any, labelKey: string, clusterPath: string) => {
   return () :string | undefined => {
     const outboundType = get(ctx, clusterPath) as OutboundType;
-    const loadBalancerSku = get(ctx, 'aksConfig.loadBalancerSku') as LoadBalancerSku;
+    const loadBalancerSku = get(ctx, 'config.loadBalancerSku') as LoadBalancerSku;
 
     if (loadBalancerSku !== 'Standard' && outboundType === 'UserDefinedRouting') {
       return ctx.t('aks.errors.outboundType');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12985
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR has some small fixes to the AKS networking section:
- fixed the label on the outboundType input
- fixed the LoadbalancerSKU validator always returning an error when User Defined Routing is selected
- marked virtual network as required when User Defined Routing is selected
- automatically switch to the azure network plugin when User Defined Routing is selected

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if thenlinked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
