### PR TITLE
Container logs dropdown

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -883,8 +883,12 @@ asyncButton:
     waiting: Saving&hellip;
   download:
     action: Download
+    actionIcon: download
+    errorIcon: error
     success: Saving
+    successIcon: checkmark
     waiting: Downloading&hellip;
+    waitingIcon: spinner
   downgrade:
     action: Downgrade
     success: Downgraded

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -883,7 +883,6 @@ asyncButton:
     waiting: Saving&hellip;
   download:
     action: Download
-    actionIcon: download
     errorIcon: error
     success: Saving
     successIcon: checkmark

--- a/shell/components/AsyncButton.vue
+++ b/shell/components/AsyncButton.vue
@@ -378,7 +378,7 @@ export default defineComponent({
 @media only screen and (max-width: 1060px) {
   .show-only-icon-in-small-view {
     &.btn {
-      padding: 0 4px 0 8px;
+      padding: 0 4px 0 10px;
     }
     .async-button-label {
       display: none;

--- a/shell/components/AsyncButton.vue
+++ b/shell/components/AsyncButton.vue
@@ -119,7 +119,20 @@ export default defineComponent({
       default: false,
     },
 
+    /**
+     * If true, the button will only show the icon in smaller views and hides the label.
+     */
     showOnlyIconInSmallView: {
+      type:    Boolean,
+      default: false,
+    },
+
+    /**
+     * If true, the 'icon' prop will be used for all button states (action, waiting, success, error),
+     * overriding any state-specific icons defined in translations.
+     * This is useful for buttons that need a static icon regardless of their phase, like Copy to Clipboard.
+     */
+    persistentIcon: {
       type:    Boolean,
       default: false,
     }
@@ -192,15 +205,26 @@ export default defineComponent({
 
       let out = '';
 
-      if ( this.icon ) {
+      // If persistentIcon is true, the icon prop always takes precedence
+      // This ensures a static icon is displayed across all phases
+      if ( this.persistentIcon && this.icon ) {
         out = this.icon;
-      } else if ( exists(key) ) {
-        out = `icon-${ t(key) }`;
-      } else if ( exists(defaultKey) ) {
-        out = `icon-${ t(defaultKey) }`;
+      } else {
+        // Otherwise, prioritize state-specific icons from translations
+        // This allows for dynamic icons based on the button's current phase (e.g., spinner for waiting).
+        if ( exists(key) ) {
+          out = `icon-${ t(key) }`;
+        } else if ( exists(defaultKey) ) {
+          out = `icon-${ t(defaultKey) }`;
+        } else if ( this.icon ) {
+          // Fallback to the generic icon prop if no state-specific translated icon is found
+          out = this.icon;
+        }
       }
 
-      if ( this.isSpinning ) {
+      // Add spinning animation for the waiting phase, unless the icon is persistent.
+      if ( this.isSpinning && !this.persistentIcon ) {
+        // If there's no icon at all, default to a spinner icon for the waiting state.
         if ( !out ) {
           out = 'icon-spinner';
         }

--- a/shell/components/AsyncButton.vue
+++ b/shell/components/AsyncButton.vue
@@ -119,6 +119,10 @@ export default defineComponent({
       default: false,
     },
 
+    showOnlyIconInSmallView: {
+      type:    Boolean,
+      default: false,
+    }
   },
 
   setup() {
@@ -167,6 +171,10 @@ export default defineComponent({
       // to it's normal state/phase
       if (this.phase === ASYNC_BUTTON_STATES.ACTION) {
         out['ready-for-action'] = true;
+      }
+
+      if (this.showOnlyIconInSmallView) {
+        out['show-only-icon-in-small-view'] = true;
       }
 
       return out;
@@ -306,24 +314,33 @@ export default defineComponent({
     :data-testid="componentTestid + '-async-button'"
     @click="clicked"
   >
-    <slot>
-      <span
-        v-if="isManualRefresh"
-        :class="{'mr-10': displayIcon && size !== 'sm', 'mr-5': displayIcon && size === 'sm'}"
-      >{{ t('action.refresh') }}</span>
-      <i
-        v-if="displayIcon"
-        v-clean-tooltip="tooltip"
-        :class="{icon: true, 'icon-lg': true, [displayIcon]: true, 'mr-0': isManualRefresh}"
-        :alt="t('asyncButton.alt.iconAlt')"
-      />
-      <span
-        v-if="labelAs === 'text' && displayLabel"
-        v-clean-tooltip="tooltip"
-        v-clean-html="displayLabel"
-        data-testid="async-btn-display-label"
-      />
-    </slot>
+    <span
+      v-if="isManualRefresh"
+      :class="{
+        'mr-10': displayIcon && size !== 'sm',
+        'mr-5': displayIcon && size === 'sm',
+        'manual-refresh-label': true
+      }"
+    >{{ t('action.refresh') }}</span>
+    <i
+      v-if="displayIcon"
+      v-clean-tooltip="tooltip"
+      :class="{
+        icon: true,
+        'icon-lg': true,
+        [displayIcon]: true,
+        'mr-0': isManualRefresh,
+        'async-button-icon': true
+      }"
+      :alt="t('asyncButton.alt.iconAlt')"
+    />
+    <span
+      v-if="labelAs === 'text' && displayLabel"
+      v-clean-tooltip="tooltip"
+      v-clean-html="displayLabel"
+      data-testid="async-btn-display-label"
+      class="async-button-label"
+    />
   </button>
 </template>
 
@@ -333,4 +350,18 @@ export default defineComponent({
   margin: 0 0 0 8px !important;
   font-size: 1rem !important;
 }
-</style>
+
+@media only screen and (max-width: 1060px) {
+  .show-only-icon-in-small-view {
+    &.btn {
+      padding: 0 4px 0 8px;
+    }
+    .async-button-label {
+      display: none;
+    }
+
+    .async-button-icon {
+      display: inline-block;
+    }
+  }
+}</style>

--- a/shell/components/AsyncButton.vue
+++ b/shell/components/AsyncButton.vue
@@ -306,22 +306,24 @@ export default defineComponent({
     :data-testid="componentTestid + '-async-button'"
     @click="clicked"
   >
-    <span
-      v-if="isManualRefresh"
-      :class="{'mr-10': displayIcon && size !== 'sm', 'mr-5': displayIcon && size === 'sm'}"
-    >{{ t('action.refresh') }}</span>
-    <i
-      v-if="displayIcon"
-      v-clean-tooltip="tooltip"
-      :class="{icon: true, 'icon-lg': true, [displayIcon]: true, 'mr-0': isManualRefresh}"
-      :alt="t('asyncButton.alt.iconAlt')"
-    />
-    <span
-      v-if="labelAs === 'text' && displayLabel"
-      v-clean-tooltip="tooltip"
-      v-clean-html="displayLabel"
-      data-testid="async-btn-display-label"
-    />
+    <slot>
+      <span
+        v-if="isManualRefresh"
+        :class="{'mr-10': displayIcon && size !== 'sm', 'mr-5': displayIcon && size === 'sm'}"
+      >{{ t('action.refresh') }}</span>
+      <i
+        v-if="displayIcon"
+        v-clean-tooltip="tooltip"
+        :class="{icon: true, 'icon-lg': true, [displayIcon]: true, 'mr-0': isManualRefresh}"
+        :alt="t('asyncButton.alt.iconAlt')"
+      />
+      <span
+        v-if="labelAs === 'text' && displayLabel"
+        v-clean-tooltip="tooltip"
+        v-clean-html="displayLabel"
+        data-testid="async-btn-display-label"
+      />
+    </slot>
   </button>
 </template>
 

--- a/shell/components/CopyToClipboard.vue
+++ b/shell/components/CopyToClipboard.vue
@@ -33,6 +33,7 @@ export default {
   <AsyncButton
     icon="icon-copy"
     :show-label="showLabel"
+    persistent-icon
     action-label="Copy"
     waiting-label="Copying..."
     success-label="Copied!"

--- a/shell/components/Window/ContainerLogs.vue
+++ b/shell/components/Window/ContainerLogs.vue
@@ -889,7 +889,7 @@ export default {
   @media only screen and (max-width: 1060px) {
     .wm-button-bar {
       .wm-btn {
-        padding: 0 4px 0 8px;
+        padding: 0 6px 0 12px;
 
         .wm-btn-large {
           display: none;

--- a/shell/components/Window/ContainerLogs.vue
+++ b/shell/components/Window/ContainerLogs.vue
@@ -630,6 +630,7 @@ export default {
           <AsyncButton
             mode="download"
             role="button"
+            icon="icon-download"
             show-only-icon-in-small-view
             :aria-label="t('asyncButton.download.action')"
             @click="download"

--- a/shell/components/Window/ContainerLogs.vue
+++ b/shell/components/Window/ContainerLogs.vue
@@ -600,7 +600,7 @@ export default {
             />
           </template>
         </Select>
-        <div class="log-action log-action-group ml-5">
+        <div class="log-action log-action-group ml-5 mmr-6">
           <button
             class="btn role-primary wm-btn"
             role="button"
@@ -630,9 +630,16 @@ export default {
           <AsyncButton
             mode="download"
             role="button"
+            class="wm-btn"
             :aria-label="t('asyncButton.download.action')"
             @click="download"
-          />
+          >
+            <t
+              class="wm-btn-large"
+              k="asyncButton.download.action"
+            />
+            <i class="wm-btn-small icon icon-download" />
+          </AsyncButton>
         </div>
 
         <div class="wm-seperator" />
@@ -820,7 +827,8 @@ export default {
       min-width: 200px;
       height: 30px;
       min-height: 30px;
-      width: initial;
+      width: 100%;
+      max-width: 960px;
     }
   }
 

--- a/shell/components/Window/ContainerLogs.vue
+++ b/shell/components/Window/ContainerLogs.vue
@@ -609,11 +609,11 @@ export default {
             :disabled="isFollowing"
             @click="follow"
           >
+            <i class="icon icon-chevron-end" />
             <t
               class="wm-btn-large"
               k="wm.containerLogs.follow"
             />
-            <i class="wm-btn-small icon icon-chevron-end" />
           </button>
           <button
             class="btn role-primary wm-btn"
@@ -621,25 +621,19 @@ export default {
             :aria-label="t('wm.containerLogs.clear')"
             @click="clear"
           >
+            <i class="icon icon-close" />
             <t
               class="wm-btn-large"
               k="wm.containerLogs.clear"
             />
-            <i class="wm-btn-small icon icon-close" />
           </button>
           <AsyncButton
             mode="download"
             role="button"
-            class="wm-btn"
+            show-only-icon-in-small-view
             :aria-label="t('asyncButton.download.action')"
             @click="download"
-          >
-            <t
-              class="wm-btn-large"
-              k="asyncButton.download.action"
-            />
-            <i class="wm-btn-small icon icon-download" />
-          </AsyncButton>
+          />
         </div>
 
         <div class="wm-seperator" />
@@ -894,7 +888,7 @@ export default {
   @media only screen and (max-width: 1060px) {
     .wm-button-bar {
       .wm-btn {
-        padding: 0 10px;
+        padding: 0 4px 0 8px;
 
         .wm-btn-large {
           display: none;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12642 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Added a gap between the left side and the right side (between the "download" button and the "use previous container" checkbox)
- Set the width for the dropdown to 100% to fill the remaining space but keep its max width to 960px
- Display icon and label for all the three buttons but only icons for smaller resolution(keeping the current breakpoint 1060px)

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- Added a new prop to AsyncButton `showOnlyIconInSmallView` to implement the same behaviour of the Clear and Follow buttons
- Added a new prop `persistentIcon` and updated the `displayIcon` logic inside `AsyncButton` in order to prevent regression. The main affected components were these three:
  - `shell/components/CopyToClipboard.vue`
  - `shell/dialog/InstallExtensionDialog.vue`
  - `shell/dialog/UninstallExtensionDialog.vue`
- Unit tests

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Check first attached video

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
I've attached a video that I'm testing the main areas that could experience regressions, but in general the places where we have async button like for save or download should be tested.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
The fix:
https://github.com/user-attachments/assets/32c89039-e21e-47bf-ad3d-cb162f77d79e

Testing areas for possible regression:
https://github.com/user-attachments/assets/b8a6686b-e273-4de5-a571-3cb48ed0c293

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
