### PR TITLE
Automation: fix url assertion issue

### DIFF
--- a/cypress/e2e/po/pages/page.po.ts
+++ b/cypress/e2e/po/pages/page.po.ts
@@ -47,6 +47,18 @@ export default class PagePo extends ComponentPo {
     return cy.url().should('equal', `${ Cypress.config().baseUrl + this.path }${ !!params ? `?${ params }` : '' }${ !!fragment ? `#${ fragment }` : '' }`);
   }
 
+  // This method provides partial URL matching when cluster context differences cause test failures.
+  // For more flexible testing, use waitForUrlPathWithoutContext() which strips cluster context.
+  // Workaround for issue: https://github.com/rancher/dashboard/issues/12077
+  waitForUrlPathWithoutContext(params?: string, fragment?: string) {
+    // Remove cluster context (/c/[cluster-id]/) from the path for comparison
+    const pathWithoutContext = this.path.replace(/\/c\/[^\/]+\//, '/');
+
+    expect(pathWithoutContext).to.not.contain('/c/');
+
+    return cy.url().should('include', `${ pathWithoutContext }${ !!params ? `?${ params }` : '' }${ !!fragment ? `#${ fragment }` : '' }`);
+  }
+
   waitForPageWithSpecificUrl(path?: string, params?: string, fragment?: string) {
     return cy.url().should('include', `${ Cypress.config().baseUrl + (!!path ? path : this.path) }${ !!params ? `?${ params }` : '' }${ !!fragment ? `#${ fragment }` : '' }`);
   }

--- a/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
@@ -47,26 +47,26 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
       const settingsEdit = settingsPage.editSettings(settingsClusterId, 'server-url');
 
-      settingsEdit.waitForPage();
+      settingsEdit.waitForUrlPathWithoutContext();
       settingsEdit.title().contains('Setting: server-url').should('be.visible');
       settingsEdit.saveAndWait('server-url').then(() => {
         removeServerUrl = true;
       });
-      settingsPage.waitForPage();
+      settingsPage.waitForUrlPathWithoutContext();
       settingsPage.settingsValue('server-url').contains(value);
 
       // Check Account and API Keys page
       AccountPagePo.navTo();
-      accountPage.waitForPage();
+      accountPage.waitForUrlPathWithoutContext();
       accountPage.isCurrentPage();
       cy.contains(value).should('be.visible');
 
       // Check reset button disabled
       SettingsPagePo.navTo();
-      settingsPage.waitForPage();
+      settingsPage.waitForUrlPathWithoutContext();
       settingsPage.editSettingsByLabel('server-url');
 
-      settingsEdit.waitForPage();
+      settingsEdit.waitForUrlPathWithoutContext();
       settingsEdit.title().contains('Setting: server-url').should('be.visible');
       settingsEdit.useDefaultButton().should('be.visible');
       settingsEdit.useDefaultButton().should('be.disabled');
@@ -80,7 +80,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'server-url');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: server-url').should('be.visible');
 
     // Check showing localhost warning banner
@@ -110,7 +110,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'ui-index');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: ui-index').should('be.visible');
     settingsEdit.settingsInput().set(settings['ui-index'].new);
     settingsEdit.saveAndWait('ui-index', settings['ui-index'].new).then(({ request, response }) => {
@@ -118,15 +118,15 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(request.body).to.have.property('value', settings['ui-index'].new);
       expect(response?.body).to.have.property('value', settings['ui-index'].new);
     });
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('ui-index').contains(settings['ui-index'].new);
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('ui-index');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: ui-index').should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait('ui-index', settingsOriginal['ui-index'].default).then(({ request, response }) => {
@@ -135,7 +135,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(response?.body).to.have.property('value', settingsOriginal['ui-index'].default);
     });
 
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('ui-index').contains(settingsOriginal['ui-index'].default);
 
     resetSettings.push('ui-index');
