### PR TITLE
Basic validation on incorrectly configured extension headers

### DIFF
--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -317,7 +317,6 @@ export default {
       // add custom table columns provided by the extensions ExtensionPoint.TABLE_COL hook
       // gate it so that we prevent errors on older versions of dashboard
       if (this.$store.$plugin?.getUIConfig) {
-        //
         const extensionCols = getApplicableExtensionEnhancements(this, ExtensionPoint.TABLE_COL, TableColumnLocation.RESOURCE, this.$route);
 
         // Try and insert the columns before the Age column

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -130,20 +130,8 @@ export type Card = {
   component: Function;
 };
 
-export type TableColumn = {
-  name?: string;
-  label?: string;
-  labelKey?: string;
-  sort?: string | string[];
-  search?: string | string[];
-  value?: string;
-  getValue?: () => any;
-  width?: number;
-  default?: string;
-  formatter?: string;
-  canBeVariable?: boolean;
-  defaultSort?: boolean;
-};
+// Duplication of HeaderOptions?
+export type TableColumn = any;
 
 /** Definition of a tab (options that can be passed when defining an extension tab enhancement) */
 export type Tab = {
@@ -341,7 +329,7 @@ export interface HeaderOptions {
   formatterOpts?: any;
 
   /**
-   * Provide a function which accets a row and returns the value that should be displayed in the column
+   * Provide a function which accepts a row and returns the value that should be displayed in the column
    * @param row This can be any value which represents the row
    * @returns Can return {@link string | number | null | undefined} to display in the column
    */


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15460
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- With vai enabled headers will be sorted/filtered on via the path in the header's `value`
- Extensions can supply headers via addTableColumn
  - This doesn't support two headers, one for non-vai and one for vai - issue pending
- Some extension's are supplying headers that either 
  - shouldn't be sort/searchable 
    - Fixed in this issue
    - NV extension would need a new release - issue pending (they explicitly use the wrong sort/search fields)
  - lack the config for ssp sort/search
    - short term - can use cluster/paginationEnabled to supply non-vai or vai off config (?)
    - long term - we need to support sending two headers - issue pending
- This issue addresses the first part and ensures incompatible headers have sort/filter disabled


### Areas or cases that should be tested
- vai on / off sort/search of columns in pods list
- add the kubwarden, ui-plugin-examples, capi-ui, nv, stack state (see https://github.com/rancher/dashboard/issues/15460#issuecomment-3303129845)


### Areas which could experience regressions
- none not covered by above

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
