### PR TITLE
fix issue with pods capacity on node list view

### DIFF
--- a/shell/models/__tests__/node.test.ts
+++ b/shell/models/__tests__/node.test.ts
@@ -1,74 +1,18 @@
-import Node from '@shell/models/management.cattle.io.node';
+import Node from '@shell/models/cluster/node';
 
 describe('class Node', () => {
-  const foo = 'foo';
-  const bar = 'bar';
-  const t = jest.fn(() => bar);
-  const ctx = { rootGetters: { 'i18n/t': t } };
-
   const resetMocks = () => {
     // Clear all mock function calls:
     jest.clearAllMocks();
   };
 
-  it('should not return addresses if they are not present in the resource status', () => {
-    const node = new Node({ status: {} });
+  it.each([
+    ['1200', 1200],
+    ['1k', 1000]
+  ])('given %p status pod capacity value from the backend, should parse the value correctly as %p', (value, result) => {
+    const node = new Node({ status: { capacity: { pods: value } } });
 
-    expect(node.addresses).toStrictEqual([]);
+    expect(node.podCapacity).toStrictEqual(result);
     resetMocks();
-  });
-
-  describe('should return addresses', () => {
-    const addresses = [foo];
-
-    it('if they are present directly on the resource status', () => {
-      const node = new Node({ status: { addresses } });
-
-      expect(node.addresses).toStrictEqual(addresses);
-    });
-  });
-
-  describe('should return an internalIp', () => {
-    const addresses = [{ type: 'InternalIP', address: foo }];
-
-    it('if addresses includes an object with an appropriate type and address', () => {
-      const node = new Node({ status: { addresses } });
-
-      expect(node.internalIp).toStrictEqual(foo);
-    });
-  });
-
-  describe('should return an externalIp', () => {
-    const addresses = [{ type: 'ExternalIP', address: foo }];
-
-    it('if addresses includes an object with an appropriate type and address', () => {
-      const node = new Node({ status: { addresses } });
-
-      expect(node.externalIp).toStrictEqual(foo);
-    });
-    it('if internalNodeStatus.addresses includes an object with an appropriate type and address', () => {
-      const node = new Node({ status: { internalNodeStatus: { addresses } } });
-
-      expect(node.externalIp).toStrictEqual(foo);
-    });
-  });
-
-  describe('should return an appropriate message', () => {
-    it('if there is no internalIp to display', () => {
-      const node = new Node({ status: {} }, ctx);
-
-      expect(node.internalIp).toStrictEqual(bar);
-      expect(t).toHaveBeenCalledTimes(1);
-      expect(t).toHaveBeenCalledWith('generic.none');
-      resetMocks();
-    });
-    it('if there is no externalIp to display', () => {
-      const node = new Node({ status: {} }, ctx);
-
-      expect(node.externalIp).toStrictEqual(bar);
-      expect(t).toHaveBeenCalledTimes(1);
-      expect(t).toHaveBeenCalledWith('generic.none');
-      resetMocks();
-    });
   });
 });

--- a/shell/models/cluster/node.js
+++ b/shell/models/cluster/node.js
@@ -227,7 +227,7 @@ export default class ClusterNode extends SteveModel {
   }
 
   get podCapacity() {
-    return Number.parseInt(this.status.capacity?.pods);
+    return parseSi(this.status.capacity?.pods);
   }
 
   get podConsumed() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15049
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix issue with pods capacity on node list view
- add unit test
- remove tests that are duplicated in a different model unit test `management.cattle.io.node`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Provision a RKE2 cluster
- once that cluster is online, edit that cluster and on `Advanced` - `Additional kubelet args` set the following value: `max-pods=1000`
- On cluster explorer, `nodes` list, check that pods percentage bar is correct

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach  screenshot or video of the changes and eventual comparison if you find it necessary -->
Before
<img width="2186" height="1261" alt="Screenshot 2025-08-06 at 12 10 31" src="https://github.com/user-attachments/assets/0ce8338f-1744-4fb6-b9aa-9e95edc4d276" />

After
<img width="2186" height="1261" alt="Screenshot 2025-08-06 at 12 10 45" src="https://github.com/user-attachments/assets/0069aec3-8bf0-4e9a-8483-38113078eb42" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
