### PR TITLE
Update addTableColumn to support server-side pagination

### DIFF
--- a/docusaurus/docs/extensions/api/table-columns.md
+++ b/docusaurus/docs/extensions/api/table-columns.md
@@ -13,12 +13,12 @@ This method adds a table column to a `ResourceTable` element-based table on the 
 Method:
 
 ```ts
-plugin.addTableColumn(where: String, when: LocationConfig, options: Object);
+plugin.addTableColumn(where: String, when: LocationConfig, column: TableColumn);
 ```
 
 _Arguments_
 
-`where` string parameter admissable values for this method:
+`where` string parameter admissible values for this method:
 
 | Key | Type | Description |
 |---|---|---|
@@ -26,28 +26,35 @@ _Arguments_
 
 <br/>
 
-`when` Object admissable values:
+`when` Object admissible values:
 
 `LocationConfig` as described above for the [LocationConfig object](./common#locationconfig).
 
-<br/>
-<br/>
+*(Rancher version v2.13.0)*
 
-### TableColumnLocation.RESOURCE options
+An addition parameter can be provided which will be used to support the column when server-side pagination is enabled. For more information and other changes required to server-side pagination see [here](../performance/scaling/lists.md).
+
+```ts
+plugin.addTableColumn(where: String, when: LocationConfig, column: TableColumn, paginationColumn?: PaginationTableColumn));
+```
+
+### TableColumnLocation.RESOURCE column
 
 ![Table Col](../screenshots/table-cols.png)
 
-`options` config object. Admissable parameters for the `options` with `'TableColumnLocation.RESOURCE'` are:
+`column` config object. Admissible parameters for the `column` with `'TableColumnLocation.RESOURCE'` are:
 
 | Key | Type | Description |
 |---|---|---|
 |`name`| String | Label for column |
-|`labelKey`| String | Same as "name" but allows for translation. Will superseed "name" |
+|`labelKey`| String | Same as "name" but allows for translation. Will supersede "name" |
 |`value`| String | Object property to obtain the value from |
-|`getValue`| Fuction | Same as "value", but it can be a function. Will superseed "value" |
+|`getValue`| Function | Same as "value", but it can be a function. Will supersede "value" |
 |`width`| Int | Column width (in `px`). Optional |
-|`sort`| Array | Object properties to be bound to the table sorting. Optional |
-|`search`| Array | Object properties to be bound to the table search. Optional |
+|`sort`| boolean,string,Array | Object properties to be bound to the table sorting. Optional |
+|`search`| boolean,string,Array | Object properties to be bound to the table search. Optional |
+| `formatter`| string | Name of a `formatter` component used to render the cell. Components should be in the extension `formatters` folder
+| `formatterOpts`| any | Provide additional values to the `formatter` component via a `formatterOpts` component param
 
 Usage example for `'TableColumnLocation.RESOURCE'`:
 

--- a/docusaurus/docs/extensions/performance/scaling/lists.md
+++ b/docusaurus/docs/extensions/performance/scaling/lists.md
@@ -18,11 +18,18 @@ Now though we recommend using the `PaginatedResourceTable` component. This does 
 
 Due to pagination happening server-side the UI can no-longer sort and filter on properties it manages locally. The column configuration that supports this new process is automatically created unless custom columns have been provided.
 
-To override existing non-compatible server-side pagination headers
-- if headers are supplied by product configuration, supply a second array to `headers(<resourcetype>, <non server-side pagination compatible headers>)`
+To override existing non-compatible headers
+- if headers are supplied by product configuration, supply a second array containing compatible headers to
+  - ```
+    headers(
+      <resourcetype>,
+      <non server-side pagination compatible headers>,
+      <server-side pagination headers>
+    )
+    ```
   - this is the recommended way to customize the columns in lists
-- if headers are supplied to the component, also set `:pagination-headers="..."`
-  - this can be used if there is a situation where the default, global columns cannot be used
+- if headers are supplied to the `PaginatedResourceTable` via `:headers=`, supply a second attribute containing compatible headers via `:pagination-headers="..."`
+  - supplying headers directly to the table can be used if there is a situation where the default, global columns cannot be used
 
 A compatible column will contain `value`, `sort` and `search` properties that reference values that exist natively in the resource server-side. Properties that reference constructed properties from the resource's model cannot be used.
 
@@ -36,6 +43,22 @@ A compatible column will contain `value`, `sort` and `search` properties that re
   - see `:pagination-headers="paginationHeaders"` 
 - rancher/dashboard `shell/pages/home.vue`
   - see `:pagination-headers="paginationHeaders"` 
+
+### Support for addTableColumn
+
+Extensions can insert additional columns to existing tables by using the `addTableColumn` method.
+
+Just like the `PaginatedResourceTable` header configuration this has been updated to support server-side pagination.
+
+If only one column is supplied it will be used when server-side pagination is disabled, but also sanitized and used when enabled. This will only be functional if the value is a path to a property in the resource itself and not one provided by the resource's model (as per `PaginatedResourceTable` header changes).
+
+To support the column when server-side paginated is enabled an additional column configuration object can be passed to `addTableColumn`.
+
+*Examples*
+
+- rancher/ui-plugin-examples `pkg/extensions-api-demo/index.ts`
+  - see both `plugin.addTableColumn` usages
+
 
 ### Secondary Resources
 
@@ -85,11 +108,28 @@ By default `PaginatedResourceTable` will fetch all of the resource type (given t
 - rancher/dashboard `shell/components/form/ResourceTabs/index.vue`
   - When viewing a specific resource, the `Events` tab shows a list of events filtered to show events related to that specific resource
 
+### Choosing fields to display, sort and filter on
+
+For all server-side pagination header and column configuration the value supplied to display, sort or filter must be a path in the resource itself and not computed locally in the browser. This ensures that all can be accessed outside of the browser when pagination occurs.
+
+Paths must also be indexed server-side. This happens by default or automatically for a number of values. These are the only values that can be supplied to sort or filter on.
+
+- `metadata.name`
+- `metadata.namespace`
+- `id`
+- `metadata.state.name`
+- `metadata.creationTimestamp`
+- all values in `metadata.labels`
+  - These are referenced as `metadata.labels.<label name>`
+- all values defined as `additionalPrinterColumns` in the resource's Custom Resource Definition
+  - These are referenced as `metadata.fields.<index>`
+
 ### Checklist
 
 1. `ResourceTable` has been replaced with `PaginatedResourceTable`
-1. If headers have been provided or configured in product, specific server-side pagination compatible ones should be provided
+1. If headers have been provided by either product configuration, `PaginatedResourceTable` attribute or `addTableColumn` method additional server-side pagination compatible ones have also been provided
    - Header `value`, `sort` and `search` all reference properties on the native object stored server-side
+   - `value`, `sort`, and `search` are all indexed server-side
 1. Components containing `PaginatedResourceTable` should fetch secondary resources efficiently as possible
    - Primary resources will be fetched automatically via the `PaginatedResourceTable` component (no extra changes required)
    - Secondary resources are fetched via functions `fetchSecondaryResources` and/or `fetchPageSecondaryResources` passed into `PaginatedResourceTable`

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -317,6 +317,7 @@ export default {
       // add custom table columns provided by the extensions ExtensionPoint.TABLE_COL hook
       // gate it so that we prevent errors on older versions of dashboard
       if (this.$store.$plugin?.getUIConfig) {
+        // { column: TableColumn, paginationColumn: PaginationTableColumn }[]
         const extensionCols = getApplicableExtensionEnhancements(this, ExtensionPoint.TABLE_COL, TableColumnLocation.RESOURCE, this.$route);
 
         // Try and insert the columns before the Age column
@@ -339,27 +340,36 @@ export default {
         }
 
         // adding extension defined cols to the correct header config
-        extensionCols.forEach((col) => {
+        extensionCols.forEach((config) => {
+          let { column: col, paginationColumn } = config;
+
           if (this.externalPaginationEnabled) {
-            // validate that the required settings are supplied to enable search and sort server-side
-            // these do not check other invalid scenarios like a path is a string but to a model property, or that the field supports sort/search via api (some basic non-breaking checks are done further on)
-            if (
-              col.search !== false && // search is explicitly disabled
-              (typeof col.search !== 'string' && !Array.isArray(col.search)) && // primary property path to search on
-              typeof col.value !== 'string' // secondary property path to search on
-            ) {
-              console.warn(`Unable to support server-side search for extension provided column "${ col.name || col.label || col.labelKey }" (column must provide \`search\` or \`value\` property containing a path to a property in the resource. search can be an array).`); // eslint-disable-line no-console
+            if (paginationColumn) {
+              // Use the pagination column, no need to
+              col = paginationColumn;
+            } else {
+              // Attempt to fall back on the single column
 
-              col.search = false;
-            }
+              // validate that the required settings are supplied to enable search and sort server-side
+              // these do not check other invalid scenarios like a path is a string but to a model property, or that the field supports sort/search via api (some basic non-breaking checks are done further on)
+              if (
+                col.search !== false && // search is explicitly disabled
+                (typeof col.search !== 'string' && !Array.isArray(col.search)) && // primary property path to search on
+                typeof col.value !== 'string' // secondary property path to search on
+              ) {
+                console.warn(`Unable to support server-side search for extension provided column "${ col.name || col.label || col.labelKey }" (column must provide \`search\` or \`value\` property containing a path to a property in the resource. search can be an array).`); // eslint-disable-line no-console
 
-            if (
-              col.sort !== false && // sort is explicitly disabled
-              (typeof col.sort !== 'string' && !Array.isArray(col.sort)) // primary property path to sort on
-            ) {
-              console.warn(`Unable to support server-side sort for extension provided column "${ col.name || col.label || col.labelKey }" (column must provide \`sort\` property containing a path to a property, or array of paths, in the resource)`); // eslint-disable-line no-console
+                col.search = false;
+              }
 
-              col.sort = false;
+              if (
+                col.sort !== false && // sort is explicitly disabled
+                (typeof col.sort !== 'string' && !Array.isArray(col.sort)) // primary property path to sort on
+              ) {
+                console.warn(`Unable to support server-side sort for extension provided column "${ col.name || col.label || col.labelKey }" (column must provide \`sort\` property containing a path to a property, or array of paths, in the resource)`); // eslint-disable-line no-console
+
+                col.sort = false;
+              }
             }
           }
 

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -294,7 +294,7 @@ export function init(store) {
       STEVE_NAMESPACE_COL,
       {
         ...INGRESS_TARGET,
-        sort:   'spec.rules[0].host', // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
+        sort:   'spec.rules[0].host',
         search: false, // This is broken in normal world, so disable here
       },
       {
@@ -359,10 +359,10 @@ export function init(store) {
       STEVE_STATE_COL,
       STEVE_NAME_COL,
       STEVE_NAMESPACE_COL,
-      HPA_REFERENCE, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
-      MIN_REPLICA, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
-      MAX_REPLICA, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
-      CURRENT_REPLICA, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
+      HPA_REFERENCE,
+      MIN_REPLICA,
+      MAX_REPLICA,
+      CURRENT_REPLICA,
       STEVE_AGE_COL
     ]
   );

--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -16,6 +16,7 @@ import {
   ModelExtensionConstructor,
   PluginRouteRecordRaw, RegisterStore, UnregisterStore, CoreStoreSpecifics, CoreStoreConfig,
   NavHooks, OnNavToPackage, OnNavAwayFromPackage, OnLogIn, OnLogOut,
+  PaginationTableColumn,
   ExtensionEnvironment
 } from './types';
 import coreStore, { coreStoreModule, coreStoreState } from '@shell/plugins/dashboard-store';
@@ -247,10 +248,21 @@ export class Plugin implements IPlugin {
   }
 
   /**
-   * Adds a new column to a table on the UI
+   * Adds a new column to a ResourceTable
+   *
+   * @param where
+   * @param when
+   * @param action
+   * @param column
+   *  The information required to show a header and values for a column in a table
+   * @param paginationColumn
+   *  As per `column`, but is used where server-side pagination is enabled
    */
-  addTableColumn(where: string, when: LocationConfig | string, column: TableColumn): void {
-    this._addUIConfig(ExtensionPoint.TABLE_COL, where, when, column);
+  addTableColumn(where: string, when: LocationConfig | string, column: TableColumn, paginationColumn?: PaginationTableColumn): void {
+    this._addUIConfig(ExtensionPoint.TABLE_COL, where, when, {
+      column,
+      paginationColumn
+    });
   }
 
   setHomePage(component: any) {

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -130,9 +130,6 @@ export type Card = {
   component: Function;
 };
 
-// Duplication of HeaderOptions?
-export type TableColumn = any;
-
 /** Definition of a tab (options that can be passed when defining an extension tab enhancement) */
 export type Tab = {
   name: string;
@@ -281,6 +278,9 @@ export interface ProductOptions {
   // typeStoreMap: string;
 }
 
+/**
+ * Configuration required to show a header in a ResourceTable
+ */
 export interface HeaderOptions {
   /**
    * Name of the header. This should be unique.
@@ -335,6 +335,21 @@ export interface HeaderOptions {
    */
   getValue?: (row: any) => string | number | null | undefined;
 }
+
+/**
+ * Configuration required to show a header in a ResourceTable when server-side pagination is enable
+ */
+export type PaginationHeaderOptions = Omit<HeaderOptions, 'getValue'>
+
+/**
+ * External extension configuration for @HeaderOptions
+ */
+export type TableColumn = HeaderOptions;
+
+/**
+ * External extension configuration for @PaginationHeaderOptions
+ */
+export type PaginationTableColumn = PaginationHeaderOptions;
 
 export interface ConfigureTypeOptions {
   /**
@@ -621,9 +636,17 @@ export interface IPlugin {
   addCard(where: CardLocation | string, when: LocationConfig | string, action: Card): void;
 
   /**
-   * Adds a new column to the SortableTable component
+   * Adds a new column to a ResourceTable
+   *
+   * @param where
+   * @param when
+   * @param action
+   * @param column
+   *  The information required to show a header and values for a column in a table
+   * @param paginationColumn
+   *  As per `column`, but is used where server-side pagination is enabled
    */
-  addTableColumn(where: TableColumnLocation | string, when: LocationConfig | string, action: TableColumn): void;
+  addTableColumn(where: TableColumnLocation | string, when: LocationConfig | string, column: TableColumn, paginationColumn?: TableColumn): void;
 
   /**
    * Set the component to use for the landing home page

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -305,7 +305,7 @@ export interface HeaderOptions {
   /**
    * A string which represents the path to access the value from the row object which we'll use to sort i.e. `row.meta.value`
    */
-  sort?: string | string[];
+  sort?: string | string[] | boolean;
 
   /**
    * A string which represents the path to access the value from the row object which we'll use to search i.e. `row.meta.value`.

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -15,9 +15,7 @@ import {
   HPA,
   SECRET
 } from '@shell/config/types';
-import {
-  CAPI as CAPI_LAB_AND_ANO, CATTLE_PUBLIC_ENDPOINTS, STORAGE, UI_PROJECT_SECRET, UI_PROJECT_SECRET_COPY
-} from '@shell/config/labels-annotations';
+import { CAPI as CAPI_LAB_AND_ANO, CATTLE_PUBLIC_ENDPOINTS, STORAGE, UI_PROJECT_SECRET_COPY } from '@shell/config/labels-annotations';
 import { Schema } from '@shell/plugins/steve/schema';
 import { PaginationSettingsStore } from '@shell/types/resources/settings';
 import paginationUtils from '@shell/utils/pagination-utils';
@@ -158,6 +156,7 @@ class StevePaginationUtils extends NamespaceProjectFilters {
       { field: 'id' },
       { field: 'metadata.state.name' },
       { field: 'metadata.creationTimestamp' },
+      { field: 'metadata.labels', startsWith: true },
     ],
     [NODE]: [
       { field: 'status.nodeInfo.kubeletVersion' },
@@ -180,18 +179,12 @@ class StevePaginationUtils extends NamespaceProjectFilters {
       { field: 'spec.internal' },
       { field: 'spec.displayName' },
       { field: `status.provider` },
-      { field: `metadata.labels["${ CAPI_LAB_AND_ANO.PROVIDER }]` },
       { field: `status.connected` },
     ],
-    [CONFIG_MAP]: [
-      { field: 'metadata.labels[harvesterhci.io/cloud-init-template]' }
-    ],
     [SECRET]: [
-      { field: `metadata.labels[${ UI_PROJECT_SECRET }]` },
       { field: `metadata.annotations[${ UI_PROJECT_SECRET_COPY }]` },
     ],
     [NAMESPACE]: [
-      { field: 'metadata.labels[field.cattle.io/projectId]' }
     ],
     [CAPI.MACHINE]: [
       { field: 'spec.clusterName' }
@@ -214,7 +207,6 @@ class StevePaginationUtils extends NamespaceProjectFilters {
       { field: 'status.releaseName' },
     ],
     [CAPI.RANCHER_CLUSTER]: [
-      { field: `metadata.labels[${ CAPI_LAB_AND_ANO.PROVIDER }]` },
       { field: `status.provider` },
       { field: 'status.clusterName' },
       { field: `metadata.annotations[${ CAPI_LAB_AND_ANO.HUMAN_NAME }]` }
@@ -224,14 +216,14 @@ class StevePaginationUtils extends NamespaceProjectFilters {
       { field: 'spec.clusterIP' },
     ],
     [INGRESS]: [
-      { field: 'spec.rules.host' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
+      { field: 'spec.rules.host' },
       { field: 'spec.ingressClassName' },
     ],
     [HPA]: [
-      { field: 'spec.scaleTargetRef.name' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
-      { field: 'spec.minReplicas' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
-      { field: 'spec.maxReplicas' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
-      { field: 'spec.currentReplicas' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50527
+      { field: 'spec.scaleTargetRef.name' },
+      { field: 'spec.minReplicas' },
+      { field: 'spec.maxReplicas' },
+      { field: 'spec.currentReplicas' },
     ],
     [PVC]: [
       { field: 'spec.volumeName' },
@@ -249,29 +241,29 @@ class StevePaginationUtils extends NamespaceProjectFilters {
     ],
     [WORKLOAD_TYPES.CRON_JOB]: [
       { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
-      { field: 'spec.template.spec.containers.image' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
+      { field: 'spec.template.spec.containers.image' },
     ],
     [WORKLOAD_TYPES.DAEMON_SET]: [
       { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
-      { field: 'spec.template.spec.containers.image' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
+      { field: 'spec.template.spec.containers.image' },
     ],
     [WORKLOAD_TYPES.DEPLOYMENT]: [
       { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
-      { field: 'spec.template.spec.containers.image' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
+      { field: 'spec.template.spec.containers.image' },
     ],
     [WORKLOAD_TYPES.JOB]: [
       { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
-      { field: 'spec.template.spec.containers.image' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
+      { field: 'spec.template.spec.containers.image' },
     ],
     [WORKLOAD_TYPES.STATEFUL_SET]: [
       { field: `metadata.annotations[${ CATTLE_PUBLIC_ENDPOINTS }]` },
-      { field: 'spec.template.spec.containers.image' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
+      { field: 'spec.template.spec.containers.image' },
     ],
     [WORKLOAD_TYPES.REPLICA_SET]: [
-      { field: 'spec.template.spec.containers.image' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
+      { field: 'spec.template.spec.containers.image' },
     ],
     [WORKLOAD_TYPES.REPLICATION_CONTROLLER]: [
-      { field: 'spec.template.spec.containers.image' }, // Pending API Support - BUG - https://github.com/rancher/rancher/issues/50526
+      { field: 'spec.template.spec.containers.image' },
     ],
   }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15480
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- add option to supply an additional column definition to addTableColumn to use when SSP is enabled

Additionally
- update list of compatible columns to search/sort on given BE fixes being resolved

### Technical notes summary
- this is designed to support running old extensions in new dashboard
  - additional param is not supplied
  - stale ResourceTable should not encounter new format of config (which would need an updated shell with non-stale ResourceTable)
- also designed to support running new extensions in old dashboards
  - the new param is just ignored
- examples have been added - https://github.com/rancher/ui-plugin-examples/pull/72

### Areas or cases that should be tested
with ui-sql-cache off and on
- run dashboard from this PR
- install the extenions-api-demo from https://github.com/rancher/ui-plugin-examples/pull/72
- visit the configmap, secrets and pods pages
- added columns should be visible and sort/searchable

### Areas which could experience regressions
with ui-sql-cache off and on
- run dashboard from master (or anything not including this PR)
- install the extenions-api-demo from https://github.com/rancher/ui-plugin-examples/pull/72
- visit the configmap, secrets and pods pages
- added columns should be visible and sort/searchable (except vai on configmap + secret column)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
