### PR TITLE
remove overflow-x: hidden from legacy masthead

### DIFF
--- a/shell/components/ResourceDetail/Masthead/legacy.vue
+++ b/shell/components/ResourceDetail/Masthead/legacy.vue
@@ -645,10 +645,10 @@ export default {
 
     h1 {
       margin: 0 0 0 -5px;
-      overflow-x: hidden;
       display: flex;
       flex-direction: row;
       align-items: center;
+      overflow: hidden;
 
       .masthead-resource-title {
         text-overflow: ellipsis;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14741 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This reverts a change made in https://github.com/rancher/dashboard/pull/13123 -- `overflow` was changed to `overflow-x` to  correct an issue with focus state styling. Going back to the commit before #13123 I can see the display issue with focus state, but reverting `overflow-x` to `overflow` does _not_ appear to reintroduce the issue.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
**each of these should verified on ff and chrome**

- Navigate to users and auth->auth providers->amazon cognito and verify that the title is on one line and doesn't have a scroll bar
- Verify that the focus state looks correct when the masthead resource type is a link (not applicable to auth providers). To see the older masthead being altered by this PR in a resource with a link, navigate to a resource detail view and append a legacy query param, eg `.../dashboard/c/local/explorer/namespace/default?legacy=true`
- Also verify that resource names that exceed the width of the page are truncated with an ellipsis. Projects may have very long names so that's a good test option.



### Screenshot/Video

https://github.com/user-attachments/assets/c8326645-1f94-4831-aa39-39ebbf82f3c7

<img width="1250" height="479" alt="Screenshot 2025-07-10 at 1 38 19 PM" src="https://github.com/user-attachments/assets/0a122b5e-27da-4f98-8d0b-d4fa77d9005b" />
<img width="1236" height="218" alt="Screenshot 2025-07-10 at 1 38 30 PM" src="https://github.com/user-attachments/assets/ff7fac5b-5a87-4640-8c38-eeb55c375476" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
