### PR TITLE
Putting together a smattering of style fixes that were pointed out during a design review

### DIFF
--- a/shell/assets/styles/themes/_dark.scss
+++ b/shell/assets/styles/themes/_dark.scss
@@ -51,6 +51,7 @@
   --slider-light-bg-right      : #{rgba($darker, 0)};
 
   --muted                      : #{$disabled};
+  --deemphasized               : #{$disabled};
 
   --body-bg                    : #{$darker};
   --body-text                  : #{$lightest};

--- a/shell/assets/styles/themes/_light.scss
+++ b/shell/assets/styles/themes/_light.scss
@@ -156,9 +156,14 @@ BODY, .theme-light {
   }
 
   --muted                      : #{$dark};
+  --deemphasized               : #717179;
 
   .text-muted {
     color: var(--muted) !important;
+  }
+
+  .text-deemphasized {
+    color: var(--deemphasized);
   }
 
   --darker                    : #{$darker};
@@ -402,7 +407,7 @@ BODY, .theme-light {
 
   --modal-bg                   : #{$lightest};
   --modal-border               : #{$dark};
-  --overlay-bg                 : #{rgba($lighter, 0.75)};
+  --overlay-bg                 : rgba(38, 42, 64, 0.35);
   --shadow                     : #{rgba($medium, 0.85)};
 
   --checkbox-tick              : #{$lightest};
@@ -468,7 +473,7 @@ BODY, .theme-light {
   --sortable-table-group-label : #{$secondary};
 
   --tag-primary                : #{$darkest};
-  --tag-bg                     : #{$medium};
+  --tag-bg                     : #EEEFF5;
 
   --popover-bg                 : var(--body-bg);
   --popover-border             : var(--border);

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
@@ -34,7 +34,7 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
       :data-testid="row.dataTestid"
     >
       <label
-        class="label text-muted"
+        class="label text-deemphasized"
         :for="getRowValueId(row)"
       >
         {{ row.label }}
@@ -95,6 +95,13 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
         display: flex;
         flex-direction: row;
         align-items: center;
+
+        &, & * {
+          max-width: 100%;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
       }
 
       .label {

--- a/shell/components/Resource/Detail/Metadata/KeyValue.vue
+++ b/shell/components/Resource/Detail/Metadata/KeyValue.vue
@@ -54,12 +54,12 @@ const showConfigurationMoreFocusSelector = computed(() => `[data-testid="${ show
 <template>
   <div class="key-value">
     <div class="heading">
-      <span class="title text-muted">{{ propertyName }}</span>
+      <span class="title text-deemphasized">{{ propertyName }}</span>
       <span class="count">{{ rows.length }}</span>
     </div>
     <div
       v-if="visibleRows.length === 0"
-      class="empty mmt-2 text-muted"
+      class="empty mmt-2 text-deemphasized"
     >
       <div class="no-rows">
         {{ i18n.t('component.resource.detail.metadata.keyValue.noRows', {propertyName: lowercasePropertyName}) }}
@@ -67,7 +67,7 @@ const showConfigurationMoreFocusSelector = computed(() => `[data-testid="${ show
       <div class="show-configuration mmt-1">
         <a
           :data-testid="showConfigurationEmptyDataTestId"
-          class="secondary text-muted"
+          class="secondary text-deemphasized"
           href="#"
           @click="(ev: MouseEvent) => {ev.preventDefault(); emit('show-configuration', showConfigurationEmptyFocusSelector);}"
         >
@@ -91,7 +91,7 @@ const showConfigurationMoreFocusSelector = computed(() => `[data-testid="${ show
       v-if="showShowAllButton"
       :data-testid="showConfigurationMoreDataTestId"
       href="#"
-      class="show-all secondary"
+      class="show-all"
       @click="(ev: MouseEvent) => {ev.preventDefault(); emit('show-configuration', showConfigurationMoreFocusSelector);}"
     >
       {{ showAllLabel }}
@@ -110,18 +110,15 @@ const showConfigurationMoreFocusSelector = computed(() => `[data-testid="${ show
     }
 
     .heading {
-        margin-bottom: 4px;
+        margin-bottom: 8px;
     }
 
     .row {
+        display: block;
         width: 100%;
 
-        &:not(:first-of-type) {
+        &:not(:nth-child(2)) {
             margin-top: 4px;
-        }
-
-        & {
-            margin-top: 8px;
         }
     }
     .show-all {
@@ -129,10 +126,15 @@ const showConfigurationMoreFocusSelector = computed(() => `[data-testid="${ show
     }
 
     .rectangle {
+      display: inline-block;
       max-width: 100%;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+    }
+
+    .no-rows {
+      line-height: 21px;
     }
 }
 </style>

--- a/shell/components/Resource/Detail/Metadata/Rectangle.vue
+++ b/shell/components/Resource/Detail/Metadata/Rectangle.vue
@@ -23,7 +23,9 @@ const props = withDefaults(
 .rectangle {
     border: 1px solid var(--tag-bg);
     border-radius: 4px;
-    padding: 4px;
+    padding: 0 8px;
+    height: 23px;
+    line-height: 23px;
 
     &:not(.outline) {
         background-color: var(--tag-bg);

--- a/shell/components/Resource/Detail/SpacedRow.vue
+++ b/shell/components/Resource/Detail/SpacedRow.vue
@@ -7,7 +7,7 @@
 <style lang="scss" scoped>
 .spaced-row {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));;
   grid-auto-flow: dense;
   grid-gap: 24px;
 }

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -140,7 +140,7 @@ watch(
     </Top>
     <div
       v-if="description"
-      class="bottom description"
+      class="bottom description text-deemphasized"
     >
       {{ description }}
     </div>
@@ -153,7 +153,7 @@ watch(
 
   .badge-state {
     font-size: 16px;
-    margin-left: 4px;
+    margin-left: 12px;
     position: relative;
   }
 

--- a/shell/components/SlideInPanelManager.vue
+++ b/shell/components/SlideInPanelManager.vue
@@ -190,9 +190,8 @@ function closePanel() {
   width: 100vw;
 }
 .slide-in-glass-open {
-  background-color: var(--body-bg);
+  background: var(--overlay-bg);
   display: block;
-  opacity: 0.5;
 }
 
 .slide-in {

--- a/shell/components/formatter/PodImages.vue
+++ b/shell/components/formatter/PodImages.vue
@@ -56,7 +56,7 @@ export default {
 
 <template>
   <span class="formatter-pod-images">
-    <span>{{ mainImage }}</span><br>
+    <span v-clean-tooltip.bottom="mainImage">{{ mainImage }}</span><br>
     <span
       v-if="images.length-1>0"
       v-clean-tooltip.bottom="imageLabels"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixing the issues outlined here:
<img width="1424" height="955" alt="image" src="https://github.com/user-attachments/assets/710b0c4e-6198-4b36-a226-fdae15759123" />

<img width="1393" height="1003" alt="image" src="https://github.com/user-attachments/assets/030c0091-1df0-4c4d-b4fc-669c81b75c97" />

Some overlap with the above screenshot but here was the original fix requests.

> e.g the overlay for the drawer should've been dark, not white; the labels and annotations do not stretch for full width, they embrace the content and have a max-width + I believe the heigh is off a bit; the 'view labels' and 'view annotations' links are not styled correctly, they should be blue; the 'image' value in the meta column for the 1st screenshot breaks format + the shade of grey used on the labels in the 1st meta column is too light; the badge in the page title is too close to the title itself; etc)


### Technical notes summary
Just style and template changes

### Areas or cases that should be tested
Shown in the outline and the video

### Screenshot/Video

https://github.com/user-attachments/assets/e3b84637-571e-4ccc-961f-87da7a388cbe


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
