### PR TITLE
Replace a modal resize hack with usage of the action-menu store.

### DIFF
--- a/shell/dialog/RollbackWorkloadDialog.vue
+++ b/shell/dialog/RollbackWorkloadDialog.vue
@@ -165,12 +165,9 @@ export default {
       return option.label;
     },
     sizeDialog() {
-      const dialogs = document.getElementsByClassName('modal-container');
-      const width = this.showDiff ? '85%' : '600px';
+      const modalWidth = this.showDiff ? '85%' : '600px';
 
-      if (dialogs.length === 1) {
-        dialogs[0].style.setProperty('width', width);
-      }
+      this.$store.commit('action-menu/updateModalData', [{ key: 'modalWidth', value: modalWidth }]);
     },
     sanitizeYaml(obj, path = '') {
       const res = {};

--- a/shell/store/action-menu.js
+++ b/shell/store/action-menu.js
@@ -111,6 +111,14 @@ export const mutations = {
     state.modalData = data;
   },
 
+  updateModalData(state, data) {
+    state.modalData = state.modalData || {};
+
+    data.forEach(({ key, value }) => {
+      state.modalData[key] = value;
+    });
+  },
+
   clearCallbackData(state) {
     state.performCallbackData = undefined;
   },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
**Note: this is for 2.14.**

Fixes #10559
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
We were hackily modifying the width of a modal dialog. This uses our existing action-menu store responsible for managing the state of the modals to update the width of the modal which is already reactive.

### Areas or cases that should be tested
WorkloadRollbackDialog when switching toggling between show/hide diff.

### Areas which could experience regressions
WorkloadRollbackDialog when switching toggling between show/hide diff.

### Screenshot/Video

https://github.com/user-attachments/assets/2bdd783b-990d-45e4-b555-107d9e0b2ef4



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
