### PR TITLE
Add support for custom node roles

### DIFF
--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -37,6 +37,8 @@ export const STORAGE = {
 
 export const MANAGEMENT_NODE = { NODE_NAME: 'management.cattle.io/nodename' };
 
+export const NODE_ROLES_LABEL = 'node-role.kubernetes.io/';
+
 export const NODE_ROLES = {
   CONTROL_PLANE_OLD: 'node-role.kubernetes.io/controlplane',
   CONTROL_PLANE:     'node-role.kubernetes.io/control-plane',

--- a/shell/models/cluster/node.js
+++ b/shell/models/cluster/node.js
@@ -505,7 +505,6 @@ export function listNodeRoles(isControlPlane, isWorker, isEtcd, customRoles = []
     }
   }
 
-  // Add custom roles with capitalized first letter
   customRoles.forEach((role) => {
     res.push(role.charAt(0).toUpperCase() + role.slice(1));
   });

--- a/shell/models/cluster/node.js
+++ b/shell/models/cluster/node.js
@@ -1,5 +1,5 @@
 import { formatPercent } from '@shell/utils/string';
-import { CAPI as CAPI_ANNOTATIONS, NODE_ROLES, RKE, SYSTEM_LABELS } from '@shell/config/labels-annotations.js';
+import { CAPI as CAPI_ANNOTATIONS, NODE_ROLES, NODE_ROLES_LABEL, RKE, SYSTEM_LABELS } from '@shell/config/labels-annotations.js';
 import {
   CAPI, MANAGEMENT, METRIC, NORMAN, POD
 } from '@shell/config/types';
@@ -171,10 +171,23 @@ export default class ClusterNode extends SteveModel {
       });
   }
 
-  get roles() {
-    const { isControlPlane, isWorker, isEtcd } = this;
+  get customRoles() {
+    const standardRoles = Object.values(NODE_ROLES);
+    const customRoles = [];
 
-    return listNodeRoles(isControlPlane, isWorker, isEtcd, this.t('generic.all'));
+    for (const labelKey in this.labels) {
+      if (labelKey.startsWith(NODE_ROLES_LABEL) && !standardRoles.includes(labelKey)) {
+        customRoles.push(labelKey.replace(NODE_ROLES_LABEL, ''));
+      }
+    }
+
+    return customRoles;
+  }
+
+  get roles() {
+    const { isControlPlane, isWorker, isEtcd, customRoles } = this;
+
+    return listNodeRoles(isControlPlane, isWorker, isEtcd, customRoles, this.t('generic.all'));
   }
 
   get version() {
@@ -472,22 +485,32 @@ function calculatePercentage(allocatable, capacity) {
   return formatPercent(percent);
 }
 
-export function listNodeRoles(isControlPlane, isWorker, isEtcd, allString) {
+export function listNodeRoles(isControlPlane, isWorker, isEtcd, customRoles = [], allString) {
   const res = [];
+  const hasAllStandardRoles = isControlPlane && isWorker && isEtcd;
 
-  if (isControlPlane) {
-    res.push('Control Plane');
+  if (hasAllStandardRoles) {
+    res.push(allString);
+  } else {
+    if (isControlPlane) {
+      res.push('Control Plane');
+    }
+
+    if (isWorker) {
+      res.push('Worker');
+    }
+
+    if (isEtcd) {
+      res.push('Etcd');
+    }
   }
 
-  if (isWorker) {
-    res.push('Worker');
-  }
+  // Add custom roles with capitalized first letter
+  customRoles.forEach((role) => {
+    res.push(role.charAt(0).toUpperCase() + role.slice(1));
+  });
 
-  if (isEtcd) {
-    res.push('Etcd');
-  }
-
-  if (res.length === 3 || res.length === 0) {
+  if (res.length === 0) {
     return allString;
   }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/15837
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

Update ClusterNode class to display every roles defined in labels `node-role.kubernetes.io` on nodes. Here is a summary of what  is displayed based on labels:
| Labels                                             | Display|
  |-------------------------------------|-------------------------------------|
  | control-plane, worker, etcd, gpu  | All, Gpu                         |
  | control-plane, worker, etcd          | All                                 |
  | worker, gpu                         | Worker, Gpu                         |
  | control-plane, worker, gpu, ingress | Control Plane, Worker, Gpu, Ingress |

I think it would be simpler to drop the `All` case but I kept it.

I did not check for `${ this.labels[labelKey] } === 'true'` because kubernetes supports label with empty value and kubectl still displays the role.  
Run `kubectl label node my-node node-role.kubernetes.io/test=`, `kubectl get nodes` should display `test` in the list.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I can add tests in https://github.com/rancher/dashboard/blob/master/shell/models/__tests__/node.test.ts if needed

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1912" height="903" alt="image" src="https://github.com/user-attachments/assets/11da556c-7d8d-47e9-bd34-dcdeb67eea63" />

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
