### PR TITLE
Adds the ability to open a drawer and navigate to a tab on open

### DIFF
--- a/shell/components/Drawer/ResourceDetailDrawer/ConfigTab.vue
+++ b/shell/components/Drawer/ResourceDetailDrawer/ConfigTab.vue
@@ -4,10 +4,13 @@ import { _VIEW } from '@shell/config/query-params';
 import { useStore } from 'vuex';
 import Tab from '@shell/components/Tabbed/Tab.vue';
 import { ConfigProps } from '@shell/components/Drawer/ResourceDetailDrawer/types';
+import { provide } from 'vue';
 
 const props = defineProps<ConfigProps>();
 const store = useStore();
 const i18n = useI18n(store);
+
+provide('default-tab', props.defaultTab);
 </script>
 <template>
   <Tab

--- a/shell/components/Drawer/ResourceDetailDrawer/index.vue
+++ b/shell/components/Drawer/ResourceDetailDrawer/index.vue
@@ -79,6 +79,7 @@ const canEdit = computed(() => {
         <ConfigTab
           v-if="configTabProps"
           v-bind="configTabProps"
+          :defaultTab="props.defaultTab"
         />
         <YamlTab
           v-if="yamlTabProps"

--- a/shell/components/Drawer/ResourceDetailDrawer/types.ts
+++ b/shell/components/Drawer/ResourceDetailDrawer/types.ts
@@ -7,10 +7,12 @@ export interface ConfigProps {
     resource: any;
     component: any;
     resourceType: string;
+    defaultTab?: string;
 }
 
 export interface ResourceDetailDrawerProps {
     resource: any;
+    defaultTab?: string;
 
     onClose?: () => void;
 }

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -15,7 +15,7 @@ export interface MetadataProps {
   identifyingInformation: IdentifyingInformationRow[],
   labels: Label[],
   annotations: Annotation[],
-  onShowConfiguration?: (returnFocusSelector: string) => void;
+  onShowConfiguration?: (returnFocusSelector: string, defaultTab?: string) => void;
 }
 
 const {
@@ -48,7 +48,7 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
         type="active"
         :rows="[]"
         :propertyName="i18n.t('component.resource.detail.metadata.labelsAndAnnotations')"
-        @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector)"
+        @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector, 'labels-and-annotations')"
       />
     </div>
     <!-- I'm not using v-else here so I can maintain the spacing correctly with the other columns in other rows. -->
@@ -58,7 +58,7 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
     >
       <Labels
         :labels="labels"
-        @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector)"
+        @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector, 'labels-and-annotations')"
       />
     </div>
     <div
@@ -67,7 +67,7 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
     >
       <Annotations
         :annotations="annotations"
-        @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector)"
+        @show-configuration="(returnFocusSelector: string) => emit('show-configuration', returnFocusSelector, 'labels-and-annotations')"
       />
     </div>
   </SpacedRow>

--- a/shell/components/Resource/Detail/composables.ts
+++ b/shell/components/Resource/Detail/composables.ts
@@ -46,12 +46,12 @@ export const useResourceDetailBannerProps = (resource: any): Ref<BannerProps | u
 };
 
 export const useOnShowConfiguration = (resource: any) => {
-  return (returnFocusSelector?: string) => {
+  return (returnFocusSelector?: string, defaultTab?: string) => {
     const resourceValue = toValue(resource);
     // Because extensions can make a copy of the resource-class it's possible that an extension will have a resource-class which predates the inclusion of showConfiguration
     // to still the rest of shell to consume
     const showConfiguration = resourceValue.showConfiguration ? resourceValue.showConfiguration.bind(resourceValue) : ResourceClass.prototype.showConfiguration.bind(resourceValue);
 
-    showConfiguration(returnFocusSelector);
+    showConfiguration(returnFocusSelector, defaultTab);
   };
 };

--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -7,6 +7,7 @@ import findIndex from 'lodash/findIndex';
 import { ExtensionPoint, TabLocation } from '@shell/core/types';
 import { getApplicableExtensionEnhancements } from '@shell/core/plugin-helpers';
 import Tab from '@shell/components/Tabbed/Tab';
+import { inject } from 'vue';
 
 export default {
   name: 'Tabbed',
@@ -115,6 +116,7 @@ export default {
     });
 
     return {
+      initialTab:    inject('default-tab', null) || this.defaultTab,
       tabs:          [...parsedExtTabs],
       extensionTabs: parsedExtTabs,
       activeTabName: null
@@ -136,7 +138,7 @@ export default {
   watch: {
     sortedTabs(tabs) {
       const {
-        defaultTab,
+        initialTab,
         useHash
       } = this;
       const activeTab = tabs.find((t) => t.active);
@@ -149,8 +151,8 @@ export default {
       if (isEmpty(activeTab)) {
         if (useHash && !isEmpty(windowHashTabMatch)) {
           this.select(windowHashTabMatch.name);
-        } else if (!isEmpty(defaultTab) && !isEmpty(tabs.find((t) => t.name === defaultTab))) {
-          this.select(defaultTab);
+        } else if (!isEmpty(initialTab) && !isEmpty(tabs.find((t) => t.name === initialTab))) {
+          this.select(initialTab);
         } else if (firstTab?.name) {
           this.select(firstTab.name);
         }

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -905,7 +905,7 @@ export default class Resource {
     return out;
   }
 
-  showConfiguration(returnFocusSelector) {
+  showConfiguration(returnFocusSelector, defaultTab) {
     const onClose = () => this.$ctx.commit('slideInPanel/close', undefined, { root: true });
 
     this.$ctx.commit('slideInPanel/open', {
@@ -920,7 +920,8 @@ export default class Resource {
         'z-index':          101, // We want this to be above the main side menu
         closeOnRouteChange: ['name', 'params', 'query'], // We want to ignore hash changes, tables in extensions can trigger the drawer to close while opening
         triggerFocusTrap:   true,
-        returnFocusSelector
+        returnFocusSelector,
+        defaultTab
       }
     }, { root: true });
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14545

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Changes how we select the default tab and adds the plumbing to allow ancestors components to provide the initial tab.

### Technical notes summary
I did create another version that's more explicit and doesn't use the provide/inject mechanism but it requires a large amount of changes: https://github.com/rancher/dashboard/pull/15685/files

### Areas or cases that should be tested
Places that have default tabs and the show configuration mechanism

### Areas which could experience regressions
See above

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
[Screencast_20251120_110910.webm](https://github.com/user-attachments/assets/81e42142-85b9-4773-a575-b8e403ee87ef)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
