### PR TITLE
Refactor `persistentvolume` data props

### DIFF
--- a/shell/edit/persistentvolume/index.vue
+++ b/shell/edit/persistentvolume/index.vue
@@ -22,6 +22,8 @@ import InfoBox from '@shell/components/InfoBox';
 import { mapFeature, UNSUPPORTED_STORAGE_DRIVERS } from '@shell/store/features';
 import ResourceManager from '@shell/mixins/resource-manager';
 
+const DEFAULT_ACCESS_MODES = ['ReadWriteOnce'];
+
 export default {
   name:         'PersistentVolume',
   inheritAttrs: false,
@@ -64,35 +66,41 @@ export default {
   },
 
   data() {
-    const NONE_OPTION = {
-      label: this.t('generic.none'),
-      value: ''
-    };
-    const defaultAccessModes = ['ReadWriteOnce'];
-
-    this.value['spec'] = this.value.spec || {};
-    this.value.spec['accessModes'] = this.value.spec.accessModes || defaultAccessModes;
-    this.value.spec['capacity'] = this.value.spec.capacity || {};
-    this.value.spec.capacity['storage'] = this.value.spec.capacity.storage || '10Gi';
-    this.value.spec['storageClassName'] = this.value.spec.storageClassName || NONE_OPTION.value;
-
-    const foundPlugin = this.value.isLonghorn ? LONGHORN_PLUGIN : VOLUME_PLUGINS.find((plugin) => this.value.spec[plugin.value]);
-    const plugin = (foundPlugin || VOLUME_PLUGINS[0]).value;
-
     return {
       secondaryResourceData: this.secondaryResourceDataConfig(),
       storageClassOptions:   [],
       currentClaim:          null,
-      plugin,
-      NONE_OPTION,
+      plugin:                '',
+      initialNodeAffinity:   null,
       NODE,
-      initialNodeAffinity:   clone(this.value.spec.nodeAffinity),
     };
+  },
+
+  created() {
+    this.value['spec'] = this.value.spec || {};
+    this.value.spec['accessModes'] = this.value.spec.accessModes || DEFAULT_ACCESS_MODES;
+    this.value.spec['capacity'] = this.value.spec.capacity || {};
+    this.value.spec.capacity['storage'] = this.value.spec.capacity.storage || '10Gi';
+    this.value.spec['storageClassName'] = this.value.spec.storageClassName || this.noneOption.value;
+
+    const foundPlugin = this.value.isLonghorn ? LONGHORN_PLUGIN : VOLUME_PLUGINS.find((plugin) => this.value.spec[plugin.value]);
+
+    this.plugin = (foundPlugin || VOLUME_PLUGINS[0]).value;
+    this.initialNodeAffinity = clone(this.value.spec.nodeAffinity);
+
+    this.registerBeforeHook(this.willSave, 'willSave');
   },
 
   computed: {
     showUnsupportedStorage: mapFeature(UNSUPPORTED_STORAGE_DRIVERS),
     ...mapGetters(['currentProduct', 'currentCluster']),
+
+    noneOption() {
+      return {
+        label: this.t('generic.none'),
+        value: ''
+      };
+    },
 
     readWriteOnce: {
       get() {
@@ -149,10 +157,6 @@ export default {
     }
   },
 
-  created() {
-    this.registerBeforeHook(this.willSave, 'willSave');
-  },
-
   methods: {
     secondaryResourceDataConfig() {
       return {
@@ -168,7 +172,7 @@ export default {
                     value: s.metadata.name
                   }));
 
-                  storageClassOptions.unshift(this.NONE_OPTION);
+                  storageClassOptions.unshift(this.noneOption);
 
                   return storageClassOptions;
                 }
@@ -194,7 +198,7 @@ export default {
       return require(`./plugins/${ name }`).default;
     },
     willSave() {
-      if (this.value.spec.storageClassName === this.NONE_OPTION.value) {
+      if (this.value.spec.storageClassName === this.noneOption.value) {
         this.value.spec['storageClassName'] = null;
       }
 

--- a/shell/edit/persistentvolume/plugins/awsElasticBlockStore.vue
+++ b/shell/edit/persistentvolume/plugins/awsElasticBlockStore.vue
@@ -14,25 +14,24 @@ export default {
       required: true,
     },
   },
-  data() {
+  created() {
     this.value.spec['awsElasticBlockStore'] = this.value.spec.awsElasticBlockStore || {};
     this.value.spec.awsElasticBlockStore['readOnly'] = this.value.spec.awsElasticBlockStore.readOnly || false;
     this.value.spec.awsElasticBlockStore['partition'] = this.value.spec.awsElasticBlockStore.partition || 0;
-
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
-    return { readOnlyOptions };
   },
   computed: {
+    readOnlyOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    },
     partition: {
       get() {
         return this.value.spec.awsElasticBlockStore.partition;

--- a/shell/edit/persistentvolume/plugins/azureDisk.vue
+++ b/shell/edit/persistentvolume/plugins/azureDisk.vue
@@ -14,57 +14,58 @@ export default {
       required: true,
     },
   },
-  data() {
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
-    const kindOptions = [
-      {
-        label: this.t('persistentVolume.azureDisk.kind.dedicated'),
-        value: 'Dedicated'
-      },
-      {
-        label: this.t('persistentVolume.azureDisk.kind.managed'),
-        value: 'Managed'
-      },
-      {
-        label: this.t('persistentVolume.azureDisk.kind.shared'),
-        value: 'Shared'
-      }
-    ];
-
-    const cachingModeOptions = [
-      {
-        label: this.t('persistentVolume.azureDisk.cachingMode.none'),
-        value: 'None'
-      },
-      {
-        label: this.t('persistentVolume.azureDisk.cachingMode.readOnly'),
-        value: 'ReadOnly'
-      },
-      {
-        label: this.t('persistentVolume.azureDisk.cachingMode.readWrite'),
-        value: 'ReadWrite'
-      }
-    ];
-
+  created() {
     this.value.spec['azureDisk'] = this.value.spec.azureDisk || {};
     this.value.spec.azureDisk['readOnly'] = this.value.spec.azureDisk.readOnly || false;
-    this.value.spec.azureDisk['cachingMode'] = this.value.spec.azureDisk.cachingMode || cachingModeOptions[0].value;
-    this.value.spec.azureDisk['kind'] = this.value.spec.azureDisk.kind || kindOptions[2].value;
-
-    return {
-      kindOptions, readOnlyOptions, cachingModeOptions
-    };
+    this.value.spec.azureDisk['cachingMode'] = this.value.spec.azureDisk.cachingMode || this.cachingModeOptions[0].value;
+    this.value.spec.azureDisk['kind'] = this.value.spec.azureDisk.kind || this.kindOptions[2].value;
   },
+  computed: {
+    readOnlyOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    },
+    kindOptions() {
+      return [
+        {
+          label: this.t('persistentVolume.azureDisk.kind.dedicated'),
+          value: 'Dedicated'
+        },
+        {
+          label: this.t('persistentVolume.azureDisk.kind.managed'),
+          value: 'Managed'
+        },
+        {
+          label: this.t('persistentVolume.azureDisk.kind.shared'),
+          value: 'Shared'
+        }
+      ];
+    },
+    cachingModeOptions() {
+      return [
+        {
+          label: this.t('persistentVolume.azureDisk.cachingMode.none'),
+          value: 'None'
+        },
+        {
+          label: this.t('persistentVolume.azureDisk.cachingMode.readOnly'),
+          value: 'ReadOnly'
+        },
+        {
+          label: this.t('persistentVolume.azureDisk.cachingMode.readWrite'),
+          value: 'ReadWrite'
+        }
+      ];
+    }
+  }
 };
 </script>
 

--- a/shell/edit/persistentvolume/plugins/azureFile.vue
+++ b/shell/edit/persistentvolume/plugins/azureFile.vue
@@ -14,23 +14,24 @@ export default {
       required: true,
     },
   },
-  data() {
+  created() {
     this.value.spec['azureFile'] = this.value.spec.azureFile || {};
     this.value.spec.azureFile['readOnly'] = this.value.spec.azureFile.readOnly || false;
-
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
-    return { readOnlyOptions };
   },
+  computed: {
+    readOnlyOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    }
+  }
 };
 </script>
 

--- a/shell/edit/persistentvolume/plugins/cephfs.vue
+++ b/shell/edit/persistentvolume/plugins/cephfs.vue
@@ -17,24 +17,25 @@ export default {
       required: true,
     },
   },
-  data() {
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
+  created() {
     this.value.spec['cephfs'] = this.value.spec.cephfs || {};
     this.value.spec.cephfs['readOnly'] = this.value.spec.cephfs.readOnly || false;
     this.value.spec.cephfs['secretRef'] = this.value.spec.cephfs.secretRef || {};
-
-    return { readOnlyOptions };
   },
+  computed: {
+    readOnlyOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    }
+  }
 };
 </script>
 

--- a/shell/edit/persistentvolume/plugins/cinder.vue
+++ b/shell/edit/persistentvolume/plugins/cinder.vue
@@ -14,24 +14,25 @@ export default {
       required: true,
     },
   },
