### PR TITLE
Automation: fix kubewarden test

### DIFF
--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -94,6 +94,8 @@ export default class ExtensionsPagePo extends PagePo {
     appRepoCreate.saveAndWaitForRequests('POST', CLUSTER_REPOS_BASE_URL);
 
     appRepoList.waitForPage();
+    cy.waitForRepositoryDownload('v1', 'catalog.cattle.io.clusterrepos', name);
+    cy.waitForResourceState('v1', 'catalog.cattle.io.clusterrepos', name);
     appRepoList.list().state(name).should('contain', 'Active');
 
     return cy.wrap(appRepoList.list());


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2068 

This PR resolves flaky Kubewarden extension tests by adding `waitForRepositoryDownload` and `waitForResourceState` to ensure the extension repo is fully downloaded and ready before installation attempts.
<!-- Define findings related to the feature or bug issue. -->


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
