### PR TITLE
Adds the ability to open a drawer and navigate to a tab

### DIFF
--- a/shell/components/Drawer/ResourceDetailDrawer/ConfigTab.vue
+++ b/shell/components/Drawer/ResourceDetailDrawer/ConfigTab.vue
@@ -8,6 +8,7 @@ export interface Props {
   resource: any;
   component: any;
   resourceType: string;
+  defaultTab?: string;
 }
 </script>
 <script setup lang="ts">
@@ -31,6 +32,7 @@ const i18n = useI18n(store);
         :real-mode="_VIEW"
         :initial-value="props.resource"
         :use-tabbed-hash="false /* Have to disable hashing on child components or it modifies the url and closes the drawer */"
+        :default-tab="props.defaultTab"
         as="config"
       />
     </div>

--- a/shell/components/Drawer/ResourceDetailDrawer/index.vue
+++ b/shell/components/Drawer/ResourceDetailDrawer/index.vue
@@ -12,7 +12,7 @@ import StateDot from '@shell/components/StateDot/index.vue';
 
 export interface Props {
   resource: any;
-
+  defaultTab?: string;
   onClose?: () => void;
 }
 </script>
@@ -85,6 +85,7 @@ const canEdit = computed(() => {
         <ConfigTab
           v-if="configTabProps"
           v-bind="configTabProps"
+          :default-tab="props.defaultTab"
         />
         <YamlTab
           v-if="yamlTabProps"

--- a/shell/components/Resource/Detail/Metadata/Annotations/index.vue
+++ b/shell/components/Resource/Detail/Metadata/Annotations/index.vue
@@ -8,7 +8,7 @@ export type Annotation = Row;
 export interface AnnotationsProps {
   annotations: Annotation[];
 
-  onShowConfiguration?: (returnFocusSelector: string) => void;
+  onShowConfiguration?: (returnFocusSelector: string, defaultTab: string) => void;
 }
 
 </script>
@@ -26,6 +26,6 @@ const i18n = useI18n(store);
     :rows="annotations"
     type="active"
 
-    @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector)"
+    @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector, 'labels-and-annotations')"
   />
 </template>

--- a/shell/components/Resource/Detail/Metadata/Labels/index.vue
+++ b/shell/components/Resource/Detail/Metadata/Labels/index.vue
@@ -8,7 +8,7 @@ export type Label = Row;
 export interface LabelsProps {
     labels: Label[];
 
-    onShowConfiguration?: (returnFocusSelector: string) => void;
+    onShowConfiguration?: (returnFocusSelector: string, defaultTab: string) => void;
 }
 
 </script>
@@ -27,6 +27,6 @@ const i18n = useI18n(store);
     :propertyName="i18n.t('component.resource.detail.metadata.labels.title')"
     :rows="labels"
     type="active"
-    @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector)"
+    @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector, 'labels-and-annotations')"
   />
 </template>

--- a/shell/components/Resource/Detail/Metadata/composables.ts
+++ b/shell/components/Resource/Detail/Metadata/composables.ts
@@ -36,7 +36,7 @@ export const useDefaultMetadataProps = (resource: any, additionalIdentifyingInfo
       identifyingInformation: identifyingInformation.value,
       labels:                 basicMetaData.value.labels,
       annotations:            basicMetaData.value.annotations,
-      onShowConfiguration:    (returnFocusSelector: string) => resourceValue.showConfiguration(returnFocusSelector)
+      onShowConfiguration:    (returnFocusSelector: string, defaultTab?: string) => resourceValue.showConfiguration(returnFocusSelector, defaultTab)
     };
   });
 };
@@ -71,7 +71,7 @@ export const useDefaultMetadataForLegacyPagesProps = (resource: any) => {
       identifyingInformation: identifyingInformation.value,
       labels:                 basicMetaData.value.labels,
       annotations:            basicMetaData.value.annotations,
-      onShowConfiguration:    (returnFocusSelector?: string) => resourceValue.showConfiguration(returnFocusSelector)
+      onShowConfiguration:    (returnFocusSelector?: string, defaultTab?: string) => resourceValue.showConfiguration(returnFocusSelector, defaultTab)
     };
   });
 };

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -48,7 +48,7 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
         type="active"
         :rows="[]"
         :propertyName="i18n.t('component.resource.detail.metadata.labelsAndAnnotations')"
