### PR TITLE
Fixed footer inconsistency for different providers

### DIFF
--- a/pkg/eks/components/AccountAccess.vue
+++ b/pkg/eks/components/AccountAccess.vue
@@ -124,7 +124,7 @@ export default defineComponent({
       />
     </div>
     <div
-      class="select-credential-container mb-10"
+      class="select-credential-container"
     >
       <SelectCredential
         :value="credential"

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -27,7 +27,6 @@ import Networking from './Networking.vue';
 import GKENodePoolComponent from './GKENodePool.vue';
 import Config from './Config.vue';
 import Import from './Import.vue';
-
 import {
   DEFAULT_GCP_ZONE, DEFAULT_GCP_SERVICE_ACCOUNT, GKEImageTypes, getGKEMachineTypes, getGKEServiceAccounts
 } from '@shell/components/google/util/gcp';
@@ -718,207 +717,204 @@ export default defineComponent({
     @error="e=>errors=e"
     @finish="save"
   >
-    <div>
-      <AccountAccess
-        v-model:credential="config.googleCredentialSecret"
-        v-model:project="config.projectID"
-        v-model:is-authenticated="isAuthenticated"
+    <AccountAccess
+      v-model:credential="config.googleCredentialSecret"
+      v-model:project="config.projectID"
+      v-model:is-authenticated="isAuthenticated"
+      :mode="mode"
+      @error="e=>errors.push(e)"
+      @cancel-credential="cancelCredential"
+    />
+    <div
+      v-if="isAuthenticated"
+      data-testid="crugke-form"
+    >
+      <Config
+        v-model:kubernetes-version="config.kubernetesVersion"
+        v-model:zone="config.zone"
+        v-model:region="config.region"
+        v-model:locations="config.locations"
+        v-model:default-image-type="defaultImageType"
+        v-model:labels="config.labels"
         :mode="mode"
-        @error="e=>errors.push(e)"
-        @cancel-credential="cancelCredential"
+        :cloud-credential-id="config.googleCredentialSecret"
+        :project-id="config.projectID"
+        :is-new-or-unprovisioned="isNewOrUnprovisioned"
+        :original-version="originalVersion"
+        :cluster-id="normanCluster.id"
+        :cluster-name="normanCluster.name"
+        :cluster-description="normanCluster.description"
+        :rules="{
+          clusterName: fvGetAndReportPathRules('clusterName')
+        }"
+        :is-import="isImport"
+        @update:clusterName="setClusterName"
+        @update:clusterDescription="setClusterDescription"
       />
 
-      <div
-        v-if="isAuthenticated"
-        data-testid="crugke-form"
+      <Accordion
+        v-if="isImport"
+        class="mb-20"
+        :title="t('gke.accordion.import')"
+        :open-initially="true"
       >
-        <Config
-          v-model:kubernetes-version="config.kubernetesVersion"
-          v-model:zone="config.zone"
-          v-model:region="config.region"
-          v-model:locations="config.locations"
-          v-model:default-image-type="defaultImageType"
-          v-model:labels="config.labels"
+        <Import
+          v-model:enable-network-policy="normanCluster.enableNetworkPolicy"
+          :credential="config.googleCredentialSecret"
+          :project="config.projectID"
+          :zone="config.zone"
+          :region="config.region"
           :mode="mode"
-          :cloud-credential-id="config.googleCredentialSecret"
-          :project-id="config.projectID"
-          :is-new-or-unprovisioned="isNewOrUnprovisioned"
-          :original-version="originalVersion"
-          :cluster-id="normanCluster.id"
-          :cluster-name="normanCluster.name"
-          :cluster-description="normanCluster.description"
+          :cluster-name="config.clusterName"
           :rules="{
-            clusterName: fvGetAndReportPathRules('clusterName')
+            importName: fvGetAndReportPathRules('importName')
           }"
-          :is-import="isImport"
-          @update:clusterName="setClusterName"
-          @update:clusterDescription="setClusterDescription"
+          @error="e=>errors.push(e)"
+          @update:clusterName="e=>config.clusterName=e"
         />
+      </Accordion>
 
-        <Accordion
-          v-if="isImport"
+      <template v-else>
+        <div><h3>{{ t('gke.accordion.nodePools') }}</h3></div>
+        <Tabbed
+          ref="pools"
+          :side-tabs="true"
+          :show-tabs-add-remove="mode !== 'view'"
           class="mb-20"
-          :title="t('gke.accordion.import')"
-          :open-initially="true"
+          :use-hash="false"
+          @addTab="addPool($event)"
+          @removeTab="removePool($event)"
         >
-          <Import
-            v-model:enable-network-policy="normanCluster.enableNetworkPolicy"
-            :credential="config.googleCredentialSecret"
-            :project="config.projectID"
-            :zone="config.zone"
-            :region="config.region"
-            :mode="mode"
-            :cluster-name="config.clusterName"
-            :rules="{
-              importName: fvGetAndReportPathRules('importName')
-            }"
-            @error="e=>errors.push(e)"
-            @update:clusterName="e=>config.clusterName=e"
-          />
-        </Accordion>
-
-        <template v-else>
-          <div><h3>{{ t('gke.accordion.nodePools') }}</h3></div>
-          <Tabbed
-            ref="pools"
-            :side-tabs="true"
-            :show-tabs-add-remove="mode !== 'view'"
-            class="mb-20"
-            :use-hash="false"
-            @addTab="addPool($event)"
-            @removeTab="removePool($event)"
+          <Tab
+            v-for="(pool) in nodePools"
+            :key="pool._id"
+            :name="pool._id || pool.name"
+            :label="pool.name || t('gke.notNamed')"
+            :error="pool._minMaxValid===false || pool._nameUnique===false"
           >
-            <Tab
-              v-for="(pool) in nodePools"
-              :key="pool._id"
-              :name="pool._id || pool.name"
-              :label="pool.name || t('gke.notNamed')"
-              :error="pool._minMaxValid===false || pool._nameUnique===false"
-            >
-              <GKENodePoolComponent
-                v-model:version="pool.version"
-                v-model:image-type="pool.config.imageType"
-                v-model:machine-type="pool.config.machineType"
-                v-model:service-account="pool.config.serviceAccount"
-                v-model:disk-type="pool.config.diskType"
-                v-model:disk-size-gb="pool.config.diskSizeGb"
-                v-model:local-ssd-count="pool.config.localSsdCount"
-                v-model:preemptible="pool.config.preemptible"
-                v-model:taints="pool.config.taints"
-                v-model:labels="pool.config.labels"
-                v-model:tags="pool.config.tags"
-                v-model:name="pool.name"
-                v-model:initial-node-count="pool.initialNodeCount"
-                v-model:max-pods-constraint="pool.maxPodsConstraint"
-                v-model:autoscaling="pool.autoscaling.enabled"
-                v-model:min-node-count="pool.autoscaling.minNodeCount"
-                v-model:max-node-count="pool.autoscaling.maxNodeCount"
-                v-model:auto-repair="pool.management.autoRepair"
-                v-model:auto-upgrade="pool.management.autoUpgrade"
-                v-model:oauth-scopes="pool.config.oauthScopes"
-                :rules="{
-                  diskSizeGb: fvGetAndReportPathRules('diskSizeGb'),
-                  initialNodeCount: fvGetAndReportPathRules('initialNodeCount'),
-                  ssdCount: fvGetAndReportPathRules('ssdCount'),
-                  poolName: fvGetAndReportPathRules('poolName'),
-                }"
-                :mode="mode"
-                :cluster-kubernetes-version="config.kubernetesVersion"
-                :machine-type-options="machineTypeOptions"
-                :service-account-options="serviceAccountOptions"
-                :loading-machine-types="loadingMachineTypes"
-                :loading-service-accounts="loadingServiceAccounts"
-                :is-new="pool._isNewOrUnprovisioned"
-              />
-            </Tab>
-          </Tabbed>
-          <Accordion
-            class="mb-20"
-            :title="t('gke.accordion.networking')"
-          >
-            <Networking
-              v-model:kubernetes-version="config.kubernetesVersion"
-              v-model:network="config.network"
-              v-model:subnetwork="config.subnetwork"
-              v-model:create-subnetwork="config.ipAllocationPolicy.createSubnetwork"
-              v-model:use-ip-aliases="config.ipAllocationPolicy.useIpAliases"
-              v-model:network-policy-config="config.clusterAddons.networkPolicyConfig"
-              v-model:enable-network-policy="normanCluster.enableNetworkPolicy"
-              v-model:network-policy-enabled="config.networkPolicyEnabled"
-              v-model:cluster-ipv4-cidr="config.clusterIpv4Cidr"
-              v-model:cluster-secondary-range-name="config.ipAllocationPolicy.clusterSecondaryRangeName"
-              v-model:services-secondary-range-name="config.ipAllocationPolicy.servicesSecondaryRangeName"
-              v-model:cluster-ipv4-cidr-block="config.ipAllocationPolicy.clusterIpv4CidrBlock"
-              v-model:services-ipv4-cidr-block="config.ipAllocationPolicy.servicesIpv4CidrBlock"
-              v-model:node-ipv4-cidr-block="config.ipAllocationPolicy.nodeIpv4CidrBlock"
-              v-model:subnetwork-name="config.ipAllocationPolicy.subnetworkName"
-              v-model:enable-private-endpoint="config.privateClusterConfig.enablePrivateEndpoint"
-              v-model:enable-private-nodes="config.privateClusterConfig.enablePrivateNodes"
-              v-model:master-ipv4-cidr-block="config.privateClusterConfig.masterIpv4CidrBlock"
-              v-model:enable-master-authorized-network="config.masterAuthorizedNetworks.enabled"
-              v-model:master-authorized-network-cidr-blocks="config.masterAuthorizedNetworks.cidrBlocks"
+            <GKENodePoolComponent
+              v-model:version="pool.version"
+              v-model:image-type="pool.config.imageType"
+              v-model:machine-type="pool.config.machineType"
+              v-model:service-account="pool.config.serviceAccount"
+              v-model:disk-type="pool.config.diskType"
+              v-model:disk-size-gb="pool.config.diskSizeGb"
+              v-model:local-ssd-count="pool.config.localSsdCount"
+              v-model:preemptible="pool.config.preemptible"
+              v-model:taints="pool.config.taints"
+              v-model:labels="pool.config.labels"
+              v-model:tags="pool.config.tags"
+              v-model:name="pool.name"
+              v-model:initial-node-count="pool.initialNodeCount"
+              v-model:max-pods-constraint="pool.maxPodsConstraint"
+              v-model:autoscaling="pool.autoscaling.enabled"
+              v-model:min-node-count="pool.autoscaling.minNodeCount"
+              v-model:max-node-count="pool.autoscaling.maxNodeCount"
+              v-model:auto-repair="pool.management.autoRepair"
+              v-model:auto-upgrade="pool.management.autoUpgrade"
+              v-model:oauth-scopes="pool.config.oauthScopes"
               :rules="{
-                masterIpv4CidrBlock: fvGetAndReportPathRules('masterIpv4CidrBlock'),
-                clusterIpv4CidrBlock: fvGetAndReportPathRules('clusterIpv4CidrBlock'),
-                nodeIpv4CidrBlock: fvGetAndReportPathRules('nodeIpv4CidrBlock'),
-                servicesIpv4CidrBlock: fvGetAndReportPathRules('servicesIpv4CidrBlock'),
-                clusterIpv4Cidr: fvGetAndReportPathRules('clusterIpv4Cidr')
+                diskSizeGb: fvGetAndReportPathRules('diskSizeGb'),
+                initialNodeCount: fvGetAndReportPathRules('initialNodeCount'),
+                ssdCount: fvGetAndReportPathRules('ssdCount'),
+                poolName: fvGetAndReportPathRules('poolName'),
               }"
               :mode="mode"
-              :zone="config.zone"
-              :region="config.region"
-              :cloud-credential-id="config.googleCredentialSecret"
-              :project-id="config.projectID"
-              :original-version="originalVersion"
-              :cluster-id="normanCluster.id"
-              :cluster-name="config.clusterName"
-              :is-new-or-unprovisioned="isNewOrUnprovisioned"
+              :cluster-kubernetes-version="config.kubernetesVersion"
+              :machine-type-options="machineTypeOptions"
+              :service-account-options="serviceAccountOptions"
+              :loading-machine-types="loadingMachineTypes"
+              :loading-service-accounts="loadingServiceAccounts"
+              :is-new="pool._isNewOrUnprovisioned"
             />