-  data() {
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
+  created() {
     this.value.spec['cinder'] = this.value.spec.cinder || {};
     this.value.spec.cinder['readOnly'] = this.value.spec.cinder.readOnly || false;
     this.value.spec.cinder['secretRef'] = this.value.spec.cinder.secretRef || {};
-
-    return { readOnlyOptions };
   },
+  computed: {
+    readOnlyOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    }
+  }
 };
 </script>
 

--- a/shell/edit/persistentvolume/plugins/csi.vue
+++ b/shell/edit/persistentvolume/plugins/csi.vue
@@ -36,32 +36,34 @@ export default {
   },
 
   data() {
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
+    return {
+      loadingDrivers: true,
+      csiDrivers:     [],
+    };
+  },
 
+  created() {
     this.value.spec['csi'] = this.value.spec.csi || {};
     this.value.spec.csi['readOnly'] = this.value.spec.csi.readOnly || false;
     this.value.spec.csi['nodePublishSecretRef'] = this.value.spec.csi.nodePublishSecretRef || {};
     this.value.spec.csi['nodeStageSecretRef'] = this.value.spec.csi.nodeStageSecretRef || {};
     this.value.spec.csi['controllerExpandSecretRef'] = this.value.spec.csi.controllerExpandSecretRef || {};
     this.value.spec.csi['controllerPublishSecretRef'] = this.value.spec.csi.controllerPublishSecretRef || {};
-
-    return {
-      readOnlyOptions,
-      loadingDrivers: true,
-      csiDrivers:     [],
-    };
   },
 
   computed: {
+    readOnlyOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    },
     driverOptions() {
       return this.csiDrivers.map((driver) => {
         return driver.metadata.name;

--- a/shell/edit/persistentvolume/plugins/fc.vue
+++ b/shell/edit/persistentvolume/plugins/fc.vue
@@ -17,25 +17,24 @@ export default {
       required: true,
     },
   },
-  data() {
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
+  created() {
     this.value.spec['fc'] = this.value.spec.fc || {};
     this.value.spec.fc['readOnly'] = this.value.spec.fc.readOnly || false;
     this.value.spec.fc['secretRef'] = this.value.spec.fc.secretRef || {};
-
-    return { readOnlyOptions };
   },
   computed: {
+    readOnlyOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    },
     lun: {
       get() {
         return this.value.spec.fc.lun;

--- a/shell/edit/persistentvolume/plugins/flexVolume.vue
+++ b/shell/edit/persistentvolume/plugins/flexVolume.vue
@@ -17,24 +17,25 @@ export default {
       required: true,
     },
   },
-  data() {
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
+  created() {
     this.value.spec['flexVolume'] = this.value.spec.flexVolume || {};
     this.value.spec.flexVolume['readOnly'] = this.value.spec.flexVolume.readOnly || false;
     this.value.spec.flexVolume['secretRef'] = this.value.spec.flexVolume.secretRef || {};
-
-    return { readOnlyOptions };
   },
+  computed: {
+    readOnlyOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    }
+  }
 };
 </script>
 

--- a/shell/edit/persistentvolume/plugins/flocker.vue
+++ b/shell/edit/persistentvolume/plugins/flocker.vue
@@ -13,10 +13,8 @@ export default {
       required: true,
     },
   },
-  data() {
+  created() {
     this.value.spec['flocker'] = this.value.spec.flocker || {};
-
-    return {};
   },
 };
 </script>

--- a/shell/edit/persistentvolume/plugins/gcePersistentDisk.vue
+++ b/shell/edit/persistentvolume/plugins/gcePersistentDisk.vue
@@ -14,25 +14,24 @@ export default {
       required: true,
     },
   },
-  data() {
+  created() {
     this.value.spec['gcePersistentDisk'] = this.value.spec.gcePersistentDisk || {};
     this.value.spec.gcePersistentDisk['readOnly'] = this.value.spec.gcePersistentDisk.readOnly || false;
     this.value.spec.gcePersistentDisk['partition'] = this.value.spec.gcePersistentDisk.partition || 0;
-
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
-    return { readOnlyOptions };
   },
   computed: {
+    readOnlyOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    },
     partition: {
       get() {
         return this.value.spec.gcePersistentDisk.partition;

--- a/shell/edit/persistentvolume/plugins/glusterfs.vue
+++ b/shell/edit/persistentvolume/plugins/glusterfs.vue
@@ -14,23 +14,24 @@ export default {
       required: true,
     },
   },
-  data() {
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
+  created() {
     this.value.spec['glusterfs'] = this.value.spec.glusterfs || {};
     this.value.spec.glusterfs['readOnly'] = this.value.spec.glusterfs.readOnly || false;
-
-    return { readOnlyOptions };
   },
+  computed: {
+    readOnlyOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    }
+  }
 };
 </script>
 

--- a/shell/edit/persistentvolume/plugins/hostPath.vue
+++ b/shell/edit/persistentvolume/plugins/hostPath.vue
@@ -14,47 +14,48 @@ export default {
       required: true,
     },
   },
-  data() {
-    const mustBeOptions = [
-      {
-        label: this.t('persistentVolume.hostPath.mustBe.anything'),
-        value: ''
-      },
-      {
-        label: this.t('persistentVolume.hostPath.mustBe.directory'),
-        value: 'DirectoryOrCreate'
-      },
-      {
-        label: this.t('persistentVolume.hostPath.mustBe.file'),
-        value: 'FileOrCreate'
-      },
-      {
-        label: this.t('persistentVolume.hostPath.mustBe.existingDirectory'),
-        value: 'Directory'
-      },
-      {
-        label: this.t('persistentVolume.hostPath.mustBe.existingFile'),
-        value: 'File'
-      },
-      {
-        label: this.t('persistentVolume.hostPath.mustBe.existingSocket'),
-        value: 'Socket'
-      },
-      {
-        label: this.t('persistentVolume.hostPath.mustBe.existingCharacter'),
-        value: 'CharDevice'
-      },
-      {
-        label: this.t('persistentVolume.hostPath.mustBe.existingBlock'),
-        value: 'BlockDevice'
-      },
-    ];
-
+  created() {
     this.value.spec['hostPath'] = this.value.spec.hostPath || {};
-    this.value.spec.hostPath['type'] = this.value.spec.hostPath.type || mustBeOptions[0].value;
-
-    return { mustBeOptions };
+    this.value.spec.hostPath['type'] = this.value.spec.hostPath.type || this.mustBeOptions[0].value;
   },
+  computed: {
+    mustBeOptions() {
+      return [
+        {
+          label: this.t('persistentVolume.hostPath.mustBe.anything'),
+          value: ''
+        },
+        {
+          label: this.t('persistentVolume.hostPath.mustBe.directory'),
+          value: 'DirectoryOrCreate'
+        },
+        {
+          label: this.t('persistentVolume.hostPath.mustBe.file'),
+          value: 'FileOrCreate'
+        },
+        {
+          label: this.t('persistentVolume.hostPath.mustBe.existingDirectory'),
+          value: 'Directory'
+        },
+        {
+          label: this.t('persistentVolume.hostPath.mustBe.existingFile'),
+          value: 'File'
+        },
+        {
+          label: this.t('persistentVolume.hostPath.mustBe.existingSocket'),
+          value: 'Socket'
+        },
+        {
+          label: this.t('persistentVolume.hostPath.mustBe.existingCharacter'),
+          value: 'CharDevice'
+        },
+        {
+          label: this.t('persistentVolume.hostPath.mustBe.existingBlock'),
+          value: 'BlockDevice'
+        },
+      ];
+    }
+  }
 };
 </script>
 

--- a/shell/edit/persistentvolume/plugins/iscsi.vue
+++ b/shell/edit/persistentvolume/plugins/iscsi.vue
@@ -17,27 +17,26 @@ export default {
       required: true,
     },
   },
