### PR TITLE
Fix matchingingresses method

### DIFF
--- a/shell/detail/__tests__/workload.test.ts
+++ b/shell/detail/__tests__/workload.test.ts
@@ -1,0 +1,164 @@
+import Workload from '@shell/detail/workload/index.vue';
+
+const { findMatchingIngresses } = Workload.methods;
+
+describe('findMatchingIngresses', () => {
+  it('should do nothing if ingress schema is not present', () => {
+    const mockThis = {
+      ingressSchema:     undefined,
+      matchingIngresses: [],
+    };
+
+    findMatchingIngresses.call(mockThis);
+    expect(mockThis.matchingIngresses).toStrictEqual([]);
+  });
+
+  it('should not find any ingresses if there are none', () => {
+    const mockThis = {
+      ingressSchema:     true,
+      allIngresses:      [],
+      matchingServices:  [],
+      matchingIngresses: [],
+      value:             { metadata: { namespace: 'test' } }
+    };
+
+    findMatchingIngresses.call(mockThis);
+    expect(mockThis.matchingIngresses).toStrictEqual([]);
+  });
+
+  it('should find matching ingresses', () => {
+    const mockThis = {
+      ingressSchema: true,
+      allIngresses:  [
+        { // matching
+          metadata: { namespace: 'test' },
+          spec:     { rules: [{ http: { paths: [{ backend: { service: { name: 'service1' } } }] } }] }
+        }
+      ],
+      matchingServices:  [{ metadata: { name: 'service1' } }],
+      matchingIngresses: [],
+      value:             { metadata: { namespace: 'test' } }
+    };
+
+    findMatchingIngresses.call(mockThis);
+    expect(mockThis.matchingIngresses).toHaveLength(1);
+    expect(mockThis.matchingIngresses[0]).toStrictEqual(mockThis.allIngresses[0]);
+  });
+
+  it('should not match ingresses from other namespaces', () => {
+    const mockThis = {
+      ingressSchema: true,
+      allIngresses:  [
+        { // not matching
+          metadata: { namespace: 'other' },
+          spec:     { rules: [{ http: { paths: [{ backend: { service: { name: 'service1' } } }] } }] }
+        }
+      ],
+      matchingServices:  [{ metadata: { name: 'service1' } }],
+      matchingIngresses: [],
+      value:             { metadata: { namespace: 'test' } }
+    };
+
+    findMatchingIngresses.call(mockThis);
+    expect(mockThis.matchingIngresses).toHaveLength(0);
+  });
+
+  it('should not match ingresses pointing to other services', () => {
+    const mockThis = {
+      ingressSchema: true,
+      allIngresses:  [
+        { // not matching
+          metadata: { namespace: 'test' },
+          spec:     { rules: [{ http: { paths: [{ backend: { service: { name: 'service2' } } }] } }] }
+        }
+      ],
+      matchingServices:  [{ metadata: { name: 'service1' } }],
+      matchingIngresses: [],
+      value:             { metadata: { namespace: 'test' } }
+    };
+
+    findMatchingIngresses.call(mockThis);
+    expect(mockThis.matchingIngresses).toHaveLength(0);
+  });
+
+  it('should handle ingresses with no rules', () => {
+    const mockThis = {
+      ingressSchema: true,
+      allIngresses:  [
+        {
+          metadata: { namespace: 'test' },
+          spec:     { }
+        }
+      ],
+      matchingServices:  [{ metadata: { name: 'service1' } }],
+      matchingIngresses: [],
+      value:             { metadata: { namespace: 'test' } }
+    };
+
+    findMatchingIngresses.call(mockThis);
+    expect(mockThis.matchingIngresses).toHaveLength(0);
+  });
+
+  it('should handle ingress rules with no paths', () => {
+    const mockThis = {
+      ingressSchema: true,
+      allIngresses:  [
+        {
+          metadata: { namespace: 'test' },
+          spec:     { rules: [{ http: {} }] }
+        }
+      ],
+      matchingServices:  [{ metadata: { name: 'service1' } }],
+      matchingIngresses: [],
+      value:             { metadata: { namespace: 'test' } }
+    };
+
+    findMatchingIngresses.call(mockThis);
+    expect(mockThis.matchingIngresses).toHaveLength(0);
+  });
+
+  it('should handle ingress paths with no backend service', () => {
+    const mockThis = {
+      ingressSchema: true,
+      allIngresses:  [
+        {
+          metadata: { namespace: 'test' },
+          spec:     { rules: [{ http: { paths: [{ backend: {} }] } }] }
+        }
+      ],
+      matchingServices:  [{ metadata: { name: 'service1' } }],
+      matchingIngresses: [],
+      value:             { metadata: { namespace: 'test' } }
+    };
+
+    findMatchingIngresses.call(mockThis);
+    expect(mockThis.matchingIngresses).toHaveLength(0);
+  });
+
+  it('should find one of many ingresses', () => {
+    const mockThis = {
+      ingressSchema: true,
+      allIngresses:  [
+        { // not matching
+          metadata: { namespace: 'other' },
+          spec:     { rules: [{ http: { paths: [{ backend: { service: { name: 'service1' } } }] } }] }
+        },
+        { // matching
+          metadata: { namespace: 'test' },
+          spec:     { rules: [{ http: { paths: [{ backend: { service: { name: 'service1' } } }] } }] }
+        },
+        { // not matching
+          metadata: { namespace: 'test' },
+          spec:     { rules: [{ http: { paths: [{ backend: { service: { name: 'service2' } } }] } }] }
+        }
+      ],
+      matchingServices:  [{ metadata: { name: 'service1' } }],
+      matchingIngresses: [],
+      value:             { metadata: { namespace: 'test' } }
+    };
+
+    findMatchingIngresses.call(mockThis);
+    expect(mockThis.matchingIngresses).toHaveLength(1);
+    expect(mockThis.matchingIngresses[0]).toStrictEqual(mockThis.allIngresses[1]);
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes  https://github.com/rancher/dashboard/issues/15068
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added try ... catch, Prevents one bad ingress from breaking all logic.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
when the input allIngresses array contains malformed or incomplete Ingress objects (e.g., missing spec.rules, http.paths, or backend.service.name or even with a defaultbackend), the function prematurely exits or throws an error. As a result, valid Ingresses that follow in the list are not evaluated, leading to incorrect or incomplete matching results...


### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Repro steps mentioned in the above issue...

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="1628" height="790" alt="image" src="https://github.com/user-attachments/assets/69673111-0eba-47e1-aa9e-9e2145ee38c6" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
