### PR TITLE
Remove icon-fw and other unused icon classes

### DIFF
--- a/shell/assets/styles/fonts/_icons.scss
+++ b/shell/assets/styles/fonts/_icons.scss
@@ -37,10 +37,6 @@ $icon-inverse:          #fff !default;
 }
 
 // Sizes
-.icon-fw {
-  width: math.div(18em, 14);
-  text-align: center;
-}
 
 .icon-sm {
   font-size: (1em*0.8);
@@ -65,37 +61,10 @@ $icon-inverse:          #fff !default;
   line-height: 1em;
   vertical-align: middle;
 }
-.icon-stack-1x, .icon-stack-2x {
+.icon-stack-1x {
   position: absolute;
   left: 0;
   width: 100%;
   text-align: center;
 }
 .icon-stack-1x { line-height: inherit; }
-.icon-stack-2x { font-size: 2em; }
-.icon-inverse { color: $icon-inverse; }
-
-// List
-.icon-ul {
-  padding-left: 0;
-  margin-left: $icon-li-width;
-  list-style-type: none;
-  > li { position: relative; }
-}
-
-.icon-li {
-  position: absolute;
-  left: -$icon-li-width;
-  width: $icon-li-width;
-  top: math.div(2em, 14);
-  text-align: center;
-  &.icon-lg {
-    left: -$icon-li-width + math.div(4em, 14);
-  }
-}
-
-.icon-rotate-90  { @include icon-rotate(90deg, 1);  }
-.icon-rotate-180 { @include icon-rotate(180deg, 2); }
-.icon-rotate-270 { @include icon-rotate(270deg, 3); }
-.icon-flip-horizontal { @include icon-flip(-1, 1, 0); }
-.icon-flip-vertical   { @include icon-flip(1, -1, 2); }

--- a/shell/components/LocaleSelector.vue
+++ b/shell/components/LocaleSelector.vue
@@ -80,7 +80,7 @@ export default {
         <rc-dropdown-trigger
           data-testid="locale-selector"
           link
-          class="baseline"
+          class="baseline locale-selector-btn"
           :aria-label="t('locale.menu')"
         >
           {{ selectedLocaleLabel }}
@@ -88,7 +88,7 @@ export default {
             v-if="showIcon"
             #after
           >
-            <i class="icon icon-fw icon-sort-down" />
+            <i class="ml-5 icon icon-chevron-down" />
           </template>
         </rc-dropdown-trigger>
         <template #dropdownCollection>
@@ -125,5 +125,10 @@ export default {
 <style lang="scss">
   .baseline {
     align-items: baseline;
+  }
+
+  .locale-selector-btn {
+    align-items: center;
+    display: flex;
   }
 </style>

--- a/shell/components/form/Members/ClusterPermissionsEditor.vue
+++ b/shell/components/form/Members/ClusterPermissionsEditor.vue
@@ -282,7 +282,7 @@ export default {
             <i
               v-if="permission.locked"
               v-clean-tooltip="permission.tooltip"
-              class="icon icon-lock icon-fw"
+              class="icon icon-lock"
             />
           </div>
         </div>

--- a/shell/components/form/ProjectMemberEditor.vue
+++ b/shell/components/form/ProjectMemberEditor.vue
@@ -309,7 +309,7 @@ export default {
             <i
               v-if="permission.locked"
               v-clean-tooltip="permission.tooltip"
-              class="icon icon-lock icon-fw"
+              class="icon icon-lock"
             />
           </div>
         </div>

--- a/shell/components/nav/WindowManager/index.vue
+++ b/shell/components/nav/WindowManager/index.vue
@@ -383,7 +383,7 @@ export default {
         <span class="tab-label"> {{ tab.label }}</span>
         <i
           data-testid="wm-tab-close-button"
-          class="closer icon icon-fw icon-x wm-closer-button"
+          class="closer icon icon-x wm-closer-button"
           :alt="t('wm.containerShell.closeShellTab', { tab: tab.label })"
           tabindex="0"
           :aria-label="t('windowmanager.closeTab', { tabId: tab.id })"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15157

### Occurred changes and/or fixed issues

This PR removes the last 4 remaining uses of the `icon-fw` class and also removes a few icon-related classes which are not used.

### Technical notes summary

Removing `icon-fw`:

**shell/components/LocaleSelector.vue**

Locale selector (on the login screen) uses this class to provide padding between the text and the icon. Replaced this with margin class and also fixed the vertical centring of the icon (note was using sort down icon, which is bottom-aligned, rather than icon-chevron, which is centreed).

Before:

<img width="123" height="61" alt="image" src="https://github.com/user-attachments/assets/796c3954-17f1-49c4-8d07-666693c99901" />

After:

<img width="148" height="78" alt="image" src="https://github.com/user-attachments/assets/e1e26b75-b133-4438-8a16-6f22641aafba" />
 
**shell/components/form/ProjectMemberEditor.vue**
**shell/components/form/Members/ClusterPermissionsEditor.vue**

Both of these use `icon-fw` on the lock icon for a locked role - this is purely to provide spacing between the text and icon. Simply removing it shows slightly less spacing, but I believe this is still acceptable.

Before:

<img width="268" height="61" alt="image" src="https://github.com/user-attachments/assets/0884de53-7bd1-45aa-b4f7-40097a7542c3" />

After:

<img width="268" height="61" alt="image" src="https://github.com/user-attachments/assets/c0629066-67a4-4c72-974e-3a859a78a5de" />

**shell/components/nav/WindowManager/index.vue**

The class is used here but has no affect, so removing it looks the same as with it present (it was on the close icon):

<img width="405" height="78" alt="image" src="https://github.com/user-attachments/assets/da1a647b-1bcb-46b1-ac85-c23bbd4fe6c3" />

Additionally, the following classes have been removed, which are not used and we don't want to encourage the use of - particularly the rotate/flip classes:

`icon-stack-2x`
`icon-inverse`
`icon-ul`
`icon-li`
`icon-rotate-90`
`icon-rotate-180`
`icon-rotate-270`
`icon-flip-horizontal`
`icon-flip-vertical`

### Areas or cases that should be tested

Test the 4 areas identified above.

Specifically:

1. Locale Selector Drop Down

On the login screen, check that the drop-down arrow on the locale selector drop-down renders as expected, i.e.:

<img width="148" height="78" alt="image" src="https://github.com/user-attachments/assets/e1e26b75-b133-4438-8a16-6f22641aafba" />

The arrow should be centre aligned vertically with the text of the language. 

2. Project Member Editor

Goto 'Users & Authentication', 'Role Templates'. Go to the 'Project/Namespace' tab and for the role, 'View Services', from the three dot menu in the table, 'Edit Config' and change 'Locked' to 'Yes' and save.

Go the local cluster, 'Cluster' and 'Projects/Namespaces'. Click 'Create Project'. Under 'Members', click 'Add', then click the 'Custom' radio button. Verify that the 'View Services' checkbox shows the locked icon and that this is vertically centred with the text with appropriate horizontal spacing, e.g. 

<img width="582" height="577" alt="image" src="https://github.com/user-attachments/assets/d699493c-6982-4bed-9fec-e05c2892a90b" />

3. Cluster Permissions Editor

Goto 'Users & Authentication', 'Role Templates'. Go to the 'Cluster' tab and for the first role, 'Manage Cluster Backups', from the three dot menu in the table, 'Edit Config' and change 'Locked' to 'Yes' and save.

Go the local cluster and to 'Cluster' > 'Cluster and Project Members'. Click 'Add' and then click 'Custom'. Verify that the 'Manage Cluster Backups' checkbox shows the locked icon and that this is vertically centred with the text with appropriate horizontal spacing, e.g. 

<img width="720" height="376" alt="image" src="https://github.com/user-attachments/assets/e96e35be-0392-488d-9ae4-519caeb5fa6d" />

5. Window Manager Tab Close Icon

In the local cluster, bring up the kubectl shell  window and check that the close icon in the tab of the shell window looks correct - should be vertically aligned with the text and well spaced, for example:

<img width="199" height="56" alt="image" src="https://github.com/user-attachments/assets/5de6503d-5e73-4a77-be08-cd02f2e898fe" />
 
### Screenshot/Video

Included above.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
