### PR TITLE
vsphere network name correction

### DIFF
--- a/shell/machine-config/__tests__/vmwarevsphere.test.ts
+++ b/shell/machine-config/__tests__/vmwarevsphere.test.ts
@@ -256,7 +256,7 @@ describe('component: vmwarevsphere', () => {
   });
 
   describe('syncNetworkValueForLegacyLabels', () => {
-    it('should update the current network value properly', () => {
+    it('should NOT update the current network value to use MOID instead of name', () => {
       const legacyName = 'legacy_name';
       const legacyValue = 'legacy_value';
       const networkLabel = 'network_label';
@@ -291,12 +291,7 @@ describe('component: vmwarevsphere', () => {
         }
       });
 
-      // check the current network before updating
       expect(wrapper.vm.value.network).toStrictEqual([legacyName]);
-
-      wrapper.vm.syncNetworkValueForLegacyLabels();
-
-      expect(wrapper.vm.value.network).toStrictEqual([legacyValue]);
     });
   });
 });

--- a/shell/machine-config/__tests__/vmwarevsphere.test.ts
+++ b/shell/machine-config/__tests__/vmwarevsphere.test.ts
@@ -255,8 +255,8 @@ describe('component: vmwarevsphere', () => {
     });
   });
 
-  describe('syncNetworkValueForLegacyLabels', () => {
-    it('should NOT update the current network value to use MOID instead of name', () => {
+  describe('network name backwards compatibility', () => {
+    it('should NOT update the current network value to use MOID instead of name', async() => {
       const legacyName = 'legacy_name';
       const legacyValue = 'legacy_value';
       const networkLabel = 'network_label';
@@ -290,6 +290,9 @@ describe('component: vmwarevsphere', () => {
           ]
         }
       });
+
+      await wrapper.vm.loadNetworks();
+      await wrapper.vm.$nextTick();
 
       expect(wrapper.vm.value.network).toStrictEqual([legacyName]);
     });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14872
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the vSphere machine config component to prevent it from altering networks without user input. Previously we were checking if the machine pool had configured networks using name or MOID, and converting those with names to MOID, to align with a UI change that came in 2.10.

### Technical notes summary
Instead of altering the machine config spec, I updated the network getter to convert names to MOID in the component template only.

### Areas or cases that should be tested
The scenario described in #14872

### Areas which could experience regressions

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
