### PR TITLE
Ensure Compliance --> Profile list loads when profiles contain `skipTests: []`

### DIFF
--- a/shell/models/__tests__/compliance.cattle.io.clusterscanprofile.spec.js
+++ b/shell/models/__tests__/compliance.cattle.io.clusterscanprofile.spec.js
@@ -1,0 +1,30 @@
+import ComplianceProfile from '@shell/models/compliance.cattle.io.clusterscanprofile';
+
+describe('class: ComplianceProfile', () => {
+  describe('getter: numberTestsSkipped', () => {
+    it('should return 0 if skipTests is not present in spec', () => {
+      const complianceProfile = new ComplianceProfile({ spec: {} });
+
+      expect(complianceProfile.numberTestsSkipped).toBe(0);
+    });
+
+    it('should return 0 if skipTests is null', () => {
+      const complianceProfile = new ComplianceProfile({ spec: { skipTests: null } });
+
+      expect(complianceProfile.numberTestsSkipped).toBe(0);
+    });
+
+    it('should return 0 if skipTests is an empty array', () => {
+      const complianceProfile = new ComplianceProfile({ spec: { skipTests: [] } });
+
+      expect(complianceProfile.numberTestsSkipped).toBe(0);
+    });
+
+    it('should return the correct number of skipped tests', () => {
+      const tests = ['test-1', 'test-2', 'test-3'];
+      const complianceProfile = new ComplianceProfile({ spec: { skipTests: tests } });
+
+      expect(complianceProfile.numberTestsSkipped).toBe(tests.length);
+    });
+  });
+});

--- a/shell/models/compliance.cattle.io.clusterscanprofile.js
+++ b/shell/models/compliance.cattle.io.clusterscanprofile.js
@@ -11,7 +11,7 @@ export default class ComplianceProfile extends SteveModel {
   get numberTestsSkipped() {
     const { skipTests = [] } = this.spec;
 
-    return skipTests.length;
+    return skipTests?.length || 0;
   }
 
   get benchmarkVersionLink() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15389
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- vai can report profiles with `skipTests: []` as `skipTests: null`
  - this is a general bug for BE to fix - https://github.com/rancher/rancher/issues/52357
- we should make this null safe though


### Areas or cases that should be tested
as per issue

### Areas which could experience regressions
display of tests skipped in Compliance --> Profiles list

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
