### PR TITLE
Ensure we don't clear list pages when saving a resource from one

### DIFF
--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -695,7 +695,7 @@ export default {
 
     const res = await dispatch('request', { opt, type });
 
-    await dispatch('load', { data: res });
+    await dispatch('load', { data: res, invalidatePageCache: opt.invalidatePageCache });
 
     if ( opt.watch !== false ) {
       dispatch('watch', createFindWatchArg({

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -1253,6 +1253,12 @@ export default class Resource {
       delete opt.replace;
     }
 
+    // Will loading this resource invalidate the resources in the cache that represent a page (resource is not from page)
+    // By default we set this to no, it won't pollute the cache. Most likely either
+    // 1. The resource came from a list already (loaded resource is already in the page that is in the cache)
+    // 2. UI is not on a page with a list (cache doesn't represent a list)
+    const invalidatePageCache = opt.invalidatePageCache || false;
+
     try {
       const res = await this.$dispatch('request', { opt, type: this.type } );
 
@@ -1261,12 +1267,6 @@ export default class Resource {
 
       // Steve sometimes returns Table responses instead of the resource you just saved.. ignore
       if ( res && res.kind !== 'Table') {
-        // Will loading this resource invalidate the resources in the cache that represent a page (resource is not from page)
-        // By default we set this to no, it won't pollute the cache. Most likely either
-        // 1. The resource came from a list already (loaded resource is already in the page that is in the cache)
-        // 2. UI is not on a page with a list (cache doesn't represent a list)
-        const invalidatePageCache = opt.invalidatePageCache || false;
-
         await this.$dispatch('load', {
           data: res, existing: (forNew ? this : undefined ), invalidatePageCache
         });
@@ -1277,7 +1277,14 @@ export default class Resource {
         await this.$dispatch('find', {
           type: this.type,
           id:   this.id,
-          opt:  { force: true }
+          opt:  {
+            // We want to update the value in cache, so force the request
+            force: true,
+            // We're not interested in opening a watch for this specific resource
+            watch: false,
+            // Unless overridden, this will be false, we're probably from a list and we don't want to clear it's state
+            invalidatePageCache
+          }
         });
       }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/15330
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- the cache can represent all resources, resources from a specific namespace, resources in a paginated list or resources relevant to a specific labelSelector
- if we load a resource into cache it can invalidate these. we only specifically invalidate when the store represents resources in a paginated list (where adding a resource to the cache would look like it was in the current page
- change is to avoid invalidating the page cache state if we're saving a resource from a model
  - Most likely either
    - The resource came from a list already (loaded resource is already in the page that is in the cache)
    - UI is not on a page with a list (cache doesn't represent a list)

### Technical notes summary
- this is done generically, which avoids explictely setting invalidatePageCache on every save that could be affected (like in shell/dialog/RedeployWorkloadDialog.vue

### Areas or cases that should be tested
- deployments - pause, resume, redeploy
- cronjob - suspend, resume


### Areas which could experience regressions
- there's quite a few places we call model save (~145) but tracking down a specific case where this could be broken is hard

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
