### PR TITLE
Add `GH_TOKEN` to `port-pr-bot` workflow 

### DIFF
--- a/.github/workflows/port-pr-bot.yaml
+++ b/.github/workflows/port-pr-bot.yaml
@@ -91,6 +91,7 @@ jobs:
         if: ${{ env.is_member == 'true' }} && ${{ env.milestone_exists == 'true' }} && ${{ env.target_branch_exists == 'true' }}
         env:
           APP_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           ORIGINAL_ISSUE_NUMBER: ${{ github.event.issue.number }}
           TYPE: ${{ env.type }}
           TARGET_BRANCH: ${{ env.target_branch }}
@@ -101,10 +102,6 @@ jobs:
           echo "Type: ${TYPE}"
           echo "Target Branch: ${TARGET_BRANCH}"
           echo "Milestone: ${MILESTONE}"
-
-          echo "Logging in with token..."
-          gh auth login --with-token <<< ${APP_TOKEN}
-          echo "Logged in with token"
 
           PATCH_FILE=$(mktemp)
           echo "Created temporary patch file: ${PATCH_FILE}"

--- a/.github/workflows/port-pr-bot.yaml
+++ b/.github/workflows/port-pr-bot.yaml
@@ -13,7 +13,7 @@ jobs:
       actions: write
       id-token: write
     runs-on: ubuntu-latest
-    if: (startsWith(github.event.comment.body, '/backport-bot') || startsWith(github.event.comment.body, '/forwardport')) && github.event.issue.pull_request
+    if: (startsWith(github.event.comment.body, '/bot-backport') || startsWith(github.event.comment.body, '/forwardport')) && github.event.issue.pull_request
     steps:
       - name: Read secrets
         uses: rancher-eio/read-vault-secrets@main


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This adds `GH_TOKEN` the to Por PR step of the `port-pr-bot` workflow. 

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
