### PR TITLE
Making it easier for a user to select a name to confirm deleting a resource

### DIFF
--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -384,6 +384,7 @@ export default {
           >
             <span
               v-clean-html="t('promptRemove.confirmName', { nameToMatch: escapeHtml(nameToMatch) }, true)"
+              class="confirm-text"
             />
           </div>
         </div>
@@ -471,6 +472,10 @@ export default {
       .spacer {
         flex: 1;
       }
+    }
+
+    .confirm-text b {
+      user-select: all;
     }
   }
 </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
When clicking on the cluster name it will now select the entire name.

Fixes #8825
<!-- Define findings related to the feature or bug issue. -->

Followed the suggestion mentioned here https://github.com/rancher/dashboard/issues/8825#issuecomment-3284624736

### Areas or cases that should be tested
The delete cluster prompt

### Areas which could experience regressions
The delete cluster prompt

### Screenshot/Video

https://github.com/user-attachments/assets/653e8806-a56f-4d23-ae87-38923c15ca94



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
