### PR TITLE
Prevent `pr-gh-project` from updating milestone for backport PRs raised by the bot

### DIFF
--- a/.github/workflows/port-pr.yaml
+++ b/.github/workflows/port-pr.yaml
@@ -76,6 +76,9 @@ jobs:
           TARGET_BRANCH=$(echo "${COMMENT_BODY}" | awk '{ print $3 }')
           echo "Target branch: ${TARGET_BRANCH}" >> $GITHUB_STEP_SUMMARY
           echo "target_branch=${TARGET_BRANCH}" >> $GITHUB_ENV
+          ISSUE_NUMBER=$(echo "${COMMENT_BODY}" | awk '{ print $4 }' | sed -e 's/#//')
+          echo "Issue number: ${ISSUE_NUMBER}" >> $GITHUB_STEP_SUMMARY
+          echo "issue_number=${ISSUE_NUMBER}" >> $GITHUB_ENV
           if gh api repos/${GITHUB_REPOSITORY}/branches --paginate | jq -e --arg TARGET_BRANCH "$TARGET_BRANCH" '.[] | select(.name == $TARGET_BRANCH)' > /dev/null; then
               echo "target_branch_exists=true" >> $GITHUB_ENV
           else
@@ -99,11 +102,13 @@ jobs:
           TYPE: ${{ env.type }}
           TARGET_BRANCH: ${{ env.target_branch }}
           MILESTONE: ${{ env.milestone }}
+          ISSUE_NUMBER: ${{ env.issue_number }}
         run: |
           echo "Starting Port PR step..."
           echo "Original Issue Number: ${ORIGINAL_ISSUE_NUMBER}"
           echo "Type: ${TYPE}"
           echo "Target Branch: ${TARGET_BRANCH}"
+          echo "Target Issue Number: ${ISSUE_NUMBER}"
           echo "Milestone: ${MILESTONE}"
 
           PATCH_FILE=$(mktemp)
@@ -144,6 +149,9 @@ jobs:
               echo -e "This is an automated request to port PR #${ORIGINAL_ISSUE_NUMBER} by @${GITHUB_ACTOR}\n\n" > $BODY
               echo -e "Original PR body:\n\n" >> $BODY
               echo "${ORIGINAL_PR}" | jq -r .body >> $BODY
+              if [ -n "$ISSUE_NUMBER" ]; then
+                  echo -e "\n\nFixes #${ISSUE_NUMBER}" >> $BODY
+              fi
 
               ASSIGNEES=$(echo "${ORIGINAL_PR}" | jq -r .assignees[].login)
               echo "Original PR Assignees: ${ASSIGNEES}"

--- a/.github/workflows/scripts/pr-gh-project.js
+++ b/.github/workflows/scripts/pr-gh-project.js
@@ -334,7 +334,7 @@ async function processOpenOrEditAction() {
     console.log('No milestones on issue(s) for this PR');
   } else if (keys.length > 1) {
     console.log('More than one milestone on issues for this PR');
-  } else {
+  } else if (event.pull_request.user.type.toLowerCase() !== 'bot') {
     // There is exactly 1 milestone, so use that for the PR
     const milestoneNumber = milestones[keys[0]];
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This fixes an issue where the `pr-gh-project` bot will update the milestone for backports raised by the `port-pr` bot.

This also adds a new, optional, target issue arg to the backport bot command. 

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Prevent updating milestone if PR was raised by bot
- Accept optional issue number in backport bot

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

`port-pr` has been migrated to a github app, which means that it now triggers other github actions, including `pr-gh-project`. 

The updated syntax for triggering the backport bot should be `/backport ${target-milestone} ${target-branch} ${target-issue}`.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

This change affects both the `port-pr` & `pr-gh-project` workflows. We will need to ensure the following:

- Backports can accept an optional milestone
- PRs raised by the backport bot adds a closing keyword to the PR body that targets the milestone when one is passed
- PRs raised by the backport bot do not get their milestone updated by the `pr-gh-project` workflow

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- `port-pr` workflow
- `pr-gh-project` workflow

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
