### PR TITLE
Fix statefulset detail page pods list

### DIFF
--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -595,6 +595,9 @@ export default class Workload extends WorkloadService {
     return selector;
   }
 
+  /**
+   * Match Expression version of the podSelector
+   */
   get podMatchExpression() {
     return this.podSelector ? parse(this.podSelector) : null;
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15231
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- normally workloads model will fetch pods via the workloads podSelector
  - fetchPods will ensure the store is populated with the pods applicable to the podSelector
  - pods getter will return the correct pods
- however for stateful sets we override the pods getter with something custom
- in a vai on world this was broken, the getter uses `podsByNamespace` which in vai world isn't populate
- fix is straightforward
  - start off with the pods that match the selector (agnostic of vai state)
  - as before filter down to the ones with the owner

### Areas or cases that should be tested
- As linked issue
- Additionally QA comments from https://github.com/rancher/dashboard/issues/7555

### Areas which could experience regressions
- Only pods list on that page should be affected


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
