### PR TITLE
Automation: disable Kontainer drivers refresh test

### DIFF
--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -5,7 +5,7 @@ import KontainerDriversPagePo from '@/cypress/e2e/po/pages/cluster-manager/konta
 // import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 // import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po';
 // import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
-import { EXTRA_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+// import { EXTRA_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 
 describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@adminUser'] }, () => {
   const driversPage = new KontainerDriversPagePo();
@@ -37,13 +37,14 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     driversPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
   });
 
-  it('can refresh kubernetes metadata', () => {
-    KontainerDriversPagePo.navTo();
-    driversPage.waitForPage();
-    cy.intercept('POST', '/v3/kontainerdrivers?action=refresh').as('refresh');
-    driversPage.refreshKubMetadata().click({ force: true });
-    cy.wait('@refresh', EXTRA_LONG_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
-  });
+  // Skipping until issue resolved: https://github.com/rancher/dashboard/issues/15782
+  // it('can refresh kubernetes metadata', () => {
+  //   KontainerDriversPagePo.navTo();
+  //   driversPage.waitForPage();
+  //   cy.intercept('POST', '/v3/kontainerdrivers?action=refresh').as('refresh');
+  //   driversPage.refreshKubMetadata().click({ force: true });
+  //   cy.wait('@refresh', EXTRA_LONG_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
+  // });
 
   // Revert commented out tests as part of https://github.com/rancher/dashboard/issues/15391
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #

This PR disables a problematic test that fails intermittently due to this issue https://github.com/rancher/dashboard/issues/15782. The test will be enabled once this issue is resolved.

<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
