### PR TITLE
fix(aks) Add availability zones for china region aks

### DIFF
--- a/pkg/aks/util/aks-regions.ts
+++ b/pkg/aks/util/aks-regions.ts
@@ -36,4 +36,7 @@ export const regionsWithAvailabilityZones = {
   westeurope:         true,
   westus2:            true,
   westus3:            true,
+  chinaeast2:         true,
+  chinanorth2:        true,
+  chinanorth3:        true,
 } as any;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
https://github.com/rancher/rancher/issues/51885

### Occurred changes and/or fixed issues
When creating an AKS cluster in Rancher using an Azure China (21Vianet) subscription, the Region with Availability Zones dropdown does not include chinaeast2, chinanorth2, or chinanorth3.

### Technical notes summary
Add china regions Availability Zones

### Areas or cases that should be tested
1. Go to Cluster Management → Create → Azure AKS.
2. Use an Azure credential tied to an Azure China tenant (environment = AzureChinaCloud).
3. Open the Region dropdown.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="423" height="298" alt="截屏2025-09-15 上午10 31 47" src="https://github.com/user-attachments/assets/a251fc17-e878-407e-bf29-32df85bfb129" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility