### PR TITLE
Fix issues in AlertManageConfig Receivers page

### DIFF
--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
@@ -34,23 +34,24 @@ export default {
 
   async fetch() {
     const inStore = this.$store.getters['currentProduct'].inStore;
-    const alertmanagerConfigId = this.value.id;
-
-    const { receiverSchema, routeSchema } = await fetchAlertManagerConfigSpecs(this.$store);
+    const { receiverSchema } = await fetchAlertManagerConfigSpecs(this.$store);
 
     this.receiverSchema = receiverSchema;
-    this.routeSchema = routeSchema;
 
-    const alertmanagerConfigResource = await this.$store.dispatch(`${ inStore }/find`, { type: MONITORING.ALERTMANAGERCONFIG, id: alertmanagerConfigId });
+    // The edit page is (mis)used as the detail page. When it's in create world none of the below is valid (there's no existing resource)
+    if (!this.isCreate) {
+      const alertmanagerConfigResource = await this.$store.dispatch(`${ inStore }/find`, { type: MONITORING.ALERTMANAGERCONFIG, id: this.value.id });
 
-    this.alertmanagerConfigId = alertmanagerConfigId;
-    this.alertmanagerConfigResource = alertmanagerConfigResource;
-    this.alertmanagerConfigDetailRoute = alertmanagerConfigResource?._detailLocation;
+      this.alertmanagerConfigId = this.value.id;
+      this.alertmanagerConfigResource = alertmanagerConfigResource;
 
-    const alertmanagerConfigActions = alertmanagerConfigResource.availableActions;
-    const receiverActions = alertmanagerConfigResource.getReceiverActions(alertmanagerConfigActions);
+      this.alertmanagerConfigDetailRoute = alertmanagerConfigResource._detailLocation;
 
-    this.receiverActions = receiverActions;
+      const alertmanagerConfigActions = alertmanagerConfigResource.availableActions;
+      const receiverActions = alertmanagerConfigResource.getReceiverActions(alertmanagerConfigActions);
+
+      this.receiverActions = receiverActions;
+    }
   },
 
   data() {

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
@@ -128,6 +128,16 @@ export default {
     const expectedFields = Object.keys(receiverSchema.resourceFields);
     const suffix = {};
 
+    // Values contains multiple receivers of two types
+    // 1. Known (expected, from schema) shown in their own tabs with explicity forms
+    // 2. unknown (not expected, missing in schema) shown as a yaml blob
+
+    // - expectedFields and suffixYaml are only used if the receiver is of type `custom`
+    // - expectedFields are the known types
+    // - suffixYaml are the unknown types
+    // - usages,
+    //   - for custom, we need to know only the unknown / yaml blog. so suffixYaml is created by extracting all known (expectedFields) from value
+    //   - on edit of custom we then combine the two again and save to value
     Object.keys(this.value).forEach((key) => {
       if (!expectedFields.includes(key)) {
         suffix[key] = this.value[key];
@@ -195,7 +205,7 @@ export default {
       return {
         duplicateName: () => {
           const receiversArray = this.alertmanagerConfigResource.spec.receivers;
-          const receiverNamesArray = receiversArray.map((R) => R.name);
+          const receiverNamesArray = receiversArray?.map((R) => R.name) || [];
           const receiversSet = new Set(receiverNamesArray);
 
           if (receiversArray.length !== receiversSet.size) {

--- a/shell/utils/alertmanagerconfig.js
+++ b/shell/utils/alertmanagerconfig.js
@@ -19,8 +19,8 @@ export const fetchAlertManagerConfigSpecs = async($store) => {
   await schema.fetchResourceFields();
 
   return {
-    receiverSchema: schema.schemaDefinitions?.[`${ schema.schemaDefinition.id }.spec.receivers`],
-    routeSchema:    schema.schemaDefinitions?.[`${ schema.schemaDefinition.id }.spec.route`],
+    receiverSchema: schema.schemaDefinitions?.[`${ schema.schemaDefinition.type }.spec.receivers`],
+    routeSchema:    schema.schemaDefinitions?.[`${ schema.schemaDefinition.type }.spec.route`],
   };
 };
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14946
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Errors are all around Monitoring --> Alerting --> Create/Edit/View AlertmangerConfigs page + view AlertmanagerConfigs Add Reciever page
  - don't try to find a resource if in create mode
  - add additional comments to confusing code
  - don't try to validate values that won't be there on create
  - ensure schema definitions are cached correctly (no id)
- a lot of these bugs are currently harmless, given the areas they affect are hidden by https://github.com/rancher/dashboard/issues/14944

### Technical notes summary
Things i've picked up not solved by this PR
- `Alerting` group in `Monitoring` group is misaligned
- Edit component is miss-used as a Detail page, which introduces weird routing everywhere
- Edit component tries to use ResourceTable with non-resources. Think this is because it wants actions
- Actions process is very weird, and broken https://github.com/rancher/dashboard/issues/14944
- Cannot create receivers when creating alertmanagerconfig (but shown ui)
- `invalid prop` warnings everywhere
- Refreshing on the add reciever page results in 404 style page

### Areas or cases that should be tested
- as per issue

### Areas which could experience regressions
none outside of above

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
