### PR TITLE
Automation: fix fleet cluster workspace change test

### DIFF
--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -94,6 +94,7 @@ declare global {
       createAmazonMachineConfig(instanceType: string, region: string, vpcId: string, zone: string, type: string, clusterName: string, namespace: string): Chainable;
       createAmazonRke2Cluster(params: CreateAmazonRke2ClusterParams): Chainable;
       createAmazonRke2ClusterWithoutMachineConfig(params: CreateAmazonRke2ClusterWithoutMachineConfigParams): Chainable;
+      getKubernetesReleases(rkeType: 'rke2' | 'k3s'): Chainable;
       createSecret(namespace: string, name: string, options?: { type?: string; metadata?: any; data?: any }): Chainable;
       createConfigMap(namespace: string, name: string, options?: { metadata?: any; data?: any }): Chainable;
       createService(namespace: string, name: string, options?: { type?: string; ports?: any[]; spec?: any; metadata?: any }): Chainable;

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -636,6 +636,22 @@ Cypress.Commands.add('deleteNodeTemplate', (nodeTemplateId, timeout = 30000, fai
   return retry();
 });
 
+Cypress.Commands.add('getKubernetesReleases', (rkeType: 'rke2' | 'k3s') => {
+  return cy.request({
+    method:  'GET',
+    url:     `${ Cypress.env('api') }/v1-${ rkeType }-release/releases`,
+    headers: {
+      'x-api-csrf': token.value,
+      Accept:       'application/json'
+    },
+  })
+    .then((resp) => {
+      expect(resp.status).to.eq(200);
+
+      return resp;
+    });
+});
+
 /**
  * Create RKE2 cluster with Amazon EC2 cloud provider
  */
@@ -644,121 +660,128 @@ Cypress.Commands.add('createAmazonRke2Cluster', (params: CreateAmazonRke2Cluster
     machineConfig, rke2ClusterAmazon, cloudCredentialsAmazon, metadata
   } = params;
 
-  return cy.createAwsCloudCredentials(cloudCredentialsAmazon.workspace, cloudCredentialsAmazon.name, cloudCredentialsAmazon.region, cloudCredentialsAmazon.accessKey, cloudCredentialsAmazon.secretKey)
-    .then((resp: Cypress.Response<any>) => {
-      const cloudCredentialId = resp.body.id;
+  return cy.getKubernetesReleases('rke2').then((resp: Cypress.Response<any>) => {
+    // Get the latest kubernetes version
+    const kubernetesVersion = resp.body.data[resp.body.data.length - 1].id;
 
-      return cy.createAmazonMachineConfig(
-        machineConfig.instanceType, machineConfig.region, machineConfig.vpcId, machineConfig.zone, machineConfig.type, machineConfig.clusterName, machineConfig.namespace)
-        .then((resp: Cypress.Response<any>) => {
-          const machineConfigId = resp.body.id.split('/');
+    cy.log(`kubernetesVersion: ${ kubernetesVersion }`);
 
-          return cy.request({
-            method:           'POST',
-            url:              `${ Cypress.env('api') }/v1/provisioning.cattle.io.clusters`,
-            failOnStatusCode: true,
-            headers:          {
-              'x-api-csrf': token.value,
-              Accept:       'application/json'
-            },
-            body: {
-              type:     'provisioning.cattle.io.cluster',
-              metadata: {
-                namespace:   rke2ClusterAmazon.namespace,
-                annotations: {
-                  'field.cattle.io/description': `${ rke2ClusterAmazon.clusterName }-description`,
-                  ...(metadata?.annotations || {}),
-                },
-                labels: metadata?.labels || {},
-                name:   rke2ClusterAmazon.clusterName
+    return cy.createAwsCloudCredentials(cloudCredentialsAmazon.workspace, cloudCredentialsAmazon.name, cloudCredentialsAmazon.region, cloudCredentialsAmazon.accessKey, cloudCredentialsAmazon.secretKey)
+      .then((resp: Cypress.Response<any>) => {
+        const cloudCredentialId = resp.body.id;
+
+        return cy.createAmazonMachineConfig(
+          machineConfig.instanceType, machineConfig.region, machineConfig.vpcId, machineConfig.zone, machineConfig.type, machineConfig.clusterName, machineConfig.namespace)
+          .then((resp: Cypress.Response<any>) => {
+            const machineConfigId = resp.body.id.split('/');
+
+            return cy.request({
+              method:           'POST',
+              url:              `${ Cypress.env('api') }/v1/provisioning.cattle.io.clusters`,
+              failOnStatusCode: true,
+              headers:          {
+                'x-api-csrf': token.value,
+                Accept:       'application/json'
               },
-              spec: {
-                rkeConfig: {
-                  chartValues:     { 'rke2-calico': {} },
-                  upgradeStrategy: {
-                    controlPlaneConcurrency:  '1',
-                    controlPlaneDrainOptions: {
-                      deleteEmptyDirData:              true,
-                      disableEviction:                 false,
-                      enabled:                         false,
-                      force:                           false,
-                      gracePeriod:                     -1,
-                      ignoreDaemonSets:                true,
-                      skipWaitForDeleteTimeoutSeconds: 0,
-                      timeout:                         120
+              body: {
+                type:     'provisioning.cattle.io.cluster',
+                metadata: {
+                  namespace:   rke2ClusterAmazon.namespace,
+                  annotations: {
+                    'field.cattle.io/description': `${ rke2ClusterAmazon.clusterName }-description`,
+                    ...(metadata?.annotations || {}),
+                  },
+                  labels: metadata?.labels || {},
+                  name:   rke2ClusterAmazon.clusterName
+                },
+                spec: {
+                  rkeConfig: {
+                    chartValues:     { 'rke2-calico': {} },
+                    upgradeStrategy: {
+                      controlPlaneConcurrency:  '1',
+                      controlPlaneDrainOptions: {
+                        deleteEmptyDirData:              true,
+                        disableEviction:                 false,
+                        enabled:                         false,
+                        force:                           false,
+                        gracePeriod:                     -1,
+                        ignoreDaemonSets:                true,
+                        skipWaitForDeleteTimeoutSeconds: 0,
+                        timeout:                         120
+                      },
+                      workerConcurrency:  '1',
+                      workerDrainOptions: {
+                        deleteEmptyDirData:              true,
+                        disableEviction:                 false,
+                        enabled:                         false,
+                        force:                           false,
+                        gracePeriod:                     -1,
+                        ignoreDaemonSets:                true,
+                        skipWaitForDeleteTimeoutSeconds: 0,
+                        timeout:                         120
+                      }
                     },
-                    workerConcurrency:  '1',
-                    workerDrainOptions: {
-                      deleteEmptyDirData:              true,
-                      disableEviction:                 false,
-                      enabled:                         false,
-                      force:                           false,
-                      gracePeriod:                     -1,
-                      ignoreDaemonSets:                true,
-                      skipWaitForDeleteTimeoutSeconds: 0,
-                      timeout:                         120
-                    }
-                  },
-                  dataDirectories: {
-                    systemAgent:  '',
-                    provisioning: '',
-                    k8sDistro:    ''
-                  },
-                  machineGlobalConfig: {
-                    cni:                   'calico',
-                    'disable-kube-proxy':  false,
-                    'etcd-expose-metrics': false
+                    dataDirectories: {
+                      systemAgent:  '',
+                      provisioning: '',
+                      k8sDistro:    ''
+                    },
+                    machineGlobalConfig: {
+                      cni:                   'calico',
+                      'disable-kube-proxy':  false,
+                      'etcd-expose-metrics': false
+                    },
+                    machineSelectorConfig: [
+                      { config: { 'protect-kernel-defaults': false } }
+                    ],
+                    etcd: {
+                      disableSnapshots:     false,
+                      s3:                   null,
+                      snapshotRetention:    5,
+                      snapshotScheduleCron: '0 */5 * * *'
+                    },
+                    registries: {
+                      configs: {},
+                      mirrors: {}
+                    },
+                    machinePools: [
+                      {
+                        name:                 'pool1',
+                        etcdRole:             true,
+                        controlPlaneRole:     true,
+                        workerRole:           true,
+                        hostnamePrefix:       '',
+                        labels:               {},
+                        quantity:             3,
+                        unhealthyNodeTimeout: '0m',
+                        machineConfigRef:     {
+                          kind: 'Amazonec2Config',
+                          name: machineConfigId[1]
+                        },
+                        drainBeforeDelete: true
+                      }
+                    ]
                   },
                   machineSelectorConfig: [
-                    { config: { 'protect-kernel-defaults': false } }
+                    { config: {} }
                   ],
-                  etcd: {
-                    disableSnapshots:     false,
-                    s3:                   null,
-                    snapshotRetention:    5,
-                    snapshotScheduleCron: '0 */5 * * *'
-                  },
-                  registries: {
-                    configs: {},
-                    mirrors: {}
-                  },
-                  machinePools: [
-                    {
-                      name:                 'pool1',
-                      etcdRole:             true,
-                      controlPlaneRole:     true,
-                      workerRole:           true,
-                      hostnamePrefix:       '',
-                      labels:               {},
-                      quantity:             3,
-                      unhealthyNodeTimeout: '0m',
-                      machineConfigRef:     {
-                        kind: 'Amazonec2Config',
-                        name: machineConfigId[1]
-                      },
-                      drainBeforeDelete: true
-                    }
-                  ]
-                },
-                machineSelectorConfig: [
-                  { config: {} }
-                ],
-                kubernetesVersion:                                    'v1.29.4+rke2r1',
-                defaultPodSecurityAdmissionConfigurationTemplateName: '',
-                cloudCredentialSecretName:                            cloudCredentialId,
-                localClusterAuthEndpoint:                             {
-                  enabled: false,
-                  caCerts: '',
-                  fqdn:    ''
+                  kubernetesVersion,
+                  defaultPodSecurityAdmissionConfigurationTemplateName: '',
+                  cloudCredentialSecretName:                            cloudCredentialId,
+                  localClusterAuthEndpoint:                             {
+                    enabled: false,
+                    caCerts: '',
+                    fqdn:    ''
+                  }
                 }
               }
-            }
-          })
-            .then((resp: Cypress.Response<any>) => {
-              expect(resp.status).to.eq(201);
-            });
-        });
-    });
+            })
+              .then((resp: Cypress.Response<any>) => {
+                expect(resp.status).to.eq(201);
+              });
+          });
+      });
+  });
 });
 
 /**


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1980

- Added loading indicator check to ensure page is fully loaded
- Improved workspace change test with proper intercepts and cluster ID fetching
- Added `getKubernetesReleases` Cypress command to fetch Kubernetes releases from the API


<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="1212" height="668" alt="image" src="https://github.com/user-attachments/assets/1524b832-607e-4c77-9b18-a198c289382d" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
