### PR TITLE
Ensure we fetch more than the default 1000 norman users

### DIFF
--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -180,7 +180,8 @@ export function init(store) {
   mapGroup(/^(.*\.)?(scc)\.cattle\.io$/, 'SCC');
 
   const dePaginateBindings = configureConditionalDepaginate({ maxResourceCount: 5000 });
-  const dePaginateNormanBindings = configureConditionalDepaginate({ maxResourceCount: 5000, isNorman: true }) ;
+  const dePaginateNormanBindings = configureConditionalDepaginate({ maxResourceCount: 5000, isNorman: true });
+  const dePaginateNormanUsers = configureConditionalDepaginate({ maxResourceCount: 5000, isNorman: true });
 
   configureType(NODE, { isCreatable: false, isEditable: true });
   configureType(WORKLOAD_TYPES.JOB, { isEditable: false, match: WORKLOAD_TYPES.JOB });
@@ -189,6 +190,7 @@ export function init(store) {
   configureType(MANAGEMENT.PROJECT, { displayName: store.getters['i18n/t']('namespace.project.label') });
   configureType(NORMAN.CLUSTER_ROLE_TEMPLATE_BINDING, { depaginate: dePaginateNormanBindings });
   configureType(NORMAN.PROJECT_ROLE_TEMPLATE_BINDING, { depaginate: dePaginateNormanBindings });
+  configureType(NORMAN.USER, { depaginate: dePaginateNormanUsers });
   configureType(SNAPSHOT, { depaginate: true });
 
   configureType(SECRET, { showListMasthead: false });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13308
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Short term fix
  - Fetch a capped amount of norman users. This is the same approach we use for bindings

### Technical notes summary
- Long term fix pending, which will be either...
  1. use new user resource which contains all of norman user functionality (no longer need to fetch secondary norman user resource). Blocked on backend
  2. use existing user resource and fetch norman user secondary resources per page

### Areas or cases that should be tested

#### Setup 
Either create 1001 users OR create at least 10 and apply the following lines to `shell/plugins/steve/actions.js` `request` action before `const out = await makeRequest(this, opt, rootGetters);`

```
if (!paginatedResult && opt.url === 'https://localhost:8005/v3/users') {
   opt.url += '?limit=5';
}
```

#### Validation
- Users & Auth --> Users list
- Open dev tools network tab
- Refresh
  - After the request to `/v3/users?me=true` and EXCLUDING `/v3/users?me=true` there should be multiple request to `/v3/users` (EXCLUDING ). These will ensure all norman users are fetched
  - For every row in the users list (or a decent spread of) ensure the `Delete` action is visible in the action menu

### Areas which could experience regressions
- User detail page, in particular the action menu delete option

### Screenshot/Video
<img width="598" height="303" alt="image" src="https://github.com/user-attachments/assets/86e3b5eb-562e-4e86-a98b-8b3429d580c2" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
