### PR TITLE
Show Ember deprecation banner on kontainer drivers page only when admin

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2604,6 +2604,8 @@ cruResource:
 drivers:
   kontainer:
     title: Cluster Drivers
+    emberDeprecationMessage: 'Support for UI Plugins (based on Ember) for cluster and node drivers was deprecated in Rancher 2.11.0 and will be removed in a future release. These need to be migrated to the new <a href="https://extensions.rancher.io" target="_blank" rel="noopener noreferrer nofollow">UI Extensions framework</a>.'
+
   node:
     title: Node Drivers
   add:

--- a/shell/pages/c/_cluster/manager/drivers/kontainerDriver/index.vue
+++ b/shell/pages/c/_cluster/manager/drivers/kontainerDriver/index.vue
@@ -1,5 +1,6 @@
 <script>
 import { NORMAN } from '@shell/config/types';
+import { isAdminUser } from '@shell/store/type-map';
 import ResourceTable from '@shell/components/ResourceTable';
 import AsyncButton from '@shell/components/AsyncButton';
 import Loading from '@shell/components/Loading';
@@ -14,21 +15,6 @@ export default {
 
   async fetch() {
     this.allDrivers = await this.$store.dispatch('rancher/findAll', { type: NORMAN.KONTAINER_DRIVER }, { root: true });
-
-    // Work out if the user has the admin role
-    const v3User = this.$store.getters['auth/v3User'] || {};
-
-    if (v3User?.links?.globalRoleBindings) {
-      try {
-        // Non-blocking fetch to get the user's global roles to see if they have the 'admin' role
-        this.$store.dispatch('management/request', { url: v3User.links.globalRoleBindings }).then((response) => {
-          const data = response?.data || [];
-          const isAdmin = !!data.find((role) => role.globalRoleId === 'admin');
-
-          this.showDeprecationBanner = isAdmin;
-        });
-      } catch {}
-    }
   },
 
   data() {
@@ -39,7 +25,7 @@ export default {
       schema:                           this.$store.getters['rancher/schemaFor'](NORMAN.KONTAINER_DRIVER),
       useQueryParamsForSimpleFiltering: false,
       forceUpdateLiveAndDelayed:        10,
-      showDeprecationBanner:            false,
+      showDeprecationBanner:            isAdminUser(this.$store.getters),
     };
   },
   computed: {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15257

### Occurred changes and/or fixed issues

This PR adds the Ember deprecation banner to the kontainer drivers page.

It is only shown if the user is an admin.

Note: The banner text is the same as was used in the Ember page - we are moving it here to be less intrusive. The work to remove it from the Ember UI is in a separate PR in the ui repository.

### Areas or cases that should be tested

As an admin user, go to the kontainer driver page and check that the banner shows.
As a non-admin (e.g. standard user), go to the kontainer driver page and check that the banner does not show.

### Screenshot/Video

<img width="997" height="792" alt="image" src="https://github.com/user-attachments/assets/90efcbfd-60a8-4014-9e44-cf3ea9966ecc" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
