### PR TITLE
Fixes an issue where workload yaml editors didn't show errors

### DIFF
--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -20,19 +20,10 @@ export default {
     },
   },
   data() {
-    return { selectedName: null, closedErrorMessages: [] };
+    return { selectedName: null, errors: [] };
   },
-  computed: {
-    ...mapGetters({ t: 'i18n/t' }),
-    errorMessages() {
-      if (!this.type) {
-        return [];
-      }
-
-      return this.fvUnreportedValidationErrors.filter((e) => !this.closedErrorMessages.includes(e));
-    }
-  },
-  methods: {
+  computed: { ...mapGetters({ t: 'i18n/t' }) },
+  methods:  {
     changed(tab) {
       const key = this.idKey;
 
@@ -94,7 +85,7 @@ export default {
       :selected-subtype="type"
       :resource="value"
       :mode="mode"
-      :errors="errorMessages"
+      :errors="errors"
       :done-route="doneRoute"
       :subtypes="workloadSubTypes"
       :apply-hooks="applyHooks"
@@ -102,7 +93,7 @@ export default {
       :errors-map="getErrorsMap(fvUnreportedValidationErrors)"
       @finish="save"
       @select-type="selectType"
-      @error="(_, closedError) => closedErrorMessages.push(closedError)"
+      @error="e=>errors = e"
     >
       <NameNsDescription
         :value="value"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14728
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Areas or cases that should be tested
This issue seems to have been originally created with the fix for https://github.com/rancher/dashboard/issues/11889.

We no longer show the workload/index.vue page so this shouldn't be a problem anymore. Regardless, I did go to `/dashboard/c/local/explorer/workload` and clicked create to verify that the premature errors aren't showing with this change.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
