### PR TITLE
Focus namespace filter input after clearing filters

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4634,6 +4634,7 @@ namespaceFilter:
   button:
     clear: Remove applied namespace filters
     clearFilter: Clear namespace options filter
+  removeNamespace: 'Remove {name} from filter'
 
 namespaceList:
   selectLabel: Namespace

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -789,6 +789,7 @@ export default {
             ghost
             class="ns-chip-button"
             :data-testid="`namespaces-values-close-${j}`"
+            :aria-label="t('namespaceFilter.removeNamespace', { name: ns.label })"
             @click="removeOption(ns, $event)"
             @keydown.enter.space.stop="removeOption(ns, $event)"
             @mousedown="handleValueMouseDown(ns, $event)"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This focuses the namespace filter dropdown when all of the filters are cleared.

Fixes #14383 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

> ⚠️ Known Issues
>
> The namespace filters dropdown is very inconsistent with how it renders chips. For example, making selections and then immediately clearing them can cause "n items selected" to be the only chip rendered:
>
>   <img width="306" height="60" alt="image" src="https://github.com/user-attachments/assets/411ad282-38cc-4533-b3c0-04ee26f58661" />
>
>
> Navigating into a page that renders namespace filters will render all of the filters, without condensing them:
>
>   <img width="306" height="60" alt="image" src="https://github.com/user-attachments/assets/452b6bf4-18b3-4736-a6cd-d97fb694319f" />

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Clearing the final namespace filter via keyboard should focus the input. Clearing the final namespace filter via mouse should open the input (same as existing behavior). 

Clearing a namespace filter when other filters exist should behave the same as before.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

We need to stress the namespace filter component to ensure that the change in functionality hasn't produced side-effects.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


https://github.com/user-attachments/assets/cfa0ba2d-2858-4c35-86e0-30481df9e92f



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
