### PR TITLE
Automation: fix cronjob test

### DIFF
--- a/cypress/e2e/po/components/resource-detail-masthead.po.ts
+++ b/cypress/e2e/po/components/resource-detail-masthead.po.ts
@@ -1,11 +1,11 @@
-import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import ComponentPo, { GetOptions } from '@/cypress/e2e/po/components/component.po';
 
 export default class ResourceDetailMastheadPo extends ComponentPo {
   /**
    * Get the resource status badge in the masthead
    */
-  resourceStatus() {
-    return this.self().find('h1.title .badge-state .msg');
+  resourceStatus(options?: GetOptions) {
+    return this.self().find('h1.title .badge-state .msg', options);
   }
 
   /**

--- a/cypress/e2e/po/edit/resource-detail.po.ts
+++ b/cypress/e2e/po/edit/resource-detail.po.ts
@@ -4,6 +4,7 @@ import CruResourcePo from '@/cypress/e2e/po/components/cru-resource.po';
 import ResourceYamlPo from '@/cypress/e2e/po/components/resource-yaml.po';
 import ResourceDetailMastheadPo from '@/cypress/e2e/po/components/resource-detail-masthead.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
+import ResourceTablePo from '@/cypress/e2e/po/components/resource-table.po';
 
 export default class ResourceDetailPo extends ComponentPo {
   /**
@@ -42,6 +43,18 @@ export default class ResourceDetailPo extends ComponentPo {
     return new TabbedPo('[data-testid="tabbed"]');
   }
 
+  /**
+   * @param tabId - the id of the tab
+   * @param index - the index of the list (only used for 'related' tab)
+   * @returns the list of the tab
+   */
+  tabbedList(tabId: string, index?: number) {
+    const baseSelector = `#${ tabId } [data-testid="sortable-table-list-container"]`;
+    const selector = tabId === 'related' ? `${ baseSelector }:nth-of-type(${ index })` : baseSelector;
+
+    return new ResourceTablePo(selector);
+  }
+
   title(): Cypress.Chainable<string> {
     return this.self().find('.title-bar h1.title, .primaryheader h1').invoke('text');
   }
@@ -52,5 +65,9 @@ export default class ResourceDetailPo extends ComponentPo {
    */
   masthead() {
     return new ResourceDetailMastheadPo(this.self());
+  }
+
+  resourceGauges() {
+    return this.self().find('.gauges .count-gauge');
   }
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2067

- Fix: Moved the Details test before List tests to avoid conflicts with intercepts used in the List tests.
- Improvements: Updated test to verify that the jobs list in the CronJob details page updates automatically without manual refresh.

<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="1134" height="422" alt="image" src="https://github.com/user-attachments/assets/736e1e61-d40f-49c3-98bd-2da90b9c03ba" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
