### PR TITLE
Fixed Harvester detail page through Cluster Management

### DIFF
--- a/cypress/e2e/po/components/tabbed.po.ts
+++ b/cypress/e2e/po/components/tabbed.po.ts
@@ -1,7 +1,7 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 
 export default class TabbedPo extends ComponentPo {
-  constructor(selector = '.dashboard-root') {
+  constructor(selector = '.dashboard-root', private componentId = 'tabbed') {
     super(selector);
   }
 
@@ -17,8 +17,8 @@ export default class TabbedPo extends ComponentPo {
     return this.self().get(`[data-testid="btn-${ name }"]`).click();
   }
 
-  allTabs() {
-    return this.self().get('[data-testid="tabbed-block"] > li');
+  allTabs(componentTestId = this.componentId) {
+    return this.self().get(`[data-testid="${ componentTestId }-block"] > li`);
   }
 
   assertTabIsActive(selector: string) {

--- a/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
+++ b/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
@@ -6,7 +6,7 @@ import ClusterReferredToListPo from '~/cypress/e2e/po/lists/cluster-referred-to-
 import ClusterSnapshotsListPo from '~/cypress/e2e/po/lists/cluster-snapshots-list.po';
 import TabbedPo from '~/cypress/e2e/po/components/tabbed.po';
 import ClusterRecentEventsListPo from '~/cypress/e2e/po/lists/cluster-recent-events-list.po';
-
+import DetailDrawer from '@/cypress/e2e/po/side-bars/detail-drawer.po';
 /**
  * Covers core functionality that's common to the dashboard's cluster detail pages
  */
@@ -27,6 +27,14 @@ export default abstract class ClusterManagerDetailPagePo extends PagePo {
 
   title() {
     return this.self().find('.title-bar h1.title, .primaryheader h1');
+  }
+
+  openShowConfiguration() {
+    return this.self().find('[data-testid="show-configuration-cta"]').click();
+  }
+
+  detailDrawer() {
+    return new DetailDrawer();
   }
 
   logsContainer() {

--- a/cypress/e2e/po/side-bars/detail-drawer.po.ts
+++ b/cypress/e2e/po/side-bars/detail-drawer.po.ts
@@ -1,0 +1,26 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
+export default class DetailDrawer extends ComponentPo {
+  constructor() {
+    super('[data-testid="slide-in-panel-component"]');
+  }
+
+  waitforContent() {
+    return this.self().find('.explain-panel').should('be.visible').within(() => {
+      cy.get('.icon-spinner').should('not.exist');
+      cy.get('.markdown').should('be.visible');
+    });
+  }
+
+  tabs() {
+    return new TabbedPo('.dashboard-root', 'configuration-drawer-tabbed');
+  }
+
+  saveButton() {
+    return this.self().get('[data-testid="save-configuration-bttn"');
+  }
+
+  closeButton() {
+    return this.self().get('[data-testid="slide-in-panel-close-resource-explain"');
+  }
+}

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -279,7 +279,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         editCreatedClusterPage.nameNsDescription().description().self().should('have.value', rke2CustomName);
       });
 
-      it('will disbable saving if an addon config has invalid data', () => {
+      it('will disable saving if an addon config has invalid data', () => {
         clusterList.goTo();
 
         clusterList.checkIsCurrentPage();
@@ -533,7 +533,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     clusterList.waitForPage();
   });
 
-  describe('Cluster Details Tabs', () => {
+  describe('Cluster Details Page and Tabs', () => {
     const tabbedPo = new TabbedPo('[data-testid="tabbed-block"]');
     const clusterDetail = new ClusterManagerDetailImportedGenericPagePo(undefined, 'local');
 
@@ -573,6 +573,23 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
       clusterDetail.machinePoolsList().resourceTable().sortableTable().noRowsShouldNotExist();
       clusterDetail.machinePoolsList().details('machine-', 2).should('be.visible');
       clusterDetail.machinePoolsList().downloadYamlButton().should('be.disabled');
+    });
+    it(`Show Configuration allows to edit config and view yaml for local cluster`, () => {
+      clusterDetail.waitForPage();
+      clusterDetail.openShowConfiguration();
+      const drawer = clusterDetail.detailDrawer();
+
+      drawer.checkExists();
+      drawer.checkVisible();
+      drawer.saveButton().should('be.visible');
+      const tabs = ['Config', 'YAML'];
+
+      drawer.tabs().tabNames().each((el, i) => {
+        expect(el).to.eq(tabs[i]);
+      });
+
+      drawer.tabs().clickTabWithName('yaml-tab');
+      drawer.saveButton().should('not.exist');
     });
 
     it('can navigate to namespace from cluster detail view', () => {
@@ -769,5 +786,54 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     if (reenableAKS) {
       cy.createRancherResource('v3', 'kontainerDrivers/azurekubernetesservice?action=activate', {});
     }
+  });
+});
+
+describe('Cluster Manager as standard user', { testIsolation: 'off', tags: ['@manager', '@standardUser'] }, () => {
+  before(() => {
+    cy.login();
+  });
+  it('can navigate to Cluster Management Page', () => {
+    HomePagePo.goTo();
+    const burgerMenu = new BurgerMenuPo();
+
+    BurgerMenuPo.toggle();
+    const clusterManagementNavItem = burgerMenu.links().contains(`Cluster Management`);
+
+    clusterManagementNavItem.should('exist');
+    clusterManagementNavItem.click();
+    const clusterList = new ClusterManagerListPagePo('_');
+
+    clusterList.waitForPage();
+  });
+
+  describe('Cluster Detail Page', () => {
+    const clusterDetail = new ClusterManagerDetailImportedGenericPagePo(undefined, 'local');
+
+    beforeEach( () => {
+      ClusterManagerListPagePo.navTo();
+      const clusterList = new ClusterManagerListPagePo('_');
+
+      clusterList.waitForPage();
+      clusterList.clickOnClusterName('local');
+    });
+
+    it(`Show Configuration allows to view but not edit config and yaml for local cluster`, () => {
+      clusterDetail.waitForPage();
+      clusterDetail.openShowConfiguration();
+      const drawer = clusterDetail.detailDrawer();
+
+      drawer.checkExists();
+      drawer.checkVisible();
+      drawer.saveButton().should('not.exist');
+      const tabs = ['Config', 'YAML'];
+
+      drawer.tabs().tabNames().each((el, i) => {
+        expect(el).to.eq(tabs[i]);
+      });
+
+      drawer.tabs().clickTabWithName('yaml-tab');
+      drawer.saveButton().should('not.exist');
+    });
   });
 });

--- a/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
+++ b/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
@@ -96,4 +96,8 @@ export default class HciCluster extends ProvCluster {
       console.error('unable to get harvester version from settings/server-version', error); // eslint-disable-line no-console
     }
   }
+
+  get disableResourceDetailDrawerConfigTab() {
+    return false;
+  }
 }

--- a/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
+++ b/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
@@ -38,7 +38,7 @@ export default class HciCluster extends ProvCluster {
   }
 
   get canEdit() {
-    return false;
+    return this.canUpdate && this.canCustomEdit;
   }
 
   // We do not allow users to edit Harvester clusters from Cluster Management, so we need to re-enable that action here.
@@ -47,7 +47,7 @@ export default class HciCluster extends ProvCluster {
     const edit = out.find((action) => action.action === 'goToEdit');
 
     if (edit) {
-      edit.enabled = this.canCustomEdit;
+      edit.enabled = this.canEdit;
     }
 
     return out;

--- a/shell/components/Drawer/ResourceDetailDrawer/index.vue
+++ b/shell/components/Drawer/ResourceDetailDrawer/index.vue
@@ -50,6 +50,10 @@ const action = computed(() => {
     action
   };
 });
+
+const canEdit = computed(() => {
+  return props.resource.canEdit;
+});
 </script>
 <template>
   <Drawer
@@ -83,6 +87,7 @@ const action = computed(() => {
     </template>
     <template #additional-actions>
       <RcButton
+        v-if="canEdit"
         :primary="true"
         :aria-label="action.ariaLabel"
         @click="action.action"

--- a/shell/components/Drawer/ResourceDetailDrawer/index.vue
+++ b/shell/components/Drawer/ResourceDetailDrawer/index.vue
@@ -17,6 +17,8 @@ export interface Props {
 }
 </script>
 <script setup lang="ts">
+const editBttnDataTestId = 'save-configuration-bttn';
+const componentTestid = 'configuration-drawer-tabbed';
 const props = defineProps<Props>();
 const emit = defineEmits(['close']);
 const store = useStore();
@@ -38,11 +40,14 @@ const title = computed(() => {
 
 const activeTab = ref<string>(configTabProps ? 'config-tab' : 'yaml-tab');
 
+const isConfig = computed(() => {
+  return activeTab.value === 'config-tab';
+});
+
 const action = computed(() => {
-  const isConfig = activeTab.value === 'config-tab';
-  const ariaLabel = isConfig ? i18n.t('component.drawer.resourceDetailDrawer.ariaLabel.editConfig') : i18n.t('component.drawer.resourceDetailDrawer.ariaLabel.editYaml');
-  const label = isConfig ? i18n.t('component.drawer.resourceDetailDrawer.ariaLabel.editConfig') : i18n.t('component.drawer.resourceDetailDrawer.ariaLabel.editYaml');
-  const action = isConfig ? () => props.resource.goToEdit() : () => props.resource.goToEditYaml();
+  const ariaLabel = isConfig.value ? i18n.t('component.drawer.resourceDetailDrawer.ariaLabel.editConfig') : i18n.t('component.drawer.resourceDetailDrawer.ariaLabel.editYaml');
+  const label = isConfig.value ? i18n.t('component.drawer.resourceDetailDrawer.ariaLabel.editConfig') : i18n.t('component.drawer.resourceDetailDrawer.ariaLabel.editYaml');
+  const action = isConfig.value ? () => props.resource.goToEdit() : () => props.resource.goToEditYaml();
 
   return {
     ariaLabel,
@@ -52,8 +57,9 @@ const action = computed(() => {
 });
 
 const canEdit = computed(() => {
-  return props.resource.canEdit;
+  return isConfig.value ? props.resource.canEdit : props.resource.canEditYaml;
 });
+
 </script>
 <template>
   <Drawer
@@ -73,6 +79,7 @@ const canEdit = computed(() => {
         class="tabbed"
         :useHash="false"
         :showExtensionTabs="false"
+        :componentTestid="componentTestid"
         @changed="({selectedName}) => {activeTab = selectedName;}"
       >
         <ConfigTab
@@ -90,6 +97,7 @@ const canEdit = computed(() => {
         v-if="canEdit"
         :primary="true"
         :aria-label="action.ariaLabel"
+        :data-testid="editBttnDataTestId"
         @click="action.action"
       >
         {{ action.label }}

--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -71,6 +71,14 @@ export default {
     showExtensionTabs: {
       type:    Boolean,
       default: true,
+    },
+    /**
+     * Inherited global identifier prefix for tests
+     * Define a term based on the parent component to avoid conflicts on multiple components
+     */
+    componentTestid: {
+      type:    String,
+      default: 'tabbed'
     }
   },
 
@@ -258,7 +266,7 @@ export default {
       'side-tabs': !!sideTabs,
       'tabs-only': tabsOnly
     }"
-    data-testid="tabbed"
+    :data-testid="componentTestid"
   >
     <ul
       v-if="!hideTabs"
@@ -266,7 +274,7 @@ export default {
       role="tablist"
       class="tabs"
       :class="{'clearfix':!sideTabs, 'vertical': sideTabs, 'horizontal': !sideTabs}"
-      data-testid="tabbed-block"
+      :data-testid="`${componentTestid}-block`"
       tabindex="0"
       @keydown.right.prevent="selectNext(1)"
       @keydown.left.prevent="selectNext(-1)"

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -85,6 +85,15 @@ export default class ProvCluster extends SteveModel {
     };
   }
 
+  get canEdit() {
+    // If the cluster is a KEV1 cluster or Harvester cluster then prevent edit
+    if (this.isKev1 || this.isHarvester) {
+      return false;
+    }
+
+    return super.canEdit;
+  }
+
   get _availableActions() {
     const out = super._availableActions;
     const isLocal = this.mgmt?.isLocal;

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -1004,4 +1004,8 @@ export default class ProvCluster extends SteveModel {
   get description() {
     return super.description || this.mgmt?.description;
   }
+
+  get disableResourceDetailDrawerConfigTab() {
+    return !!this.isHarvester;
+  }
 }

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -860,6 +860,10 @@ export default class Resource {
 
   // ------------------------------------------------------------------
 
+  get canEdit() {
+    return this.canUpdate && this.canCustomEdit;
+  }
+
   get availableActions() {
     const all = this._availableActions;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14285 
Fixes #15005  
<!-- Define findings related to the feature or bug issue. -->
Modified detail drawer to only allow editing if that action is enabled for the resource. This prevented loading Ember pages for Harvester cluster from management cluster detail page.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added a way to see if cluster should be editable.
Separated check if resource can be edited through config vs through yaml.
Only enabled config tab for Harvester when it is accessed through Virtualization Manager

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Added a new canEdit property to the models that indicates that resource configuration should be editable.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
For edit:
1. Create a standard user and add them as Cluster Member to a cluster.
2. Log in as that user
3. Cluster Management -> Check that 'Show Configuration' is enabled.
4. Verify that you can only view Config and YAML tabs but not edit them
5. Log in as admin
6. Cluster Management -> Check that 'Show Configuration' is enabled.
7. Verify that you can edit Config tab and view YAML tab
8. Go to local cluster -> workloads. Find one that allows editing YAML. Go to 'Show configuration'
9. Verify that you can view and edit both Config and YAML tabs
10.  Verify that same applies when 'Show configuration' is accessed through resource detail page

For Harvester:
Import Harvester cluster
1. Global settings -> feature flags -> "harvester-baremetal-container-workload" -> enable
5. Cluster Management -> Check that 'Show Configuration' is enabled, but only YAML tab is shown and you can only view it, but not save
11. Click on the Harvester cluster and got to the detail page. -> Check that 'Show Configuration' is enabled, but only YAML tab is shown and you can only view it, but not save

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
I've overwritten canEdit for Harvester resource, so that might introduce regressions, but I didn't see it being used in both dashboard and harvester ui extension.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
