### PR TITLE
fix focus-visible outline in dark mode

### DIFF
--- a/shell/components/nav/Favorite.vue
+++ b/shell/components/nav/Favorite.vue
@@ -56,5 +56,9 @@ export default {
     &.icon-star-closed {
       color: var(--body-text);
     }
+
+    &:focus-visible {
+      @include focus-outline;
+    }
   }
 </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14106 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix broken focus-visible outline in dark mode

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- keyboard nav in any star icon on any resource list in both light and dark mode

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

Before:
https://github.com/user-attachments/assets/f9cbb8bb-c4dd-44f4-bbb0-f6118cf3ad4f

After:

light (this was ok)
<img width="2186" height="1316" alt="light" src="https://github.com/user-attachments/assets/3a65a0ec-7086-45c5-b18b-ecc6a0df95a3" />


dark (this was broken)
<img width="2186" height="1316" alt="dark" src="https://github.com/user-attachments/assets/5572d19c-59ff-403e-a54c-83fafd46c259" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
