### PR TITLE
[2.12.1] Fix RcDropdown overflow

### DIFF
--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdown.test.ts
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdown.test.ts
@@ -1,0 +1,102 @@
+import { mount } from '@vue/test-utils';
+import { defineComponent } from 'vue';
+import { RcDropdown } from '@components/RcDropdown';
+
+const vDropdownMock = defineComponent({
+  template: `
+    <div class="popper">
+      <slot name="popper" />
+    </div>
+  `,
+});
+
+describe('component: RcDropdown.vue', () => {
+  it('should not change the height if the dropdown fits within the screen', async() => {
+    Object.defineProperty(window, 'innerHeight', { value: 800 });
+
+    const wrapper = mount(RcDropdown, { global: { components: { 'v-dropdown': vDropdownMock } } });
+
+    const dropdownTarget = wrapper.find('[dropdown-menu-collection]').element as HTMLElement;
+
+    Object.defineProperty(dropdownTarget, 'getBoundingClientRect', {
+      value: () => ({
+        top:    200,
+        bottom: 600,
+        height: 400,
+      }),
+      writable: true,
+    });
+
+    await wrapper.findComponent(vDropdownMock).vm.$emit('apply-show');
+    await wrapper.vm.$nextTick();
+
+    expect(dropdownTarget.style.height).toBe('');
+    expect(dropdownTarget.style.overflow).toBe('');
+  });
+
+  it('should apply correct overflow and height if dropdown exceeds the top edge', async() => {
+    Object.defineProperty(window, 'innerHeight', { value: 800 });
+
+    const wrapper = mount(RcDropdown, { global: { components: { 'v-dropdown': vDropdownMock } } });
+
+    const dropdownTarget = wrapper.find('[dropdown-menu-collection]').element as HTMLElement;
+
+    Object.defineProperty(dropdownTarget, 'getBoundingClientRect', {
+      value: () => ({
+        top:    2, // Exceeds (top - padding)
+        bottom: 300,
+        height: 298,
+      }),
+    });
+
+    await wrapper.findComponent(vDropdownMock).vm.$emit('apply-show');
+    await wrapper.vm.$nextTick();
+
+    expect(dropdownTarget.style.overflow).toBe('auto');
+    expect(dropdownTarget.style.height).toBe('268px');
+  });
+
+  it('should apply correct overflow and height if dropdown exceeds the bottom edge', async() => {
+    Object.defineProperty(window, 'innerHeight', { value: 925 });
+
+    const wrapper = mount(RcDropdown, { global: { components: { 'v-dropdown': vDropdownMock } } });
+
+    const dropdownTarget = wrapper.find('[dropdown-menu-collection]').element as HTMLElement;
+
+    Object.defineProperty(dropdownTarget, 'getBoundingClientRect', {
+      value: () => ({
+        top:    200,
+        bottom: 920, // Exceeds (bottom + padding)
+        height: 720,
+      }),
+    });
+
+    await wrapper.findComponent(vDropdownMock).vm.$emit('apply-show');
+    await wrapper.vm.$nextTick();
+
+    expect(dropdownTarget.style.overflow).toBe('auto');
+    expect(dropdownTarget.style.height).toBe('693px');
+  });
+
+  it('should apply correct overflow and height if dropdown exceeds both top and bottom edges', async() => {
+    Object.defineProperty(window, 'innerHeight', { value: 400 });
+
+    const wrapper = mount(RcDropdown, { global: { components: { 'v-dropdown': vDropdownMock } } });
+
+    const dropdownTarget = wrapper.find('[dropdown-menu-collection]').element as HTMLElement;
+
+    Object.defineProperty(dropdownTarget, 'getBoundingClientRect', {
+      value: () => ({
+        top:    -800, // Exceeds top
+        bottom: 800, // Exceeds bottom
+        height: 1600,
+      }),
+    });
+
+    await wrapper.findComponent(vDropdownMock).vm.$emit('apply-show');
+    await wrapper.vm.$nextTick();
+
+    expect(dropdownTarget.style.overflow).toBe('auto');
+    expect(dropdownTarget.style.height).toBe('368px');
+  });
+});

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdown.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdown.vue
@@ -47,6 +47,7 @@ const {
   provideDropdownContext,
   registerDropdownCollection,
   handleKeydown,
+  setDropdownDimensions
 } = useDropdownContext(emit);
 
 provideDropdownContext();
@@ -57,6 +58,7 @@ const dropdownTarget = ref(null);
 useClickOutside(dropdownTarget, () => showMenu(false));
 
 const applyShow = () => {
+  setDropdownDimensions(dropdownTarget.value);
   registerDropdownCollection(dropdownTarget.value);
   setFocus('down');
 };

--- a/pkg/rancher-components/src/components/RcDropdown/useDropdownContext.ts
+++ b/pkg/rancher-components/src/components/RcDropdown/useDropdownContext.ts
@@ -89,6 +89,27 @@ export const useDropdownContext = (emit: typeof rcDropdownEmits) => {
     });
   };
 
+  const setDropdownDimensions = (target: HTMLElement | null) => {
+    if (!target) {
+      return;
+    }
+
+    const { top, bottom } = target.getBoundingClientRect();
+    const padding = 32;
+
+    // The dropdown exceeds the top or bottom edge of the screen (or both).
+    if (top - padding < 0 || bottom + padding > window.innerHeight) {
+      const height = Math.min(
+        bottom,
+        window.innerHeight - top,
+        window.innerHeight
+      );
+
+      target.style.height = `${ height - padding }px`;
+      target.style.overflow = 'auto';
+    }
+  };
+
   /**
   * Provides Dropdown Context data and methods to descendants of RcDropdown.
   * Accessed in descendents with the `inject()` function.
@@ -115,5 +136,6 @@ export const useDropdownContext = (emit: typeof rcDropdownEmits) => {
     provideDropdownContext,
     registerDropdownCollection,
     handleKeydown,
+    setDropdownDimensions,
   };
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15051
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
