### PR TITLE
Clean up data props in `networking.k8s.io.networkpolicy`

### DIFF
--- a/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
@@ -47,16 +47,6 @@ export default {
     },
   },
   data() {
-    if (!this.value[TARGET_OPTIONS.IP_BLOCK] &&
-      !this.value[TARGET_OPTIONS.POD_SELECTOR] &&
-      !this.value[TARGET_OPTIONS.NAMESPACE_SELECTOR] &&
-      !this.value[TARGET_OPTIONS.NAMESPACE_AND_POD_SELECTOR]
-    ) {
-      this.$nextTick(() => {
-        this.value[TARGET_OPTIONS.IP_BLOCK] = {};
-      });
-    }
-
     return {
       portOptions:  ['TCP', 'UDP'],
       matchingPods: {
@@ -73,6 +63,17 @@ export default {
       inStore:                this.$store.getters['currentProduct'].inStore,
       debouncedUpdateMatches: debounce(this.updateMatches, 500)
     };
+  },
+  created() {
+    if (!this.value[TARGET_OPTIONS.IP_BLOCK] &&
+      !this.value[TARGET_OPTIONS.POD_SELECTOR] &&
+      !this.value[TARGET_OPTIONS.NAMESPACE_SELECTOR] &&
+      !this.value[TARGET_OPTIONS.NAMESPACE_AND_POD_SELECTOR]
+    ) {
+      this.$nextTick(() => {
+        this.value[TARGET_OPTIONS.IP_BLOCK] = {};
+      });
+    }
   },
   computed: {
     /**

--- a/shell/edit/networking.k8s.io.networkpolicy/PolicyRules.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/PolicyRules.vue
@@ -32,12 +32,10 @@ export default {
       default: undefined
     }
   },
-  data() {
+  created() {
     if (!this.value.spec[this.type]) {
       this.value.spec[this.type] = [];
     }
-
-    return {};
   },
   methods: {
     addPolicyRule() {

--- a/shell/edit/networking.k8s.io.networkpolicy/index.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/index.vue
@@ -47,6 +47,23 @@ export default {
   },
 
   data() {
+    return {
+      POD,
+      matchingPods: {
+        matched: 0,
+        matches: [],
+        none:    true,
+        sample:  null,
+        total:   0,
+      },
+      podTableHeaders: this.$store.getters['type-map/headersFor'](
+        this.$store.getters['cluster/schemaFor'](POD)
+      ),
+      inStore: this.$store.getters['currentProduct'].inStore,
+    };
+  },
+
+  created() {
     if ( !this.value.spec ) {
       this.value['spec'] = {
         policyTypes: [],
@@ -56,23 +73,6 @@ export default {
         }
       };
     }
-
-    const matchingPods = {
-      matched: 0,
-      matches: [],
-      none:    true,
-      sample:  null,
-      total:   0,
-    };
-
-    return {
-      POD,
-      matchingPods,
-      podTableHeaders: this.$store.getters['type-map/headersFor'](
-        this.$store.getters['cluster/schemaFor'](POD)
-      ),
-      inStore: this.$store.getters['currentProduct'].inStore,
-    };
   },
 
   computed: {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This refactors data props that contain initialization logic so that they use patterns that are more idiomatic to Vue.

Fixes #14778 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Refactor data props in
   - shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
   - shell/edit/networking.k8s.io.networkpolicy/PolicyRules.vue
   - shell/edit/networking.k8s.io.networkpolicy/index.vue

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This PR involves shifting initialization logic outside of `data()` and into the `created()` hook.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

CRUD operations for network policy

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

CRUD operations for network policy

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
