### PR TITLE
fix: show repository missing warning if install harvester ui ext from catalog image

### DIFF
--- a/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
@@ -119,8 +119,8 @@ export default {
 
     harvester() {
       const extension = this.uiplugins?.find((c) => c.name === HARVESTER_CHART.name);
-
-      const missingRepository = !!extension && !this.harvesterRepository;
+      // if no harvester ui extension in uiplugins and no harvester repository, then we will show missing repository warning
+      const missingRepository = !!extension === false && !this.harvesterRepository;
 
       const action = async(btnCb) => {
         const action = `${ !extension ? 'install' : 'update' }HarvesterExtension`;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14141 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
fix: show repository missing warning if harvester ui extension installed from catalog image


Note. we can backport this fix to 2.12.1, 2.11.5 and 2.10.9.


### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
Before 
<img width="1468" height="798" alt="Screenshot 2025-08-05 at 2 41 58 PM" src="https://github.com/user-attachments/assets/20ed5318-a9b0-4cfa-af1a-39b161774038" />


After 
<img width="1470" height="807" alt="Screenshot 2025-08-05 at 2 44 17 PM" src="https://github.com/user-attachments/assets/338f7e2c-075b-42e6-b455-3678402214cb" />


See recording 
https://github.com/user-attachments/assets/fbd26821-cc73-40be-8527-fb47a71f5b81


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility



