### PR TITLE
 Fixed an issue where the current cluster is used when navigating to the auth configuration portion of the app 

### DIFF
--- a/cypress/e2e/po/pages/users-and-auth/users.po.ts
+++ b/cypress/e2e/po/pages/users-and-auth/users.po.ts
@@ -19,7 +19,7 @@ export default class UsersPo extends ClusterPage {
     return sideNav.navToSideMenuEntryByLabel('Users');
   }
 
-  constructor(private clusterId = 'local') {
+  constructor(private clusterId = '_') {
     super(clusterId, 'auth/management.cattle.io.user');
   }
 

--- a/cypress/e2e/po/pages/users-and-auth/users.po.ts
+++ b/cypress/e2e/po/pages/users-and-auth/users.po.ts
@@ -19,7 +19,7 @@ export default class UsersPo extends ClusterPage {
     return sideNav.navToSideMenuEntryByLabel('Users');
   }
 
-  constructor(private clusterId = '_') {
+  constructor(private clusterId = 'local') {
     super(clusterId, 'auth/management.cattle.io.user');
   }
 

--- a/cypress/e2e/po/pages/users-and-auth/users.po.ts
+++ b/cypress/e2e/po/pages/users-and-auth/users.po.ts
@@ -23,6 +23,10 @@ export default class UsersPo extends ClusterPage {
     super(clusterId, 'auth/management.cattle.io.user');
   }
 
+  mastheadTitle() {
+    return this.self().find('.title h1').invoke('text');
+  }
+
   waitForRequests() {
     UsersPo.goToAndWaitForGet(this.goTo.bind(this), ['/v3/users?limit=0'], 15000);
   }

--- a/cypress/e2e/tests/navigation/side-nav/product-side-nav-highlighting.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/product-side-nav-highlighting.spec.ts
@@ -62,7 +62,7 @@ describe('Side navigation: Highlighting ', { tags: ['@navigation', '@adminUser']
     const productNavPo = new ProductNavPo();
 
     usersPo.goTo();
-    usersPo.waitForPage();
+    usersPo.waitForMastheadTitle('Users');
     productNavPo.activeNavItem().should('equal', 'Users');
 
     usersPo.userRetentionLink().click();

--- a/cypress/e2e/tests/pages/generic/prime.spec.ts
+++ b/cypress/e2e/tests/pages/generic/prime.spec.ts
@@ -17,8 +17,8 @@ function interceptVersionAndSetToPrime() {
 }
 
 describe('Prime Extension', { testIsolation: 'off', tags: ['@generic', '@adminUser'] }, () => {
-  const authProviderPo = new AuthProviderPo('local');
-  const azureadPo = new AzureadPo('local');
+  const authProviderPo = new AuthProviderPo('_');
+  const azureadPo = new AzureadPo('_');
 
   before(() => {
     interceptVersionAndSetToPrime().as('rancherVersion');

--- a/shell/components/form/ResourceTabs/composable.ts
+++ b/shell/components/form/ResourceTabs/composable.ts
@@ -39,7 +39,7 @@ export const useTabCountWatcher = () => {
 
 export const useTabCountUpdater = () => {
   const tabKey = randomStr();
-  const updateCount = inject<UpdateCountFn>(UPDATE_COUNT_PROVIDER_KEY);
+  const updateCount = inject<UpdateCountFn | undefined>(UPDATE_COUNT_PROVIDER_KEY, undefined);
 
   const updateTabCount = (count: number | undefined) => {
     updateCount?.(tabKey, count);

--- a/shell/config/product/auth.js
+++ b/shell/config/product/auth.js
@@ -6,6 +6,7 @@ import {
   RBAC_BUILTIN, RBAC_DEFAULT, STATE, NAME as HEADER_NAME, AGE, SIMPLE_NAME
 } from '@shell/config/table-headers';
 import { MULTI_CLUSTER } from '@shell/store/features';
+import { BLANK_CLUSTER } from '@shell/store/store-types';
 
 export const NAME = 'auth';
 
@@ -37,7 +38,7 @@ export function init(store) {
     to:                  {
       name:   'c-cluster-product-resource',
       params: {
-        product: 'auth', resource: 'management.cattle.io.user', cluster: 'local'
+        product: NAME, resource: MANAGEMENT.USER, cluster: BLANK_CLUSTER
       }
     }
   });
@@ -62,7 +63,7 @@ export function init(store) {
     route:      {
       name:   'c-cluster-product-resource',
       params: {
-        cluster:  'local',
+        cluster:  BLANK_CLUSTER,
         product:  NAME,
         resource: MANAGEMENT.USER,
       }

--- a/shell/config/product/auth.js
+++ b/shell/config/product/auth.js
@@ -34,6 +34,12 @@ export function init(store) {
     removable:           false,
     showClusterSwitcher: false,
     category:            'configuration',
+    to:                  {
+      name:   'c-cluster-product-resource',
+      params: {
+        product: 'auth', resource: 'management.cattle.io.user', cluster: 'local'
+      }
+    }
   });
 
   virtualType({


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10709
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
Added a route definition which includes the `_` blank cluster as a param.

### Areas or cases that should be tested
Navigating to the auth configuration from both local and downstream clusters and verifying we always see the local cluster in the url.

### Areas which could experience regressions
Navigating to the auth configuration from both local and downstream clusters and verifying we always see the `_` blank cluster in the url.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


https://github.com/user-attachments/assets/8abdb9b9-d551-4e0c-8993-4ec045fa6b87



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