-  data() {
-    const yesNoOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
+  created() {
     this.value.spec['iscsi'] = this.value.spec.iscsi || {};
     this.value.spec.iscsi['readOnly'] = this.value.spec.iscsi.readOnly || false;
     this.value.spec.iscsi['secretRef'] = this.value.spec.iscsi.secretRef || {};
     this.value.spec.iscsi['chapAuthDiscovery'] = this.value.spec.iscsi.chapAuthDiscovery || false;
     this.value.spec.iscsi['chapAuthSession'] = this.value.spec.iscsi.chapAuthSession || false;
-
-    return { yesNoOptions };
   },
   computed: {
+    yesNoOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    },
     lun: {
       get() {
         return this.value.spec.iscsi.lun;

--- a/shell/edit/persistentvolume/plugins/local.vue
+++ b/shell/edit/persistentvolume/plugins/local.vue
@@ -13,10 +13,8 @@ export default {
       required: true,
     },
   },
-  data() {
+  created() {
     this.value.spec['local'] = this.value.spec.local || {};
-
-    return { };
   },
 };
 </script>

--- a/shell/edit/persistentvolume/plugins/longhorn.vue
+++ b/shell/edit/persistentvolume/plugins/longhorn.vue
@@ -5,6 +5,13 @@ import { RadioGroup } from '@components/Form/Radio';
 import { _CREATE } from '@shell/config/query-params';
 import { LONGHORN_DRIVER } from '@shell/config/types';
 
+const DEFAULT_VOLUME_ATTRIBUTES = {
+  size:                '2Gi',
+  numberOfReplicas:    '3',
+  staleReplicaTimeout: '20',
+  fromBackup:          ''
+};
+
 export default {
   components: {
     LabeledInput, KeyValue, RadioGroup
@@ -19,33 +26,27 @@ export default {
       required: true,
     },
   },
-  data() {
-    const defaultVolumeAttributes = {
-      size:                '2Gi',
-      numberOfReplicas:    '3',
-      staleReplicaTimeout: '20',
-      fromBackup:          ''
-    };
-
+  created() {
     if (this.mode === _CREATE) {
       this.value.spec['csi'] = this.value.spec.csi || {};
       this.value.spec.csi['driver'] = LONGHORN_DRIVER;
       this.value.spec.csi['readOnly'] = this.value.spec.csi.readOnly || false;
-      this.value.spec.csi['volumeAttributes'] = this.value.spec.csi.volumeAttributes || defaultVolumeAttributes;
+      this.value.spec.csi['volumeAttributes'] = this.value.spec.csi.volumeAttributes || DEFAULT_VOLUME_ATTRIBUTES;
     }
-
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
-    return { readOnlyOptions };
+  },
+  computed: {
+    readOnlyOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    }
   },
 };
 </script>

--- a/shell/edit/persistentvolume/plugins/nfs.vue
+++ b/shell/edit/persistentvolume/plugins/nfs.vue
@@ -14,23 +14,24 @@ export default {
       required: true,
     },
   },
-  data() {
+  created() {
     this.value.spec['nfs'] = this.value.spec.nfs || {};
     this.value.spec.nfs['readOnly'] = this.value.spec.nfs.readOnly || false;
-
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
-    return { readOnlyOptions };
   },
+  computed: {
+    readOnlyOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    }
+  }
 };
 </script>
 