@@ -148,7 +148,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'ui-dashboard-index');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: ui-dashboard-index').should('be.visible');
     settingsEdit.settingsInput().set(settings['ui-dashboard-index'].new);
     settingsEdit.saveAndWait('ui-dashboard-index', settings['ui-dashboard-index'].new).then(({ request, response }) => {
@@ -156,15 +156,15 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(request.body).to.have.property('value', settings['ui-dashboard-index'].new);
       expect(response?.body).to.have.property('value', settings['ui-dashboard-index'].new);
     });
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('ui-dashboard-index').contains(settings['ui-dashboard-index'].new);
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('ui-dashboard-index');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: ui-dashboard-index').should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait('ui-dashboard-index', settingsOriginal['ui-dashboard-index'].default).then(({ request, response }) => {
@@ -173,7 +173,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(response?.body).to.have.property('value', settingsOriginal['ui-dashboard-index'].default);
     });
 
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('ui-dashboard-index').contains(settingsOriginal['ui-dashboard-index'].default);
 
     resetSettings.push('ui-dashboard-index');
@@ -186,7 +186,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'ui-offline-preferred');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: ui-offline-preferred').should('be.visible');
     settingsEdit.selectSettingsByLabel(settings['ui-offline-preferred'].new);
     settingsEdit.saveAndWait('ui-offline-preferred', 'Local').then(({ request, response }) => {
@@ -194,14 +194,14 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(request.body).to.have.property('value', 'true');
       expect(response?.body).to.have.property('value', 'true');
     });
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('ui-offline-preferred').contains(settings['ui-offline-preferred'].new);
 
     // Update settings: Remote
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('ui-offline-preferred');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: ui-offline-preferred').should('be.visible');
     settingsEdit.selectSettingsByLabel(settings['ui-offline-preferred'].new2);
     settingsEdit.saveAndWait('ui-offline-preferred', 'Remote').then(({ request, response }) => {
@@ -209,14 +209,14 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(request.body).to.have.property('value', 'false');
       expect(response?.body).to.have.property('value', 'false');
     });
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('ui-offline-preferred').contains(settings['ui-offline-preferred'].new2);
 
     // Update settings: Dynamic
     SettingsPagePo.navTo();
     settingsPage.editSettingsByLabel('ui-offline-preferred');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: ui-offline-preferred').should('be.visible');
     settingsEdit.selectSettingsByLabel(settings['ui-offline-preferred'].new3);
     settingsEdit.saveAndWait('ui-offline-preferred', 'dynamic').then(({ request, response }) => {
@@ -224,15 +224,15 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(request.body).to.have.property('value', 'dynamic');
       expect(response?.body).to.have.property('value', 'dynamic');
     });
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('ui-offline-preferred').contains(settings['ui-offline-preferred'].new3);
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('ui-offline-preferred');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: ui-offline-preferred').should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait('ui-offline-preferred', settingsOriginal['ui-offline-preferred'].default).then(({ request, response }) => {
@@ -240,7 +240,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(request.body).to.have.property('value', settingsOriginal['ui-offline-preferred'].default);
       expect(response?.body).to.have.property('value', settingsOriginal['ui-offline-preferred'].default);
     });
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
 
     // This should be used above...
     let visualDefault = 'Dynamic';
@@ -269,11 +269,11 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'ui-brand');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: ui-brand').should('be.visible');
     settingsEdit.settingsInput().set(settings['ui-brand'].new);
     settingsEdit.saveAndWait('ui-brand');
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('ui-brand').contains(settings['ui-brand'].new);
 
     // Check logos in top-level navigation header for updated logo
@@ -293,15 +293,15 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('ui-brand');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: ui-brand').should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait('ui-brand');
 
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('ui-brand').should('not.contain', settings['ui-brand'].new);
 
     // Check logos in top-level navigation header for updated logo
@@ -323,29 +323,29 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'hide-local-cluster');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: hide-local-cluster').should('be.visible');
     settingsEdit.settingsRadioBtn().set(0);
     settingsEdit.saveAndWait('hide-local-cluster');
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('hide-local-cluster').contains(settings['hide-local-cluster'].new);
 
     // Check home page for local cluster
     HomePagePo.navTo();
-    homePage.waitForPage();
+    homePage.waitForUrlPathWithoutContext();
     cy.contains('local').should('not.exist');
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('hide-local-cluster');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: hide-local-cluster').should('be.visible');
     settingsEdit.settingsRadioBtn().set(1);
     settingsEdit.saveAndWait('hide-local-cluster');
 
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('hide-local-cluster').contains(settingsOriginal['hide-local-cluster'].default);
 
     resetSettings.push('hide-local-cluster');
