### PR TITLE
Harvester machine config fix

### DIFF
--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -18,6 +18,7 @@ import { Checkbox } from '@components/Form/Checkbox';
 import { Banner } from '@components/Banner';
 import { clone, get } from '@shell/utils/object';
 import { uniq, removeObject } from '@shell/utils/array';
+import paginationUtils from '@shell/utils/pagination-utils';
 
 import { _CREATE, _VIEW } from '@shell/config/query-params';
 
@@ -133,8 +134,9 @@ export default {
 
       if (clusterId) {
         let configMapsUrl = `${ url }/${ CONFIG_MAP }s`;
+        const harvesterClusterVaiEnabled = await paginationUtils.isDownstreamSteveCacheEnabled({ dispatch: this.$store.dispatch }, clusterId);
 
-        if (this.$store.getters[`cluster/paginationEnabled`](CONFIG_MAP)) {
+        if (harvesterClusterVaiEnabled && this.$store.getters[`cluster/paginationEnabled`](CONFIG_MAP)) {
           const pagination = new FilterArgs({
             filters: [
               PaginationParamFilter.createMultipleFields([


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11549
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Fix issue where vai filters to a downstream cluster with vai disabled fails
- At some point harvester will bump to 2.12.0 which will then have it enabled. Until then revert back to the old way

### Areas or cases that should be tested
- spin up a harvester cluster and in Advanced / Cloud Configuration Templates create one User and one Network 
- import a harvester cluster into rancher
- create (in cluster manager) a harvester cluster --> advanced
- user and data drop downs should contain the templates above

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
