### PR TITLE
Use scoped style for banner graphic

### DIFF
--- a/shell/assets/styles/themes/_suse.scss
+++ b/shell/assets/styles/themes/_suse.scss
@@ -83,11 +83,12 @@
     --toggle-off-bg: #{$grey-70};
     --sortable-table-selected-bg: #3f4350;
   }
-  
-  // SUSE Theme uses a smaller banner graphic
-  .suse-banner-graphic {
-    height: 160px;
 
+  // SUSE Theme uses a smaller banner graphic
+  --banner-graphic-height: 160px;
+
+  // SUSE Theme positions from right, so ship stays visible as browser width shrinks
+  .suse-banner-graphic {
     > img {
       object-position: right;
     }

--- a/shell/components/BannerGraphic.vue
+++ b/shell/components/BannerGraphic.vue
@@ -36,7 +36,7 @@ export default {
 <template>
   <div
     v-if="shown"
-    class="banner-graphic"
+    class="banner-graphic-area"
     :class="{[alignClass]: true}"
   >
     <div
@@ -67,10 +67,10 @@ export default {
   </div>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
   $banner-height: 200px;
 
-  .banner-graphic {
+  .banner-graphic-area {
     position: relative;
 
     .graphic {
@@ -109,6 +109,6 @@ export default {
 
   // Use top-level style so that a theme style can easily override via its own style without having to worry about specificity of CSS styles
   .banner-graphic-height {
-    height: $banner-height;
+    height: var(--banner-graphic-height, $banner-height);
   }
 </style>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15822

### Occurred changes and/or fixed issues

The BannerGraphic styles don't need to be global - this PR changes them to `scoped` - they are only used in this component.

We rename the top-level style (adding `-area`) so that any extensions built with older shell will not interfere going forward.

We also use a CSS var for the banner height to avoid issues with CSS specitivity.

### Areas or cases that should be tested

Check the home page banner graphic appears correctly with the suse and modern brands/themes.

Bonus points - install the Harvester extension and check that the home page banner when `ui-brand` is set to `suse` is unaffected.

Things that are broken to validate, when the brand is `suse` and the Harvester UI Extension is loaded:

- The banner height becomes 200px and not 160px
- The banner text gets a 20px margin instead of 0 margin - so the text does not appear vertically centred in the banner 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
