### PR TITLE
Decoupled Show Advanced from the checkbox in Registries

### DIFF
--- a/cypress/e2e/po/components/registries-tab.po.ts
+++ b/cypress/e2e/po/components/registries-tab.po.ts
@@ -13,8 +13,12 @@ export default class RegistriesTabPo extends ComponentPo {
     return new CheckboxInputPo('[data-testid="registries-enable-checkbox"]');
   }
 
+  showAdvanced() {
+    return this.self().find('[data-testid="registries-advanced-section"]');
+  }
+
   clickShowAdvanced(): void {
-    this.self().find('[data-testid="registries-advanced-section"]').click();
+    this.showAdvanced().click();
   }
 
   advancedToggle() {

--- a/cypress/e2e/tests/pages/manager/registries.spec.ts
+++ b/cypress/e2e/tests/pages/manager/registries.spec.ts
@@ -25,6 +25,31 @@ describe('Registries for RKE2', { tags: ['@manager', '@adminUser'] }, () => {
     });
   });
 
+  it('11135: Show Advanced should be decoupled from Enable cluster scoped container registry ... checkbox', () => {
+    const clusterList = new ClusterManagerListPagePo();
+    const createCustomClusterPage = new ClusterManagerCreateRke2CustomPagePo();
+
+    clusterList.goTo();
+
+    clusterList.checkIsCurrentPage();
+    clusterList.createCluster();
+
+    createCustomClusterPage.waitForPage();
+
+    createCustomClusterPage.selectCustom(0);
+
+    // navigate to Registries tab
+    createCustomClusterPage.clusterConfigurationTabs().clickTabWithSelector('#registry');
+    // enable registry
+    createCustomClusterPage.registries().enableRegistryCheckbox().set();
+    createCustomClusterPage.registries().enableRegistryCheckbox().isChecked();
+    createCustomClusterPage.registries().showAdvanced().should('be.visible');
+    // disable registry
+    createCustomClusterPage.registries().enableRegistryCheckbox().set();
+    createCustomClusterPage.registries().enableRegistryCheckbox().isUnchecked();
+    createCustomClusterPage.registries().showAdvanced().should('be.visible');
+  });
+
   it('HTTP Basic Auth: Should send the correct payload to the server', function() {
     const clusterList = new ClusterManagerListPagePo();
     const createCustomClusterPage = new ClusterManagerCreateRke2CustomPagePo();

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1838,12 +1838,12 @@ export default {
 
       const hasMirrorsOrAuthConfig = Object.keys(regs.configs).length > 0 || Object.keys(regs.mirrors).length > 0;
 
-      if (this.registryHost || registrySecret || hasMirrorsOrAuthConfig) {
+      if (this.registryHost || registrySecret) {
         this.showCustomRegistryInput = true;
+      }
 
-        if (hasMirrorsOrAuthConfig) {
-          this.showCustomRegistryAdvancedInput = true;
-        }
+      if (hasMirrorsOrAuthConfig) {
+        this.showCustomRegistryAdvancedInput = true;
       }
     },
 

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/registries/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/registries/index.vue
@@ -78,7 +78,6 @@ export default {
     <div class="row">
       <Checkbox
         :value="showCustomRegistryInput"
-        class="mb-20"
         :label="t('cluster.privateRegistry.label')"
         data-testid="registries-enable-checkbox"
         @update:value="$emit('custom-registry-changed', $event)"
@@ -86,7 +85,7 @@ export default {
     </div>
     <div
       v-if="showCustomRegistryInput"
-      class="row"
+      class="row mt-20"
     >
       <div class="col span-6">
         <LabeledInput
@@ -114,7 +113,6 @@ export default {
       </div>
     </div>
     <div
-      v-if="showCustomRegistryInput"
       class="row"
     >
       <AdvancedSection


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11134 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Made 'Show Advanced' section independent from the 'Enable cluster scoped container registry ..." checkbox

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
I've checked with Hostbusters and these sections are independent of each other.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Cluster management -> any RKE2/Custom cluster -> Registries
Show advanced (and area hidden under it) should always be there, independently from 'Enable cluster scoped container registry ..." checkbox

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1387" height="883" alt="Screenshot 2025-07-10 at 5 14 34 PM" src="https://github.com/user-attachments/assets/ffd21aa2-87af-470c-bf51-216e49bb3cb6" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
