### PR TITLE
Fix AKS, GKE upstream spec diff

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -378,7 +378,7 @@ export default defineComponent({
 
     // only save values that differ from upstream aks spec - see diffUpstreamSpec comments for details
     removeUnchangedConfigFields(): void {
-      const upstreamConfig = this.normanCluster?.status?.aksStatus?.upstreamSpec;
+      const upstreamConfig = this.normanCluster?.aksStatus?.upstreamSpec;
 
       if (upstreamConfig) {
         const diff = diffUpstreamSpec(upstreamConfig, this.config);

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -675,7 +675,7 @@ export default defineComponent({
 
     // only save values that differ from upstream aks spec - see diffUpstreamSpec comments for details
     removeUnchangedConfigFields(): void {
-      const upstreamConfig = this.normanCluster?.status?.gkeStatus?.upstreamSpec;
+      const upstreamConfig = this.normanCluster?.gkeStatus?.upstreamSpec;
 
       if (upstreamConfig) {
         const diff = diffUpstreamSpec(upstreamConfig, this.config);
@@ -735,7 +735,6 @@ export default defineComponent({
         v-model:region="config.region"
         v-model:locations="config.locations"
         v-model:default-image-type="defaultImageType"
-        v-model:labels="config.labels"
         :mode="mode"
         :cloud-credential-id="config.googleCredentialSecret"
         :project-id="config.projectID"
@@ -883,6 +882,7 @@ export default defineComponent({
             v-model:http-load-balancing="config.clusterAddons.httpLoadBalancing"
             v-model:horizontal-pod-autoscaling="config.clusterAddons.horizontalPodAutoscaling"
             v-model:enable-kubernetes-alpha="config.enableKubernetesAlpha"
+            v-model:labels="config.labels"
             :mode="mode"
             :is-new-or-unprovisioned="isNewOrUnprovisioned"
           />

--- a/shell/utils/__tests__/kontainer.test.ts
+++ b/shell/utils/__tests__/kontainer.test.ts
@@ -18,6 +18,25 @@ describe('fx: diffUpstreamSpec', () => {
   });
 
   it.each([
+    [{
+      a: { one: 'a' },
+      b: ['1', 'b'],
+      c: 'c'
+    }, {
+      a: {},
+      b: [],
+      c: ''
+    }, {
+      a: {},
+      b: [],
+      c: ''
+    }],
+    [{ a: 'a' }, { b: null }, { }],
+  ])('should include fields that are empty objects, arrays or strings on the local object regardless of upstream definition', (upstream, local, diff) => {
+    expect(diffUpstreamSpec(upstream, local)).toStrictEqual(diff);
+  });
+
+  it.each([
     [{ a: null }, { a: {} }, {}],
     [{ a: null }, { a: [] }, {}],
     [{ a: null }, { a: '' }, {}],

--- a/shell/utils/kontainer.ts
+++ b/shell/utils/kontainer.ts
@@ -17,11 +17,9 @@ export function syncUpstreamConfig(configPrefix: string, normanCluster: {[key: s
 
   if (!isEmpty(upstreamConfig)) {
     Object.keys(upstreamConfig).forEach((key) => {
-      if (typeof upstreamConfig[key] === 'object') {
-        if (isEmpty(rancherConfig[key]) && !isEmpty(upstreamConfig[key])) {
-          set(rancherConfig, key, upstreamConfig[key]);
-        }
-      } else if ((rancherConfig[key] === null || rancherConfig[key] === undefined) && upstreamConfig[key] !== null && upstreamConfig[key] !== undefined) {
+      const empty = typeof upstreamConfig[key] === 'object' && isEmpty(upstreamConfig[key]);
+
+      if ((rancherConfig[key] === null || rancherConfig[key] === undefined) && upstreamConfig[key] !== null && upstreamConfig[key] !== undefined && !empty) {
         set(rancherConfig, key, upstreamConfig[key]);
       }
     });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14720
Fixes #11413 
<!-- Define findings related to the feature or bug issue. -->

**EDIT:
NOTE ABOUT AKS**
There is an open issue with one field in AKS, `linuxAdminUsername` https://github.com/rancher/rancher/issues/51297...a side effect of this bug is that PUT requests to update aks clusters always include this field. From what I can see, the UI code is still functioning correctly.

### Occurred changes and/or fixed issues
This PR fixes a mistake in the AKS and GKE edit pages that effectively prevented the upstream syncing functionality from running on save. That syncing functionality generally should be verified in AKS and GKE - I've described some scenarios to check below. This functionality has been enabled for EKS for a few releases.

This PR also fixes an issue where some edits would not be reflected when re-loading the UI for up to 5 minutes.

I also fixed an issue setting GKE labels.

### Technical notes summary
AKS, EKS, and GKE norman cluster objects contain a status field with the spec of the cluster as it is defined upstream in the relevant cloud provider (ie in azure, aws, and gcp, respectively): `aksStatus.upstreamSpec`, `eksStatus.upstreamSpec`, and `gkeStatus.upstreamSpec` - see the following github issues for motivation (the same rationale in these issues applies to AKS and GKE)

- ui issue: https://github.com/rancher/rancher/issues/28541
- backend issue: https://github.com/rancher/rancher/issues/28422



### Areas or cases that should be tested
The following scenarios should be tested in GKE or AKS. I've provided some specific examples but it would probably be good to verify some fields I haven't checked myself, too.


Fixed in this PR:
-   If the local spec is an empty object or array, the field should be empty in the ui, even if it is defined in `upstreamSpec`
      -  eg create an AKS cluster with authorized IP ranges defined, then remove all IP ranges, and immediately re-edit the cluster


Other upstream syncing functionality previously enabled for EKS, now enabled for AKS and GKE too:
-  The UI should populate the form with values from `upstreamSpec` if the local spec is `undefined` or `null`
         - Every 5 minutes the backend will sync upstreamSpec with the local spec, and set any values that are not defined on the local spec, so this scenario is always temporary.
         - This functionality exists in the dashboard because I saw that it was implemented in the old UI; however, in practice, I found this to be a difficult scenario to produce through the dashboard alone: every field that will be populated in `upstreamSpec` when the cluster provisions is defined in the dashboard's POST request to create the cluster
         - HOWEVER in theory users could create EKS, AKS, GKE clusters via terraform or some other automation through our API, and leave fields null/undefined. I engaged in shennanigans (editing the management cluster object through our "view in API" ui) to verify this code:
         

>  I created a GKE cluster and I set the maintenance window to 12am “00:00”. I waited for upstreamSpec to exist and contain this value. Then I used our API UI to set this value to null  which is not how we clear out values through the UI, but it is a configuration the API accepts. After setting maintenanceWindow to null I went back to the UI to edit the cluster. As expected, the UI grabs the value from upstreamSpec “00:00" and displays that. When I click save without actually touching that field, maintenanceWindow is not included in the put request. 

      
-   When users click save, only fields in gkeConfig, aksConfig, eksConfig that have been changed should be sent in the request*
   -    EXCEPT the entirety of nodePools or nodeGroups, labels, and tags if defined, should be sent in every PUT request

-  If users clear all values from a nested object or an array in the cluster spec, the PUT request should include an empty object or array.
   - eg create an AKS cluster with authorized IP ranges defined, then remove all IP ranges


*when editing a cluster within 5 minutes of having provisioned it, you might see some other fields included in the PUT request. Some fields left as empty objects or strings during cluster creation are auto-populated by the backend. For example when a GKE cluster first provisions, `clusterIpv4Cidr` will be '' in the `gkeConfig`, and defined in `upstreamSpec`. If you edit this cluster and don't touch that field, the PUT request will include `clusterIpv4Cidr: ''`  because from the UI's perspective thats a difference between `gkeConfig` and `upstreamSpec` that you're trying to save. In ~5 minutes, `gkeConfig.clusterIpv4Cidr` should have been synced with the value from `upstreamSpec`, and if you edit the GKE cluster after this point, will not be included in the PUT request.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
