### PR TITLE
Implement UI context metadata

### DIFF
--- a/shell/config/store.js
+++ b/shell/config/store.js
@@ -40,6 +40,7 @@ let store = {};
   resolveStoreModules(require('../store/cru-resource.ts'), 'cru-resource.ts');
   resolveStoreModules(require('../store/notifications.ts'), 'notifications.ts');
   resolveStoreModules(require('../store/cookies.ts'), 'cookies.ts');
+  resolveStoreModules(require('../store/ui-context.ts'), 'ui-context.ts');
 
   // If the environment supports hot reloading...
 
@@ -71,6 +72,7 @@ let store = {};
       '../store/cru-resource.ts',
       '../store/notifications.ts',
       '../store/cookies.ts',
+      '../store/ui-context.ts',
     ], () => {
       // Update `root.modules` with the latest definitions.
       updateModules();

--- a/shell/directives/ui-context.ts
+++ b/shell/directives/ui-context.ts
@@ -1,0 +1,76 @@
+import { get } from '@shell/utils/object';
+
+interface Context {
+  tag: string;
+  path?: string;
+  value?: any;
+  description?: string;
+  icon?: string;
+}
+
+function isValid(context: Context ): context is Context {
+  return (
+    context !== null &&
+    typeof context === 'object' &&
+    (
+      (context.path === undefined && context.value === undefined) || // both undefined is allowed
+      (typeof context.path === 'string' && context.path?.length > 0 && context.value === undefined) || // path defined, value undefined
+      (context.value !== undefined && context.path === undefined) // value defined, path undefined
+    ) &&
+    typeof context.tag === 'string' && context.tag?.length > 0 &&
+    (typeof context.description === 'string' || context.description === undefined)
+  );
+}
+
+/** UI Context Directive
+ *
+ * Usage:
+ *   <div v-ui-context="{ tag: 'example-tag', path: 'some.path.in.component', description: 'An example context' }"></div>
+ *   or
+ *   <div v-ui-context="{ tag: 'example-tag', value: 'Direct Value', description: 'An example context with direct value' }"></div>
+ *   or
+ *   <div v-ui-context="{ tag: 'example-tag', description: 'An example context with text content' }">Text Content Value</div>
+ *
+ * The directive will register the context on mount and unregister it before unmounting.
+ *
+ * The context object must have a 'tag' and either a 'path' or a 'value'.
+ * If both 'path' and 'value' are undefined, the element's textContent will be used as the value.
+ *
+ * !IMPORTANT:
+ *   The value object will be reactive only when using 'path'.
+ *   Using 'value' or textContent will not be reactive.
+ *
+*/
+export default {
+  async mounted(el: any, binding: { value: Context, instance: any }) {
+    const context = binding.value;
+
+    if (!isValid(context)) {
+      throw new Error(`Invalid ui-context value: ${ JSON.stringify({ tag: (context as Context).tag, description: (context as Context).description }) }`);
+    }
+
+    if (context.path === undefined && context.value === undefined) {
+      // path and value undefined, use textContent as value
+      context.value = el.textContent;
+    } else if (context.value === undefined) {
+      // Use context.value directly if provided, otherwise resolve it from the component instance using context.path
+      const value = get(binding.instance, context.path);
+
+      if (value === undefined) {
+        throw new Error(`[ui-context] path "${ context.path }" is undefined on the component instance`);
+      }
+
+      context.value = value;
+    }
+
+    delete context.path;
+
+    el._uiContextId = await binding.instance.$store.dispatch('ui-context/add', context);
+  },
+
+  async beforeUnmount(el: any, binding: { instance: any }) {
+    const store = binding.instance.$store;
+
+    await store.dispatch('ui-context/remove', el._uiContextId);
+  }
+};

--- a/shell/initialize/install-directives.js
+++ b/shell/initialize/install-directives.js
@@ -11,6 +11,7 @@ import positiveIntNumberDirective from '@shell/directives/positive-int-number.js
 import trimWhitespaceDirective from '@shell/directives/trim-whitespace';
 import intNumberDirective from '@shell/directives/int-number';
 import htmlStrippedAriaLabelDirective from '@shell/directives/strip-html-aria-label';
+import uiContextDirective from '@shell/directives/ui-context';
 
 /**
  * Prevent extensions from overriding existing directives
@@ -49,6 +50,7 @@ function addDirectives(vueApp) {
   vueApp.directive('intNumber', intNumberDirective);
   vueApp.directive('positiveIntNumber', positiveIntNumberDirective);
   vueApp.directive('stripped-aria-label', htmlStrippedAriaLabelDirective);
+  vueApp.directive('ui-context', uiContextDirective);
 }
 
 /**

--- a/shell/store/ui-context.ts
+++ b/shell/store/ui-context.ts
@@ -1,0 +1,85 @@
+interface Context {
+  tag: string;
+  value: any;
+  description?: string;
+  icon?: string;
+}
+
+interface Element {
+  id: number;
+  context: Context
+}
+
+interface State {
+  idCounter: number;
+  elements: Record<string, Element>;
+}
+
+export const state = function(): State {
+  return {
+    idCounter: 0,
+    elements:  {}
+  };
+};
+
+export const getters = {
+  all: (state: State) => {
+    return Object.values(state.elements)
+      .map((e) => e.context)
+      .sort((a, b) => (a.tag || '').localeCompare(b.tag || '') || 0);
+  },
+};
+
+export const mutations = {
+  add(state: State, element: Element) {
+    state.elements[element.id] = element;
+  },
+
+  update(state: State, element: Element) {
+    const existingElement = state.elements[element.id];
+
+    if (existingElement) {
+      existingElement.context = element.context;
+    }
+  },
+
+  remove(state: State, element: Element) {
+    delete state.elements[element.id];
+  }
+};
+
+let id = null;
+
+export const actions = {
+  add({ commit, state }: { commit: Function, state: State }, context: Context) {
+    if (context?.value === undefined || !context?.tag) {
+      throw new Error(`[ui-context] context {{${ JSON.stringify(context) }}} is not valid`);
+    }
+
+    id = `ctx-${ state.idCounter++ }`;
+
+    commit('add', { id, context });
+
+    return id;
+  },
+
+  update({ commit, state }: { commit: Function, state: State }, element: Element) {
+    const old = state.elements[element.id];
+
+    if (!old) {
+      throw new Error(`[ui-context] element with id {{${ element.id }}} not found`);
+    }
+
+    commit('update', element);
+  },
+
+  remove({ commit, state }: { commit: Function, state: State }, id: number) {
+    const element = state.elements[id];
+
+    if (!element) {
+      throw new Error(`[ui-context] element with id {{${ id }}} not found`);
+    }
+
+    commit('remove', element);
+  }
+};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15528
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

It adds the new `ui-context` directive & store to handle the UI context metadata.

The directive will register the context on mount and unregister it before unmounting.
This means the context will be available in the store until the bound elements stay on screen.

Usage:
  ```
  <div v-ui-context="{ tag: 'example-tag', path: 'some.path.in.component', description: 'An example context' }"></div>
  or
  <div v-ui-context="{ tag: 'example-tag', value: 'Direct Value', description: 'An example context with direct value' }"></div>
  or
  <div v-ui-context="{ tag: 'example-tag', description: 'An example context with text content' }">Text Content Value</div>
```

The context object must have a 'tag' and either a 'path' or a 'value'.
If both 'path' and 'value' are undefined, the element's textContent will be used as the value.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
