### PR TITLE
Update resource table styling

### DIFF
--- a/shell/components/form/ResourceTabs/index.vue
+++ b/shell/components/form/ResourceTabs/index.vue
@@ -234,6 +234,8 @@ export default {
 
 <template>
   <Tabbed
+    class="resource-tabs"
+    :class="{[mode]: true}"
     v-bind="$attrs"
     :default-tab="defaultTab"
     :resource="value"
@@ -296,3 +298,21 @@ export default {
     </Tab>
   </Tabbed>
 </template>
+
+<style lang="scss" scoped>
+.resource-tabs {
+  // For the time being we're only targeting detail pages for the new styling. Remove this if we want this style to apply to all pages.
+  &.view {
+    :deep() .tabs.horizontal {
+      border: none;
+    }
+
+    :deep() .tabs.horizontal + .tab-container {
+      border: none;
+      border-top: 1px solid var(--border);
+      padding: 0;
+      padding-top: 24px;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Implements the tab styling in #13328

Updates the style of Tabs on detail pages to reflect the new design. I can provide a link to figma if you'd like.
<img width="1198" height="753" alt="image" src="https://github.com/user-attachments/assets/4944d316-192d-4850-92e2-39da99fd31fe" />

### Areas or cases that should be tested
Detail and edit pages with `ResourceTabs`

I know the Node resource has both an edit and detail page with resource tabs.

### Areas which could experience regressions
Same as above

### Screenshot/Video
Detail:
<img width="1269" height="852" alt="image" src="https://github.com/user-attachments/assets/2380d875-bddd-4ff7-9ede-ad85c53c81c5" />

Edit:
<img width="950" height="576" alt="image" src="https://github.com/user-attachments/assets/5c8313d6-3b84-4d06-97bf-21f35746901e" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
