### PR TITLE
Fleet dashboard Card errors not fixed height, height adapted to the row

### DIFF
--- a/shell/components/fleet/dashboard/ResourceCard.vue
+++ b/shell/components/fleet/dashboard/ResourceCard.vue
@@ -170,6 +170,7 @@ export default {
 <style lang="scss" scoped>
   .dashboard-resource-card {
     margin: 1px;
+    height: 100%;
   }
 
   .icon-lg {

--- a/shell/components/fleet/dashboard/ResourceCardSummary.vue
+++ b/shell/components/fleet/dashboard/ResourceCardSummary.vue
@@ -89,7 +89,7 @@ export default {
       >
         <span
           v-clean-tooltip="value.stateDescription"
-          class="label wrap-text fixed-height"
+          class="label wrap-text"
           :class="{ 'text-error' : value.stateObj.error }"
         >
           {{ value.stateDescription }}

--- a/shell/components/fleet/dashboard/ResourceCardSummary.vue
+++ b/shell/components/fleet/dashboard/ResourceCardSummary.vue
@@ -192,8 +192,4 @@ export default {
     -webkit-line-clamp: 5;
     -webkit-box-orient: vertical;
   }
-
-  .fixed-height {
-    height: 80px;
-  }
 </style>


### PR DESCRIPTION
### Summary
Fixes:
- Card error text doesn't have a fixed height
- The cards take 100% of height, adapting to the maximum height in their row (max of 5 lines of error message).

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
