### PR TITLE
Use `bg-info` instead of `role-tertiary` for cluster count badge

### DIFF
--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -800,7 +800,7 @@ export default defineComponent({
                     <BadgeState
                       v-if="clusterCount && !tooManyClusters"
                       :label="clusterCount.toString()"
-                      color="role-tertiary ml-20 mr-20"
+                      color="bg-info ml-20 mr-20"
                     />
                   </div>
                 </template>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This uses `bg-info` instead of `role-tertiary` for cluster count badge. 

Fixes #15669 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Use `bg-info` instead of `role-tertiary` for cluster count badge

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

`role-tertiary` is a button style and is not a known variant of a badge.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Home Page cluster counts

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- NA

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="1377" height="1165" alt="image" src="https://github.com/user-attachments/assets/ddbc4bcf-4826-4904-9057-3d6db90cfccb" />

<img width="1377" height="1165" alt="image" src="https://github.com/user-attachments/assets/6b850825-f4cc-44dd-a645-9b8f2bbdb59b" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
