### PR TITLE
clean up stale helm version in rancher ui about page

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -383,7 +383,6 @@ about:
     component: Component
     version: Version
     cli: CLI
-    helm: Helm
     machine: Machine
     rancher: Rancher
     releaseNotes: 'View release notes'

--- a/shell/config/settings.ts
+++ b/shell/config/settings.ts
@@ -31,7 +31,6 @@ export const SETTING = {
   VERSION_RANCHER: 'server-version',
   VERSION_CLI:     'cli-version',
   VERSION_MACHINE: 'machine-version',
-  VERSION_HELM:    'helm-version',
   CLI_URL:         {
     DARWIN:  'cli-url-darwin',
     WINDOWS: 'cli-url-windows',

--- a/shell/pages/about.vue
+++ b/shell/pages/about.vue
@@ -38,9 +38,6 @@ export default {
     cliVersion() {
       return this.settings.find((s) => s.id === SETTING.VERSION_CLI);
     },
-    helmVersion() {
-      return this.settings.find((s) => s.id === SETTING.VERSION_HELM);
-    },
     dockerMachineVersion() {
       return this.settings.find((s) => s.id === SETTING.VERSION_MACHINE);
     },
@@ -151,19 +148,6 @@ export default {
             {{ appName }} {{ t("about.versions.cli") }}
           </a>
         </td><td>{{ cliVersion.value }}</td>
-      </tr>
-      <tr v-if="helmVersion">
-        <td>
-          <a
-            href="https://github.com/rancher/helm"
-            target="_blank"
-            rel="nofollow noopener noreferrer"
-            role="link"
-            :aria-label="t('about.versions.githubRepo', {name: t(`about.versions.helm`) })"
-          >
-            {{ t("about.versions.helm") }}
-          </a>
-        </td><td>{{ helmVersion.value }}</td>
       </tr>
       <tr v-if="dockerMachineVersion">
         <td>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/14758
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The Rancher "About" page currently displays Helm v2.16.8-rancher2, which is misleading.

As per official documentation, Helm v2 support was deprecated in Rancher v2.7 and fully removed in v2.9. We’ve also dropped all [backend](https://github.com/rancher/rancher/pull/47661/commits/356f6c38e9c0a4f5dc111c3c1d193862fe70e585#diff-c55d1ee74f32cd4b9eeeceaec981a180f52e761acb158a5b0b0e088c7725c9ca) use of Helm v2/v3 customization logic as of v2.11.


### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
![image](https://github.com/user-attachments/assets/a77f5911-d533-4c91-bc32-9bb14dfd8170)

![image](https://github.com/user-attachments/assets/c9fd655a-2ebb-432d-ac57-72c5a56bbad4)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
