### PR TITLE
pin docusaurus package versions

### DIFF
--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -15,19 +15,19 @@
     "install:ci": "yarn install --frozen-lockfile"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.6.3",
-    "@docusaurus/plugin-client-redirects": "^3.6.3",
-    "@docusaurus/preset-classic": "^3.6.3",
-    "@mdx-js/react": "^3.0.0",
-    "clsx": "^1.2.0",
-    "docusaurus-lunr-search": "^3.5.0",
-    "prism-react-renderer": "^2.1.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "yaml": "2.5.1"
+    "@docusaurus/core": "3.8.1",
+    "@docusaurus/plugin-client-redirects": "3.8.1",
+    "@docusaurus/preset-classic": "3.8.1",
+    "@mdx-js/react": "3.1.1",
+    "clsx": "1.2.1",
+    "docusaurus-lunr-search": "3.5.0",
+    "prism-react-renderer": "2.4.1",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "yaml": "2.8.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.6.3",
+    "@docusaurus/module-type-aliases": "3.8.1",
     "@docusaurus/types": "3.0.0"
   },
   "browserslist": {


### PR DESCRIPTION
Docusaurus builds are failing, see: https://github.com/rancher/dashboard/actions/runs/19078807391/job/54505932172#step:4:10

There appears to be a known issue with one of the packages the latest version of Docusaurus depends on https://github.com/algolia/docsearch/issues/2791

This PR updates our docusaurus package.json to use the latest working version of the docusaurus package, and pins all other versions in the package.json to the latest patch version of the given major version

- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`