### PR TITLE
[2.12] Fixed adding a new machine pool to existing GCE instance

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -172,6 +172,8 @@ export default {
   },
 
   data() {
+    const isGoogle = this.provider === GOOGLE;
+
     if (!this.value.spec.rkeConfig) {
       this.value.spec.rkeConfig = {};
     }
@@ -270,7 +272,8 @@ export default {
       clusterAgentDefaultPC:                    null,
       clusterAgentDefaultPDB:                   null,
       activeTab:                                null,
-      isAuthenticated:                          this.provider !== GOOGLE || this.mode === _EDIT,
+      isGoogle,
+      isAuthenticated:                          !isGoogle || this.mode === _EDIT,
       projectId:                                null,
       REGISTRIES_TAB_NAME,
       labelForAddon,
@@ -1027,6 +1030,9 @@ export default {
 
       if (!this.machinePools) {
         await this.initMachinePools(this.value.spec.rkeConfig.machinePools);
+        if (this.isEdit && this.isGoogle && this.machinePools?.length > 0 && this.machinePools[0]?.config?.project) {
+          this.projectId = this.machinePools[0]?.config?.project;
+        }
         if (this.mode === _CREATE && !this.machinePools.length) {
           await this.addMachinePool();
         }
@@ -2219,7 +2225,7 @@ export default {
     </div>
     <AccountAccess
       v-if="!isAuthenticated"
-      v-model:credential="credential"
+      v-model:credential="credentialId"
       v-model:project="projectId"
       v-model:is-authenticated="isAuthenticated"
       :mode="mode"

--- a/shell/machine-config/components/GCEImage.vue
+++ b/shell/machine-config/components/GCEImage.vue
@@ -47,6 +47,10 @@ export default {
       type:     Object,
       required: true
     },
+    poolCreateMode: {
+      type:    Boolean,
+      default: true
+    },
     rules: {
       type:    Object,
       default: () => {
@@ -85,7 +89,7 @@ export default {
   },
   created() {
     this.debouncedLoadFamilies = debounce(this.getFamilies, 500);
-    if (this.mode !== _CREATE) {
+    if (!this.poolCreateMode) {
       this.imageProjects = `${ this.getProjectFromImage() }`;
     }
   },
@@ -110,9 +114,6 @@ export default {
         }
 
       };
-    },
-    isCreate() {
-      return this.mode === _CREATE;
     },
     project() {
       return this.value.project;
@@ -284,7 +285,7 @@ export default {
     async getImages(val) {
       this.loadingImages = true;
       try {
-        const isOriginal = !this.isCreate && this.machineImage === this.getImageNameFromImage(this.originalMachineImage);
+        const isOriginal = !this.poolCreateMode && this.machineImage === this.getImageNameFromImage(this.originalMachineImage);
 
         this.machineImages = await this.getImagesInProject(val, this.showDeprecated);
         // If we had to reload list of images, we need to reset selected image if it is no longer in the list,

--- a/shell/machine-config/google.vue
+++ b/shell/machine-config/google.vue
@@ -78,7 +78,11 @@ export default {
     disabled: {
       type:    Boolean,
       default: false
-    }
+    },
+    poolCreateMode: {
+      type:    Boolean,
+      default: true
+    },
   },
 
   async fetch() {
@@ -122,7 +126,7 @@ export default {
     };
   },
   created() {
-    if (this.mode === _CREATE) {
+    if (this.poolCreateMode) {
       this.$emit('validationChanged', false);
       this.value.project = this.projectId;
       for (const key in this.defaultConfig) {
@@ -156,7 +160,7 @@ export default {
     'value.setExternalFirewallRulePrefix'(neu) {
       if (!neu) {
         this.value.openPort = [];
-      } else if (this.isCreate) {
+      } else if (this.poolCreateMode) {
         this.value.openPort.push('6443');
       } else {
         this.value.openPort = this.originalOpenPort.length > 0 ? this.originalOpenPort : ['6443'];
@@ -333,7 +337,7 @@ export default {
 
         if (!cur ) {
           // If default is not actually available, reset
-          if (this.isCreate) {
+          if (this.poolCreateMode) {
             this.value.diskType = '';
           }
         } else {
@@ -447,6 +451,7 @@ export default {
         :originalMachineImage="originalMachineImage"
         :mode="mode"
         :location="location"
+        :pool-create-mode="poolCreateMode"
         :rules="{machineImage: fvGetAndReportPathRules('machineImage')}"
         @min-disk-changed="(val)=>minDiskFromImage=val"
         @error="(val)=>errors.push(val)"
@@ -493,7 +498,7 @@ export default {
           label-key="cluster.machineConfig.gce.network.label"
           :mode="mode"
           :options="networkOptions"
-          :disabled="!isCreate"
+          :disabled="!poolCreateMode"
           option-key="name"
           option-label="label"
           :loading="loadingNetworks"
@@ -507,7 +512,7 @@ export default {
           label-key="cluster.machineConfig.gce.subnetwork.label"
           :mode="mode"
           :options="subnetworkOptions"
-          :disabled="!isCreate"
+          :disabled="!poolCreateMode"
           option-key="name"
           option-label="name"
           :loading="loadingNetworks"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15447 
<!-- Define findings related to the feature or bug issue. -->
Backport of https://github.com/rancher/dashboard/pull/15446

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
