### PR TITLE
Reintroducing a stub implementation of `type-map/hasGraph` for backwards compatibility of extensions.

### DIFF
--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -1171,6 +1171,13 @@ export const getters = {
     };
   },
 
+  // This has to be left in to support extensions which use shell version 3.0.5-rc.8 or earlier, this extensions have a version of ResourceDetail/index.vue which still invokes this method.
+  hasGraph() {
+    return () => {
+      return null;
+    };
+  },
+
   hasCustomEdit(state, getters, rootState) {
     return (rawType, subType) => {
       const key = getters.componentFor(rawType, subType);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
fixes #15402

### Occurred changes and/or fixed issues
Reintroducing a stub implementation of `type-map/hasGraph` for backwards compatibility of extensions.

### Technical notes summary
Extensions with detail pages effectively have a copy of @shell/ResourceDetail/index.vue which checks hasGraph. If they get built with a new shell they'll be fine but without it they'll break.

### Areas or cases that should be tested
Details pages on extensions like Elemental.

### Screenshot/Video
<img width="1273" height="639" alt="image" src="https://github.com/user-attachments/assets/95b33c9f-4317-40e1-b794-b02a8cf00dc8" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
