### PR TITLE
Automation: resolve GKE test failure

### DIFF
--- a/cypress/e2e/po/components/labeled-input.po.ts
+++ b/cypress/e2e/po/components/labeled-input.po.ts
@@ -22,18 +22,25 @@ export default class LabeledInputPo extends ComponentPo {
    * Type value in the input
    * @param value Value to be typed
    * @param secret Pass in true to hide sensitive data from logs
+   * @param parseSpecialCharSequences Pass in false to disable special character parsing (useful for JSON)
    * @returns
    */
-  set(value: any, secret?: boolean): Cypress.Chainable {
+  set(value: any, secret?: boolean, parseSpecialCharSequences?: boolean): Cypress.Chainable {
     this.input().should('be.visible');
     this.input().focus();
     this.input().clear();
 
+    const typeOptions: any = {};
+
     if (secret) {
-      return this.input().type(value, { log: false });
-    } else {
-      return this.input().type(value);
+      typeOptions.log = false;
     }
+
+    if (parseSpecialCharSequences === false) {
+      typeOptions.parseSpecialCharSequences = false;
+    }
+
+    return this.input().type(value, typeOptions);
   }
 
   getAttributeValue(attr: string): Cypress.Chainable {

--- a/cypress/e2e/tests/pages/manager/gke-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/gke-cluster-provisioning.spec.ts
@@ -42,6 +42,9 @@ describe('Deploy GKE cluster with default settings', { tags: ['@manager', '@admi
     console.warn('gkeServiceAccount environment variable is undefined or empty.');
   }
 
+  // Convert service account object to JSON string for input field
+  const serviceAccountJsonString = serviceAccount ? JSON.stringify(serviceAccount) : '';
+
   before(() => {
     cy.login();
     HomePagePo.goTo();
@@ -85,9 +88,7 @@ describe('Deploy GKE cluster with default settings', { tags: ['@manager', '@admi
     // create GKE cloud credential
     cloudCredForm.saveButton().expectToBeDisabled();
     cloudCredForm.nameNsDescription().name().set(this.gkeCloudCredentialName);
-    // while issue #1717 in qa-tasks is open, line 91 is duplicated as a workaround. The duplicate line needs to be removed after issue is fixed
-    cloudCredForm.serviceAccount().set(serviceAccount);
-    cloudCredForm.serviceAccount().set(serviceAccount);
+    cloudCredForm.serviceAccount().set(serviceAccountJsonString, false, false);
     cloudCredForm.saveButton().expectToBeEnabled();
 
     cy.intercept('GET', `${ USERS_BASE_URL }?*`).as('pageLoad');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1950

- Fix GKE cluster provisioning test failing with "cy.type() can only accept a string or number"
  - Convert service account object to JSON string before passing to input field
- Enhance LabeledInputPo.set() method with parseSpecialCharSequences parameter

<img width="1318" height="294" alt="image" src="https://github.com/user-attachments/assets/af601776-aa72-4dc4-a0d5-fc9189493c95" />

<!-- Define findings related to the feature or bug issue. -->


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
