### PR TITLE
Resolves a spacing issue for metadata components

### DIFF
--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -30,7 +30,10 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
 </script>
 
 <template>
-  <SpacedRow class="metadata ppb-3">
+  <SpacedRow
+    class="metadata ppb-3"
+    v-bind="$attrs"
+  >
     <div
       class="identifying-info"
     >


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
fixes #14996


### Technical notes summary
When I re-introduced the ExtensionPanel I did it as a separate child of the Metadata component. This implicitly disables inheritAttrs so the class was no longer being passed.

We now explicitly bind the attrs to the appropriate child.

### Areas or cases that should be tested
The masthead on any resource detail page

### Areas which could experience regressions
The masthead on any resource detail page

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
