### PR TITLE
Update charts e2e test so that it doesn't rely on version

### DIFF
--- a/cypress/e2e/po/pages/explorer/charts/chart.po.ts
+++ b/cypress/e2e/po/pages/explorer/charts/chart.po.ts
@@ -55,6 +55,10 @@ export class ChartPage extends PagePo {
     return this.self().find('[data-testid="chart-versions"]');
   }
 
+  versionLinks() {
+    return this.versions().find('[data-testid="chart-version-link"]');
+  }
+
   showMoreVersions() {
     return this.self().find('[data-testid="chart-show-more-versions"]');
   }

--- a/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
@@ -40,11 +40,14 @@ describe('Apps/Charts', { tags: ['@explorer', '@adminUser'] }, () => {
     // Set up intercept for the network request triggered by $fetch
     cy.intercept('GET', `**${ CLUSTER_REPOS_BASE_URL }/**`).as('fetchChartDataAfterSelect');
 
-    // making sure it's not hidden under the show more results
-    chartPage.showMoreVersions().click();
-    chartPage.selectVersion('105.2.1+up4.10.0');
+    // Select the first active version link
+    chartPage.versionLinks()
+      .first()
+      .then((firstVersion) => {
+        chartPage.selectVersion(firstVersion.text());
 
-    cy.wait('@fetchChartDataAfterSelect').its('response.statusCode').should('eq', 200);
+        cy.wait('@fetchChartDataAfterSelect').its('response.statusCode').should('eq', 200);
+      });
   });
 
   it('should not call fetch when navigating back to charts page', () => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates the `should call fetch when route query changes with valid parameters` test so that it navigates to the first active link in the list of versions.

The test does not need to rely on a specific version in order to assert its case. Relying on the specific version is prone to failure if the backend stops providing it for any reason.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Remove specific version requirement from `should call fetch when route query changes with valid parameters` test

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This change has been introduced to the `release-2.11` and `release-2.12` branches[^1] [^2] - the intent is to keep the implementation as consistent as possible between all active development branches. 

[^1]: https://github.com/rancher/dashboard/pull/15014
[^2]: https://github.com/rancher/dashboard/pull/15001

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Affected e2e test should pass.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

NA

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
