### PR TITLE
Adds support for for an additional actions slot in our titlebar/masthead

### DIFF
--- a/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
+++ b/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
@@ -74,4 +74,8 @@ export default abstract class ClusterManagerDetailPagePo extends PagePo {
   namespace() {
     return cy.get('[data-testid="masthead-subheader-namespace"]');
   }
+
+  exploreButton() {
+    return cy.get('[data-testid="detail-explore-button"]');
+  }
 }

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -835,5 +835,13 @@ describe('Cluster Manager as standard user', { testIsolation: 'off', tags: ['@ma
       drawer.tabs().clickTabWithName('yaml-tab');
       drawer.saveButton().should('not.exist');
     });
+
+    it('Shows the explore button and navigates to the cluster explorer when clicked', () => {
+      clusterDetail.waitForPage();
+      clusterDetail.exploreButton().should('exist');
+
+      clusterDetail.exploreButton().click();
+      cy.url().should('include', '/c/local/explorer');
+    });
   });
 });

--- a/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
+++ b/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
@@ -100,4 +100,8 @@ export default class HciCluster extends ProvCluster {
   get disableResourceDetailDrawerConfigTab() {
     return false;
   }
+
+  get fullDetailPageOverride() {
+    return false;
+  }
 }

--- a/shell/components/Resource/Detail/Masthead/composable.ts
+++ b/shell/components/Resource/Detail/Masthead/composable.ts
@@ -1,0 +1,16 @@
+import { useDefaultMetadataForLegacyPagesProps } from '@shell/components/Resource/Detail/Metadata/composables';
+import { useDefaultTitleBarProps } from '@shell/components/Resource/Detail/TitleBar/composables';
+import { MastheadProps } from '@shell/components/Resource/Detail/Masthead/index.vue';
+import { computed, Ref } from 'vue';
+
+export const useDefaultMastheadProps = (resource: any): Ref<MastheadProps> => {
+  const titleBarProps = useDefaultTitleBarProps(resource);
+  const metadataProps = useDefaultMetadataForLegacyPagesProps(resource);
+
+  return computed(() => {
+    return {
+      titleBarProps: titleBarProps.value,
+      metadataProps: metadataProps.value,
+    };
+  });
+};

