### PR TITLE
[2.12.3] Fleet allow SSH url with numeric ports

### DIFF
--- a/shell/utils/validators/formRules/__tests__/index.test.ts
+++ b/shell/utils/validators/formRules/__tests__/index.test.ts
@@ -114,6 +114,8 @@ describe('formRules', () => {
       ['git@github.com:rancher/dashboard/', undefined],
       ['git@github.com:rancher/%20dashboard/', undefined],
       ['git@github.com:rancher/dashboard/%20', undefined],
+      ['git@git.apps.local:fleet/fleet-local.git', undefined],
+      ['git@git.apps.local:33333/fleet/fleet-local.git', undefined],
 
       // Not valid HTTP(s)
       ['https://github.com/rancher/  dashboard.git', message],
@@ -140,6 +142,7 @@ describe('formRules', () => {
       ['git@githubcomrancher/dashboard', message],
       ['%20git@github.comrancher/dashboard', message],
       ['git@git%20hub.comrancher/dashboard', message],
+      ['git@git.apps.local:/fleet/fleet-local.git', message],
       ['git@.git', message],
       ['git@', message],
 

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -189,6 +189,7 @@ export default function(
       protocol,
       authority,
       host,
+      port,
       path
     } = parse(url);
 
@@ -203,7 +204,7 @@ export default function(
     }
 
     // Test ssh, authority must be valid (SSH user + host)
-    if (!protocol && !authority.endsWith(':')) {
+    if (!protocol && !port && (!authority.endsWith(':') || path.startsWith('/'))) {
       return message;
     }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15398
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
