### PR TITLE
Ensure build-extension-charts runs that create PRs have GH_TOKEN set

### DIFF
--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -91,6 +91,8 @@ jobs:
       - name: Run build script
         shell: bash
         id: build_script
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           publish="yarn publish-pkgs -s ${{ github.repository }} -b ${{ inputs.target_branch }}"
 


### PR DESCRIPTION
### Occurred changes and/or fixed issues
- extension repos will use the `.github/workflows/build-extension-charts.yml` workflow to build extension helm charts
- some will pass in `create_pr` which creates a PR with the changes instead of pushing directly to a branch
- the step that does this `Run build script` currently fails due to a missing GH_TOKEN env var - https://github.com/rancher/ui-plugin-examples/actions/runs/18319242795/job/52167913911
- set the GH_TOKEN env as per the `Parse Extension Name` step above


### Technical notes summary
- Future Attempt 1
  - if this fails we should make sure the permissions are correct in `build-extension-charts.yml`
    - `pull-requests: write`
- Future Attempt 2
  - if that also fails we should pass in that calling repo's secret.
    -  calling repo's `build-extension-charts.yml` --> secrets: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    -  dashboard's `build-extension-charts.yml` --> secrets: CALLER_GH_TOKEN: required: false
    -  dashboard's `build-extension-charts.yml` --> step --> env: GH_TOKEN: ${{ secrets.CALLER_GH_TOKEN }}


https://github.com/rancher/dashboard `plugin-examples-build-fix`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
