### PR TITLE
Automation: fix repositories test

### DIFF
--- a/cypress/e2e/po/components/sortable-table.po.ts
+++ b/cypress/e2e/po/components/sortable-table.po.ts
@@ -219,7 +219,20 @@ export default class SortableTablePo extends ComponentPo {
    */
   rowActionMenuOpen(name: string) {
     this.rowWithName(name).actionBtn()
-      .click();
+      .click().then((el) => {
+        expect(el).to.have.attr('aria-expanded', 'true');
+      });
+
+    return this.rowActionMenu();
+  }
+
+  rowActionMenuClose(name: string) {
+    this.rowWithName(name).actionBtn().then((el) => {
+      expect(el).to.have.attr('aria-expanded', 'true');
+    }).click()
+      .then((el) => {
+        expect(el).to.have.attr('aria-expanded', 'false');
+      });
 
     return this.rowActionMenu();
   }

--- a/cypress/e2e/po/lists/base-resource-list.po.ts
+++ b/cypress/e2e/po/lists/base-resource-list.po.ts
@@ -18,6 +18,10 @@ export default class BaseResourceList extends ComponentPo {
     return this.resourceTable().sortableTable().rowActionMenuOpen(rowLabel);
   }
 
+  actionMenuClose(rowLabel: string) {
+    return this.resourceTable().sortableTable().rowActionMenuClose(rowLabel);
+  }
+
   rowWithName(rowLabel: string) {
     return this.resourceTable().sortableTable().rowWithName(rowLabel);
   }

--- a/cypress/e2e/po/lists/chart-repositories.po.ts
+++ b/cypress/e2e/po/lists/chart-repositories.po.ts
@@ -4,14 +4,6 @@ import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
  * List component for catalog.cattle.io.clusterrepo resources
  */
 export default class ChartRepositoriesListPo extends BaseResourceList {
-  actionMenu(repoName: string) {
-    return this.resourceTable().sortableTable().rowActionMenuOpen(repoName);
-  }
-
-  closeActionMenu() {
-    cy.get('body').type('{esc}');
-  }
-
   openBulkActionDropdown() {
     return this.resourceTable().sortableTable().bulkActionDropDownOpen();
   }

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -120,6 +120,7 @@ declare global {
       waitForRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, testFn: (resp: any) => boolean, retries?: number, config?: {failOnStatusCode?: boolean}): Chainable;
       waitForRancherResources(prefix: 'v3' | 'v1', resourceType: string, expectedResourcesTotal: number, greaterThan?: boolean): Chainable;
       waitForRepositoryDownload(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, retries?: number): Chainable;
+      waitForResourceState(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, resourceState?: string, retries?: number): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1' | 'k8s', resourceType: string, resourceId: string, failOnStatusCode?: boolean): Chainable;
       getClusterIdByName(clusterName: string): Chainable<string>;
       deleteNodeTemplate(nodeTemplateId: string, timeout?: number, failOnStatusCode?: boolean)

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -595,6 +595,17 @@ Cypress.Commands.add('waitForRepositoryDownload', (prefix, resourceType, resourc
 });
 
 /**
+ * Wait for repository to be state
+ */
+Cypress.Commands.add('waitForResourceState', (prefix, resourceType, resourceId, resourceState = 'active', retries = 20) => {
+  return cy.waitForRancherResource(prefix, resourceType, resourceId, (resp) => {
+    const state = resp.body.metadata?.state;
+
+    return state && state.transitioning === false && state.name === resourceState;
+  }, retries);
+});
+
+/**
  * delete a node template
  */
 Cypress.Commands.add('deleteNodeTemplate', (nodeTemplateId, timeout = 30000, failOnStatusCode = false) => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2053

Fixes flaky repository tests:
- Replaced closeActionMenu() escape key method with proper rowActionMenuClose() that validates aria-expanded state
- Added cy.waitForRepositoryDownload() and cy.waitForResourceState() to replace arbitrary waits
- Simplified deletion logic using cy.deleteRancherResource() and removed redundant methods

<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
