### PR TITLE
Ensure PolicyRuleTarget updates in prod builds

### DIFF
--- a/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/PolicyRuleTarget.vue
@@ -149,25 +149,35 @@ export default {
   },
   watch: {
     namespace: {
-      handler:   'debouncedUpdateMatches',
+      handler() {
+        this.debouncedUpdateMatches();
+      },
       immediate: true
     },
     'value.podSelector': {
-      handler:   'debouncedUpdateMatches',
+      handler() {
+        this.debouncedUpdateMatches();
+      },
       immediate: true
     },
     'value.namespaceSelector': {
-      handler:   'debouncedUpdateMatches',
+      handler() {
+        this.debouncedUpdateMatches();
+      },
       immediate: true
     },
     'value.ipBlock.cidr':   'validateCIDR',
     'value.ipBlock.except': 'validateCIDR',
     podSelectorExpressions: {
-      handler:   'debouncedUpdateMatches',
+      handler() {
+        this.debouncedUpdateMatches();
+      },
       immediate: true
     },
     namespaceSelectorExpressions: {
-      handler:   'debouncedUpdateMatches',
+      handler() {
+        this.debouncedUpdateMatches();
+      },
       immediate: true
     }
   },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15652
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- vue watch -->  `handler:   'debouncedUpdateMatches'`, --> `debouncedUpdateMatches: debounce(this.updateMatches, 500)` seems broken in prod... but not dev
  -> `yarn dev` --> fine
  -> `yarn start:prod` --> fail
- fix is just to unwrap it

### Technical notes summary
  - `handler:   debounce(this.updateMatches, 500),` would have been neater, however fails with  `this` issues
  - `handler:   'updateMatches',` ==> works interestingly works, so it's just scenarios where a debounced function is stored as a variable. i've had a look where this happens and the file in the PR is the only one

### Areas or cases that should be tested
Setup
Create a namespace and give it a unique name + label (for example `aaa`:`aaa`). Create a pod in that namespace and give it a unique label (for example `bbb`:`bbb`

- Policy --> Network Policies --> Create
- Ingress Rules --> check `Configure ingress rules to restrict incoming traffic`
- click `+` --> click `Add allowed traffic source`
- Test each of the following. After entering the required label key value the text showing selected resources should contain correct values
  - Namespace Label Selector
  - Pod Label Selector
  - Namespace/Pod Label Selector

### Areas which could experience regressions
- no other area should be affected

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
