### PR TITLE
loadCluster without navigating

### DIFF
--- a/shell/components/SideNav.vue
+++ b/shell/components/SideNav.vue
@@ -20,6 +20,8 @@ import { TYPE_MODES } from '@shell/store/type-map';
 import { NAME as NAVLINKS } from '@shell/config/product/navlinks';
 import Group from '@shell/components/nav/Group';
 import LocaleSelector from '@shell/components/LocaleSelector';
+import { getClusterFromRoute } from 'utils/router';
+import { BLANK_CLUSTER } from 'store/store-types';
 
 export default {
   name:       'SideNav',
@@ -91,7 +93,13 @@ export default {
     },
 
     clusterReady(a, b) {
-      if ( !isEqual(a, b) ) {
+      const currentInStore = this.currentProduct?.inStore;
+      const rootInStore = this.rootProduct?.inStore;
+
+      const isClusterBasedProduct = currentInStore === 'cluster' || rootInStore === 'cluster';
+      const clusterInRoute = getClusterFromRoute(this.$route) && getClusterFromRoute(this.$route) !== BLANK_CLUSTER;
+
+      if ( (isClusterBasedProduct || clusterInRoute) && !isEqual(a, b) ) {
         // Immediately update because you'll see it come in later
         this.getGroups();
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
Test using https://github.com/rancher/virtual-clusters-ui/pull/83/

### Areas which could experience regressions
- navigating between two products that use cluster store
- navigating between a product that uses the cluster store and one that does not
- navigating in/out of a product with a custom cluster store (epinio?)
- navigating in/out of harvester ui

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
