### PR TITLE
Clear stale S3 config when toggling back to default storage option

### DIFF
--- a/shell/edit/resources.cattle.io.restore.vue
+++ b/shell/edit/resources.cattle.io.restore.vue
@@ -159,19 +159,16 @@ export default {
       if (neu === 'useDefault') {
         delete this.value.spec.storageLocation;
         delete this.value.spec.backupFilename;
-      } else if (!this.value.spec.storageLocation && neu === 'configureS3') {
-        this.value.spec['storageLocation'] = { s3: {} };
-        this.s3 = this.value.spec.storageLocation.s3;
-      }
-      if (neu === 'useBackup') {
+        this.s3 = {};
+      } else if (neu === 'configureS3') {
+        this.s3 = this.value.spec.storageLocation?.s3 || {};
+        this.value.spec.storageLocation = { s3: this.s3 };
+      } else if (neu === 'useBackup') {
         delete this.value.spec.storageLocation;
 
         if (this.availableBackups.length === 1) {
           this.updateTargetBackup(this.availableBackups[0]);
         }
-      } else {
-        delete this.value.spec.backupFilename;
-        this.value.spec.storageLocation = { s3: this.s3 };
       }
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/14818
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
When toggling between storage options in the Restore UI (rancher-backup chart), specifically from "Configure S3" back to "Default", the S3 config (`this.s3` and `spec.storageLocation.s3`) was not fully cleared.

Although `spec.storageLocation` was being deleted in the watcher, it was immediately reintroduced via a shared else block that restored `this.s3` unconditionally, even when no longer needed...

So I have Removed the general else block

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Test steps:
- Install the rancher manager
- Install the backup and restore chart
- Create the backup
- Now try to restore the backup created in step 3, Ensure toggling between "Use Default", "Configure S3" UI reflects only relevant fields per selected storage source...

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
