### PR TITLE
[backport fix] fix issue with addon modal in cluster edit

### DIFF
--- a/shell/components/PromptModal.vue
+++ b/shell/components/PromptModal.vue
@@ -94,7 +94,7 @@ export default {
       this.errors = [];
 
       // Guard against events that can be implicitly passed by components
-      const modalData = (data instanceof Event || !data?.performCallback) ? undefined : data;
+      const modalData = data instanceof Event ? undefined : data;
 
       this.$store.commit('action-menu/togglePromptModal', modalData);
 

--- a/shell/dialog/GenericPrompt.vue
+++ b/shell/dialog/GenericPrompt.vue
@@ -47,7 +47,7 @@ export default {
     decodeHtml,
     close() {
       this.confirm(false);
-      this.$emit('close');
+      this.$emit('close', false);
     },
 
     async apply(buttonDone) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15183 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix issue with addon modal in cluster edit, where `emit('close')` should not send any argument otherwise it's going to hit https://github.com/rancher/dashboard/blob/master/shell/components/PromptModal.vue#L97. 

This is used to perform callbacks in modals, which afaik is only done in https://github.com/rancher/dashboard/blob/master/shell/dialog/MoveNamespaceDialog.vue#L85

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- check same scenario as original issue to confirm that problem is resolverd

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
https://github.com/user-attachments/assets/d1a60025-aeed-4192-8488-e5b250f83bee

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
