### PR TITLE
Strip closing keywords from the body

### DIFF
--- a/.github/workflows/port-pr.yaml
+++ b/.github/workflows/port-pr.yaml
@@ -148,7 +148,7 @@ jobs:
               echo "Created temporary body file: ${BODY}"
               echo -e "This is an automated request to port PR #${ORIGINAL_ISSUE_NUMBER} by @${GITHUB_ACTOR}\n\n" > $BODY
               echo -e "Original PR body:\n\n" >> $BODY
-              CLEANED_BODY=$(echo "${ORIGINAL_PR}" | jq -r .body | sed -E 's/(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):?\s+([a-zA-Z0-9-]+\/[a-zA-Z0-9-.]*)?#[0-9]+\s*,?\s*//gI')
+              CLEANED_BODY=$(echo "${ORIGINAL_PR}" | jq -r .body | sed -E 's/(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):?\s+([a-zA-Z0-9-]+\/[a-zA-Z0-9-.]*)?#[0-9]+\s*,?\s*/Original text redacted by port-pr.yaml /gI'
               echo "${CLEANED_BODY}" >> $BODY
               if [ -n "$ISSUE_NUMBER" ]; then
                   echo -e "\n\nFixes #${ISSUE_NUMBER}" >> $BODY


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This attempts to strip closing keywords from the body of a backport PR.  

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Strip closing keywords from the body

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Previous attempts to prevent altering backport PR milestones haven't worked. I think that a straightforward approach will be to attempt removal of closing keywords from the PR body, this should stop the `.github/workflows/scripts/pr-gh-project.js` script from altering the milestone based on the linked issues.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Backporting PRs should no longer set the milestone to that of the original issue.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This change could inadvertently clobber the body of the backport PR in undefined ways.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
