### PR TITLE
Fix deprecated charts not being returned from store

### DIFF
--- a/shell/mixins/__tests__/chart.test.ts
+++ b/shell/mixins/__tests__/chart.test.ts
@@ -101,4 +101,50 @@ describe('chartMixin', () => {
       expect(warnings).toHaveLength(expected as number);
     }
   );
+
+  describe('fetchChart', () => {
+    it('should call catalog/version with showDeprecated', async() => {
+      const mockStore = {
+        dispatch: jest.fn(() => Promise.resolve()),
+        getters:  {
+          currentCluster: () => {},
+          isRancher:      () => true,
+          'catalog/repo': () => {
+            return () => 'repo';
+          },
+          'catalog/chart': () => {
+            return { id: 'chart-id', versions: [{ version: '1.0.0' }] };
+          },
+          'catalog/version': jest.fn(),
+          'prefs/get':       () => {},
+          'i18n/t':          () => jest.fn()
+        }
+      };
+
+      const DummyComponent = {
+        mixins:   [ChartMixin],
+        template: '<div></div>',
+      };
+
+      const wrapper = mount(
+        DummyComponent,
+        {
+          global: {
+            mocks: {
+              $store: mockStore,
+              $route: {
+                query: {
+                  chart:      'chart_name',
+                  deprecated: 'true'
+                }
+              }
+            }
+          }
+        });
+
+      await wrapper.vm.fetchChart();
+
+      expect(mockStore.getters['catalog/version']).toHaveBeenCalledWith(expect.objectContaining({ showDeprecated: true }));
+    });
+  });
 });

