### PR TITLE
SCC Offline registration status does not update on complete

### DIFF
--- a/pkg/rancher-prime/pages/registration.composable.test.ts
+++ b/pkg/rancher-prime/pages/registration.composable.test.ts
@@ -230,16 +230,51 @@ describe('registration composable', () => {
       expect(registrationStatus.value).toStrictEqual('registering-offline');
     });
 
-    it.skip('should create a new registration', async() => {
-      const expectation = {};
+    it('should update existing registration', async() => {
+      const hash = 'whatever';
+      const certificate = 'the certificate';
+      const secrets = [{
+        metadata: {
+          namespace: REGISTRATION_NAMESPACE,
+          name:      REGISTRATION_SECRET,
+          labels:    { [REGISTRATION_LABEL]: hash }
+        },
+        data: {},
+        save: () => {},
+      }];
+      const registrations = [{
+        spec:     { mode: 'offline' },
+        metadata: { labels: { [REGISTRATION_LABEL]: hash } },
+        links:    { view: '123' },
+        status:   {
+          activationStatus: { activated: true },
+          conditions:       [
+            {},
+            {},
+            {},
+            {
+              type:   'OfflineActivationDone',
+              status: 'True',
+            },
+          ]
+        },
+      }];
+
+      dispatchSpy = jest.fn()
+        .mockReturnValueOnce(Promise.resolve(/** Ensure namespace */))
+        .mockReturnValueOnce(Promise.resolve(secrets))
+        .mockReturnValueOnce(Promise.resolve(registrations));
       const {
         registerOffline,
         registration,
       } = usePrimeRegistration();
 
-      await registerOffline('');
+      await registerOffline(certificate);
 
-      expect(registration.value).toStrictEqual(expectation);
+      expect(dispatchSpy).toHaveBeenCalledTimes(3);
+      expect(dispatchSpy).toHaveBeenCalledWith('management/find', namespaceRequest);
+      expect(dispatchSpy).toHaveBeenCalledWith('management/findAll', { type: 'scc.cattle.io.registration' });
+      expect(registration.value.active).toStrictEqual(true);
     });
 
     it.skip('should reset registrationCode', async() => {

--- a/pkg/rancher-prime/pages/registration.composable.test.ts
+++ b/pkg/rancher-prime/pages/registration.composable.test.ts
@@ -249,9 +249,7 @@ describe('registration composable', () => {
         status:   {
           activationStatus: { activated: true },
           conditions:       [
-            {},
-            {},
-            {},
+            { type: 'OfflineRequestReady' },
             {
               type:   'OfflineActivationDone',
               status: 'True',

--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -314,7 +314,7 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
     const isError = lastCondition.type === 'RegistrationActivated' && lastCondition.status === 'False';
     const isError2 = lastCondition.type === 'Failure' && lastCondition.status === 'True';
     const isCompleteOnline = mode === 'online' && lastCondition.type === 'Done' && lastCondition.status === 'True';
-    const isCompleteOffline = mode === 'offline' && lastCondition.type === 'OfflineActivationDone' && lastCondition.status === 'True';
+    const isCompleteOffline = mode === 'offline' && registration.status?.conditions.length > 3 && lastCondition.type === 'OfflineActivationDone' && lastCondition.status === 'True';
 
     return isError || isError2 || isCompleteOnline || isCompleteOffline;
   };
@@ -497,8 +497,7 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
         const newHash: string = resource?.metadata?.labels[REGISTRATION_LABEL];
 
         const passExtraConditions = (!extraConditionFn || extraConditionFn(resource)); // Run further conditions, default none
-        const isHashChanged: boolean = (!!originalHash && !newHash) ||
-          (!originalHash && !!newHash) ||
+        const isHashChanged: boolean = (!originalHash && !!newHash) ||
           (!!originalHash && !!newHash && originalHash !== newHash); // Ensure hash has changed
 
         if (passExtraConditions && isHashChanged) {

--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -297,7 +297,8 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
    */
   const isRegistrationOfflineProgress = (registration: PartialRegistration): boolean => {
     const isOffline = registration.spec?.mode === 'offline';
-    const isInProgress = registration.status?.conditions[0]?.type === 'Progressing';
+    const lastCondition = registration.status?.conditions[registration.status?.conditions.length - 1];
+    const isInProgress = lastCondition.type === 'OfflineRequestReady';
     const isActive = registration.status.activationStatus.activated === true;
 
     return isOffline && !isActive && isInProgress;
@@ -314,7 +315,7 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
     const isError = lastCondition.type === 'RegistrationActivated' && lastCondition.status === 'False';
     const isError2 = lastCondition.type === 'Failure' && lastCondition.status === 'True';
     const isCompleteOnline = mode === 'online' && lastCondition.type === 'Done' && lastCondition.status === 'True';
-    const isCompleteOffline = mode === 'offline' && registration.status?.conditions.length > 3 && lastCondition.type === 'OfflineActivationDone' && lastCondition.status === 'True';
+    const isCompleteOffline = mode === 'offline' && lastCondition.type === 'OfflineActivationDone' && lastCondition.status === 'True';
 
     return isError || isError2 || isCompleteOnline || isCompleteOffline;
   };

--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -182,6 +182,8 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
     await ensureNamespace();
     if (!needSecret) {
       await deleteSecret();
+    } else {
+      secret.value = await getSecret();
     }
   };
 
@@ -243,12 +245,12 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
   const registerOffline = async(certificate: string) => {
     registrationStatus.value = 'registering-offline';
     registrationCode.value = null;
+    const originalHash = secretHash.value;
+
     await preRegistration(true);
     offlineRegistrationCertificate.value = certificate ? atob(certificate) : null;
 
     try {
-      const originalHash = secretHash.value;
-
       updateSecret(secret.value, offlineRegistrationCertificate.value);
       registration.value = await pollResource(originalHash, findRegistration, mapRegistration);
       registrationStatus.value = registration.value ? 'registered' : null;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14813
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

Fixed registration to be updated.

### Technical notes summary

- Added unit tests for offline registration
- Ensured secret to be loaded also in registering offline third step

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video


https://github.com/user-attachments/assets/4a825d7e-7cb5-4084-8df8-a592381e91ca



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
