### PR TITLE
Clean up data props in `provisioning.cattle.io.cluster`

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -171,7 +171,7 @@ export default {
     this.setAgentConfiguration();
   },
 
-  data() {
+  beforeCreate() {
     if (!this.value.spec.rkeConfig) {
       this.value.spec.rkeConfig = {};
     }
@@ -218,9 +218,9 @@ export default {
     if (!this.value.spec.rkeConfig.machineSelectorConfig?.length) {
       this.value.spec.rkeConfig.machineSelectorConfig = [{ config: {} }];
     }
+  },
 
-    const truncateLimit = this.value.defaultHostnameLengthLimit || 0;
-
+  data() {
     return {
       loadedOnce:                      false,
       lastIdx:                         0,
@@ -257,7 +257,7 @@ export default {
       }],
       harvesterVersionRange:                    {},
       complianceOverride:                       false,
-      truncateLimit,
+      truncateLimit:                            this.value.defaultHostnameLengthLimit || 0,
       busy:                                     false,
       machinePoolValidation:                    {}, // map of validation states for each machine pool
       machinePoolErrors:                        {},
@@ -273,8 +273,7 @@ export default {
       isAuthenticated:                          this.provider !== GOOGLE || this.mode === _EDIT,
       projectId:                                null,
       REGISTRIES_TAB_NAME,
-      labelForAddon
-
+      labelForAddon,
     };
   },
 

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/AgentConfiguration.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/AgentConfiguration.vue
@@ -81,6 +81,14 @@ export default {
   },
 
   data() {
+    return {
+      defaultAffinity: {},
+      affinitySetting: DEFAULT,
+      nodeAffinity:    {}
+    };
+  },
+
+  created() {
     const nodeAffinity = this.value?.overrideAffinity?.nodeAffinity;
     const podAffinity = this.value?.overrideAffinity?.podAffinity;
     const podAntiAffinity = this.value?.overrideAffinity?.podAntiAffinity;
@@ -93,14 +101,8 @@ export default {
       hasAffinityPopulated = true;
     }
 
-    return {
-      defaultAffinity: {},
-      affinitySetting: hasAffinityPopulated ? CUSTOM : DEFAULT,
-      nodeAffinity:    {}
-    };
-  },
+    this.affinitySetting = hasAffinityPopulated ? CUSTOM : DEFAULT;
 
-  created() {
     this.ensureValue();
   },
 

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
@@ -44,23 +44,21 @@ export default {
     },
   },
   data() {
-    let dataConfigRadioValue = DATA_DIR_RADIO_OPTIONS.DEFAULT;
-    let k8sDistroSubDir = DEFAULT_SUBDIRS.K8S_DISTRO_RKE2;
-
+    return {
+      DATA_DIR_RADIO_OPTIONS,
+      dataConfigRadioValue: DATA_DIR_RADIO_OPTIONS.DEFAULT,
+      k8sDistroSubDir:      DEFAULT_SUBDIRS.K8S_DISTRO_RKE2,
+      commonConfig:         '',
+    };
+  },
+  created() {
     if (this.k8sVersion && this.k8sVersion.includes('k3s')) {
-      k8sDistroSubDir = DEFAULT_SUBDIRS.K8S_DISTRO_K3S;
+      this.k8sDistroSubDir = DEFAULT_SUBDIRS.K8S_DISTRO_K3S;
     }
 
     if (this.mode !== _CREATE) {
-      dataConfigRadioValue = DATA_DIR_RADIO_OPTIONS.CUSTOM;
+      this.dataConfigRadioValue = DATA_DIR_RADIO_OPTIONS.CUSTOM;
     }
-
-    return {
-      DATA_DIR_RADIO_OPTIONS,
-      dataConfigRadioValue,
-      k8sDistroSubDir,
-      commonConfig: '',
-    };
   },
   watch: {
     commonConfig(neu) {

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
@@ -89,47 +89,10 @@ export default {
   },
 
   data() {
-    const parseDuration = (duration) => {
-      // The back end stores the timeout in Duration format, for example, "42d31h10m30s".
-      // Here we convert that string to an integer and return the duration as seconds.
-      const splitStr = duration.split(/([a-z])/);
-
-      const durationsAsSeconds = splitStr.reduce((old, neu, idx) => {
-        const parsed = parseInt(neu);
-
-        if ( isNaN(parsed) ) {
-          return old;
-        }
-
-        const interval = splitStr[(idx + 1)];
-
-        switch (interval) {
-        case 'd':
-          old.push(parsed * 24 * 60 * 60);
-          break;
-        case 'h':
-          old.push(parsed * 60 * 60);
-          break;
-        case 'm':
-          old.push(parsed * 60);
-          break;
-        case 's':
-          old.push(parsed);
-          break;
-        default:
-          break;
-        }
-
-        return old;
-      }, []);
-
-      return durationsAsSeconds.reduce((old, neu) => old + neu);
-    };
-
     return {
       uuid: randomStr(),
 
-      unhealthyNodeTimeoutInteger: this.value.pool.unhealthyNodeTimeout ? parseDuration(this.value.pool.unhealthyNodeTimeout) : 0,
+      unhealthyNodeTimeoutInteger: 0,
 
       validationErrors: [],
 
@@ -183,6 +146,8 @@ export default {
    * On creation, ensure that the pool is marked valid - custom machine pools can emit further validation events
    */
   created() {
+    this.unhealthyNodeTimeoutInteger = this.value.pool.unhealthyNodeTimeout ? this.parseDuration(this.value.pool.unhealthyNodeTimeout) : 0;
+
     this.$emit('validationChanged', true);
   },
 
@@ -192,6 +157,42 @@ export default {
   },
 
   methods: {
+    parseDuration(duration) {
+      // The back end stores the timeout in Duration format, for example, "42d31h10m30s".
+      // Here we convert that string to an integer and return the duration as seconds.
+      const splitStr = duration.split(/([a-z])/);
+
+      const durationsAsSeconds = splitStr.reduce((old, neu, idx) => {
+        const parsed = parseInt(neu);
+
+        if ( isNaN(parsed) ) {
+          return old;
+        }
+
+        const interval = splitStr[(idx + 1)];
+
+        switch (interval) {
+        case 'd':
+          old.push(parsed * 24 * 60 * 60);
+          break;
+        case 'h':
+          old.push(parsed * 60 * 60);
+          break;
+        case 'm':
+          old.push(parsed * 60);
+          break;
+        case 's':
+          old.push(parsed);
+          break;
+        default:
+          break;
+        }
+
+        return old;
+      }, []);
+
+      return durationsAsSeconds.reduce((old, neu) => old + neu);
+    },
     emitError(e) {
       this.$emit('error', e);
     },

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/etcd/S3Config.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/etcd/S3Config.vue
@@ -36,19 +36,18 @@ export default {
   },
 
   data() {
-    const config = {
-      bucket:              '',
-      cloudCredentialName: null,
-      endpoint:            '',
-      endpointCA:          '',
-      folder:              '',
-      region:              '',
-      skipSSLVerify:       false,
-
-      ...(this.value || {}),
+    return {
+      config: {
+        bucket:              '',
+        cloudCredentialName: null,
+        endpoint:            '',
+        endpointCA:          '',
+        folder:              '',
+        region:              '',
+        skipSSLVerify:       false,
+        ...(this.value || {}),
+      }
     };
-
-    return { config };
   },
 
   computed: {

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/registries/RegistryConfigs.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/registries/RegistryConfigs.vue
@@ -44,35 +44,16 @@ export default {
   },
 
   data() {
-    const configMap = clone(this.value.spec.rkeConfig?.registries?.configs) || {};
-    const entries = [];
-
-    const defaultAddValue = {
-      hostname:             '',
-      authConfigSecretName: null,
-      caBundle:             '',
-      insecureSkipVerify:   false,
-      tlsSecretName:        null,
-    };
-
-    for ( const hostname in configMap ) {
-      if (configMap[hostname]) {
-        configMap[hostname].insecureSkipVerify = configMap[hostname].insecureSkipVerify ?? defaultAddValue.insecureSkipVerify;
-        configMap[hostname].authConfigSecretName = configMap[hostname].authConfigSecretName ?? defaultAddValue.authConfigSecretName;
-
-        const caBundle = configMap[hostname].caBundle ?? defaultAddValue.caBundle;
-
-        configMap[hostname].caBundle = isBase64(caBundle) ? base64Decode(caBundle) : caBundle;
-
-        configMap[hostname].tlsSecretName = configMap[hostname].tlsSecretName ?? defaultAddValue.tlsSecretName;
+    return {
+      entries:         [],
+      defaultAddValue: {
+        hostname:             '',
+        authConfigSecretName: null,
+        caBundle:             '',
+        insecureSkipVerify:   false,
+        tlsSecretName:        null,
       }
-      entries.push({
-        hostname,
-        ...configMap[hostname],
-      });
-    }
-
-    return { entries, defaultAddValue };
+    };
   },
 
   computed: {
@@ -87,9 +68,27 @@ export default {
     window.z = this;
   },
 
-  // created() {
-  //   set(this.value, 'spec.rkeConfig.registries.configs', {});
-  // },
+  created() {
+    const configMap = clone(this.value.spec.rkeConfig?.registries?.configs) || {};
+
+    for ( const hostname in configMap ) {
+      if (configMap[hostname]) {
+        configMap[hostname].insecureSkipVerify = configMap[hostname].insecureSkipVerify ?? this.defaultAddValue.insecureSkipVerify;
+        configMap[hostname].authConfigSecretName = configMap[hostname].authConfigSecretName ?? this.defaultAddValue.authConfigSecretName;
+
+        const caBundle = configMap[hostname].caBundle ?? this.defaultAddValue.caBundle;
+
+        configMap[hostname].caBundle = isBase64(caBundle) ? base64Decode(caBundle) : caBundle;
+
+        configMap[hostname].tlsSecretName = configMap[hostname].tlsSecretName ?? this.defaultAddValue.tlsSecretName;
+      }
+
+      this.entries.push({
+        hostname,
+        ...configMap[hostname],
+      });
+    }
+  },
 
   methods: {
     update() {

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/registries/RegistryMirrors.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/registries/RegistryMirrors.vue
@@ -22,23 +22,22 @@ export default {
   },
 
   data() {
-    const mirrorMap = this.value.spec.rkeConfig?.registries?.mirrors || {};
-    const entries = [];
-
-    for ( const hostname in mirrorMap ) {
-      entries.push({
-        hostname,
-        endpoints: (mirrorMap[hostname].endpoint || []).join(', '),
-        rewrite:   mirrorMap[hostname].rewrite || {},
-      });
-    }
-
-    return { entries };
+    return { entries: [] };
   },
 
   created() {
     if (!this.value.spec.rkeConfig?.registries?.mirrors) {
       set(this.value, 'spec.rkeConfig.registries.mirrors', {});
+    }
+
+    const mirrorMap = this.value.spec.rkeConfig?.registries?.mirrors || {};
+
+    for ( const hostname in mirrorMap ) {
+      this.entries.push({
+        hostname,
+        endpoints: (mirrorMap[hostname].endpoint || []).join(', '),
+        rewrite:   mirrorMap[hostname].rewrite || {},
+      });
     }
   },
 

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/upgrade/DrainOptions.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/upgrade/DrainOptions.vue
@@ -34,23 +34,30 @@ export default {
   },
 
   data() {
-    const out = {};
-
-    for ( const k in DEFAULTS ) {
-      if ( typeof this.value[k] === 'undefined' ) {
-        out[k] = DEFAULTS[k];
-      } else {
-        out[k] = this.value[k];
-      }
-    }
-
-    out.customGracePeriod = out.gracePeriod >= 0;
-    out.customTimeout = out.timeout >= 0;
-
-    return out;
+    return {
+      deleteEmptyDirData:              DEFAULTS.deleteEmptyDirData,
+      disableEviction:                 DEFAULTS.disableEviction,
+      enabled:                         DEFAULTS.enabled,
+      force:                           DEFAULTS.force,
+      gracePeriod:                     DEFAULTS.gracePeriod,
+      ignoreDaemonSets:                DEFAULTS.ignoreDaemonSets,
+      skipWaitForDeleteTimeoutSeconds: DEFAULTS.skipWaitForDeleteTimeoutSeconds,
+      timeout:                         DEFAULTS.timeout,
+    };
   },
 
   created() {
+    for ( const k in DEFAULTS ) {
+      if ( typeof this.value[k] === 'undefined' ) {
+        this.$data[k] = DEFAULTS[k];
+      } else {
+        this.$data[k] = this.value[k];
+      }
+    }
+
+    this.customGracePeriod = this.gracePeriod >= 0;
+    this.customTimeout = this.timeout >= 0;
+
     this.update();
   },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This refactors data props that contain initialization logic so that they use patterns that are more idiomatic to Vue.

Fixes #14863 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Refactor data props in 
   - shell/edit/provisioning.cattle.io.cluster/rke2.vue
   - shell/edit/provisioning.cattle.io.cluster/tabs/AgentConfiguration.vue
   - shell/edit/provisioning.cattle.io.cluster/tabs/DirectoryConfig.vue
   - shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
   - shell/edit/provisioning.cattle.io.cluster/tabs/etcd/S3Config.vue
   - shell/edit/provisioning.cattle.io.cluster/tabs/registries/RegistryConfigs.vue
   - shell/edit/provisioning.cattle.io.cluster/tabs/registries/RegistryMirrors.vue
   - shell/edit/provisioning.cattle.io.cluster/tabs/upgrade/DrainOptions.vue

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The most complex changes in this PR involve shifting initialization logic outside of `data()` and into the `created()` hook. We will want to validate that the initialization order remains correct in cases where the `created()` hook already contains logic.

There's a few instances where the refactor is done for style to discourage the pattern of using the `data()` prop for anything other than declaring state (`S3Config.vue`). I'm of the mindset that it's best to keep these patterns consistent to avoid promoting examples that might lead to current issues that we are trying to resolve. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

This modifies provisioning and has a high risk for impact if anything goes wrong. I think that we need to pay attention to all the different modes of provisioning downstream rke2 clusters. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Creating/editing downstream rke2 clusters:

- Hosted Providers
- Downstream rke2
- Imported clusters

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