--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -262,10 +262,11 @@ export default {
     fetchStoreChart() {
       if (!this.chart && this.repo && this.query.chartName) {
         this.chart = this.$store.getters['catalog/chart']({
-          repoType:      this.query.repoType,
-          repoName:      this.query.repoName,
-          chartName:     this.query.chartName,
-          includeHidden: true
+          repoType:       this.query.repoType,
+          repoName:       this.query.repoName,
+          chartName:      this.query.chartName,
+          includeHidden:  true,
+          showDeprecated: this.showDeprecated
         });
       }
 

--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -345,10 +345,11 @@ export default {
 
       try {
         this.version = this.$store.getters['catalog/version']({
-          repoType:    this.query.repoType,
-          repoName:    this.query.repoName,
-          chartName:   this.query.chartName,
-          versionName: this.query.versionName
+          repoType:       this.query.repoType,
+          repoName:       this.query.repoName,
+          chartName:      this.query.chartName,
+          versionName:    this.query.versionName,
+          showDeprecated: this.showDeprecated
         });
       } catch (e) {
         console.error('Unable to fetch Version: ', e); // eslint-disable-line no-console

--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -262,11 +262,10 @@ export default {
     fetchStoreChart() {
       if (!this.chart && this.repo && this.query.chartName) {
         this.chart = this.$store.getters['catalog/chart']({
-          repoType:       this.query.repoType,
-          repoName:       this.query.repoName,
-          chartName:      this.query.chartName,
-          includeHidden:  true,
-          showDeprecated: this.showDeprecated
+          repoType:      this.query.repoType,
+          repoName:      this.query.repoName,
+          chartName:     this.query.chartName,
+          includeHidden: true
         });
       }
 

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -6,7 +6,7 @@ import ChartReadme from '@shell/components/ChartReadme';
 import LazyImage from '@shell/components/LazyImage';
 import isEqual from 'lodash/isEqual';
 import {
-  CHART, REPO, REPO_TYPE, VERSION, SEARCH_QUERY, CATEGORY, TAG
+  CHART, REPO, REPO_TYPE, VERSION, SEARCH_QUERY, CATEGORY, TAG, DEPRECATED
 } from '@shell/config/query-params';
 import { DATE_FORMAT } from '@shell/store/prefs';
 import { ZERO_TIME } from '@shell/config/types';
@@ -144,10 +144,11 @@ export default {
           product: this.$store.getters['productId'],
         },
         query: {
-          [REPO_TYPE]: this.query.repoType,
-          [REPO]:      this.query.repoName,
-          [CHART]:     this.query.chartName,
-          [VERSION]:   this.query.versionName,
+          [REPO_TYPE]:  this.query.repoType,
+          [REPO]:       this.query.repoName,
+          [CHART]:      this.query.chartName,
+          [VERSION]:    this.query.versionName,
+          [DEPRECATED]: this.query.deprecated,
         }
       });
     },

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -296,4 +296,32 @@ describe('catalog', () => {
       expect(result).toHaveLength(0);
     });
   });
+
+  describe('getters', () => {
+    describe('version', () => {
+      it('should call chart getter with showDeprecated', () => {
+        const chartGetter = jest.fn();
+        const state = {};
+        const localGetters = { chart: chartGetter };
+
+        const versionGetter = getters.version(state, localGetters);
+        const args = {
+          repoType:       'cluster',
+          repoName:       'rancher-charts',
+          chartName:      'rancher-monitoring',
+          versionName:    '100.1.0',
+          showDeprecated: true
+        };
+
+        versionGetter(args);
+
+        expect(chartGetter).toHaveBeenCalledWith({
+          repoType:       args.repoType,
+          repoName:       args.repoName,
+          chartName:      args.chartName,
+          showDeprecated: args.showDeprecated
+        });
+      });
+    });
+  });
 });

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -299,28 +299,63 @@ describe('catalog', () => {
 
   describe('getters', () => {
     describe('version', () => {
-      it('should call chart getter with showDeprecated', () => {
-        const chartGetter = jest.fn();
-        const state = {};
-        const localGetters = { chart: chartGetter };
-
-        const versionGetter = getters.version(state, localGetters);
-        const args = {
-          repoType:       'cluster',
-          repoName:       'rancher-charts',
-          chartName:      'rancher-monitoring',
-          versionName:    '100.1.0',
-          showDeprecated: true
+      it('should find a version from a chart, respecting the showDeprecated flag for charts', () => {
+        // A regular chart with some versions
+        const regularChart = {
+          repoType:   'cluster',
+          repoName:   'rancher-charts',
+          chartName:  'regular-chart',
+          deprecated: false,
+          versions:   [{ version: '1.2.3' }, { version: '1.2.4' }]
+        };
+        // A deprecated chart with some versions
+        const deprecatedChart = {
+          repoType:   'cluster',
+          repoName:   'rancher-charts',
+          chartName:  'deprecated-chart',
+          deprecated: true,
+          versions:   [{ version: '2.0.0' }, { version: '2.1.0' }]
         };
 
-        versionGetter(args);
+        const allCharts = [regularChart, deprecatedChart];
+        const state = {};
+        const localGetters = {
+          charts: allCharts,
+          chart:  (args: any) => getters.chart(state, { charts: allCharts })(args)
+        };
 
-        expect(chartGetter).toHaveBeenCalledWith({
-          repoType:       args.repoType,
-          repoName:       args.repoName,
-          chartName:      args.chartName,
-          showDeprecated: args.showDeprecated
+        // Scenario 1: Get a version from a regular chart
+        const result1 = getters.version(state, localGetters)({
+          repoType:       'cluster',
+          repoName:       'rancher-charts',
+          chartName:      'regular-chart',
+          versionName:    '1.2.3',
+          showDeprecated: false
         });
+
+        expect(result1).toStrictEqual({ version: '1.2.3' });
+
+        // Scenario 2: Get a version from a deprecated chart
+        const result2 = getters.version(state, localGetters)({
+          repoType:       'cluster',
+          repoName:       'rancher-charts',
+          chartName:      'deprecated-chart',
+          versionName:    '2.0.0',
+          showDeprecated: true
+        });
+
+        expect(result2).toStrictEqual({ version: '2.0.0' });
+
+        // Scenario 3: Try to get a version from a deprecated chart without the flag should fail
+        const result3 = getters.version(state, localGetters)({
+          repoType:       'cluster',
+          repoName:       'rancher-charts',
+          chartName:      'deprecated-chart',
+          versionName:    '2.0.0',
+          showDeprecated: false
+        });
+
+        expect(result3).toBeNull();
       });
     });
   });

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -296,35 +296,4 @@ describe('catalog', () => {
       expect(result).toHaveLength(0);
     });
   });
-
-  describe('getters', () => {
-    describe('chart', () => {
-      it('should return the correct chart', () => {
-        const chartGetter = getters.chart as Function;
-        const state = {};
-        const localGetters = {
-          charts: [
-            {
-              repoType:  'cluster',
-              repoName:  'rancher-charts',
-              chartName: 'foo',
-            },
-            {
-              repoType:  'cluster',
-              repoName:  'rancher-charts',
-              chartName: 'bar',
-            },
-          ],
-        };
-
-        const chart = chartGetter(state, localGetters)({
-          repoType:  'cluster',
-          repoName:  'rancher-charts',
-          chartName: 'foo',
-        });
-
-        expect(chart.chartName).toBe('foo');
-      });
-    });
-  });
 });

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -296,4 +296,35 @@ describe('catalog', () => {
       expect(result).toHaveLength(0);
     });
   });
+
+  describe('getters', () => {
+    describe('chart', () => {
+      it('should return the correct chart', () => {
+        const chartGetter = getters.chart as Function;
+        const state = {};
+        const localGetters = {
+          charts: [
+            {
+              repoType:  'cluster',
+              repoName:  'rancher-charts',
+              chartName: 'foo',
+            },
+            {
+              repoType:  'cluster',
+              repoName:  'rancher-charts',
+              chartName: 'bar',
+            },
+          ],
+        };
+
+        const chart = chartGetter(state, localGetters)({
+          repoType:  'cluster',
+          repoName:  'rancher-charts',
+          chartName: 'foo',
+        });
+
+        expect(chart.chartName).toBe('foo');
+      });
+    });
+  });
 });

