### PR TITLE
fix: warning banner content color is not obvious in dark theme

### DIFF
--- a/shell/assets/styles/themes/_modern.scss
+++ b/shell/assets/styles/themes/_modern.scss
@@ -1058,7 +1058,7 @@ BODY, .theme-dark {
   --rc-disabled-text-color: #{$gray004};
 
   --error-text    : #FFAC99;
-  --warning-text  : #{contrast-color($warning)};;
+  --warning-text  : #{contrast-color($warning)};
 
   --success-badge     : #{rgba($success, 10%)};
   --on-success-banner : #00B752;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15169 


### Occurred changes and/or fixed issues
Previous [PR](https://github.com/rancher/dashboard/pull/15625) changed warning-text color to black to make warning button obvious, but it makes warning banner text not obvious in dark theme.


~~Remove `.warning .banner__content` color css~~
Update -warning-banner-text and --error-banner-text color schema in dark/light theme.


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
Before
<img width="1496" height="819" alt="Screenshot 2025-10-20 at 3 02 42 PM" src="https://github.com/user-attachments/assets/d0ca987f-876a-4dd6-82f5-71984b5f4266" />


After
<img width="1488" height="811" alt="Screenshot 2025-10-20 at 3 13 55 PM" src="https://github.com/user-attachments/assets/e06996ac-3f0f-478b-912f-8704e97e441b" />

<img width="1463" height="801" alt="image" src="https://github.com/user-attachments/assets/b986ed1d-702d-4de1-8e3d-aeab84c98371" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
