### PR TITLE
Update last update check to point last conditions and ignore the status

### DIFF
--- a/pkg/rancher-prime/pages/registration.composable.test.ts
+++ b/pkg/rancher-prime/pages/registration.composable.test.ts
@@ -39,10 +39,7 @@ describe('registration composable', () => {
         links:    { view: '123' },
         status:   {
           activationStatus: { activated: true },
-          conditions:       [{
-            type:   'Done',
-            status: 'True',
-          }]
+          currentCondition: { type: 'Done' }
         },
       }];
 
@@ -85,20 +82,11 @@ describe('registration composable', () => {
         links:    { view: '123' },
         status:   {
           activationStatus: { activated: false },
-          conditions:       [
-            {
-              type:    'Failure',
-              status:  'True',
-              message: 'Message not for the user',
-              reason:  'Give me a reason',
-            },
-            {
-              type:    'RegistrationActivated',
-              status:  'False',
-              message: errorMessage,
-              reason:  'Give me a reason',
-            },
-          ]
+          currentCondition: {
+            type:    'RegistrationActivated',
+            message: errorMessage,
+            reason:  'Give me a reason',
+          },
         },
       }];
 
@@ -136,10 +124,7 @@ describe('registration composable', () => {
         links:    { view: '123' },
         status:   {
           activationStatus: { activated: true },
-          conditions:       [{
-            type:   'Done',
-            status: 'True',
-          }]
+          currentCondition: { type: 'Done' }
         },
       }];
 
@@ -228,10 +213,7 @@ describe('registration composable', () => {
         links:    { view: '123' },
         status:   {
           activationStatus: { activated: true },
-          conditions:       [{
-            type:   'Done',
-            status: 'True',
-          }]
+          currentCondition: { type: 'Done' }
         },
       }];
       const secretRequest = {
@@ -299,13 +281,7 @@ describe('registration composable', () => {
         links:    { view: '123' },
         status:   {
           activationStatus: { activated: true },
-          conditions:       [
-            { type: 'OfflineRequestReady' },
-            {
-              type:   'OfflineActivationDone',
-              status: 'True',
-            },
-          ]
+          currentCondition: { type: 'OfflineActivationDone' },
         },
       }];
 

--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -356,27 +356,6 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
   };
 
   /**
-   * Return prioritized condition with reason and message
-   * @param conditions
-   * @returns
-   */
-  const getErrorMessages = (conditions: PartialCondition[]): PartialCondition | undefined => {
-    const errorConditions = conditions.filter((condition) => condition.reason && condition.message);
-
-    // Prioritize conditions that are not 'Failure' type
-    if (errorConditions.length > 1) {
-      return errorConditions.find((condition) => condition.type !== 'Failure') || errorConditions[0];
-    }
-
-    // Default return the condition containing the message
-    if (errorConditions.length === 1) {
-      return errorConditions[0];
-    }
-
-    return undefined;
-  };
-
-  /**
    * Get the registration request from the secret data
    * @param secret PartialSecret containing the request data
    */

--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -57,6 +57,7 @@ interface PartialRegistration {
       systemUrl: string;
     };
     conditions: PartialCondition[];
+    currentCondition: PartialCondition;
   };
 }
 
@@ -302,7 +303,7 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
    */
   const isRegistrationOfflineProgress = (registration: PartialRegistration): boolean => {
     const isOffline = registration.spec?.mode === 'offline';
-    const lastCondition = registration.status?.conditions[registration.status?.conditions.length - 1];
+    const lastCondition = registration.status?.currentCondition;
     const isInProgress = lastCondition.type === 'OfflineRequestReady';
     const isActive = registration.status.activationStatus.activated === true;
 
@@ -316,11 +317,14 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
    */
   const isRegistrationCompleted = (registration: PartialRegistration): boolean => {
     const mode = registration.spec?.mode;
-    const lastCondition = registration.status?.conditions[registration.status?.conditions.length - 1];
-    const isError = lastCondition.type === 'RegistrationActivated' && lastCondition.status === 'False';
-    const isError2 = lastCondition.type === 'Failure' && lastCondition.status === 'True';
-    const isCompleteOnline = mode === 'online' && lastCondition.type === 'Done' && lastCondition.status === 'True';
-    const isCompleteOffline = mode === 'offline' && lastCondition.type === 'OfflineActivationDone' && lastCondition.status === 'True';
+    const lastCondition = registration.status?.currentCondition;
+
+    if (!lastCondition.type) return false;
+
+    const isError = lastCondition.type === 'RegistrationActivated';
+    const isError2 = lastCondition.type === 'RegistrationAnnounced';
+    const isCompleteOnline = mode === 'online' && lastCondition.type === 'Done';
+    const isCompleteOffline = mode === 'offline' && lastCondition.type === 'OfflineActivationDone';
 
     return isError || isError2 || isCompleteOnline || isCompleteOffline;
   };

--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -411,8 +411,7 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
         };
       } else {
         // Retrieve failure message from conditions
-        const conditions = registration.status?.conditions || [];
-        const errorMessage = getErrorMessages(conditions);
+        const errorMessage = registration.status?.currentCondition;
 
         if (errorMessage) {
           onError(errorMessage);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15232
Fixes #14940
Fixes #14985
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

Updated logic so the message would be always provided by the `currentCondition` and will stop on certain types.

### Technical notes summary

This will remove entirely the implementation set in place with https://github.com/rancher/dashboard/issues/14940

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video


https://github.com/user-attachments/assets/d9e6a1bd-e3d4-4285-9a2c-815fdbc25806



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
