### PR TITLE
Improvements to workload detail page resource lists

### DIFF
--- a/shell/detail/workload/index.vue
+++ b/shell/detail/workload/index.vue
@@ -168,11 +168,11 @@ export default {
     },
 
     ingressHeaders() {
-      return this.$store.getters['type-map/headersFor'](this.ingressSchema);
+      return this.$store.getters['type-map/headersFor'](this.ingressSchema).filter((h) => !h.name || h.name !== NAMESPACE_COL.name);
     },
 
     serviceHeaders() {
-      return this.$store.getters['type-map/headersFor'](this.serviceSchema);
+      return this.$store.getters['type-map/headersFor'](this.serviceSchema).filter((h) => !h.name || h.name !== NAMESPACE_COL.name);
     },
 
     totalRuns() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14949
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- workload detail page used ResourceTable with canned input (provided directly to component, not automatically fetched by it)
- ResourceTable would by default fitler input via the values in the header's namespace filter
  - this is old behaviour, not introduced in 2.12.0
- fix is to ensure these single namespace lists ignore the namespace filter
- bonus - don't show redundant namespace column in job list (shown for cronjobs)


### Areas or cases that should be tested
- for ALL of the below toggle between `Only User Namespaces` and `Only System Namespaces` in the following places
  - `api-extension` deployment detail page and
    - the pods list should continue to contain the one pod
    - the services list should continue to contain the one pod
  - `rke2-machineconfig-cleanup-cronjob` cronjob detail page
    - the jobs list should continue to contain the one pod
  - create deployment with pod label a=a, create service that targets the deployment with the pod selector a=a, create an ingress that uses the service. go to the deployment detail page
    - the ingresses list should continue to contain the one pod

### Areas which could experience regressions
- none

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
