### PR TITLE
Add scoped css attribute to Rancher Components

### DIFF
--- a/pkg/rancher-components/src/components/Card/Card.vue
+++ b/pkg/rancher-components/src/components/Card/Card.vue
@@ -98,7 +98,7 @@ export default defineComponent({
   </div>
 </template>
 
-<style lang='scss'>
+<style lang='scss' scoped>
  .card-container {
   &.highlight-border {
     border-left: 5px solid var(--primary);

--- a/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
+++ b/pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue
@@ -360,7 +360,7 @@ export default defineComponent({
   </div>
 </template>
 
-<style lang='scss'>
+<style lang='scss' scoped>
 $fontColor: var(--input-label);
 
 .checkbox-outer-container {

--- a/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioButton.vue
@@ -226,7 +226,7 @@ export default defineComponent({
   </label>
 </template>
 
-<style lang='scss'>
+<style lang='scss' scoped>
 $fontColor: var(--input-label);
 
 .radio-view {

--- a/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
+++ b/pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue
@@ -311,7 +311,7 @@ export default defineComponent({
   </div>
 </template>
 
-<style lang='scss'>
+<style lang='scss' scoped>
 .radio-group {
   &:focus, &:focus-visible {
     border: none;

--- a/pkg/rancher-components/src/components/LabeledTooltip/LabeledTooltip.vue
+++ b/pkg/rancher-components/src/components/LabeledTooltip/LabeledTooltip.vue
@@ -95,7 +95,7 @@ export default defineComponent({
   </div>
 </template>
 
-<style lang='scss'>
+<style lang='scss' scoped>
 .labeled-tooltip {
     position: absolute;
     width: 100%;

--- a/pkg/rancher-components/src/components/LabeledTooltip/LabeledTooltip.vue
+++ b/pkg/rancher-components/src/components/LabeledTooltip/LabeledTooltip.vue
@@ -137,14 +137,4 @@ export default defineComponent({
         @include tooltipColors(var(--success));
     }
 }
-
-// Ensure code blocks inside tootips don't look awful
-.v-popper__popper.v-popper--theme-tooltip {
-  .v-popper__inner {
-    pre {
-      padding: 2px;
-      vertical-align: middle;
-    }
-  }
-}
 </style>

--- a/shell/assets/styles/global/_tooltip.scss
+++ b/shell/assets/styles/global/_tooltip.scss
@@ -12,6 +12,12 @@
     color: var(--tooltip-text);
     border-radius: var(--border-radius);
     padding: 8px;
+
+    // Ensure code blocks inside tooltips don't look awful
+    pre {
+      padding: 2px;
+      vertical-align: middle;
+    }
   }
 
   .v-popper__arrow-container {
@@ -159,3 +165,4 @@
 .icon-info.v-popper--has-tooltip {
   font-size: 14px;
 }
+


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This scopes css for all components in Rancher Components so that css will apply only to elements of the components in question. 

Fixes #15422
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add scoped attribute to all components in Rancher Components

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Since css in these components were applied globally when the components were rendered, there's a chance that other components could regress as a result of adding the scoped attribute. The only area where I see the highest risk of regression is in `LabeledTooltip.vue`, where we apply styles to `v-popper` via `.v-popper__popper.v-popper--theme-tooltip {`. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Checkboxes, radio buttons, radio groups, cards and labeled tooltips should all render properly. We need to confirm that other weren't inadvertently relying on one of these styles being active while any of the given components were rendered.. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Checkboxes, radio buttons, radio groups, cards and labeled tooltips should all render properly.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
