### PR TITLE
[Automation]: Add missing cypress-terminal-report plugin to Jenkins config

### DIFF
--- a/cypress/jenkins/cypress.config.jenkins.ts
+++ b/cypress/jenkins/cypress.config.jenkins.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from 'cypress';
 import { removeDirectory } from 'cypress-delete-downloads-folder';
 import websocketTasks from '../../cypress/support/utils/webSocket-utils';
+import path from 'path';
 
 // Required for env vars to be available in cypress
 require('dotenv').config();
@@ -89,6 +90,8 @@ export default defineConfig({
     azureClientSecret:   process.env.AZURE_CLIENT_SECRET,
     customNodeIp:        process.env.CUSTOM_NODE_IP,
     customNodeKey:       process.env.CUSTOM_NODE_KEY,
+    accessibility:       !!process.env.TEST_A11Y, // Are we running accessibility tests?
+    a11yFolder:          path.join('.', 'cypress', 'accessibility'),
     gkeServiceAccount:   process.env.GKE_SERVICE_ACCOUNT,
     customNodeIpRke1:    process.env.CUSTOM_NODE_IP_RKE1,
     customNodeKeyRke1:   process.env.CUSTOM_NODE_KEY_RKE1
@@ -109,8 +112,22 @@ export default defineConfig({
     setupNodeEvents(on, config) {
       require('cypress-mochawesome-reporter/plugin')(on);
       require('@cypress/grep/src/plugin')(config);
+
+      // Load Accessibility plugin if configured
+      if (process.env.TEST_A11Y) {
+        require('../../cypress/support/plugins/accessibility').default(on, config);
+      }
+
       on('task', { removeDirectory });
       websocketTasks(on, config);
+
+      require('cypress-terminal-report/src/installLogsPrinter')(on, {
+        outputRoot:           `${ config.projectRoot }/browser-logs/`,
+        outputTarget:         { 'out.html': 'html' },
+        logToFilesOnAfterRun: true,
+        printLogsToConsole:   'never',
+        // printLogsToFile:      'always', // default prints on failures
+      });
 
       return config;
     },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1904

Jenkins recurring test runs were failing when running against head image due to a missing Cypress task registration. Added cypress-terminal-report plugin to Jenkins configuration to resolve the issue.
- Verified fix works: Tests run successfully with the plugin enabled
- Confirmed root cause: Disabling the plugin brings back the original ctrLogFiles error
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
