### PR TITLE
[Backport] add gating mechanism to extensions logic so that prime-only extensions aren't loaded onto Ranche

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -124,6 +124,7 @@ generic:
   enable: Enable
   disable: Disable
   experimental: Experimental
+  primeOnly: Prime Only
 
   deprecated: Deprecated
   upgradeable: Upgradeable
@@ -5046,6 +5047,7 @@ inactivity:
 # Rancher Extensions
 plugins:
   altIcon: Icon for {extension} extension card
+  incompatiblePrimeOnly: "The latest version of this extension ({ version }) needs Rancher Prime in order to be installed."
   incompatibleRancherVersion: "The latest version of this extension ({ version }) is not compatible with the current Rancher version ({ required })."
   incompatibleKubeVersion: "The latest version of this extension ({ version }) is not compatible with the current Kube version ({ required })."
   incompatibleUiExtensionsApiVersionMissing: 'The latest version of this extension ({ version }) is missing the mandatory annotation catalog.cattle.io/ui-extensions-version from Rancher 2.10 and onwards.'
@@ -5055,6 +5057,7 @@ plugins:
   closePluginPanel: Close plugin description panel
   viewVersionDetails: View extension {name} version {version} details/Readme
   labels:
+    primeOnly: Prime Only
     builtin: Built-in
     experimental: Experimental
     third-party: Third-Party
@@ -5064,6 +5067,7 @@ plugins:
     menu: Extensions menu
     reloadRancher: Reload Rancher
   descriptions:
+    primeOnly: This Extension requires Rancher Prime
     experimental: This Extension is marked as experimental
     third-party: This Extension is provided by a Third-Party
     built-in: This Extension is built-in
@@ -5072,6 +5076,7 @@ plugins:
     title: Error loading extension
     message: Could not load extension code
     generic: Extension error
+    primeOnly: Unable to load Rancher Prime Extension in Rancher Community
     apiAnnotationMissing: 'Unable to load Extension. The version installed is not compatible with the current Extensions API Version (Extension is missing the annotation catalog.cattle.io/ui-extensions-version which implies incompatibility with Rancher 2.10 and onwards)'
     api: Unable to load Extension. The version installed is not compatible with the current Extensions API version
     host: Unable to load Extension. The version installed is not compatible with this application host
@@ -5094,6 +5099,7 @@ plugins:
     detail: Detail
     versions: Versions
     versionError: Could not load version information
+    requiresRancherPrime: "Requires Rancher Prime"
     requiresRancherVersion: "Requires Rancher {required}"
     requiresKubeVersion: "Requires Kube version {required}"
     requiresExtensionApiVersionMissing: 'Missing the annotation catalog.cattle.io/ui-extensions-version which implies incompatibility with Rancher 2.10 and onwards'

