### PR TITLE
Fix error during custom cluster creation with slow network speeds

### DIFF
--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -369,7 +369,11 @@ export default class ProvCluster extends SteveModel {
   }
 
   get mgmtClusterId() {
-    return this.status?.clusterName;
+    // when a cluster is created `this` instance isn't immediately updated with `status.clusterName`
+    // Workaround - Get fresh copy from the store
+    const pCluster = this.$rootGetters['management/byId'](CAPI.RANCHER_CLUSTER, this.id);
+
+    return this.status?.clusterName || pCluster?.status?.clusterName;
   }
 
   get mgmt() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15538 
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
This is the line throwing the error

```
    async saveRoleBindings() {
      await this.value.waitForMgmt();

      if (this.membershipUpdate.save) {
        await this.membershipUpdate.save(this.value.mgmt.id); <------ this.value.mgmt is undefined here
      }
    },

```

My own local testing and console logs in the issue's screenshot confirm that the wait for management ended because management was found; it didn't time out. The issue appears to be that for a brief window after a provisioning cluster is created, the model's `this` doesn't include updated status so we can't get the management cluster's id. There is already a workaround for this in `waitForMgmt`. I added the same workaround to the `mgmtId` getter 


### Areas or cases that should be tested
The scenario as described in the issue should be tested. Note for my fellow firefox enjoyers: it seems specific to chrome

### Areas which could experience regressions
none

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
