### PR TITLE
Automation: fix logging chart test

### DIFF
--- a/cypress/e2e/po/components/kubectl.po.ts
+++ b/cypress/e2e/po/components/kubectl.po.ts
@@ -29,7 +29,7 @@ export default class Kubectl extends ComponentPo {
   }
 
   waitForTerminalStatus(status: 'Connected' | 'Disconnected', options?: GetOptions) {
-    this.self().find('.active .status').contains(status, options).should('be.visible');
+    this.self().contains('.active .status', status, options);
   }
 
   /**

--- a/cypress/e2e/tests/pages/charts/logging.spec.ts
+++ b/cypress/e2e/tests/pages/charts/logging.spec.ts
@@ -10,6 +10,7 @@ import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import ChartInstalledAppsListPagePo from '@/cypress/e2e/po/pages/chart-installed-apps.po';
 import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 import { CLUSTER_APPS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
+import CardPo from '~/cypress/e2e/po/components/card.po';
 
 describe('Logging Chart', { testIsolation: 'off', tags: ['@charts', '@adminUser'] }, () => {
   const kubectl = new Kubectl();
@@ -115,6 +116,7 @@ describe('Logging Chart', { testIsolation: 'off', tags: ['@charts', '@adminUser'
     installedAppsPage.goTo();
     installedAppsPage.waitForPage();
     cy.wait('@getCharts', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
+    installedAppsPage.appsList().checkVisible(MEDIUM_TIMEOUT_OPT);
     installedAppsPage.appsList().sortableTable().checkLoadingIndicatorNotVisible();
     installedAppsPage.appsList().sortableTable().noRowsShouldNotExist();
     installedAppsPage.appsList().resourceTableDetails(chartApp, 1).should('exist');
@@ -134,6 +136,10 @@ describe('Logging Chart', { testIsolation: 'off', tags: ['@charts', '@adminUser'
     promptRemove.checkbox().set();
     promptRemove.checkbox().isChecked();
     promptRemove.remove();
+
+    const card = new CardPo();
+
+    card.checkNotExists(MEDIUM_TIMEOUT_OPT);
     cy.wait('@chartUninstall').its('response.statusCode').should('eq', 201);
     cy.wait('@crdUninstall').its('response.statusCode').should('eq', 201);
 
@@ -145,6 +151,7 @@ describe('Logging Chart', { testIsolation: 'off', tags: ['@charts', '@adminUser'
     installedAppsPage.goTo();
     installedAppsPage.waitForPage();
     cy.wait('@getCharts', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
+    installedAppsPage.appsList().checkVisible(MEDIUM_TIMEOUT_OPT);
     installedAppsPage.appsList().sortableTable().checkLoadingIndicatorNotVisible();
     installedAppsPage.appsList().sortableTable().noRowsShouldNotExist();
     installedAppsPage.appsList().sortableTable().rowNames('.col-link-detail', MEDIUM_TIMEOUT_OPT)


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #

Fixes flaky logging test.

- Added a visibility check for the installed apps list container before proceeding with sortable table operations. This ensures that the [data-testid="installed-app-catalog-list"] element is present and visible before the test attempts to interact with its child elements (the sortable table).
- Also added a check to ensure the prompt remove dialog is no longer visible after the uninstall operation.

<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
