### PR TITLE
[2.13]force re-loading norman schemas in generic cloud credential component

### DIFF
--- a/shell/cloud-credential/generic.vue
+++ b/shell/cloud-credential/generic.vue
@@ -28,7 +28,7 @@ export default {
     const configId = `${ normanType }credentialconfig`;
 
     this.normanSchema = await this.$store.dispatch('rancher/find', {
-      type: SCHEMA, id: configId, opt: { url: `/v3/schemas/${ configId }`, force: true }
+      type: SCHEMA, id: configId, opt: { url: `/v3/schemas/${ configId }` }
     });
 
     if ( this.normanSchema?.resourceFields ) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13723 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the generic credential component to fetch the new node driver credential schema and show the correct fields after a user has enabled a node driver.

### Technical notes summary
The url used to fetch the schema is hardcoded because automatically constructing those urls requires a schema, and there is no schema for norman schemas (ie /v3/schemas/schema returns 404). 

### Areas or cases that should be tested
The scenario described in #13723

### Areas which could experience regressions
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
