### PR TITLE
add aws-iso-f to aws update-data script

### DIFF
--- a/scripts/aws/update-data
+++ b/scripts/aws/update-data
@@ -17,7 +17,7 @@ console.log('');
 
 const SCRIPT = process.argv[1];
 const DIR = path.resolve(SCRIPT, '../../..');
-const PARTITIONS = ['aws', 'aws-us-gov', 'aws-cn', 'aws-iso', 'aws-iso-b'];
+const PARTITIONS = ['aws', 'aws-us-gov', 'aws-cn', 'aws-iso', 'aws-iso-b', 'aws-iso-f'];
 const ENDPOINTS_URL = 'https://raw.githubusercontent.com/boto/botocore/develop/botocore/data/endpoints.json';
 const JS_FILE = path.resolve(DIR, 'shell/assets/data/aws-regions.json');
 


### PR DESCRIPTION
### Summary
Fixes #14812

Fixes `aws-iso-f` region not being available.
I added the missing region to the `PARTITION` array in `scripts/aws/update-data`

Output when tested locally.
```
❯ ./aws-regions                                                                                                                                                                                                                                                                              
Updating Amazon EC2 region list
===============================

Checking regions for ec2
  + new region us-isof-east-1
  + new region us-isof-south-1
```
### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
