### PR TITLE
Ensure we don't pin chrome for a11y-test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -96,6 +96,11 @@ jobs:
 
       # Installing fixed version of Chrome since latest version does not work (128 didn't work)
       # Leaving this here again in case we need to pin to a specific Chrome version in the future
+      # NOTE - If we need to pin chrome again we should...
+      # 1. create a repo gh action to install chrome (see .github/actions)
+      # 2. call it here
+      # 3. call it from `a11y-test` as well
+
       # - name: Install Chrome 127
       #   run: |
       #     sudo apt-get install -y wget libu2f-udev
@@ -176,17 +181,6 @@ jobs:
           fetch-depth: 1
       - name: Setup env
         uses: ./.github/actions/setup
-
-      # Installing fixed version of Chrome since latest version does not work (128 didn't work)
-      # Leaving this here again in case we need to pin to a specific Chrome version in the future
-      - name: Install Chrome 127
-        run: |
-          sudo apt-get install -y wget libu2f-udev
-          cd /tmp
-          wget -q http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_127.0.6533.72-1_amd64.deb
-          sudo dpkg -i google-chrome-stable_127.0.6533.72-1_amd64.deb
-          sudo apt-get install -y --allow-downgrades ./google-chrome-stable_127.0.6533.72-1_amd64.deb
-          google-chrome --version
 
       - name: Download e2e build
         uses:  actions/download-artifact@v4


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- we unpined chrome for main e2e tests a while ago
- this currently fails to install anyway
- if we need to pin again we should create a gh action and call from both test and a11-test


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
