### PR TITLE
[2.10] Added input validation to s3 endpoint field in cluster

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2100,6 +2100,19 @@ cluster:
         label: Metrics
         false: Only available inside the cluster
         true: Exposed to the public interface
+      s3config:
+        bucket:
+          label: Bucket
+        folder:
+          label: Folder
+        region:
+          label: Region
+        endpoint:
+          label: Endpoint
+        skipSSLVerify:
+          label: Accept any certificate (insecure)
+        endpointCA:
+          label: Endpoint CA Cert
   k3s:
     systemService:
       coredns: 'CoreDNS'
@@ -6070,6 +6083,7 @@ validation:
       localhost: If the Server URL is internal to the Rancher server (e.g. localhost) the downstream clusters may not be able to communicate with Rancher.
       trailingForwardSlash: Server URL should not have a trailing forward slash.
       url: Server URL must be an URL.
+      awsStyleEndpoint: Endpoint URL has to be a valid domain-based endpoint and cannot start with a protocol (e.g https:// or http://)
   stringLength:
     between: '"{key}" should be between {min} and {max} {max, plural, =1 {character} other {characters}}'
     exactly: '"{key}" should be {count, plural, =1 {# character} other {# characters}}'

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -251,7 +251,8 @@ export default {
       addonConfigValidation: {}, // validation state of each addon config (boolean of whether codemirror's yaml lint passed)
       allNamespaces:         [],
       extensionTabs:         getApplicableExtensionEnhancements(this, ExtensionPoint.TAB, TabLocation.CLUSTER_CREATE_RKE2, this.$route, this),
-      labelForAddon
+      labelForAddon,
+      etcdConfigValid:       true,
     };
   },
 
