### PR TITLE
backport pr 15701

### DIFF
--- a/pkg/rancher-prime/config/navigation.ts
+++ b/pkg/rancher-prime/config/navigation.ts
@@ -1,5 +1,7 @@
 import { IPlugin } from '@shell/core/types';
 import { PRODUCT_SETTING_NAME, SETTING_PAGE_NAME } from './constants';
+import { IF_HAVE } from '@shell/store/type-map';
+import { SCC } from '@shell/store/features';
 
 // Product configuration
 export function init($plugin: IPlugin, store: any) {
@@ -9,9 +11,11 @@ export function init($plugin: IPlugin, store: any) {
   } = $plugin.DSL(store, PRODUCT_SETTING_NAME);
 
   virtualType({
-    labelKey: 'registration.navigation.label',
-    name:     SETTING_PAGE_NAME,
-    route:    { name: SETTING_PAGE_NAME },
+    ifHave:    IF_HAVE.ADMIN,
+    ifFeature: SCC,
+    labelKey:  'registration.navigation.label',
+    name:      SETTING_PAGE_NAME,
+    route:     { name: SETTING_PAGE_NAME },
   });
 
   basicType([SETTING_PAGE_NAME]);

--- a/pkg/rancher-prime/index.test.ts
+++ b/pkg/rancher-prime/index.test.ts
@@ -1,0 +1,40 @@
+import { SCC } from '@shell/store/features';
+const { IF_HAVE } = require('@shell/store/type-map');
+
+jest.doMock('@rancher/auto-import', () => ({ importTypes: jest.fn() }), { virtual: true });
+
+describe('extension: rancher-prime', () => {
+  it('should enable routing for admin users with SCC feature', async() => {
+    const plugin = await import('./index'); // initialized after the mock
+    const virtualTypeSpy = jest.fn();
+    const basicTypeSpy = jest.fn();
+    const dslMock = jest.fn().mockReturnValue({
+      virtualType: virtualTypeSpy,
+      basicType:   basicTypeSpy
+    });
+
+    const pluginMock = {
+      environment: { isPrime: true },
+      addProduct:  jest.fn(),
+      addRoutes:   jest.fn(),
+      addPanel:    jest.fn(),
+      addNavHooks: jest.fn(),
+      register:    jest.fn(), // Used in installDocHandler
+      metadata:    {},
+      DSL:         dslMock
+    } as any;
+
+    plugin.default(pluginMock); // basic extension import
+    pluginMock.addProduct.mock.calls[0][0].init(pluginMock, {}); // force init to trigger as in @rancher/shell
+
+    expect(pluginMock.addProduct).toHaveBeenCalledWith(
+      expect.objectContaining({ init: expect.any(Function) })
+    );
+    expect(virtualTypeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ifHave:    IF_HAVE.ADMIN,
+        ifFeature: SCC
+      })
+    );
+  });
+});

--- a/pkg/rancher-prime/index.ts
+++ b/pkg/rancher-prime/index.ts
@@ -53,8 +53,8 @@ const poolRegistration = (store: Store<any>) => {
     if (store.state['managementReady']) {
       setNotification(store);
       clearInterval(id);
+      attempts -= 1;
     }
-    attempts -= 1;
   }, 1000);
 };
 

--- a/shell/store/features.js
+++ b/shell/store/features.js
@@ -37,6 +37,7 @@ export const STEVE_CACHE = create('ui-sql-cache', false);
 export const UIEXTENSION = create('uiextension', true);
 export const PROVISIONING_PRE_BOOTSTRAP = create('provisioningprebootstrap', false);
 export const SCHEDULING_CUSTOMIZATION = create(SCHEDULING_CUSTOMIZATION_FEATURE, false);
+export const SCC = create('rancher-scc-registration-extension', true);
 
 // Not currently used.. no point defining ones we don't use
 // export const EMBEDDED_CLUSTER_API = create('embedded-cluster-api', true);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15701
Fixes #15703
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

Restricted navigation to **admin** only and **feature flag**.

### Technical notes summary

- Added FF `rancher-scc-registration-extension`
- Added extensions unit tests (first project case)
  - Role must be identified by Rancher as admin
  - Feature flag must be passed by Rancher 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions

NOTE: If you stop and restart the feature flag in Docker it will make Rancher crash. Use a new instance to test this out if you have a lot of data.

Navigation to the registration page using the UI or both admin and standard user.

### Screenshot/Video

Comparison admin to standard

<img width="1921" height="1015" alt="Screenshot 2025-10-14 at 16 32 20" src="https://github.com/user-attachments/assets/12edfbac-b040-4182-bc57-2859db603292" />

Navigation and notifications are missing if no feature as admin

<img width="954" height="614" alt="Screenshot 2025-10-14 at 17 35 17" src="https://github.com/user-attachments/assets/f951f4a1-3c58-4323-b2b8-f935c7a7ce3c" />



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