--- a/shell/edit/persistentvolume/plugins/photonPersistentDisk.vue
+++ b/shell/edit/persistentvolume/plugins/photonPersistentDisk.vue
@@ -13,23 +13,10 @@ export default {
       required: true,
     },
   },
-  data() {
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
+  created() {
     this.value.spec['photonPersistentDisk'] = this.value.spec.photonPersistentDisk || {};
     this.value.spec.photonPersistentDisk['readOnly'] = this.value.spec.photonPersistentDisk.readOnly || false;
     this.value.spec.photonPersistentDisk['secretRef'] = this.value.spec.photonPersistentDisk.secretRef || {};
-
-    return { readOnlyOptions };
   },
 };
 </script>

--- a/shell/edit/persistentvolume/plugins/portworxVolume.vue
+++ b/shell/edit/persistentvolume/plugins/portworxVolume.vue
@@ -14,24 +14,25 @@ export default {
       required: true,
     },
   },
-  data() {
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
+  created() {
     this.value.spec['portworxVolume'] = this.value.spec.portworxVolume || {};
     this.value.spec.portworxVolume['readOnly'] = this.value.spec.portworxVolume.readOnly || false;
     this.value.spec.portworxVolume['secretRef'] = this.value.spec.portworxVolume.secretRef || {};
-
-    return { readOnlyOptions };
   },
+  computed: {
+    readOnlyOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    }
+  }
 };
 </script>
 

