### PR TITLE
Fixing an issue where the Constraint subtype menu wasn't displayed/selected causing problems with saving

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3229,6 +3229,7 @@ footer:
   slack: Slack
 
 gatekeeperConstraint:
+  templateRequired: You must have at least one Template before attempting to create a Constraint.
   downloadViolations: Download Violations
   match:
     title: Match

--- a/shell/edit/constraints.gatekeeper.sh.constraint/index.vue
+++ b/shell/edit/constraints.gatekeeper.sh.constraint/index.vue
@@ -17,6 +17,7 @@ import { saferDump } from '@shell/utils/create-yaml';
 import NamespaceList, { NAMESPACE_FILTERS_HELPER } from './NamespaceList';
 import MatchKinds from './MatchKinds';
 import Scope, { SCOPE_OPTIONS } from './Scope';
+import Banner from '@components/Banner/Banner';
 
 function findConstraintTypes(schemas) {
   return schemas
@@ -43,7 +44,8 @@ export default {
     Scope,
     Tab,
     Tabbed,
-    YamlEditor
+    YamlEditor,
+    Banner
   },
 
   mixins: [CreateEditView],
@@ -230,11 +232,17 @@ export default {
 };
 </script>
 <template>
+  <Banner
+    v-if="templateSubtypes.length === 0"
+    color="warning"
+  >
+    {{ t('gatekeeperConstraint.templateRequired') }}
+  </Banner>
   <CruResource
+    v-else
     :done-route="doneRoute"
     :mode="mode"
     :resource="value"
-    :selected-subtype="value.kind"
     :subtypes="templateSubtypes"
     :validation-passed="true"
     :errors="errors"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
We now display a banner informing the user that templates need to be present before creating a constraint.

Fixes #12948
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
When templates weren't available we weren't prompting the user to select an appropriate template. This lead to an issue where the `kind` was defined when we were saving.

Also, there can be delay between templates being deleted and schemas updating. This means this solution isn't complete but I think it's satisfactory given the chart is deprecated and we suggest moving to kubewarden.

### Areas or cases that should be tested
Creating constraints when templates are both present and not present.

### Areas which could experience regressions
The constraint create/edit page.

### Screenshot/Video

https://github.com/user-attachments/assets/a657eb31-ec4e-45f9-8284-2413dd63ec9a



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
