### PR TITLE
Fix IPV6 machine pool validation

### DIFF
--- a/shell/machine-config/components/EC2Networking.vue
+++ b/shell/machine-config/components/EC2Networking.vue
@@ -157,8 +157,11 @@ export default {
       this.$emit('update:hasIpv6', neu);
     },
 
-    allValid(neu) {
-      this.$emit('validationChanged', neu);
+    allValid: {
+      handler(neu) {
+        this.$emit('validationChanged', neu);
+      },
+      immediate: true
     }
   },
 

--- a/shell/machine-config/components/__tests__/EC2Networking.test.ts
+++ b/shell/machine-config/components/__tests__/EC2Networking.test.ts
@@ -121,4 +121,28 @@ describe('component: EC2Networking', () => {
     expect(wrapper.vm.enableIpv6).toBe(false);
     expect(ipv6AddressCountInput.exists()).toBe(false);
   });
+
+  it('should emit a validationChanged: false event when created with ipv6 enabled while some other pools have ipv6 disabled', async() => {
+    const wrapper = shallowMount(EC2Networking, {
+      ...defaultCreateSetup,
+      propsData: {
+        ...defaultCreateSetup.propsData,
+        machinePools: [{ hasIpv6: true }, { hasIpv6: false }],
+      },
+    });
+
+    expect(wrapper.emitted('validationChanged')?.[0][0]).toBe(false);
+  });
+
+  it('should emit a validationChanged: true event when created with ipv6 enabled while all other pools also have ipv6 enabled', async() => {
+    const wrapper = shallowMount(EC2Networking, {
+      ...defaultCreateSetup,
+      propsData: {
+        ...defaultCreateSetup.propsData,
+        machinePools: [{ hasIpv6: true }, { hasIpv6: true }],
+      },
+    });
+
+    expect(wrapper.emitted('validationChanged')?.[0][0]).toBe(true);
+  });
 });


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15793 - specifically https://github.com/rancher/dashboard/issues/15793#issuecomment-3483182026
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the ec2 networking component to update its validation status when first rendered.

### Technical notes summary
`validationChanged` events are used to control the display of error icons in machine pool tabs, and disable the save button when machine pools report errors. ec2Networking needs to emit `validationChanged` events when first rendered, as ec2 pools can be added in what the UI interprets to be an error state.

### Areas or cases that should be tested
1. Navigate to the cluster management list view, click "create" and select "amazon ec2" 
2. Check "Enable IPv6" in the only machine pool
3. Click the plus icon in the machine pool tab component to add a machine pool. 
4. The new pool should have "Enable IPv6" checked. Uncheck it.
5. An error banner should appear in the pool's networking section. An error icon should appear on the other pool's tab 
6. Click the plus icon again to add a third pool
7. The third pool should have "Enable IPv6" checked and an error banner should be displayed in the networking section
8. Select one of the other two pools and verify that the third pool now has an error icon on its tab

### Areas which could experience regressions
- create button should be disabled when the ipv6 machine pool errors are shown
- create button should be enabled when ipv6 machine pool errors are resolved and there are no other errors in the form

### Screenshot/Video

https://github.com/user-attachments/assets/3028542b-338c-43d0-8709-5f7b1072e1aa



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
