### PR TITLE
Resolve `defineExpose` compiler warning

### DIFF
--- a/pkg/rancher-components/src/components/RcButton/RcButton.vue
+++ b/pkg/rancher-components/src/components/RcButton/RcButton.vue
@@ -7,7 +7,7 @@
  *
  * <rc-button primary @click="doAction">Perform an Action</rc-button>
  */
-import { computed, ref, defineExpose } from 'vue';
+import { computed, ref } from 'vue';
 import { ButtonRoleProps, ButtonSizeProps } from './types';
 
 const buttonRoles: { role: keyof ButtonRoleProps, className: string }[] = [


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves the Vue compiler warning that is printed to the console during builds:

```
[@vue/compiler-sfc] `defineExpose` is a compiler macro and no longer needs to be imported.
```

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Remove `defineExpose` import from `RcButton.vue`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

`defineExpose` is a compiler macro and no longer needs to be imported.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Accessing the `focus` method exposed via `RcButton` should not raise any typescript warnings. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Risk of regression is low - this change resolves a compiler warning.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
