### PR TITLE
fix keyboard nav on show advanced in cluster create/edit

### DIFF
--- a/cypress/e2e/po/components/registries-tab.po.ts
+++ b/cypress/e2e/po/components/registries-tab.po.ts
@@ -14,7 +14,7 @@ export default class RegistriesTabPo extends ComponentPo {
   }
 
   showAdvanced() {
-    return this.self().find('[data-testid="registries-advanced-section"]');
+    return this.self().find('[data-testid="registries-advanced-section"] a');
   }
 
   clickShowAdvanced(): void {

--- a/shell/components/AdvancedSection.vue
+++ b/shell/components/AdvancedSection.vue
@@ -32,9 +32,17 @@ export default {
       v-t="show ? 'generic.hideAdvanced' : 'generic.showAdvanced'"
       class="hand block"
       :class="{'mb-10': show}"
+      tabindex="0"
+      @keydown.enter.space.prevent="toggle"
       @click="toggle"
     />
 
     <slot v-if="show" />
   </div>
 </template>
+
+<style lang="scss" scoped>
+.hand.block {
+  max-width: fit-content;
+}
+</style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14306
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix keyboard nav on show advanced in cluster create/edit

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/c03a1543-31cf-44bf-9c70-cbff676dea0a


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
