### PR TITLE
Add a custom action menu to alert manager config

### DIFF
--- a/shell/models/monitoring.coreos.com.alertmanagerconfig.js
+++ b/shell/models/monitoring.coreos.com.alertmanagerconfig.js
@@ -33,7 +33,7 @@ export default class AlertmanagerConfig extends SteveModel {
   }
 
   getReceiverActions(alertmanagerConfigActions) {
-    return alertmanagerConfigActions.filter((actionData) => {
+    const actions = alertmanagerConfigActions.filter((actionData) => {
       if (actionData.divider) {
         return true;
       }
@@ -48,6 +48,9 @@ export default class AlertmanagerConfig extends SteveModel {
         return false;
       }
     });
+
+    // remove the first action if it is a divider
+    return actions.filter((action, index) => !(index === 0 && action.divider));
   }
 
   get alertmanagerConfigDoneRouteName() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This replaces the legacy action menu implementation in alert manager config with the new `ActionMenuShell` component.

Fixes #14944 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- add ActionMenuShell to alert manager config

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I initially thought that the broken menu was a side effect of the new dropdown menu component, but I observed this menu being broken in v2.10 of Rancher - this is before we implemented the new action menu. 

We will need to custom solution if we desire to backport this fix to Rancher 2.10.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Detailed in the issue.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Detailed in the issue.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

## Action Menu

<img width="1418" height="1112" alt="image" src="https://github.com/user-attachments/assets/eed43a31-b92d-4392-b40c-d1f8e8313854" />

## Dropdown Menu
<img width="1419" height="1110" alt="image" src="https://github.com/user-attachments/assets/89591efd-a33e-421e-a80f-1bd6b255e8a9" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
