### PR TITLE
Remove icon-fw class in action menus (models)

### DIFF
--- a/shell/models/catalog.cattle.io.app.js
+++ b/shell/models/catalog.cattle.io.app.js
@@ -31,7 +31,7 @@ export default class CatalogApp extends SteveModel {
     const upgrade = {
       action:  'goToUpgrade',
       enabled: true,
-      icon:    'icon icon-fw icon-edit',
+      icon:    'icon icon-edit',
       label:   this.t('catalog.install.action.goToUpgrade'),
     };
 

--- a/shell/models/catalog.cattle.io.operation.js
+++ b/shell/models/catalog.cattle.io.operation.js
@@ -17,7 +17,7 @@ export default class CatalogOperation extends SteveModel {
     const openLogs = {
       action:  'openLogs',
       enabled: true,
-      icon:    'icon icon-fw icon-chevron-right',
+      icon:    'icon icon-chevron-right',
       label:   this.t('action.openLogs'),
       total:   1,
     };

--- a/shell/models/cluster.x-k8s.io.machine.js
+++ b/shell/models/cluster.x-k8s.io.machine.js
@@ -60,13 +60,13 @@ export default class CapiMachine extends SteveModel {
     const openSsh = {
       action:  'openSsh',
       enabled: !!this.links.shell && this.isRunning,
-      icon:    'icon icon-fw icon-chevron-right',
+      icon:    'icon icon-chevron-right',
       label:   'SSH Shell',
     };
     const downloadKeys = {
       action:  'downloadKeys',
       enabled: !!this.links.sshkeys,
-      icon:    'icon icon-fw icon-download',
+      icon:    'icon icon-download',
       label:   this.t('node.actions.downloadSSHKey'),
     };
     const forceRemove = {
@@ -80,7 +80,7 @@ export default class CapiMachine extends SteveModel {
       action:     'toggleScaleDownModal',
       bulkAction: 'toggleScaleDownModal',
       enabled:    !!this.canScaleDown,
-      icon:       'icon icon-minus icon-fw',
+      icon:       'icon icon-minus',
       label:      this.t('node.actions.scaleDown'),
       bulkable:   true
     };

--- a/shell/models/cluster/node.js
+++ b/shell/models/cluster/node.js
@@ -16,7 +16,7 @@ export default class ClusterNode extends SteveModel {
     const cordon = {
       action:   'cordon',
       enabled:  !!normanAction.cordon,
-      icon:     'icon icon-fw icon-pause',
+      icon:     'icon icon-pause',
       label:    'Cordon',
       total:    1,
       bulkable: true
@@ -25,7 +25,7 @@ export default class ClusterNode extends SteveModel {
     const uncordon = {
       action:   'uncordon',
       enabled:  !!normanAction.uncordon,
-      icon:     'icon icon-fw icon-play',
+      icon:     'icon icon-play',
       label:    'Uncordon',
       total:    1,
       bulkable: true
@@ -34,7 +34,7 @@ export default class ClusterNode extends SteveModel {
     const drain = {
       action:     'drain',
       enabled:    !!normanAction.drain,
-      icon:       'icon icon-fw icon-dot-open',
+      icon:       'icon icon-dot-open',
       label:      this.t('drainNode.action'),
       bulkable:   true,
       bulkAction: 'drain'
@@ -43,7 +43,7 @@ export default class ClusterNode extends SteveModel {
     const stopDrain = {
       action:   'stopDrain',
       enabled:  !!normanAction.stopDrain,
-      icon:     'icon icon-fw icon-x',
+      icon:     'icon icon-x',
       label:    this.t('drainNode.actionStop'),
       bulkable: true,
     };
@@ -51,14 +51,14 @@ export default class ClusterNode extends SteveModel {
     const openSsh = {
       action:  'openSsh',
       enabled: !!this.provisionedMachine?.links?.shell,
-      icon:    'icon icon-fw icon-chevron-right',
+      icon:    'icon icon-chevron-right',
       label:   'SSH Shell',
     };
 
     const downloadKeys = {
       action:  'downloadKeys',
       enabled: !!this.provisionedMachine?.links?.sshkeys,
-      icon:    'icon icon-fw icon-download',
+      icon:    'icon icon-download',
       label:   this.t('node.actions.downloadSSHKey'),
     };
 

--- a/shell/models/compliance.cattle.io.clusterscan.js
+++ b/shell/models/compliance.cattle.io.clusterscan.js
@@ -52,7 +52,7 @@ export default class ClusterScan extends SteveModel {
     const downloadReport = {
       action:  'downloadLatestReport',
       enabled: this.hasReport,
-      icon:    'icon icon-fw icon-download',
+      icon:    'icon icon-download',
       label:   t('compliance.downloadReport'),
       total:   1,
     };
@@ -60,7 +60,7 @@ export default class ClusterScan extends SteveModel {
     const downloadAllReports = {
       action:  'downloadAllReports',
       enabled: this.hasReport,
-      icon:    'icon icon-fw icon-download',
+      icon:    'icon icon-download',
       label:   t('compliance.downloadAllReports'),
       total:   1,
     };

--- a/shell/models/constraints.gatekeeper.sh.constraint.js
+++ b/shell/models/constraints.gatekeeper.sh.constraint.js
@@ -15,7 +15,7 @@ export default class GateKeeperConstraint extends SteveModel {
 
     const downloadViolations = {
       action: 'downloadViolations',
-      icon:   'icon icon-fw icon-download',
+      icon:   'icon icon-download',
       label:  t('gatekeeperConstraint.downloadViolations'),
       total:  1,
     };

--- a/shell/models/persistentvolumeclaim.js
+++ b/shell/models/persistentvolumeclaim.js
@@ -41,7 +41,7 @@ export default class PVC extends SteveModel {
     insertAt(out, 0, {
       action:  'goToEditVolumeSize',
       enabled: this.expandable && this.bound,
-      icon:    'icon icon-fw icon-plus',
+      icon:    'icon icon-plus',
       label:   this.t('persistentVolumeClaim.expand.label'),
     });
 

--- a/shell/models/pod.js
+++ b/shell/models/pod.js
@@ -61,7 +61,7 @@ export default class Pod extends WorkloadService {
     return {
       action:  'openShell',
       enabled: !!this.links.view && this.isRunning,
-      icon:    'icon icon-fw icon-chevron-right',
+      icon:    'icon-chevron-right',
       label:   'Execute Shell',
       total:   1,
     };
@@ -71,7 +71,7 @@ export default class Pod extends WorkloadService {
     return {
       action:  'openLogs',
       enabled: !!this.links.view,
-      icon:    'icon icon-fw icon-chevron-right',
+      icon:    'icon icon-chevron-right',
       label:   'View Logs',
       total:   1,
     };

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -143,7 +143,7 @@ export default class ProvCluster extends SteveModel {
       }, {
         action:  'restoreSnapshotAction',
         label:   this.$rootGetters['i18n/t']('nav.restoreSnapshot'),
-        icon:    'icon icon-fw icon-backup-restore',
+        icon:    'icon icon-backup-restore',
         enabled: canSnapshot,
       }, {
         action:  'rotateCertificates',

--- a/shell/models/rke.cattle.io.etcdsnapshot.js
+++ b/shell/models/rke.cattle.io.etcdsnapshot.js
@@ -17,7 +17,7 @@ export default class EtcdBackup extends NormanModel {
     return [{
       action: 'promptRestore',
       enabled,
-      icon:   'icon icon-fw icon-backup-restore',
+      icon:   'icon icon-backup-restore',
       label:  'Restore'
     }];
   }

--- a/shell/models/storage.k8s.io.storageclass.js
+++ b/shell/models/storage.k8s.io.storageclass.js
@@ -141,14 +141,14 @@ export default class extends SteveModel {
       out.unshift({
         action:  'resetDefault',
         enabled: true,
-        icon:    'icon icon-fw icon-checkmark',
+        icon:    'icon icon-checkmark',
         label:   this.t('storageClass.actions.resetDefault'),
       });
     } else {
       out.unshift({
         action:  'setDefault',
         enabled: true,
-        icon:    'icon icon-fw icon-checkmark',
+        icon:    'icon icon-checkmark',
         label:   this.t('storageClass.actions.setAsDefault'),
       });
     }

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -76,7 +76,7 @@ export default class Workload extends WorkloadService {
     insertAt(out, 0, {
       action:  'openShell',
       enabled: !!this.links.view,
-      icon:    'icon icon-fw icon-chevron-right',
+      icon:    'icon icon-chevron-right',
       label:   this.t('action.openShell'),
       total:   1,
     });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15130
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

This PR removes the `icon-fw` class from models, to fix alignment issues of the icon/text.

### Areas or cases that should be tested

The following resources should be validated by going to the list page and opening the action menu for a row (creating a resource first if necessary to ensure there is at least one row in the resource table):

(the actions that are incorrectly aligned are shown in parenthesis)

In Cluster Explorer (exploring a downstream cluster):

- Apps/Installed Apps (Edit/Upgrade)
- Apps/Recent Operations (Open Logs)
- Nodes (Pause, Uncordon, Drain, Stop Drain, SSH Shell, Download Keys)
- Compliance/Scans (Download Report, Download All Reports)
- Gatekeeper/Constraint (Download)
- Storage/Persistent Volume Claims (Expand)
- Workloads/Pod (Execute Shell, View Logs)
- Storage/Storage Class (Reset Default, Set Default)
- Workloads (Open Shell)

In Cluster Management:

- Cluster (Restore Snapshot)
- Machines (Open SSH, Download Keys, Scale Down)
- Cluster/Snapshots (Restore)

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

A couple of examples:

Before
<img width="250" height="272" alt="image" src="https://github.com/user-attachments/assets/39a59974-57c3-45d6-b69f-e26e348fbb34" />
After
<img width="250" height="272" alt="image" src="https://github.com/user-attachments/assets/7b749ad6-9158-402d-9712-107f9bd6b921" />

Before
<img width="197" height="220" alt="image" src="https://github.com/user-attachments/assets/fd4280fd-9d41-405a-884d-81bc607d8024" />

After
<img width="197" height="220" alt="image" src="https://github.com/user-attachments/assets/f8ef3664-8369-4ffc-b5eb-0b7eac03ed6d" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
