### PR TITLE
fix jwt auth tests p2

### DIFF
--- a/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
+++ b/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
@@ -8,7 +8,7 @@ const jwtAuthenticationPage = new JWTAuthenticationPagePo();
 
 // Go the JWT Authentication page and ensure the page is fully loaded
 function goToJWTAuthenticationPageAndSettle() {
-  cy.intercept('GET', '/v1/management.cattle.io.clusterproxyconfigs?*').as('fetchJWTAuthentication');
+  cy.intercept('GET', '/v1/management.cattle.io.clusterproxyconfigs*').as('fetchJWTAuthentication');
   jwtAuthenticationPage.goTo();
   jwtAuthenticationPage.waitForPage();
   cy.wait('@fetchJWTAuthentication');
@@ -30,7 +30,6 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
 
   before(() => {
     cy.login();
-    HomePagePo.goTo();
     cy.createE2EResourceName('rke2cluster0').as('rke2Ec2ClusterName0');
     cy.createE2EResourceName('rke2cluster1').as('rke2Ec2ClusterName1');
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1974

There's is a URL mismatch between VAI on/off environments (when calling `fetchJWTAuthentication` intercept). Jenkins CI runs with VAI disabled, causing a URL mismatch.

Expected: /v1/management.cattle.io.clusterproxyconfigs?pagesize=100000 (VAI on)
Actual: /v1/management.cattle.io.clusterproxyconfigs (VAI off)

Updated the intercept pattern to handle both query parameter variations. Tested fix in both VAI enabled and disabled environments.
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="1026" height="300" alt="image" src="https://github.com/user-attachments/assets/495ac06d-b4f8-49e5-94d2-c4dd2ad9d5fd" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
