### PR TITLE
Ensure SecretSelector resets on namespace change

### DIFF
--- a/shell/components/form/SecretSelector.vue
+++ b/shell/components/form/SecretSelector.vue
@@ -138,6 +138,13 @@ export default {
     }
   },
 
+  watch: {
+    namespace() {
+      // Namespace has changed, reset the selections
+      this.$emit('update:value', { [this.mountKey]: { secretKeyRef: { [this.nameKey]: undefined, [this.keyKey]: '' } } });
+    }
+  },
+
   methods: {
     /**
      * Provide a set of options for the LabelSelect ([none, ...{label, value}])
@@ -208,6 +215,7 @@ export default {
     <div class="input-container">
       <!-- key by namespace to ensure label select current page is recreated on ns change -->
       <ResourceLabeledSelect
+        :key="namespace"
         v-model:value="name"
         :disabled="!isView && disabled"
         :label="secretNameLabel"
@@ -219,6 +227,7 @@ export default {
       />
       <LabeledSelect
         v-if="showKeySelector"
+        :key="namespace"
         v-model:value="key"
         class="col span-6"
         :disabled="isKeyDisabled"

--- a/shell/components/form/labeled-select-utils/labeled-select-pagination.ts
+++ b/shell/components/form/labeled-select-utils/labeled-select-pagination.ts
@@ -1,46 +1,11 @@
 import { debounce } from 'lodash';
 import { PropType, defineComponent } from 'vue';
-import { ComputedOptions, MethodOptions } from 'vue/types/v3-component-options';
 import { LabelSelectPaginateFn, LABEL_SELECT_NOT_OPTION_KINDS, LABEL_SELECT_KINDS } from '@shell/types/components/labeledSelect';
-
-interface Props {
-  paginate?: LabelSelectPaginateFn
-}
-
-interface Data {
-  currentPage: number,
-  search: string,
-  pageSize: number,
-
-  page: any[],
-  pages: number,
-  totalResults: number,
-
-  paginating: boolean,
-
-  debouncedRequestPagination: Function
-}
-
-interface Computed extends ComputedOptions {
-  canPaginate: () => boolean,
-
-  canLoadMore: () => boolean,
-
-  optionsInPage: () => number,
-
-  optionCounts: () => string,
-}
-
-interface Methods extends MethodOptions {
-  loadMore: () => void
-  setPaginationFilter: (filter: string) => void
-  requestPagination: () => Promise<any>;
-}
 
 /**
  * 'mixin' to provide pagination support to LabeledSelect
  */
-export default defineComponent<Props, any, Data, Computed, Methods>({
+export default defineComponent({
   props: {
     paginate: {
       default: null,
@@ -61,7 +26,7 @@ export default defineComponent<Props, any, Data, Computed, Methods>({
     },
   },
 
-  data(): Data {
+  data() {
     return {
       // Internal
       currentPage: 1,
@@ -72,7 +37,7 @@ export default defineComponent<Props, any, Data, Computed, Methods>({
       debouncedRequestPagination: debounce(this.requestPagination, 700),
 
       // External
-      page:         [],
+      page:         [] as any[],
       totalResults: 0,
       paginating:   false,
     };

--- a/shell/edit/logging.banzaicloud.io.output/index.vue
+++ b/shell/edit/logging.banzaicloud.io.output/index.vue
@@ -21,7 +21,7 @@ import YamlEditor, { EDITOR_MODES } from '@shell/components/YamlEditor';
 export default {
   components: {
     Banner, CruResource, Labels, LabeledSelect, NameNsDescription, Tab, Tabbed, YamlEditor, Loading
-  }, //
+  },
 
   mixins: [CreateEditView],
 

--- a/shell/edit/logging.banzaicloud.io.output/providers/awsElasticsearch.vue
+++ b/shell/edit/logging.banzaicloud.io.output/providers/awsElasticsearch.vue
@@ -51,7 +51,6 @@ export default {
       </div>
     </div>
     <div class="row mb-10">
-      {{ value.namespace }}
       <div class="col span-6">
         <SecretSelector
           v-model:value="value.endpoint.access_key_id"


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14849
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- re-render the core controls, reset the selected values
- also
  - fixed typing in labeled-select-pagination. something over the versions broke this. however.. a lot of the custom typing now isn't needed
  - removed empty comment root output edit page
  - removed debug line in awsElasticsearch


### Areas or cases that should be tested
- install logging app
- nav go Logging --> Outputs --> create
- in output tab, leave Amazon Elasticsearch selected, in Access select a secret and key in both sections
- change the namespace at the top
  - The selections should be cleared
  - secrets in the new namespace should be shown in the access dropdowns (and their keys)

### Areas which could experience regressions
- tests with the elastic search output, however in theory all others are affected
- create rke2 cluster --> registries tab --> show advanced --> TLS Secret drop down (note - need a tls secret in the fleet-default ns)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