@@ -358,7 +358,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'k3s-based-upgrader-uninstall-concurrency');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: k3s-based-upgrader-uninstall-concurrency').should('be.visible');
     settingsEdit.settingsInput().set(settings['k3s-based-upgrader-uninstall-concurrency'].new);
     settingsEdit.saveAndWait('k3s-based-upgrader-uninstall-concurrency').then(({ request, response }) => {
@@ -366,15 +366,15 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(request.body).to.have.property('value', settings['k3s-based-upgrader-uninstall-concurrency'].new);
       expect(response?.body).to.have.property('value', settings['k3s-based-upgrader-uninstall-concurrency'].new);
     });
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('k3s-based-upgrader-uninstall-concurrency').contains(settings['k3s-based-upgrader-uninstall-concurrency'].new);
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('k3s-based-upgrader-uninstall-concurrency');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: k3s-based-upgrader-uninstall-concurrency').should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait('k3s-based-upgrader-uninstall-concurrency').then(({ request, response }) => {
@@ -383,7 +383,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(response?.body).to.have.property('value', settingsOriginal['k3s-based-upgrader-uninstall-concurrency'].default);
     });
 
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('k3s-based-upgrader-uninstall-concurrency').contains(settingsOriginal['k3s-based-upgrader-uninstall-concurrency'].default);
 
     resetSettings.push('k3s-based-upgrader-uninstall-concurrency');
@@ -396,7 +396,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'system-agent-upgrader-install-concurrency');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: system-agent-upgrader-install-concurrency').should('be.visible');
     settingsEdit.settingsInput().set(settings['system-agent-upgrader-install-concurrency'].new);
     settingsEdit.saveAndWait('system-agent-upgrader-install-concurrency').then(({ request, response }) => {
@@ -404,7 +404,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(request.body).to.have.property('value', settings['system-agent-upgrader-install-concurrency'].new);
       expect(response?.body).to.have.property('value', settings['system-agent-upgrader-install-concurrency'].new);
     });
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('system-agent-upgrader-install-concurrency').contains(settings['system-agent-upgrader-install-concurrency'].new);
 
     // Reset
@@ -418,11 +418,11 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'system-default-registry');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: system-default-registry').should('be.visible');
     settingsEdit.settingsInput().set(settings['system-default-registry'].new);
     settingsEdit.saveAndWait('system-default-registry');
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('system-default-registry').contains(settings['system-default-registry'].new);
 
     // Check cluster manager > create
@@ -432,7 +432,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     clusterList.checkIsCurrentPage();
     clusterList.createCluster();
 
-    createRKE2ClusterPage.waitForPage();
+    createRKE2ClusterPage.waitForUrlPathWithoutContext();
 
     createRKE2ClusterPage.selectCustom(0);
     createRKE2ClusterPage.clusterConfigurationTabs().clickTabWithSelector('[data-testid="btn-rke2-calico"]');
@@ -443,15 +443,15 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPageBlank.waitForPage();
+    settingsPageBlank.waitForUrlPathWithoutContext();
     settingsPageBlank.editSettingsByLabel('system-default-registry');
 
-    settingsEditBlank.waitForPage();
+    settingsEditBlank.waitForUrlPathWithoutContext();
     settingsEditBlank.title().contains('Setting: system-default-registry').should('be.visible');
     settingsEditBlank.settingsInput().clear();
     settingsEditBlank.saveAndWait('system-default-registry');
 
-    settingsPageBlank.waitForPage();
+    settingsPageBlank.waitForUrlPathWithoutContext();
     // settingsPageBlank.settingsValue('system-default-registry').contains(settingsOriginal['system-default-registry'].default); // .. empty value
 
     resetSettings.push('system-default-registry');

--- a/cypress/e2e/tests/pages/global-settings/settings.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings.spec.ts
@@ -90,7 +90,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = newSettingsPage.editSettings(settingsClusterId, sessionIdleSetting);
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains(`Setting: ${ sessionIdleSetting }`).should('be.visible');
     settingsEdit.settingsInput().set(settings[sessionIdleSetting].new);
 
@@ -99,7 +99,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(request.body).to.have.property('value', settings[sessionIdleSetting].new);
       expect(response?.body).to.have.property('value', settings[sessionIdleSetting].new);
     });
