### PR TITLE
add retries to cypress open mode

### DIFF
--- a/.github/workflows/pr-gh-project.yaml
+++ b/.github/workflows/pr-gh-project.yaml
@@ -1,7 +1,7 @@
 name: gh-project-integration
 on:
   pull_request_target:
-    types: [ opened, reopened, edited, closed ]
+    types: [ opened, reopened, edited, closed, labeled, unlabeled ]
 
 jobs:
   rancher_gh_project:

--- a/.github/workflows/scripts/pr-gh-project.js
+++ b/.github/workflows/scripts/pr-gh-project.js
@@ -272,7 +272,7 @@ async function processOpenOrEditAction() {
     console.log("+ This PR does not fix any issues");
 
     // PRs must fix an issue or have the label 'QA/None'
-    if (!hasLabel(pr, QA_NONE_LABEL) && !hasLabel(pr, GH_DEPENDENCIES_LABEL)) {
+    if (!hasLabel(pr, QA_NONE_LABEL) || !hasLabel(pr, GH_DEPENDENCIES_LABEL)) {
       console.log('Error: A PR MUST either declare which issues it fixes OR must have the QA/None label');
       process.exit(1);
     }

--- a/.github/workflows/scripts/pr-gh-project.js
+++ b/.github/workflows/scripts/pr-gh-project.js
@@ -272,7 +272,7 @@ async function processOpenOrEditAction() {
     console.log("+ This PR does not fix any issues");
 
     // PRs must fix an issue or have the label 'QA/None'
-    if (!hasLabel(pr, QA_NONE_LABEL) || !hasLabel(pr, GH_DEPENDENCIES_LABEL)) {
+    if (!hasLabel(pr, QA_NONE_LABEL) && !hasLabel(pr, GH_DEPENDENCIES_LABEL)) {
       console.log('Error: A PR MUST either declare which issues it fixes OR must have the QA/None label');
       process.exit(1);
     }

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -67,7 +67,7 @@ export default defineConfig({
   chromeWebSecurity:     false,
   retries:               {
     runMode:  2,
-    openMode: 0
+    openMode: 2
   },
   env: {
     grepFilterSpecs:  true,

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -67,7 +67,7 @@ export default defineConfig({
   chromeWebSecurity:     false,
   retries:               {
     runMode:  2,
-    openMode: 2
+    openMode: process.env.TEST_RETRIES ? +process.env.TEST_RETRIES : 2,
   },
   env: {
     grepFilterSpecs:  true,

--- a/docusaurus/docs/internal/testing/e2e-test.md
+++ b/docusaurus/docs/internal/testing/e2e-test.md
@@ -74,6 +74,11 @@ If you want your tests to be tracked on Cypress dashboards you will have to enab
 - `TEST_PROJECT_ID` // Project ID used by Cypress/Sorry cypress to run the tests
 - `TEST_RUN_ID` (optional) // Identifier for your dashboard run, default value is timestamp
 
+### Test Retries
+
+Use the `TEST_RETRIES` environment variable to configure how many times a failing test should be retried when using the `yarn cy:open` command. When tests fail in our CI suite they are re-run twice. Read more about cypress test retries in the [official documentation](https://docs.cypress.io/app/guides/test-retries).
+
+
 ### Skip and only features
 
 Existing `TEST_SKIP_SETUP` logic has been replaced with something more generic included in the `cypress.ts` script/utility.


### PR DESCRIPTION
### Occurred changes and/or fixed issues
This PR updates our cypress configuration to allow retries when tests fail when run from the cypress ui (`yarn cy:open`). We already retry failures when using `cy:run` (eg when we run e2e tests against PRs). We have some tests that will always fail on retry. Replicating retry logic in the cypress ui will help debug test flakiness stemming from this un-repeatability. 

### Areas or cases that should be tested
Run `yarn cy:open` and verify that you can still run tests through the cypress UI

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