--- a/shell/store/catalog.js
+++ b/shell/store/catalog.js
@@ -237,10 +237,10 @@ export const getters = {
 
   version(state, getters) {
     return ({
-      repoType, repoName, chartName, versionName
+      repoType, repoName, chartName, versionName, showDeprecated
     }) => {
       const chart = getters['chart']({
-        repoType, repoName, chartName
+        repoType, repoName, chartName, showDeprecated
       });
 
       if ( !chart ) {

--- a/shell/store/catalog.js
+++ b/shell/store/catalog.js
@@ -114,7 +114,7 @@ export const getters = {
 
   chart(state, getters) {
     return ({
-      key, repoType, repoName, chartName, includeHidden, multiple
+      key, repoType, repoName, chartName, includeHidden, showDeprecated, multiple
     }) => {
       if ( key && !repoType && !repoName && !chartName) {
         const parsed = parseKey(key);
@@ -127,7 +127,8 @@ export const getters = {
       let matchingCharts = filterBy(getters.charts, {
         repoType,
         repoName,
-        chartName
+        chartName,
+        deprecated: !!showDeprecated,
       });
 
       if ( includeHidden === false ) {

--- a/shell/store/catalog.js
+++ b/shell/store/catalog.js
@@ -114,7 +114,7 @@ export const getters = {
 
   chart(state, getters) {
     return ({
-      key, repoType, repoName, chartName, includeHidden, showDeprecated, multiple
+      key, repoType, repoName, chartName, includeHidden, multiple
     }) => {
       if ( key && !repoType && !repoName && !chartName) {
         const parsed = parseKey(key);
@@ -127,8 +127,7 @@ export const getters = {
       let matchingCharts = filterBy(getters.charts, {
         repoType,
         repoName,
-        chartName,
-        deprecated: !!showDeprecated,
+        chartName
       });
 
       if ( includeHidden === false ) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15144 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
`showDeprecated` flag was added to the store getter `calatog/chart` when the checkbox "Show deprecated apps" was added to the UI in 2.9 in order to show/hide deprecated charts. The url query parameter(`?deprecated` or `?deprecated=true`) was missing in a couple of places such as when we get the versions from the store or when we go to the install/upgrade page.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- Added missing deprecated parameter to `'catalog/version'` and `install` method
- Unit tests

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Make sure you can install deprecated charts
### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Check Explorer => Cluster tools page, you should not see a deprecated chart by default like `Istio`, but by manually adding `deprecated=true` to the url you should be able to see it
### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/edb38efc-c680-4c3c-8fb3-9e1cedf8686c


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
