### PR TITLE
Watch `value` to ensure that Certificate hosts and secretName update in DOM

### DIFF
--- a/shell/edit/networking.k8s.io.ingress/Certificate.vue
+++ b/shell/edit/networking.k8s.io.ingress/Certificate.vue
@@ -35,12 +35,15 @@ export default {
       defaultCert,
       hosts,
       secretName,
+      secretVal: DEFAULT_CERT_VALUE,
     };
   },
   watch: {
     value(newVal) {
       this.hosts = newVal.hosts;
-    }
+      this.secretName = newVal.secretName;
+      this.secretVal = this.secretName === null ? DEFAULT_CERT_VALUE : this.secretName;
+    },
   },
   computed: {
     certsWithDefault() {
@@ -64,7 +67,7 @@ export default {
     update() {
       const out = { hosts: this.hosts };
 
-      out.secretName = this.secretName;
+      out.secretName = this.secretVal;
 
       if (out.secretName === DEFAULT_CERT_VALUE) {
         out.secretName = null;
@@ -73,7 +76,7 @@ export default {
       this.$emit('update:value', out);
     },
     onSecretInput(e) {
-      this.secretName = e && typeof e === 'object' ? e.label : e;
+      this.secretVal = e && typeof e === 'object' ? e.label : e;
       this.update();
     },
     onHostsInput(e) {
@@ -91,7 +94,7 @@ export default {
   >
     <div class="col span-6">
       <LabeledSelect
-        v-model:value="secretName"
+        v-model:value="secretVal"
         class="secret-name"
         :options="certsWithDefault"
         :label="t('ingress.certificates.certificate.label')"

--- a/shell/edit/networking.k8s.io.ingress/Certificate.vue
+++ b/shell/edit/networking.k8s.io.ingress/Certificate.vue
@@ -37,6 +37,11 @@ export default {
       secretName,
     };
   },
+  watch: {
+    value(newVal) {
+      this.hosts = newVal.hosts;
+    }
+  },
   computed: {
     certsWithDefault() {
       return [this.defaultCert, ...this.certs.map((c) => ({ label: c, value: c }))];


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This is a follow-up to provide a more targeted approach after the revert in #14742.

Fixes #14404
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

> 🗒️ Note: `secretVal` was added to the local state for `Certificate.vue`
> 
> Default Ingress Controller Certificate was unable to be selected when updating `secretName` in the watcher - this happens because we set `secretName` to null in the `update` method if the default ingress controller certificate method is selected. Based on this logic, `null` and the default value are the same. This change means that the default value is selected on first render, but the end result should be the same: a value of `null` for `secretName`. 

We need to watch changes to `value` in `Certificate.vue` in order to ensure that the component triggers changes - without an ID to properly track changes in ArrayList, the watcher helps to ensure that updates are reactive to deletes in the array.  

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Adding and removing Certificates: Service Discovery => Ingresses => Create

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
