### PR TITLE
add refs wherever possible for focus trap init

### DIFF
--- a/pkg/kubectl-explain/components/SlideInPanel.vue
+++ b/pkg/kubectl-explain/components/SlideInPanel.vue
@@ -41,7 +41,7 @@ export default {
     // and therefore not triggering the focus trap
     isOpen(neu, old) {
       if (neu && neu !== old) {
-        useWatcherBasedSetupFocusTrapWithDestroyIncluded(() => this.isOpen, '[data-testid="slide-in-panel-resource-explain"]', {
+        useWatcherBasedSetupFocusTrapWithDestroyIncluded(() => this.isOpen, this.$refs.slideInPanelResourceExplain, {
           escapeDeactivates: false,
           allowOutsideClick: true,
           // putting the initial focus on the first element that is not conditionally displayed
@@ -205,6 +205,7 @@ export default {
       @click="close()"
     />
     <aside
+      ref="slideInPanelResourceExplain"
       class="slide-in"
       :class="{ 'slide-in-open': isOpen }"
       :style="{ width, right, top, height }"

--- a/pkg/rancher-components/src/components/Card/Card.vue
+++ b/pkg/rancher-components/src/components/Card/Card.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
-import { useBasicSetupFocusTrap } from '@shell/composables/focusTrap';
 
 export default defineComponent({
 
@@ -51,23 +50,6 @@ export default defineComponent({
     sticky: {
       type:    Boolean,
       default: false,
-    },
-    triggerFocusTrap: {
-      type:    Boolean,
-      default: false,
-    },
-  },
-  setup(props) {
-    if (props.triggerFocusTrap) {
-      useBasicSetupFocusTrap('#focus-trap-card-container-element', {
-        // needs to be false because of import YAML modal from header
-        // where the YAML editor itself is a focus trap
-        // and we can't have it superseed the "escape key" to blur that UI element
-        // In this case the focus trap moves the focus out of the modal
-        // correctly once it closes because of the "onBeforeUnmount" trigger
-        escapeDeactivates: false,
-        allowOutsideClick: true,
-      });
     }
   }
 });

--- a/shell/components/SlideInPanelManager.vue
+++ b/shell/components/SlideInPanelManager.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, onBeforeUnmount, watch } from 'vue';
+import { computed, onBeforeUnmount, watch, useTemplateRef } from 'vue';
 import { useStore } from 'vuex';
 import {
   DEFAULT_FOCUS_TRAP_OPTS,
@@ -9,6 +9,9 @@ import { isEqual } from 'lodash';
 import { useRouter } from 'vue-router';
 
 const HEADER_HEIGHT = 55;
+
+const slideInPanelManager = useTemplateRef('SlideInPanelManager');
+const slideInPanelManagerClose = useTemplateRef('SlideInPanelManagerClose');
 
 const store = useStore();
 const isOpen = computed(() => store.getters['slideInPanel/isOpen']);
@@ -72,7 +75,9 @@ watch(
           }
 
           return returnFocusSelector || '.dashboard-root';
-        }
+        },
+        // putting the initial focus on the first element that is not conditionally displayed
+        initialFocus: slideInPanelManagerClose.value
       };
 
       useWatcherBasedSetupFocusTrapWithDestroyIncluded(
@@ -83,7 +88,7 @@ watch(
 
           return isOpen?.value && !isClosing?.value;
         },
-        '#slide-in-panel-manager',
+        slideInPanelManager.value as HTMLElement,
         opts,
         false
       );
@@ -128,6 +133,7 @@ function closePanel() {
   <Teleport to="#slides">
     <div
       id="slide-in-panel-manager"
+      ref="SlideInPanelManager"
       @keydown.escape="closePanel"
     >
       <div
@@ -155,6 +161,7 @@ function closePanel() {
             {{ panelTitle }}
           </div>
           <i
+            ref="SlideInPanelManagerClose"
             class="icon icon-close"
             data-testid="slide-in-close"
             :tabindex="isOpen ? 0 : -1"


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13344 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- remove unsused focus trap from `Card` component 
- add refs wherever possible for focus trap init

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

From the 5 hits we got on code search for the focus trap init methods usage:
- `Card` component -> removed as there is no usage for focus trap with `Card` component
- `SlideInPanel` -> kube-explain built-in extension icon on header for resources - init element replaced. Cannot replace `initialFocus` element as it's not rendered in the DOM yet
- `AppModal` - cannot be replaced as the whole logic is conditional and there's no `ref` access on `setup` method
- `SlideInPanelManager` -> `Show configuration` action for any table row resource item - init element and `initialFocus` element replaced
- `PluginInfoPanel` -> Extension Slide In Panel - cannot use refs as elements aren't rendered on `created`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- `SlideInPanel` -> kube-explain built-in extension icon on header for resources
- `SlideInPanelManager` -> `Show configuration` action for any table row resource item

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
