### PR TITLE
fix issue importing gke clusters when using third party auth

### DIFF
--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -142,7 +142,8 @@ const defaultImportedCluster = {
     projectID:              '',
     region:                 '',
   },
-  labels: {}
+  labels:      {},
+  annotations: {}
 };
 
 export default defineComponent({


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15065 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
When using third-party auth the UI sets an annotation on the cluster object. The default object used to instantiate imported clusters did not have annotations defined, causing fetch to throw an error and the form to no longer work.

### Areas or cases that should be tested
1. Create a GKE cluster from the google cloud platform, to be imported
2. Enable any third-party auth provider in Rancher
3. attempt to import a GKE cluster

### Areas which could experience regressions
None.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
