### PR TITLE
[backport v2.12.2] SCC: Update condition architecture logic to define a completed operation

### DIFF
--- a/pkg/rancher-prime/pages/registration.composable.test.ts
+++ b/pkg/rancher-prime/pages/registration.composable.test.ts
@@ -39,10 +39,7 @@ describe('registration composable', () => {
         links:    { view: '123' },
         status:   {
           activationStatus: { activated: true },
-          conditions:       [{
-            type:   'Done',
-            status: 'True',
-          }]
+          currentCondition: { type: 'Done' }
         },
       }];
 
@@ -85,20 +82,11 @@ describe('registration composable', () => {
         links:    { view: '123' },
         status:   {
           activationStatus: { activated: false },
-          conditions:       [
-            {
-              type:    'Failure',
-              status:  'True',
-              message: 'Message not for the user',
-              reason:  'Give me a reason',
-            },
-            {
-              type:    'RegistrationActivated',
-              status:  'False',
-              message: errorMessage,
-              reason:  'Give me a reason',
-            },
-          ]
+          currentCondition: {
+            type:    'RegistrationActivated',
+            message: errorMessage,
+            reason:  'Give me a reason',
+          },
         },
       }];
 
@@ -136,10 +124,7 @@ describe('registration composable', () => {
         links:    { view: '123' },
         status:   {
           activationStatus: { activated: true },
-          conditions:       [{
-            type:   'Done',
-            status: 'True',
-          }]
+          currentCondition: { type: 'Done' }
         },
       }];
 
@@ -228,10 +213,7 @@ describe('registration composable', () => {
         links:    { view: '123' },
         status:   {
           activationStatus: { activated: true },
-          conditions:       [{
-            type:   'Done',
-            status: 'True',
-          }]
+          currentCondition: { type: 'Done' }
         },
       }];
       const secretRequest = {
@@ -299,13 +281,7 @@ describe('registration composable', () => {
         links:    { view: '123' },
         status:   {
           activationStatus: { activated: true },
-          conditions:       [
-            { type: 'OfflineRequestReady' },
-            {
-              type:   'OfflineActivationDone',
-              status: 'True',
-            },
-          ]
+          currentCondition: { type: 'OfflineActivationDone' },
         },
       }];
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15338
Fixes #15274
Fixes #14984
Fixes #15272
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
