### PR TITLE
Fixes an issue where we failed to render deployment pages when match expressions with multiple values are present

### DIFF
--- a/shell/utils/__tests__/selector-typed.test.ts
+++ b/shell/utils/__tests__/selector-typed.test.ts
@@ -1,0 +1,263 @@
+import { labelSelectorToSelector } from '@shell/utils/selector-typed';
+import { KubeLabelSelector } from '@shell/types/kube/kube-api';
+
+describe('selector-typed', () => {
+  describe('labelSelectorToSelector', () => {
+    describe('empty label selectors', () => {
+      it('should return empty string for undefined label selector', () => {
+        const result = labelSelectorToSelector(undefined);
+
+        expect(result).toBe('');
+      });
+
+      it('should return empty string for label selector with no matchLabels and no matchExpressions', () => {
+        const labelSelector: KubeLabelSelector = {};
+        const result = labelSelectorToSelector(labelSelector);
+
+        expect(result).toBe('');
+      });
+
+      it('should return empty string for label selector with empty matchLabels', () => {
+        const labelSelector: KubeLabelSelector = { matchLabels: {} };
+        const result = labelSelectorToSelector(labelSelector);
+
+        expect(result).toBe('');
+      });
+
+      it('should return empty string for label selector with empty matchExpressions', () => {
+        const labelSelector: KubeLabelSelector = { matchExpressions: [] };
+        const result = labelSelectorToSelector(labelSelector);
+
+        expect(result).toBe('');
+      });
+
+      it('should return empty string for label selector with both empty matchLabels and matchExpressions', () => {
+        const labelSelector: KubeLabelSelector = {
+          matchLabels:      {},
+          matchExpressions: []
+        };
+        const result = labelSelectorToSelector(labelSelector);
+
+        expect(result).toBe('');
+      });
+    });
+
+    describe('matchLabels conversion', () => {
+      it('should convert single matchLabel to selector string', () => {
+        const labelSelector: KubeLabelSelector = { matchLabels: { app: 'nginx' } };
+        const result = labelSelectorToSelector(labelSelector);
+
+        expect(result).toBe('app=nginx');
+      });
+
+      it('should convert multiple matchLabels to comma-separated selector string', () => {
+        const labelSelector: KubeLabelSelector = {
+          matchLabels: {
+            app:     'nginx',
+            version: 'v1.0',
+            env:     'production'
+          }
+        };
+        const result = labelSelectorToSelector(labelSelector);
+
+        expect(result).toBe('app=nginx,version=v1.0,env=production');
+      });
+
+      it('should handle matchLabels with special characters', () => {
+        const labelSelector: KubeLabelSelector = { matchLabels: { 'app.kubernetes.io/name': 'my-app' } };
+        const result = labelSelectorToSelector(labelSelector);
+
+        expect(result).toBe('app.kubernetes.io/name=my-app');
+      });
+
+      it('should handle matchLabels with numeric values', () => {
+        const labelSelector: KubeLabelSelector = { matchLabels: { tier: '3' } };
+        const result = labelSelectorToSelector(labelSelector);
+
+        expect(result).toBe('tier=3');
+      });
+    });
+
+    describe('matchExpressions conversion with In operator', () => {
+      it('should convert matchExpression with In operator and single value to equality selector', () => {
+        const labelSelector: KubeLabelSelector = {
+          matchExpressions: [
+            {
+              key:      'app',
+              operator: 'In',
+              values:   ['nginx']
+            }
+          ]
+        };
+        const result = labelSelectorToSelector(labelSelector);
+
+        expect(result).toBe('app=nginx');
+      });
+
+      it('should convert matchExpression with In operator and multiple values to in() selector', () => {
+        const labelSelector: KubeLabelSelector = {
+          matchExpressions: [
+            {
+              key:      'env',
+              operator: 'In',
+              values:   ['dev', 'staging', 'prod']
+            }
+          ]
+        };
+        const result = labelSelectorToSelector(labelSelector);
+
+        expect(result).toBe('env in (dev,staging,prod)');
+      });
+
+      it('should convert multiple matchExpressions with In operator', () => {
+        const labelSelector: KubeLabelSelector = {
+          matchExpressions: [
+            {
+              key:      'app',
+              operator: 'In',
+              values:   ['nginx']
+            },
+            {
+              key:      'env',
+              operator: 'In',
+              values:   ['dev', 'staging']
+            }
+          ]
+        };
+        const result = labelSelectorToSelector(labelSelector);
+
+        expect(result).toBe('app=nginx,env in (dev,staging)');
+      });
+
+      it('should handle matchExpression with empty values array for In operator', () => {
+        const labelSelector: KubeLabelSelector = {
+          matchExpressions: [
+            {
+              key:      'app',
+              operator: 'In',
+              values:   []
+            }
+          ]
+        };
+        const result = labelSelectorToSelector(labelSelector);
+
+        // With empty values array, it should create an in() with no values
+        expect(result).toBe('app in ()');
+      });
+    });
+
+    describe('combined matchLabels and matchExpressions', () => {
+      it('should combine matchLabels and matchExpressions with single values', () => {
+        const labelSelector: KubeLabelSelector = {
+          matchLabels:      { tier: 'frontend' },
+          matchExpressions: [
+            {
+              key:      'env',
+              operator: 'In',
+              values:   ['prod']
+            }
+          ]
+        };
+        const result = labelSelectorToSelector(labelSelector);
+
+        expect(result).toBe('tier=frontend,env=prod');
+      });
+
+      it('should combine multiple matchLabels and matchExpressions', () => {
+        const labelSelector: KubeLabelSelector = {
+          matchLabels: {
+            tier:    'frontend',
+            version: 'v2'
+          },
+          matchExpressions: [
+            {
+              key:      'env',
+              operator: 'In',
+              values:   ['dev', 'staging']
+            },
+            {
+              key:      'region',
+              operator: 'In',
+              values:   ['us-west-1']
+            }
+          ]
+        };
+        const result = labelSelectorToSelector(labelSelector);
+
+        expect(result).toBe('tier=frontend,version=v2,env in (dev,staging),region=us-west-1');
+      });
+
+      it('should combine matchLabels with multiple matchExpressions using in() notation', () => {
+        const labelSelector: KubeLabelSelector = {
+          matchLabels:      { 'app.kubernetes.io/name': 'myapp' },
+          matchExpressions: [
+            {
+              key:      'env',
+              operator: 'In',
+              values:   ['dev', 'test', 'prod']
+            }
+          ]
+        };
+        const result = labelSelectorToSelector(labelSelector);
+
+        expect(result).toBe('app.kubernetes.io/name=myapp,env in (dev,test,prod)');
+      });
+    });
+
+    describe('unsupported operators', () => {
+      it('should throw error for NotIn operator', () => {
+        const labelSelector: KubeLabelSelector = {
+          matchExpressions: [
+            {
+              key:      'env',
+              operator: 'NotIn',
+              values:   ['prod']
+            }
+          ]
+        };
+
+        expect(() => labelSelectorToSelector(labelSelector)).toThrow('Unsupported matchExpression found when converting to selector string.');
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle matchExpression with In operator but undefined values', () => {
+        const labelSelector: KubeLabelSelector = {
+          matchExpressions: [
+            {
+              key:      'app',
+              operator: 'In',
+              values:   undefined
+            }
+          ]
+        };
+
+        // When values is undefined, the function throws an error
+        expect(() => labelSelectorToSelector(labelSelector)).toThrow('Unsupported matchExpression found when converting to selector string.');
+      });
+
+      it('should preserve order of matchLabels and matchExpressions', () => {
+        const labelSelector: KubeLabelSelector = {
+          matchLabels: {
+            first:  'value1',
+            second: 'value2'
+          },
+          matchExpressions: [
+            {
+              key:      'third',
+              operator: 'In',
+              values:   ['value3']
+            }
+          ]
+        };
+        const result = labelSelectorToSelector(labelSelector);
+
+        // matchLabels come before matchExpressions
+        expect(result).toContain('first=value1');
+        expect(result).toContain('second=value2');
+        expect(result).toContain('third=value3');
+        expect(result.indexOf('first')).toBeLessThan(result.indexOf('third'));
+      });
+    });
+  });
+});