-    newSettingsPage.waitForPage();
+    newSettingsPage.waitForUrlPathWithoutContext();
     newSettingsPage.settingsValue(sessionIdleSetting).contains(settings[sessionIdleSetting].new);
 
     cy.wait('@getUpdatedUserActivity', { timeout: 15000 });
@@ -138,10 +138,10 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     // Reset setting value
     SettingsPagePo.navTo();
-    newSettingsPage.waitForPage();
+    newSettingsPage.waitForUrlPathWithoutContext();
     newSettingsPage.editSettingsByLabel(sessionIdleSetting);
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains(`Setting: ${ sessionIdleSetting }`).should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait(sessionIdleSetting).then(({ request, response }) => {
@@ -150,7 +150,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(response?.body).to.have.property('value', settingsOriginal[sessionIdleSetting].default);
     });
 
-    newSettingsPage.waitForPage();
+    newSettingsPage.waitForUrlPathWithoutContext();
     newSettingsPage.settingsValue(sessionIdleSetting).contains(settingsOriginal[sessionIdleSetting].default);
 
     resetSettings.push(sessionIdleSetting);
@@ -175,7 +175,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'engine-iso-url');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: engine-iso-url').should('be.visible');
     settingsEdit.settingsInput().set(settings['engine-iso-url'].new);
     settingsEdit.saveAndWait('engine-iso-url').then(({ request, response }) => {
@@ -183,7 +183,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(request.body).to.have.property('value', settings['engine-iso-url'].new);
       expect(response?.body).to.have.property('value', settings['engine-iso-url'].new);
     });
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('engine-iso-url').contains(settings['engine-iso-url'].new);
     // Scroll to the setting
     cy.get('.main-layout').scrollTo('bottom');
@@ -191,10 +191,10 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('engine-iso-url');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: engine-iso-url').should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait('engine-iso-url').then(({ request, response }) => {
@@ -203,7 +203,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(response?.body).to.have.property('value', settingsOriginal['engine-iso-url'].default);
     });
 
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('engine-iso-url').contains(settingsOriginal['engine-iso-url'].default);
     settingsPage.modifiedLabel('engine-iso-url').should('not.exist'); // modified label should not display after reset
 
@@ -217,11 +217,11 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'password-min-length');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: password-min-length').should('be.visible');
     settingsEdit.settingsInput().set(settings['password-min-length'].new);
     settingsEdit.saveAndWait('password-min-length');
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('password-min-length').contains(settings['password-min-length'].new);
 
     // this just causes problems
@@ -250,15 +250,15 @@ describe('Settings', { testIsolation: 'off' }, () => {
     // banner.banner().contains(`Password must be at least ${ settings['password-min-length'].new } characters`).should('be.visible');
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('password-min-length');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: password-min-length').should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait('password-min-length');
 
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('password-min-length').contains(settingsOriginal['password-min-length'].default);
 
     resetSettings.push('password-min-length');
@@ -271,7 +271,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'ingress-ip-domain');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: ingress-ip-domain').should('be.visible');
     settingsEdit.settingsInput().set(settings['ingress-ip-domain'].new);
     settingsEdit.saveAndWait('ingress-ip-domain').then(({ request, response }) => {
@@ -279,15 +279,15 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(request.body).to.have.property('value', settings['ingress-ip-domain'].new);
       expect(response?.body).to.have.property('value', settings['ingress-ip-domain'].new);
     });
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('ingress-ip-domain').contains(settings['ingress-ip-domain'].new);
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('ingress-ip-domain');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: ingress-ip-domain').should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait('ingress-ip-domain').then(({ request, response }) => {
@@ -296,7 +296,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(response?.body).to.have.property('value', settingsOriginal['ingress-ip-domain'].default);
     });
 
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('ingress-ip-domain').contains(settingsOriginal['ingress-ip-domain'].default);
 
     resetSettings.push('ingress-ip-domain');
