### PR TITLE
Deprecated charts - fix cancel redirect and installation from the tools page

### DIFF
--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -504,18 +504,24 @@ export default {
         version:  this.query.versionName,
       };
 
+      const query = {
+        [REPO_TYPE]: provider.repoType,
+        [REPO]:      provider.repoName,
+        [CHART]:     provider.name,
+        [VERSION]:   provider.version,
+      };
+
+      if (this.showDeprecated) {
+        query[DEPRECATED_QUERY] = this.query.deprecated;
+      }
+
       return {
         name:   install ? 'c-cluster-apps-charts-install' : 'c-cluster-apps-charts-chart',
         params: {
           cluster: this.$route.params.cluster,
           product: this.$store.getters['productId'],
         },
-        query: {
-          [REPO_TYPE]: provider.repoType,
-          [REPO]:      provider.repoName,
-          [CHART]:     provider.name,
-          [VERSION]:   provider.version,
-        }
+        query
       };
     },
 
@@ -531,13 +537,20 @@ export default {
     },
 
     clusterToolsLocation() {
+      const query = {};
+
+      if (this.showDeprecated) {
+        query[DEPRECATED_QUERY] = this.query.deprecated;
+      }
+
       return {
         name:   `c-cluster-explorer-tools`,
         params: {
           product:  EXPLORER,
           cluster:  this.$store.getters['clusterId'],
           resource: CATALOG.APP,
-        }
+        },
+        query
       };
     },
 

--- a/shell/models/chart.js
+++ b/shell/models/chart.js
@@ -1,6 +1,6 @@
 import { compatibleVersionsFor, APP_UPGRADE_STATUS } from '@shell/store/catalog';
 import {
-  REPO_TYPE, REPO, CHART, VERSION, _FLAGGED, HIDE_SIDE_NAV, CATEGORY, TAG
+  REPO_TYPE, REPO, CHART, VERSION, _FLAGGED, HIDE_SIDE_NAV, CATEGORY, TAG, DEPRECATED as DEPRECATED_QUERY
 } from '@shell/config/query-params';
 import { BLANK_CLUSTER } from '@shell/store/store-types.js';
 import SteveModel from '@shell/plugins/steve/steve-class';
@@ -28,6 +28,10 @@ export default class Chart extends SteveModel {
       [CHART]:     this.chartName,
       [VERSION]:   version,
     };
+
+    if (this.deprecated) {
+      out[DEPRECATED_QUERY] = true;
+    }
 
     if ( from ) {
       out[from] = _FLAGGED;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15144 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
This PR addresses two other places where there were issues with the deprecated charts that was not considered on the [previous PR](https://github.com/rancher/dashboard/pull/15149):

- cancel redirect logic should consider the deprecated status
- installing a deprecated chart from cluster tools should be working

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/1299a554-4fe5-49f8-93ff-8e8f5e88c2b1


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