-          </Accordion>
-          <Accordion
-            class="mb-20"
-            :title="t('gke.accordion.advanced')"
-          >
-            <AdvancedOptions
-              v-model:logging-service="config.loggingService"
-              v-model:monitoring-service="config.monitoringService"
-              v-model:maintenance-window="config.maintenanceWindow"
-              v-model:http-load-balancing="config.clusterAddons.httpLoadBalancing"
-              v-model:horizontal-pod-autoscaling="config.clusterAddons.horizontalPodAutoscaling"
-              v-model:enable-kubernetes-alpha="config.enableKubernetesAlpha"
-              :mode="mode"
-              :is-new-or-unprovisioned="isNewOrUnprovisioned"
-            />
-          </Accordion>
-        </template>
+          </Tab>
+        </Tabbed>
+        <Accordion
+          class="mb-20"
+          :title="t('gke.accordion.networking')"
+        >
+          <Networking
+            v-model:kubernetes-version="config.kubernetesVersion"
+            v-model:network="config.network"
+            v-model:subnetwork="config.subnetwork"
+            v-model:create-subnetwork="config.ipAllocationPolicy.createSubnetwork"
+            v-model:use-ip-aliases="config.ipAllocationPolicy.useIpAliases"
+            v-model:network-policy-config="config.clusterAddons.networkPolicyConfig"
+            v-model:enable-network-policy="normanCluster.enableNetworkPolicy"
+            v-model:network-policy-enabled="config.networkPolicyEnabled"
+            v-model:cluster-ipv4-cidr="config.clusterIpv4Cidr"
+            v-model:cluster-secondary-range-name="config.ipAllocationPolicy.clusterSecondaryRangeName"
+            v-model:services-secondary-range-name="config.ipAllocationPolicy.servicesSecondaryRangeName"
+            v-model:cluster-ipv4-cidr-block="config.ipAllocationPolicy.clusterIpv4CidrBlock"
+            v-model:services-ipv4-cidr-block="config.ipAllocationPolicy.servicesIpv4CidrBlock"
+            v-model:node-ipv4-cidr-block="config.ipAllocationPolicy.nodeIpv4CidrBlock"
+            v-model:subnetwork-name="config.ipAllocationPolicy.subnetworkName"
+            v-model:enable-private-endpoint="config.privateClusterConfig.enablePrivateEndpoint"
+            v-model:enable-private-nodes="config.privateClusterConfig.enablePrivateNodes"
+            v-model:master-ipv4-cidr-block="config.privateClusterConfig.masterIpv4CidrBlock"
+            v-model:enable-master-authorized-network="config.masterAuthorizedNetworks.enabled"
+            v-model:master-authorized-network-cidr-blocks="config.masterAuthorizedNetworks.cidrBlocks"
+            :rules="{
+              masterIpv4CidrBlock: fvGetAndReportPathRules('masterIpv4CidrBlock'),
+              clusterIpv4CidrBlock: fvGetAndReportPathRules('clusterIpv4CidrBlock'),
+              nodeIpv4CidrBlock: fvGetAndReportPathRules('nodeIpv4CidrBlock'),
+              servicesIpv4CidrBlock: fvGetAndReportPathRules('servicesIpv4CidrBlock'),
+              clusterIpv4Cidr: fvGetAndReportPathRules('clusterIpv4Cidr')
+            }"
+            :mode="mode"
+            :zone="config.zone"
+            :region="config.region"
+            :cloud-credential-id="config.googleCredentialSecret"
+            :project-id="config.projectID"
+            :original-version="originalVersion"
+            :cluster-id="normanCluster.id"
+            :cluster-name="config.clusterName"
+            :is-new-or-unprovisioned="isNewOrUnprovisioned"
+          />
+        </Accordion>
+        <Accordion
+          class="mb-20"
+          :title="t('gke.accordion.advanced')"
+        >
+          <AdvancedOptions
+            v-model:logging-service="config.loggingService"
+            v-model:monitoring-service="config.monitoringService"
+            v-model:maintenance-window="config.maintenanceWindow"
+            v-model:http-load-balancing="config.clusterAddons.httpLoadBalancing"
+            v-model:horizontal-pod-autoscaling="config.clusterAddons.horizontalPodAutoscaling"
+            v-model:enable-kubernetes-alpha="config.enableKubernetesAlpha"
+            :mode="mode"
+            :is-new-or-unprovisioned="isNewOrUnprovisioned"
+          />
+        </Accordion>
+      </template>
 
