### PR TITLE
Fix missing Fleet clusters updates after saving

### DIFF
--- a/shell/edit/fleet.cattle.io.cluster.vue
+++ b/shell/edit/fleet.cattle.io.cluster.vue
@@ -61,6 +61,7 @@ export default {
 
         await this.normanCluster.save();
 
+        // Changes (such as labels or annotations fields) to normanCluster are reflected in the fleet cluster via Rancher services, so wait for that to occur
         await this.waitForFleetClusterLastRevision();
 
         this.done();
@@ -74,15 +75,15 @@ export default {
     async waitForFleetClusterLastRevision() {
       const inStore = this.$store.getters['currentProduct'].inStore;
 
+      const currRev = this.value?.metadata?.resourceVersion;
+
       try {
         return await this.value.waitForTestFn(() => {
-          const curr = this.value.metadata?.resourceVersion;
-          const nue = this.$store.getters[`${ inStore }/byId`](this.value.type, this.value.id)?.metadata?.resourceVersion;
+          const rev = this.$store.getters[`${ inStore }/byId`](this.value.type, this.value.id)?.metadata?.resourceVersion;
 
-          return curr && curr !== nue;
+          return currRev && currRev !== rev;
         }, `${ this.value.id } - wait for resourceVersion to change`, 1000, 200);
       } catch (e) {
-
       }
     }
   },

--- a/shell/edit/fleet.cattle.io.cluster.vue
+++ b/shell/edit/fleet.cattle.io.cluster.vue
@@ -56,9 +56,12 @@ export default {
     async save(buttonDone) {
       try {
         this.errors = [];
+
         await this.value.save();
 
         await this.normanCluster.save();
+
+        await this.waitForFleetClusterLastRevision();
 
         this.done();
         buttonDone(true);
@@ -67,6 +70,21 @@ export default {
         buttonDone(false);
       }
     },
+
+    async waitForFleetClusterLastRevision() {
+      const inStore = this.$store.getters['currentProduct'].inStore;
+
+      try {
+        return await this.value.waitForTestFn(() => {
+          const curr = this.value.metadata?.resourceVersion;
+          const nue = this.$store.getters[`${ inStore }/byId`](this.value.type, this.value.id)?.metadata?.resourceVersion;
+
+          return curr && curr !== nue;
+        }, `${ this.value.id } - wait for resourceVersion to change`, 1000, 200);
+      } catch (e) {
+
+      }
+    }
   },
 };
 </script>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15284
<!-- Define findings related to the feature or bug issue. -->

Cached resource's re-watch was introduced in https://github.com/rancher/dashboard/pull/15011.
However, the `dispatch('watch')` call  triggers an `unwatch` with missing `type` and `id` params.

It seems we have a raise condition or a bug in the re-watch mechanism.

[Screencast from 2025-09-02 10-15-44.webm](https://github.com/user-attachments/assets/b705bba3-eac3-47fa-805a-7794031a7e56)

UPDATE @richard-cox :

When the `ui-sql-cache` flag (pagination) is `disabled`, the UI shows the updates, when enabled it doesn't.
Using a local UI instance on `master` branch, I compared the websocket incoming messages with the 2 flag conditions after adding a new label and hitting `save` in the edit form.
Left enabled, right disabled:

<img width="1691" height="461" alt="Screenshot from 2025-09-02 12-42-12" src="https://github.com/user-attachments/assets/a949d86a-8761-4e56-b3bb-91c6ac413945" />

In the left side - no updates, flag enabled - there is a missing `resource.create` for `fleet.cattle.io.cluster` resource.
Pretty sure that this the root cause of the issue, since it's the only difference between the incoming messages.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- We verified that incoming data from websocket are correct.
- The fix consists in adding a wait condition after saving the clusters, so that they receives the updates, then show up the clusters table.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

1. Go to Fleet -> Clusters tab
2. Edit the `local` cluster, add a generic label
3. Verify that the cluster lists show the correct labels.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

[Screencast from 2025-09-04 11-24-42.webm](https://github.com/user-attachments/assets/da1c2d5d-e2f9-47a3-974d-9ee20ffe187e)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
