### PR TITLE
fix side nav highlight test

### DIFF
--- a/cypress/e2e/po/side-bars/product-side-nav.po.ts
+++ b/cypress/e2e/po/side-bars/product-side-nav.po.ts
@@ -95,7 +95,7 @@ export default class ProductNavPo extends ComponentPo {
    * Active navigation item
    */
   activeNavItem() {
-    return this.groups().get('.router-link-active').should('exist').invoke('text')
+    return this.groups().find('.router-link-active').should('exist').invoke('text')
       .then((s) => s.trim());
   }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2045

Changed the selector method from .get() to .find() in the activeNavItem() method to ensure the method correctly extracts only the navigation item text.
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="285" height="285" alt="Screenshot 2025-10-14 at 3 45 29 PM" src="https://github.com/user-attachments/assets/263d605e-e826-4acd-ba66-91fbefb7a20a" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
