### PR TITLE
Fix HelmOps DownstreamResources - move from `spec.helm` to `spec`

### DIFF
--- a/scripts/check-i18n-links
+++ b/scripts/check-i18n-links
@@ -271,7 +271,7 @@ async function check(links) {
       statusMessage = e.response ? e.response.statusText : e.statusText;
     }
 
-    if (statusCode !== 200) {
+    if (statusCode !== 200 && statusCode !== 202) {
       const sc = `${ statusCode }`.padEnd(5);
 
       console.log(`  ${ link } : ${ sc } ${ statusMessage || '' }`); // eslint-disable-line no-console

--- a/shell/edit/__tests__/fleet.cattle.io.helmop.test.ts
+++ b/shell/edit/__tests__/fleet.cattle.io.helmop.test.ts
@@ -243,7 +243,7 @@ describe.each([
 
     await fleetSecretSelector.vm.$emit('update:value', ['secret2', 'secret3']);
 
-    expect(wrapper.vm.value.spec.helm.downstreamResources).toStrictEqual([{ name: 'secret2', kind: 'Secret' }, { name: 'secret3', kind: 'Secret' }]);
+    expect(wrapper.vm.value.spec.downstreamResources).toStrictEqual([{ name: 'secret2', kind: 'Secret' }, { name: 'secret3', kind: 'Secret' }]);
   });
 
   it('should update downstreamResources with new ConfigMaps when FleetConfigMapSelector emits update event', async() => {
@@ -260,6 +260,6 @@ describe.each([
 
     await fleetConfigMapSelector.vm.$emit('update:value', ['configMap2', 'configMap3']);
 
-    expect(wrapper.vm.value.spec.helm.downstreamResources).toStrictEqual([{ name: 'configMap2', kind: 'ConfigMap' }, { name: 'configMap3', kind: 'ConfigMap' }]);
+    expect(wrapper.vm.value.spec.downstreamResources).toStrictEqual([{ name: 'configMap2', kind: 'ConfigMap' }, { name: 'configMap3', kind: 'ConfigMap' }]);
   });
 });

--- a/shell/edit/fleet.cattle.io.helmop.vue
+++ b/shell/edit/fleet.cattle.io.helmop.vue
@@ -237,11 +237,11 @@ export default {
     },
 
     downstreamSecretsList() {
-      return (this.value.spec.helm.downstreamResources || []).filter((r) => r.kind === 'Secret').map((r) => r.name);
+      return (this.value.spec.downstreamResources || []).filter((r) => r.kind === 'Secret').map((r) => r.name);
     },
 
     downstreamConfigMapsList() {
-      return (this.value.spec.helm.downstreamResources || []).filter((r) => r.kind === 'ConfigMap').map((r) => r.name);
+      return (this.value.spec.downstreamResources || []).filter((r) => r.kind === 'ConfigMap').map((r) => r.name);
     },
   },
 
@@ -446,14 +446,14 @@ export default {
     updateDownstreamResources(kind, list) {
       switch (kind) {
       case 'Secret':
-        this.value.spec.helm.downstreamResources = [
-          ...(this.value.spec.helm.downstreamResources || []).filter((r) => r.kind !== 'Secret'),
+        this.value.spec.downstreamResources = [
+          ...(this.value.spec.downstreamResources || []).filter((r) => r.kind !== 'Secret'),
           ...(list || []).map((name) => ({ name, kind: 'Secret' })),
         ];
         break;
       case 'ConfigMap':
-        this.value.spec.helm.downstreamResources = [
-          ...(this.value.spec.helm.downstreamResources || []).filter((r) => r.kind !== 'ConfigMap'),
+        this.value.spec.downstreamResources = [
+          ...(this.value.spec.downstreamResources || []).filter((r) => r.kind !== 'ConfigMap'),
           ...(list || []).map((name) => ({ name, kind: 'ConfigMap' })),
         ];
         break;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15344
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

The UI is saving the HelmOp's `downstreamResources` in the wrong field 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

- It fixes the `downstreamResources` field: ~~HelmOp.spec.helm~~ -> `HelmOp.spec`
- ~~It adds tooltips based on the Fleet documentation - https://fleet.rancher.io/experimental-downstream-resources~~ postponed to 2.14

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Fleet -> HelmOps -> Advanced step -> select ConfigMaps and Secrets

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

[Screencast from 2025-11-12 10-23-42.webm](https://github.com/user-attachments/assets/bec7f88d-5b83-4c2d-addd-70a4754e6810)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
