### PR TITLE
Ensure side bar cluster list shows icons for clusters with no annotations

### DIFF
--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -278,7 +278,7 @@ export default class MgmtCluster extends SteveModel {
 
   // Color to use as the underline for the icon in the app bar
   get iconColor() {
-    return this.metadata?.annotations[CLUSTER_BADGE.COLOR];
+    return this.metadata?.annotations?.[CLUSTER_BADGE.COLOR];
   }
 
   // Custom badge to show for the Cluster (if the appropriate annotations are set)


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15488
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- annotations can be missing. this is unlikely in the norman mcm world, but with this disabled and the rke1 annotations missing it occurs
- fix is to ensure it's null safe
- note cluster badge cannot be set - https://github.com/rancher/dashboard/issues/15491

### Areas or cases that should be tested
- as per issue

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
