### PR TITLE
Fix error when creating node driver clusters from yaml view

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1437,6 +1437,8 @@ export default {
           entry.pool.machineConfigRef.name = neu.metadata.name;
           entry.create = false;
           entry.update = true;
+
+          this.initialMachinePoolsValues[entry.config.id] = clone(neu);
         } else if (entry.update) {
           entry.config = await entry.config.save();
         }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15329 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR fixes an issue saving a node driver cluster from the yaml view, either on initial creation or when adding a new machine pool.

### Technical notes summary
Provisioning node driver clusters involves creating more than just the provisioning.cattle.io.cluster resource: the UI will also create a cloud-provider-specific machine config resource and add a reference to it in the provisioning cluster spec. This complicates the edit-as-yaml experience, which only shows the provisioning cluster resource.

When users click the 'edit as yaml' button, the UI will save all machine configs and add references to the provisioning cluster resource. When a user clicks 'save,' whether in yaml or form mode, the machine configs are saved, then the provisioning cluster resource is saved.

If editing an existing cluster, existing machine configs are updated. In order to do so the UI must fetch the latest version of the machine config from the backend and update any fields the backend has changed, and the user has not, and, importantly here, the UI needs to update the machine config to use the latest `resourceVersion` from the backend. In order to determine which fields users have changed, the UI must store the state of machine configs when the edit form is loaded, before the user has changed anything. They are stored in the `initialMachinePoolsValues` property in the `rke2.vue` component.

The bug reported in #15329 occurs because when the user switches to the edit-as-yaml view, machineConfigs are saved, but not present in `initialMachinePoolsValues`. When the user attempts to save from the yaml view,  the function comparing local machine config values to freshly-retrieved backend values, `syncMachineConfigWithLatest`, returns an error because no config has been stored in `initialMachinePoolsValues` and it compares an empty object to the config spec returned from the backend. 

The fix in this PR is to add the machine configs to `initialMachinePoolsValues` when they are saved before switching to the yaml view. A consequence is that when a user clicks save from the yaml view, configs will be re-saved despite there being no means for the user to edit them from the yaml view. I have preserved this behavior because it doesn't seem to cause issues and it is how the UI behaved previously. It also ensures that if a user switches from form to yaml, then back to form, and edits a value that maps to a machine config not the cluster resource, the config is going to be saved again.

### Areas or cases that should be tested
1. The scenario described in #15329
2. Same as 1 but switch back to the form view before saving
3. Add a machine pool to an existing cluster, switch to the yaml editing view, and save.
4. Same as 3 but go back to the form view before saving
5. Same as 3 but do not go to the yaml view before saving
6. In an existing cluster, update a machine pool value that is stored in a machine config, eg change the region of the pool (anything provider-specific in the machine pool section is stored in the machine config). Switch to the yaml mode, and save. 
7. Same as 6 but switch back to the form mode before saving
8. Same as 6 but do not switch to yaml mode before saving
9. Test machine pool validation: go to the rke2 cluster creation form and introduce a validation error to the machine pool section. An easy one is to try to create an ec2 rke2 cluster without specifying a vpc. Before saving, try to switch to edit as yaml mode. You should see an error banner and not be able to switch. Correct your machine pool error, and try again. The machine config should be saved and you should be switched to the yaml view.


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