--- a/shell/edit/persistentvolume/plugins/quobyte.vue
+++ b/shell/edit/persistentvolume/plugins/quobyte.vue
@@ -14,23 +14,24 @@ export default {
       required: true,
     },
   },
-  data() {
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
+  created() {
     this.value.spec['quobyte'] = this.value.spec.quobyte || {};
     this.value.spec.quobyte['readOnly'] = this.value.spec.quobyte.readOnly || false;
-
-    return { readOnlyOptions };
   },
+  computed: {
+    readOnlyOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    }
+  }
 };
 </script>
 

--- a/shell/edit/persistentvolume/plugins/rbd.vue
+++ b/shell/edit/persistentvolume/plugins/rbd.vue
@@ -17,24 +17,25 @@ export default {
       required: true,
     },
   },
-  data() {
-    const readOnlyOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
+  created() {
     this.value.spec['rbd'] = this.value.spec.rbd || {};
     this.value.spec.rbd['readOnly'] = this.value.spec.rbd.readOnly || false;
     this.value.spec.rbd['secretRef'] = this.value.spec.rbd.secretRef || {};
-
-    return { readOnlyOptions };
   },
+  computed: {
+    readOnlyOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    }
+  }
 };
 </script>
 

--- a/shell/edit/persistentvolume/plugins/scaleIO.vue
+++ b/shell/edit/persistentvolume/plugins/scaleIO.vue
@@ -14,25 +14,26 @@ export default {
       required: true,
     },
   },
