### PR TITLE
Automation: disable flaky cluster badge test

### DIFF
--- a/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
@@ -1,6 +1,6 @@
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dashboard.po';
-import CardPo from '@/cypress/e2e/po/components/card.po';
+// import CardPo from '@/cypress/e2e/po/components/card.po';
 import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import SimpleBoxPo from '@/cypress/e2e/po/components/simple-box.po';
@@ -107,70 +107,71 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
     cy.wait('@copyKubeConfig');
   });
 
-  it('can add cluster badge', () => {
-    const settings = {
-      description: {
-        original: '',
-        new:      'E2E Test'
-      },
-      iconText:        'E2E',
-      backgroundColor: {
-        original: '#ff0000',
-        new:      '#f80dd8',
-        newRGB:   'rgb(248, 13, 216)'
-      }
-    };
+  // Skipping until issue resolved: https://github.com/rancher/dashboard/issues/15697
+  // it('can add cluster badge', () => {
+  //   const settings = {
+  //     description: {
+  //       original: '',
+  //       new:      'E2E Test'
+  //     },
+  //     iconText:        'E2E',
+  //     backgroundColor: {
+  //       original: '#ff0000',
+  //       new:      '#f80dd8',
+  //       newRGB:   'rgb(248, 13, 216)'
+  //     }
+  //   };
 
-    ClusterDashboardPagePo.navTo();
+  //   ClusterDashboardPagePo.navTo();
 
-    // Add Badge
-    clusterDashboard.customizeAppearanceButton().click();
+  //   // Add Badge
+  //   clusterDashboard.customizeAppearanceButton().click();
 
-    const customClusterCard = new CardPo();
+  //   const customClusterCard = new CardPo();
 
-    customClusterCard.getTitle().contains('Cluster Appearance');
+  //   customClusterCard.getTitle().contains('Cluster Appearance');
 
-    // update badge
-    clusterDashboard.customBadge().selectCheckbox('Show cluster comment').set();
-    clusterDashboard.customBadge().badgeCustomDescription().set(settings.description.new);
+  //   // update badge
+  //   clusterDashboard.customBadge().selectCheckbox('Show cluster comment').set();
+  //   clusterDashboard.customBadge().badgeCustomDescription().set(settings.description.new);
 
-    // update color
-    clusterDashboard.customBadge().colorPicker().value().should('not.eq', settings.backgroundColor.new);
-    clusterDashboard.customBadge().selectCheckbox('Badge background color').set();
-    clusterDashboard.customBadge().colorPicker().set(settings.backgroundColor.new);
-    clusterDashboard.customBadge().colorPicker().previewColor().should('eq', settings.backgroundColor.newRGB);
+  //   // update color
+  //   clusterDashboard.customBadge().colorPicker().value().should('not.eq', settings.backgroundColor.new);
+  //   clusterDashboard.customBadge().selectCheckbox('Badge background color').set();
+  //   clusterDashboard.customBadge().colorPicker().set(settings.backgroundColor.new);
+  //   clusterDashboard.customBadge().colorPicker().previewColor().should('eq', settings.backgroundColor.newRGB);
 
-    // update icon
-    clusterDashboard.customBadge().selectCheckbox('Use custom badge').set();
-    clusterDashboard.customBadge().iconText().set(settings.iconText);
-    clusterDashboard.customBadge().clusterIcon().contains(settings.iconText);
+  //   // update icon
+  //   clusterDashboard.customBadge().selectCheckbox('Use custom badge').set();
+  //   clusterDashboard.customBadge().iconText().set(settings.iconText);
+  //   clusterDashboard.customBadge().clusterIcon().contains(settings.iconText);
 
-    // Apply Changes
-    clusterDashboard.customBadge().applyAndWait('/v3/clusters/local');
+  //   // Apply Changes
+  //   clusterDashboard.customBadge().applyAndWait('/v3/clusters/local');
 
-    // check header and side nav for update
-    header.clusterIcon().children().should('have.class', 'cluster-badge-logo');
-    header.clusterName().should('contain', 'local');
-    header.customBadge().should('contain', settings.description.new);
-    const burgerMenu = new BurgerMenuPo();
+  //   // check header and side nav for update
+  //   header.clusterIcon().children().should('have.class', 'cluster-badge-logo');
+  //   header.clusterName().should('contain', 'local');
+  //   header.customBadge().should('contain', settings.description.new);
+  //   const burgerMenu = new BurgerMenuPo();
 
-    burgerMenu.clusterNotPinnedList().first().find('span').should('contain', settings.iconText);
+  //   burgerMenu.clusterNotPinnedList().first().find('span').should('contain', settings.iconText);
 
-    // Reset
-    clusterDashboard.customizeAppearanceButton().click();
-    clusterDashboard.customBadge().selectCheckbox('Use custom badge').set();
-    clusterDashboard.customBadge().selectCheckbox('Badge background color').set();
-    clusterDashboard.customBadge().selectCheckbox('Show cluster comment').set();
+  //   // Reset
+  //   clusterDashboard.customizeAppearanceButton().click();
+  //   clusterDashboard.customBadge().selectCheckbox('Use custom badge').set();
+  //   clusterDashboard.customBadge().selectCheckbox('Badge background color').set();
+  //   clusterDashboard.customBadge().selectCheckbox('Show cluster comment').set();
 
-    // Apply Changes
-    clusterDashboard.customBadge().applyAndWait('/v3/clusters/local');
+  //   // Apply Changes
+  //   clusterDashboard.customBadge().applyAndWait('/v3/clusters/local');
 
-    // check header and side nav for update
-    header.clusterIcon().children().should('have.class', 'cluster-local-logo');
-    header.clusterName().should('contain', 'local');
-    header.customBadge().should('not.exist');
-    burgerMenu.clusterNotPinnedList().first().find('svg').should('have.class', 'cluster-local-logo');
-  });
+  //   // check header and side nav for update
+  //   header.clusterIcon().children().should('have.class', 'cluster-local-logo');
+  //   header.clusterName().should('contain', 'local');
+  //   header.customBadge().should('not.exist');
+  //   burgerMenu.clusterNotPinnedList().first().find('svg').should('have.class', 'cluster-local-logo');
+  // });
 
   it('can view deployments', () => {
     clusterDashboard.goTo();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #

Disable flaky cluster badge test due to performance issue.
This PR temporarily disables the can add cluster badge test that fails intermittently due to a performance issue documented in #15697.
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