--- a/shell/config/__test__/uiplugins.test.ts
+++ b/shell/config/__test__/uiplugins.test.ts
@@ -1,0 +1,309 @@
+import {
+  UI_PLUGIN_ANNOTATION,
+  UI_PLUGIN_CHART_ANNOTATIONS,
+  EXTENSIONS_INCOMPATIBILITY_TYPES,
+  isUIPlugin,
+  uiPluginHasAnnotation,
+  parseRancherVersion,
+  // shouldNotLoadPlugin, this is required per test so that we can mock semver.coerce
+  isSupportedChartVersion,
+  isChartVersionHigher
+} from '@shell/config/uiplugins';
+
+import * as VersionModule from '@shell/config/version';
+
+let semver;
+let originalCoerce: any;
+const MOCK_API_VERSION = '33.33.33';
+
+describe('uiPlugins Config methods', () => {
+  describe('fx: isUIPlugin', () => {
+    const pluginChart = { versions: [{ annotations: { [UI_PLUGIN_ANNOTATION.NAME]: UI_PLUGIN_ANNOTATION.VALUE } }, { annotations: {} }] };
+
+    it('should return true if any version has the UI plugin annotation', () => {
+      expect(isUIPlugin(pluginChart)).toBe(true);
+    });
+    it('should return false if chart is null/undefined', () => {
+      expect(isUIPlugin(null)).toBe(false);
+    });
+  });
+
+  describe('fx: uiPluginHasAnnotation', () => {
+    const version1 = { annotations: { [UI_PLUGIN_ANNOTATION.NAME]: UI_PLUGIN_ANNOTATION.VALUE } };
+    const chart = { versions: [version1] };
+
+    it('should return true if it finds version with annotation and its corresponding value', () => {
+      expect(uiPluginHasAnnotation(chart, UI_PLUGIN_ANNOTATION.NAME, UI_PLUGIN_ANNOTATION.VALUE)).toBe(true);
+    });
+    it('should return false if chart has no version with a given pair of annotation/value', () => {
+      expect(uiPluginHasAnnotation(chart, 'bananas', UI_PLUGIN_ANNOTATION.VALUE)).toBe(false);
+    });
+  });
+
+  describe('fx: parseRancherVersion', () => {
+    it('should handle standard version strings', () => {
+      expect(parseRancherVersion('v2.8.1')).toBe('2.8.1');
+    });
+    it('should apply .999 patch for RC versions', () => {
+      expect(parseRancherVersion('v2.8.1-rc1')).toBe('2.8.999');
+    });
+    it('should apply .999 patch for "head" versions', () => {
+      expect(parseRancherVersion('2.8.0-head')).toBe('2.8.999');
+    });
+  });
+
+  const PLUGIN_NAME = 'test-plugin';
+
+  const basePluginResource = {
+    name:     PLUGIN_NAME,
+    version:  '1.0.0',
+    endpoint: '/some/path',
+    metadata: { [UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_VERSION]: '>=1.0.0' }
+  };
+  const compatibleEnv = {
+    rancherVersion: '2.7.5',
+    kubeVersion:    'v1.25.10',
+  };
+
+  describe('fx: shouldNotLoadPlugin', () => {
+    beforeEach(() => {
+      jest.resetModules();
+      process.env.UI_EXTENSIONS_API_VERSION = MOCK_API_VERSION;
+
+      semver = require('semver');
+      originalCoerce = semver.coerce;
+
+      jest.spyOn(semver, 'coerce').mockImplementation((v) => {
+        if (v === MOCK_API_VERSION) {
+          return { version: '3.0.0' };
+        }
+
+        // Use the original for all other inputs (Rancher, Kube)
+        return originalCoerce(v);
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return false when compatible', () => {
+      const { shouldNotLoadPlugin } = require('./../uiplugins');
+
+      expect(shouldNotLoadPlugin(basePluginResource, compatibleEnv, [])).toBe(false);
+    });
+
+    it('should return "plugins.error.api" if Extensions API version is incompatible', () => {
+      const { shouldNotLoadPlugin } = require('./../uiplugins');
+
+      const incompatibleApiPlugin = {
+        ...basePluginResource,
+        metadata: { [UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_VERSION]: '>=4.0.0' }
+      };
+
+      expect(shouldNotLoadPlugin(incompatibleApiPlugin, compatibleEnv, [])).toBe('plugins.error.api');
+    });
+
+    it('should return "plugins.error.primeOnly" if extension is Prime-only and Rancher is not Prime', () => {
+      const { shouldNotLoadPlugin } = require('./../uiplugins');
+
+      jest.spyOn(VersionModule, 'isRancherPrime').mockReturnValue(false);
+
+      const incompatibleApiPlugin = {
+        ...basePluginResource,
+        metadata: {
+          [UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_VERSION]: '>=1.0.0',
+          [UI_PLUGIN_CHART_ANNOTATIONS.PRIME_ONLY]:         'true'
+        }
+      };
+
+      expect(shouldNotLoadPlugin(incompatibleApiPlugin, compatibleEnv, [])).toBe('plugins.error.primeOnly');
+    });
+
+    it('should return "plugins.error.host" if HOST application value is incompatible', () => {
+      const { shouldNotLoadPlugin } = require('./../uiplugins');
+
+      const incompatibleApiPlugin = {
+        ...basePluginResource,
+        metadata: {
+          [UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_VERSION]: '>=1.0.0',
+          [UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_HOST]:    'rancher-dummy-host'
+        }
+      };
+
+      expect(shouldNotLoadPlugin(incompatibleApiPlugin, compatibleEnv, [])).toBe('plugins.error.host');
+    });
+
+    it('should return "plugins.error.kubeVersion" if incompatible', () => {
+      const { shouldNotLoadPlugin } = require('./../uiplugins');
+
+      const incompatibleApiPlugin = {
+        ...basePluginResource,
+        metadata: {
+          [UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_VERSION]: '>=1.0.0',
+          [UI_PLUGIN_CHART_ANNOTATIONS.KUBE_VERSION]:       '>= 2.0.0'
+        }
+      };
+
+      expect(shouldNotLoadPlugin(incompatibleApiPlugin, compatibleEnv, [])).toBe('plugins.error.kubeVersion');
+    });
+
+    it('should return "plugins.error.version" if incompatible', () => {
+      const { shouldNotLoadPlugin } = require('./../uiplugins');
+
+      const incompatibleApiPlugin = {
+        ...basePluginResource,
+        metadata: {
+          [UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_VERSION]: '>=1.0.0',
+          [UI_PLUGIN_CHART_ANNOTATIONS.RANCHER_VERSION]:    '>= 3.0.0'
+        }
+      };
+
+      expect(shouldNotLoadPlugin(incompatibleApiPlugin, compatibleEnv, [])).toBe('plugins.error.version');
+    });
+
+    it('should return "plugins.error.developerPkg" if a builtin extension with the same name was loaded first', () => {
+      const { shouldNotLoadPlugin } = require('./../uiplugins');
+
+      const incompatibleApiPlugin = {
+        ...basePluginResource,
+        metadata: { [UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_VERSION]: '>=1.0.0' }
+      };
+
+      expect(shouldNotLoadPlugin(incompatibleApiPlugin, compatibleEnv, [{ name: PLUGIN_NAME, builtin: true }])).toBe('plugins.error.developerPkg');
+    });
+  });
+
+  describe('fx: isSupportedChartVersion', () => {
+    beforeEach(() => {
+      jest.resetModules();
+      process.env.UI_EXTENSIONS_API_VERSION = MOCK_API_VERSION;
+
+      semver = require('semver');
+      originalCoerce = semver.coerce;
+
+      jest.spyOn(semver, 'coerce').mockImplementation((v) => {
+        if (v === MOCK_API_VERSION) {
+          return { version: '3.0.0' };
+        }
+
+        // Use the original for all other inputs (Rancher, Kube)
+        return originalCoerce(v);
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    const versionData = {
+      rancherVersion: 'v2.7.5',
+      kubeVersion:    'v1.25.10',
+      version:        '1.0.0'
+    };
+
+    it('should return "isVersionCompatible" true when compatible', () => {
+      const { isSupportedChartVersion } = require('./../uiplugins');
+
+      const annotations = {
+        [UI_PLUGIN_CHART_ANNOTATIONS.KUBE_VERSION]:       '>=1.0.0',
+        [UI_PLUGIN_CHART_ANNOTATIONS.RANCHER_VERSION]:    '>=2.0.0',
+        [UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_VERSION]: '>=2.0.0'
+      };
+      const data = { ...versionData, version: { annotations } };
+      const result = isSupportedChartVersion(data, true);
+
+      expect(result.isVersionCompatible).toBe(true);
+      expect(result.versionIncompatibilityData).toStrictEqual({});
+    });
+
+    it('should return incompatibility object for kube version mismatch', () => {
+      const annotations = { [UI_PLUGIN_CHART_ANNOTATIONS.KUBE_VERSION]: '>=2.0.0' };
+      const data = { ...versionData, version: { annotations } };
+      const result = isSupportedChartVersion(data, true);
+
+      expect(result.isVersionCompatible).toBe(false);
+      expect(result.versionIncompatibilityData.type).toBe(EXTENSIONS_INCOMPATIBILITY_TYPES.KUBE);
+      expect(result.versionIncompatibilityData.required).toBe('>=2.0.0');
+    });
+
+    it('should return incompatibility object for Rancher version mismatch', () => {
+      const annotations = { [UI_PLUGIN_CHART_ANNOTATIONS.RANCHER_VERSION]: '>=3.0.0' };
+      const data = { ...versionData, version: { annotations } };
+      const result = isSupportedChartVersion(data, true);
+
+      expect(result.isVersionCompatible).toBe(false);
+      expect(result.versionIncompatibilityData.type).toBe(EXTENSIONS_INCOMPATIBILITY_TYPES.UI);
+      expect(result.versionIncompatibilityData.required).toBe('>=3.0.0');
+    });
+
+    it('should return incompatibility object for UI version mismatch', () => {
+      const annotations = { [UI_PLUGIN_CHART_ANNOTATIONS.UI_VERSION]: '>=3.0.0' };
+      const data = { ...versionData, version: { annotations } };
+      const result = isSupportedChartVersion(data, true);
+
+      expect(result.isVersionCompatible).toBe(false);
+      expect(result.versionIncompatibilityData.type).toBe(EXTENSIONS_INCOMPATIBILITY_TYPES.UI);
+      expect(result.versionIncompatibilityData.required).toBe('>=3.0.0');
+    });
+
+    it('should return incompatibility object for extensions api missing', () => {
+      const annotations = {};
+      const data = { ...versionData, version: { annotations } };
+      const result = isSupportedChartVersion(data, true);
+
+      expect(result.isVersionCompatible).toBe(false);
+      expect(result.versionIncompatibilityData.type).toBe(EXTENSIONS_INCOMPATIBILITY_TYPES.EXTENSIONS_API_MISSING);
+      expect(result.versionIncompatibilityData.required).toBeUndefined();
+    });
+
+    it('should return incompatibility object for extensions API version mismatch', () => {
+      const { isSupportedChartVersion } = require('./../uiplugins');
+
+      const annotations = { [UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_VERSION]: '>=4.0.0' };
+      const data = { ...versionData, version: { annotations } };
+      const result = isSupportedChartVersion(data, true);
+
+      expect(result.isVersionCompatible).toBe(false);
+      expect(result.versionIncompatibilityData.type).toBe(EXTENSIONS_INCOMPATIBILITY_TYPES.EXTENSIONS_API);
+      expect(result.versionIncompatibilityData.required).toBe('>=4.0.0');
+    });
+
+    it('should return incompatibility object for HOST_APP mismatch', () => {
+      const { isSupportedChartVersion } = require('./../uiplugins');
+
+      const annotations = { [UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_VERSION]: '>=1.0.0 < 5.0.0', [UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_HOST]: 'rancher-dummy-host' };
+      const data = { ...versionData, version: { annotations } };
+      const result = isSupportedChartVersion(data, true);
+
+      expect(result.isVersionCompatible).toBe(false);
+      expect(result.versionIncompatibilityData.type).toBe(EXTENSIONS_INCOMPATIBILITY_TYPES.HOST);
+      expect(result.versionIncompatibilityData.required).toBe('rancher-dummy-host');
+    });
+
+    it('should return incompatibility object for Prime only extension running in non-prime env', () => {
+      const { isSupportedChartVersion } = require('./../uiplugins');
+
+      jest.spyOn(VersionModule, 'isRancherPrime').mockReturnValue(false);
+
+      const annotations = { [UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_VERSION]: '>=1.0.0 < 5.0.0', [UI_PLUGIN_CHART_ANNOTATIONS.PRIME_ONLY]: 'true' };
+      const data = { ...versionData, version: { annotations } };
+      const result = isSupportedChartVersion(data, true);
+
+      expect(result.isVersionCompatible).toBe(false);
+      expect(result.versionIncompatibilityData.type).toBe(EXTENSIONS_INCOMPATIBILITY_TYPES.PRIME_ONLY);
+      expect(result.versionIncompatibilityData.required).toBe(true);
+    });
+  });
+
+  describe('fx: isChartVersionHigher', () => {
+    // Tests now rely on the actual semver.gt implementation
+    it('should return true when version A is higher', () => {
+      expect(isChartVersionHigher('2.1.0', '2.0.0')).toBe(true);
+    });
+    it('should return false when version A is lower or equal', () => {
+      expect(isChartVersionHigher('2.0.0', '2.1.0')).toBe(false);
+      expect(isChartVersionHigher('2.0.0', '2.0.0')).toBe(false);
+    });
+  });
+});

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -78,6 +78,7 @@ export const CATALOG = {
   _PARTNER:  'partner',
   _OTHER:    'other',
 
+  PRIME_ONLY:   'catalog.cattle.io/prime-only',
   EXPERIMENTAL: 'catalog.cattle.io/experimental',
   NAMESPACE:    'catalog.cattle.io/namespace',
   RELEASE_NAME: 'catalog.cattle.io/release-name',

--- a/shell/config/uiplugins.js
+++ b/shell/config/uiplugins.js
@@ -1,4 +1,5 @@
 import semver from 'semver';
+import { isRancherPrime } from '@shell/config/version';
 
 // Version of the plugin API supported
 // here we inject the current shell version that we read in vue.config
@@ -43,6 +44,7 @@ export const UI_PLUGIN_CHART_ANNOTATIONS = {
   EXTENSIONS_HOST:    'catalog.cattle.io/ui-extensions-host',
   DISPLAY_NAME:       'catalog.cattle.io/display-name',
   HIDDEN_BUILTIN:     'catalog.cattle.io/ui-hidden-builtin',
+  PRIME_ONLY:         'catalog.cattle.io/prime-only'
 };
 
 // Extension catalog labels
@@ -58,6 +60,7 @@ export const EXTENSIONS_INCOMPATIBILITY_TYPES = {
   EXTENSIONS_API:         'extensionsApiVersion',
   KUBE:                   'kubeVersion',
   HOST:                   'host',
+  PRIME_ONLY:             'primeOnly',
 };
 
 export const EXTENSIONS_INCOMPATIBILITY_DATA = {
@@ -87,6 +90,11 @@ export const EXTENSIONS_INCOMPATIBILITY_DATA = {
     tooltipKey:     'plugins.info.requiresHost',
     mainHost:       UI_PLUGIN_HOST_APP,
   },
+  PRIME_ONLY: {
+    type:           EXTENSIONS_INCOMPATIBILITY_TYPES.PRIME_ONLY,
+    cardMessageKey: 'plugins.incompatiblePrimeOnly',
+    tooltipKey:     'plugins.info.requiresRancherPrime',
+  },
 };
 
 export function isUIPlugin(chart) {
@@ -107,7 +115,7 @@ export function uiPluginAnnotation(chart, name) {
 /**
  * Parse the Rancher version string
  */
-function parseRancherVersion(v) {
+export function parseRancherVersion(v) {
   let parsedVersion = semver.coerce(v)?.version;
   const splitArr = parsedVersion?.split('.');
 
@@ -124,10 +132,29 @@ function parseRancherVersion(v) {
  * Check if a version is incompatible with the current environment
  */
 function checkIncompatibility(currentVersion, requiredVersion, incompatibilityData, returnObj, versionObj) {
-  if ((incompatibilityData.type === EXTENSIONS_INCOMPATIBILITY_TYPES.EXTENSIONS_API_MISSING && !requiredVersion) || (requiredVersion && !semver.satisfies(currentVersion, requiredVersion))) {
+  let passed = true;
+
+  switch (incompatibilityData.type) {
+  case EXTENSIONS_INCOMPATIBILITY_TYPES.PRIME_ONLY:
+    if (requiredVersion && !currentVersion) {
+      passed = false;
+    }
+    break;
+  case EXTENSIONS_INCOMPATIBILITY_TYPES.EXTENSIONS_API_MISSING:
+    !requiredVersion ? passed = false : passed = true;
+    break;
+  default:
+    if (requiredVersion && !semver.satisfies(currentVersion, requiredVersion)) {
+      passed = false;
+    }
+    break;
+  }
+
+  if (!passed) {
     if (!returnObj) {
       return false;
     }
+
     versionObj.isVersionCompatible = false;
     versionObj.versionIncompatibilityData = { ...incompatibilityData, required: requiredVersion };
 
@@ -137,7 +164,7 @@ function checkIncompatibility(currentVersion, requiredVersion, incompatibilityDa
   return true;
 }
 
-// i18n-uses plugins.error.generic, plugins.error.api, plugins.error.host, plugins.error.kubeVersion, plugins.error.version, plugins.error.developerPkg, plugins.error.apiAnnotationMissing
+// i18n-uses plugins.error.generic, plugins.error.api, plugins.error.host, plugins.error.kubeVersion, plugins.error.version, plugins.error.developerPkg, plugins.error.apiAnnotationMissing, plugins.error.primeOnly
 
 /**
  * Whether an extension should be loaded based on the metadata returned by the backend in the UIPlugins resource instance
@@ -148,6 +175,8 @@ function checkIncompatibility(currentVersion, requiredVersion, incompatibilityDa
  * @returns String | Boolean
  */
 export function shouldNotLoadPlugin(UIPluginResource, { rancherVersion, kubeVersion }, loadedPlugins) {
+  const isCurrRancherPrime = isRancherPrime();
+
   const {
     name, version, endpoint, compressedEndpoint
   } = UIPluginResource;
@@ -169,6 +198,13 @@ export function shouldNotLoadPlugin(UIPluginResource, { rancherVersion, kubeVers
     return 'plugins.error.apiAnnotationMissing';
   } else if (requiredUiExtensionsVersion && !semver.satisfies(parsedUiExtensionsApiVersion, requiredUiExtensionsVersion)) {
     return 'plugins.error.api';
+  }
+
+  // Prime only
+  const primeOnlyAnnotation = UIPluginResource.metadata?.[UI_PLUGIN_CHART_ANNOTATIONS.PRIME_ONLY] === 'true';
+
+  if (!isCurrRancherPrime && primeOnlyAnnotation) {
+    return 'plugins.error.primeOnly';
   }
 
   // Host application
@@ -220,10 +256,13 @@ export function shouldNotLoadPlugin(UIPluginResource, { rancherVersion, kubeVers
  * @returns Boolean | Object
  */
 export function isSupportedChartVersion(versionData, returnObj = false) {
+  const isCurrRancherPrime = isRancherPrime();
+
   const { version, rancherVersion, kubeVersion } = versionData;
   const versionObj = {
     ...version, isVersionCompatible: true, versionIncompatibilityData: {}
   };
+
   const parsedRancherVersion = rancherVersion ? parseRancherVersion(rancherVersion) : '';
   const parsedUiExtensionsApiVersion = semver.coerce(UI_EXTENSIONS_API_VERSION)?.version;
 
@@ -258,6 +297,11 @@ export function isSupportedChartVersion(versionData, returnObj = false) {
       requiredVersion:     version.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.EXTENSIONS_HOST],
       incompatibilityData: EXTENSIONS_INCOMPATIBILITY_DATA.HOST,
     },
+    {
+      currentVersion:      isCurrRancherPrime,
+      requiredVersion:     version.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.PRIME_ONLY] === 'true',
+      incompatibilityData: EXTENSIONS_INCOMPATIBILITY_DATA.PRIME_ONLY,
+    }
   ];
 
   for (const { currentVersion, requiredVersion, incompatibilityData } of checks) {

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -268,12 +268,14 @@ export default {
         const latestNotCompatible = item.versions.find((version) => !version.isVersionCompatible);
 
         if (latestCompatible) {
+          item.primeOnly = latestCompatible?.annotations?.[CATALOG_ANNOTATIONS.PRIME_ONLY] === 'true';
           item.experimental = latestCompatible?.annotations?.[CATALOG_ANNOTATIONS.EXPERIMENTAL] === 'true';
           item.certified = latestCompatible?.annotations?.[CATALOG_ANNOTATIONS.CERTIFIED] === CATALOG_ANNOTATIONS._RANCHER;
 
           item.displayVersion = latestCompatible.version;
           item.icon = latestCompatible.icon;
         } else {
+          item.primeOnly = uiPluginHasAnnotation(chart, CATALOG_ANNOTATIONS.PRIME_ONLY, 'true');
           item.experimental = uiPluginHasAnnotation(chart, CATALOG_ANNOTATIONS.EXPERIMENTAL, 'true');
           item.certified = uiPluginHasAnnotation(chart, CATALOG_ANNOTATIONS.CERTIFIED, CATALOG_ANNOTATIONS._RANCHER);
 
@@ -327,6 +329,7 @@ export default {
             displayVersion: p.metadata?.version || '-',
             installed:      true,
             builtin:        !!p.builtin,
+            primeOnly:      rancher?.annotations?.[CATALOG_ANNOTATIONS.PRIME_ONLY] === 'true',
             experimental:   rancher?.annotations?.[CATALOG_ANNOTATIONS.EXPERIMENTAL] === 'true',
             certified:      rancher?.annotations?.[CATALOG_ANNOTATIONS.CERTIFIED] === CATALOG_ANNOTATIONS._RANCHER
           };
@@ -357,6 +360,7 @@ export default {
             const installedVersion = (chart.installableVersions || []).find((v) => v?.version === p.version);
 
             if (installedVersion) {
+              chart.primeOnly = installedVersion?.annotations?.[CATALOG_ANNOTATIONS.PRIME_ONLY] === 'true';
               chart.experimental = installedVersion?.annotations?.[CATALOG_ANNOTATIONS.EXPERIMENTAL] === 'true';
               chart.certified = installedVersion?.annotations?.[CATALOG_ANNOTATIONS.CERTIFIED] === CATALOG_ANNOTATIONS._RANCHER;
             }
@@ -979,6 +983,12 @@ export default {
                     v-clean-tooltip="t('plugins.descriptions.experimental')"
                   >
                     {{ t('plugins.labels.experimental') }}
+                  </div>
+                  <div
+                    v-if="plugin.primeOnly"
+                    v-clean-tooltip="t('plugins.descriptions.primeOnly')"
+                  >
+                    {{ t('plugins.labels.primeOnly') }}
                   </div>
                 </div>
                 <div class="plugin-spacer" />

--- a/shell/store/catalog.js
+++ b/shell/store/catalog.js
@@ -504,11 +504,15 @@ function addChart(ctx, map, chart, repo) {
 
   if ( !obj ) {
     if ( ctx ) { }
+    const primeOnly = chart.annotations?.[CATALOG_ANNOTATIONS.PRIME_ONLY] === 'true';
     const experimental = !!chart.annotations?.[CATALOG_ANNOTATIONS.EXPERIMENTAL];
     const windowsIncompatible = !(chart.annotations?.[CATALOG_ANNOTATIONS.PERMITTED_OS] || '').includes('windows');
     const deploysOnWindows = (chart.annotations?.[CATALOG_ANNOTATIONS.DEPLOYED_OS] || '').includes('windows');
     const tags = [];
 
+    if (primeOnly) {
+      tags.push(ctx.rootGetters['i18n/withFallback']('generic.primeOnly'));
+    }
     if (experimental) {
       tags.push(ctx.rootGetters['i18n/withFallback']('generic.experimental'));
     }
@@ -541,6 +545,7 @@ function addChart(ctx, map, chart, repo) {
       versions:         [],
       categories:       filterCategories(chart.keywords),
       deprecated:       !!chart.deprecated,
+      primeOnly,
       experimental,
       hidden:           !!chart.annotations?.[CATALOG_ANNOTATIONS.HIDDEN],
       targetNamespace:  chart.annotations?.[CATALOG_ANNOTATIONS.NAMESPACE],


### PR DESCRIPTION
**Backport of PR https://github.com/rancher/dashboard/pull/15934**

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15937  
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- add gating mechanism to extensions logic so that prime-only extensions aren't loaded onto Rancher 
- add Prime-only tag to extension cards 
- add unit tests

**NOTE: Bear in mind that branch 2.12 still uses the old cards so they are a bit different**

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
extension is considered "prime only" if it has the annotation `'catalog.cattle.io/prime-only': 'true'` as per https://github.com/rancher/ui-plugin-examples/blob/main/pkg/homepageprime/package.json#L8


### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- add the `ui-plugin-examples` repository -> `https://github.com/rancher/ui-plugin-examples` branch `main`

**run Rancher in prime mode `API=https://..... PRIME=true yarn dev`**
- check the extension card for `homepageprime` extension
- extension should be installable, install fine and run fine

with the extension installed, **run Rancher non-prime mode `API=https://..... yarn dev`**
- extension should appear on installed tabs, but it should not load. check card for `!` icon + click on card and check version on slideIn Panel
- uninstall extension
- refresh page and go extensions screen again
- extension should not be installed nor installable. check card for `!` icon + click on card and check version 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="2161" height="1324" alt="Screenshot 2025-11-21 at 10 14 41" src="https://github.com/user-attachments/assets/4de2eb73-419c-4d93-ae83-509dd550b615" />
<img width="2161" height="1324" alt="Screenshot 2025-11-21 at 10 13 57" src="https://github.com/user-attachments/assets/bb361c9c-18d8-4d11-bff2-9449e40bf610" />
<img width="2161" height="1324" alt="Screenshot 2025-11-21 at 10 12 47" src="https://github.com/user-attachments/assets/b2f30fb3-65ea-436c-99b8-7a50839d77f3" />
<img width="2161" height="1324" alt="Screenshot 2025-11-21 at 10 12 44" src="https://github.com/user-attachments/assets/40ff0fda-47a9-45ee-895b-bbac915c3088" />
<img width="2161" height="1324" alt="Screenshot 2025-11-21 at 10 12 42" src="https://github.com/user-attachments/assets/fa6584b9-565e-4422-bca3-f34f6f77dd52" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