-        @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector)"
+        @show-configuration="(returnFocusSelector: string, defaultTab: string) => emit('show-configuration', returnFocusSelector, defaultTab)"
       />
     </div>
     <!-- I'm not using v-else here so I can maintain the spacing correctly with the other columns in other rows. -->
@@ -58,7 +58,7 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
     >
       <Labels
         :labels="labels"
-        @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector)"
+        @show-configuration="(returnFocusSelector: string, defaultTab: string) => emit('show-configuration', returnFocusSelector, defaultTab)"
       />
     </div>
     <div
@@ -67,7 +67,7 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
     >
       <Annotations
         :annotations="annotations"
-        @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector)"
+        @show-configuration="(returnFocusSelector: string, defaultTab: string) => emit('show-configuration', returnFocusSelector, defaultTab)"
       />
     </div>
   </SpacedRow>

--- a/shell/edit/autoscaling.horizontalpodautoscaler/index.vue
+++ b/shell/edit/autoscaling.horizontalpodautoscaler/index.vue
@@ -209,6 +209,7 @@ export default {
       <Tabbed
         :side-tabs="true"
         :use-hash="useTabbedHash"
+        :default-tab="defaultTab"
       >
         <Tab
           name="target"

--- a/shell/edit/configmap.vue
+++ b/shell/edit/configmap.vue
@@ -111,6 +111,7 @@ export default {
     <Tabbed
       :side-tabs="true"
       :use-hash="useTabbedHash"
+      :default-tab="defaultTab"
     >
       <Tab
         name="data"

--- a/shell/edit/constraints.gatekeeper.sh.constraint/index.vue
+++ b/shell/edit/constraints.gatekeeper.sh.constraint/index.vue
@@ -278,6 +278,8 @@ export default {
       <Tabbed
         :side-tabs="true"
         :use-hash="useTabbedHash"
+        :default-tab="defaultTab"
+
         @changed="onTabChanged"
       >
         <Tab

--- a/shell/edit/helm.cattle.io.projecthelmchart.vue
+++ b/shell/edit/helm.cattle.io.projecthelmchart.vue
@@ -143,6 +143,7 @@ export default {
           ref="tabs"
           :side-tabs="true"
           :use-hash="useTabbedHash"
+          :default-tab="defaultTab"
         >
           <Questions
             v-model:value="value.spec.values"

--- a/shell/edit/k8s.cni.cncf.io.networkattachmentdefinition.vue
+++ b/shell/edit/k8s.cni.cncf.io.networkattachmentdefinition.vue
@@ -74,6 +74,7 @@ export default {
       class="mt-15"
       :side-tabs="true"
       :use-hash="useTabbedHash"
+      :default-tab="defaultTab"
     >
       <Tab
         name="basics"

--- a/shell/edit/logging-flow/index.vue
+++ b/shell/edit/logging-flow/index.vue
@@ -405,6 +405,8 @@ export default {
     <Tabbed
       :side-tabs="true"
       :use-hash="useTabbedHash"
+      :default-tab="defaultTab"
+
       @changed="tabChanged($event)"
     >
       <Tab

--- a/shell/edit/logging.banzaicloud.io.output/index.vue
+++ b/shell/edit/logging.banzaicloud.io.output/index.vue
@@ -212,6 +212,8 @@ export default {
         ref="tabbed"
         :side-tabs="true"
         :use-hash="useTabbedHash"
+        :default-tab="defaultTab"
+
         @changed="tabChanged($event)"
       >
         <Tab

--- a/shell/edit/management.cattle.io.fleetworkspace.vue
+++ b/shell/edit/management.cattle.io.fleetworkspace.vue
@@ -199,7 +199,7 @@ export default {
 
     <Tabbed
       :side-tabs="true"
-      default-tab="members"
+      :default-tab="defaultTab || 'members'"
       :use-hash="useTabbedHash"
     >
       <!-- <Tab name="members" label-key="generic.members" :weight="2">

--- a/shell/edit/management.cattle.io.project.vue
+++ b/shell/edit/management.cattle.io.project.vue
@@ -198,6 +198,7 @@ export default {
     <Tabbed
       :side-tabs="true"
       :use-hash="useTabbedHash"
+      :default-tab="defaultTab"
     >
       <Tab
         v-if="canViewMembers"

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
@@ -204,7 +204,10 @@ export default {
       @input="$emit('input', $event)"
     />
 
-    <Tabbed :use-hash="useTabbedHash">
+    <Tabbed
+      :use-hash="useTabbedHash"
+      :default-tab="defaultTab"
+    >
       <Tab
         :label="t('monitoring.route.label')"
         :weight="1"

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/receiverConfig.vue
@@ -313,8 +313,9 @@ export default {
     <Tabbed
       ref="tabbed"
       :side-tabs="true"
-      default-tab="overview"
+      :default-tab="defaultTab || 'overview'"
       :use-hash="useTabbedHash"
+
       @changed="tabChanged"
     >
       <Tab

--- a/shell/edit/monitoring.coreos.com.prometheusrule/index.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/index.vue
@@ -155,6 +155,8 @@ export default {
         :side-tabs="true"
         :show-tabs-add-remove="mode !== 'view'"
         :use-hash="useTabbedHash"
+        :default-tab="defaultTab"
+
         @addTab="addRuleGroup"
         @removeTab="removeGroupRule"
       >

--- a/shell/edit/monitoring.coreos.com.receiver/index.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/index.vue
@@ -218,8 +218,9 @@ export default {
     <Tabbed
       ref="tabbed"
       :side-tabs="true"
-      default-tab="overview"
+      :default-tab="defaultTab || 'overview'"
       :use-hash="useTabbedHash"
+
       @changed="tabChanged"
     >
       <Tab

--- a/shell/edit/monitoring.coreos.com.route.vue
+++ b/shell/edit/monitoring.coreos.com.route.vue
@@ -102,7 +102,7 @@ export default {
     <Tabbed
       ref="tabbed"
       :side-tabs="true"
-      default-tab="overview"
+      :default-tab="defaultTab || 'overview'"
       :use-hash="useTabbedHash"
     >
       <Tab

--- a/shell/edit/namespace.vue
+++ b/shell/edit/namespace.vue
@@ -203,6 +203,8 @@ export default {
       :mode="mode"
       :side-tabs="true"
       :use-hash="useTabbedHash"
+      :default-tab="defaultTab"
+
       @update:value="$emit('input', $event)"
     >
       <Tab

--- a/shell/edit/networking.istio.io.destinationrule/index.vue
+++ b/shell/edit/networking.istio.io.destinationrule/index.vue
@@ -69,6 +69,7 @@ export default {
       <Tabbed
         :side-tabs="true"
         :use-hash="useTabbedHash"
+        :default-tab="defaultTab"
       >
         <Tab
           name="subsets"

--- a/shell/edit/networking.k8s.io.ingress/index.vue
+++ b/shell/edit/networking.k8s.io.ingress/index.vue
@@ -229,6 +229,7 @@ export default {
     <Tabbed
       :side-tabs="true"
       :use-hash="useTabbedHash"
+      :default-tab="defaultTab"
     >
       <Tab
         :label="firstTabLabel"

--- a/shell/edit/networking.k8s.io.networkpolicy/PolicyRules.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/PolicyRules.vue
@@ -59,6 +59,8 @@ export default {
           :side-tabs="true"
           :show-tabs-add-remove="mode !== 'view'"
           :use-hash="useTabbedHash"
+          :default-tab="defaultTab"
+
           @addTab="addPolicyRule"
           @removeTab="removePolicyRule"
         >

--- a/shell/edit/networking.k8s.io.networkpolicy/index.vue
+++ b/shell/edit/networking.k8s.io.networkpolicy/index.vue
@@ -178,6 +178,7 @@ export default {
         <Tabbed
           :side-tabs="true"
           :use-hash="useTabbedHash"
+          :default-tab="defaultTab"
         >
           <Tab
             name="ingress"

--- a/shell/edit/node.vue
+++ b/shell/edit/node.vue
@@ -51,6 +51,8 @@ export default {
       :value="value"
       :mode="mode"
       :use-hash="useTabbedHash"
+      :default-tab="defaultTab"
+
       @update:value="$emit('input', $event)"
     >
       <Tab

--- a/shell/edit/persistentvolume/index.vue
+++ b/shell/edit/persistentvolume/index.vue
@@ -280,6 +280,7 @@ export default {
     <Tabbed
       :side-tabs="true"
       :use-hash="useTabbedHash"
+      :default-tab="defaultTab"
     >
       <Tab
         name="plugin-configuration"

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2369,6 +2369,8 @@ export default {
           :side-tabs="true"
           class="min-height"
           :use-hash="useTabbedHash"
+          :default-tab="defaultTab"
+
           @changed="handleTabChange"
         >
           <Tab

--- a/shell/edit/secret/index.vue
+++ b/shell/edit/secret/index.vue
@@ -485,7 +485,7 @@ export default {
         v-else
         :side-tabs="true"
         :use-hash="useTabbedHash"
-        default-tab="data"
+        :default-tab="defaultTab || 'data'"
       >
         <Tab
           name="data"

--- a/shell/edit/service.vue
+++ b/shell/edit/service.vue
@@ -347,6 +347,7 @@ export default {
     <Tabbed
       :side-tabs="true"
       :use-hash="useTabbedHash"
+      :default-tab="defaultTab"
     >
       <Tab
         v-if="checkTypeIs('ExternalName')"

--- a/shell/edit/serviceaccount.vue
+++ b/shell/edit/serviceaccount.vue
@@ -145,6 +145,7 @@ export default {
     <Tabbed
       :side-tabs="true"
       :use-hash="useTabbedHash"
+      :default-tab="defaultTab"
     >
       <Tab
         name="data"

--- a/shell/edit/storage.k8s.io.storageclass/index.vue
+++ b/shell/edit/storage.k8s.io.storageclass/index.vue
@@ -240,6 +240,7 @@ export default {
     <Tabbed
       :side-tabs="true"
       :use-hash="useTabbedHash"
+      :default-tab="defaultTab"
     >
       <Tab
         name="parameters"

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -155,6 +155,7 @@ export default {
         :default-tab="defaultTab"
         :flat="true"
         :use-hash="useTabbedHash"
+
         data-testid="workload-horizontal-tabs"
         @changed="changed"
       >
@@ -171,6 +172,7 @@ export default {
             :weight="99"
             :data-testid="`workload-container-tabs-${i}`"
             :use-hash="useTabbedHash"
+            :default-tab="defaultTab"
           >
             <Tab
               :label="t('workload.container.titles.general')"
@@ -368,6 +370,7 @@ export default {
             data-testid="workload-general-tabs"
             :side-tabs="true"
             :use-hash="useTabbedHash"
+            :default-tab="defaultTab"
           >
             <Tab
               name="labels"
@@ -410,6 +413,7 @@ export default {
             data-testid="workload-pod-tabs"
             :side-tabs="true"
             :use-hash="useTabbedHash"
+            :default-tab="defaultTab"
           >
             <Tab
               :label="t('workload.storage.title')"

--- a/shell/mixins/create-edit-view/index.js
+++ b/shell/mixins/create-edit-view/index.js
@@ -48,6 +48,11 @@ export default defineComponent({
     useTabbedHash: {
       type:    Boolean,
       default: undefined
+    },
+
+    defaultTab: {
+      type:    String,
+      default: undefined
     }
   },
 });

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -906,7 +906,7 @@ export default class Resource {
     return out;
   }
 
-  showConfiguration(returnFocusSelector) {
+  showConfiguration(returnFocusSelector, defaultTab) {
     const onClose = () => this.$ctx.commit('slideInPanel/close', undefined, { root: true });
 
     this.$ctx.commit('slideInPanel/open', {
@@ -921,7 +921,8 @@ export default class Resource {
         'z-index':          101, // We want this to be above the main side menu
         closeOnRouteChange: ['name', 'params', 'query'], // We want to ignore hash changes, tables in extensions can trigger the drawer to close while opening
         triggerFocusTrap:   true,
-        returnFocusSelector
+        returnFocusSelector,
+        defaultTab
       }
     }, { root: true });
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14545

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Changes how we select the default tab and adds the plumbing to allow ancestors components to provide the initial tab.

### Technical notes summary
I did create a more concise version which uses inject/provide but it was requested that we use this version instead. https://github.com/rancher/dashboard/pull/15686#discussion_r2547217355

### Areas or cases that should be tested
Places that have default tabs and the show configuration mechanism

### Areas which could experience regressions
See above - All edit pages could also technically have issues.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
[Screencast_20251120_110910.webm](https://github.com/user-attachments/assets/81e42142-85b9-4773-a575-b8e403ee87ef)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
