### PR TITLE
Three pagination wrapper socket related fixes

### DIFF
--- a/shell/plugins/subscribe-events.ts
+++ b/shell/plugins/subscribe-events.ts
@@ -167,7 +167,7 @@ export class SteveWatchEventListenerManager {
 
     if (eventWatcher) {
       Object.values(eventWatcher.callbacks).forEach((cb) => {
-        cb();
+        cb({ forceWatch: params.forceWatch }); // eslint-disable-line node/no-callback-literal
       });
     }
   }
@@ -176,7 +176,9 @@ export class SteveWatchEventListenerManager {
     const watch = this.getWatch({ params });
 
     watch.listeners.forEach((l) => {
-      Object.values(l.callbacks || {}).forEach((cb) => cb());
+      Object.values(l.callbacks || {}).forEach((cb) => {
+        cb({ forceWatch: params.forceWatch });// eslint-disable-line node/no-callback-literal
+      });
     });
   }
 

--- a/shell/types/store/subscribe-events.types.ts
+++ b/shell/types/store/subscribe-events.types.ts
@@ -13,9 +13,16 @@ export interface STEVE_WATCH_EVENT_PARAMS_COMMON {
 }
 
 /**
+ * Args for @STEVE_WATCH_EVENT_LISTENER_CALLBACK
+ */
+export type STEVE_WATCH_EVENT_LISTENER_CALLBACK_PARAMS = {
+  forceWatch?: boolean,
+}
+
+/**
  * Executes when a watch event has a listener and it's triggered
  */
-export type STEVE_WATCH_EVENT_LISTENER_CALLBACK = () => void
+export type STEVE_WATCH_EVENT_LISTENER_CALLBACK = (params: STEVE_WATCH_EVENT_LISTENER_CALLBACK_PARAMS) => void
 
 /**
  * Common params used when a watcher adds a listener to a watch

--- a/shell/types/store/subscribe.types.ts
+++ b/shell/types/store/subscribe.types.ts
@@ -30,5 +30,6 @@ export interface STEVE_WATCH_PARAMS {
   namespace?: string,
   stop?: boolean,
   force?: boolean,
+  forceWatch?: boolean,
   mode?: STEVE_WATCH_MODE
 }

--- a/shell/utils/back-off.ts
+++ b/shell/utils/back-off.ts
@@ -137,9 +137,9 @@ class BackOff {
 
       // First step is immediate (0.001s)
       // Second and others are exponential
-      // 1,      2,     3,  4,     5,  6,      7,   8,      9
-      // 1,      4,     9, 16,    25, 36,     49,  64,     81
-      // 0.25s, 1s, 2.25s, 4s, 6.25s, 9s, 12.25s, 16s, 20.25s
+      // Try:         1,     2,   3,     4,    5,      6,    7,       8,    9
+      // Multiple:    1,     4,   9,     16,   25,     36,   49,      64,   81
+      // Actual Time: 0.25s, 1s,  2.25s, 4s,   6.25s,  9s,   12.25s,  16s,  20.25s
       const delay = backOffTry === 0 ? 1 : Math.pow(backOffTry, 2) * 250;
 
       this.log('info', id, `Delaying call (attempt ${ backOffTry + 1 }, delayed by ${ delay }ms)`, description);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15879

Contributes to #15871, #15872
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Reminder socket message flow for handling errors

Scenario 1 - backend just stops watch, we re-watch via browser --> rancher watch message
rancher --> browser : resource.start
rancher --> browser : resource.stop
browser --> rancher : (re)watch command

Scenario 2 - there's an error with the watch (unknown revision), we re-watch via browser --> rancher watch message
rancher --> browser : resource.start
rancher --> browser : resource.error
rancher --> browser : resource.stop
browser --> rancher : (re)watch command

Watches work in two ways
1. Legacy/Vanilla - track state of watch and actual resources in vuex store
2. Transient - piggyback watches onto legacy watches and track state and actual resources OUTSIDE of the vuex store

Fix 1 - Don't process `resource.stop` messages for sockets in error
- for legacy watches the resource.stop --> watch even aborts if socket is in error
- for transient watches we also need to ensure resource.stop --> trigger listeners abort if socket is in error
- as in both cases the resource.error message triggers the requests needed to fix state
- fix is just in shell/plugins/steve/subscribe.js resource.stop handler

Fix 2 - Ensure watches following resource.error ignore errors
- for legacy watches the resource.error --> `find` requests have force --> which means the `watch` ignores errors and re-watches
- for transient watches the resource.error --> listeners also need to pass through concept of force to re-watch
- fix is a lot of plumbing of a forceWatch param

Fix 3 - Ensure pagination wrapper requests correctly call watch on first run AND when forced
- related to fix 2, mostly plumbing
- fix is just in shell/utils/pagination-wrapper.ts

### Areas or cases that should be tested
- Creating an AWS EC2 based rke2 cluster succeeds
  - In tab A navigate to the cluster management clusters list
  - In tab B create an AWS EC2 based rke2 cluster, the UI then shows the clusters list
  - In both tab A and B
    - The new cluster `State` and `Machines` columns correctly update as the cluster comes up
    - The new cluster is shown in the side bar
- Scaling a AWS EC2 based rke2 cluster succeeds
  - In tab A navigate to the cluster management clusters list
  - In tab B navigate to the detail page of the cluster and scale UP a node pool
  - In tab A the `State` and `Machines` column correctly update
- Deleting a cluster succeeds
  - In tab A navigate to the cluster management clusters list
  - In tab B navigate to the cluster management clusters list and a delete a cluster
  - In both tab A and B the cluster should be removed from the side bar and the cluster list
- General updates succeed
  - In tab A navigate to the cluster explorer --> Workloads -->  Pods list
  - In tab B navigate to the cluster explorer --> Workloads -->  Pods list and create a Pod
  - In both tab A and B the pod should appear in the pods list and eventually reach the correct active state

### Areas which could experience regressions
- General socket updates (anything that shows changes to resources without refreshing the page

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
