### PR TITLE
Ensure workloads pages redirect to 404 for types it cannot display

### DIFF
--- a/cypress/e2e/tests/navigation/side-nav/product-side-nav.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/product-side-nav.spec.ts
@@ -1,7 +1,6 @@
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
-import WorkloadPagePo from '@/cypress/e2e/po/pages/explorer/workloads.po';
 import { WorkloadsDeploymentsListPagePo } from '@/cypress/e2e/po/pages/explorer/workloads/workloads-deployments.po';
 import { createDeploymentBlueprint } from '@/cypress/e2e/blueprints/explorer/workloads/deployments/deployment-create';
 import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dashboard.po';
@@ -70,11 +69,10 @@ describe('Side navigation: Cluster ', { tags: ['@navigation', '@adminUser'] }, (
     productNavPo.groups().get('.expanded').as('openGroup');
 
     productNavPo.visibleNavTypes().eq(1).should('be.visible').click(); // Go into Workloads
-    const workload = new WorkloadPagePo('local');
 
-    workload.goTo();
-    workload.waitForPage();
-    workload.goToDetailsPage(workloadName);
+    deploymentsListPage.goTo();
+    deploymentsListPage.waitForPage();
+    deploymentsListPage.goToDetailsPage(workloadName);
     cy.get('@openGroup').should('be.visible');
     cy.get('@openGroup').find('.router-link-active').should('have.length.gt', 0);
   });

--- a/cypress/e2e/tests/pages/explorer2/workloads/workloads.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/workloads.spec.ts
@@ -5,7 +5,7 @@ import WorkloadPagePo from '@/cypress/e2e/po/pages/explorer/workloads.po';
 
 const podName = 'some-pod-name';
 
-describe('Workloads', { tags: ['@explorer2', '@adminUser'] }, () => {
+describe('Workloads', { tags: ['@noVai', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });

--- a/shell/list/__tests__/workload.test.ts
+++ b/shell/list/__tests__/workload.test.ts
@@ -37,6 +37,7 @@ describe('component: workload', () => {
               'prefs/get':                   () => resource,
               'cluster/schemaFor':           () => {},
               'cluster/all':                 () => [{}],
+              'features/get':                () => false,
             }
           },
           $fetchState: {

--- a/shell/list/workload.vue
+++ b/shell/list/workload.vue
@@ -5,6 +5,7 @@ import {
 } from '@shell/config/types';
 import ResourceFetch from '@shell/mixins/resource-fetch';
 import PaginatedResourceTable from '@shell/components/PaginatedResourceTable';
+import { STEVE_CACHE } from '@shell/store/features';
 
 const workloadSchema = {
   id:         'workload',
@@ -84,11 +85,17 @@ export default {
   },
 
   data() {
+    const allTypes = this.$route.params.resource === workloadSchema.id;
+
+    if (allTypes && this.$store.getters['features/get'](STEVE_CACHE)) {
+      this.$store.dispatch('loadingError', new Error(this.t('nav.failWhale.resourceListNotFound', { resource: workloadSchema.id }, true)));
+
+      return;
+    }
     // Ensure these are set on load (to determine if the NS filter is required) rather than too late on `fetch`
     const { loadResources, loadIndeterminate } = $loadingResources(this.$route, this.$store);
 
     const { params:{ resource: type } } = this.$route;
-    const allTypes = this.$route.params.resource === workloadSchema.id;
     const schema = type !== workloadSchema.id ? this.$store.getters['cluster/schemaFor'](type) : workloadSchema;
     const paginationEnabled = !allTypes && this.$store.getters[`cluster/paginationEnabled`]?.({ id: type });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15371
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- The workloads page, where ui lists all workload types together, isn't supported in vai on world
  - will be brought back as a overview page via https://github.com/rancher/dashboard/issues/11513
- With vai on clicking the `Workloads` group will not take the user to the workloads list
- However navigating directly to it would (it ignores the missing schema)
- Now ensure that when vai is on we 404 for workloads

### Technical notes summary
- i originally changed this to 404 when schema was empty, however it's always empty (it's a virtual cluster
- the 404 method is the same as the parent https://github.com/rancher/dashboard/blob/master/shell/components/ResourceList/index.vue#L77


### Areas or cases that should be tested
- vai on
  - Nav to to cluster --> click on workloads group. should show `Deployments` list
  - Nav to workloads group --> pods. Replace `pods` in url with `workload` --> hit return. Should show resource not found 404 page
- vai off (`ui-sql-cache` feature flag)
  - Nav to to cluster --> click on workloads group. should show `Workloads` list
  - Nav to workloads group --> pods. Replace `pods` in url with `workload` --> hit return. should show `Workloads` list

### Areas which could experience regressions
- No other


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
