### PR TITLE
Ensuring Checkbox components have the `mode` prop where appropriate

### DIFF
--- a/pkg/gke/components/Config.vue
+++ b/pkg/gke/components/Config.vue
@@ -504,6 +504,7 @@ export default defineComponent({
           :key="i"
           :label="zoneOpt.name"
           :value="locations.includes(zoneOpt.name)"
+          :mode="mode"
           :data-testid="`gke-extra-zones-${zoneOpt.name}`"
           :disabled="isView"
           class="extra-zone-checkbox"

--- a/pkg/imported/components/Basics.vue
+++ b/pkg/imported/components/Basics.vue
@@ -162,6 +162,7 @@ export default defineComponent({
       <div class="col-basics span-6 mt-15">
         <Checkbox
           v-model:value="showDeprecatedPatchVersions"
+          :mode="mode"
           :label="t('cluster.kubernetesVersion.deprecatedPatches')"
           :tooltip="t('cluster.kubernetesVersion.deprecatedPatchWarning')"
           :disabled="versionInformationDisabled"

--- a/shell/components/PodSecurityAdmission.vue
+++ b/shell/components/PodSecurityAdmission.vue
@@ -222,6 +222,7 @@ export default defineComponent({
         <Checkbox
           v-if="!labelsAlwaysActive"
           v-model:value="psaControl.active"
+          :mode="mode"
           :data-testid="componentTestid + '--psaControl-' + i + '-active'"
           :label="level"
           :label-key="`podSecurityAdmission.labels.${ level }`"
@@ -281,6 +282,7 @@ export default defineComponent({
         <span class="col span-2">
           <Checkbox
             v-model:value="psaExemptionsControl.active"
+            :mode="mode"
             :data-testid="componentTestid + '--psaExemptionsControl-' + i + '-active'"
             :label="dimension"
             :label-key="`podSecurityAdmission.labels.${ dimension }`"

--- a/shell/components/form/ProjectMemberEditor.vue
+++ b/shell/components/form/ProjectMemberEditor.vue
@@ -286,6 +286,7 @@ export default {
       <template v-slot:body>
         <RadioGroup
           v-model:value="value.permissionGroup"
+          :mode="mode"
           data-testid="permission-options"
           :options="options"
           name="permission-group"
@@ -301,6 +302,7 @@ export default {
           >
             <Checkbox
               v-model:value="permission.value"
+              :mode="mode"
               :data-testid="`custom-permission-${i}`"
               :disabled="permission.locked"
               class="mb-5"

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/AddOnAdditionalManifest.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/AddOnAdditionalManifest.vue
@@ -41,6 +41,7 @@ export default {
     <YamlEditor
       ref="yaml-additional"
       v-model:value="additionalManifest"
+      :mode="mode"
       :editor-mode="mode === 'view' ? 'VIEW_CODE' : 'EDIT_CODE'"
       initial-yaml-values="# Additional Manifest YAML"
       class="yaml-editor"

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/AddOnConfig.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/AddOnConfig.vue
@@ -99,6 +99,7 @@ export default {
         ref="yaml-values"
         data-testid="addon-yaml-editor"
         :value="initYamlEditor(addonVersion.name)"
+        :mode="mode"
         :scrolling="true"
         :as-object="true"
         :editor-mode="mode === 'view' ? 'VIEW_CODE' : 'EDIT_CODE'"

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
@@ -493,6 +493,7 @@ export default {
         />
         <Checkbox
           :value="showDeprecatedPatchVersions"
+          :mode="mode"
           :label="t('cluster.kubernetesVersion.deprecatedPatches')"
           :tooltip="t('cluster.kubernetesVersion.deprecatedPatchWarning')"
           class="patch-version"

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/etcd/S3Config.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/etcd/S3Config.vue
@@ -165,6 +165,7 @@ export default {
       <LabeledInput
         v-if="!config.skipSSLVerify"
         v-model:value="config.endpointCA"
+        :mode="mode"
         type="multiline"
         :label="t('cluster.rke2.etcd.s3config.endpointCA.label')"
         :placeholder="ccData.defaultEndpointCA"

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/registries/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/registries/index.vue
@@ -78,6 +78,7 @@ export default {
     <div class="row">
       <Checkbox
         :value="showCustomRegistryInput"
+        :mode="mode"
         :label="t('cluster.privateRegistry.label')"
         data-testid="registries-enable-checkbox"
         @update:value="$emit('custom-registry-changed', $event)"
@@ -90,6 +91,7 @@ export default {
       <div class="col span-6">
         <LabeledInput
           :value="registryHost"
+          :mode="mode"
           label-key="catalog.chart.registry.custom.inputLabel"
           placeholder-key="catalog.chart.registry.custom.placeholder"
           :min-height="30"

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/upgrade/DrainOptions.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/upgrade/DrainOptions.vue
@@ -102,6 +102,7 @@ export default {
       <div class="mt-20">
         <Checkbox
           v-model:value="deleteEmptyDirData"
+          :mode="mode"
           label-key="cluster.rke2.drain.deleteEmptyDir.label"
           tooltip-key="cluster.rke2.drain.deleteEmptyDir.tooltip"
           @update:value="update"
@@ -110,6 +111,7 @@ export default {
       <div>
         <Checkbox
           v-model:value="force"
+          :mode="mode"
           label="Delete standalone pods"
           label-key="cluster.rke2.drain.force.label"
           tooltip="Delete standalone pods which are not managed by a Workload controller (Deployment, Job, etc).  Draining will fail if this is not set and there are standalone pods."
@@ -120,12 +122,14 @@ export default {
       <div>
         <Checkbox
           v-model:value="customGracePeriod"
+          :mode="mode"
           label-key="cluster.rke2.drain.gracePeriod.checkboxLabel"
           @update:value="update"
         />
         <UnitInput
           v-if="customGracePeriod"
           v-model:value="gracePeriod"
+          :mode="mode"
           label-key="cluster.rke2.drain.gracePeriod.inputLabel"
           :suffix="t('suffix.seconds', {count: timeout})"
           class="mb-10"
@@ -135,12 +139,14 @@ export default {
       <div>
         <Checkbox
           v-model:value="customTimeout"
+          :mode="mode"
           label-key="cluster.rke2.drain.timeout.checkboxLabel"
           @update:value="update"
         />
         <UnitInput
           v-if="customTimeout"
           v-model:value="timeout"
+          :mode="mode"
           label-key="cluster.rke2.drain.timeout.inputLabel"
           :suffix="t('suffix.seconds', {count: timeout})"
           class="drain-timeout"


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14481
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Add `mode` to a handful of input components that needed the prop.

### Technical notes summary
There are still a large number of input components missing this prop. Most of the remaining ones are in locations where the mode doesn't make sense such as dialogs, the chart index page, settings pages.

### Areas or cases that should be tested
The areas outlined in https://github.com/rancher/dashboard/issues/14481
- GKE Config area
- Imported Basics accordion
- Pod Security Admission for namespace `Show Configuration`
- All the tabs when viewing the `Show Configuration` of an rke2 cluster

### Areas which could experience regressions
The areas outlined in https://github.com/rancher/dashboard/issues/14481
- GKE Config area
- Imported Basics accordion
- Pod Security Admission for namespace `Show Configuration`
- All the tabs when viewing the `Show Configuration` of an rke2 cluster

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
