### PR TITLE
Fixing view yaml in general and specifically in the case of provisioning clusters

### DIFF
--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -310,7 +310,7 @@ export default {
       }), {});
     },
     isFullPageOverride() {
-      return this.isView && this.value.fullDetailPageOverride;
+      return this.isView && this.value.fullDetailPageOverride && !this.isYaml;
     }
   },
 

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -9,7 +9,6 @@ import { get, set } from '@shell/utils/object';
 import { sortBy } from '@shell/utils/sort';
 import { ucFirst } from '@shell/utils/string';
 import { compare } from '@shell/utils/version';
-import { AS, MODE, _VIEW, _YAML } from '@shell/config/query-params';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import { CAPI as CAPI_ANNOTATIONS, NODE_ARCHITECTURE } from '@shell/config/labels-annotations';
 import { KEV1 } from '@shell/models/management.cattle.io.kontainerdriver';
@@ -258,26 +257,6 @@ export default class ProvCluster extends SteveModel {
       await harvesterCluster.goToCluster();
     } catch {
     }
-  }
-
-  goToViewYaml() {
-    let location;
-
-    if ( !this.isRke2 ) {
-      location = this.mgmt?.detailLocation;
-    }
-
-    if ( !location ) {
-      location = this.detailLocation;
-    }
-
-    location.query = {
-      ...location.query,
-      [MODE]: _VIEW,
-      [AS]:   _YAML
-    };
-
-    this.currentRouter().push(location);
   }
 
   get canDelete() {


### PR DESCRIPTION
### Summary
Fixes #15736
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
There were actually two problems that got fixed here. 
- One issue was that when a resource detail page was fully overriden we'd display a blank page when viewing yaml.
- The other issue was that for provisioning clusters we would show the yaml for management clusters.
   - Historically I think this was the correct solution but I don't think it's correct anymore, for both download yaml and edit yaml we've been showing the provisioning yaml for quite some time. By viewing the provisioning yaml for all cluster types we're now making each of these actions consistent.
  
### Areas or cases that should be tested
Viewing, editing and downloading yaml for each cluster provider type.

To make `View Yaml` visible you should login to a standard user that has been made a cluster member to the cluster you wish to invoke `View Yaml` on.

### Areas which could experience regressions
See above

### Screenshot/Video

https://github.com/user-attachments/assets/efffb851-bebe-4beb-862a-5d58025119c9



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
