### PR TITLE
Migrate logout endpoint to `v1/logout`

### DIFF
--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -404,18 +404,18 @@ export const actions = {
     // Unload plugins - we will load again on login
     await rootState.$plugin.logout();
 
-    let logoutAction = 'logout';
+    let logoutAction = '';
     const data = {};
 
     // SLO - Single-sign logout - will logout auth provider from all places where it's logged in
     if (options.slo) {
-      logoutAction = 'logoutAll';
+      logoutAction = '?logoutAll';
       data.finalRedirectUrl = returnTo({ isSlo: true }, this);
     }
 
     try {
       const res = await dispatch('rancher/request', {
-        url:                  `/v3/tokens?action=${ logoutAction }`,
+        url:                  `/v1/logout${ logoutAction }`,
         method:               'post',
         data,
         headers:              { 'Content-Type': 'application/json' },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates the logout endpoint to `v1/logout`.

~Fixes # 15326~ 
Contributes to https://github.com/rancher/dashboard/issues/15326
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Migrate logout endpoint from `v3/tokens` to `v1/logout`
- Update the logout action to match the requirements for the new endpoint

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This appears to behave mostly the same as before - the biggest change is that there is no `logoutAction` for the base case. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Local & Auth Providers logout actions, including SLO.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Local & Auth Providers logout actions, including SLO.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
