### PR TITLE
backport: fix problem with Kubewarden chart upgrade

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1203,7 +1203,7 @@ export default {
         const { allValues, values: crdValues } = versionInfo;
 
         // only save crd values that differ from the defaults defined in chart values.yaml
-        const customizedCrdValues = diff(crdValues, allValues);
+        const customizedCrdValues = diff(crdValues, allValues, true);
 
         // CRD globals should be overwritten by main chart globals
         // we want to avoid including globals present on crd values and not main chart values

--- a/shell/utils/__tests__/object.test.ts
+++ b/shell/utils/__tests__/object.test.ts
@@ -182,6 +182,25 @@ describe('fx: diff', () => {
 
     expect(result).toStrictEqual(expected);
   });
+  it('should return an object with property "baz" different than "null" if using the flag "preventNull" as true', () => {
+    const from = {
+      foo: 'bar',
+      baz: 'bang',
+    };
+    const to = {
+      foo:  'bar',
+      bang: 'baz'
+    };
+
+    const result = diff(from, to, true);
+    const expected = {
+      // the property "baz" having value !== null covers test case for https://github.com/rancher/dashboard/issues/15710
+      baz:  'bang',
+      bang: 'baz'
+    };
+
+    expect(result).toStrictEqual(expected);
+  });
   it('should return an object and dot characters in object should still be respected', () => {
     const from = {};
     const to = { foo: { 'bar.baz': 'bang' } };

--- a/shell/utils/object.js
+++ b/shell/utils/object.js
@@ -205,7 +205,7 @@ export function definedKeys(obj) {
   return compact(flattenDeep(keys));
 }
 
-export function diff(from, to) {
+export function diff(from, to, preventNull = false) {
   from = from || {};
   to = to || {};
 
@@ -234,7 +234,25 @@ export function diff(from, to) {
   const missing = difference(fromKeys, toKeys);
 
   for ( const k of missing ) {
-    set(out, k, null);
+    // we need to gate this in order to prevent unforseen problems with addonConfig
+    if (preventNull) {
+    // keys that come from "definedKeys" method are strings with "" chars inside... We need to clean them up
+      // so that we can access the value of the obj property
+      let key = k;
+
+      if (!k.includes('.')) {
+        key = k.replaceAll('"', '');
+      }
+
+      // // if value exists in "from" but is missing in "to", let's add it, otherwise we just set it null as we did before
+      if (from[key] !== undefined && from[key] !== null) {
+        set(out, key, from[key]);
+      } else {
+        set(out, key, null);
+      }
+    } else {
+      set(out, k, null);
+    }
   }
 
   return out;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15761 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix problem with Kubewarden chart upgrade 
- update unit test

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

**1) Direct usecase for issue (problem upgrading KW chart):**
- Add kubewarden repository in `local` - `Apps` - `Repositories` of type `http` and `url` `https://charts.kubewarden.io`
- Go To `Apps` - `Repositories`, search for `Kubewarden` and install the chart
- Verify that `kubewarden-controller` version `5.7.0` and `kubewarden-crds` version `1.21.0` are installed
- Go to "Preferences" -> Helm Chart -> "Include Prerelease Versions"
- Go To `Apps` - `Repositories`, search for `Kubewarden` and click to upgrade the chart (should be upgrading to `5.8.0-rc1`)
- Verify that upgrade succeeded

**2) Test general chart install**
**3) Test general chart upgrade**

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- installing/upgrading charts

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/905e796a-fb01-4d09-8500-83040fe6be5a

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
