### PR TITLE
Updates to `valid milestone change` workflow

### DIFF
--- a/.github/workflows/valid-milestone-change.yml
+++ b/.github/workflows/valid-milestone-change.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: read
+  organization: read
  
 jobs:
   notify-on-milestone-change:
@@ -38,11 +39,13 @@ jobs:
     - name: Check Team Membership
       id: check_team
       continue-on-error: true
+      if: |
+        github.event.sender.login != 'rancher-ui-project-bot' &&
+        github.event.sender.login != 'rancher-backport-assistant'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        gh api --silent \
-          /orgs/rancher/teams/ui/memberships/${{ github.event.sender.login }}
+        gh api --silent /orgs/rancher/teams/ui/memberships/${{ env.ACTOR }}
     - name: "Send Slack message if user is not a team member"
       if: steps.check_team.outcome == 'failure'
       uses: slackapi/slack-github-action@v2.1.1


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Follow on from https://github.com/rancher/dashboard/pull/15328


Currently all requests to fetch team membership 404 - https://github.com/rancher/dashboard/actions/runs/19737497640/job/56552851317#step:3:14

### Occurred changes and/or fixed issues
- Fixes
  - grant access to orgs so workflow can fetch team
- Improvements
  - don't warn if it's one of our bots that changed the milestone
    - could be blanket done with `if: github.event.sender.type != 'Bot'`
  - slight env optimisation

### Technical notes summary
- The slack hook still only DMs me directly

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
