### PR TITLE
fix: vGPU option is empty when creating harvester downstream cluster

### DIFF
--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -498,13 +498,18 @@ export default {
     },
 
     vGpuOptions() {
-      const vGpuTypes = uniq([
-        ...this.vGpusInit,
-        ...Object.values(this.vGpuDevices)
-          .filter((vGpu) => vGpu.enabled && !!vGpu.type && (vGpu.allocatable === null || vGpu.allocatable > 0))
-      ]);
+      const availableDevices = Object.values(this.vGpuDevices)
+        .filter((vGpu) => vGpu.enabled &&
+          vGpu.type &&
+          (vGpu.allocatable === null || vGpu.allocatable > 0)
+        );
 
-      return vGpuTypes;
+      const uniqueTypes = uniq(availableDevices.map((vGpu) => vGpu.type));
+
+      return uniqueTypes.map((type) => ({
+        label: this.vGpuOptionLabel(type),
+        value: type
+      }));
     },
 
     showVGpuAllocationInfo() {
@@ -1487,7 +1492,6 @@ export default {
             :select-props="{
               mode,
               disabled,
-              getOptionLabel: vGpuOptionLabel
             }"
             :options="vGpuOptions"
             label-key="harvesterManager.vGpu.label"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15801 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Rewrite `vGpuOptions` to return `label` and `values`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
N/A

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
N/A

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Cluster create page

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/8f3603b0-d3ef-47ca-9661-69733e55f69f


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
