### PR TITLE
Resolves a z-index issue with the kubectl-explain drawer

### DIFF
--- a/pkg/kubectl-explain/components/SlideInPanel.vue
+++ b/pkg/kubectl-explain/components/SlideInPanel.vue
@@ -451,6 +451,8 @@ export default {
     right: -$slidein-width;
     transition: right 0.5s;
     border-left: 1px solid var(--border);
+
+    z-index: calc(z-index('slide-in') + 1);
   }
 
   .slide-in-open {
@@ -468,6 +470,8 @@ export default {
       left: 0;
       height :100vh;
       width: 100vw;
+
+      z-index: z-index('slide-in');
 
     &.slide-in-glass-open {
       background-color: var(--body-bg);


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
fixes #14840 

Based on https://github.com/rancher/dashboard/pull/14840#issuecomment-3114000279
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
The original fix https://github.com/rancher/dashboard/pull/14840 missed this because I didn't realize the kubectl-explain extension has fully implemented it's own slide-in. I put this change in because I want something small that we can backport.

We most likely want to switch to the standard slidein and standard drawer ui elements. I've started a draft https://github.com/rancher/dashboard/pull/14901 but will open an issue and talk to UX before that gets in and I don't intend to backport it.

### Areas or cases that should be tested
Resource Explain button on list pages

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
