### PR TITLE
SCC - unclear error message for invalid registration code

### DIFF
--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -1,4 +1,3 @@
-import { get } from '@shell/utils/object';
 import { computed, ref, Ref } from 'vue';
 import { type Store, useStore } from 'vuex';
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14940
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

Updated the logic as indicated in comment: https://github.com/rancher/dashboard/issues/14940#issuecomment-3136144587

### Technical notes summary

Added case for errors and specifically the order mentioned.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video


https://github.com/user-attachments/assets/bbe00735-450b-4924-a0e8-7f9078414f2c



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
