### PR TITLE
Update the vSphere url

### DIFF
--- a/cypress/e2e/tests/pages/charts/question-tabs.spec.ts
+++ b/cypress/e2e/tests/pages/charts/question-tabs.spec.ts
@@ -15,7 +15,7 @@ describe('Charts Install', { tags: ['@charts', '@adminUser'] }, () => {
     describe('Vsphere Cpi chart install - Tabs visibility', () => {
       it('Should not show any tabs on "Edit Options" screen if there is only 1 group', () => {
         ChartPage.navTo(null, 'vSphere CPI');
-        chartPage.waitForPage('repo-type=cluster&repo=rancher-charts&chart=rancher-vsphere-cpi');
+        chartPage.waitForPage('repo-type=cluster&repo=rancher-rke2-charts&chart=rancher-vsphere-cpi&version=1.12.100');
         chartPage.goToInstall();
         installChart.nextPage();
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates the vSphere url for the `Vsphere Cpi chart install - Tabs visibility` test. 

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This change currently unblocks CI, and further changes will need to be made in order to make this test less fragile. I anticipate that this test will fail as we publish new chart versions in future.

Failures appear to be in some part related to recent deprecation of RKE1 charts:

- https://github.com/rancher/charts/pull/6452
- https://github.com/rancher/charts/pull/6453
- https://github.com/rancher/charts/pull/6456

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

`Vsphere Cpi chart install - Tabs visibility` test should pass CI.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This test is too rigid and has a high likelihood to fail again in the future.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