@@ -309,7 +309,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'auth-user-info-max-age-seconds');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: auth-user-info-max-age-seconds').should('be.visible');
     settingsEdit.settingsInput().set(settings['auth-user-info-max-age-seconds'].new);
     settingsEdit.saveAndWait('auth-user-info-max-age-seconds').then(({ request, response }) => {
@@ -317,15 +317,15 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(request.body).to.have.property('value', settings['auth-user-info-max-age-seconds'].new);
       expect(response?.body).to.have.property('value', settings['auth-user-info-max-age-seconds'].new);
     });
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('auth-user-info-max-age-seconds').contains(settings['auth-user-info-max-age-seconds'].new);
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('auth-user-info-max-age-seconds');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: auth-user-info-max-age-seconds').should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait('auth-user-info-max-age-seconds').then(({ request, response }) => {
@@ -334,7 +334,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(response?.body).to.have.property('value', settingsOriginal['auth-user-info-max-age-seconds'].default);
     });
 
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('auth-user-info-max-age-seconds').contains(settingsOriginal['auth-user-info-max-age-seconds'].default);
 
     resetSettings.push('auth-user-info-max-age-seconds');
@@ -347,7 +347,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'auth-user-session-ttl-minutes');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: auth-user-session-ttl-minutes').should('be.visible');
     settingsEdit.settingsInput().set(settings['auth-user-session-ttl-minutes'].new);
     settingsEdit.saveAndWait('auth-user-session-ttl-minutes').then(({ request, response }) => {
@@ -355,15 +355,15 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(request.body).to.have.property('value', settings['auth-user-session-ttl-minutes'].new);
       expect(response?.body).to.have.property('value', settings['auth-user-session-ttl-minutes'].new);
     });
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('auth-user-session-ttl-minutes').contains(settings['auth-user-session-ttl-minutes'].new);
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('auth-user-session-ttl-minutes');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: auth-user-session-ttl-minutes').should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait('auth-user-session-ttl-minutes').then(({ request, response }) => {
@@ -372,7 +372,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(response?.body).to.have.property('value', settingsOriginal['auth-user-session-ttl-minutes'].default);
     });
 
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('auth-user-session-ttl-minutes').contains(settingsOriginal['auth-user-session-ttl-minutes'].default);
 
     resetSettings.push('auth-user-session-ttl-minutes');
@@ -388,32 +388,32 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'auth-token-max-ttl-minutes');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: auth-token-max-ttl-minutes').should('be.visible');
     settingsEdit.settingsInput().set(settings['auth-token-max-ttl-minutes'].new);
     settingsEdit.saveAndWait('auth-token-max-ttl-minutes');
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('auth-token-max-ttl-minutes').contains(settings['auth-token-max-ttl-minutes'].new);
 
     // Check api keys expiry options
     AccountPagePo.navTo();
     accountPage.create();
-    createKeyPage.waitForPage();
+    createKeyPage.waitForUrlPathWithoutContext();
     createKeyPage.isCurrentPage();
     createKeyPage.expiryOptions().isChecked(0);
     cy.contains('10 mins - Maximum allowed').should('be.visible');
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('auth-token-max-ttl-minutes');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: auth-token-max-ttl-minutes').should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait('auth-token-max-ttl-minutes');
 
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('auth-token-max-ttl-minutes').contains(settingsOriginal['auth-token-max-ttl-minutes'].default);
 
     resetSettings.push('auth-token-max-ttl-minutes');
@@ -426,24 +426,24 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'agent-tls-mode');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: agent-tls-mode').should('be.visible');
     settingsEdit.selectSettingsByLabel('System Store');
     settingsEdit.saveAndWait('agent-tls-mode');
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('agent-tls-mode').contains('System Store');
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('agent-tls-mode');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: agent-tls-mode').should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait('agent-tls-mode');
 
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('agent-tls-mode').contains('Strict');
 
     resetSettings.push('agent-tls-mode');
@@ -456,7 +456,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'kubeconfig-default-token-ttl-minutes');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: kubeconfig-default-token-ttl-minutes').should('be.visible');
     settingsEdit.settingsInput().set(settings['kubeconfig-default-token-ttl-minutes'].new);
     settingsEdit.saveAndWait('kubeconfig-default-token-ttl-minutes').then(({ request, response }) => {
@@ -464,15 +464,15 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(request.body).to.have.property('value', settings['kubeconfig-default-token-ttl-minutes'].new);
       expect(response?.body).to.have.property('value', settings['kubeconfig-default-token-ttl-minutes'].new);
     });
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('kubeconfig-default-token-ttl-minutes').contains(settings['kubeconfig-default-token-ttl-minutes'].new);
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('kubeconfig-default-token-ttl-minutes');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: kubeconfig-default-token-ttl-minutes').should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait('kubeconfig-default-token-ttl-minutes').then(({ request, response }) => {
@@ -481,7 +481,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(response?.body).to.have.property('value', settingsOriginal['kubeconfig-default-token-ttl-minutes'].default);
     });
 
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('kubeconfig-default-token-ttl-minutes').contains(settingsOriginal['kubeconfig-default-token-ttl-minutes'].default);
 
     resetSettings.push('kubeconfig-default-token-ttl-minutes');
