### PR TITLE
Fixing an issue where we stopped showing the yaml editor when an error occurred

### DIFF
--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -481,7 +481,7 @@ export default {
     </div>
 
     <ResourceYaml
-      v-else-if="isYaml"
+      v-if="isYaml"
       ref="resourceyaml"
       :value="value"
       :mode="mode"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14728
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Changed one of the conditions so that we still show the editor even when an error is present.

### Areas or cases that should be tested
Verify edit config and edit yaml both function as expected when an error is present.

### Areas which could experience regressions
Same as above,

### Screenshot/Video


https://github.com/user-attachments/assets/0fb26d46-efc8-4d97-af8a-811d1f4622ae



<img width="1274" height="1305" alt="image" src="https://github.com/user-attachments/assets/ea281909-e6dc-4677-ac62-570c3dc8a7a9" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
