### PR TITLE
Update value watcher for ArrayList to preserve focus on input

### DIFF
--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -164,21 +164,29 @@ export default {
       { deep: true }
     );
 
+    /**
+     * Watching props.value helps to maintain internal state when slots are used
+     */
     watch(
       () => props.value,
-      (newVal) => {
+      (newVal, oldVal) => {
         lastUpdateWasFromValue.value = true;
-        const newRows = (newVal || []).map((value) => {
-          const existingRow = rows.value.find((row) => row.value === value);
 
-          if (existingRow) {
-            return { value, id: existingRow.id };
-          } else {
-            return { value, id: randomStr() };
-          }
+        // find member of the array that has been modified
+        const modifiedIdx = newVal.findIndex((current, idx) => {
+          return current !== oldVal[idx];
         });
 
-        rows.value = newRows;
+        // a member has been added or removed
+        if (newVal.length !== oldVal.length || modifiedIdx < 0) {
+          rows.value = (newVal || []).map((value) => {
+            return { value, id: randomStr() };
+          });
+
+          return;
+        }
+
+        rows.value[modifiedIdx].value = newVal[modifiedIdx];
       },
       { deep: true }
     );


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The previous implementation attempted to preserve the id when newVal matched oldVal. This means that a new id would be generated when editing an existing value, causing the component to re-render and lose focus on the input.

Fixes #14692 

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This new approach preserves the existing id by locating the modified index and updating the value in place.

This solution comes with a tradeoff - add or deleting values will cause a new ID to be generated for each member of the ArrayList. This will force a re-render of the entire list and can become expensive when the ArrayList becomes arbitrarily large. Attempting to preserve the ids can become complicated on deletion when multiple members of the ArrayList have the same value.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

The attached issue contains a good example for testing. Other instances of ArrayList should be retested.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Instances of ArrayList used throughout Dashboard.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
