### PR TITLE
Ensure we keep the same cached list and previous entries when SSP pages update

### DIFF
--- a/shell/plugins/__tests__/mutations.tests.ts
+++ b/shell/plugins/__tests__/mutations.tests.ts
@@ -1,0 +1,179 @@
+import mutations from '@shell/plugins/dashboard-store/mutations';
+import getters from '@shell/plugins/steve/getters';
+import { StorePagination } from '@shell/types/store/pagination.types';
+import { VuexStore } from '@shell/types/store/vuex';
+import Pod from '@shell/models/pod';
+
+describe('mutations', () => {
+  jest.mock('vue', () => ({ reactive: jest.fn((arr) => arr) }));
+
+  // Import the function we are testing
+  const { loadPage } = mutations;
+
+  let state: any;
+  let ctx: Partial<VuexStore>;
+  let resourceType: string;
+  let pagination: Partial<StorePagination>;
+  let revision: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    state = { types: {} };
+    ctx = {
+      getters: {
+        keyFieldForType: jest.fn(() => 'id'),
+        cleanResource:   getters.cleanResource()
+      }
+    };
+    resourceType = 'pod';
+    pagination = { request: undefined, result: undefined };
+    revision = 'abc-123';
+    ctx.getters.classify = () => Pod;
+  });
+
+  describe('loadPage', () => {
+    it('should perform an initial load into an empty cache', () => {
+      const data = [
+        {
+          id: 'a', name: 'pod-a', type: resourceType
+        },
+        {
+          id: 'b', name: 'pod-b', type: resourceType
+        }
+      ];
+
+      loadPage(state, {
+        type: resourceType, data, ctx, pagination, revision
+      });
+
+      // Get the cache created by the *real* 'registerType'
+      const cache = state.types[resourceType];
+
+      // Check cache metadata
+      expect(cache.generation).toBe(1);
+      expect(cache.havePage).toBe(pagination);
+      expect(cache.revision).toBe(revision);
+
+      // Check 'list' (should contain classified proxies)
+      expect(cache.list).toHaveLength(2);
+      expect(cache.list[0]).toStrictEqual(expect.objectContaining({ id: 'a' }));
+      expect(cache.list[1]).toStrictEqual(expect.objectContaining({ id: 'b' }));
+
+      // Check 'map'
+      expect(cache.map.size).toBe(2);
+      expect(cache.map.get('a')).toBe(cache.list[0]); // Map and list must reference the *same* objects
+      expect(cache.map.get('b')).toBe(cache.list[1]);
+    });
+
+    it('should update existing resources in-place (tests "replaceResource" effect)', () => {
+      const v1Resource = new Pod({ id: 'a', metadata: { a: 'v1-a' } }, ctx);
+
+      state.types[resourceType] = {
+        list:       [v1Resource],
+        map:        new Map([['a', v1Resource]]),
+        generation: 1,
+      };
+
+      // Keep a reference to the *original list array* and *original resource object*
+      const originalListRef = state.types[resourceType].list;
+      const originalResourceRef = v1Resource;
+
+      const newData = [
+        { id: 'a', metadata: { a: 'v2-a' } }, // This is the update
+      ];
+      const newRevision = 'rev-2';
+
+      loadPage(state, {
+        type: resourceType, data: newData, ctx, pagination, revision: newRevision
+      });
+
+      const cache = state.types[resourceType];
+
+      expect(cache.list).toBe(originalListRef);
+      expect(cache.list).toHaveLength(1);
+
+      expect(cache.list[0]).toBe(originalResourceRef);
+
+      expect(originalResourceRef.metadata.a).toBe('v2-a');
+
+      expect(cache.map.get('a')).toBe(originalResourceRef);
+
+      expect(cache.generation).toBe(2);
+      expect(cache.revision).toBe(newRevision);
+    });
+
+    it('should remove stale data from list and map (paging)', () => {
+      const page1Proxy = new Pod({ id: 'a', name: 'stale-pod' }, ctx);
+
+      state.types[resourceType] = {
+        list:       [page1Proxy],
+        map:        new Map([['a', page1Proxy]]),
+        generation: 1,
+      };
+
+      const listRef = state.types[resourceType].list;
+
+      const page2Data = [
+        { id: 'b', name: 'new-pod' },
+      ];
+
+      loadPage(state, {
+        type: resourceType, data: page2Data, ctx, pagination, revision
+      });
+
+      const cache = state.types[resourceType];
+
+      expect(cache.list).toBe(listRef); // List reference must be preserved
+
+      expect(cache.list).toHaveLength(1);
+      expect(cache.list[0].id).toBe('b');
+
+      expect(cache.map.size).toBe(1);
+      expect(cache.map.has('a')).toBe(false); // Stale 'a' is gone
+      expect(cache.map.has('b')).toBe(true);
+    });
+
+    it('should handle partial overlaps (update, remove stale, add new)', () => {
+      // 1. Pre-load cache
+      const staleResource = new Pod({ id: 'a', prop: 'stale-pod' }, ctx);
+      const v1Resource = new Pod({ id: 'b', prop: 'v1-pod-b' }, ctx);
+
+      state.types[resourceType] = {
+        list:       [staleResource, v1Resource],
+        map:        new Map([['a', staleResource], ['b', v1Resource]]),
+        generation: 1,
+      };
+
+      const listRef = state.types[resourceType].list;
+      const v1ResourceRef = v1Resource;
+
+      const newData = [
+        { id: 'b', prop: 'v2-pod-b' }, // Updated
+        { id: 'c', prop: 'new-pod-c' }, // New
+      ];
+
+      loadPage(state, {
+        type: resourceType, data: newData, ctx, pagination, revision
+      });
+
+      const cache = state.types[resourceType];
+
+      expect(cache.list).toBe(listRef); // List reference preserved
+
+      expect(cache.list).toHaveLength(2);
+      expect(cache.list[0].id).toBe('b');
+      expect(cache.list[1].id).toBe('c');
+
+      expect(cache.list[0]).toBe(v1ResourceRef);
+      expect(v1ResourceRef.prop).toBe('v2-pod-b');
+
+      expect(cache.list[1]).toStrictEqual(expect.objectContaining({ id: 'c' }));
+
+      expect(cache.map.size).toBe(2);
+      expect(cache.map.has('a')).toBe(false); // Stale, removed
+      expect(cache.map.get('b')).toBe(v1ResourceRef); // Updated
+      expect(cache.map.get('c')).toBe(cache.list[1]); // Added
+    });
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15847
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- when a SSP enable page receives an update the entries in the store (list and map) get updated
- the map is just a key:value collection and was updated in place
  - new entries added, existing ones updated, old ones removed
- the list, which is an ordered array representing the page, was emptied and repopulated with the new page
  - this meant anything that _referenced_ the old entries were disconnected from their new matching entries in the list
  - this broke places like sortable table selection that relied on object reference checks

### Areas or cases that should be tested

- Deployments List - Selected Row Changes
  - Tab A - Deployments list - select a deployment
  - Tab B - scale up/down the deployment
  - Tab A - Row should remain selected, the deployment column's ready count should update
- Deployments List - Selected Row is removed
  - Tab A - Deployments list - select two deployment
  - Tab B - delete one of the deployments
  - Tab A - deleted deployment's row should be removed, the selected count should drop by one
- Deployments List - Row is added
  - Tab A - Select a deployment with name starting with something other than A. There are other deployments below that row
  - Tab B - create a deployment with name starting with A
  - Tab A - The originally selected row remains selected (but not highlighted)

### Areas which could experience regressions
- This is an impactful change given it affects all paginated calls (tables, drop downs with pagination, anything else that uses the advanced filtering like label selector requests, etc)
- Table
  - Covered in core test cases
- Drop Down
  - Installing `Logging` app
  - Create some opaque secrets in a namespace (values do not matter)
  - Logging --> Output --> Create
  - Select namespace with secrets in 
  - `Output` tab `Access` dropdowns should show secrets
- Label Selector example
  - similar set of tests as the deployments list, however the pods list in the deployment detail page



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
