### PR TITLE
Add workflow to notify slack of milestone changes made by those external to team

### DIFF
--- a/.github/workflows/valid-milestone-change.yml
+++ b/.github/workflows/valid-milestone-change.yml
@@ -1,0 +1,91 @@
+name: Notify Slack on Milestone Change
+
+on:
+  issues:
+    types: [milestoned, demilestoned]
+
+permissions:
+  issues: read
+  organization_projects: read # Needed for some GitHub API calls related to teams
+
+env:
+  TEAM_NAME: "rancher/ui"
+
+jobs:
+  notify-on-milestone-change:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Check if user is in a team"
+      id: check-team-membership
+      uses: actions/github-script@v7
+      with:
+        script: |
+          try {
+            // Get the team name from the environment variable.
+            const [org, teamSlug] = process.env.TEAM_NAME.split('/');
+            // Check if the user who triggered the event is a member of the specified team.
+            const { status } = await github.rest.teams.getMembershipForUserInOrg({
+                org: org,
+                team_slug: teamSlug,
+                username: context.payload.sender.login,
+            });
+
+            // Set an output variable based on the check.
+            // Status 200 means the user is a member, 404 means they are not.
+            console.log(`Membership check status: ${status}`);
+            if (status === 200) {
+                core.setOutput('is_member', 'true');
+            } else {
+                core.setOutput('is_member', 'false');
+            }
+          } catch (error) {
+            // If the user is not found, or there's an API error,
+            // we assume they are not a member for the purpose of this script.
+            console.error('An error occurred during team membership check:', error);
+            core.setOutput('is_member', 'false');
+          }
+    - name: "Send Slack message if user is not a team member"
+      # This step only runs if the 'is_member' output from the previous step is 'false'.
+      if: steps.check-team-membership.outputs.is_member == 'false'
+      uses: slackapi/slack-github-action@v1.26.0
+      with:
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "🚨 Unexpected Milestone Changed on an Issue",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Issue:* <${{ github.event.issue.html_url }}|${{ github.event.issue.title }}>"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Changed by:* ${{ github.event.sender.login }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Old Milestone:* `${{ github.event.issue.milestone.title }}`"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*New Milestone:* `${{ github.event.issue.milestone.title }}`"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Reason:* The user who changed the milestone is not a member of ${{env.TEAM_NAME}}."
+                  }
+                ]
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
