### PR TITLE
prevent sending notification for SCC no registration to non-admin users and if feature flag is not enabled

### DIFF
--- a/pkg/rancher-prime/index.ts
+++ b/pkg/rancher-prime/index.ts
@@ -1,13 +1,14 @@
 import { importTypes } from '@rancher/auto-import';
 import { IPlugin, PanelLocation } from '@shell/core/types';
 import { installDocHandler } from './docs';
-
 import routing from './routing/index';
 import { useI18n } from '@shell/composables/useI18n';
 import { usePrimeRegistration } from './pages/registration.composable';
 import { type Store } from 'vuex';
 import { NotificationLevel } from '@shell/types/notifications';
 import { REGISTRATION_NOTIFICATION_ID } from './config/constants';
+import { isAdminUser } from '@shell/store/type-map';
+import { SCC } from '@shell/store/features';
 
 /**
  * Trigger notification on plugin loaded and no active registration is found.
@@ -20,7 +21,7 @@ const setNotification = (store: Store<any>) => {
   } = usePrimeRegistration(store);
 
   initRegistration().then(() => {
-    if (!registration.value.active) {
+    if (!registration.value.active && isAdminUser(store.getters) && store.getters['features/get'](SCC)) {
       const { t } = useI18n(store);
 
       const notification = {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15807 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- prevent sending notification for SCC no registration to non-admin users and if feature flag is not enabled

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- Followed same gating as https://github.com/rancher/dashboard/blob/master/pkg/rancher-prime/config/navigation.ts#L14-L15
- For now we can't prevent registering routes from extensions, as per https://github.com/rancher/dashboard/issues/15645, so next best thing is to prevent displaying links to "protected" areas

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- With a Rancher Prime version, not registered with SCC, do a login:

- **Admin**: should see notification that Rancher isn't registered
- **Standard** user: should NOT see notification that Rancher isn't registered
- **User Base**: should NOT see notification that Rancher isn't registered

**IMPORTANT NOTE:** If while Admin you're not seeing SCC registration entry in the settings area, make sure that feature flag `rancher-scc-registration-extension` is enabled
 
### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
