### PR TITLE
Automation: Fix kubewarden install test

### DIFF
--- a/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
@@ -38,6 +38,13 @@ describe('Kubewarden Extension', { tags: ['@extensions', '@adminUser'] }, () => 
     extensionsPo.extensionTabAvailableClick();
     extensionsPo.waitForPage(null, 'available');
 
+    // Get the extension version dynamically from the card and wait for the info endpoint to return 200
+    extensionsPo.extensionCardVersion(extensionName).then((version) => {
+      const trimmedVersion = version.trim();
+
+      cy.waitForExtensionInfo(gitRepoName, extensionName, trimmedVersion);
+    });
+
     // click on install button on card
     extensionsPo.extensionCardInstallClick(extensionName);
     extensionsPo.extensionInstallModal().should('be.visible' );

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -122,6 +122,7 @@ declare global {
       waitForRancherResources(prefix: 'v3' | 'v1', resourceType: string, expectedResourcesTotal: number, greaterThan?: boolean): Chainable;
       waitForRepositoryDownload(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, retries?: number): Chainable;
       waitForResourceState(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, resourceState?: string, retries?: number): Chainable;
+      waitForExtensionInfo(gitRepoName: string, extensionName: string, version: string, retries?: number): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1' | 'k8s', resourceType: string, resourceId: string, failOnStatusCode?: boolean): Chainable;
       getClusterIdByName(clusterName: string): Chainable<string>;
       deleteNodeTemplate(nodeTemplateId: string, timeout?: number, failOnStatusCode?: boolean)


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1560

Adds a custom Cypress command waitForExtensionInfo that waits for the extension info endpoint to return 200 before proceeding with installation, preventing test failures when the endpoint isn't ready.
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="1128" height="432" alt="image" src="https://github.com/user-attachments/assets/291d286e-65d9-475a-9486-f0c393ebdde4" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
