### PR TITLE
[backport 2.12.4] Automation: fix about page prime test 

### DIFF
--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -151,11 +151,19 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
       });
     }
 
-    it('should show prime panel on about page', () => {
-      interceptVersionAndSetToPrime().as('rancherVersion');
+    beforeEach(() => {
       cy.login();
-      aboutPage.goTo();
+      interceptVersionAndSetToPrime().as('rancherVersion');
+    });
+
+    it('should show prime panel on about page', () => {
+      HomePagePo.goToAndWaitForGet();
+
+      AboutPagePo.navTo();
       aboutPage.waitForPage();
+
+      // Wait for the intercepted rancherversion request to complete
+      cy.wait('@rancherVersion');
 
       aboutPage.rancherPrimeInfo().should('exist');
     });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1953

Backport of original issue ^
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
