### PR TITLE
Automation: fix cluster provisioning tests

### DIFF
--- a/cypress/e2e/po/components/labeled-input.po.ts
+++ b/cypress/e2e/po/components/labeled-input.po.ts
@@ -6,7 +6,7 @@ export default class LabeledInputPo extends ComponentPo {
     return new LabeledInputPo(
       self
         .contains('.labeled-input', label, { includeShadowDom: true })
-        .find('input')
+        .find('[id^="input-"]')
     );
   }
 

--- a/cypress/e2e/tests/pages/manager/aks-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/aks-cluster-provisioning.spec.ts
@@ -73,7 +73,7 @@ describe('Create AKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     createAKSClusterPage.selectKubeProvider(1);
     loadingPo.checkNotExists();
     createAKSClusterPage.rke2PageTitle().should('include', 'Create Azure AKS');
-    createAKSClusterPage.waitForPage('type=azureaks&rkeType=rke2');
+    createAKSClusterPage.waitForPage('type=aks&rkeType=rke2');
 
     // create azure cloud credential
     cloudCredForm.saveButton().expectToBeDisabled();
@@ -91,7 +91,7 @@ describe('Create AKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     });
 
     loadingPo.checkNotExists();
-    createAKSClusterPage.waitForPage('type=azureaks&rkeType=rke2');
+    createAKSClusterPage.waitForPage('type=aks&rkeType=rke2');
   });
 
   beforeEach( () => {
@@ -131,7 +131,7 @@ describe('Create AKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     loadingPo.checkNotExists();
     createAKSClusterPage.rke2PageTitle().should('include', 'Create Azure AKS');
     cy.intercept('GET', '**/meta/aksVersions*').as('getAksVersions');
-    createAKSClusterPage.waitForPage('type=azureaks&rkeType=rke2');
+    createAKSClusterPage.waitForPage('type=aks&rkeType=rke2');
 
     // Verify that aks-zone-select dropdown is set to the default zone
     createAKSClusterPage.getRegion().checkOptionSelected(aksSettings.aksRegion);

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -97,7 +97,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
       createRKE2ClusterPage.basicsTab().kubernetesVersions().clickOptionWithLabel(version);
 
       createRKE2ClusterPage.machinePoolTab().networks().toggle();
-      createRKE2ClusterPage.machinePoolTab().networks().clickOptionWithLabel('maxdualstack-vpc');
+      createRKE2ClusterPage.machinePoolTab().networks().clickOptionWithLabel('default');
 
       cy.intercept('POST', 'v1/provisioning.cattle.io.clusters').as('createRke2Cluster');
       createRKE2ClusterPage.create();
@@ -109,7 +109,12 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
         clusterId = response?.body.id;
       });
       clusterList.waitForPage();
-      clusterList.list().state(this.rke2Ec2ClusterName).should('contain.text', 'Reconciling');
+      clusterList.list().state(this.rke2Ec2ClusterName).should('be.visible')
+        .and(($el) => {
+          const status = $el.text().trim();
+
+          expect(['Reconciling', 'Updating']).to.include(status);
+        });
     });
   });
 

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-azure-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-azure-rke2.spec.ts
@@ -155,7 +155,12 @@ describe('Deploy RKE2 cluster using node driver on Azure', { testIsolation: 'off
         clusterId = response?.body.id;
       });
       clusterList.waitForPage();
-      clusterList.list().state(this.rke2AzureClusterName).should('contain', 'Reconciling');
+      clusterList.list().state(this.rke2AzureClusterName).should('be.visible')
+        .and(($el) => {
+          const status = $el.text().trim();
+
+          expect(['Reconciling', 'Updating']).to.include(status);
+        });
     });
   });
 

--- a/cypress/e2e/tests/pages/manager/eks-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/eks-cluster-provisioning.spec.ts
@@ -60,7 +60,7 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     createEKSClusterPage.selectKubeProvider(0);
     loadingPo.checkNotExists();
     createEKSClusterPage.rke2PageTitle().should('include', 'Create Amazon EKS');
-    createEKSClusterPage.waitForPage('type=amazoneks&rkeType=rke2');
+    createEKSClusterPage.waitForPage('type=eks&rkeType=rke2');
 
     // create amazon cloud credential
     cloudCredForm.saveButton().expectToBeDisabled();
