### PR TITLE
[backport 2.12.4] Automation: Remove orphaned cloud creds before running test

### DIFF
--- a/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
@@ -30,6 +30,7 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
   let disableFeature = false;
   let clusterId = '';
   let clusterName = '';
+  let cloudcredentialId = '';
   let gitRepo = '';
   let customWorkspace = '';
   const feature = 'provisioningv2-fleet-workspace-back-population';
@@ -70,7 +71,8 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
           namespace,
         },
         metadata: { labels: { foo: 'bar' } }
-      }).then(() => {
+      }).then((req) => {
+        cloudcredentialId = req.body.spec.cloudCredentialSecretName;
         removeCluster = true;
       });
 
@@ -370,6 +372,11 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
       featureFlagsPage.list().clickRowActionMenuItem(feature, 'Deactivate');
       featureFlagsPage.clickCardActionButtonAndWait('Deactivate', feature, false, { waitForModal: true, waitForRequest: true });
       featureFlagsPage.list().details(feature, 0).should('include.text', 'Disabled');
+    }
+
+    if (cloudcredentialId) {
+      // delete cloud credential
+      cy.deleteRancherResource('v3', 'cloudCredentials', cloudcredentialId, false);
     }
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2043

Backport of original issue ^

<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
