### PR TITLE
Add CRD support to kubectl-explain drawer

### DIFF
--- a/pkg/kubectl-explain/components/ExplainPanel.vue
+++ b/pkg/kubectl-explain/components/ExplainPanel.vue
@@ -161,7 +161,7 @@ export default {
             v-else
             class="field-type"
           >
-            {{ t('kubectl-explain.object') }}
+            {{ field.type === 'array' && field.items?.type ? field.items.type : t('kubectl-explain.object') }}
           </div>
         </div>
       </div>

--- a/pkg/kubectl-explain/components/ExplainPanel.vue
+++ b/pkg/kubectl-explain/components/ExplainPanel.vue
@@ -119,7 +119,7 @@ export default {
           </a>
         </div>
         <div
-          v-if="field.type && field.type !== 'array'"
+          v-if="field.type && field.type !== 'array' && !field.$refName"
           class="field-type"
         >
           <div>

--- a/pkg/kubectl-explain/components/SlideInPanel.vue
+++ b/pkg/kubectl-explain/components/SlideInPanel.vue
@@ -84,7 +84,9 @@ export default {
     },
 
     scrollTop() {
-      this.$refs.main.$el.scrollTop = 0;
+      if (this.$refs.main?.$el) {
+        this.$refs.main.$el.scrollTop = 0;
+      }
     },
 
     addCloseKeyHandler() {

--- a/pkg/kubectl-explain/open-api-utils.ts
+++ b/pkg/kubectl-explain/open-api-utils.ts
@@ -6,6 +6,11 @@ type OpenApIDefinitions = {
   [name: string]: OpenApIDefinition;
 };
 
+type Breadcrumb = {
+  name: string;
+  id: string;
+};
+
 // Regex for more info in descriptions
 // Some kube docs use a common pattern for a URL with more info - we extract these and show a link icon, rather than clogging up the UI
 // with a long URL - this makes it easier to read
@@ -71,7 +76,7 @@ export function makeOpenAPIBreadcrumb(id: string): any {
  * @param definition Definition to expand
  * @param breadcrumbs Current breadcrumbs to use as a breadcrumb path to the definition
  */
-export function expandOpenAPIDefinition(definitions: OpenApIDefinitions, definition: OpenApIDefinition, breadcrumbs = []): void {
+export function expandOpenAPIDefinition(definitions: OpenApIDefinitions, definition: OpenApIDefinition, breadcrumbs: Breadcrumb[] = []): void {
   Object.keys(definition?.properties || {}).forEach((propName) => {
     const prop = definition.properties[propName];
     const propRef = prop.$ref || prop.items?.$ref;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes [#15249](https://github.com/rancher/dashboard/issues/15249)
<!-- Define findings related to the feature or bug issue. -->

this change adds support for displaying CRDs fields definition similar to what is already done for native resources.  
It also fixes the kind displayed for fields like `pod.spec.containers.args` which are `[]string` but the UI previously showed `[]Object`

I tested manually with a few CRDs (see video below)

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

before:

https://github.com/user-attachments/assets/f5d5b5aa-d766-4506-9314-999cc60e188c

after:


https://github.com/user-attachments/assets/25fa94d4-e5b8-4a78-99a8-81e58fe6e56e




### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
