### PR TITLE
Putting in an override for no-unused-vars in regards to .d.ts files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,6 +67,13 @@ module.exports = {
   },
   overrides: [
     {
+      files: ['*.d.ts'],
+      rules: {
+        'no-unused-vars':                    'off',
+        '@typescript-eslint/no-unused-vars': 'warn',
+      },
+    },
+    {
       files: [
         '*.js'
       ],

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -66,7 +66,6 @@ export interface CreateResourceNameOptions {
 }
 
 declare global {
-  // eslint-disable-next-line no-unused-vars
   namespace Cypress {
     interface Chainable {
       setupWebSocket: any;

--- a/shell/types/resources/settings.d.ts
+++ b/shell/types/resources/settings.d.ts
@@ -39,7 +39,7 @@ export interface PaginationSettings {
    * List of specific features that can be enabled / disabled
    */
   features?: {
-    [key in PaginationFeature]: { // eslint-disable-line no-unused-vars
+    [key in PaginationFeature]: {
       enabled: boolean,
     }
   },


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #9746
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
The `no-unused-vars` has issues handling the scope of `.d.ts` files as documented here https://github.com/typescript-eslint/typescript-eslint/issues/1856. I switched to using `@typescript-eslint/no-unused-vars` in the `.d.ts` file. 

I didn't enable  `@typescript-eslint/no-unused-vars` for the entire app because we have a huge amount of unused variables throughout the app. So I documented it in a related issue https://github.com/rancher/dashboard/issues/6817#issuecomment-3133949165.

### Areas or cases that should be tested
None, this should just affect the lint command.

### Areas which could experience regressions
None, this should just affect the lint command.

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
