### PR TITLE
Include feature flag `ui-sql-cache` when determining dynamic content 

### DIFF
--- a/shell/utils/dynamic-content/__tests__/info.test.ts
+++ b/shell/utils/dynamic-content/__tests__/info.test.ts
@@ -163,6 +163,9 @@ describe('systemInfoProvider', () => {
     mockGetters['uiplugins/plugins'] = null; // No plugins
     mockGetters['auth/principalId'] = null; // No user
     mockGetters['localCluster'] = null; // No clusters
+    mockGetters['features/get'] = () => {
+      throw new Error('unknown feature');
+    };
 
     const infoProvider = new SystemInfoProvider(mockGetters, {});
     const qs = infoProvider.buildQueryString();
@@ -179,6 +182,7 @@ describe('systemInfoProvider', () => {
     expect(qs).not.toContain('lnc=');
     expect(qs).not.toContain('xkn=');
     expect(qs).not.toContain('xcc=');
+    expect(qs).not.toContain('ff-usc=');
   });
 
   it('should handle getAll returning undefined when types are not registered', () => {

--- a/shell/utils/dynamic-content/info.ts
+++ b/shell/utils/dynamic-content/info.ts
@@ -156,9 +156,18 @@ export class SystemInfoProvider {
     const screenSize = `${ window.screen?.width || '?' }x${ window.screen?.height || '?' }`;
     const browserSize = `${ window.innerWidth }x${ window.innerHeight }`;
 
-    Object.entries(ffs).forEach(([id, ff]) => {
-      ff.value = getters['features/get'](id);
-    });
+    const safeFfs = Object.entries(ffs).reduce((res, [id, ff]) => {
+      try {
+        res[id] = {
+          param: ff.param,
+          value: getters['features/get'](id),
+        };
+      } catch (e) {
+        console.debug(`Cannot include Feature Flag "${ id }" in dynamic feature request: `, e); // eslint-disable-line no-console
+      }
+
+      return res;
+    }, {} as FeatureFlagInfos);
 
     return {
       systemUUID,
@@ -175,7 +184,7 @@ export class SystemInfoProvider {
       screenSize,
       browserSize,
       language:           window.navigator?.language,
-      featureFlags:       ffs,
+      featureFlags:       safeFfs,
     };
   }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15867
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- include the actual value used for ff ui-sql-cache in request to determine dynamic content


### Areas or cases that should be tested
- ensure local storage `rancher-updates-fetch-next` value is empty
- refresh page
- confirm request to fetch dynamic content includes correct `ff-usc` payload
  - default = `true`
  - vai manually set to on = `true`
  - vai manually set to off = `false`

### Areas which could experience regressions
- sending of dc request


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
