### PR TITLE
Implement CRD logic for SCC registration offline

### DIFF
--- a/pkg/rancher-prime/config/constants.ts
+++ b/pkg/rancher-prime/config/constants.ts
@@ -10,3 +10,5 @@ export const REGISTRATION_NAMESPACE = `cattle-scc-system`;
 export const REGISTRATION_SECRET = `scc-registration`;
 export const REGISTRATION_RESOURCE_NAME = 'scc.cattle.io.registration';
 export const REGISTRATION_LABEL = `scc.cattle.io/scc-hash`;
+export const REGISTRATION_REQUEST_PREFIX = `offline-request-`;
+export const REGISTRATION_REQUEST_FILENAME = 'rancher-offline-registration-request.json';

--- a/pkg/rancher-prime/pages/Registration.vue
+++ b/pkg/rancher-prime/pages/Registration.vue
@@ -170,7 +170,7 @@ onMounted(async() => {
             :action-label="t('registration.offline.button.register.label')"
             data-testid="registration-offline-cta"
             :disabled="isRegistered || isRegistering"
-            :currentPhase="'waiting'"
+            :currentPhase="isRegisteringOffline ? 'waiting' : 'success'"
           />
         </div>
 

--- a/pkg/rancher-prime/pages/Registration.vue
+++ b/pkg/rancher-prime/pages/Registration.vue
@@ -180,6 +180,7 @@ onMounted(async() => {
             class="role-primary mt-20"
             :label="t('registration.offline.button.register.label')"
             :disabled="isRegistered || isRegistering"
+            accept="image/*,.cert"
             data-testid="registration-offline-cta"
             @selected="registerOffline"
           />

--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -318,7 +318,7 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
    * Get the registration request from the secret data
    * @param request PartialSecret containing the request data
    */
-  const getRegistrationRequest = (request: PartialSecret | null): string | null => request?.data?.request ?? null;
+  const getRegistrationRequest = (request: PartialSecret | null): string | null => request?.data?.request ? atob(request?.data?.request) : null;
 
   /**
    * Map registration to the displayed format

--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -489,12 +489,12 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
         // Get resource with matching hash
         const hash = secretHash.value;
         const resource = await fetchFn(hash);
-        const newHash = resource?.metadata?.labels[REGISTRATION_LABEL];
+        const newHash: string = resource?.metadata?.labels[REGISTRATION_LABEL];
 
         const passExtraConditions = (!extraConditionFn || extraConditionFn(resource)); // Run further conditions, default none
-        const isHashChanged = ((originalHash && !newHash) ||
-          (!originalHash && newHash) ||
-          (originalHash && newHash && originalHash !== newHash)); // Ensure hash has changed
+        const isHashChanged: boolean = (!!originalHash && !newHash) ||
+          (!originalHash && !!newHash) ||
+          (!!originalHash && !!newHash && originalHash !== newHash); // Ensure hash has changed
 
         if (passExtraConditions && isHashChanged) {
           clearInterval(interval);

--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -318,7 +318,7 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
    * @param hash current registration hash
    */
   const findRegistration = async(hash: string | null): Promise<PartialRegistration | undefined> => {
-    const registrations: PartialRegistration[] = await store.dispatch('management/findAll', { type: REGISTRATION_RESOURCE_NAME });
+    const registrations: PartialRegistration[] = await store.dispatch('management/findAll', { type: REGISTRATION_RESOURCE_NAME }) || [];
     const registration = registrations.find((registration) => registration.metadata?.labels[REGISTRATION_LABEL] === hash &&
       !isRegistrationOfflineProgress(registration) &&
       isRegistrationCompleted(registration)
@@ -332,7 +332,7 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
    * @param hash current registration hash
    */
   const findOfflineRequest = async(hash: string | null): Promise<PartialSecret | null> => {
-    const secrets: PartialSecret[] = await store.dispatch('management/findAll', { type: SECRET });
+    const secrets: PartialSecret[] = await store.dispatch('management/findAll', { type: SECRET }) || [];
     const request = secrets.find((secret) => secret.metadata?.namespace === REGISTRATION_NAMESPACE &&
       secret.metadata?.name.startsWith(REGISTRATION_REQUEST_PREFIX)) ?? null;
 
@@ -395,7 +395,7 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
    * Get unique secret code with hardcoded namespace and name
    */
   const getSecret = async(): Promise<PartialSecret | null> => {
-    const secrets: PartialSecret[] = await store.dispatch('management/findAll', { type: SECRET });
+    const secrets: PartialSecret[] = await store.dispatch('management/findAll', { type: SECRET }) || [];
 
     return secrets.find((secret) => secret.metadata?.namespace === REGISTRATION_NAMESPACE &&
       secret.metadata?.name === REGISTRATION_SECRET) ?? null;

--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -466,8 +466,9 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
    */
   const initRegistration = async() => {
     secret.value = await getSecret();
-    registrationCode.value = regCode.value;
-
+    if (secret.value?.data?.registrationType && atob(secret.value.data.registrationType) === 'online') {
+      registrationCode.value = regCode.value;
+    }
     registrationStatus.value = await getRegistration();
   };
 

--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -309,11 +309,13 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
    * @param registration
    * @returns
    */
-  const isCompleteException = (registration: PartialRegistration): boolean => {
+  const isRegistrationCompleted = (registration: PartialRegistration): boolean => {
     const lastCondition = registration.status?.conditions[registration.status?.conditions.length - 1];
+    const isError = lastCondition.type === 'RegistrationActivated' && lastCondition.status === 'False';
+    const isError2 = lastCondition.type === 'Failure' && lastCondition.status === 'True';
+    const isComplete = lastCondition.type === 'Done' && lastCondition.status === 'True';
 
-    return (lastCondition.type === 'RegistrationActivated' && lastCondition.status === 'False') ||
-      (lastCondition.type === 'Done' && lastCondition.status === 'True');
+    return isError || isError2 || isComplete;
   };
 
   /**
@@ -324,7 +326,7 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
     const registrations: PartialRegistration[] = await store.dispatch('management/findAll', { type: REGISTRATION_RESOURCE_NAME });
     const registration = registrations.find((registration) => registration.metadata?.labels[REGISTRATION_LABEL] === hash &&
       !isRegistrationOfflineException(registration) &&
-      isCompleteException(registration)
+      isRegistrationCompleted(registration)
     );
 
     return registration;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14675
Fixes #14814
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

- Added offline implementation (#14675)
- Fixed issue with online registration glitch due latest condition of registration still in status `In Progress` (#14814)
- Updated condition specification of complete 


### Technical notes summary

- Added further unit tests:
  - initialization
  - download
- Code cleanup

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video


https://github.com/user-attachments/assets/ff0f0e9a-1f11-4150-a29f-1286b1dc0e65



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
