### PR TITLE
Refactor `monitoring.coreos.com` data props

### DIFF
--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/auth.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/auth.vue
@@ -21,44 +21,61 @@ export default {
     }
   },
   data() {
-    this.value['basicAuth'] = this.value.basicAuth || {};
-
-    const authOptions = [
-      {
-        value: 'none',
-        label: this.t('monitoringReceiver.auth.none.label'),
-      },
-      {
-        value:   'basicAuth',
-        label:   this.t('monitoringReceiver.auth.basicAuth.label'),
-        default: {},
-      },
-      {
-        value:   'bearerTokenSecret',
-        label:   this.t('monitoringReceiver.auth.bearerToken.label'),
-        default: {},
-      },
-    ];
-    const authTypes = authOptions.map((option) => option.value);
-    const authType =
-      authTypes.find((authType) => !isEmpty(this.value[authType])) ||
-      authTypes[0];
-
-    this.initializeType(authOptions, authType);
-
     return {
-      authOptions,
-      authTypes,
-      authType,
-      view:                               _VIEW,
-      none:                               '__[[NONE]]__',
-      initialBearerTokenSecretName:       this.value?.bearerTokenSecret?.name ? this.value.bearerTokenSecret.name : '',
-      initialBearerTokenSecretKey:        this.value?.bearerTokenSecret?.key ? this.value.bearerTokenSecret.key : '',
-      initialBasicAuthUsernameSecretName: this.value?.basicAuth?.username?.name ? this.value.basicAuth.username.name : '',
-      initialBasicAuthUsernameSecretKey:  this.value?.basicAuth?.username?.key ? this.value.basicAuth.username.key : '',
-      initialBasicAuthPasswordSecretName: this.value?.basicAuth?.password?.name ? this.value.basicAuth.password.name : '',
-      initialBasicAuthPasswordSecretKey:  this.value?.basicAuth?.password?.key ? this.value.basicAuth.password.key : ''
+      authType: null,
+      view:     _VIEW,
+      none:     '__[[NONE]]__',
     };
+  },
+  computed: {
+    authOptions() {
+      return [
+        {
+          value: 'none',
+          label: this.t('monitoringReceiver.auth.none.label'),
+        },
+        {
+          value:   'basicAuth',
+          label:   this.t('monitoringReceiver.auth.basicAuth.label'),
+          default: {},
+        },
+        {
+          value:   'bearerTokenSecret',
+          label:   this.t('monitoringReceiver.auth.bearerToken.label'),
+          default: {},
+        },
+      ];
+    },
+    authTypes() {
+      return this.authOptions.map((option) => option.value);
+    },
+    initialBearerTokenSecretName() {
+      return this.value?.bearerTokenSecret?.name ? this.value.bearerTokenSecret.name : '';
+    },
+    initialBearerTokenSecretKey() {
+      return this.value?.bearerTokenSecret?.key ? this.value.bearerTokenSecret.key : '';
+    },
+    initialBasicAuthUsernameSecretName() {
+      return this.value?.basicAuth?.username?.name ? this.value.basicAuth.username.name : '';
+    },
+    initialBasicAuthUsernameSecretKey() {
+      return this.value?.basicAuth?.username?.key ? this.value.basicAuth.username.key : '';
+    },
+    initialBasicAuthPasswordSecretName() {
+      return this.value?.basicAuth?.password?.name ? this.value.basicAuth.password.name : '';
+    },
+    initialBasicAuthPasswordSecretKey() {
+      return this.value?.basicAuth?.password?.key ? this.value.basicAuth.password.key : '';
+    }
+  },
+  created() {
+    this.value.basicAuth = this.value.basicAuth || {};
+    const authType =
+      this.authTypes.find((authType) => !isEmpty(this.value[authType])) ||
+      this.authTypes[0];
+
+    this.authType = authType;
+    this.initializeType(this.authOptions, authType);
   },
   methods: {
     initializeType(authOptions, type) {

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
@@ -55,18 +55,12 @@ export default {
   },
 
   data() {
-    this.value.applyDefaults();
-
-    const defaultReceiverValues = {};
-    const receiverOptions = (this.value?.spec?.receivers || []).map((receiver) => receiver.name);
-
     return {
       actionMenuTargetElement:  null,
       actionMenuTargetEvent:    null,
       config:                   _CONFIG,
       create:                   _CREATE,
-      createReceiverLink:       this.value.getCreateReceiverRoute(),
-      defaultReceiverValues,
+      defaultReceiverValues:    {},
       receiverActionMenuIsOpen: false,
       receiverTableHeaders:     [
         {
@@ -88,7 +82,6 @@ export default {
       ],
       newReceiverType:      null,
       receiverActions:      [],
-      receiverOptions,
       receiverTypes:        RECEIVERS_TYPES,
       selectedReceiverName: '',
       selectedRowValue:     null,
@@ -97,7 +90,6 @@ export default {
   },
 
   computed: {
-
     editorMode() {
       if ( this.mode === _VIEW ) {
         return EDITOR_MODES.VIEW_CODE;
@@ -105,7 +97,20 @@ export default {
 
       return EDITOR_MODES.EDIT_CODE;
     },
+
+    receiverOptions() {
+      return (this.value?.spec?.receivers || []).map((receiver) => receiver.name);
+    },
+
+    createReceiverLink() {
+      return this.value.getCreateReceiverRoute();
+    },
   },
+
+  created() {
+    this.value.applyDefaults();
+  },
+
   methods: {
 
     translateReceiverTypes() {

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/tls.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/tls.vue
@@ -23,18 +23,35 @@ export default {
     }
   },
   data() {
-    this.value['tlsConfig'] = this.value.tlsConfig || {};
-
     return {
-      initialCaSecretKey:          this.value.tlsConfig.ca?.secret?.key ? this.value.tlsConfig.ca.secret.key : '',
-      initialCaSecretName:         this.value.tlsConfig.ca?.secret?.name ? this.value.tlsConfig.ca.secret.name : '',
-      initialClientCertSecretKey:  this.value.tlsConfig.cert?.secret?.key ? this.value.tlsConfig.cert.secret.key : '',
-      initialClientCertSecretName: this.value.tlsConfig.cert?.secret?.name ? this.value.tlsConfig.cert.secret.name : '',
-      initialClientKeySecretKey:   this.value.tlsConfig.keySecret?.key ? this.value.tlsConfig.keySecret.key : '',
-      initialClientKeySecretName:  this.value.tlsConfig.keySecret?.name ? this.value.tlsConfig.keySecret.name : '',
-      view:                        _VIEW,
-      none:                        '__[[NONE]]__'
+      view: _VIEW,
+      none: '__[[NONE]]__'
     };
+  },
+
+  computed: {
+    initialCaSecretKey() {
+      return this.value.tlsConfig.ca?.secret?.key ? this.value.tlsConfig.ca.secret.key : '';
+    },
+    initialCaSecretName() {
+      return this.value.tlsConfig.ca?.secret?.name ? this.value.tlsConfig.ca.secret.name : '';
+    },
+    initialClientCertSecretKey() {
+      return this.value.tlsConfig.cert?.secret?.key ? this.value.tlsConfig.cert.secret.key : '';
+    },
+    initialClientCertSecretName() {
+      return this.value.tlsConfig.cert?.secret?.name ? this.value.tlsConfig.cert.secret.name : '';
+    },
+    initialClientKeySecretKey() {
+      return this.value.tlsConfig.keySecret?.key ? this.value.tlsConfig.keySecret.key : '';
+    },
+    initialClientKeySecretName() {
+      return this.value.tlsConfig.keySecret?.name ? this.value.tlsConfig.keySecret.name : '';
+    },
+  },
+
+  created() {
+    this.value.tlsConfig = this.value.tlsConfig || {};
   },
 
   methods: {

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/opsgenie.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/opsgenie.vue
@@ -60,39 +60,29 @@ export default {
     }
   },
   data() {
-    this.value['httpConfig'] = this.value.httpConfig || {};
-    this.value['sendResolved'] = typeof this.value.sendResolved === 'boolean' ? this.value.send_resolved : true;
-    this.value['responders'] = this.value.responders || [];
-
-    const responders = this.value.responders.map((responder) => {
-      const target = TARGETS.find((target) => responder[target.value]);
-
-      return {
-        type:   responder.type,
-        target: target.value,
-        value:  responder[target.value]
-      };
-    });
-
     return {
       defaultResponder: {
         type:   TYPES[0].value,
         target: TARGETS[0].value,
         value:  ''
       },
-      responders,
+      responders: [],
       TARGETS,
       TYPES,
-      view:                    _VIEW,
-      initialApiKeySecretName: this.value?.apiKey?.name ? this.value.apiKey.name : '',
-      initialApiKeySecretKey:  this.value?.apiKey?.key ? this.value.apiKey.key : '',
-      none:                    '__[[NONE]]__',
+      view:       _VIEW,
+      none:       '__[[NONE]]__',
     };
   },
 
   computed: {
     isView() {
       return this.mode === _VIEW;
+    },
+    initialApiKeySecretName() {
+      return this.value?.apiKey?.name || '';
+    },
+    initialApiKeySecretKey() {
+      return this.value?.apiKey?.key || '';
     }
   },
 
@@ -110,6 +100,22 @@ export default {
         this.value['responders'] = responders;
       }
     }
+  },
+
+  created() {
+    this.value.httpConfig = this.value.httpConfig || {};
+    this.value.sendResolved = typeof this.value.sendResolved === 'boolean' ? this.value.sendResolved : true;
+    this.value.responders = this.value.responders || [];
+
+    this.responders = this.value.responders.map((responder) => {
+      const target = TARGETS.find((target) => responder[target.value]);
+
+      return {
+        type:   responder.type,
+        target: target.value,
+        value:  responder[target.value]
+      };
+    });
   },
 
   methods: {

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/pagerduty.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/pagerduty.vue
@@ -5,6 +5,13 @@ import { Checkbox } from '@components/Form/Checkbox';
 import SimpleSecretSelector from '@shell/components/form/SimpleSecretSelector';
 import { _VIEW } from '@shell/config/query-params';
 
+const integrationMapping = {
+  'Events API v2': 'routingKey',
+  Prometheus:      'serviceKey'
+};
+
+const integrationTypeOptions = Object.keys(integrationMapping);
+
 export default {
   components: {
     Checkbox, LabeledInput, LabeledSelect, SimpleSecretSelector
@@ -24,27 +31,27 @@ export default {
     }
   },
   data() {
-    this.value['httpConfig'] = this.value.httpConfig || {};
-    this.value['sendResolved'] = typeof this.value.send_resolved === 'boolean' ? this.value.send_resolved : true;
-
-    const integrationMapping = {
-      'Events API v2': 'routingKey',
-      Prometheus:      'serviceKey'
-    };
-
-    const integrationTypeOptions = Object.keys(integrationMapping);
-
     return {
       integrationMapping,
       integrationTypeOptions,
-      integrationType:             this.value.serviceKey ? integrationTypeOptions[1] : integrationTypeOptions[0],
-      initialRoutingKeySecretKey:  this.value.routingKey?.key || '',
-      initialRoutingKeySecretName: this.value.routingKey?.name || '',
-      initialServiceKeySecretKey:  this.value.serviceKey?.key || '',
-      initialServiceKeySecretName: this.value.serviceKey?.name || '',
-      view:                        _VIEW,
-      none:                        '__[[NONE]]__',
+      integrationType: this.value.serviceKey ? integrationTypeOptions[1] : integrationTypeOptions[0],
+      view:            _VIEW,
+      none:            '__[[NONE]]__',
     };
+  },
+  computed: {
+    initialRoutingKeySecretKey() {
+      return this.value.routingKey?.key || '';
+    },
+    initialRoutingKeySecretName() {
+      return this.value.routingKey?.name || '';
+    },
+    initialServiceKeySecretKey() {
+      return this.value.serviceKey?.key || '';
+    },
+    initialServiceKeySecretName() {
+      return this.value.serviceKey?.name || '';
+    },
   },
   watch: {
     integrationType() {
@@ -52,6 +59,10 @@ export default {
         this.value[this.integrationMapping[option]] = null;
       });
     }
+  },
+  created() {
+    this.value.httpConfig = this.value.httpConfig || {};
+    this.value.sendResolved = typeof this.value.sendResolved === 'boolean' ? this.value.sendResolved : true;
   },
   methods: {
     updateRoutingKeySecretName(name) {

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/slack.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/types/slack.vue
@@ -24,19 +24,28 @@ export default {
     }
   },
   data() {
-    this.value['httpConfig'] = this.value.httpConfig || {};
-    this.value['sendResolved'] = this.value.sendResolved || false;
+    return {
+      view: _VIEW,
+      none: '__[[NONE]]__',
+    };
+  },
+
+  computed: {
+    initialSecretKey() {
+      return this.value?.apiURL?.key ? this.value.apiURL.key : '';
+    },
+    initialSecretName() {
+      return this.value.apiURL?.name ? this.value.apiURL.name : '';
+    },
+  },
+
+  created() {
+    this.value.httpConfig = this.value.httpConfig || {};
+    this.value.sendResolved = this.value.sendResolved || false;
 
     if (this.mode === _CREATE) {
       this.value.text = this.value.text || '{{ template "slack.rancher.text" . }}';
     }
-
-    return {
-      view:              _VIEW,
-      initialSecretKey:  this.value?.apiURL?.key ? this.value.apiURL.key : '',
-      initialSecretName: this.value.apiURL?.name ? this.value.apiURL.name : '',
-      none:              '__[[NONE]]__',
-    };
   },
 
   methods: {

--- a/shell/edit/monitoring.coreos.com.receiver/auth.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/auth.vue
@@ -24,39 +24,42 @@ export default {
     }
   },
   data() {
-    this.value['basic_auth'] = this.value.basic_auth || {};
+    return { authType: null };
+  },
+  computed: {
+    authOptions() {
+      return [
+        {
+          value: 'none',
+          label: this.t('monitoringReceiver.auth.none.label')
+        },
+        {
+          value:   'basic_auth',
+          label:   this.t('monitoringReceiver.auth.basicAuth.label'),
+          default: {}
+        },
+        {
+          value:   'bearer_token',
+          label:   this.t('monitoringReceiver.auth.bearerToken.label'),
+          default: ''
+        },
+        {
+          value:   'bearer_token_file',
+          label:   this.t('monitoringReceiver.auth.bearerTokenFile.label'),
+          default: ''
+        }
+      ];
+    },
+    authTypes() {
+      return this.authOptions.map((option) => option.value);
+    },
+  },
+  created() {
+    this.value.basic_auth = this.value.basic_auth || {};
+    const authType = this.authTypes.find((authType) => !isEmpty(this.value[authType])) || this.authTypes[0];
 
-    const authOptions = [
-      {
-        value: 'none',
-        label: this.t('monitoringReceiver.auth.none.label')
-      },
-      {
-        value:   'basic_auth',
-        label:   this.t('monitoringReceiver.auth.basicAuth.label'),
-        default: {}
-      },
-      {
-        value:   'bearer_token',
-        label:   this.t('monitoringReceiver.auth.bearerToken.label'),
-        default: ''
-      },
-      {
-        value:   'bearer_token_file',
-        label:   this.t('monitoringReceiver.auth.bearerTokenFile.label'),
-        default: ''
-      }
-    ];
-    const authTypes = authOptions.map((option) => option.value);
-    const authType = authTypes.find((authType) => !isEmpty(this.value[authType])) || authTypes[0];
-
-    this.initializeType(authOptions, authType);
-
-    return {
-      authOptions,
-      authTypes,
-      authType
-    };
+    this.authType = authType;
+    this.initializeType(this.authOptions, authType);
   },
   methods: {
     initializeType(authOptions, type) {

--- a/shell/edit/monitoring.coreos.com.receiver/tls.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/tls.vue
@@ -22,10 +22,8 @@ export default {
       required: true
     }
   },
-  data() {
+  created() {
     this.value.tls_config = this.value.tls_config || {};
-
-    return {};
   },
 };
 </script>

--- a/shell/edit/monitoring.coreos.com.receiver/types/email.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/types/email.vue
@@ -26,12 +26,10 @@ export default {
       required: true
     }
   },
-  data() {
+  created() {
     this.value['send_resolved'] = this.value.send_resolved || false;
     this.value['require_tls'] = this.value.require_tls || false;
-
-    return {};
-  },
+  }
 };
 </script>
 

--- a/shell/edit/monitoring.coreos.com.receiver/types/opsgenie.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/types/opsgenie.vue
@@ -63,27 +63,13 @@ export default {
     }
   },
   data() {
-    this.value['http_config'] = this.value.http_config || {};
-    this.value['send_resolved'] = typeof this.value.send_resolved === 'boolean' ? this.value.send_resolved : true;
-    this.value['responders'] = this.value.responders || [];
-
-    const responders = this.value.responders.map((responder) => {
-      const target = TARGETS.find((target) => responder[target.value]);
-
-      return {
-        type:   responder.type,
-        target: target.value,
-        value:  responder[target.value]
-      };
-    });
-
     return {
       defaultResponder: {
         type:   TYPES[0].value,
         target: TARGETS[0].value,
         value:  ''
       },
-      responders,
+      responders: [],
       TARGETS,
       TYPES
     };
@@ -109,6 +95,22 @@ export default {
         this.value['responders'] = responders;
       }
     }
+  },
+
+  created() {
+    this.value.http_config = this.value.http_config || {};
+    this.value.send_resolved = typeof this.value.send_resolved === 'boolean' ? this.value.send_resolved : true;
+    this.value.responders = this.value.responders || [];
+
+    this.responders = this.value.responders.map((responder) => {
+      const target = TARGETS.find((target) => responder[target.value]);
+
+      return {
+        type:   responder.type,
+        target: target.value,
+        value:  responder[target.value]
+      };
+    });
   },
 
   methods: {

--- a/shell/edit/monitoring.coreos.com.receiver/types/pagerduty.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/types/pagerduty.vue
@@ -11,6 +11,13 @@ import { LabeledInput } from '@components/Form/LabeledInput';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { Checkbox } from '@components/Form/Checkbox';
 
+const integrationMapping = {
+  'Events API v2': 'routing_key',
+  Prometheus:      'service_key'
+};
+
+const integrationTypeOptions = Object.keys(integrationMapping);
+
 export default {
   components: {
     Checkbox, LabeledInput, LabeledSelect
@@ -26,16 +33,6 @@ export default {
     }
   },
   data() {
-    this.value['http_config'] = this.value.http_config || {};
-    this.value['send_resolved'] = typeof this.value.send_resolved === 'boolean' ? this.value.send_resolved : true;
-
-    const integrationMapping = {
-      'Events API v2': 'routing_key',
-      Prometheus:      'service_key'
-    };
-
-    const integrationTypeOptions = Object.keys(integrationMapping);
-
     return {
       integrationMapping,
       integrationTypeOptions,
@@ -48,6 +45,10 @@ export default {
         this.value[this.integrationMapping[option]] = null;
       });
     }
+  },
+  created() {
+    this.value.http_config = this.value.http_config || {};
+    this.value.send_resolved = typeof this.value.send_resolved === 'boolean' ? this.value.send_resolved : true;
   }
 };
 </script>

--- a/shell/edit/monitoring.coreos.com.receiver/types/slack.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/types/slack.vue
@@ -23,15 +23,13 @@ export default {
       required: true,
     },
   },
-  data() {
-    this.value['http_config'] = this.value.http_config || {};
-    this.value['send_resolved'] = this.value.send_resolved || false;
+  created() {
+    this.value.http_config = this.value.http_config || {};
+    this.value.send_resolved = this.value.send_resolved || false;
 
     if (this.mode === _CREATE) {
       this.value.text = this.value.text || '{{ template "slack.rancher.text" . }}';
     }
-
-    return {};
   },
 };
 </script>

--- a/shell/edit/monitoring.coreos.com.receiver/types/webhook.vue
+++ b/shell/edit/monitoring.coreos.com.receiver/types/webhook.vue
@@ -29,13 +29,17 @@ export default {
       required: true
     }
   },
-  data() {
-    this.value['http_config'] = this.value.http_config || {};
-    this.value['send_resolved'] = this.value.send_resolved || false;
-    const isDriverUrl = this.value.url === MS_TEAMS_URL || this.value.url === ALIBABA_CLOUD_SMS_URL;
+  computed: {
+    showNamespaceBanner() {
+      const isDriverUrl = this.value.url === MS_TEAMS_URL || this.value.url === ALIBABA_CLOUD_SMS_URL;
 
-    return { showNamespaceBanner: isDriverUrl && this.mode !== _VIEW };
-  }
+      return isDriverUrl && this.mode !== _VIEW;
+    }
+  },
+  created() {
+    this.value.http_config = this.value.http_config || {};
+    this.value.send_resolved = this.value.send_resolved || false;
+  },
 };
 </script>
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This refactors components under `monitoring.coreos.com` so that data initialization logic is no longer in the data prop.

Fixes #14865 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Refactor `monitoring.coreos.com` data props

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Most of the changes represented in this PR fall under two buckets:

1. Moving data props over to computed props
2. Moving data initialization into the created hook

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Install monitoring in a downstream cluster
- Navigate to Monitoring => Alerting
- Test adding, editing, deleting Alert Manager Configs/Routes and Receivers

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Moving initialization code from `data` to the `created` hook can alter the component logic. Common side-effects will be exposed as components failing to render, or rendering with incorrect default data.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