-        <Accordion
-          class="mb-20"
-          :title="t('members.memberRoles')"
+      <Accordion
+        class="mb-20"
+        :title="t('members.memberRoles')"
+      >
+        <Banner
+          v-if="isEdit"
+          color="info"
         >
-          <Banner
-            v-if="isEdit"
-            color="info"
-          >
-            {{ t('cluster.memberRoles.removeMessage') }}
-          </Banner>
-          <ClusterMembershipEditor
-            v-if="canManageMembers"
-            :mode="mode"
-            :parent-id="normanCluster.id ? normanCluster.id : null"
-            @membership-update="onMembershipUpdate"
-          />
-        </Accordion>
-        <Accordion
-          class="mb-20"
-          :title="t('gke.accordion.labels')"
-        >
-          <Labels
-            v-model:value="normanCluster"
-            :mode="mode"
-          />
-        </Accordion>
-      </div>
+          {{ t('cluster.memberRoles.removeMessage') }}
+        </Banner>
+        <ClusterMembershipEditor
+          v-if="canManageMembers"
+          :mode="mode"
+          :parent-id="normanCluster.id ? normanCluster.id : null"
+          @membership-update="onMembershipUpdate"
+        />
+      </Accordion>
+      <Accordion
+        class="mb-20"
+        :title="t('gke.accordion.labels')"
+      >
+        <Labels
+          v-model:value="normanCluster"
+          :mode="mode"
+        />
+      </Accordion>
     </div>
     <template
       v-if="!hasCredential"

