### PR TITLE
Automation: fix cluster provisioning tests

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -97,7 +97,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
       createRKE2ClusterPage.basicsTab().kubernetesVersions().clickOptionWithLabel(version);
 
       createRKE2ClusterPage.machinePoolTab().networks().toggle();
-      createRKE2ClusterPage.machinePoolTab().networks().clickOptionWithLabel('maxdualstack-vpc');
+      createRKE2ClusterPage.machinePoolTab().networks().clickOptionWithLabel('default');
 
       cy.intercept('POST', 'v1/provisioning.cattle.io.clusters').as('createRke2Cluster');
       createRKE2ClusterPage.create();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #

Fixes two issue:
1. Amazon EC2 cluster provisioning tests were failing after the IPv6 support feature was merged #15691. The test was attempting to select a network option labeled 'maxdualstack-vpc' which is not available when IPv4 configuration is selected (IPv4 is the default Stack Preference). The IPv6 support feature introduced logic that filters available network options based on IPv6 configuration - dual-stack networks like 'maxdualstack-vpc' only appear when IPv6 is enabled. This fix updates the test to use the 'default' network option instead, ensuring the test passes without requiring additional UI interactions to enable IPv6 mode.
2. Additionally, this PR fixes flakiness with cluster state assertions by updating the test to accept both 'Reconciling' and 'Updating' states instead of only checking for 'Reconciling'. This addresses timing issues where the cluster may transition through different states during the provisioning process, ensuring the test reliably passes regardless of which state is observed immediately after cluster creation.
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
