### PR TITLE
Enable description editing for imported clusters

### DIFF
--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -429,7 +429,6 @@ export default defineComponent({
           :mode="mode"
           :namespaced="false"
           :nameEditable="!isEdit"
-          :descriptionDisabled="!enableInstanceDescription"
           nameKey="name"
           descriptionKey="description"
           name-label="cluster.name.label"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Enable description editing for imported clusters. Closer to an enhancement than a bug.

Fixes #15358
<!-- Define findings related to the feature or bug issue. -->

### Areas or cases that should be tested
Imported cluster creation/editing.

### Areas which could experience regressions
Imported cluster creation/editing.

### Screenshot/Video


https://github.com/user-attachments/assets/fc642366-0b5b-4f14-8640-90c08d4c6911


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
