### PR TITLE
Fix indentation and highlighting for `More Resources`

### DIFF
--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -130,11 +130,20 @@ export default {
           index = (found === -1) ? 0 : found;
         }
 
-        const route = items[index].route;
+        const item = items[index];
+        const route = item.route;
 
         if (route) {
           this.$router.replace(route);
+        } else if (item) {
+          this.routeToFirstChild(item);
         }
+      }
+    },
+
+    routeToFirstChild(item) {
+      if (item.children.length && item.children[0].route) {
+        this.$router.replace(item.children[0].route);
       }
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This ensures that child items in the Side Nav are indented consistently when expanded. This also navigates to the first child of "More Resources" (or other menu options that may not contain a route) so that the click behavior remains consistent with other items. 

Fixes #15666 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Fix indentation for More Resources
- Route to first child if route does not exist

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The indentation for nesting appears to require increased specificity to properly indent child items.

New behavior - clicking on More Resources will navigate to the first child route instead of just expanding the section. This is done to ensure consistency with other menu items.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Side nav behavior - need to ensure that indentation behaves as expected, highlighting of items needs to remain consistent across all areas.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Indentation of nav items.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="1376" height="1165" alt="image" src="https://github.com/user-attachments/assets/c0616426-b97d-4f4c-95b7-be8c5b185707" />

<img width="1376" height="1165" alt="image" src="https://github.com/user-attachments/assets/cea7426a-6c7c-409f-8195-4972b972ddd6" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
