### PR TITLE
Clean up dead code in Certificate.vue and add additional unit tests

### DIFF
--- a/shell/edit/networking.k8s.io.ingress/Certificate.vue
+++ b/shell/edit/networking.k8s.io.ingress/Certificate.vue
@@ -83,10 +83,7 @@ export default {
 </script>
 
 <template>
-  <div
-    class="cert row"
-    @update:value="update"
-  >
+  <div class="cert row">
     <div class="col span-6">
       <LabeledSelect
         v-model:value="secretVal"

--- a/shell/edit/networking.k8s.io.ingress/Certificate.vue
+++ b/shell/edit/networking.k8s.io.ingress/Certificate.vue
@@ -59,11 +59,6 @@ export default {
     },
   },
   methods: {
-    addHost(ev) {
-      ev.preventDefault();
-      this.hosts.push('');
-      this.update();
-    },
     update() {
       const out = { hosts: this.hosts };
 

--- a/shell/edit/networking.k8s.io.ingress/__tests__/Certificate.test.ts
+++ b/shell/edit/networking.k8s.io.ingress/__tests__/Certificate.test.ts
@@ -34,4 +34,132 @@ describe('networking.k8s.io.ingress/Certificate.vue', () => {
     expect(wrapper.vm.certs).toStrictEqual(certs);
     expect(wrapper.vm.rules).toStrictEqual(rules);
   });
+
+  it('emits update:value when update is called', async() => {
+    const wrapper = createWrapper();
+
+    wrapper.vm.hosts = ['host1'];
+    wrapper.vm.secretVal = 'cert1';
+    wrapper.vm.update();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted('update:value')).toBeTruthy();
+    expect(wrapper.emitted('update:value')[0][0]).toStrictEqual({
+      hosts:      ['host1'],
+      secretName: 'cert1',
+    });
+  });
+
+  it('sets secretName to null when secretVal is DEFAULT_CERT_VALUE', async() => {
+    const wrapper = createWrapper();
+
+    wrapper.vm.hosts = ['host1'];
+    wrapper.vm.secretVal = DEFAULT_CERT_VALUE;
+    wrapper.vm.update();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted('update:value')[0][0].secretName).toBeNull();
+  });
+
+  it('updates secretVal when onSecretInput is called with an object', async() => {
+    const wrapper = createWrapper();
+    const newCert = { label: 'cert1', value: 'cert1' };
+
+    wrapper.vm.onSecretInput(newCert);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.secretVal).toStrictEqual('cert1');
+    expect(wrapper.emitted('update:value')).toBeTruthy();
+    expect(wrapper.emitted('update:value')[0][0].secretName).toStrictEqual('cert1');
+  });
+
+  it('updates secretVal when onSecretInput is called with a string', async() => {
+    const wrapper = createWrapper();
+
+    wrapper.vm.onSecretInput('cert1');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.secretVal).toStrictEqual('cert1');
+    expect(wrapper.emitted('update:value')).toBeTruthy();
+    expect(wrapper.emitted('update:value')[0][0].secretName).toStrictEqual('cert1');
+  });
+
+  it('updates hosts when onHostsInput is called', async() => {
+    const wrapper = createWrapper();
+
+    wrapper.vm.onHostsInput(['host1', 'host2']);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.hosts).toStrictEqual(['host1', 'host2']);
+    expect(wrapper.emitted('update:value')).toBeTruthy();
+    expect(wrapper.emitted('update:value')[0][0].hosts).toStrictEqual(['host1', 'host2']);
+  });
+
+  it('computes certsWithDefault correctly', () => {
+    const certs = ['cert1', 'cert2'];
+    const wrapper = createWrapper({ certs });
+    const expectedCerts = [
+      { label: '%ingress.certificates.defaultCertLabel%', value: DEFAULT_CERT_VALUE },
+      { label: 'cert1', value: 'cert1' },
+      { label: 'cert2', value: 'cert2' },
+    ];
+
+    expect(wrapper.vm.certsWithDefault).toStrictEqual(expectedCerts);
+  });
+
+  it('returns warning status for non-existent certificate', () => {
+    const wrapper = createWrapper({
+      certs: ['cert1', 'cert2'],
+      value: { hosts: [''], secretName: 'non-existent-cert' },
+    });
+
+    expect(wrapper.vm.certificateStatus).toStrictEqual('warning');
+  });
+
+  it('returns null status for existing certificate', () => {
+    const wrapper = createWrapper({
+      certs: ['cert1', 'cert2'],
+      value: { hosts: [''], secretName: 'cert1' },
+    });
+
+    expect(wrapper.vm.certificateStatus).toBeNull();
+  });
+
+  it('returns null status for default certificate', () => {
+    const wrapper = createWrapper({
+      certs: ['cert1', 'cert2'],
+      value: { hosts: [''], secretName: null },
+    });
+
+    expect(wrapper.vm.certificateStatus).toBeNull();
+  });
+
+  it('returns correct tooltip for non-existent certificate', () => {
+    const wrapper = createWrapper({
+      certs: ['cert1', 'cert2'],
+      value: { hosts: [''], secretName: 'non-existent-cert' },
+    });
+
+    expect(wrapper.vm.certificateTooltip).toStrictEqual('%ingress.certificates.certificate.doesntExist%');
+  });
+
+  it('returns null tooltip for existing certificate', () => {
+    const wrapper = createWrapper({
+      certs: ['cert1', 'cert2'],
+      value: { hosts: [''], secretName: 'cert1' },
+    });
+
+    expect(wrapper.vm.certificateTooltip).toBeNull();
+  });
+
+  it('watches value prop changes', async() => {
+    const wrapper = createWrapper({ value: { hosts: ['host1'], secretName: 'cert1' } });
+
+    await wrapper.setProps({ value: { hosts: ['host2'], secretName: 'cert2' } });
+    expect(wrapper.vm.hosts).toStrictEqual(['host2']);
+    expect(wrapper.vm.secretVal).toStrictEqual('cert2');
+    expect(wrapper.vm.secretName).toStrictEqual('cert2');
+  });
+
+  it('handles null secretName in value prop', async() => {
+    const wrapper = createWrapper({ value: { hosts: ['host1'], secretName: null } });
+
+    expect(wrapper.vm.secretVal).toStrictEqual(DEFAULT_CERT_VALUE);
+    expect(wrapper.vm.secretName).toBeNull();
+  });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This is a follow-up to PRs #14755 and #14784 to address some issues that I noted in Certificate.vue during development - adding test coverage and removing dead code from the component.

Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Remove unused `addHost()` method
- Remove unused `@update:value` event listener 
- Add additional unit tests to improve the coverage of Certificate.vue

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

`addHost()` is unused.

`@update:value` does not belong on a div and is not listening to any events. 

Adding test coverage helps to prevent regressions in the future. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Navigate to Local Cluster Explorer => Service Discovery => Ingresses
- Click on Create
- Click on the Certificates Tab and click Create

Adding, updating, and deleting certificates should behave as they did before.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

The removal of `addHost()` could break some parent component that was invoking the method directly from the child. I did not find any suggestion that this was happening in Dashboard.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
