### PR TITLE
Fix cluster edit for local cluster on refresh

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -163,9 +163,8 @@ export default {
     };
 
     this.extensions = this.$extension.getProviders(context);
-  },
 
-  data() {
+    // At this point, we know we definitely have the mgmt cluster, so we can access `isImported` and `isLocal`
     let subType = null;
 
     subType = this.$route.query[SUB_TYPE] || null;
@@ -176,6 +175,11 @@ export default {
     } else if (this.value.isLocal) {
       subType = LOCAL;
     }
+
+    this.subType = subType;
+  },
+
+  data() {
     const rkeType = this.$route.query[RKE_TYPE] || null;
     const chart = this.$route.query[CHART] || null;
     const isImport = this.realMode === _IMPORT;
@@ -184,7 +188,7 @@ export default {
       nodeDrivers:      [],
       kontainerDrivers: [],
       extensions:       [],
-      subType,
+      subType:          null,
       rkeType,
       chart,
       isImport,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15797
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

With some changes to support scalability, we no longer fetch all mgmt clusters in the UI early on.

It turns out that the cluster edit page for the local cluster (when loaded via page refresh) has a bug where it assumes the mgmt cluster information is available.

This PR fixes this bug.
 
### Technical notes summary

Although the cluster edit page fetches the mgmt clusters, there is code in the `data` method which calculates `subType`. Unfortunately, `data` runs before `fetch`, so if the mgmt clusters have not already been loaded, then the `data` method will incorrectly calculate `subType`.

The fix is easy - move the calculation of `subType` from the `data` method to `fecth`. This ensures it occurs after the mgmt clusters have been fetched.

### Areas or cases that should be tested

Go the cluster edit page for the `local` cluster.

Hit refresh on the browser.

Make sure you get the Vue page and not the Ember page.

### Screenshot/Video

Vue screen that you should now see:

<img width="1091" height="851" alt="image" src="https://github.com/user-attachments/assets/c30ee586-0827-4383-a076-2d962cd2cfcc" />

Ember screen that is shown on refresh before the fix in this PR:

<img width="1091" height="851" alt="image" src="https://github.com/user-attachments/assets/32c35a4e-2faa-4594-a7bc-ddcef45835d3" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