--- a/shell/utils/selector-typed.ts
+++ b/shell/utils/selector-typed.ts
@@ -199,8 +199,12 @@ export function labelSelectorToSelector(labelSelector?: KubeLabelSelector): stri
   });
 
   (labelSelector?.matchExpressions || []).forEach((value: KubeLabelSelectorExpression) => {
-    if (value.operator === 'In' && value.values?.length === 1) {
-      res.push(`${ value.key }=${ value.values[0] }`);
+    if (value.operator === 'In' && value.values !== undefined) {
+      if (value.values?.length === 1) {
+        res.push(`${ value.key }=${ value.values[0] }`);
+      } else {
+        res.push(`${ value.key } in (${ value.values.join(',') })`);
+      }
     } else {
       throw new Error(`Unsupported matchExpression found when converting to selector string. ${ value }`);
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15908
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Added support for multi-value matchExpressions when retrieving pods related to a deployment.

### Technical notes summary
We didn't originally support match expressions with multiple values. This change adds the support.

### Areas or cases that should be tested
Multi-value matchExpressions when retrieving pods related to a deployment for both vai enabled and vai disabled.

### Areas which could experience regressions
Multi-value matchExpressions when retrieving pods related to a deployment for both vai enabled and vai disabled.

### Screenshot/Video

[Screencast_20251110_132831.webm](https://github.com/user-attachments/assets/98b1e812-1d44-445a-a30c-195a3b0c4323)

[Screencast_20251110_140037.webm](https://github.com/user-attachments/assets/ff77ad9e-b297-439d-ac86-9d677f09f1f6)

I want to make a note, when vai is enabled it seems that the results of filtered api requests can be cached  and won't change even if labels are removed/changed that are necessary for matching. This is a separate backend issue and I'll open a new issue once I confirm the problem.

[Screencast_20251110_140237.webm](https://github.com/user-attachments/assets/cb6f0d57-eb70-48ed-b158-712d1cbd5a4c)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
