### PR TITLE
Fixing the storybook theme to work with the changes to the dashboard themes

### DIFF
--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -107,6 +107,7 @@ const config: StorybookConfig = {
     getAbsolutePath("@storybook/addon-essentials"),
     getAbsolutePath("@storybook/addon-interactions"),
     getAbsolutePath('@storybook/addon-webpack5-compiler-babel'),
+    getAbsolutePath('@storybook/addon-themes'),
     // Add support for table generation from markdown using MDX files
     {
       name: '@storybook/addon-docs',

--- a/storybook/.storybook/preview.ts
+++ b/storybook/.storybook/preview.ts
@@ -1,7 +1,7 @@
 import type { Preview } from "@storybook/vue3";
 import { setup } from '@storybook/vue3';
-import { themes } from '@storybook/theming';
 import RancherTheme from './theme-rancher';
+import '../src/assets/style.scss';
 
 import vSelect from 'vue-select';
 import FloatingVue from 'floating-vue';
@@ -12,6 +12,7 @@ import cleanHtmlDirective from '@shell/directives/clean-html';
 import trimWhitespaceDirective from '@shell/directives/trim-whitespace';
 import htmlStrippedAriaLabelDirective from '@shell/directives/strip-html-aria-label';
 import store from './store'
+import { withThemeByClassName } from '@storybook/addon-themes';
 
 // i18n
 import i18n from '@shell/plugins/i18n';
@@ -35,6 +36,10 @@ setup((vueApp) => {
 
 const preview: Preview = {
   parameters: {
+    // This disables the background selector control, it conflicts with the theme selector
+    backgrounds: {
+      disable: true,
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,
@@ -52,7 +57,18 @@ const preview: Preview = {
     },
   },
 
-  tags: ['autodocs']
+  tags: ['autodocs'],
+  decorators: [
+    // This adds the theme-light/theme-dark classes to the body of the document when the theme changes
+    withThemeByClassName({
+      themes: {
+        light: 'theme-light',
+        dark: 'theme-dark',
+      },
+      defaultTheme: 'light',
+      parentSelector: 'body'
+    }),
+  ]
 };
 
 export default preview;

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -17,6 +17,7 @@
     "@storybook/addon-interactions": "^8.4.2",
     "@storybook/addon-links": "^8.4.2",
     "@storybook/addon-onboarding": "^8.4.2",
+    "@storybook/addon-themes": "^8.4.2",
     "@storybook/addon-webpack5-compiler-babel": "^3.0.3",
     "@storybook/addon-webpack5-compiler-swc": "^1.0.5",
     "@storybook/blocks": "^8.4.2",

--- a/storybook/src/assets/style.scss
+++ b/storybook/src/assets/style.scss
@@ -2,3 +2,15 @@
   display: flex;
   gap: 10px
 }
+
+.theme-dark {
+  &, .docs-story {
+    background-color: #1b1c21;
+  }
+}
+
+.theme-light {
+  &, .docs-story {
+    background-color: #ffffff;
+  }
+}

--- a/storybook/yarn.lock
+++ b/storybook/yarn.lock
@@ -615,6 +615,13 @@
     "@storybook/global" "^5.0.0"
     ts-dedent "^2.0.0"
 
+"@storybook/addon-themes@^8.4.2":
+  version "8.6.14"
+  resolved "http://localhost:4873/@storybook/addon-themes/-/addon-themes-8.6.14.tgz#37630b8e719a0237b6e2514ee2e58ac387f0f619"
+  integrity sha512-/HJCgskA3OFGectuoLEBQ3JX1nQhE7lnpSv5gH13CWyyaMEk/mP8JYF1uO25YQqwGuSgL2gaEox+aK7UmglAmQ==
+  dependencies:
+    ts-dedent "^2.0.0"
+
 "@storybook/addon-toolbars@8.4.5":
   version "8.4.5"
   resolved "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.4.5.tgz#ebe20f0577a3e399858ba591066dbc8ac9636a5c"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
The themeing in storybook was a little off. I noticed that the changes to rancher was causing the conflict.

I also made it easier to switch between the themes and get the background colors to change in the stories.


### Areas or cases that should be tested
Just storybook stories in both docs and examples

### Areas which could experience regressions
Same as above

### Screenshot/Video
https://github.com/user-attachments/assets/dd2d5a4d-8765-4386-842b-ae13f5abb1fc


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
