### PR TITLE
Automation: resolve generic cluster import test failure p2

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -404,8 +404,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         importClusterPage.create();
 
         cy.wait('@importRequest').then((intercept) => {
-          cy.wrap(intercept.response.body.id).as('importedClusterId');
-
+          expect(intercept.response.statusCode).to.eq(201);
           expect(intercept.request.body).to.deep.equal({
             type:           importType,
             agentEnvVars:   [],
@@ -416,8 +415,8 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
           });
         });
 
-        cy.get('@importedClusterId').then((importedClusterId) => {
-          const detailClusterPage = new ClusterManagerDetailImportedGenericPagePo(undefined, importedClusterId.toString());
+        cy.getClusterIdByName(importGenericName).then((clusterId) => {
+          const detailClusterPage = new ClusterManagerDetailImportedGenericPagePo(undefined, clusterId);
 
           detailClusterPage.waitForPage(undefined, 'registration');
           detailClusterPage.kubectlCommandForImported().contains('--insecure').then(($value) => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1947

Second attempt at fixing `Cluster Manager -> Imported Generic -> can create new cluster`

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Removed direct extraction of intercept.response.body.id
- Added explicit 201 status code validation
- Replaced with cy.getClusterIdByName(importGenericName) for robust cluster ID retrieval
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Screenshot/Video
<img width="540" height="656" alt="Screenshot 2025-09-22 at 3 13 49 PM" src="https://github.com/user-attachments/assets/5c6e9681-6aea-410c-b9a2-920073708a76" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