@@ -831,7 +832,12 @@ export default {
       set(newValue) {
         this.$emit('update:value', newValue);
       }
-    }
+    },
+    overallFormValidationPassed() {
+      return this.validationPassed &&
+            this.fvFormIsValid &&
+            this.etcdConfigValid;
+    },
   },
 
   watch: {
@@ -2175,7 +2181,7 @@ export default {
     v-else
     ref="cruresource"
     :mode="mode"
-    :validation-passed="validationPassed && fvFormIsValid"
+    :validation-passed="overallFormValidationPassed"
     :resource="value"
     :errors="errors"
     :cancel-event="true"
@@ -2396,6 +2402,7 @@ export default {
             @update:value="$emit('input', $event)"
             @s3-backup-changed="handleS3BackupChanged"
             @config-etcd-expose-metrics-changed="handleConfigEtcdExposeMetricsChanged"
+            @etcd-validation-changed="(val)=>etcdConfigValid = val"
           />
         </Tab>
 

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/etcd/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/etcd/index.vue
@@ -7,7 +7,7 @@ import S3Config from '@shell/edit/provisioning.cattle.io.cluster/tabs/etcd/S3Con
 import UnitInput from '@shell/components/form/UnitInput';
 
 export default {
-  emits: ['s3-backup-changed', 'config-etcd-expose-metrics-changed'],
+  emits: ['s3-backup-changed', 'config-etcd-expose-metrics-changed', 'etcd-validation-changed'],
 
   components: {
     LabeledInput,
@@ -55,6 +55,18 @@ export default {
     },
 
   },
+  methods: {
+    s3BackupChanged(val) {
+      this.$emit('s3-backup-changed', val);
+      this.$emit('etcd-validation-changed', !val);
+    },
+    disableSnapshotsChanged(val) {
+      if (val) {
+        this.$emit('etcd-validation-changed', true);
+        this.$emit('s3-backup-changed', false);
+      }
+    }
+  }
 };
 </script>
 
@@ -69,6 +81,7 @@ export default {
           :label="t('cluster.rke2.etcd.disableSnapshots.label')"
           :labels="[t('generic.disable'), t('generic.enable')]"
           :mode="mode"
+          @update:value="disableSnapshotsChanged"
         />
       </div>
     </div>
@@ -105,7 +118,7 @@ export default {
         label="Backup Snapshots to S3"
         :labels="['Disable','Enable']"
         :mode="mode"
-        @update:value="$emit('s3-backup-changed', $event)"
+        @update:value="s3BackupChanged"
       />
 
       <S3Config
@@ -114,6 +127,7 @@ export default {
         :namespace="value.metadata.namespace"
         :register-before-hook="registerBeforeHook"
         :mode="mode"
+        @validationChanged="$emit('etcd-validation-changed', $event)"
       />
     </template>
 

--- a/shell/utils/__tests__/setting.test.js
+++ b/shell/utils/__tests__/setting.test.js
@@ -1,0 +1,92 @@
+import {
+  isServerUrl,
+  isHttps,
+  isDomainWithoutProtocol,
+  isLocalhost,
+  hasTrailingForwardSlash,
+} from '@shell/utils/validators/setting';
+
+describe('isServerUrl', () => {
+  it.each([
+    ['server-url', true],
+    ['SERVER-URL', false],
+    ['server-url/', false],
+    ['not-server-url', false],
+    ['', false],
+  ])('should validate that isServerUrl("%s") returns %s', (input, expected) => {
+    expect(isServerUrl(input)).toBe(expected);
+  });
+});
+
+describe('isHttps', () => {
+  it.each([
+    ['https://example.com', true],
+    ['HTTPS://EXAMPLE.COM', true],
+    ['http://example.com', false],
+    ['ftp://example.com', false],
+    ['example.com', false],
+    ['', false],
+  ])('should validate that isHttps("%s") returns %s', (input, expected) => {
+    expect(isHttps(input)).toBe(expected);
+  });
+});
+
+describe('isDomainWithoutProtocol (follows domain format, no protocol)', () => {
+  it.each([
+    ['ec2.us-west-2.amazonaws.com', true],
+    ['ec2.us-west-2.api.aws', true],
+    ['ec2.us-west-2.amazonaws.com.cn', true],
+    ['s3.eu-central-1.amazonaws.com.cn', true],
+    ['my-service.internal.net', true],
+    ['db.example.org:5432', true],
+    ['ex.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.com', true],
+    ['service.company.local/path/to/resource', true],
+    ['example.org:443', true],
+    ['https://ec2.us-west-2.amazonaws.com', false],
+    ['http://example.com', false],
+    ['udp://example.com', false],
+    ['ftp://example.com', false],
+    ['ftps://example.com', false],
+    ['example://example.com', false],
+    ['example', false],
+    ['-bad.example.com', false],
+    ['bad-.example.com', false],
+    ['example.c', false],
+    ['exa mple.com', false],
+    ['exa.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.example.com', false],
+    ['', false],
+  ])('should validate that isDomainWithoutProtocol("%s") returns %s', (input, expected) => {
+    expect(isDomainWithoutProtocol(input)).toBe(expected);
+  });
+});
+
+describe('isLocalhost', () => {
+  it.each([
+    ['localhost', true],
+    ['LOCALHOST', true],
+    ['http://localhost', true],
+    ['https://localhost:3000', true],
+    ['127.0.0.1', true],
+    ['http://127.0.0.1:8080/path', true],
+    ['HTTPS://127.0.0.1/Health', true],
+    ['127.0.0.2', false],
+    ['http://127.0.0.2', false],
+    ['mylocalhost', false],
+  ])('should validate that isLocalhost("%s") returns %s', (input, expected) => {
+    expect(isLocalhost(input)).toBe(expected);
+  });
+});
+
+describe('hasTrailingForwardSlash', () => {
+  it.each([
+    ['https://example.com/', true],
+    ['http://example.com/', true],
+    ['HTTPS://EXAMPLE.COM/', true],
+    ['https://example.com/path/', true],
+    ['https://example.com', false],
+    ['http://example.com/path', false],
+    ['example.com/', false],
+  ])('should validate that hasTrailingForwardSlash("%s") returns %s', (input, expected) => {
+    expect(hasTrailingForwardSlash(input)).toBe(expected);
+  });
+});

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -6,7 +6,7 @@ import isUrl from 'is-url';
 // import uniq from 'lodash/uniq';
 import cronstrue from 'cronstrue';
 import { Translation } from '@shell/types/t';
-import { isHttps, isLocalhost, hasTrailingForwardSlash } from '@shell/utils/validators/setting';
+import { isHttps, isLocalhost, hasTrailingForwardSlash, isDomainWithoutProtocol } from '@shell/utils/validators/setting';
 
 // import uniq from 'lodash/uniq';
 export type Validator<T = undefined | string> = (val: any, arg?: any) => T;
@@ -136,7 +136,7 @@ export default function(t: Translation, { key = 'Value' }: ValidationOptions): {
       return t('validation.invalidCron');
     }
   };
-
+  const awsStyleEndpoint: Validator = (val: string) => val && !isDomainWithoutProtocol(val) ? t('validation.setting.serverUrl.awsStyleEndpoint') : undefined;
   const https: Validator = (val: string) => val && !isHttps(val) ? t('validation.setting.serverUrl.https') : undefined;
 
   const localhost: Validator = (val: string) => isLocalhost(val) ? t('validation.setting.serverUrl.localhost') : undefined;
@@ -478,6 +478,7 @@ export default function(t: Translation, { key = 'Value' }: ValidationOptions): {
     hostname,
     imageUrl,
     interval,
+    awsStyleEndpoint,
     https,
     localhost,
     trailingForwardSlash,

--- a/shell/utils/validators/setting.js
+++ b/shell/utils/validators/setting.js
@@ -1,5 +1,7 @@
 import isUrl from 'is-url';
 
+// Note that these function cover specific use cases and you need to make sure it works for your use case before using them.
+// ie they would consider empty values as valid, not all endpoint formatting is enforced
 export const isServerUrl = (value) => value === 'server-url';
 
 export const isHttps = (value) => value.toLowerCase().startsWith('https://');
@@ -7,3 +9,16 @@ export const isHttps = (value) => value.toLowerCase().startsWith('https://');
 export const isLocalhost = (value) => (/^(?:https?:\/\/)?(?:localhost|127\.0\.0\.1)/i).test(value);
 
 export const hasTrailingForwardSlash = (value) => isUrl(value) && value?.toLowerCase().endsWith('/');
+/**
+ * Checks that provided string is a domain without protocol (case insensitive):
+ * - Cannot start with any protocol, such as http://, https://, ftp://, ftps://, udp://
+ * - Must only use the letters a to z, the numbers 0 to 9, and the dot (.) and hyphen (-) characters.
+ * - if the hyphen character is used in a domain name, it cannot be the first or the last character in the name.
+ * - The length of each label can be 2-63 characters
+ * - TLD is at least 2 characters
+ * - The total length of a domain name, including the dot at the end, cannot exceed 254 characters.
+ * - Allows for optional port and path
+ * @param {*} value
+ * @returns boolean indicating if the value is a domain without protocol
+ */
+export const isDomainWithoutProtocol = (value) => (/^(?=.{1,254}$)(?![a-z][a-z0-9+.-]*:\/\/)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}(?::\d{1,5})?(?:\/\S*)?$/i).test(value);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14681
Backport of https://github.com/rancher/dashboard/pull/14557
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
