### PR TITLE
Adding the Show Configuration action to all resource availableActions

### DIFF
--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -283,6 +283,9 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
   });
 
   it('can disable/enable a repository', function() {
+    // The context menu can slightly clip at the top of the screen. This ensures it's visible.
+    cy.viewport(1280, 720);
+
     // create repo
     ChartRepositoriesPagePo.navTo();
     repositoriesPage.waitForPage();

--- a/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
@@ -81,7 +81,6 @@ describe('Roles Templates', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
   describe('Roles', () => {
     beforeEach(() => {
       cy.login();
-      cy.viewport(1280, 720);
     });
 
     it('can create a Global Role template', () => {
@@ -296,7 +295,7 @@ describe('Roles Templates', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
 
       const actionMenu = detailPage.detail().openMastheadActionMenu();
 
-      actionMenu.clickMenuItem(4);
+      actionMenu.clickMenuItem(5);
 
       const promptRemove = new PromptRemove();
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@aws-sdk/client-kms": "3.8.1",
     "@novnc/novnc": "1.2.0",
     "@popperjs/core": "2.11.8",
-    "@rancher/icons": "2.0.37",
+    "@rancher/icons": "2.0.38",
     "@vee-validate/zod": "4.15.0",
     "ansi_up": "5.0.0",
     "axios": "1.9.0",

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -8217,6 +8217,7 @@ action:
   runNow: Run Now
   suspend: Suspend
   resume: Resume
+  showConfiguration: Show Configuration
 
 unit:
   sec: secs

--- a/shell/components/Drawer/ResourceDetailDrawer/__tests__/composables.test.ts
+++ b/shell/components/Drawer/ResourceDetailDrawer/__tests__/composables.test.ts
@@ -1,7 +1,6 @@
-import { useDefaultConfigTabProps, useDefaultYamlTabProps, useResourceDetailDrawer } from '@shell/components/Drawer/ResourceDetailDrawer/composables';
+import { useDefaultConfigTabProps, useDefaultYamlTabProps } from '@shell/components/Drawer/ResourceDetailDrawer/composables';
 import * as helpers from '@shell/components/Drawer/ResourceDetailDrawer/helpers';
 import * as vuex from 'vuex';
-import * as drawer from '@shell/composables/drawer';
 
 jest.mock('@shell/components/Drawer/ResourceDetailDrawer/helpers');
 jest.mock('vuex');
@@ -77,30 +76,6 @@ describe('composables: ResourceDetailDrawer', () => {
       expect(importEditSpy).toHaveBeenCalledWith(resource.type);
       expect(props?.component).toStrictEqual(editComponent);
       expect(props?.resource).toStrictEqual(resource);
-    });
-  });
-
-  describe('useResourceDetailDrawer', () => {
-    it('should create a wrapper that passes that appropriate properties to the drawer methods', () => {
-      const openSpy = jest.fn();
-      const closeSpy = jest.fn();
-      const selector = '.selector';
-      const useDrawerSpy = jest.spyOn(drawer, 'useDrawer').mockImplementation(() => ({ open: openSpy, close: closeSpy }));
-      const resourceDetailDrawer = useResourceDetailDrawer();
-
-      resourceDetailDrawer.openResourceDetailDrawer(resource, selector);
-
-      expect(useDrawerSpy).toHaveBeenCalledTimes(1);
-      expect(openSpy).toHaveBeenCalledWith({ name: 'ResourceDetailDrawer' }, selector, {
-        resource,
-        onClose:            closeSpy,
-        width:              '73%',
-        // We want this to be full viewport height top to bottom
-        height:             '100vh',
-        top:                '0',
-        'z-index':          101, // We want this to be above the main side menu
-        closeOnRouteChange: ['name', 'params', 'query']
-      });
     });
   });
 });

--- a/shell/components/Drawer/ResourceDetailDrawer/composables.ts
+++ b/shell/components/Drawer/ResourceDetailDrawer/composables.ts
@@ -1,30 +1,7 @@
-import ResourceDetailDrawer from '@shell/components/Drawer/ResourceDetailDrawer/index.vue';
 import { Props as YamlTabProps } from '@shell/components/Drawer/ResourceDetailDrawer/YamlTab.vue';
 import { Props as ConfigTabProps } from '@shell/components/Drawer/ResourceDetailDrawer/ConfigTab.vue';
 import { useStore } from 'vuex';
-import { useDrawer } from '@shell/composables/drawer';
 import { getYaml } from '@shell/components/Drawer/ResourceDetailDrawer/helpers';
-
-export function useResourceDetailDrawer() {
-  const { open, close } = useDrawer();
-
-  const openResourceDetailDrawer = (resource: any, returnFocusSelector: string) => {
-    open(ResourceDetailDrawer,
-      returnFocusSelector,
-      {
-        resource,
-        onClose:            close,
-        width:              '73%',
-        // We want this to be full viewport height top to bottom
-        height:             '100vh',
-        top:                '0',
-        'z-index':          101, // We want this to be above the main side menu
-        closeOnRouteChange: ['name', 'params', 'query'] // We want to ignore hash changes, tables in extensions can trigger the drawer to close while opening
-      });
-  };
-
-  return { openResourceDetailDrawer };
-}
 
 export async function useDefaultYamlTabProps(resource: any): Promise<YamlTabProps> {
   const yaml = await getYaml(resource);

--- a/shell/components/Resource/Detail/Metadata/__tests__/composables.test.ts
+++ b/shell/components/Resource/Detail/Metadata/__tests__/composables.test.ts
@@ -2,16 +2,7 @@ import { useDefaultMetadataForLegacyPagesProps } from '@shell/components/Resourc
 import * as IdentifyingFields from '@shell/components/Resource/Detail/Metadata/IdentifyingInformation/identifying-fields';
 import { computed } from 'vue';
 
-const mockDrawer = { openResourceDetailDrawer: jest.fn() };
-
 jest.mock('@shell/components/Resource/Detail/Metadata/IdentifyingInformation/identifying-fields');
-jest.mock('@shell/components/Drawer/ResourceDetailDrawer/composables', () => {
-  return {
-    useResourceDetailDrawer() {
-      return mockDrawer;
-    }
-  };
-});
 
 describe('composables: Metadata/composables', () => {
   beforeEach(() => {
@@ -28,9 +19,10 @@ describe('composables: Metadata/composables', () => {
 
     it('should filter out undefined identifyingInformation', () => {
       const resource = {
-        type:        'RESOURCE',
-        annotations: { annotation: 'ANNOTATION' },
-        labels:      { label: 'LABEL' }
+        type:              'RESOURCE',
+        annotations:       { annotation: 'ANNOTATION' },
+        labels:            { label: 'LABEL' },
+        showConfiguration: jest.fn()
       };
       const result = useDefaultMetadataForLegacyPagesProps(resource);
 
@@ -39,7 +31,7 @@ describe('composables: Metadata/composables', () => {
       expect(result.value.annotations).toStrictEqual([{ key: 'annotation', value: resource.annotations.annotation }]);
       expect(result.value.labels).toStrictEqual([{ key: 'label', value: resource.labels.label }]);
       expect(result.value.identifyingInformation).toHaveLength(0);
-      expect(mockDrawer.openResourceDetailDrawer).toHaveBeenCalledTimes(1);
+      expect(resource.showConfiguration).toHaveBeenCalledTimes(1);
     });
 
     it('should fill identifyingInformation', () => {
@@ -51,9 +43,10 @@ describe('composables: Metadata/composables', () => {
       useResourceDetailsSpy.mockReturnValue(computed(() => [{ label: 'RESOURCE_DETAILS' }]));
 
       const resource = {
-        type:        'RESOURCE',
-        annotations: { annotation: 'ANNOTATION' },
-        labels:      { label: 'LABEL' }
+        type:              'RESOURCE',
+        annotations:       { annotation: 'ANNOTATION' },
+        labels:            { label: 'LABEL' },
+        showConfiguration: jest.fn()
       };
       const result = useDefaultMetadataForLegacyPagesProps(resource);
 
@@ -69,7 +62,7 @@ describe('composables: Metadata/composables', () => {
         { label: 'CREATED_BY' },
         { label: 'RESOURCE_DETAILS' }
       ]);
-      expect(mockDrawer.openResourceDetailDrawer).toHaveBeenCalledTimes(1);
+      expect(resource.showConfiguration).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/shell/components/Resource/Detail/Metadata/composables.ts
+++ b/shell/components/Resource/Detail/Metadata/composables.ts
@@ -3,7 +3,6 @@ import { useDefaultIdentifyingInformation } from '@shell/components/Resource/Det
 import { useDefaultLabels } from '@shell/components/Resource/Detail/Metadata/Labels/composable';
 import { useDefaultAnnotations } from '@shell/components/Resource/Detail/Metadata/Annotations/composable';
 import { computed, toValue, Ref } from 'vue';
-import { useResourceDetailDrawer } from '@shell/components/Drawer/ResourceDetailDrawer/composables';
 import {
   useCreatedBy,
   useLiveDate, useNamespace, useProject, useResourceDetails, useWorkspace
@@ -12,13 +11,13 @@ import {
 export const useBasicMetadata = (resource: any) => {
   const labels = useDefaultLabels(resource);
   const annotations = useDefaultAnnotations(resource);
-  const { openResourceDetailDrawer } = useResourceDetailDrawer();
+  const resourceValue = toValue(resource);
 
   return computed(() => {
     return {
       labels:              labels.value,
       annotations:         annotations.value,
-      onShowConfiguration: (returnFocusSelector: string) => openResourceDetailDrawer(resource, returnFocusSelector)
+      onShowConfiguration: () => resourceValue.showConfiguration()
     };
   });
 };
@@ -29,14 +28,14 @@ export const useDefaultMetadataProps = (resource: any, additionalIdentifyingInfo
 
   const identifyingInformation = computed(() => [...defaultIdentifyingInformation.value, ...(additionalIdentifyingInformationValue || [])]);
   const basicMetaData = useBasicMetadata(resource);
-  const { openResourceDetailDrawer } = useResourceDetailDrawer();
+  const resourceValue = toValue(resource);
 
   return computed(() => {
     return {
       identifyingInformation: identifyingInformation.value,
       labels:                 basicMetaData.value.labels,
       annotations:            basicMetaData.value.annotations,
-      onShowConfiguration:    (returnFocusSelector: string) => openResourceDetailDrawer(resource, returnFocusSelector)
+      onShowConfiguration:    () => resourceValue.showConfiguration()
     };
   });
 };
@@ -48,6 +47,7 @@ export const useDefaultMetadataForLegacyPagesProps = (resource: any) => {
   const namespace = useNamespace(resource);
   const liveDate = useLiveDate(resource);
   const createdBy = useCreatedBy(resource);
+  const resourceValue = toValue(resource);
 
   const identifyingInformation = computed((): IdentifyingInformationRow[] => {
     const defaultInfo = [
@@ -65,14 +65,13 @@ export const useDefaultMetadataForLegacyPagesProps = (resource: any) => {
     return info.filter((info) => typeof info !== 'undefined');
   });
   const basicMetaData = useBasicMetadata(resource);
-  const { openResourceDetailDrawer } = useResourceDetailDrawer();
 
   return computed(() => {
     return {
       identifyingInformation: identifyingInformation.value,
       labels:                 basicMetaData.value.labels,
       annotations:            basicMetaData.value.annotations,
-      onShowConfiguration:    () => openResourceDetailDrawer(resource)
+      onShowConfiguration:    () => resourceValue.showConfiguration()
     };
   });
 };

--- a/shell/components/Resource/Detail/TitleBar/__tests__/composables.test.ts
+++ b/shell/components/Resource/Detail/TitleBar/__tests__/composables.test.ts
@@ -11,20 +11,19 @@ const mockStore = {
   }
 };
 const mockRoute = { params: { cluster: 'CLUSTER' } };
-const mockDrawer = { openResourceDetailDrawer: jest.fn() };
 
 jest.mock('vuex', () => ({ useStore: () => mockStore }));
 jest.mock('vue-router', () => ({ useRoute: () => mockRoute }));
-jest.mock('@shell/components/Drawer/ResourceDetailDrawer/composables', () => ({ useResourceDetailDrawer: () => mockDrawer }));
 
 describe('composables: TitleBar', () => {
   const resource = {
-    nameDisplay:     'RESOURCE_NAME',
-    namespace:       'RESOURCE_NAMESPACE',
-    type:            'RESOURCE_TYPE',
-    stateBackground: 'RESOURCE_STATE_BACKGROUND',
-    stateDisplay:    'RESOURCE_STATE_DISPLAY',
-    description:     'RESOURCE_DESCRIPTION',
+    nameDisplay:       'RESOURCE_NAME',
+    namespace:         'RESOURCE_NAMESPACE',
+    type:              'RESOURCE_TYPE',
+    stateBackground:   'RESOURCE_STATE_BACKGROUND',
+    stateDisplay:      'RESOURCE_STATE_DISPLAY',
+    description:       'RESOURCE_DESCRIPTION',
+    showConfiguration: jest.fn(),
   };
   const labelFor = 'LABEL_FOR';
   const schema = { type: 'SCHEMA' };
@@ -58,6 +57,6 @@ describe('composables: TitleBar', () => {
     expect(props.value.showViewOptions).toStrictEqual(hasGraph);
 
     props.value.onShowConfiguration?.('callback');
-    expect(mockDrawer.openResourceDetailDrawer).toHaveBeenCalledTimes(1);
+    expect(resource.showConfiguration).toHaveBeenCalledTimes(1);
   });
 });

--- a/shell/components/Resource/Detail/TitleBar/composables.ts
+++ b/shell/components/Resource/Detail/TitleBar/composables.ts
@@ -1,4 +1,3 @@
-import { useResourceDetailDrawer } from '@shell/components/Drawer/ResourceDetailDrawer/composables';
 import { TitleBarProps } from '@shell/components/Resource/Detail/TitleBar/index.vue';
 import { computed, Ref, toValue } from 'vue';
 import { useRoute } from 'vue-router';
@@ -7,7 +6,6 @@ import { useStore } from 'vuex';
 export const useDefaultTitleBarProps = (resource: any, resourceSubtype?: Ref<string | undefined>): Ref<TitleBarProps> => {
   const route = useRoute();
   const store = useStore();
-  const { openResourceDetailDrawer } = useResourceDetailDrawer();
   const resourceValue = toValue(resource);
 
   return computed(() => {
@@ -26,7 +24,7 @@ export const useDefaultTitleBarProps = (resource: any, resourceSubtype?: Ref<str
       }
     };
     const hasGraph = !!store.getters['type-map/hasGraph'](resourceValue.type);
-    const onShowConfiguration = resourceValue.disableResourceDetailDrawer ? undefined : (returnFocusSelector: string) => openResourceDetailDrawer(resourceValue, returnFocusSelector);
+    const onShowConfiguration = resourceValue.disableResourceDetailDrawer ? undefined : (returnFocusSelector: string) => resourceValue.showConfiguration(returnFocusSelector);
 
     return {
       resourceTypeLabel,

--- a/shell/models/management.cattle.io.setting.js
+++ b/shell/models/management.cattle.io.setting.js
@@ -68,4 +68,8 @@ export default class Setting extends HybridModel {
       super.goToEdit();
     }
   }
+
+  get disableResourceDetailDrawer() {
+    return true;
+  }
 }

--- a/shell/package.json
+++ b/shell/package.json
@@ -37,7 +37,7 @@
     "@babel/preset-typescript": "7.16.7",
     "@novnc/novnc": "1.2.0",
     "@popperjs/core": "2.11.8",
-    "@rancher/icons": "2.0.37",
+    "@rancher/icons": "2.0.38",
     "@types/is-url": "1.2.30",
     "@types/node": "20.10.8",
     "@types/semver": "^7.5.8",

--- a/shell/utils/dynamic-importer.js
+++ b/shell/utils/dynamic-importer.js
@@ -68,6 +68,14 @@ export function importDialog(name) {
   return defineAsyncComponent(() => import(/* webpackChunkName: "dialog" */ `@shell/dialog/${name}`));
 }
 
+export function importDrawer(name) {
+  if ( !name ) {
+    throw new Error('Name required');
+  }
+
+  return defineAsyncComponent(() => import(/* webpackChunkName: "drawer" */ `@shell/components/Drawer/${name}`));
+}
+
 export function importWindowComponent(name) {
   if ( !name ) {
     throw new Error('Name required');

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -2925,11 +2925,6 @@
   resolved "https://registry.yarnpkg.com/@jsep-plugin/regex/-/regex-1.0.4.tgz#cb2fc423220fa71c609323b9ba7f7d344a755fcc"
   integrity sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==
 
-"@kurkle/color@^0.3.0":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.4.tgz#4d4ff677e1609214fc71c580125ddddd86abcabf"
-  integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
-
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz#4fc56c15c580b9adb7dc3c333a134e540b44bfb1"
@@ -3072,10 +3067,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
-"@rancher/icons@2.0.37":
-  version "2.0.37"
-  resolved "https://registry.yarnpkg.com/@rancher/icons/-/icons-2.0.37.tgz#61dd947009a4a3d27b2e4dca630da05583925744"
-  integrity sha512-T2FqiZraz9yte9tNMCGqIDQVPwXKTAPUTE8eAaQjhOJEbwfk/ttXDIKGYZ9mHApJX6s8JYVXAbRPcgXgc4zKpA==
+"@rancher/icons@2.0.29":
+  version "2.0.29"
+  resolved "https://registry.yarnpkg.com/@rancher/icons/-/icons-2.0.29.tgz#6546d69768c706bebd66bfa73b36aef3d105987a"
+  integrity sha512-qBBqfazS9y5VjV7fJDPNXmxd9AP/2uiE05mKFWP41kpbO+tEb62RnUBXCm14XLeScDZQcOuiAKVHMmvCFzF0BA==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3325,10 +3325,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
-"@rancher/icons@2.0.37":
-  version "2.0.37"
-  resolved "https://registry.yarnpkg.com/@rancher/icons/-/icons-2.0.37.tgz#61dd947009a4a3d27b2e4dca630da05583925744"
-  integrity sha512-T2FqiZraz9yte9tNMCGqIDQVPwXKTAPUTE8eAaQjhOJEbwfk/ttXDIKGYZ9mHApJX6s8JYVXAbRPcgXgc4zKpA==
+"@rancher/icons@2.0.38":
+  version "2.0.38"
+  resolved "https://registry.yarnpkg.com/@rancher/icons/-/icons-2.0.38.tgz#29c86d9af699909070e45c3146325f1d31d1535c"
+  integrity sha512-biVHLVwiuModxOCgM5YhPVwbu9LmZFQAQ1YWlRUiAHyFe7zh3lmw2KWEdg4k0963it1DMKuMve45VWYU5YeaWA==
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
fixes #14824
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
Ultimately composables weren't a good fit for supporting the show configuration action and instead of supporting two versions I replaced the composable with showConfiguration on the reosurce models. This lead to seemingly more code changes but most of it is just moving the code.

### Areas or cases that should be tested
Areas which show action menus for resources

### Areas which could experience regressions
It's a new feature so I don't expect a regression but possibly in the menus.

### Screenshot/Video

Showing that we include the `Show Configuration` action on resources that have an edit config or yaml page available but hide it on the resources that don't.

https://github.com/user-attachments/assets/6224da06-3f69-46a4-bb01-6fe9dbe1642a


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
