### PR TITLE
Implement the kubectl-explain to be consistent with the new drawer design

### DIFF
--- a/pkg/kubectl-explain/index.ts
+++ b/pkg/kubectl-explain/index.ts
@@ -26,7 +26,7 @@ export default function(plugin: IPlugin, internal: IInternal): void {
     tooltipKey: 'kubectl-explain.tooltip',
     svg:        require('./explain.svg'),
     invoke:     (opts, res, globals) => {
-      explain(store, globals.$route);
+      explain(store, globals.$route, `[data-testid="extension-header-action-kubectl-explain.action"]`);
     }
   });
 }

--- a/pkg/kubectl-explain/slide-in.js
+++ b/pkg/kubectl-explain/slide-in.js
@@ -1,51 +1,30 @@
-import { createApp } from 'vue';
-import cleanHtmlDirective from '@shell/directives/clean-html';
-import i18n from '@shell/plugins/i18n';
-
 import Panel from './components/SlideInPanel';
-import { OpenAPI } from './open-api';
-
-const PANEL_ID = 'kubectl-explain';
-
-// Cache of the Open API Data for a cluster
-const openAPI = new OpenAPI();
-
-// Slide in panel component
-let slideInPanel;
 
 /**
  * Show the slide-in panel with the resource explanation
  */
-export async function explain(store, route) {
+export async function explain(store, route, returnFocusSelector) {
   const typeName = route.params?.resource;
   const schema = typeName ? store.getters[`cluster/schemaFor`](typeName) : undefined;
   const cluster = store.getters['currentCluster'] || 'local';
 
-  // Create slide-in panel, if this is the first-time it is being shown
-  if (!slideInPanel) {
-    // Create a DIV that we can mount the slide-in panel component into
-    const div = document.createElement('div');
+  const onClose = () => store.commit('slideInPanel/close', undefined, { root: true });
 
-    div.id = PANEL_ID;
-    document.body.appendChild(div);
-
-    const slideInPanelApp = createApp(Panel);
-
-    slideInPanelApp.directive('clean-html', cleanHtmlDirective);
-    slideInPanelApp.use(store);
-    slideInPanelApp.use(i18n, { store });
-    slideInPanel = slideInPanelApp.mount(`#${ PANEL_ID }`);
-  }
-
-  // Open the slide-in panel
-  setTimeout(() => {
-    slideInPanel.open();
-
-    // Fetch the open API data for the cluster
-    openAPI.get(cluster?.id, store.dispatch).then((data) => {
-      slideInPanel.load(data, schema);
-    }).catch((e) => {
-      slideInPanel.load(undefined, schema, e);
-    });
-  }, 0);
+  store.commit('slideInPanel/open', {
+    component:      Panel,
+    componentProps: {
+      resource:           this,
+      onClose,
+      width:              '50%',
+      // We want this to be full viewport height top to bottom
+      height:             '100vh',
+      top:                '0',
+      'z-index':          101, // We want this to be above the main side menu
+      closeOnRouteChange: ['name', 'params', 'query'], // We want to ignore hash changes, tables in extensions can trigger the drawer to close while opening
+      triggerFocusTrap:   true,
+      returnFocusSelector,
+      schema,
+      cluster
+    }
+  }, { root: true });
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Partial fix for #14904

### Occurred changes and/or fixed issues
Just making our slideouts/drawers more consistent.

### Technical notes summary
I'm considering adding a drawer/open drawer/close commit to the slidein store which has some of the defaults already in place.

### Areas or cases that should be tested
Anywhere an explain drawer is present.

### Areas which could experience regressions
The explain drawer.

### Screenshot/Video
Old:

https://github.com/user-attachments/assets/0db43938-77ae-43c9-bb96-d531ea8ae4f2




New:

https://github.com/user-attachments/assets/0075e7c8-6654-4026-81e7-b131c7d46afe



### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
