### PR TITLE
fix bug with empty space above side menu

### DIFF
--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -226,7 +226,10 @@ export default {
     class="accordion"
     :class="{[`depth-${depth}`]: true, 'expanded': isExpanded, 'has-children': hasChildren, 'group-highlight': isGroupActive }"
   >
-    <div class="accordion-item">
+    <div
+      v-if="showHeader || (!onlyHasOverview && canCollapse)"
+      class="accordion-item"
+    >
       <div
         v-if="showHeader"
         class="header"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14762 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix bug with empty space above side menu by adding missing `v-if` conditions so that it won't render an empty `div`

**Before**
<img width="720" height="349" alt="Image" src="https://github.com/user-attachments/assets/462a9153-51d0-40df-8c71-30774560c699" />

**After**
<img width="2268" height="1321" alt="Screenshot 2025-07-10 at 15 05 33" src="https://github.com/user-attachments/assets/33c9dd70-8d45-4cb7-9e27-d6066b8bc866" />


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Navigate to Continuous Delivery --> Dashboard
make sure that blank menu is not present there

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
