### PR TITLE
Use fake timers in LiveDate unit tests

### DIFF
--- a/shell/components/formatter/__tests__/LiveDate.test.ts
+++ b/shell/components/formatter/__tests__/LiveDate.test.ts
@@ -16,6 +16,15 @@ const defaultMock = {
 };
 
 describe('component: LiveDate', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2025-07-10T10:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('should show a dash if no date is provided', () => {
     const wrapper = mount(LiveDate as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, { global: { mocks: defaultMock } });
     const element = wrapper.find('span');
@@ -55,8 +64,7 @@ describe('component: LiveDate', () => {
     let element = wrapper.find('span');
 
     expect(element.text()).toContain('Just now');
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    await wrapper.vm.liveUpdate(Date.now());
+    await wrapper.vm.liveUpdate(Date.now() + 1000);
 
     element = wrapper.find('span');
     expect(element.text()).toContain('1 %unit.sec%');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This uses jest fake timers and sets a system time for the LiveDate unit tests.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

While rare, there are scenarios where using the actual system time can fail the LiveDate unit test[^1] - these failures can occur if a test takes too long, or runs at an inopportune time. Making use of fake timers allows the LiveData tests to be deterministic.

[^1]: Example of LiveDate failure in CI: https://github.com/rancher/dashboard/actions/runs/16271213959/job/45939063987

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- LiveDate unit test should pass

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- LiveDate unit test should pass

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
