### PR TITLE
Bump rancher version to `v2.12-head` for e2e scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "install:ci": "yarn install --frozen-lockfile",
     "dev": "bash -c 'source ./scripts/version && NODE_ENV=dev ./node_modules/.bin/vue-cli-service serve'",
     "mem-dev": "bash -c 'source ./scripts/version && NODE_ENV=dev node --max-old-space-size=8192 ./node_modules/.bin/vue-cli-service serve'",
-    "docker:local:start": "docker run -d --restart=unless-stopped -p 80:80 -p 443:443 -e CATTLE_BOOTSTRAP_PASSWORD=password -e CATTLE_PASSWORD_MIN_LENGTH=3 --name cypress --privileged rancher/rancher:head",
+    "docker:local:start": "docker run -d --restart=unless-stopped -p 80:80 -p 443:443 -e CATTLE_BOOTSTRAP_PASSWORD=password -e CATTLE_PASSWORD_MIN_LENGTH=3 --name cypress --privileged rancher/rancher:v2.12-head",
     "docker:local:stop": "docker kill cypress || true && docker rm cypress || true",
     "docker:local:logs": "docker logs cypress > $E2E_RANCHER_LOG 2>&1",
     "build": "NODE_OPTIONS=--max_old_space_size=4096 ./node_modules/.bin/vue-cli-service build",

--- a/scripts/e2e-docker-start
+++ b/scripts/e2e-docker-start
@@ -7,7 +7,7 @@ DASHBOARD_DIST=${DIR}/dist
 EMBER_DIST=${DIR}/dist_ember
 
 # Image version
-RANCHER_IMG_VERSION=head
+RANCHER_IMG_VERSION=v2.12-head
 # RANCHER_IMG_VERSION=v2.12-8bf56b046af7879386aa5928f50eee678f84b057-head - breaking commit
 # RANCHER_IMG_VERSION=v2.12-146a265b2d3e50d789ae55ad13daec8a1416c5fb-head - commit before - works
 


### PR DESCRIPTION
This bumps the rancher version to `v2.12-head` for e2e scripts