### PR TITLE
Fixed adding a new machine pool to existing GCE instance

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -221,6 +221,8 @@ export default {
   },
 
   data() {
+    const isGoogle = this.provider === GOOGLE;
+
     return {
       loadedOnce:                      false,
       lastIdx:                         0,
@@ -270,7 +272,8 @@ export default {
       clusterAgentDefaultPC:                    null,
       clusterAgentDefaultPDB:                   null,
       activeTab:                                null,
-      isAuthenticated:                          this.provider !== GOOGLE || this.mode === _EDIT,
+      isGoogle,
+      isAuthenticated:                          !isGoogle || this.mode === _EDIT,
       projectId:                                null,
       REGISTRIES_TAB_NAME,
       labelForAddon,
@@ -1029,6 +1032,9 @@ export default {
 
       if (!this.machinePools) {
         await this.initMachinePools(this.value.spec.rkeConfig.machinePools);
+        if (this.isEdit && this.isGoogle && this.machinePools?.length > 0 && this.machinePools[0]?.config?.project) {
+          this.projectId = this.machinePools[0]?.config?.project;
+        }
         if (this.mode === _CREATE && !this.machinePools.length) {
           await this.addMachinePool();
         }
@@ -2221,7 +2227,7 @@ export default {
     </div>
     <AccountAccess
       v-if="!isAuthenticated"
-      v-model:credential="credential"
+      v-model:credential="credentialId"
       v-model:project="projectId"
       v-model:is-authenticated="isAuthenticated"
       :mode="mode"

--- a/shell/machine-config/components/GCEImage.vue
+++ b/shell/machine-config/components/GCEImage.vue
@@ -43,6 +43,10 @@ export default {
       type:    String,
       default: _CREATE,
     },
+    poolCreateMode: {
+      type:    Boolean,
+      default: false
+    },
     location: {
       type:     Object,
       required: true
@@ -85,7 +89,7 @@ export default {
   },
   created() {
     this.debouncedLoadFamilies = debounce(this.getFamilies, 500);
-    if (!this.isNewOrUnprovisioned) {
+    if (!this.poolCreateMode) {
       this.imageProjects = `${ this.getProjectFromImage() }`;
     }
   },
@@ -110,9 +114,6 @@ export default {
         }
 
       };
-    },
-    isNewOrUnprovisioned() {
-      return this.mode === _CREATE || !this.value?.metadata?.uid;
     },
     project() {
       return this.value.project;
@@ -284,7 +285,7 @@ export default {
     async getImages(val) {
       this.loadingImages = true;
       try {
-        const isOriginal = !this.isNewOrUnprovisioned && this.machineImage === this.getImageNameFromImage(this.originalMachineImage);
+        const isOriginal = !this.poolCreateMode && this.machineImage === this.getImageNameFromImage(this.originalMachineImage);
 
         this.machineImages = await this.getImagesInProject(val, this.showDeprecated);
         // If we had to reload list of images, we need to reset selected image if it is no longer in the list,

--- a/shell/machine-config/components/GCEImage.vue
+++ b/shell/machine-config/components/GCEImage.vue
@@ -45,7 +45,7 @@ export default {
     },
     poolCreateMode: {
       type:    Boolean,
-      default: false
+      default: true
     },
     location: {
       type:     Object,

--- a/shell/machine-config/components/GCEImage.vue
+++ b/shell/machine-config/components/GCEImage.vue
@@ -85,7 +85,7 @@ export default {
   },
   created() {
     this.debouncedLoadFamilies = debounce(this.getFamilies, 500);
-    if (this.mode !== _CREATE) {
+    if (!this.isNewOrUnprovisioned) {
       this.imageProjects = `${ this.getProjectFromImage() }`;
     }
   },
@@ -111,8 +111,8 @@ export default {
 
       };
     },
-    isCreate() {
-      return this.mode === _CREATE;
+    isNewOrUnprovisioned() {
+      return this.mode === _CREATE || !this.value?.metadata?.uid;
     },
     project() {
       return this.value.project;
@@ -284,7 +284,7 @@ export default {
     async getImages(val) {
       this.loadingImages = true;
       try {
-        const isOriginal = !this.isCreate && this.machineImage === this.getImageNameFromImage(this.originalMachineImage);
+        const isOriginal = !this.isNewOrUnprovisioned && this.machineImage === this.getImageNameFromImage(this.originalMachineImage);
 
         this.machineImages = await this.getImagesInProject(val, this.showDeprecated);
         // If we had to reload list of images, we need to reset selected image if it is no longer in the list,

--- a/shell/machine-config/google.vue
+++ b/shell/machine-config/google.vue
@@ -82,7 +82,7 @@ export default {
     },
     poolCreateMode: {
       type:    Boolean,
-      default: false
+      default: true
     },
   },
 

--- a/shell/machine-config/google.vue
+++ b/shell/machine-config/google.vue
@@ -79,7 +79,11 @@ export default {
     disabled: {
       type:    Boolean,
       default: false
-    }
+    },
+    poolCreateMode: {
+      type:    Boolean,
+      default: false
+    },
   },
 
   async fetch() {
@@ -123,7 +127,7 @@ export default {
     };
   },
   created() {
-    if (this.isNewOrUnprovisioned) {
+    if (this.poolCreateMode) {
       this.$emit('validationChanged', false);
       this.value.project = this.projectId;
       for (const key in this.defaultConfig) {
@@ -157,7 +161,7 @@ export default {
     'value.setExternalFirewallRulePrefix'(neu) {
       if (!neu) {
         this.value.openPort = [];
-      } else if (this.isNewOrUnprovisioned) {
+      } else if (this.poolCreateMode) {
         this.value.openPort.push('6443');
       } else {
         this.value.openPort = this.originalOpenPort.length > 0 ? this.originalOpenPort : ['6443'];
@@ -213,10 +217,6 @@ export default {
     },
     project() {
       return this.value.project;
-    },
-
-    isNewOrUnprovisioned() {
-      return this.mode === _CREATE || !this.value?.metadata?.uid;
     },
 
     sharedNetworks() {
@@ -338,7 +338,7 @@ export default {
 
         if (!cur ) {
           // If default is not actually available, reset
-          if (this.isNewOrUnprovisioned) {
+          if (this.poolCreateMode) {
             this.value.diskType = '';
           }
         } else {
@@ -450,6 +450,7 @@ export default {
         :credentialId="credentialId"
         :projectId="value.project"
         :originalMachineImage="originalMachineImage"
+        :pool-create-mode="poolCreateMode"
         :mode="mode"
         :location="location"
         :rules="{machineImage: fvGetAndReportPathRules('machineImage')}"
@@ -498,7 +499,7 @@ export default {
           label-key="cluster.machineConfig.gce.network.label"
           :mode="mode"
           :options="networkOptions"
-          :disabled="!isNewOrUnprovisioned"
+          :disabled="!poolCreateMode"
           option-key="name"
           option-label="label"
           :loading="loadingNetworks"
@@ -512,7 +513,7 @@ export default {
           label-key="cluster.machineConfig.gce.subnetwork.label"
           :mode="mode"
           :options="subnetworkOptions"
-          :disabled="!isNewOrUnprovisioned"
+          :disabled="!poolCreateMode"
           option-key="name"
           option-label="name"
           :loading="loadingNetworks"

--- a/shell/machine-config/google.vue
+++ b/shell/machine-config/google.vue
@@ -123,7 +123,7 @@ export default {
     };
   },
   created() {
-    if (this.mode === _CREATE) {
+    if (this.isNewOrUnprovisioned) {
       this.$emit('validationChanged', false);
       this.value.project = this.projectId;
       for (const key in this.defaultConfig) {
@@ -157,7 +157,7 @@ export default {
     'value.setExternalFirewallRulePrefix'(neu) {
       if (!neu) {
         this.value.openPort = [];
-      } else if (this.isCreate) {
+      } else if (this.isNewOrUnprovisioned) {
         this.value.openPort.push('6443');
       } else {
         this.value.openPort = this.originalOpenPort.length > 0 ? this.originalOpenPort : ['6443'];
@@ -213,6 +213,10 @@ export default {
     },
     project() {
       return this.value.project;
+    },
+
+    isNewOrUnprovisioned() {
+      return this.mode === _CREATE || !this.value?.metadata?.uid;
     },
 
     sharedNetworks() {
@@ -334,7 +338,7 @@ export default {
 
         if (!cur ) {
           // If default is not actually available, reset
-          if (this.isCreate) {
+          if (this.isNewOrUnprovisioned) {
             this.value.diskType = '';
           }
         } else {
@@ -494,7 +498,7 @@ export default {
           label-key="cluster.machineConfig.gce.network.label"
           :mode="mode"
           :options="networkOptions"
-          :disabled="!isCreate"
+          :disabled="!isNewOrUnprovisioned"
           option-key="name"
           option-label="label"
           :loading="loadingNetworks"
@@ -508,7 +512,7 @@ export default {
           label-key="cluster.machineConfig.gce.subnetwork.label"
           :mode="mode"
           :options="subnetworkOptions"
-          :disabled="!isCreate"
+          :disabled="!isNewOrUnprovisioned"
           option-key="name"
           option-label="name"
           :loading="loadingNetworks"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15417
<!-- Define findings related to the feature or bug issue. -->
Adding a new machine pool was being treated as edit and not creation, so I was not fetching and setting the required information.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Modified rke2.vue to assign projectId from existing pool to all new pools
Modified google.vue and GCEImage.vue files to differentiate between editing and creation better.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Instead of re-authenticating with projectId and credentials like we do for GKE, I am taking projectId from an existing pool since we already confirmed that it is valid during provisioning, and we do not re-check credentials for any other provider on edit.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Enable Google GCE driver
2. Provision GCE instance. Make sure provisioning was successful
3. Edit -> Machine Pools -> Make sure existing pool was loaded successfully and you can modify it
4. Add new pool. No errors should be displayed and you should be able to add a new pool successfully

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
No functionality outside of GCE should be affected

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/cf7f1728-586d-4636-b90c-692e783f8ba9


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
