### PR TITLE
Update formatSubnetworkOptions to prioritize selfLink over network

### DIFF
--- a/pkg/gke/components/__tests__/Networking.test.ts
+++ b/pkg/gke/components/__tests__/Networking.test.ts
@@ -135,7 +135,7 @@ describe('gke Networking', () => {
 
     wrapper.setProps({ network: 'host-shared-vpc' });
     await wrapper.vm.$nextTick();
-    expect(wrapper.emitted('update:subnetwork')?.[0]?.[0]).toBe('projects/host-project-309915/regions/us-west1/subnetworks/host-shared-vpc-us-west1-subnet-public');
+    expect(wrapper.emitted('update:subnetwork')?.[0]?.[0]).toBe('projects/host-project-309915/global/networks/host-shared-vpc');
   });
 
   it('should show text input for cluster and service secondary range if no subnetwork is selected, otherwise should show a dropdown', async() => {

--- a/shell/components/google/util/__tests__/formatter.test.ts
+++ b/shell/components/google/util/__tests__/formatter.test.ts
@@ -7,13 +7,14 @@ describe('formatter', () => {
     it('should format subnetwork options correctly', () => {
       const gkeSubnetworks = [
         {
-          name:        'subnet-1',
+          name:        'subnet-1-name',
           network:     'my-network',
           subnetwork:  'projects/project-1/regions/region-1/subnetworks/subnet-1',
           ipCidrRange: '10.0.0.0/24',
           selfLink:    'https://www.googleapis.com/compute/v1/projects/project-1/regions/region-1/subnetworks/subnet-1'
         },
         {
+          // has no name
           network:     'my-network',
           subnetwork:  'projects/project-1/regions/region-1/subnetworks/subnet-2',
           ipCidrRange: '10.0.1.0/24',
@@ -26,8 +27,8 @@ describe('formatter', () => {
       expect(formattedOptions).toHaveLength(2);
 
       expect(formattedOptions[0]).toStrictEqual({
-        name:        'projects/project-1/regions/region-1/subnetworks/subnet-1',
-        label:       'subnet-1 (10.0.0.0/24)',
+        name:        'https://www.googleapis.com/compute/v1/projects/project-1/regions/region-1/subnetworks/subnet-1',
+        label:       'subnet-1-name (10.0.0.0/24)',
         network:     'my-network',
         subnetwork:  'projects/project-1/regions/region-1/subnetworks/subnet-1',
         ipCidrRange: '10.0.0.0/24',
@@ -35,8 +36,8 @@ describe('formatter', () => {
       });
 
       expect(formattedOptions[1]).toStrictEqual({
-        name:        'projects/project-1/regions/region-1/subnetworks/subnet-2',
-        label:       'subnet-2 (10.0.1.0/24)',
+        name:        'https://www.googleapis.com/compute/v1/projects/project-1/regions/region-1/subnetworks/subnet-2',
+        label:       'my-network (10.0.1.0/24)',
         network:     'my-network',
         subnetwork:  'projects/project-1/regions/region-1/subnetworks/subnet-2',
         ipCidrRange: '10.0.1.0/24',

--- a/shell/components/google/util/formatter.ts
+++ b/shell/components/google/util/formatter.ts
@@ -67,8 +67,8 @@ export function formatSubnetworkOptions(t: Translation, network: string, subnetw
   }
 
   const labeled: GKESubnetworkOption[] = out.map((sn: GKESubnetwork) => {
-    const shortName = sn.name ? sn.name : (sn.subnetwork || '').split('/').pop();
-    const fullName = sn.subnetwork || sn.selfLink || shortName;
+    const shortName = sn.name ? sn.name : (sn.network || '').split('/').pop();
+    const fullName = sn.selfLink || sn.network || shortName;
 
     return {
       ...sn,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16052 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
