### PR TITLE
[backport 2.12.1] Resolved an issue where the new masthead broke the existing extension panels

### DIFF
--- a/shell/components/Resource/Detail/Metadata/composables.ts
+++ b/shell/components/Resource/Detail/Metadata/composables.ts
@@ -16,6 +16,7 @@ export const useBasicMetadata = (resource: any) => {
 
   return computed(() => {
     return {
+      resource:            toValue(resource),
       labels:              labels.value,
       annotations:         annotations.value,
       onShowConfiguration: (returnFocusSelector: string) => openResourceDetailDrawer(resource, returnFocusSelector)
@@ -33,6 +34,7 @@ export const useDefaultMetadataProps = (resource: any, additionalIdentifyingInfo
 
   return computed(() => {
     return {
+      resource:               toValue(resource),
       identifyingInformation: identifyingInformation.value,
       labels:                 basicMetaData.value.labels,
       annotations:            basicMetaData.value.annotations,
@@ -69,6 +71,7 @@ export const useDefaultMetadataForLegacyPagesProps = (resource: any) => {
 
   return computed(() => {
     return {
+      resource:               toValue(resource),
       identifyingInformation: identifyingInformation.value,
       labels:                 basicMetaData.value.labels,
       annotations:            basicMetaData.value.annotations,

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -7,15 +7,20 @@ import KeyValue from '@shell/components/Resource/Detail/Metadata/KeyValue.vue';
 import { computed } from 'vue';
 import { useI18n } from '@shell/composables/useI18n';
 import { useStore } from 'vuex';
+import { ExtensionPoint, PanelLocation } from '@shell/core/types';
+import ExtensionPanel from '@shell/components/ExtensionPanel.vue';
 
 export interface MetadataProps {
+  resource: any;
   identifyingInformation: IdentifyingInformationRow[],
   labels: Label[],
   annotations: Annotation[],
   onShowConfiguration?: (returnFocusSelector: string) => void;
 }
 
-const { identifyingInformation, labels, annotations } = defineProps<MetadataProps>();
+const {
+  resource, identifyingInformation, labels, annotations
+} = defineProps<MetadataProps>();
 const emit = defineEmits(['show-configuration']);
 
 const store = useStore();
@@ -62,6 +67,13 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
       />
     </div>
   </SpacedRow>
+  <!-- Extensions area -->
+  <ExtensionPanel
+    class="ppb-3"
+    :resource="resource"
+    :type="ExtensionPoint.PANEL"
+    :location="PanelLocation.DETAIL_TOP"
+  />
 </template>
 
 <style lang="scss" scoped>

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -30,7 +30,10 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
 </script>
 
 <template>
-  <SpacedRow class="metadata ppb-3">
+  <SpacedRow
+    class="metadata ppb-3"
+    v-bind="$attrs"
+  >
     <div
       class="identifying-info"
     >

--- a/shell/components/Resource/Detail/TitleBar/composables.ts
+++ b/shell/components/Resource/Detail/TitleBar/composables.ts
@@ -29,6 +29,7 @@ export const useDefaultTitleBarProps = (resource: any, resourceSubtype?: Ref<str
     const onShowConfiguration = resourceValue.disableResourceDetailDrawer ? undefined : (returnFocusSelector: string) => openResourceDetailDrawer(resourceValue, returnFocusSelector);
 
     return {
+      resource:           resourceValue,
       resourceTypeLabel,
       resourceTo,
       resourceName,

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -11,6 +11,8 @@ import TabTitle from '@shell/components/TabTitle';
 import { computed, ref, watch } from 'vue';
 import { _CONFIG, _GRAPH, AS } from '@shell/config/query-params';
 import ButtonGroup from '@shell/components/ButtonGroup';
+import { ExtensionPoint, PanelLocation } from '@shell/core/types';
+import ExtensionPanel from '@shell/components/ExtensionPanel.vue';
 
 export interface Badge {
   color: 'bg-success' | 'bg-error' | 'bg-warning' | 'bg-info';
@@ -18,6 +20,7 @@ export interface Badge {
 }
 
 export interface TitleBarProps {
+  resource: any;
   resourceTypeLabel: string;
   resourceName: string;
 
@@ -40,7 +43,7 @@ const showConfigurationIcon = require(`@shell/assets/images/icons/document.svg`)
 
 <script setup lang="ts">
 const {
-  resourceTypeLabel, resourceTo, resourceName, description, badge, showViewOptions, onShowConfiguration,
+  resource, resourceTypeLabel, resourceTo, resourceName, description, badge, showViewOptions, onShowConfiguration,
 } = defineProps<TitleBarProps>();
 
 const store = useStore();
@@ -144,6 +147,11 @@ watch(
     >
       {{ description }}
     </div>
+    <ExtensionPanel
+      :resource="resource"
+      :type="ExtensionPoint.PANEL"
+      :location="PanelLocation.DETAILS_MASTHEAD"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Puts the following extension points back into the masthead:
- PanelLocation.DETAILS_MASTHEAD
- PanelLocation.DETAIL_TOP


fixes #15021
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
The extension points were omitted from the new design. This puts them back in.

### Areas or cases that should be tested
I used the https://github.com/rancher/ui-plugin-examples with a `yarn link @rancher/shell` to verify these changes. The plugin examples will add both panels to the gitrepo resource.

### Screenshot/Video
<img width="1591" height="539" alt="image" src="https://github.com/user-attachments/assets/5a96d22d-bfca-4ef3-895b-d8d31a1074db" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
