### PR TITLE
fix: show user data and network data by id

### DIFF
--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -188,14 +188,14 @@ export default {
 
           if (cloudTemplate === 'user') {
             userDataOptions.push({
-              label: O.metadata.name,
+              label: O.id,
               value: O.data.cloudInit
             });
           }
 
           if (cloudTemplate === 'network') {
             networkDataOptions.push({
-              label: O.metadata.name,
+              label: O.id,
               value: O.data.cloudInit
             });
           }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15171

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
When creating harvester downstream cluster, change `user & network data` to show by id ({namespace}/{name})

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<img width="1468" height="803" alt="Screenshot 2025-08-18 at 3 13 50 PM" src="https://github.com/user-attachments/assets/0c0d80e1-5917-411f-9136-a750a13c91a0" />
<img width="1468" height="798" alt="Screenshot 2025-08-18 at 3 13 58 PM" src="https://github.com/user-attachments/assets/b00d2300-950b-4a66-9bd5-7bd3967ef365" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
