### PR TITLE
adjust main workflow to be able to create a PR instead of committing directly to a given branch

### DIFF
--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -148,7 +148,7 @@ jobs:
         name: Commit Changes and push to a branch
         run: |
           git checkout -b sync-${{ env.NOW }}
-          git add ./{assets,charts,extensions,icons,index.yaml}
+          git add ./{assets,charts,extensions,index.yaml}
           git commit -a -m "Sync extensions ${{ env.NOW }}"
           git push origin sync-${{ env.NOW }}
 

--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           git checkout -b sync-${{ env.NOW }}
           git add ./{assets,charts,extensions,index.yaml}
-          git commit -a -m "Sync extensions ${{ env.NOW }}"
+          git commit -a -m "Merging extension ${{ inputs.tagged_release }} ${{ env.NOW }}"
           git push origin sync-${{ env.NOW }}
 
       - if: inputs.create_pr == 'true'
@@ -157,7 +157,7 @@ jobs:
         run: |
           # Create the PR using the GitHub CLI
           pr_number=$(gh pr create \
-            --title "Create PR for extension sync: ${{ env.NOW }}" \
+            --title "Create PR for extension ${{ inputs.tagged_release }} merge: ${{ env.NOW }}" \
             --body "This PR was automatically created by a GitHub Action." \
             --base main \
             --head sync-${{ env.NOW }} \

--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -12,6 +12,9 @@ on:
       is_test:
         required: false
         type: string
+      create_pr:
+        required: false
+        type: string
       test_ext_repo:
         required: false
         type: string
@@ -136,7 +139,40 @@ jobs:
         with:
           name: charts
 
-      - name: Commit build
+      # this is if we want to create a PR instead of push directly to a branch
+      - if: inputs.create_pr == 'true'
+        name: Generate branch name based on date and time
+        run: echo "NOW=$(date +'%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV
+
+      - if: inputs.create_pr == 'true'
+        name: Commit Changes and push to a branch
+        run: |
+          git checkout -b sync-${{ env.NOW }}
+          git add ./{assets,charts,extensions,icons,index.yaml}
+          git commit -a -m "Sync extensions ${{ env.NOW }}"
+          git push origin sync-${{ env.NOW }}
+
+      - if: inputs.create_pr == 'true'
+        name: Create Pull Request
+        run: |
+          # Create the PR using the GitHub CLI
+          pr_number=$(gh pr create \
+            --title "Create PR for extension sync: ${{ env.NOW }}" \
+            --body "This PR was automatically created by a GitHub Action." \
+            --base main \
+            --head sync-${{ env.NOW }} \
+            --fill \
+            --repo ${{ github.repository }} | awk '{print $NF}') # Get the PR URL and Extract the last element (the PR number)
+
+          # Check if pr_number is empty (creation failed)
+          if [ -z "$pr_number" ]; then
+            echo "Failed to create PR."
+            exit 1
+          fi
+      # end of PR creation
+
+      - if: inputs.create_pr != 'true'
+        name: Commit build
         run: |
           git add ./{assets,charts,extensions,index.yaml}
           git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14761
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- adjust main workflow to be able to create a PR instead of committing directly to a given branch

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This is based on the work done with this PR + the change https://github.com/aalves08/ui-plugin-examples/blob/main/.github/workflows/build-extension-charts.yml where I've added the new input `create_pr` along with changing the branch for testing. The latest workflow run yielded https://github.com/aalves08/ui-plugin-examples/actions/runs/16270065373/job/45935202787 (failing because I am missing a github env var) + https://github.com/rancher/ui-plugin-examples/pull/68 where we can see the PR created (at least it provided me the link for it because it failed on the github env var part.

The only concern I've got is: https://github.com/rancher/ui-plugin-examples/pull/68/files#diff-ed4387ee079107e573999863e8f35e5d64c1c531468f963b2f8e389351792a04 where there's an overwrite of some annotations 🤔  can't exactly put my finger where and why this comes from, but it's not the main `index.yaml`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
