### PR TITLE
Fix general and specific resource detail watch issues

### DIFF
--- a/shell/detail/workload/index.vue
+++ b/shell/detail/workload/index.vue
@@ -313,6 +313,16 @@ export default {
 
       this.matchingIngresses = matchingIngresses;
     }
+  },
+
+  watch: {
+    async 'value.jobRelationships.length'(neu, old) {
+      // If there are MORE jobs ensure we go out and fetch them (changes and removals are tracked by watches)
+      if (neu > old) {
+        // We don't need to worry about spam, this won't be called often and it will be infrequent
+        await this.value.matchingJobs();
+      }
+    }
   }
 };
 </script>

--- a/shell/mixins/resource-fetch-api-pagination.js
+++ b/shell/mixins/resource-fetch-api-pagination.js
@@ -352,7 +352,7 @@ export default {
     }
   },
 
-  unmounted() {
+  async beforeUnmount() {
     if (this.havePaginated) {
       // of type @STEVE_WATCH_PARAMS
       const watchArgs = {
@@ -360,9 +360,8 @@ export default {
         mode: STEVE_WATCH_MODE.RESOURCE_CHANGES,
       };
 
-      this.$store.dispatch(`${ this.overrideInStore || this.inStore }/forgetType`, this.resource, (watchParams) => {
-        return watchParams.type === watchArgs.type &&
-        watchParams.mode === watchArgs.type.mode;
+      await this.$store.dispatch(`${ this.overrideInStore || this.inStore }/forgetType`, this.resource, (watchParams) => {
+        return watchParams.type === watchArgs.type && watchParams.mode === watchArgs.type.mode;
       });
     }
   }

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -1,7 +1,7 @@
 import { findBy, insertAt } from '@shell/utils/array';
 import { CATTLE_PUBLIC_ENDPOINTS } from '@shell/config/labels-annotations';
 import { WORKLOAD_TYPES, SERVICE, POD } from '@shell/config/types';
-import { get, set } from '@shell/utils/object';
+import { set } from '@shell/utils/object';
 import day from 'dayjs';
 import { convertSelectorObj, parse } from '@shell/utils/selector';
 import { SEPARATOR } from '@shell/config/workload';
@@ -632,7 +632,7 @@ export default class Workload extends WorkloadService {
       return undefined;
     }
 
-    return (get(this, 'metadata.relationships') || []).filter((relationship) => relationship.toType === WORKLOAD_TYPES.JOB);
+    return this.metadata.relationships?.filter((relationship) => relationship.toType === WORKLOAD_TYPES.JOB) || [];
   }
 
   /**

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -632,7 +632,7 @@ export default class Workload extends WorkloadService {
       return undefined;
     }
 
-    return this.metadata.relationships?.filter((relationship) => relationship.toType === WORKLOAD_TYPES.JOB) || [];
+    return this.metadata?.relationships?.filter((relationship) => relationship.toType === WORKLOAD_TYPES.JOB) || [];
   }
 
   /**

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -79,6 +79,29 @@ const findAllGetter = (getters, type, opt) => {
   return opt.namespaced ? getters.matching(type, null, opt.namespaced, { skipSelector: true }) : getters.all(type);
 };
 
+const createFindWatchArg = ({
+  type, id, opt, res
+}) => {
+  const revision = typeof opt.revision !== 'undefined' ? opt.revision : res?.metadata?.resourceVersion;
+  const watchMsg = {
+    type,
+    id,
+    // Although not used by sockets, we need this for when resyncWatch calls find... which needs namespace to construct the url
+    namespace: opt.namespaced,
+    revision:  revision || '',
+    force:     opt.forceWatch === true,
+  };
+
+  const idx = id.indexOf('/');
+
+  if ( idx > 0 ) {
+    watchMsg.namespace = id.substr(0, idx);
+    watchMsg.id = id.substr(idx + 1);
+  }
+
+  return watchMsg;
+};
+
 export default {
   request() {
     throw new Error('Not Implemented');
@@ -657,6 +680,12 @@ export default {
       out = getters.byId(type, id);
 
       if ( out ) {
+        if ( opt.watch !== false ) {
+          dispatch('watch', createFindWatchArg({
+            type, id, opt, res: undefined
+          }));
+        }
+
         return out;
       }
     }
@@ -669,26 +698,9 @@ export default {
     await dispatch('load', { data: res });
 
     if ( opt.watch !== false ) {
-      const watchMsg = {
-        type,
-        id,
-        // Although not used by sockets, we need this for when resyncWatch calls find... which needs namespace to construct the url
-        namespace: opt.namespaced,
-        // Override the revision. Used in cases where we need to avoid using the resource's own revision which would be `too old`.
-        // For the above case opt.revision will be `null`. If left as `undefined` the subscribe mechanism will try to determine a revision
-        // from resources in store (which would be this one, with the too old revision)
-        revision:  typeof opt.revision !== 'undefined' ? opt.revision : res?.metadata?.resourceVersion,
-        force:     opt.forceWatch === true,
-      };
-
-      const idx = id.indexOf('/');
-
-      if ( idx > 0 ) {
-        watchMsg.namespace = id.substr(0, idx);
-        watchMsg.id = id.substr(idx + 1);
-      }
-
-      dispatch('watch', watchMsg);
+      dispatch('watch', createFindWatchArg({
+        type, id, opt, res
+      }));
     }
 
     out = getters.byId(type, id);


### PR DESCRIPTION
Blocked on https://github.com/rancher/dashboard/pull/14994
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14981
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Navigating from a list to a detail page resulted in missed resource updates
  - In vai on world when we leave a list we forget the type completely (removes resources from store and unwatches it)
  - However this process would happen after the navigation to the resource detail page and it's process to find and watch the resource
  - This meant the page would show a stale resource that was removed from store. So even if we started a watch for it any updates would be on a different resource to the one used to show the detail view
  - Fix is to forget type with beforeUnmount rather than unmounted
- Fix a gap in the watch mechanism
  - This is slightly related to above, but wasn't the fix for it. However it's an improvement that should stay in
  - If a resource is in the store the `find` action doesn't go and re-fetch it, it just returns the store version
  - However sometimes this resource isn't watched so, if the `find` options dictate it, ensure we do
- Ensure new jobs are shown whilst on the cronjob detail page
  - Applicable to both navigating to the detail page or refreshing on it
  - Jobs come from a specific list that's in the cronjob
  - we explicitly go out and fetch this list
  - when a new job is created the list in the cronjob updates... and we need to then go out and explicitly fetch it

### Areas or cases that should be tested
Test in a rke2/k3s local cluster 

Test 1
- In Tab 1 - Nav to CronJobs list, click on `rke2-machineconfig-cleanup-cronjob`. If there are three jobs delete them all
- In Tab 2 - Nav to CronJobs list, click on `rke2-machineconfig-cleanup-cronjob` and click on three dot menu top right and 'Run Now'
- In Tab 1 - A new Job should appear

Test 2
- In Tab 1 - Nav to CronJobs list, click on `rke2-machineconfig-cleanup-cronjob`. If there are three jobs delete them all
- In Tab 1 - Refresh the page
- In Tab 2 - Nav to CronJobs list, click on `rke2-machineconfig-cleanup-cronjob` and click on three dot menu top right and 'Run Now'
- In Tab 1 - A new Job should appear

Test 3
- In Tab 1 - Nav to CronJobs list, click on `rke2-machineconfig-cleanup-cronjob`. If there are three jobs delete them all (and wait a minute or two, the linked resources take time to clear)
- In Tab 1 - Click on three dot menu top right and 'Run Now'
- user will be sent to the new job page
- In Tab 1 - Nav to CronJobs list, click on `rke2-machineconfig-cleanup-cronjob`
- In Tab 1 - The job should eventually be shown as 'Active' (not stuck at 'in progress')


### Areas which could experience regressions
- any resource detail page resource info

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
