### PR TITLE
Fallback to legacy configmaps request when vai state is underterminable

### DIFF
--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -134,7 +134,13 @@ export default {
 
       if (clusterId) {
         let configMapsUrl = `${ url }/${ CONFIG_MAP }s`;
-        const harvesterClusterVaiEnabled = await paginationUtils.isDownstreamSteveCacheEnabled({ dispatch: this.$store.dispatch }, clusterId);
+        let harvesterClusterVaiEnabled = false;
+
+        try {
+          harvesterClusterVaiEnabled = await paginationUtils.isDownstreamSteveCacheEnabled({ dispatch: this.$store.dispatch }, clusterId);
+        } catch (e) {
+          console.error('Failed to determine if vai is enabled in imported harvester cluster, reverting to non-vai process', e); // eslint-disable-line no-console
+        }
 
         if (harvesterClusterVaiEnabled && this.$store.getters[`cluster/paginationEnabled`](CONFIG_MAP)) {
           const pagination = new FilterArgs({


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15234
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- lots more detail in the issue
- add a try/catch around vai in host/imported harvester cluster
- if this fails it just reverts back to previously (fetch all configmaps)

### Areas or cases that should be tested
- as per issue

### Areas which could experience regressions
- no other areas

### Screenshot/Video
- see 'expected' section of issue

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
