### PR TITLE
Switch the Import Yaml modal to use the first available namespace instead of the `default` namespace to ensure the user has access

### DIFF
--- a/shell/dialog/ImportDialog.vue
+++ b/shell/dialog/ImportDialog.vue
@@ -28,12 +28,16 @@ export default {
   props: {
     defaultNamespace: {
       type:    String,
-      default: 'default'
+      default: undefined
     },
   },
 
   async fetch() {
     this.allNamespaces = await this.$store.dispatch('cluster/findAll', { type: NAMESPACE, opt: { url: 'namespaces' } });
+
+    if (this.selectedNamespace === undefined) {
+      this.selectedNamespace = this.allNamespaces?.[0]?.name;
+    }
   },
 
   data() {


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #7613
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
We swapped from using the default `default` namespace and now select the first namespace the user has. This avoids the situation where a user without access to the `default` namespace can use the feature without a problem.

### Areas or cases that should be tested
The import yaml dialog anywhere in the cluster explorer.

### Areas which could experience regressions
A user without any namespaces will be presented with zero options in the namespace dropdown. I don't think this is an issue because such a user wouldn't be able to create any resources with a namespace.

### Screenshot/Video
https://github.com/user-attachments/assets/38724863-b5dc-4cc8-8b3b-c5011e92cfa4

If the user doesn't have any namespaces (the dialog is probably useless in this case) the dropdown will look like:
<img width="1413" height="869" alt="image" src="https://github.com/user-attachments/assets/67283323-1fc8-4412-88bc-4ce2ba1240ac" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