--- a/shell/components/google/AccountAccess.vue
+++ b/shell/components/google/AccountAccess.vue
@@ -106,57 +106,55 @@ export default defineComponent({
 </script>
 
 <template>
-  <div>
+  <div
+    :class="{'showing-form': !credential}"
+    class="credential-project"
+  >
     <div
-      :class="{'showing-form': !credential}"
-      class="credential-project"
+      v-show="!!credential"
+      class="project mb-10"
     >
-      <div
-        v-show="!!credential"
-        class="project mb-10"
-      >
-        <LabeledInput
-          :disabled="isAuthenticated"
-          :value="project"
-          label-key="gke.project.label"
-          required
-          @update:value="(val) => $emit('update:project', val.trim())"
-        />
-      </div>
-      <div
-        :class="{'view': isView}"
-        class="select-credential-container mb-10"
-      >
-        <SelectCredential
-          :value="credential"
-          data-testid="crugke-select-credential"
-          :mode="(isView|| isAuthenticated) ? VIEW : CREATE"
-          provider="gcp"
-          :default-on-cancel="true"
-          :showing-form="!credential"
-          class="select-credential"
-          :cancel="()=>$emit('cancel-credential')"
-          @update:value="$emit('update:credential', $event)"
-          @credential-created="parseNewCredential"
-        />
-      </div>
+      <LabeledInput
+        :disabled="isAuthenticated"
+        :value="project"
+        label-key="gke.project.label"
+        required
+        @update:value="(val) => $emit('update:project', val.trim())"
+      />
     </div>
     <div
-      v-if="!isView && !isAuthenticated"
-      class="row mt-10"
+      :class="{'view': isView}"
+      class="select-credential-container"
     >
-      <div
-        v-show="!!credential"
-        class="auth-button-container mb-10"
-      >
-        <AsyncButton
-          :disabled="!credential || !project || isAuthenticated"
-          type="button"
-          class="btn"
-          mode="authenticate"
-          @click="testProjectId"
-        />
-      </div>
+      <SelectCredential
+        :value="credential"
+        data-testid="crugke-select-credential"
+        :mode="(isView|| isAuthenticated) ? VIEW : CREATE"
+        provider="gcp"
+        :default-on-cancel="true"
+        :showing-form="!credential"
+        class="select-credential"
+        :cancel="()=>$emit('cancel-credential')"
+        @update:value="$emit('update:credential', $event)"
+        @credential-created="parseNewCredential"
+      />
+    </div>
+  </div>
+  <div
+    v-if="!isView && !isAuthenticated && !!credential"
+    class="row mt-10"
+  >
+    <div
+      v-show="!!credential"
+      class="auth-button-container mb-10"
+    >
+      <AsyncButton
+        :disabled="!credential || !project || isAuthenticated"
+        type="button"
+        class="btn"
+        mode="authenticate"
+        @click="testProjectId"
+      />
     </div>
   </div>
 </template>

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -858,6 +858,9 @@ export default {
       set(newValue) {
         this.$emit('update:value', newValue);
       }
+    },
+    hideFooter() {
+      return this.needCredential && !this.credential;
     }
   },
 
@@ -2216,7 +2219,10 @@ export default {
       @error="e=>errors.push(e)"
       @cancel-credential="cancelCredential"
     />
-    <div v-else>
+    <div
+      v-else
+      class="authenticated"
+    >
       <SelectCredential
         v-if="needCredential"
         v-model:value="credentialId"
@@ -2610,7 +2616,7 @@ export default {
       />
     </div>
     <template
-      v-if="needCredential && !credentialId"
+      v-if="hideFooter"
       #form-footer
     >
       <div><!-- Hide the outer footer --></div>
@@ -2619,6 +2625,12 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+.authenticated {
+    display:flex;
+    flex-direction: column;
+    flex-grow: 1;
+}
+
 .min-height {
   min-height: 40em;
 }

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2207,17 +2207,15 @@ export default {
         <span v-clean-html="t('cluster.banner.rke2-k3-reprovisioning', {}, true)" />
       </Banner>
     </div>
-    <div v-if="!isAuthenticated">
-      <AccountAccess
-
-        v-model:credential="credential"
-        v-model:project="projectId"
-        v-model:is-authenticated="isAuthenticated"
-        :mode="mode"
-        @error="e=>errors.push(e)"
-        @cancel-credential="cancelCredential"
-      />
-    </div>
+    <AccountAccess
+      v-if="!isAuthenticated"
+      v-model:credential="credential"
+      v-model:project="projectId"
+      v-model:is-authenticated="isAuthenticated"
+      :mode="mode"
+      @error="e=>errors.push(e)"
+      @cancel-credential="cancelCredential"
+    />
     <div v-else>
       <SelectCredential
         v-if="needCredential"

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2207,15 +2207,17 @@ export default {
         <span v-clean-html="t('cluster.banner.rke2-k3-reprovisioning', {}, true)" />
       </Banner>
     </div>
-    <AccountAccess
-      v-if="!isAuthenticated"
-      v-model:credential="credential"
-      v-model:project="projectId"
-      v-model:is-authenticated="isAuthenticated"
-      :mode="mode"
-      @error="e=>errors.push(e)"
-      @cancel-credential="cancelCredential"
-    />
+    <div v-if="!isAuthenticated">
+      <AccountAccess
+
+        v-model:credential="credential"
+        v-model:project="projectId"
+        v-model:is-authenticated="isAuthenticated"
+        :mode="mode"
+        @error="e=>errors.push(e)"
+        @cancel-credential="cancelCredential"
+      />
+    </div>
     <div v-else>
       <SelectCredential
         v-if="needCredential"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13605 
Fixes #14847
<!-- Define findings related to the feature or bug issue. -->
- Placing SelectCredential inside a div made it no longer occupy the whole view, so the footer during credential creation was no longer sticking to the bottom of the page
- Added footer to the authentication step during GCE creation
- Made footers for all credentials the same size

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
While creating and editing clusters (hosted, node-driver or custom) footer should always be present and be at the bottom of the screen. That includes creating new credential 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Creating, viewing and editing clusters could experience unexpected side-effects to styling

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
