### PR TITLE
Reverted the color of the loading background while maintaining the new color for the rest of overlays

### DIFF
--- a/shell/assets/styles/themes/_dark.scss
+++ b/shell/assets/styles/themes/_dark.scss
@@ -95,6 +95,7 @@
 
   --modal-bg                   : #{$dark};
   --modal-border               : #{$medium};
+  --subtle-overlay-bg          : #{rgba($darkest, 0.75)};
   --overlay-bg                 : #{rgba($darkest, 0.75)};
   --shadow                     : #{rgba($darkest, 0.9)};
 

--- a/shell/assets/styles/themes/_light.scss
+++ b/shell/assets/styles/themes/_light.scss
@@ -407,6 +407,7 @@ BODY, .theme-light {
 
   --modal-bg                   : #{$lightest};
   --modal-border               : #{$dark};
+  --subtle-overlay-bg          : #{rgba($lighter, 0.75)};
   --overlay-bg                 : rgba(38, 42, 64, 0.35);
   --shadow                     : #{rgba($medium, 0.85)};
 

--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -444,7 +444,7 @@ export default {
         justify-content: center;
         border: 1px solid transparent;
         color: var(--darker);
-        background-color: var(--overlay-bg);
+        background-color: var(--subtle-overlay-bg);
         font-size: 12px;
 
         .close-indicator {

--- a/shell/components/Loading.vue
+++ b/shell/components/Loading.vue
@@ -59,7 +59,7 @@ export default {
 <style lang="scss" scoped>
   .overlay {
     align-items: center;
-    background-color: var(--overlay-bg);
+    background-color: var(--subtle-overlay-bg);
     display: flex;
     justify-content: center;
     position: absolute;

--- a/shell/components/form/FileImageSelector.vue
+++ b/shell/components/form/FileImageSelector.vue
@@ -132,7 +132,7 @@ $logo: 60px;
       left: 0;
       width: 100%;
       height: 100%;
-      background-color: var(--overlay-bg);
+      background-color: var(--subtle-overlay-bg);
     }
 
   }


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
fixes #14856
<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
The loading overlay and modal/drawer overlays

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1275" height="722" alt="image" src="https://github.com/user-attachments/assets/bd672e1f-e20f-4a09-bc53-464d3cbc1bd3" />

<img width="1275" height="717" alt="image" src="https://github.com/user-attachments/assets/789fda0b-3e3c-4eab-9551-03ce9b09e0e5" />

<img width="1209" height="727" alt="image" src="https://github.com/user-attachments/assets/ceb8c3e5-7ce2-4a91-b525-992a043cdc3a" />

<img width="1276" height="727" alt="image" src="https://github.com/user-attachments/assets/35f8435c-444f-457e-9e15-6da020641766" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
