### PR TITLE
Handles the namespace glance when the namespace isn't in a project

### DIFF
--- a/shell/models/__tests__/namespace.test.ts
+++ b/shell/models/__tests__/namespace.test.ts
@@ -186,4 +186,73 @@ describe('class Namespace', () => {
   it.todo('should return the resourceQuota');
   it.todo('should set the resourceQuota as reactive Vue property');
   it.todo('should reset project with cleanForNew');
+
+  describe('glance', () => {
+    it('should return projectGlance instead of namespace when namespace is in a project', () => {
+      const t = jest.fn((key) => key);
+      const ctx = { rootGetters: { 'i18n/t': t } };
+      const namespace = new Namespace({}, ctx);
+
+      const project = {
+        detailLocation: 'project-detail',
+        nameDisplay:    'My Project',
+      };
+
+      jest.spyOn(namespace, 'project', 'get').mockReturnValue(project);
+      Object.defineProperty(namespace, '_glance', { get: jest.fn(() => [{ name: 'namespace' }, { name: 'other' }]) });
+
+      const result = namespace.glance;
+
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('project');
+      expect(result[0].label).toBe('component.resource.detail.glance.project');
+      expect(result[0].formatter).toBe('Link');
+      expect(result[0].formatterOpts?.to).toBe('project-detail');
+      expect(result[0].content).toBe('My Project');
+      expect(result[1].name).toBe('other');
+    });
+
+    it('should remove namespace from glance when namespace is not in a project', () => {
+      const namespace = new Namespace({});
+
+      jest.spyOn(namespace, 'project', 'get').mockReturnValue(null);
+      Object.defineProperty(namespace, '_glance', { get: jest.fn(() => [{ name: 'namespace' }, { name: 'other' }]) });
+
+      const result = namespace.glance;
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('other');
+    });
+  });
+
+  describe('projectGlance', () => {
+    it('should return undefined if namespace is not in a project', () => {
+      const namespace = new Namespace({});
+
+      jest.spyOn(namespace, 'project', 'get').mockReturnValue(null);
+
+      expect(namespace.projectGlance).toBeUndefined();
+    });
+
+    it('should return project glance information if namespace is in a project', () => {
+      const t = jest.fn((key) => key);
+      const ctx = { rootGetters: { 'i18n/t': t } };
+      const namespace = new Namespace({}, ctx);
+
+      const project = {
+        detailLocation: 'project-detail',
+        nameDisplay:    'My Project',
+      };
+
+      jest.spyOn(namespace, 'project', 'get').mockReturnValue(project);
+
+      const result = namespace.projectGlance;
+
+      expect(result?.name).toBe('project');
+      expect(result?.label).toBe('component.resource.detail.glance.project');
+      expect(result?.formatter).toBe('Link');
+      expect(result?.formatterOpts.to).toBe('project-detail');
+      expect(result?.content).toBe('My Project');
+    });
+  });
 });

--- a/shell/models/namespace.js
+++ b/shell/models/namespace.js
@@ -276,17 +276,27 @@ export default class Namespace extends SteveModel {
     const namespaceIndex = glance.findIndex((item) => item.name === 'namespace');
 
     if (namespaceIndex > -1) {
-      glance.splice(namespaceIndex, 1, {
-        name:          'project',
-        label:         this.t('component.resource.detail.glance.project'),
-        formatter:     'Link',
-        formatterOpts: {
-          to: this.project.detailLocation, row: {}, options: { internal: true }
-        },
-        content: this.project.nameDisplay
-      });
+      glance.splice(namespaceIndex, 1, this.projectGlance);
     }
 
-    return glance;
+    // projectGlance could be undefined
+    return glance.filter(Boolean);
+  }
+
+  get projectGlance() {
+    // Not all namespaces are in a project
+    if (!this.project) {
+      return undefined;
+    }
+
+    return {
+      name:          'project',
+      label:         this.t('component.resource.detail.glance.project'),
+      formatter:     'Link',
+      formatterOpts: {
+        to: this.project.detailLocation, row: {}, options: { internal: true }
+      },
+      content: this.project.nameDisplay
+    };
   }
 }


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15377
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
Not all namespaces are in projects. This now conditionally adds a project to the glance only if a project is present.

### Areas or cases that should be tested
Try creating a config in a namespace that doesn't have a project and use the resource detail popover.

### Areas which could experience regressions
Try creating a config in a namespace that doesn't have a project and use the resource detail popover.

### Screenshot/Video

https://github.com/user-attachments/assets/5fc12a75-1c6b-46f8-8398-445491cfbb55



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