@@ -494,7 +494,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'auth-user-info-resync-cron');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: auth-user-info-resync-cron').should('be.visible');
     settingsEdit.settingsInput().set(settings['auth-user-info-resync-cron'].new);
     settingsEdit.saveAndWait('auth-user-info-resync-cron').then(({ request, response }) => {
@@ -502,15 +502,15 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(request.body).to.have.property('value', settings['auth-user-info-resync-cron'].new);
       expect(response?.body).to.have.property('value', settings['auth-user-info-resync-cron'].new);
     });
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('auth-user-info-resync-cron').contains(settings['auth-user-info-resync-cron'].new);
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('auth-user-info-resync-cron');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: auth-user-info-resync-cron').should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait('auth-user-info-resync-cron').then(({ request, response }) => {
@@ -519,7 +519,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
       expect(response?.body).to.have.property('value', settingsOriginal['auth-user-info-resync-cron'].default);
     });
 
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('auth-user-info-resync-cron').contains(settingsOriginal['auth-user-info-resync-cron'].default);
 
     resetSettings.push('auth-user-info-resync-cron');
@@ -532,24 +532,24 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'kubeconfig-generate-token');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: kubeconfig-generate-token').should('be.visible');
     settingsEdit.settingsRadioBtn().set(1);
     settingsEdit.saveAndWait('kubeconfig-generate-token');
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('kubeconfig-generate-token').contains(settings['kubeconfig-generate-token'].new);
 
     // Reset
     SettingsPagePo.navTo();
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.editSettingsByLabel('kubeconfig-generate-token');
 
-    settingsEdit.waitForPage();
+    settingsEdit.waitForUrlPathWithoutContext();
     settingsEdit.title().contains('Setting: kubeconfig-generate-token').should('be.visible');
     settingsEdit.useDefaultButton().click();
     settingsEdit.saveAndWait('kubeconfig-generate-token');
 
-    settingsPage.waitForPage();
+    settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('kubeconfig-generate-token').contains(settingsOriginal['kubeconfig-generate-token'].default);
 
     // Check kubeconfig file

--- a/cypress/e2e/tests/pages/users-and-auth/azuread.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/azuread.spec.ts
@@ -27,9 +27,9 @@ describe('AzureAD', { tags: ['@adminUser', '@usersAndAuths'] }, () => {
     cy.login();
     HomePagePo.goToAndWaitForGet();
     AuthProviderPo.navTo();
-    authProviderPo.waitForPage();
+    authProviderPo.waitForUrlPathWithoutContext();
     authProviderPo.selectProvider(AuthProvider.AZURE);
-    azureadPo.waitForPage();
+    azureadPo.waitForUrlPathWithoutContext();
   });
 
   it('can navigate Auth Provider and select AzureAD', () => {

--- a/cypress/e2e/tests/pages/users-and-auth/cognito.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/cognito.spec.ts
@@ -19,9 +19,9 @@ describe('Amazon Cognito', { tags: ['@adminUser', '@usersAndAuths'] }, () => {
     cy.login();
     HomePagePo.goToAndWaitForGet();
     AuthProviderPo.navTo();
-    authProviderPo.waitForPage();
+    authProviderPo.waitForUrlPathWithoutContext();
     authProviderPo.selectProvider(AuthProvider.AMAZON_COGNITO);
-    cognitoPo.waitForPage();
+    cognitoPo.waitForUrlPathWithoutContext();
   });
 
   it('can navigate Auth Provider and select Amazon Cognito', () => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2078

Adds `waitForUrlPathWithoutCluster()` method to handle URL cluster context issue described in #12077. The method strips cluster context (/c/local/ or /c/_/) from URL paths and uses partial matching to work regardless of ui-sql-cache feature flag state.
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
