### PR TITLE
Automation: fix WebSocket tests

### DIFF
--- a/cypress/e2e/tests/pages/explorer/dashboard/websockets/connection.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/dashboard/websockets/connection.spec.ts
@@ -64,22 +64,31 @@ describe('Pod management and WebSocket interaction', { tags: ['@jenkins', '@admi
 
   it('should create a new folder', () => {
     executeWebSocket('mkdir test-directory && echo "Directory created successfully"', podName, nsName, 'container-0', token).then((messages: any[]) => {
-      expect(messages[2]).not.to.equal(undefined);
-      expect(messages[2]).to.include('Directory created successfully');
+      // Find the message containing the success text
+      const successMessage = messages.find((msg) => msg && msg.includes('Directory created successfully'));
+
+      expect(successMessage).not.to.equal(undefined);
+      expect(successMessage).to.include('Directory created successfully');
     });
   });
 
   it('should validate the folder name', () => {
     executeWebSocket('ls', podName, nsName, 'container-0', token).then((messages: any[]) => {
-      expect(messages[2]).not.to.equal(undefined);
-      expect(messages[2]).to.include('test-directory');
+      // Find the message containing the directory listing
+      const lsMessage = messages.find((msg) => msg && msg.includes('test-directory'));
+
+      expect(lsMessage).not.to.equal(undefined);
+      expect(lsMessage).to.include('test-directory');
     });
   });
 
   it('should delete the folder', () => {
     executeWebSocket('rm -rf test-directory && echo "Directory deleted successfully"', podName, nsName, 'container-0', token).then((messages: any[]) => {
-      expect(messages[2]).not.to.equal(undefined);
-      expect(messages[2]).to.include('Directory deleted successfully');
+      // Find the message containing the deletion success text
+      const deleteMessage = messages.find((msg) => msg && msg.includes('Directory deleted successfully'));
+
+      expect(deleteMessage).not.to.equal(undefined);
+      expect(deleteMessage).to.include('Directory deleted successfully');
     });
   });
   after(() => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1941

Before: Tests were failing because they expected messages at a specific array index (messages[2]) which was often undefined
After: Tests now use messages.find() to search through all received messages for the expected content
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="449" height="204" alt="Screenshot 2025-10-08 at 9 11 21 PM" src="https://github.com/user-attachments/assets/00e78a1b-b913-4714-ab68-ee88089ebf90" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