@@ -79,7 +79,7 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
 
     cy.wait('@pageLoad').its('response.statusCode').should('eq', 200);
     loadingPo.checkNotExists();
-    createEKSClusterPage.waitForPage('type=amazoneks&rkeType=rke2');
+    createEKSClusterPage.waitForPage('type=eks&rkeType=rke2');
   });
 
   beforeEach( () => {
@@ -115,7 +115,7 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     createEKSClusterPage.selectKubeProvider(0);
     loadingPo.checkNotExists();
     createEKSClusterPage.rke2PageTitle().should('include', 'Create Amazon EKS');
-    createEKSClusterPage.waitForPage('type=amazoneks&rkeType=rke2');
+    createEKSClusterPage.waitForPage('type=eks&rkeType=rke2');
 
     // Verify that eks-zone-select dropdown is set to the default zone
     createEKSClusterPage.getRegion().checkOptionSelected(eksSettings.eksRegion);

--- a/cypress/e2e/tests/pages/manager/gke-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/gke-cluster-provisioning.spec.ts
@@ -83,7 +83,7 @@ describe('Deploy GKE cluster with default settings', { tags: ['@manager', '@admi
     createGKEClusterPage.selectKubeProvider(2);
     loadingPo.checkNotExists();
     createGKEClusterPage.rke2PageTitle().should('include', 'Create Google GKE');
-    createGKEClusterPage.waitForPage('type=googlegke&rkeType=rke2');
+    createGKEClusterPage.waitForPage('type=gke&rkeType=rke2');
 
     // create GKE cloud credential
     cloudCredForm.saveButton().expectToBeDisabled();
@@ -98,7 +98,7 @@ describe('Deploy GKE cluster with default settings', { tags: ['@manager', '@admi
       cloudcredentialId = req.response?.body.id.replace(':', '%3A');
 
       // Authenticate GKE credential by providing the Project ID
-      createGKEClusterPage.waitForPage('type=googlegke&rkeType=rke2');
+      createGKEClusterPage.waitForPage('type=gke&rkeType=rke2');
       createGKEClusterPage.authProjectId().set( gkeProjectId );
       cy.intercept('POST', `/meta/gkeVersions?cloudCredentialId=${ cloudcredentialId }&projectId=${ gkeProjectId }&zone=${ gkeDefaultZone }`).as('getGKEVersions');
       cloudCredForm.authenticateButton().click();
@@ -106,7 +106,7 @@ describe('Deploy GKE cluster with default settings', { tags: ['@manager', '@admi
       loadingPo.checkNotExists();
 
       // Verify that gke-zone-select dropdown is set to the default zone
-      createGKEClusterPage.waitForPage('type=googlegke&rkeType=rke2');
+      createGKEClusterPage.waitForPage('type=gke&rkeType=rke2');
       ClusterManagerCreateGKEPagePo.getGkeZoneSelect().checkOptionSelected(DEFAULT_GCP_ZONE);
 
       // Get latest GKE kubernetes version and verify that gke-version-select dropdown is set to the default version as defined by versionOptions(); in Config.vue


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2082

Fixes issues with cluster provisioning tests:
1. Updated the LabeledInputPo selector from .find('input') to .find('[id^="input-"]') to handle both input and textarea elements when labeled inputs are configured as multiline.
2. Amazon EC2 cluster provisioning tests were failing after the IPv6 support feature was merged #15691. The test was attempting to select a network option labeled 'maxdualstack-vpc' which is not available when IPv4 configuration is selected (IPv4 is the default Stack Preference). The IPv6 support feature introduced logic that filters available network options based on IPv6 configuration - dual-stack networks like 'maxdualstack-vpc' only appear when IPv6 is enabled. This fix updates the test to use the 'default' network option instead, ensuring the test passes without requiring additional UI interactions to enable IPv6 mode.
3. Fixes flakiness with cluster state assertions by updating the test to accept both 'Reconciling' and 'Updating' states instead of only checking for 'Reconciling', ensuring the test reliably passes regardless of which state is observed immediately after cluster creation.
4. Updates URL assertions across multiple hosted provider provisioning tests (AKS, EKS, GKE) to reflect changes in the hosted provider URLs. The URL parameters have been simplified, for example, from type=amazoneks to type=aks.
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