--- a/shell/components/Resource/Detail/Masthead/index.vue
+++ b/shell/components/Resource/Detail/Masthead/index.vue
@@ -1,0 +1,37 @@
+<script lang="ts">
+import TitleBar, { TitleBarProps } from '@shell/components/Resource/Detail/TitleBar/index.vue';
+import Metadata, { MetadataProps } from '@shell/components/Resource/Detail/Metadata/index.vue';
+
+export interface MastheadProps {
+  titleBarProps: TitleBarProps;
+  metadataProps: MetadataProps;
+}
+</script>
+
+<script setup lang="ts">
+const props = defineProps<MastheadProps>();
+
+</script>
+<template>
+  <div class="masthead">
+    <TitleBar v-bind="props.titleBarProps">
+      <template
+        v-if="$slots['additional-actions']"
+        #additional-actions
+      >
+        <slot name="additional-actions" />
+      </template>
+    </TitleBar>
+    <Metadata
+      v-bind="props.metadataProps"
+    />
+  </div>
+</template>
+
+<style lang='scss' scoped>
+.masthead {
+    :deep().metadata {
+        margin-top: 24px;
+    }
+}
+</style>

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/identifying-fields.ts
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/identifying-fields.ts
@@ -16,7 +16,7 @@ export const useNamespace = (resource: any): ComputedRef<Row> | undefined => {
   const i18n = useI18n(store);
   const resourceValue = toValue(resource);
 
-  if (!resourceValue.namespace || resourceValue.namespaces) {
+  if (!resourceValue.namespace || resourceValue.namespaces || resourceValue.isProjectScoped) {
     return;
   }
 

--- a/shell/components/Resource/Detail/Page.vue
+++ b/shell/components/Resource/Detail/Page.vue
@@ -1,23 +1,39 @@
+<script setup lang="ts">
+import Loading from '@shell/components/Loading.vue';
+
+interface Props {
+  loading?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), { loading: false });
+
+</script>
+
 <template>
-  <div class="resource-detail-page">
-    <div
-      v-if="$slots['top-area']"
-      class="top-area"
-    >
-      <slot name="top-area" />
-    </div>
-    <div
-      v-if="$slots['middle-area']"
-      class="middle-area mmt-6"
-    >
-      <slot name="middle-area" />
-    </div>
-    <div
-      v-if="$slots['bottom-area']"
-      class="bottom-area mmt-6"
-    >
-      <slot name="bottom-area" />
-    </div>
+  <div
+    class="resource-detail-page"
+  >
+    <Loading v-if="props.loading" />
+    <template v-else>
+      <div
+        v-if="$slots['top-area']"
+        class="top-area"
+      >
+        <slot name="top-area" />
+      </div>
+      <div
+        v-if="$slots['middle-area']"
+        class="middle-area mmt-6"
+      >
+        <slot name="middle-area" />
+      </div>
+      <div
+        v-if="$slots['bottom-area']"
+        class="bottom-area mmt-6"
+      >
+        <slot name="bottom-area" />
+      </div>
+    </template>
   </div>
 </template>
 <style lang="scss" scoped>

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -117,6 +117,7 @@ watch(
           v-model:value="currentView"
           :options="viewOptions"
         />
+        <slot name="additional-actions" />
         <RcButton
           v-if="onShowConfiguration"
           :data-testid="showConfigurationDataTestId"

--- a/shell/detail/__tests__/provisioning.cattle.io.cluster.test.ts
+++ b/shell/detail/__tests__/provisioning.cattle.io.cluster.test.ts
@@ -1,11 +1,22 @@
 import { shallowMount } from '@vue/test-utils';
 import ProvisioningCattleIoCluster from '@shell/detail/provisioning.cattle.io.cluster.vue';
+import * as MastheadComposable from '@shell/components/Resource/Detail/Masthead/composable';
 
 jest.mock('@shell/utils/clipboard', () => {
   return { copyTextToClipboard: jest.fn(() => Promise.resolve({})) };
 });
 
+jest.mock('@shell/components/Resource/Detail/Masthead/composable');
+
 describe('view: provisioning.cattle.io.cluster', () => {
+  const useDefaultMastheadPropsSpy = jest.spyOn(MastheadComposable, 'useDefaultMastheadProps');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useDefaultMastheadPropsSpy.mockReturnValue({} as any);
+  });
+
   const mockStore = {
     getters: {
       'management/canList':      () => true,

--- a/shell/detail/configmap.vue
+++ b/shell/detail/configmap.vue
@@ -1,42 +1,33 @@
 <script setup lang="ts">
 import DetailPage from '@shell/components/Resource/Detail/Page.vue';
-import TitleBar from '@shell/components/Resource/Detail/TitleBar/index.vue';
-import { useDefaultTitleBarProps } from '@shell/components/Resource/Detail/TitleBar/composables';
-import Metadata from '@shell/components/Resource/Detail/Metadata/index.vue';
-import { useDefaultMetadataProps } from '@shell/components/Resource/Detail/Metadata/composables';
 import { CONFIG_MAP } from '@shell/config/types';
 import ResourceTabs from '@shell/components/form/ResourceTabs/index.vue';
 import ConfigMapDataTab from '@shell/components/Resource/Detail/ResourceTabs/ConfigMapDataTab/index.vue';
 import { useGetConfigMapDataTabProps } from '@shell/components/Resource/Detail/ResourceTabs/ConfigMapDataTab/composables';
 import { useStore } from 'vuex';
 import { computed } from 'vue';
+import Masthead from '@shell/components/Resource/Detail/Masthead/index.vue';
+import { useDefaultMastheadProps } from '@shell/components/Resource/Detail/Masthead/composable';
 
 const store = useStore();
 const props = defineProps<{
   value: any;
 }>();
 
-const secret = props.value;
+const configmap = props.value;
 const schema = computed(() => store.getters['cluster/schemaFor'](CONFIG_MAP));
-const titleBarProps = useDefaultTitleBarProps(secret);
-const metadataProps = useDefaultMetadataProps(secret);
-const configMapDataTabProps = useGetConfigMapDataTabProps(secret);
+const defaultMastheadProps = useDefaultMastheadProps(configmap);
+const configMapDataTabProps = useGetConfigMapDataTabProps(configmap);
 </script>
 
 <template>
   <DetailPage>
     <template #top-area>
-      <TitleBar
-        v-bind="titleBarProps"
-      />
-      <Metadata
-        class="mmt-6"
-        v-bind="metadataProps"
-      />
+      <Masthead v-bind="defaultMastheadProps" />
     </template>
     <template #bottom-area>
       <ResourceTabs
-        :value="secret"
+        :value="configmap"
         :schema="schema"
       >
         <ConfigMapDataTab

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -1,5 +1,4 @@
 <script>
-import Loading from '@shell/components/Loading';
 import { Banner } from '@components/Banner';
 import ResourceTable, { defaultTableSortGenerationFn } from '@shell/components/ResourceTable';
 import ResourceTabs from '@shell/components/form/ResourceTabs';
@@ -31,6 +30,9 @@ import Socket, {
 import { get } from '@shell/utils/object';
 import CapiMachineDeployment from '@shell/models/cluster.x-k8s.io.machinedeployment';
 import { isAlternate } from '@shell/utils/platform';
+import DetailPage from '@shell/components/Resource/Detail/Page.vue';
+import Masthead from '@shell/components/Resource/Detail/Masthead/index.vue';
+import { useDefaultMastheadProps } from '@shell/components/Resource/Detail/Masthead/composable';
 
 let lastId = 1;
 const ansiup = new AnsiUp();
@@ -60,7 +62,6 @@ export default {
   emits: ['input'],
 
   components: {
-    Loading,
     Banner,
     ResourceTable,
     ResourceTabs,
@@ -70,6 +71,8 @@ export default {
     CustomCommand,
     AsyncButton,
     MachineSummaryGraph,
+    DetailPage,
+    Masthead,
   },
 
   props: {
@@ -79,6 +82,10 @@ export default {
         return {};
       }
     }
+  },
+
+  setup(props) {
+    return { defaultMastheadProps: useDefaultMastheadProps(props.value) };
   },
 
   async fetch() {
@@ -755,347 +762,366 @@ export default {
     },
   }
 };
+
 </script>
 
 <template>
-  <Loading v-if="$fetchState.pending" />
-  <div v-else>
-    <Banner
-      v-if="showWindowsWarning"
-      color="error"
-      :label="t('cluster.banner.os', { newOS: 'Windows', existingOS: 'Linux' })"
-    />
-    <Banner
-      v-if="showEksNodeGroupWarning"
-      color="error"
-      :label="t('cluster.banner.desiredNodeGroupWarning')"
-    />
-
-    <Banner
-      v-if="$fetchState.error"
-      color="error"
-      :label="$fetchState.error"
-    />
-
-    <Banner
-      v-if="value.isRke1"
-      color="warning"
-      label-key="cluster.banner.rke1DeprecationMessage"
-    />
-    <ResourceTabs
-      :value="value"
-      :default-tab="defaultTab"
-      :need-related="hasLocalAccess"
-      :extension-params="extCustomParams"
-      :needRelated="extDetailTabsRelated"
-      :needEvents="extDetailTabsEvents"
-      :needConditions="extDetailTabsConditions"
-      @update:value="$emit('input', $event)"
-    >
-      <Tab
-        v-if="showMachines"
-        name="machine-pools"
-        :label-key="value.isCustom ? 'cluster.tabs.machines' : 'cluster.tabs.machinePools'"
-        :weight="4"
-      >
-        <ResourceTable
-          :rows="machines"
-          :schema="machineSchema"
-          :headers="machineHeaders"
-          default-sort-by="name"
-          group-ref="pool"
-          :group-default="machineGroupOption.value"
-          :group-sort="['pool.nameDisplay']"
-          :group-options="value.isCustom ? [noneGroupOption] : machineGroupOptions"
-          :sort-generation-fn="machineSortGenerationFn"
-        >
-          <template #main-row:isFake="{fullColspan}">
-            <tr class="main-row">
-              <td
-                :colspan="fullColspan"
-                class="no-entries"
-              >
-                {{ t('node.list.noNodes') }}
-              </td>
-            </tr>
-          </template>
-
-          <template #group-by="{group}">
-            <div
-              class="pool-row"
-              :class="{'has-description':group.ref && group.ref.template}"
-            >
-              <div
-                v-trim-whitespace
-                class="group-tab"
-              >
-                <div
-                  v-if="group && group.ref"
-                  v-clean-html="group.ref.groupByPoolShortLabel"
-                />
-                <div
-                  v-else
-                  v-clean-html="t('resourceTable.groupLabel.notInANodePool')"
-                />
-                <div
-                  v-if="group.ref && group.ref.providerSummary"
-                  class="description text-muted text-small"
-                >
-                  {{ group.ref.providerSummary }}
-                </div>
-              </div>
-              <div
-                v-if="group.ref"
-                class="right group-header-buttons mr-20"
-              >
-                <MachineSummaryGraph
-                  v-if="poolSummaryInfo[group.ref]"
-                  :row="poolSummaryInfo[group.ref]"
-                  :horizontal="true"
-                  class="mr-20"
-                />
-                <template v-if="value.hasLink('update') && group.ref.showScalePool">
-                  <button
-                    v-clean-tooltip="t('node.list.scaleDown')"
-                    :disabled="!group.ref.canScaleDownPool()"
-                    type="button"
-                    class="btn btn-sm role-secondary"
-                    @click="toggleScaleDownModal($event, group.ref)"
-                  >
-                    <i class="icon icon-sm icon-minus" />
-                  </button>
-                  <button
-                    v-clean-tooltip="t('node.list.scaleUp')"
-                    :disabled="!group.ref.canScaleUpPool()"
-                    type="button"
-                    class="btn btn-sm role-secondary ml-10"
-                    @click="group.ref.scalePool(1)"
-                  >
-                    <i class="icon icon-sm icon-plus" />
-                  </button>
-                </template>
-              </div>
-            </div>
-          </template>
-        </ResourceTable>
-      </Tab>
-
-      <Tab
-        v-else-if="showNodes"
-        name="node-pools"
-        :label-key="value.isCustom ? 'cluster.tabs.machines' : 'cluster.tabs.machinePools'"
-        :weight="4"
-      >
-        <ResourceTable
-          :schema="mgmtNodeSchema"
-          :headers="mgmtNodeSchemaHeaders"
-          :rows="nodes"
-          group-ref="pool"
-          :group-default="poolGroupOption.value"
-          :group-sort="['pool.nameDisplay']"
-          :group-options="value.isCustom ? [noneGroupOption] : poolGroupOptions"
-          :sort-generation-fn="nodeSortGenerationFn"
-          :hide-grouping-controls="true"
-        >
-          <template #main-row:isFake="{fullColspan}">
-            <tr class="main-row">
-              <td
-                :colspan="fullColspan"
-                class="no-entries"
-              >
-                {{ t('node.list.noNodes') }}
-              </td>
-            </tr>
-          </template>
-
-          <template #group-by="{group}">
-            <div
-              class="pool-row"
-              :class="{'has-description':group.ref && group.ref.nodeTemplate}"
-            >
-              <div
-                v-trim-whitespace
-                class="group-tab"
-              >
-                <div
-                  v-if="group.ref"
-                  v-clean-html="t('resourceTable.groupLabel.nodePool', { name: group.ref.spec.hostnamePrefix}, true)"
-                />
-                <div
-                  v-else
-                  v-clean-html="t('resourceTable.groupLabel.notInANodePool')"
-                />
-                <div
-                  v-if="group.ref && group.ref.nodeTemplate"
-                  class="description text-muted text-small"
-                >
-                  {{ group.ref.providerDisplay }} &ndash;  {{ group.ref.providerLocation }} / {{ group.ref.providerSize }} ({{ group.ref.providerName }})
-                </div>
-              </div>
-              <div
-                v-if="group.ref && !isRke1"
-                class="right group-header-buttons"
-              >
-                <MachineSummaryGraph
-                  :row="poolSummaryInfo[group.ref]"
-                  :horizontal="true"
-                  class="mr-20"
-                />
-                <template v-if="group.ref.hasLink('update')">
-                  <button
-                    v-clean-tooltip="t('node.list.scaleDown')"
-                    :disabled="!group.ref.canScaleDownPool()"
-                    type="button"
-                    class="btn btn-sm role-secondary"
-                    @click="toggleScaleDownModal($event, group.ref)"
-                  >
-                    <i class="icon icon-sm icon-minus" />
-                  </button>
-                  <button
-                    v-clean-tooltip="t('node.list.scaleUp')"
-                    type="button"
-                    class="btn btn-sm role-secondary ml-10"
-                    @click="group.ref.scalePool(1)"
-                  >
-                    <i class="icon icon-sm icon-plus" />
-                  </button>
-                </template>
-
-                <button
-                  type="button"
-                  class="project-action btn btn-sm role-multi-action actions mr-5 ml-15"
-                  :class="{invisible: !showPoolActionButton(group.ref)}"
-                  @click="showPoolAction($event, group.ref)"
-                >
-                  <i class="icon icon-actions" />
-                </button>
-              </div>
-            </div>
-          </template>
-        </ResourceTable>
-      </Tab>
-
-      <Tab
-        v-if="showLog"
-        name="log"
-        :label="t('cluster.tabs.log')"
-        :weight="3"
-        class="logs-container"
-      >
-        <table
-          class="fixed"
-          cellpadding="0"
-          cellspacing="0"
-        >
-          <tbody class="logs-body">
-            <template v-if="logs.length">
-              <tr
-                v-for="(line, i) in logs"
-                :key="i"
-              >
-                <td
-                  v-clean-html="format(line.time)"
-                  class="time"
-                />
-                <td
-                  v-clean-html="line.msg"
-                  class="msg"
-                />
-              </tr>
-            </template>
-            <tr
-              v-else-if="!logOpen"
-              v-t="'cluster.log.connecting'"
-              colspan="2"
-              class="msg text-muted"
-            />
-            <tr
-              v-else
-              v-t="'cluster.log.noData'"
-              colspan="2"
-              class="msg text-muted"
-            />
-          </tbody>
-        </table>
-      </Tab>
-
-      <Tab
-        v-if="showRegistration"
-        name="registration"
-        :label="t('cluster.tabs.registration')"
-        :weight="2"
-      >
-        <Banner
-          v-if="!value.isCustom"
-          color="warning"
-          :label="t('cluster.import.warningBanner')"
-        />
-        <CustomCommand
-          v-if="value.isCustom"
-          :cluster-token="clusterToken"
-          :cluster="value"
-          @copied-windows="hasWindowsMachine ? null : showWindowsWarning = true"
-        />
-        <template v-else>
-          <h4 v-clean-html="t('cluster.import.commandInstructions', null, true)" />
-          <CopyCode class="m-10 p-10">
-            {{ clusterToken.command }}
-          </CopyCode>
-
-          <h4
-            v-clean-html="t('cluster.import.commandInstructionsInsecure', null, true)"
-            class="mt-10"
-          />
-          <CopyCode class="m-10 p-10">
-            {{ clusterToken.insecureCommand }}
-          </CopyCode>
-
-          <h4
-            v-clean-html="t('cluster.import.clusterRoleBindingInstructions', null, true)"
-            class="mt-10"
-          />
-          <CopyCode class="m-10 p-10">
-            {{ t('cluster.import.clusterRoleBindingCommand', null, true) }}
-          </CopyCode>
+  <DetailPage :loading="$fetchState.pending">
+    <template #top-area>
+      <Masthead v-bind="defaultMastheadProps">
+        <template #additional-actions>
+          <button
+            data-testid="detail-explore-button"
+            type="button"
+            class="btn role-primary actions"
+            :disabled="!value.canExplore"
+            @click="value.explore()"
+          >
+            {{ t('cluster.explore') }}
+          </button>
         </template>
-      </Tab>
+      </Masthead>
+    </template>
+    <template #bottom-area>
+      <div>
+        <Banner
+          v-if="showWindowsWarning"
+          color="error"
+          :label="t('cluster.banner.os', { newOS: 'Windows', existingOS: 'Linux' })"
+        />
+        <Banner
+          v-if="showEksNodeGroupWarning"
+          color="error"
+          :label="t('cluster.banner.desiredNodeGroupWarning')"
+        />
 
-      <Tab
-        v-if="showSnapshots"
-        name="snapshots"
-        label="Snapshots"
-        :weight="1"
-      >
-        <SortableTable
-          class="snapshots"
-          :data-testid="'cluster-snapshots-list'"
-          :headers="rke2SnapshotHeaders"
-          default-sort-by="age"
-          :table-actions="value.isRke1"
-          :rows="rke2Snapshots"
-          :search="false"
-          :groupable="true"
-          :group-by="snapshotsGroupBy"
+        <Banner
+          v-if="$fetchState.error"
+          color="error"
+          :label="$fetchState.error"
+        />
+
+        <Banner
+          v-if="value.isRke1"
+          color="warning"
+          label-key="cluster.banner.rke1DeprecationMessage"
+        />
+        <ResourceTabs
+          :value="value"
+          :default-tab="defaultTab"
+          :need-related="hasLocalAccess"
+          :extension-params="extCustomParams"
+          :needRelated="extDetailTabsRelated"
+          :needEvents="extDetailTabsEvents"
+          :needConditions="extDetailTabsConditions"
+          @update:value="$emit('input', $event)"
         >
-          <template #header-right>
-            <AsyncButton
-              mode="snapshot"
-              class="btn role-primary"
-              :disabled="!isClusterReady"
-              @click="takeSnapshot"
+          <Tab
+            v-if="showMachines"
+            name="machine-pools"
+            :label-key="value.isCustom ? 'cluster.tabs.machines' : 'cluster.tabs.machinePools'"
+            :weight="4"
+          >
+            <ResourceTable
+              :rows="machines"
+              :schema="machineSchema"
+              :headers="machineHeaders"
+              default-sort-by="name"
+              group-ref="pool"
+              :group-default="machineGroupOption.value"
+              :group-sort="['pool.nameDisplay']"
+              :group-options="value.isCustom ? [noneGroupOption] : machineGroupOptions"
+              :sort-generation-fn="machineSortGenerationFn"
+            >
+              <template #main-row:isFake="{fullColspan}">
+                <tr class="main-row">
+                  <td
+                    :colspan="fullColspan"
+                    class="no-entries"
+                  >
+                    {{ t('node.list.noNodes') }}
+                  </td>
+                </tr>
+              </template>
+
+              <template #group-by="{group}">
+                <div
+                  class="pool-row"
+                  :class="{'has-description':group.ref && group.ref.template}"
+                >
+                  <div
+                    v-trim-whitespace
+                    class="group-tab"
+                  >
+                    <div
+                      v-if="group && group.ref"
+                      v-clean-html="group.ref.groupByPoolShortLabel"
+                    />
+                    <div
+                      v-else
+                      v-clean-html="t('resourceTable.groupLabel.notInANodePool')"
+                    />
+                    <div
+                      v-if="group.ref && group.ref.providerSummary"
+                      class="description text-muted text-small"
+                    >
+                      {{ group.ref.providerSummary }}
+                    </div>
+                  </div>
+                  <div
+                    v-if="group.ref"
+                    class="right group-header-buttons mr-20"
+                  >
+                    <MachineSummaryGraph
+                      v-if="poolSummaryInfo[group.ref]"
+                      :row="poolSummaryInfo[group.ref]"
+                      :horizontal="true"
+                      class="mr-20"
+                    />
+                    <template v-if="value.hasLink('update') && group.ref.showScalePool">
+                      <button
+                        v-clean-tooltip="t('node.list.scaleDown')"
+                        :disabled="!group.ref.canScaleDownPool()"
+                        type="button"
+                        class="btn btn-sm role-secondary"
+                        @click="toggleScaleDownModal($event, group.ref)"
+                      >
+                        <i class="icon icon-sm icon-minus" />
+                      </button>
+                      <button
+                        v-clean-tooltip="t('node.list.scaleUp')"
+                        :disabled="!group.ref.canScaleUpPool()"
+                        type="button"
+                        class="btn btn-sm role-secondary ml-10"
+                        @click="group.ref.scalePool(1)"
+                      >
+                        <i class="icon icon-sm icon-plus" />
+                      </button>
+                    </template>
+                  </div>
+                </div>
+              </template>
+            </ResourceTable>
+          </Tab>
+
+          <Tab
+            v-else-if="showNodes"
+            name="node-pools"
+            :label-key="value.isCustom ? 'cluster.tabs.machines' : 'cluster.tabs.machinePools'"
+            :weight="4"
+          >
+            <ResourceTable
+              :schema="mgmtNodeSchema"
+              :headers="mgmtNodeSchemaHeaders"
+              :rows="nodes"
+              group-ref="pool"
+              :group-default="poolGroupOption.value"
+              :group-sort="['pool.nameDisplay']"
+              :group-options="value.isCustom ? [noneGroupOption] : poolGroupOptions"
+              :sort-generation-fn="nodeSortGenerationFn"
+              :hide-grouping-controls="true"
+            >
+              <template #main-row:isFake="{fullColspan}">
+                <tr class="main-row">
+                  <td
+                    :colspan="fullColspan"
+                    class="no-entries"
+                  >
+                    {{ t('node.list.noNodes') }}
+                  </td>
+                </tr>
+              </template>
+
+              <template #group-by="{group}">
+                <div
+                  class="pool-row"
+                  :class="{'has-description':group.ref && group.ref.nodeTemplate}"
+                >
+                  <div
+                    v-trim-whitespace
+                    class="group-tab"
+                  >
+                    <div
+                      v-if="group.ref"
+                      v-clean-html="t('resourceTable.groupLabel.nodePool', { name: group.ref.spec.hostnamePrefix}, true)"
+                    />
+                    <div
+                      v-else
+                      v-clean-html="t('resourceTable.groupLabel.notInANodePool')"
+                    />
+                    <div
+                      v-if="group.ref && group.ref.nodeTemplate"
+                      class="description text-muted text-small"
+                    >
+                      {{ group.ref.providerDisplay }} &ndash;  {{ group.ref.providerLocation }} / {{ group.ref.providerSize }} ({{ group.ref.providerName }})
+                    </div>
+                  </div>
+                  <div
+                    v-if="group.ref && !isRke1"
+                    class="right group-header-buttons"
+                  >
+                    <MachineSummaryGraph
+                      :row="poolSummaryInfo[group.ref]"
+                      :horizontal="true"
+                      class="mr-20"
+                    />
+                    <template v-if="group.ref.hasLink('update')">
+                      <button
+                        v-clean-tooltip="t('node.list.scaleDown')"
+                        :disabled="!group.ref.canScaleDownPool()"
+                        type="button"
+                        class="btn btn-sm role-secondary"
+                        @click="toggleScaleDownModal($event, group.ref)"
+                      >
+                        <i class="icon icon-sm icon-minus" />
+                      </button>
+                      <button
+                        v-clean-tooltip="t('node.list.scaleUp')"
+                        type="button"
+                        class="btn btn-sm role-secondary ml-10"
+                        @click="group.ref.scalePool(1)"
+                      >
+                        <i class="icon icon-sm icon-plus" />
+                      </button>
+                    </template>
+
+                    <button
+                      type="button"
+                      class="project-action btn btn-sm role-multi-action actions mr-5 ml-15"
+                      :class="{invisible: !showPoolActionButton(group.ref)}"
+                      @click="showPoolAction($event, group.ref)"
+                    >
+                      <i class="icon icon-actions" />
+                    </button>
+                  </div>
+                </div>
+              </template>
+            </ResourceTable>
+          </Tab>
+
+          <Tab
+            v-if="showLog"
+            name="log"
+            :label="t('cluster.tabs.log')"
+            :weight="3"
+            class="logs-container"
+          >
+            <table
+              class="fixed"
+              cellpadding="0"
+              cellspacing="0"
+            >
+              <tbody class="logs-body">
+                <template v-if="logs.length">
+                  <tr
+                    v-for="(line, i) in logs"
+                    :key="i"
+                  >
+                    <td
+                      v-clean-html="format(line.time)"
+                      class="time"
+                    />
+                    <td
+                      v-clean-html="line.msg"
+                      class="msg"
+                    />
+                  </tr>
+                </template>
+                <tr
+                  v-else-if="!logOpen"
+                  v-t="'cluster.log.connecting'"
+                  colspan="2"
+                  class="msg text-muted"
+                />
+                <tr
+                  v-else
+                  v-t="'cluster.log.noData'"
+                  colspan="2"
+                  class="msg text-muted"
+                />
+              </tbody>
+            </table>
+          </Tab>
+
+          <Tab
+            v-if="showRegistration"
+            name="registration"
+            :label="t('cluster.tabs.registration')"
+            :weight="2"
+          >
+            <Banner
+              v-if="!value.isCustom"
+              color="warning"
+              :label="t('cluster.import.warningBanner')"
             />
-          </template>
-          <template #group-by="{group}">
-            <div class="group-bar">
-              <div class="group-tab">
-                {{ t('cluster.snapshot.groupLabel') }}: {{ group.key }}
-              </div>
-            </div>
-          </template>
-        </SortableTable>
-      </Tab>
-    </ResourceTabs>
-  </div>
+            <CustomCommand
+              v-if="value.isCustom"
+              :cluster-token="clusterToken"
+              :cluster="value"
+              @copied-windows="hasWindowsMachine ? null : showWindowsWarning = true"
+            />
+            <template v-else>
+              <h4 v-clean-html="t('cluster.import.commandInstructions', null, true)" />
+              <CopyCode class="m-10 p-10">
+                {{ clusterToken.command }}
+              </CopyCode>
+
+              <h4
+                v-clean-html="t('cluster.import.commandInstructionsInsecure', null, true)"
+                class="mt-10"
+              />
+              <CopyCode class="m-10 p-10">
+                {{ clusterToken.insecureCommand }}
+              </CopyCode>
+
+              <h4
+                v-clean-html="t('cluster.import.clusterRoleBindingInstructions', null, true)"
+                class="mt-10"
+              />
+              <CopyCode class="m-10 p-10">
+                {{ t('cluster.import.clusterRoleBindingCommand', null, true) }}
+              </CopyCode>
+            </template>
+          </Tab>
+
+          <Tab
+            v-if="showSnapshots"
+            name="snapshots"
+            label="Snapshots"
+            :weight="1"
+          >
+            <SortableTable
+              class="snapshots"
+              :data-testid="'cluster-snapshots-list'"
+              :headers="rke2SnapshotHeaders"
+              default-sort-by="age"
+              :table-actions="value.isRke1"
+              :rows="rke2Snapshots"
+              :search="false"
+              :groupable="true"
+              :group-by="snapshotsGroupBy"
+            >
+              <template #header-right>
+                <AsyncButton
+                  mode="snapshot"
+                  class="btn role-primary"
+                  :disabled="!isClusterReady"
+                  @click="takeSnapshot"
+                />
+              </template>
+              <template #group-by="{group}">
+                <div class="group-bar">
+                  <div class="group-tab">
+                    {{ t('cluster.snapshot.groupLabel') }}: {{ group.key }}
+                  </div>
+                </div>
+              </template>
+            </SortableTable>
+          </Tab>
+        </ResourceTabs>
+      </div>
+    </template>
+  </DetailPage>
 </template>
 
 <style lang='scss' scoped>

--- a/shell/detail/secret.vue
+++ b/shell/detail/secret.vue
@@ -1,18 +1,15 @@
 <script setup lang="ts">
 import DetailPage from '@shell/components/Resource/Detail/Page.vue';
-import TitleBar from '@shell/components/Resource/Detail/TitleBar/index.vue';
-import { useDefaultTitleBarProps } from '@shell/components/Resource/Detail/TitleBar/composables';
-import Metadata from '@shell/components/Resource/Detail/Metadata/index.vue';
 import { MANAGEMENT, SECRET } from '@shell/config/types';
 import ResourceTabs from '@shell/components/form/ResourceTabs/index.vue';
 import SecretDataTab from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/index.vue';
 import KnownHostsTab from '@shell/components/Resource/Detail/ResourceTabs/KnownHostsTab/index.vue';
 import { useGetKnownHostsTabProps } from '@shell/components/Resource/Detail/ResourceTabs/KnownHostsTab/composables';
 import { useSecretDataTabDefaultProps } from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/composeables';
-import { useSecretIdentifyingInformation } from '@shell/components/Resource/Detail/Metadata/IdentifyingInformation/composable';
 import { useStore } from 'vuex';
-import { useBasicMetadata } from '@shell/components/Resource/Detail/Metadata/composables';
 import { computed } from 'vue';
+import Masthead from '@shell/components/Resource/Detail/Masthead/index.vue';
+import { useDefaultMastheadProps } from '@shell/components/Resource/Detail/Masthead/composable';
 
 const store = useStore();
 
@@ -26,9 +23,8 @@ const secret = props.value;
 if (secret.isProjectScoped) {
   store.dispatch('management/find', { id: secret.projectId, type: MANAGEMENT.PROJECT });
 }
-const titleBarProps = useDefaultTitleBarProps(secret);
-const identifyingInformation = useSecretIdentifyingInformation(secret, secret.isProjectScoped);
-const metaDataProps = useBasicMetadata(secret);
+
+const defaultMastheadProps = useDefaultMastheadProps(secret);
 const knownHostsTabProps = useGetKnownHostsTabProps(secret);
 const secretDataTabProps = useSecretDataTabDefaultProps(secret);
 
@@ -36,12 +32,7 @@ const secretDataTabProps = useSecretDataTabDefaultProps(secret);
 <template>
   <DetailPage>
     <template #top-area>
-      <TitleBar v-bind="titleBarProps" />
-      <Metadata
-        class="mmt-6"
-        v-bind="metaDataProps"
-        :identifyingInformation="identifyingInformation"
-      />
+      <Masthead v-bind="defaultMastheadProps" />
     </template>
     <template #bottom-area>
       <ResourceTabs

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -74,15 +74,8 @@ export default class ProvCluster extends SteveModel {
     return super.creationTimestamp;
   }
 
-  // Models can specify a single action that will be shown as a button in the details masthead
-  get detailsAction() {
-    const canExplore = this.mgmt?.isReady && !this.hasError;
-
-    return {
-      action:  'explore',
-      label:   this.$rootGetters['i18n/t']('cluster.explore'),
-      enabled: canExplore,
-    };
+  get canExplore() {
+    return this.mgmt?.isReady && !this.hasError;
   }
 
   get canEdit() {
@@ -1016,5 +1009,9 @@ export default class ProvCluster extends SteveModel {
 
   get disableResourceDetailDrawerConfigTab() {
     return !!this.isHarvester;
+  }
+
+  get fullDetailPageOverride() {
+    return true;
   }
 }


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14977
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
- Created the masthead component to make it easier to share across multiple pages.
- Added a slot so pages can control what gets rendered as additional actions
- Added the explore button back to the cluster management detail page using the slot

### Areas or cases that should be tested
Configmap, secret and provisioning.cattle.io.cluster detail pages.

### Areas which could experience regressions
See above

### Screenshot/Video
The spacing between buttons are larger than the original but consistent with our new styling.

<img width="1273" height="431" alt="image" src="https://github.com/user-attachments/assets/b4f70a93-1e99-419c-b792-67ca2ba4d0f5" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
