### PR TITLE
Automation: fix upgrade group create test

### DIFF
--- a/cypress/e2e/po/components/labeled-input.po.ts
+++ b/cypress/e2e/po/components/labeled-input.po.ts
@@ -6,7 +6,7 @@ export default class LabeledInputPo extends ComponentPo {
     return new LabeledInputPo(
       self
         .contains('.labeled-input', label, { includeShadowDom: true })
-        .find('[id^="input-"]')
+        .find('[id^="input-"], input')
     );
   }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2086

This PR fixes `Extensions Compatibility` -> `Should create an Upgrade Group` by updating the labeled input selector to handle inputs without id^="input-" pattern.

Fixed an issue where LabeledInputPo.byLabel() could not find input elements that don't have an id starting with "input-". Updated the selector to also match plain input elements as a fallback. This improves selector reliability across different input implementations in labeled-input components.
<!-- Define findings related to the feature or bug issue. -->


### Screenshot/Video
<img width="976" height="452" alt="image" src="https://github.com/user-attachments/assets/bde59018-dd66-4683-8fbe-cd16e26222d4" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
