### PR TITLE
Guard against DOM events in modal close method

### DIFF
--- a/shell/components/PromptModal.vue
+++ b/shell/components/PromptModal.vue
@@ -92,7 +92,12 @@ export default {
       }
 
       this.errors = [];
-      this.$store.commit('action-menu/togglePromptModal', data);
+
+      // Guard against events that can be implicitly passed by components
+      const modalData = data instanceof Event ? undefined : data;
+
+      this.$store.commit('action-menu/togglePromptModal', modalData);
+
       if (this.backgroundClosing) {
         this.backgroundClosing();
       }

--- a/shell/dialog/MoveNamespaceDialog.vue
+++ b/shell/dialog/MoveNamespaceDialog.vue
@@ -121,7 +121,7 @@ export default {
     <template #actions>
       <button
         class="btn role-secondary"
-        @click="close(undefined)"
+        @click="close"
       >
         {{ t('generic.cancel') }}
       </button>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This guards against DOM events from being used when they are implicitly passed to the PromptModal close method. 

Fixes #14716 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Pass `undefined` if a DOM event has been passed to the PrompModal close method

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

DOM events are implicitly passed as an argument when listening to events in Vue (:click="close"). This change ensures that we filter out any DOM events and supply `undefined` when one is encountered. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

MoveNamespaceDialog.vue will be the proof that this works properly. All other modals that might be implicitly passing a DOM event will be fixed as well. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

@aalves08 and myself have independently reviewed each instance of the close event used for modals and dialogs and haven't encountered this pattern in any other places. 

The Harvester issue in #14605 looks to be different, but warrants a good look as well.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
