### PR TITLE
Automation: Add k8s upgrade e2e test

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -2,6 +2,7 @@ import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import ClusterManagerCreateRke2AmazonPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-amazon.po';
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterManagerDetailRke2AmazonEc2PagePo from '@/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-rke2-amazon.po';
+import ClusterManagerEditGenericPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-generic.po';
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import LoadingPo from '@/cypress/e2e/po/components/loading.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
@@ -16,6 +17,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
   let removeCloudCred = false;
   let cloudcredentialId = '';
   let k8sVersion = '';
+  let olderK8sVersion = '';
   let clusterId = '';
 
   before(() => {
@@ -83,16 +85,24 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
     createRKE2ClusterPage.nameNsDescription().name().set(this.rke2Ec2ClusterName);
     createRKE2ClusterPage.nameNsDescription().description().set(`${ this.rke2Ec2ClusterName }-description`);
 
-    // Get latest kubernetes version
+    // Get kubernetes versions - use an older version for initial creation, then upgrade later
     cy.wait('@getRke2Releases').then(({ response }) => {
       expect(response.statusCode).to.eq(200);
-      const length = response.body.data.length - 1;
+      const index1 = response.body.data.length - 1;
 
-      k8sVersion = response.body.data[length].id;
+      // Store the latest version for upgrade test
+      k8sVersion = response.body.data[index1].id;
       cy.wrap(k8sVersion).as('k8sVersion');
+
+      // Use the older version for cluster creation
+      // This allows us to test the upgrade scenario
+      const index2 = index1 - 1;
+
+      olderK8sVersion = response.body.data[index2].id;
+      cy.wrap(olderK8sVersion).as('olderK8sVersion');
     });
 
-    cy.get<string>('@k8sVersion').then((version) => {
+    cy.get<string>('@olderK8sVersion').then((version) => {
       createRKE2ClusterPage.basicsTab().kubernetesVersions().toggle();
       createRKE2ClusterPage.basicsTab().kubernetesVersions().clickOptionWithLabel(version);
 
@@ -132,7 +142,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
 
     // check k8s version
     clusterList.list().version(this.rke2Ec2ClusterName).then((el) => {
-      expect(el.text().trim()).contains(k8sVersion);
+      expect(el.text().trim()).contains(olderK8sVersion);
     });
 
     // check provider
@@ -164,6 +174,68 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
     clusterDetails.selectTab(tabbedPo, '[data-testid="btn-events"]');
     clusterDetails.waitForPage(null, 'events');
     clusterDetails.recentEventsList().checkTableIsEmpty();
+  });
+
+  it('can upgrade Kubernetes version', function() {
+    ClusterManagerListPagePo.navTo();
+    clusterList.waitForPage();
+
+    // Navigate to edit page
+    clusterList.list().actionMenu(this.rke2Ec2ClusterName).getMenuItem('Edit Config').click();
+
+    const editClusterPage = new ClusterManagerEditGenericPagePo('_', this.rke2Ec2ClusterName);
+
+    editClusterPage.waitForPage('mode=edit', 'basic');
+
+    // Verify we're starting with the older version
+    editClusterPage.basicsTab().kubernetesVersions().checkContainsOptionSelected(olderK8sVersion);
+
+    // Select the latest version for upgrade
+    editClusterPage.basicsTab().kubernetesVersions().toggle();
+    editClusterPage.basicsTab().kubernetesVersions().clickOptionWithLabel(k8sVersion);
+
+    cy.intercept('PUT', `/v1/provisioning.cattle.io.clusters/fleet-default/${ this.rke2Ec2ClusterName }`).as('clusterUpdate');
+    // Save the cluster to upgrade the Kubernetes version
+    editClusterPage.save().click();
+
+    // Wait for the cluster update to complete
+    cy.wait('@clusterUpdate').then((interception) => {
+      // If 409 conflict, wait for retry
+      if (interception.response?.statusCode === 409) {
+        cy.log('Cluster update failed with 409 error, waiting for retry...');
+
+        return cy.wait('@clusterUpdate', MEDIUM_TIMEOUT_OPT);
+      }
+
+      return cy.wrap(interception);
+    }).then(({ response }: any) => {
+      expect(response?.statusCode).to.equal(200);
+      expect(response?.body).to.have.property('kind', 'Cluster');
+      expect(response?.body.metadata).to.have.property('name', this.rke2Ec2ClusterName);
+      expect(response?.body.spec).to.have.property('kubernetesVersion').contains(k8sVersion);
+    });
+
+    clusterList.waitForPage();
+    clusterList.list().state(this.rke2Ec2ClusterName).should('contain.text', 'Updating');
+    clusterList.list().state(this.rke2Ec2ClusterName).contains('Active', { timeout: 700000 });
+
+    // check k8s version
+    clusterList.list().version(this.rke2Ec2ClusterName).then((el) => {
+      expect(el.text().trim()).contains(k8sVersion);
+    });
+
+    // Navigate back to edit page to verify older version is disabled in dropdown
+    clusterList.list().actionMenu(this.rke2Ec2ClusterName).getMenuItem('Edit Config').click();
+    editClusterPage.waitForPage('mode=edit', 'basic');
+
+    // Verify current version is selected
+    editClusterPage.basicsTab().kubernetesVersions().checkContainsOptionSelected(k8sVersion);
+
+    // Open dropdown and verify older version is disabled
+    editClusterPage.basicsTab().kubernetesVersions().toggle();
+    editClusterPage.basicsTab().kubernetesVersions().getOptions()
+      .contains('li', olderK8sVersion)
+      .should('have.class', 'vs__dropdown-option--disabled');
   });
 
   it('can create snapshot', function() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1978

Adds an e2e test to verify Kubernetes version upgrades for RKE2 clusters on Amazon EC2. The test creates a cluster with an older Kubernetes version and upgrades it to the latest version.

<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="656" height="306" alt="Screenshot 2025-11-24 at 8 22 36 PM" src="https://github.com/user-attachments/assets/21a62db0-028d-4ef7-a1d4-c999777d1165" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
