### PR TITLE
Auth Providers: Add search_using_service_account field

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -607,6 +607,8 @@ authConfig:
     starttls:
       label: Start TLS
       tip: Upgrades non-encrypted connections by wrapping with TLS during the connection process. Can not be used in conjunction with TLS.
+    searchUsingServiceAccount: 
+      label: Enable Service Account Search
     tls: TLS
     userEnabledAttribute: User Enabled Attribute
     userMemberAttribute: User Member Attribute

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -609,6 +609,7 @@ authConfig:
       tip: Upgrades non-encrypted connections by wrapping with TLS during the connection process. Can not be used in conjunction with TLS.
     searchUsingServiceAccount: 
       label: Enable Service Account Search
+      tip: When enabled, Rancher will use the service account instead of the user account to search for users and groups.
     tls: TLS
     userEnabledAttribute: User Enabled Attribute
     userMemberAttribute: User Member Attribute

--- a/shell/edit/auth/ldap/__tests__/config.test.ts
+++ b/shell/edit/auth/ldap/__tests__/config.test.ts
@@ -41,4 +41,11 @@ describe('lDAP config', () => {
     expect(userLoginFilter.element.value).toBe(expectedValue);
     expect(wrapper.vm.model.userLoginFilter).toBeUndefined();
   });
+
+  it('should display searchUsingServiceAccount checkbox', () => {
+    const wrapper = mount(LDAPConfig);
+    const checkbox = wrapper.find('[data-testid="searchUsingServiceAccount"]');
+
+    expect(checkbox).toBeDefined();
+  });
 });

--- a/shell/edit/auth/ldap/__tests__/config.test.ts
+++ b/shell/edit/auth/ldap/__tests__/config.test.ts
@@ -42,8 +42,15 @@ describe('lDAP config', () => {
     expect(wrapper.vm.model.userLoginFilter).toBeUndefined();
   });
 
-  it('should display searchUsingServiceAccount checkbox', () => {
-    const wrapper = mount(LDAPConfig);
+  it.each([
+    'openldap', 'freeipa'
+  ])('should display searchUsingServiceAccount checkbox if type %p', (type) => {
+    const wrapper = mount(LDAPConfig, {
+      propsData: {
+        value: {},
+        type,
+      }
+    });
     const checkbox = wrapper.find('[data-testid="searchUsingServiceAccount"]');
 
     expect(checkbox).toBeDefined();

--- a/shell/edit/auth/ldap/config.vue
+++ b/shell/edit/auth/ldap/config.vue
@@ -245,6 +245,7 @@ export default {
           data-testid="searchUsingServiceAccount"
           class="full-height"
           :label="t('authConfig.ldap.searchUsingServiceAccount.label')"
+          :tooltip="t('authConfig.ldap.searchUsingServiceAccount.tip')"
         />
       </div>
     </div>

--- a/shell/edit/auth/ldap/config.vue
+++ b/shell/edit/auth/ldap/config.vue
@@ -226,6 +226,18 @@ export default {
         />
       </div>
     </div>
+
+    <div class="row mb-20">
+      <div class="col">
+        <Checkbox
+          v-model:value="model.searchUsingServiceAccount"
+          :mode="mode"
+          class="full-height"
+          :label="t('authConfig.ldap.searchUsingServiceAccount.label')"
+        />
+      </div>
+    </div>
+
     <div class="row mb-20">
       <div class="col span-6">
         <LabeledInput

--- a/shell/edit/auth/ldap/config.vue
+++ b/shell/edit/auth/ldap/config.vue
@@ -11,6 +11,8 @@ const DEFAULT_TLS_PORT = 636;
 
 export const SHIBBOLETH = 'shibboleth';
 export const OKTA = 'okta';
+export const OPEN_LDAP = 'openldap';
+export const FREE_IPA = 'freeipa';
 
 export default {
   emits: ['update:value'],
@@ -227,7 +229,10 @@ export default {
       </div>
     </div>
 
-    <div class="row mb-20">
+    <div
+      v-if="type === OPEN_LDAP || type === FREE_IPA"
+      class="row mb-20"
+    >
       <div class="col">
         <Checkbox
           v-model:value="model.searchUsingServiceAccount"

--- a/shell/edit/auth/ldap/config.vue
+++ b/shell/edit/auth/ldap/config.vue
@@ -232,6 +232,7 @@ export default {
         <Checkbox
           v-model:value="model.searchUsingServiceAccount"
           :mode="mode"
+          data-testid="searchUsingServiceAccount"
           class="full-height"
           :label="t('authConfig.ldap.searchUsingServiceAccount.label')"
         />

--- a/shell/edit/auth/ldap/config.vue
+++ b/shell/edit/auth/ldap/config.vue
@@ -66,6 +66,11 @@ export default {
     // Does the auth provider support LDAP for search in addition to SAML?
     isSamlProvider() {
       return this.type === SHIBBOLETH || this.type === OKTA;
+    },
+
+    // Allow to enable user search just for these providers
+    isSearchAllowed() {
+      return this.type === OPEN_LDAP || this.type === FREE_IPA;
     }
   },
 
@@ -230,7 +235,7 @@ export default {
     </div>
 
     <div
-      v-if="type === OPEN_LDAP || type === FREE_IPA"
+      v-if="isSearchAllowed"
       class="row mb-20"
     >
       <div class="col">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This re-introduces PR #13223, which was reverted via #13860. This change is ready to go for 2.12. 

Fixes #12871
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

Added checkbox with field `searchUsingServiceAccount` only if `type` is `openldap` or `freeipa`.

### Technical notes summary

- Added checkbox and i18n
- Created new unit test for the view to ensure the checkbox

### Areas or cases that should be tested

- Auth provider configuration with OpenLDAP, search "Setting up an OpenLDAP Auth Provider on Rancher Dashboard for testing" in Confluence if needed
- Member search on Cluster member configuration

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

Configuration checkbox

<img width="1904" alt="Screenshot 2025-01-28 at 20 05 55" src="https://github.com/user-attachments/assets/e886637d-c16d-4a28-b3f7-a08b6c23d226" />

Payload submission

<img width="1313" alt="Screenshot 2025-01-28 at 19 48 43" src="https://github.com/user-attachments/assets/086f7395-dd30-43ed-964c-ca6405f1a98e" />

User search

<img width="1452" alt="Screenshot 2025-01-28 at 20 03 36" src="https://github.com/user-attachments/assets/66002970-e97f-4cf6-82ed-b881345d5f8e" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