-  data() {
-    const yesNoOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
+  created() {
     this.value.spec['scaleIO'] = this.value.spec.scaleIO || {};
     this.value.spec.scaleIO['readOnly'] = this.value.spec.scaleIO.readOnly || false;
     this.value.spec.scaleIO['secretRef'] = this.value.spec.scaleIO.secretRef || {};
     this.value.spec.scaleIO['sslEnabled'] = this.value.spec.scaleIO.sslEnabled || false;
-
-    return { yesNoOptions };
   },
+  computed: {
+    yesNoOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    }
+  }
 };
 </script>
 

--- a/shell/edit/persistentvolume/plugins/storageos.vue
+++ b/shell/edit/persistentvolume/plugins/storageos.vue
@@ -14,24 +14,25 @@ export default {
       required: true,
     },
   },
-  data() {
-    const yesNoOptions = [
-      {
-        label: this.t('generic.yes'),
-        value: true
-      },
-      {
-        label: this.t('generic.no'),
-        value: false
-      }
-    ];
-
+  created() {
     this.value.spec['storageos'] = this.value.spec.storageos || {};
     this.value.spec.storageos['readOnly'] = this.value.spec.storageos.readOnly || false;
     this.value.spec.storageos['secretRef'] = this.value.spec.storageos.secretRef || {};
-
-    return { yesNoOptions };
   },
+  computed: {
+    yesNoOptions() {
+      return [
+        {
+          label: this.t('generic.yes'),
+          value: true
+        },
+        {
+          label: this.t('generic.no'),
+          value: false
+        }
+      ];
+    }
+  }
 };
 </script>
 

--- a/shell/edit/persistentvolume/plugins/vsphereVolume.vue
+++ b/shell/edit/persistentvolume/plugins/vsphereVolume.vue
@@ -13,10 +13,8 @@ export default {
       required: true,
     },
   },
-  data() {
+  created() {
     this.value.spec['vsphereVolume'] = this.value.spec.vsphereVolume || {};
-
-    return { };
   },
 };
 </script>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This refactors components under `shell/edit/persistentvolume` so that data initialization logic is no longer in the data prop.

Fixes #14864
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Refactor persistentvolume data props

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Most of the changes represented in this PR fall under two buckets:

1. Moving data props over to computed props
2. Moving data initialization into the created hook

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Persistent volumes - created/edit/delete

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Moving initialization code from `data` to the `created` hook can alter the component logic. Common side-effects will be exposed as components failing to render, or rendering with incorrect default data.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
