### PR TITLE
Automation: Add support for multiple K8s versions in Jenkins pipeline

### DIFF
--- a/cypress/jenkins/Jenkinsfile_multi
+++ b/cypress/jenkins/Jenkinsfile_multi
@@ -1,8 +1,67 @@
 #!groovy
 
 def branch = "master"
-def test_tags = "${env.TEST_TAGS}".split(',')
+def test_tags_raw = "${env.TEST_TAGS}".split(',')
+def test_tags = []
+for (String tag : test_tags_raw) {
+    test_tags.add(tag.trim())
+}
 def all_cypress_tags = "${env.CYPRESS_TAGS}".split('\\|')
+
+// Function to get KDM branch for a Rancher version
+def getKdmBranch(rancherVersion, testTags) {
+    if (rancherVersion == "head") {
+        // Find the highest version from test tags and increment it
+        def latestVersion = ""
+        for (String tag : testTags) {
+            def versionMatch = tag =~ /v(\d+\.\d+)-head/
+            if (versionMatch) {
+                def currentVersion = versionMatch[0][1]
+                if (currentVersion > latestVersion) {
+                    latestVersion = currentVersion
+                }
+            }
+        }
+        // Increment minor version
+        if (latestVersion.isEmpty()) {
+            error("Cannot determine KDM branch for 'head' image. Please provide at least one version tag (e.g., v2.12-head) in TEST_TAGS.")
+        }
+        def parts = latestVersion.split('\\.')
+        def minor = (parts[1] as Integer) + 1
+        return "dev-v${parts[0]}.${minor}"
+    }
+    
+    // Extract version from image tags (e.g."v2.12-head")
+    def versionMatch = rancherVersion =~ /v(\d+\.\d+)-head/
+    if (versionMatch) {
+        def majorMinor = versionMatch[0][1]
+        return "dev-v${majorMinor}"
+    }
+    
+    error("Unable to determine KDM branch for Rancher version: ${rancherVersion}")
+}
+
+// Function to fetch latest K3s version from KDM
+def getLatestK3sVersion(rancherVersion, testTags) {
+    def kdmBranch = getKdmBranch(rancherVersion, testTags)
+    def kdmUrl = "https://raw.githubusercontent.com/rancher/kontainer-driver-metadata/${kdmBranch}/data/data.json"
+    
+    try {
+        def kdmData = sh(
+            script: "curl -s '${kdmUrl}' | grep '\"version\":' | grep '+k3s' | sed 's/.*\"version\": \"\\([^\"]*+k3s[0-9]*\\)\".*/\\1/' | tail -1",
+            returnStdout: true
+        ).trim()
+        
+        if (!kdmData || kdmData.isEmpty()) {
+            error("Failed to fetch K3s version from KDM for ${rancherVersion}")
+        }
+        
+        return kdmData
+    } catch (Exception e) {
+        error("Error fetching KDM data for ${rancherVersion}: ${e.getMessage()}")
+    }
+}
+
 if ("${env.branch}" != "null" && "${env.branch}" != "") {
   branch = "${env.branch}"
 }
@@ -32,11 +91,21 @@ node {
                         userRemoteConfigs: scm.userRemoteConfigs
                     ])
             }
+            
+            // Generate K8s versions dynamically from KDM
+            def k8s_versions = []
+            for (String rancherVersion : test_tags) {
+                def k8sVersion = getLatestK3sVersion(rancherVersion, test_tags)
+                k8s_versions.add(k8sVersion)
+            }
+            
             try {
                 stage('Run Tests') {
                     jobs = [:]
-                    for( String val : test_tags ) {
-                        for ( String ct : all_cypress_tags ) {
+                    test_tags.eachWithIndex { String rancher_version, int i ->
+                        String k8s_version = k8s_versions[i]
+                        all_cypress_tags.each { String ct ->
+                            echo "RANCHER_TAG: ${rancher_version}, K8S_VERSION: ${k8s_version}, CYPRESS_TAGS: ${ct}"
                             params = null
                             params = [  string(name: 'JOB_TYPE', value: "${JOB_TYPE}"),
                                         string(name: 'CORRAL_PACKAGES_BRANCH', value: "${CORRAL_PACKAGES_BRANCH}"),
@@ -60,7 +129,7 @@ node {
                                         string(name: 'RANCHER_HOST', value: ""),
                                         string(name: 'RANCHER_USERNAME', value: "${RANCHER_USERNAME}"),
                                         string(name: 'RANCHER_PASSWORD', value: "${RANCHER_PASSWORD}"),
-                                        string(name: 'K3S_KUBERNETES_VERSION', value: "${K3S_KUBERNETES_VERSION}"),
+                                        string(name: 'K3S_KUBERNETES_VERSION', value: k8s_version),
                                         string(name: 'CERT_MANAGER_VERSION', value: "${CERT_MANAGER_VERSION}"),
                                         string(name: 'SERVER_COUNT', value: "${SERVER_COUNT}"),
                                         string(name: 'AGENT_COUNT', value: "${AGENT_COUNT}"),
@@ -71,11 +140,9 @@ node {
                                         string(name: 'CHROME_VERSION', value: "${CHROME_VERSION}"),
                                         string(name: 'QASE_PROJECT', value: "${QASE_PROJECT}"),
                                         string(name: 'QASE_REPORT', value: "${QASE_REPORT}"),
-                                        string(name: 'RANCHER_IMAGE_TAG', value: val)]
-                            echo "TAG: ${params}"
+                                        string(name: 'RANCHER_IMAGE_TAG', value: rancher_version)]
                             build (job: 'ui-automation-job', parameters: params, propagate: false, wait: false)
                         }
-                        
                     }
                 }
             } catch (err) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1957

This PR adds support for testing multiple Kubernetes versions in the Jenkins pipeline, allowing testing across different Rancher/K8s version combinations.
The "Cluster Dashboard | can search by resource group" test was failing because it was running against K8s v1.26.13+k3s2 (which has `TokenReviews`) but expecting `SelfSubjectReviews` which is only available in newer K8s versions.

Instead of making the test more complex, this PR enables testing against the correct K8s versions for each Rancher image tag:

- Rancher v2.10 → K8s v1.31.11+k3s1
- Rancher v2.11 → K8s v1.32.7+k3s1
- Rancher v2.12 → K8s v1.33.4+k3s1 
- Rancher head → K8s v1.33.3+k3s1

PLEASE SEE JENKINS STAGING ENV FOR RESULTS:
- ui-automation-multi-recurring-job - run 42
- ui-automation-job-yonas - run 49-56

<img width="493" height="218" alt="Screenshot 2025-09-18 at 12 21 35 PM" src="https://github.com/user-attachments/assets/da6c8350-e167-4b32-8fdb-66a42667ec82" />


<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Dashboard:

- Enhanced logging to show which K8s/Image tag combinations are being tested
- Dynamically fetching K3s versions from KDM repo based on Rancher version
- Implemented paired testing approach where each Rancher version gets its compatible K3s version
- Removed dependency on K3S_KUBERNETES_VERSION

JJB:
- This PR relies on [**JJB PR**](https://github.com/rancherlabs/jenkins-job-builder/pull/860)
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
**Benefits:**
- Tests run against the actual supported K8s versions for each Rancher release
- Eliminates version-related test failures
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
