### PR TITLE
Use a more sensible default for ResourceLabeledSelect inStore

### DIFF
--- a/shell/components/form/ResourceLabeledSelect.vue
+++ b/shell/components/form/ResourceLabeledSelect.vue
@@ -34,7 +34,7 @@ export default defineComponent({
 
     inStore: {
       type:    String,
-      default: 'cluster',
+      default: undefined,
     },
 
     /**
@@ -63,7 +63,20 @@ export default defineComponent({
   },
 
   data() {
-    return { paginate: false };
+    let validInStore = this.inStore;
+
+    if (!validInStore && this.resourceType) {
+      validInStore = this.$store.getters['currentStore'](this.resourceType);
+    }
+
+    if (!validInStore) {
+      validInStore = 'cluster';
+    }
+
+    return {
+      paginate: false,
+      validInStore,
+    };
   },
 
   async fetch() {
@@ -72,13 +85,13 @@ export default defineComponent({
       this.paginate = false;
       break;
     case RESOURCE_LABEL_SELECT_MODE.DYNAMIC:
-      this.paginate = this.$store.getters[`${ this.inStore }/paginationEnabled`](this.resourceType);
+      this.paginate = this.$store.getters[`${ this.validInStore }/paginationEnabled`](this.resourceType);
       break;
     }
 
     if (!this.paginate) {
       // The resource won't be paginated and component expects everything up front
-      await this.$store.dispatch(`${ this.inStore }/findAll`, { type: this.resourceType });
+      await this.$store.dispatch(`${ this.validInStore }/findAll`, { type: this.resourceType });
     }
   },
 
@@ -104,7 +117,7 @@ export default defineComponent({
         return [];
       }
 
-      const all = this.$store.getters[`${ this.inStore }/all`](this.resourceType);
+      const all = this.$store.getters[`${ this.validInStore }/all`](this.resourceType);
 
       return this.allResourcesSettings?.updateResources ? this.allResourcesSettings.updateResources(all) : all;
     }
@@ -130,7 +143,7 @@ export default defineComponent({
         type:  this.resourceType,
         ctx:   { getters: this.$store.getters, dispatch: this.$store.dispatch },
         sort:  [{ asc: true, field: 'metadata.name' }],
-        store: this.inStore
+        store: this.validInStore
       };
       const options = this.paginatedResourceSettings?.requestSettings ? this.paginatedResourceSettings.requestSettings(defaultOptions) : defaultOptions;
       const res = await labelSelectPaginationFunction(options);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14942
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Ensure we fall back on a more sensible default for inStore
- This avoids a lot of plumbing (specifically in usages of `<SimpleSecretSelector` in shell/edit/monitoring.coreos.com.alertmanagerconfig/type components)
- However does introduce some risk to usages of `<ResourceLabeledSelect`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
- alertmanager receiver config (as per issue), including usage in Harvester

### Areas which could experience regressions
- some usage of <ResourceLabeledSelect
  - Rancher Backups chart install wizard default storage location s3-compatible credentials secret selector
- some usages of <SecretSelector
  - create custom rke2 cluster --> registries --> authentication (might be worth creating a new one in a new cluster, and then finding it again when creating another cluster)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
