### PR TITLE
Automation: Remove orphaned cloud creds before running test

### DIFF
--- a/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
@@ -29,6 +29,7 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
   let removeWorkspace = false;
   let disableFeature = false;
   let clusterName = '';
+  let cloudcredentialId = '';
   let gitRepo = '';
   let customWorkspace = '';
   const feature = 'provisioningv2-fleet-workspace-back-population';
@@ -69,7 +70,9 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
           namespace,
         },
         metadata: { labels: { foo: 'bar' } }
-      }).then(() => {
+      }).then((req) => {
+        cloudcredentialId = req.body.spec.cloudCredentialSecretName;
+
         removeCluster = true;
       });
     });
@@ -364,6 +367,11 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
       featureFlagsPage.list().clickRowActionMenuItem(feature, 'Deactivate');
       featureFlagsPage.clickCardActionButtonAndWait('Deactivate', feature, false, { waitForModal: true, waitForRequest: true });
       featureFlagsPage.list().details(feature, 0).should('include.text', 'Disabled');
+    }
+
+    if (cloudcredentialId) {
+      // delete cloud credential
+      cy.deleteRancherResource('v3', 'cloudCredentials', cloudcredentialId, false);
     }
   });
 });

--- a/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
@@ -9,10 +9,33 @@ import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattl
 import LoadingPo from '@/cypress/e2e/po/components/loading.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 
+/******
+*  Running this test will delete all Amazon cloud credentials from the target cluster
+******/
 describe('Cloud Credential', { tags: ['@manager', '@adminUser'] }, () => {
   const clusterList = new ClusterManagerListPagePo();
   const doCreatedCloudCredsIds = [];
   const azCreatedCloudCredsIds = [];
+
+  before(() => {
+    cy.login();
+    // Clean up any orphaned Amazon cloud credentials from previous test runs to ensure tests start with a clean state
+    cy.getRancherResource('v3', 'cloudcredentials', null, null).then((resp: Cypress.Response<any>) => {
+      const body = resp.body;
+
+      if (body.pagination['total'] > 0) {
+        body.data.forEach((item: any) => {
+          if (item.amazonec2credentialConfig) {
+            const id = item.id;
+
+            cy.deleteRancherResource('v3', 'cloudcredentials', id, false);
+          } else {
+            cy.log('There are no existing amazon cloud credentials to delete');
+          }
+        });
+      }
+    });
+  });
 
   beforeEach(() => {
     cy.login();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2043

Problem
A e2e test (`cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts`) creates an AWS cloud credential during setup but doesn't clean it up, leaving orphaned credentials that can affect subsequent test runs.

Solution
- Track the cloud credential ID created during cluster setup and delete it in the after hook cleanup.
- As fallback, clean up any orphaned Amazon cloud credentials before test execution in cloud-credential.spec.ts

<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video

<img width="553" height="149" alt="Screenshot 2025-10-31 at 10 42 34 AM" src="https://github.com/user-attachments/assets/7153faf7-c69e-472c-9ba3-3917045c8393" />


<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
