### PR TITLE
Certificate.vue: Initialize secretVal if `value.secretName` has data

### DIFF
--- a/shell/edit/networking.k8s.io.ingress/Certificate.vue
+++ b/shell/edit/networking.k8s.io.ingress/Certificate.vue
@@ -35,7 +35,7 @@ export default {
       defaultCert,
       hosts,
       secretName,
-      secretVal: DEFAULT_CERT_VALUE,
+      secretVal: this.value.secretName ?? DEFAULT_CERT_VALUE,
     };
   },
   watch: {

--- a/shell/edit/networking.k8s.io.ingress/__tests__/Certificate.test.ts
+++ b/shell/edit/networking.k8s.io.ingress/__tests__/Certificate.test.ts
@@ -1,0 +1,37 @@
+import { shallowMount } from '@vue/test-utils';
+import Certificate from '../Certificate.vue';
+
+const DEFAULT_CERT_VALUE = '__[[DEFAULT_CERT]]__';
+
+const createWrapper = (propsData = {}) => {
+  return shallowMount(Certificate, { propsData });
+};
+
+describe('networking.k8s.io.ingress/Certificate.vue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('initializes with default values', () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.vm.hosts).toStrictEqual(['']);
+    expect(wrapper.vm.secretVal).toStrictEqual(DEFAULT_CERT_VALUE);
+    expect(wrapper.vm.secretName).toStrictEqual(DEFAULT_CERT_VALUE);
+  });
+
+  it('initializes with provided props', () => {
+    const value = { hosts: ['host1', 'host2'], secretName: 'some-secret' };
+    const certs = ['cert1', 'cert2'];
+    const rules = { host: ['rule1'] };
+    const wrapper = createWrapper({
+      value, certs, rules
+    });
+
+    expect(wrapper.vm.hosts).toStrictEqual(['host1', 'host2']);
+    expect(wrapper.vm.secretVal).toStrictEqual('some-secret');
+    expect(wrapper.vm.secretName).toStrictEqual('some-secret');
+    expect(wrapper.vm.certs).toStrictEqual(certs);
+    expect(wrapper.vm.rules).toStrictEqual(rules);
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves an issue with displaying the correct value for Certificate - Secret Name when editing Ingress certificates.

Fixes #14404
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Initialize `secretVal` if `value.secretName` has data
- Unit test changes to assert that defaults are set correctly

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Regression was introduced via #14755

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Editing Ingress certificates that don't contain a default value for Certificate - Secret Name.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Ingress certificates

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before

<img width="1419" height="1108" alt="image" src="https://github.com/user-attachments/assets/ed6859cc-dd68-4f73-96f4-341eeb0b43eb" />

#### After

<img width="1419" height="1108" alt="image" src="https://github.com/user-attachments/assets/9b413df9-f918-4c44-8229-dfca02f589aa" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
