### PR TITLE
Fixes an issue where a user had to click items in a dropdown menu twice in order to trigger an action

### DIFF
--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownItem.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownItem.vue
@@ -36,6 +36,7 @@ const handleClick = (e: MouseEvent) => {
     @click.stop="handleClick"
     @keydown.enter.space="handleActivate"
     @keydown.up.down.prevent.stop="handleKeydown"
+    @mousedown.prevent="() => {/*We use this to prevent clicks from triggering the @focusin below. When we scroll on a click it prevents the action from occurring on the first click.*/}"
     @focusin="scrollIntoView"
   >
     <slot name="before">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15520
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
We would scroll the menu item into view when the menu item received focus. This in turn would prevent the action from getting triggered. We now prevent the focusin event from occurring the user clicks. This allows the focus event to still fire during keyboard navigation.

### Areas or cases that should be tested
Anywhere that there's a dropdown menu which has a scrollbar.

### Areas which could experience regressions
Keyboard navigation in the dropdown menu.

### Screenshot/Video
The cluster page example isn't as obvious because I only had one event but you can tell it's working since the action menu closes on click.

https://github.com/user-attachments/assets/1611939e-2268-43fa-ba21-3424e64b5890



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
