### PR TITLE
Ensure PaginatedResourceTable displays correct initial page

### DIFF
--- a/shell/components/PaginatedResourceTable.vue
+++ b/shell/components/PaginatedResourceTable.vue
@@ -116,15 +116,11 @@ export default defineComponent({
   },
 
   async fetch() {
-    const promises = [
-      this.$fetchType(this.resource, [], this.overrideInStore || this.inStore),
-    ];
-
     if (this.fetchSecondaryResources) {
-      promises.push(this.fetchSecondaryResources({ canPaginate: this.canPaginate }));
+      await this.fetchSecondaryResources({ canPaginate: this.canPaginate });
     }
 
-    await Promise.all(promises);
+    await this.$fetchType(this.resource, [], this.overrideInStore || this.inStore);
   },
 
   computed: {

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -302,8 +302,11 @@ export default defineComponent({
         return Promise.resolve({});
       }
 
+      const promises = [];
+
       if ( this.canViewMgmtClusters ) {
-        this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER });
+        // This is the only one we need to block on (needed for the initial sort on mgmt name)
+        promises.push(this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER }));
       }
 
       if ( this.canViewMachine ) {
@@ -323,7 +326,7 @@ export default defineComponent({
         this.$store.dispatch('management/findAll', { type: MANAGEMENT.NODE_TEMPLATE });
       }
 
-      return Promise.resolve({});
+      return Promise.all(promises);
     },
 
     async fetchPageSecondaryResources({


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15853
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- a list may need secondary resources
- these can either be to support the whole list (fetchSecondaryResources), or an individual page (fetchPageSecondaryResources)
- for fetchSecondaryResources, often used when SSP is disabled, the list will call it concurrently with fetching the primary resource
- however as soon as the primary resource was fetched, before the secondary resources were fetched, the list would calculate the first page
- if the page depends on secondary resources for sorting/filtering then they would be missed
  - the home page shows prov clusters but then sorts them on mgmt clusters name
  - the mgmt clusters are fetched as secondary resources
  - the list was showing the prov clusters before the mgmt clusters were fetched and sorting on prov cluster id instead of mgmt cluster spec.displayName
- fix
  - instead of fetching both primary at secondary in parallel fetch in sequence
  - this ensure the initial sort/filter is correct

### Technical notes summary
- this change does mean other usages of fetchSecondaryResources are affected, however looking at their comments it seems having a guaranteed order (secondary --> show list) is preferred

### Areas or cases that should be tested
- as per issue

### Areas which could experience regressions
- vai on and off
  - ingress, service lists 
- vai off
  - node, persistent volume lists

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
