### PR TITLE
Remove complex init logic from ingress data props

### DIFF
--- a/shell/edit/networking.k8s.io.ingress/Certificate.vue
+++ b/shell/edit/networking.k8s.io.ingress/Certificate.vue
@@ -27,7 +27,7 @@ export default {
   data() {
     return {
       hosts:      this.value?.hosts ?? [''],
-      secretName: this.value?.secretName ?? DEFAULT_CERT_VALUE,
+      secretName: this.value?.secretName === undefined ? DEFAULT_CERT_VALUE : this.value?.secretName,
       secretVal:  this.value?.secretName ?? DEFAULT_CERT_VALUE,
     };
   },

--- a/shell/edit/networking.k8s.io.ingress/Certificate.vue
+++ b/shell/edit/networking.k8s.io.ingress/Certificate.vue
@@ -25,17 +25,14 @@ export default {
     }
   },
   data() {
-    const defaultCert = {
-      label: this.t('ingress.certificates.defaultCertLabel'),
-      value: DEFAULT_CERT_VALUE,
-    };
-    const { hosts = [''], secretName = defaultCert.value } = this.value;
-
     return {
-      defaultCert,
-      hosts,
-      secretName,
-      secretVal: this.value.secretName ?? DEFAULT_CERT_VALUE,
+      defaultCert: {
+        label: this.t('ingress.certificates.defaultCertLabel'),
+        value: DEFAULT_CERT_VALUE,
+      },
+      hosts:      this.value?.hosts ?? [''],
+      secretName: this.value?.secretName ?? DEFAULT_CERT_VALUE,
+      secretVal:  this.value?.secretName ?? DEFAULT_CERT_VALUE,
     };
   },
   watch: {

--- a/shell/edit/networking.k8s.io.ingress/Certificate.vue
+++ b/shell/edit/networking.k8s.io.ingress/Certificate.vue
@@ -26,10 +26,6 @@ export default {
   },
   data() {
     return {
-      defaultCert: {
-        label: this.t('ingress.certificates.defaultCertLabel'),
-        value: DEFAULT_CERT_VALUE,
-      },
       hosts:      this.value?.hosts ?? [''],
       secretName: this.value?.secretName ?? DEFAULT_CERT_VALUE,
       secretVal:  this.value?.secretName ?? DEFAULT_CERT_VALUE,
@@ -44,7 +40,12 @@ export default {
   },
   computed: {
     certsWithDefault() {
-      return [this.defaultCert, ...this.certs.map((c) => ({ label: c, value: c }))];
+      const defaultCert = {
+        label: this.t('ingress.certificates.defaultCertLabel'),
+        value: DEFAULT_CERT_VALUE,
+      };
+
+      return [defaultCert, ...this.certs.map((c) => ({ label: c, value: c }))];
     },
     certificateStatus() {
       const isValueAnOption = !this.secretName || this.certsWithDefault.find((cert) => this.secretName === cert.value);

--- a/shell/edit/networking.k8s.io.ingress/DefaultBackend.vue
+++ b/shell/edit/networking.k8s.io.ingress/DefaultBackend.vue
@@ -34,11 +34,16 @@ export default {
     }
   },
   data() {
+    return {
+      serviceName: '',
+      servicePort: '',
+    };
+  },
+  created() {
     const backend = get(this.value.spec, this.value.defaultBackendPath);
-    const serviceName = get(backend, this.value.serviceNamePath) || '';
-    const servicePort = get(backend, this.value.servicePortPath) || '';
 
-    return { serviceName, servicePort };
+    this.serviceName = get(backend, this.value.serviceNamePath) || '';
+    this.servicePort = get(backend, this.value.servicePortPath) || '';
   },
   computed: {
     isView() {

--- a/shell/edit/networking.k8s.io.ingress/IngressClass.vue
+++ b/shell/edit/networking.k8s.io.ingress/IngressClass.vue
@@ -23,10 +23,7 @@ export default {
     }
   },
   data() {
-    return { ingressClassName: undefined };
-  },
-  created() {
-    this.ingressClassName = get(this.value, 'spec.ingressClassName');
+    return { ingressClassName: get(this.value, 'spec.ingressClassName') };
   },
   computed: {
     ingressClassOptions() {

--- a/shell/edit/networking.k8s.io.ingress/IngressClass.vue
+++ b/shell/edit/networking.k8s.io.ingress/IngressClass.vue
@@ -23,7 +23,10 @@ export default {
     }
   },
   data() {
-    return { ingressClassName: get(this.value, 'spec.ingressClassName') };
+    return { ingressClassName: undefined };
+  },
+  created() {
+    this.ingressClassName = get(this.value, 'spec.ingressClassName');
   },
   computed: {
     ingressClassOptions() {

--- a/shell/edit/networking.k8s.io.ingress/Rule.vue
+++ b/shell/edit/networking.k8s.io.ingress/Rule.vue
@@ -32,12 +32,9 @@ export default {
     }
   },
   data() {
-    const { host = '', http = {} } = this.value;
-    const { paths = [{ id: random32(1) }] } = http;
-
     return {
-      host,
-      paths,
+      host:     this.value?.host ?? '',
+      paths:    this.value?.http?.paths ?? [{ id: random32(1) }],
       ruleMode: this.value.asDefault ? 'asDefault' : 'setHost',
     };
   },

--- a/shell/edit/networking.k8s.io.ingress/RulePath.vue
+++ b/shell/edit/networking.k8s.io.ingress/RulePath.vue
@@ -34,13 +34,17 @@ export default {
       type: Object,
     }
   },
+  setup() {
+    const pathTypes = [
+      'Prefix',
+      'Exact',
+      'ImplementationSpecific'
+    ];
+
+    return { pathTypes };
+  },
   data() {
     return {
-      pathTypes: [
-        'Prefix',
-        'Exact',
-        'ImplementationSpecific'
-      ],
       serviceName: undefined,
       servicePort: undefined,
       pathType:    this.value.pathType,

--- a/shell/edit/networking.k8s.io.ingress/RulePath.vue
+++ b/shell/edit/networking.k8s.io.ingress/RulePath.vue
@@ -35,23 +35,16 @@ export default {
     }
   },
   data() {
-    const pathTypes = [
-      'Prefix',
-      'Exact',
-      'ImplementationSpecific'
-    ];
-
-    set(this.value, 'backend', this.value.backend || {});
-    set(this.value, 'path', this.value.path || '');
-    set(this.value, 'pathType', this.value.pathType || pathTypes[0]);
-    set(this.value.backend, this.ingress.serviceNamePath, get(this.value.backend, this.ingress.serviceNamePath) || '');
-    set(this.value.backend, this.ingress.servicePortPath, get(this.value.backend, this.ingress.servicePortPath) || '');
-
-    const serviceName = get(this.value.backend, this.ingress.serviceNamePath);
-    const servicePort = get(this.value.backend, this.ingress.servicePortPath);
-
     return {
-      pathTypes, serviceName, servicePort, pathType: this.value.pathType, path: this.value.path
+      pathTypes: [
+        'Prefix',
+        'Exact',
+        'ImplementationSpecific'
+      ],
+      serviceName: undefined,
+      servicePort: undefined,
+      pathType:    this.value.pathType,
+      path:        this.value.path,
     };
   },
   computed: {
@@ -77,6 +70,15 @@ export default {
   created() {
     this.queueUpdate = debounce(this.update, 500);
     this.queueUpdatePathTypeAndPath = debounce(this.updatePathTypeAndPath, 500);
+
+    set(this.value, 'backend', this.value.backend || {});
+    set(this.value, 'path', this.value.path || '');
+    set(this.value, 'pathType', this.value.pathType || this.pathTypes[0]);
+    set(this.value.backend, this.ingress.serviceNamePath, get(this.value.backend, this.ingress.serviceNamePath) || '');
+    set(this.value.backend, this.ingress.servicePortPath, get(this.value.backend, this.ingress.servicePortPath) || '');
+
+    this.serviceName = get(this.value.backend, this.ingress.serviceNamePath);
+    this.servicePort = get(this.value.backend, this.ingress.servicePortPath);
   },
   methods: {
     update() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This refactors form components that contain initialization logic in their data props so that they use patterns that are more idiomatic to Vue.

Fixes #14777
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Refactor data props in 
   - shell/edit/networking.k8s.io.ingress/Certificate.vue
   - shell/edit/networking.k8s.io.ingress/DefaultBackend.vue
   - shell/edit/networking.k8s.io.ingress/IngressClass.vue
   - shell/edit/networking.k8s.io.ingress/Rule.vue
   - shell/edit/networking.k8s.io.ingress/RulePath.vue

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The most complex changes in this PR involve shifting initialization logic outside of `data()` and into the `created()` hook. We will want to validate that the initialization order remains correct in cases where the `created()` hook already contains logic.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Assert that CRUD operations behave as expected for

- shell/edit/networking.k8s.io.ingress/Certificate.vue
- shell/edit/networking.k8s.io.ingress/DefaultBackend.vue
- shell/edit/networking.k8s.io.ingress/IngressClass.vue
- shell/edit/networking.k8s.io.ingress/Rule.vue
- shell/edit/networking.k8s.io.ingress/RulePath.vue

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Same as the areas that should be tested.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
