### PR TITLE
fix: use harvester inStore to GET secret data when creating Flow on Harvester

### DIFF
--- a/shell/components/form/SecretSelector.vue
+++ b/shell/components/form/SecretSelector.vue
@@ -66,12 +66,9 @@ export default {
   },
 
   data() {
-    const validInStore = this.inStore || this.$store.getters['currentStore']() || 'cluster';
-
     return {
       secrets:            null,
       SECRET,
-      validInStore,
       allSecretsSettings: {
         updateResources: (secrets) => {
           const allSecretsInNamespace = secrets.filter((secret) => this.types.includes(secret._type) && secret.namespace === this.namespace);
@@ -130,6 +127,10 @@ export default {
         label: key,
         value: key
       }));
+    },
+
+    validInStore() {
+      return this.inStore || this.$store.getters['currentStore']() || 'cluster';
     },
 
     isView() {

--- a/shell/components/form/SecretSelector.vue
+++ b/shell/components/form/SecretSelector.vue
@@ -61,14 +61,17 @@ export default {
     },
     inStore: {
       type:    String,
-      default: 'cluster',
+      default: undefined,
     }
   },
 
   data() {
+    const validInStore = this.inStore || this.$store.getters['currentStore']() || 'cluster';
+
     return {
       secrets:            null,
       SECRET,
+      validInStore,
       allSecretsSettings: {
         updateResources: (secrets) => {
           const allSecretsInNamespace = secrets.filter((secret) => this.types.includes(secret._type) && secret.namespace === this.namespace);
@@ -221,7 +224,7 @@ export default {
         :label="secretNameLabel"
         :mode="mode"
         :resource-type="SECRET"
-        :in-store="inStore"
+        :in-store="validInStore"
         :paginated-resource-settings="paginateSecretsSetting"
         :all-resources-settings="allSecretsSettings"
       />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes # https://github.com/harvester/harvester/issues/6107

### Occurred changes and/or fixed issues
In harvester UI, there doesn't have `cluster` inStore that causes ResourceLabeledSelect.vue unable to fetch the secret data back.

Change the logic to use `harvester` inStore when using in harvester UI.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
Harvester create logging Flow 
<img width="1492" height="815" alt="Screenshot 2025-10-01 at 1 38 29 PM" src="https://github.com/user-attachments/assets/559e8877-f83d-4e79-a7c5-b78c3e3c75ad" />


Rancher create logging Flow
<img width="1496" height="645" alt="Screenshot 2025-10-01 at 1 23 03 PM" src="https://github.com/user-attachments/assets/3d10b183-49a6-450e-9c7b-d701c4d24933" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility

