### PR TITLE
Automation: Scale machine pool tests

### DIFF
--- a/browser-logs/out.html
+++ b/browser-logs/out.html
@@ -1,0 +1,2037 @@
+<html>
+<head>
+  <style>
+    body { font-family: monospace; }
+    p { margin: 0; padding: 0; }
+    pre { display: inline; margin: 0; }
+    h2 { margin: 0; font-size: 1.2em; }
+  </style>
+</head>
+
+<body>
+
+<h1>cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts</h1>
+<h2>Deploy RKE2 cluster using node driver on Amazon EC2 -&gt; can scale down a machine pool</h2>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: defineEmits() is a compiler-hint helper that is only usable inside &lt;script setup&gt; of a single file component. Its arguments should be compiled away and passing it at runtime has no effect.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Component &quot;v-select&quot; has already been registered in target app.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/rancherversion
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/version
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/uiplugins
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.setting</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.settings?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:green;">    cy:request✔</pre> <pre style="color:grey;">GET https://localhost:8005/v1/userpreferences
+                Status: 200
+                Response body: {
+                  &quot;type&quot;: &quot;collection&quot;,
+                  &quot;links&quot;: {
+                    &quot;self&quot;: &quot;https://localhost:8005/v1/userpreferences&quot;
+                  },
+                  &quot;actions&quot;: {},
+                  &quot;resourceType&quot;: &quot;userpreference&quot;,
+                  &quot;data&quot;: [
+                    {
+                      &quot;id&quot;: &quot;user-lbwft&quot;,
+                      &quot;type&quot;: &quot;userpreference&quot;,
+                      &quot;links&quot;: {
+                        &quot;remove&quot;: &quot;https://localhost:8005/v1/userpreferences/user-lbwft&quot;,
+                        &quot;self&quot;: &quot;https://localhost:8005/v1/userpreferences/user-lbwft&quot;,
+                        &quot;update&quot;: &quot;https://localhost:8005/v1/userpreferences/user-lbwft&quot;
+                      },
+                      &quot;data&quot;: {
+                        &quot;cluster&quot;: &quot;_&quot;,
+                        &quot;group-by&quot;: &quot;poolId&quot;,
+                        &quot;locale&quot;: &quot;en-us&quot;,
+                        &quot;seen-whatsnew&quot;: &quot;\&quot;v2.13.1-alpha4\&quot;&quot;
+                      }
+                    }
+                  ]
+                }</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:green;">    cy:request✔</pre> <pre style="color:grey;">PUT https://localhost:8005/v1/userpreferences/user-lbwft
+                Status: 200
+                Response body: {
+                  &quot;id&quot;: &quot;user-lbwft&quot;,
+                  &quot;type&quot;: &quot;userpreference&quot;,
+                  &quot;links&quot;: {
+                    &quot;remove&quot;: &quot;https://localhost:8005/v1/userpreferences/user-lbwft&quot;,
+                    &quot;self&quot;: &quot;https://localhost:8005/v1/userpreferences/user-lbwft&quot;,
+                    &quot;update&quot;: &quot;https://localhost:8005/v1/userpreferences/user-lbwft&quot;
+                  },
+                  &quot;data&quot;: {
+                    &quot;cluster&quot;: &quot;_&quot;,
+                    &quot;group-by&quot;: &quot;poolId&quot;,
+                    &quot;locale&quot;: &quot;en-us&quot;,
+                    &quot;scale-pool-prompt&quot;: &quot;false&quot;,
+                    &quot;seen-whatsnew&quot;: &quot;\&quot;v2.13.1-alpha4\&quot;&quot;
+                  }
+                }</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [rancher] user</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v3/users?me=true
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [rancher] principal</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v3/principals
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>All of schema is not loaded yet</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>All of schema is not loaded yet</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>All of namespace is not loaded yet</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Loading management...</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>All of count is not loaded yet</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Socket connecting (id=1, url=wss://localhost:8005/v1/subscribe)</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] schema</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [rancher] schema</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/schemas?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v3/schemas
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Socket opened (state=connecting, id=1)</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.feature</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] userpreference</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Socket connecting (id=2, url=wss://localhost:8005/v3/subscribe)</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] count</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] namespace</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.fleetworkspace</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.features?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/userpreferences?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/counts?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/namespaces?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.fleetworkspaces?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Socket opened (state=connecting, id=2)</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">PUT https://localhost:8005/v1/userpreferences/user-lbwft
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] management.cattle.io.cluster local</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters/local?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Done loading management; isRancher=true; isMultiCluster=true</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: defineEmits() is a compiler-hint helper that is only usable inside &lt;script setup&gt; of a single file component. Its arguments should be compiled away and passing it at runtime has no effect.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] catalog.cattle.io.app. Page: null. Size: null. Sort: </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.rancherusernotification</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [rancher] authconfig azuread</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [rancher] authprovider</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;resource&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] management.cattle.io.setting ui-custom-links</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] management.cattle.io.setting ui-issues</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] management.cattle.io.setting ui-community-links</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.cluster</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] cluster.x-k8s.io.machine</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.node</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.nodepool</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: injection &quot;update-count&quot; not found.,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                manualRefreshButtonSize=&quot;sm&quot;,
+                group-sort=null,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                ref=&quot;table&quot;,
+                table-actions=false,
+                row-actions=false,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;PaginatedResourceTable,
+                key=0,
+                schema=,
+                {
+                  &quot;id&quot;: &quot;provisioning.cattle.io.cluster&quot;,
+                  &quot;type&quot;: &quot;schema&quot;,
+                  &quot;links&quot;: {
+                    &quot;collection&quot;: &quot;https://localhost:8005/v1/provisioning.cattle.io.clusters&quot;,
+                    &quot;self&quot;: &quot;https://localhost:8005/v1/schemas/provisioning.cattle.io.cluster&quot;
+                  },
+                  &quot;description&quot;: &quot;Cluster is the Schema for the provisioning API.&quot;,
+                  &quot;pluralName&quot;: &quot;provisioning.cattle.io.clusters&quot;,
+                  &quot;resourceMethods&quot;: [
+                    &quot;PATCH&quot;,
+                    &quot;GET&quot;,
+                    &quot;DELETE&quot;,
+                    &quot;PUT&quot;
+                  ],
+                  &quot;_resourceFields&quot;: null,
+                  &quot;requiresResourceFields&quot;: true,
+                  &quot;collectionMethods&quot;: [
+                    &quot; ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/catalog.cattle.io.apps?pagesize=100000&amp;filter=metadata.name=rancher-csp-adapter,metadata.name=rancher-csp-billing-adapter&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.rancherusernotifications?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v3/authconfig/azuread
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v3-public/authProviders
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/cluster.x-k8s.io.machines?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.nodes?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.nodepools?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Reset store: ,
+                cluster</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>All of schema is not loaded yet</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>All of namespace is not loaded yet</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] userpreference</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/userpreferences?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] provisioning.cattle.io.cluster</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [rancher] authconfig azuread</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;resource&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] provisioning.cattle.io.cluster</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [rancher] cluster</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] rke.cattle.io.etcdsnapshot</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] cluster.x-k8s.io.machine</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.node</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.nodepool</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] cluster.x-k8s.io.machinedeployment</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: injection &quot;update-count&quot; not found.,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                data-testid=&quot;cluster-list&quot;,
+                headers=,
+                [
+                  {
+                    &quot;name&quot;: &quot;state&quot;,
+                    &quot;labelKey&quot;: &quot;tableHeaders.state&quot;,
+                    &quot;sort&quot;: [
+                      &quot;stateSort&quot;,
+                      &quot;nameSort&quot;
+                    ],
+                    &quot;width&quot;: 100,
+                    &quot;default&quot;: &quot;unknown&quot;,
+                    &quot;formatter&quot;: &quot;BadgeStateFormatter&quot;,
+                    &quot;valueProp&quot;: &quot;stateDisplay&quot;
+                  },
+                  {
+                    &quot;name&quot;: &quot;name&quot;,
+                    &quot;labelKey&quot;: &quot;tableHeaders.name&quot;,
+                    &quot;value&quot;: &quot;nameDisplay&quot;,
+                    &quot;sort&quot;: [
+                      &quot;nameSort&quot;
+                    ],
+                    &quot;formatter&quot;: &quot;ClusterLink&quot;,
+                    &quot;canBeVariable&quot;: true
+                  },
+                  {
+                    &quot;name&quot;: &quot;kubernetesVersion&quot;,
+                    &quot;labelKey&quot;: &quot;tableHeaders.version&quot;,
+                    &quot;subLabel&quot;: &quot;Architecture&quot;,
+                    &quot;value&quot;: &quot;kubernetesVersion&quot;,
+                    &quot;sort&quot;: &quot;kubernetesVersion&quot;,
+                    &quot;search&quot;: &quot;kubernetesVersion&quot;
+                  },
+                  {
+                    &quot;name&quot;: &quot;provider&quot;,
+                  ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v3/clusters
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/rke.cattle.io.etcdsnapshots?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/cluster.x-k8s.io.machines?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/cluster.x-k8s.io.machinedeployments?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">PUT https://localhost:8005/v1/userpreferences/user-lbwft
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] provisioning.cattle.io.cluster fleet-default/e2e-test-1765913830843-rke2ec2cluster</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;resource&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Socket connecting (id=3, url=wss://localhost:8005/v1/management.cattle.io.clusters/c-m-tx2tgs8k)</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] management.cattle.io.cluster c-m-tx2tgs8k</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Starting wait for,
+                set provisioner</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Wait for,
+                set provisioner,
+                done immediately</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/schemaDefinitions/provisioning.cattle.io.cluster
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Socket opened (state=connecting, id=3)</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] rke-machine.cattle.io.amazonec2machinetemplate</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/rke-machine.cattle.io.amazonec2machinetemplates?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Property &quot;tabChange&quot; was accessed during render but is not defined on instance.,
+                
+                ,
+                 at &lt;ResourceTabs,
+                value=,
+                {
+                  &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster&quot;,
+                  &quot;type&quot;: &quot;provisioning.cattle.io.cluster&quot;,
+                  &quot;links&quot;: {
+                    &quot;patch&quot;: &quot;https://localhost:8005/v1/provisioning.cattle.io.clusters/fleet-default/e2e-test-1765913830843-rke2ec2cluster&quot;,
+                    &quot;remove&quot;: &quot;https://localhost:8005/v1/provisioning.cattle.io.clusters/fleet-default/e2e-test-1765913830843-rke2ec2cluster&quot;,
+                    &quot;self&quot;: &quot;https://localhost:8005/v1/provisioning.cattle.io.clusters/fleet-default/e2e-test-1765913830843-rke2ec2cluster&quot;,
+                    &quot;update&quot;: &quot;https://localhost:8005/v1/provisioning.cattle.io.clusters/fleet-default/e2e-test-1765913830843-rke2ec2cluster&quot;,
+                    &quot;view&quot;: &quot;https://localhost:8005/apis/provision ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] event</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/events?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;resource&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] userpreference</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/userpreferences?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Wait for,
+                set provisioner,
+                done</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">PUT https://localhost:8005/v1/userpreferences/user-lbwft
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://updates.rancher.io/rancher/community/updates?dcv=v1&amp;s=ee64a9013dce9fddb80033b8732c7ce7&amp;u=6b96973d2b98797e6d820ae71584e403&amp;uuid=62f440b0-256f-4e26-a6b1-7e4c51d516d8&amp;svt=dev&amp;v=v2.13.1&amp;dev=true&amp;p=false&amp;cc=2&amp;lkv=v1.34.2&amp;lcp=rke2&amp;lnc=3&amp;xkn=&amp;xcc=0&amp;bl=en-US&amp;bs=1000x660&amp;ss=1920x1080&amp;ff-usc=true
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">(scaleDownMachineDeployment) PUT https://localhost:8005/v1/provisioning.cattle.io.clusters/fleet-default/e2e-test-1765913830843-rke2ec2cluster
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] namespace fleet-default</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Avoid app logic that relies on enumerating keys on a component instance. The keys will be empty in production mode to avoid performance overhead.</pre></p>
+<p><pre style="color:red;">    cons:error✘</pre> <pre>TypeError: Cannot read properties of undefined (reading &#039;primary&#039;)
+                    at ComputedRefImpl.fn (https://localhost:8005/js/index.js:50283:89)
+                    at refreshComputed (https://localhost:8005/js/chunk-vendors.js:7176:28)
+                    at get value (https://localhost:8005/js/chunk-vendors.js:8423:5)
+                    at unref (https://localhost:8005/js/chunk-vendors.js:8268:29)
+                    at https://localhost:8005/js/shell_components_Resource_Detail_ResourcePopover_index_vue.js:210:84
+                    at setVars (https://localhost:8005/js/chunk-vendors.js:17918:18)
+                    at callWithErrorHandling (https://localhost:8005/js/chunk-vendors.js:9049:33)
+                    at callWithAsyncErrorHandling (https://localhost:8005/js/chunk-vendors.js:9056:17)
+                    at baseWatchOptions.call (https://localhost:8005/js/chunk-vendors.js:15066:47)
+                    at ReactiveEffect.gette ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Socket closed (id=2, code=1006, reason=, clean=false)</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Socket closed. Attempting to reconnect (state=reconnecting, id=0)</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Socket connecting (id=4, url=wss://localhost:8005/v3/subscribe)</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Socket opened (state=connecting, id=4)</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Invalid prop: type check failed for prop &quot;groupSort&quot;. Expected String with value &quot;pool.nameDisplay&quot;, got Array ,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                default-sort-by=&quot;name&quot;,
+                group-ref=&quot;pool&quot;,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                rows=,
+                [
+                  {
+                    &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                    &quot;type&quot;: &quot;cluster.x-k8s.io.machine&quot;,
+                    &quot;links&quot;: {
+                      &quot;patch&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;remove&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75v5l&quot;,
+                      &quot;self&quot;: &quot;https://localhost:8005/v1/cluster.x-k8s.io.machines/fleet-default/e2e-test-1765913830843-rke2ec2cluster-pool1-pm7mw-75 ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<p><pre style="color:darkcyan;">     cons:info✱</pre> <pre>Ping [management] from dev</pre></p>
+<br>
+<h2>Deploy RKE2 cluster using node driver on Amazon EC2 -&gt; can delete an Amazon EC2 RKE2 cluster</h2>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: defineEmits() is a compiler-hint helper that is only usable inside &lt;script setup&gt; of a single file component. Its arguments should be compiled away and passing it at runtime has no effect.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: Component &quot;v-select&quot; has already been registered in target app.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/rancherversion
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/version
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/uiplugins
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.setting</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.settings?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [rancher] user</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v3/users?me=true
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [rancher] principal</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v3/principals
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>All of schema is not loaded yet</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>All of schema is not loaded yet</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>All of namespace is not loaded yet</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Loading management...</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>All of count is not loaded yet</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Socket connecting (id=1, url=wss://localhost:8005/v1/subscribe)</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] schema</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [rancher] schema</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/schemas?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v3/schemas
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Socket opened (state=connecting, id=1)</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.feature</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] userpreference</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Socket connecting (id=2, url=wss://localhost:8005/v3/subscribe)</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] count</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] namespace</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.fleetworkspace</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.features?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/userpreferences?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/counts?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/namespaces?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.fleetworkspaces?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Socket opened (state=connecting, id=2)</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">PUT https://localhost:8005/v1/userpreferences/user-lbwft
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] management.cattle.io.cluster local</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters/local?exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Done loading management; isRancher=true; isMultiCluster=true</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: defineEmits() is a compiler-hint helper that is only usable inside &lt;script setup&gt; of a single file component. Its arguments should be compiled away and passing it at runtime has no effect.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] catalog.cattle.io.app. Page: null. Size: null. Sort: </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.rancherusernotification</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [rancher] authconfig azuread</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [rancher] authprovider</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;resource&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] management.cattle.io.setting ui-custom-links</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] management.cattle.io.setting ui-issues</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [management] management.cattle.io.setting ui-community-links</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.cluster</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] cluster.x-k8s.io.machine</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.node</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.nodepool</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: injection &quot;update-count&quot; not found.,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                manualRefreshButtonSize=&quot;sm&quot;,
+                group-sort=null,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;ResourceTable,
+                ref=&quot;table&quot;,
+                table-actions=false,
+                row-actions=false,
+                 ...,
+                &gt;,
+                
+                ,
+                 at &lt;PaginatedResourceTable,
+                key=0,
+                schema=,
+                {
+                  &quot;id&quot;: &quot;provisioning.cattle.io.cluster&quot;,
+                  &quot;type&quot;: &quot;schema&quot;,
+                  &quot;links&quot;: {
+                    &quot;collection&quot;: &quot;https://localhost:8005/v1/provisioning.cattle.io.clusters&quot;,
+                    &quot;self&quot;: &quot;https://localhost:8005/v1/schemas/provisioning.cattle.io.cluster&quot;
+                  },
+                  &quot;description&quot;: &quot;Cluster is the Schema for the provisioning API.&quot;,
+                  &quot;pluralName&quot;: &quot;provisioning.cattle.io.clusters&quot;,
+                  &quot;resourceMethods&quot;: [
+                    &quot;PATCH&quot;,
+                    &quot;GET&quot;,
+                    &quot;DELETE&quot;,
+                    &quot;PUT&quot;
+                  ],
+                  &quot;_resourceFields&quot;: null,
+                  &quot;requiresResourceFields&quot;: true,
+                  &quot;collectionMethods&quot;: [
+                    &quot; ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/catalog.cattle.io.apps?pagesize=100000&amp;filter=metadata.name=rancher-csp-adapter,metadata.name=rancher-csp-billing-adapter&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.rancherusernotifications?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v3/authconfig/azuread
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v3-public/authProviders
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/cluster.x-k8s.io.machines?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.nodes?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.nodepools?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] provisioning.cattle.io.cluster</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Reset store: ,
+                cluster</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>All of schema is not loaded yet</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>All of namespace is not loaded yet</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] userpreference</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/userpreferences?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find: [rancher] authconfig azuread</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;resource&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue Router warn]: Discarded invalid param(s) &quot;product&quot; when navigating. See https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22 for more details.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] provisioning.cattle.io.cluster</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [rancher] cluster</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] rke.cattle.io.etcdsnapshot</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] cluster.x-k8s.io.machine</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.node</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] management.cattle.io.nodepool</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find All: [management] cluster.x-k8s.io.machinedeployment</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[Vue warn]: injection &quot;update-count&quot; not found.,
+                
+                ,
+                 at &lt;SortableTable,
+                ref=&quot;table&quot;,
+                data-testid=&quot;cluster-list&quot;,
+                headers=,
+                [
+                  {
+                    &quot;name&quot;: &quot;state&quot;,
+                    &quot;labelKey&quot;: &quot;tableHeaders.state&quot;,
+                    &quot;sort&quot;: [
+                      &quot;stateSort&quot;,
+                      &quot;nameSort&quot;
+                    ],
+                    &quot;width&quot;: 100,
+                    &quot;default&quot;: &quot;unknown&quot;,
+                    &quot;formatter&quot;: &quot;BadgeStateFormatter&quot;,
+                    &quot;valueProp&quot;: &quot;stateDisplay&quot;
+                  },
+                  {
+                    &quot;name&quot;: &quot;name&quot;,
+                    &quot;labelKey&quot;: &quot;tableHeaders.name&quot;,
+                    &quot;value&quot;: &quot;nameDisplay&quot;,
+                    &quot;sort&quot;: [
+                      &quot;nameSort&quot;
+                    ],
+                    &quot;formatter&quot;: &quot;ClusterLink&quot;,
+                    &quot;canBeVariable&quot;: true
+                  },
+                  {
+                    &quot;name&quot;: &quot;kubernetesVersion&quot;,
+                    &quot;labelKey&quot;: &quot;tableHeaders.version&quot;,
+                    &quot;subLabel&quot;: &quot;Architecture&quot;,
+                    &quot;value&quot;: &quot;kubernetesVersion&quot;,
+                    &quot;sort&quot;: &quot;kubernetesVersion&quot;,
+                    &quot;search&quot;: &quot;kubernetesVersion&quot;
+                  },
+                  {
+                    &quot;name&quot;: &quot;provider&quot;,
+                  ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v3/clusters
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/rke.cattle.io.etcdsnapshots?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/cluster.x-k8s.io.machines?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/cluster.x-k8s.io.machinedeployments?pagesize=100000&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">PUT https://localhost:8005/v1/userpreferences/user-lbwft
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">DELETE https://localhost:8005/v1/provisioning.cattle.io.clusters/fleet-default/e2e-test-1765913830843-rke2ec2cluster
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://updates.rancher.io/rancher/community/updates?dcv=v1&amp;s=ee64a9013dce9fddb80033b8732c7ce7&amp;u=6b96973d2b98797e6d820ae71584e403&amp;uuid=62f440b0-256f-4e26-a6b1-7e4c51d516d8&amp;svt=dev&amp;v=v2.13.1&amp;dev=true&amp;p=false&amp;cc=2&amp;lkv=v1.34.2&amp;lcp=rke2&amp;lnc=3&amp;xkn=&amp;xcc=0&amp;bl=en-US&amp;bs=1000x660&amp;ss=1920x1080&amp;ff-usc=true
+                Status: 200</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] management.cattle.io.cluster. Page: 1. Size: 10. Sort: spec.internal, status.connected, spec.displayName</pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/management.cattle.io.clusters?page=1&amp;pagesize=10&amp;sort=-spec.internal,-status.connected,spec.displayName&amp;filter=metadata.labels[provider.cattle.io]!=harvester&amp;filter=status.provider!=harvester&amp;exclude=metadata.managedFields
+                Status: 200</pre></p>
+<p><pre style="color:darkcyan;">      cons:log✱</pre> <pre>Find Page: [management] provisioning.cattle.io.cluster. Page: 1. Size: undefined. Sort: </pre></p>
+<p><pre style="color:lightgrey;">        cy:xhr➟</pre> <pre style="color:lightgrey;">GET https://localhost:8005/v1/provisioning.cattle.io.clusters?page=1&amp;pagesize=100000&amp;filter=status.clusterName=local,status.clusterName=c-m-tx2tgs8k&amp;exclude=metadata.managedFields</pre></p>
+<br>
+<h2>Deploy RKE2 cluster using node driver on Amazon EC2 -&gt; [[ after all #1 ]]</h2>
+<p><pre style="color:green;">    cy:request✔</pre> <pre style="color:grey;">DELETE https://localhost:8005/v1/provisioning.cattle.io.clusters/fleet-default/e2e-test-1765913830843-rke2ec2cluster
+                Status: 200
+                Response body: {
+                  &quot;id&quot;: &quot;fleet-default/e2e-test-1765913830843-rke2ec2cluster&quot;,
+                  &quot;type&quot;: &quot;provisioning.cattle.io.cluster&quot;,
+                  &quot;links&quot;: {
+                    &quot;patch&quot;: &quot;https://localhost:8005/v1/provisioning.cattle.io.clusters/fleet-default/e2e-test-1765913830843-rke2ec2cluster&quot;,
+                    &quot;remove&quot;: &quot;https://localhost:8005/v1/provisioning.cattle.io.clusters/fleet-default/e2e-test-1765913830843-rke2ec2cluster&quot;,
+                    &quot;self&quot;: &quot;https://localhost:8005/v1/provisioning.cattle.io.clusters/fleet-default/e2e-test-1765913830843-rke2ec2cluster&quot;,
+                    &quot;update&quot;: &quot;https://localhost:8005/v1/provisioning.cattle.io.clusters/fleet-default/e2e-test-1765913830843-rke2ec2cluster&quot;,
+                    &quot;view&quot;: &quot;https://localhost:8005/apis/provisioning.cattle.io/v1/namespaces/fleet-default/clusters/e2e-test-1765913830843-rke2ec2cluster&quot;
+                  },
+                  &quot;apiVersion&quot;: &quot;provisioning.cattle.io/v1&quot;,
+                  &quot;kind&quot;: &quot;Cluster&quot;,
+                  &quot;metadata&quot;: {
+                    &quot;annotations&quot;: {
+                      &quot;field.cattle.io/creatorId&quot;: &quot;user-lbwft&quot;,
+                      &quot;field.cattle.io/description&quot;: &quot;e2e-test-1765913830843-rke2ec2cluster-description&quot;,
+                      &quot;provisioning.cattle.io/management-cluster-display-name&quot;: &quot;e2e-test-1765913830843-rke2ec2cluster&quot;
+                    },
+                    &quot;creationTimestamp&quot;: &quot;2025-12-16T19:37:38Z&quot;,
+                    &quot;deletionGracePeriodSeconds&quot;: 0,
+                    &quot;deletionTimestamp&quot;: &quot;2025-12-16T20:01:49Z&quot;,
+                    &quot;fields&quot;: [
+                      &quot;e2e-test-1765913830843-rke2ec2cluster&quot;,
+                      &quot;v1.34.2+rke2r1&quot;,
+                      &quot;c-m-tx2tgs8k&quot;,
+                      &quot;24m&quot;,
+                      &quot;e2e-test-1765913830843-rke2ec2cluster-kubeconfig&quot;,
+                      &quot;true&quot;
+                    ],
+                    &quot;finalizers&quot;: [
+                      &quot;wrangler.cattle.io/provisioning-cluster-remove&quot;,
+                      &quot;wrangler.cattle.io/rke-cluster-remove&quot;
+                    ],
+                    &quot;generation&quot;: 9,
+                    &quot;managedFields&quot;: [
+                      {
+                        &quot;apiVersion&quot;: &quot;provisioning.cattle.io/v1&quot;,
+                        &quot;fieldsType&quot;: &quot;FieldsV1&quot;,
+                        &quot;fieldsV1&quot;: {
+                          &quot;f:metadata&quot;: {
+                            &quot;f:finalizers&quot;: {}
+                          }
+                        },
+                        &quot;manager&quot;: &quot;rancher-v2.13.1-alpha4-secret-migrator&quot;,
+                        &quot;operation&quot;: &quot;Update&quot;,
+                        &quot;time&quot;: &quot;2025-12-16T19:48:28Z&quot;
+                      },
+                      {
+                        &quot;apiVersion&quot;: &quot;provisioning.cattle.io/v1&quot;,
+                        &quot;fieldsType&quot;: &quot;FieldsV1&quot;,
+                        &quot;fieldsV1&quot;: {
+                          &quot;f:metadata&quot;: {
+                            &quot;f:annotations&quot;: {
+                              &quot;.&quot;: {},
+                              &quot;f:field.cattle.io/description&quot;: {},
+                              &quot;f:provisioning.cattle.io/management-cluster-display-name&quot;: {}
+                            },
+                            &quot;f:finalizers&quot;: {
+                              &quot;v:\&quot;wrangler.cattle.io/provisioning-cluster-remove\&quot;&quot;: {},
+                              &quot;v:\&quot;wrangler.cattle.io/rke-cluster-remove\&quot;&quot;: {}
+                            }
+                          },
+                          &quot;f:spec&quot;: {
+                            &quot;.&quot;: {},
+                            &quot;f:cloudCredentialSecretName&quot;: {},
+                            &quot;f:kubernetesVersion&quot;: {},
+                            &quot;f:localClusterAuthEndpoint&quot;: {},
+                            &quot;f:rkeConfig&quot;: {
+                              &quot;.&quot;: {},
+                              &quot;f:chartValues&quot;: {
+                                &quot;.&quot;: {},
+                                &quot;f:rke2-calico&quot;: {}
+                              },
+                              &quot;f:dataDirectories&quot;: {},
+                              &quot;f:etcd&quot;: {
+                                &quot;.&quot;: {},
+                                &quot;f:snapshotRetention&quot;: {},
+                                &quot;f:snapshotScheduleCron&quot;: {}
+                              },
+                              &quot;f:etcdSnapshotCreate&quot;: {
+                                &quot;.&quot;: {},
+                                &quot;f:generation&quot;: {}
+                              },
+                              &quot;f:machineGlobalConfig&quot;: {
+                                &quot;.&quot;: {},
+                                &quot;f:cni&quot;: {},
+                                &quot;f:disable-kube-proxy&quot;: {},
+                                &quot;f:etcd-expose-metrics&quot;: {}
+                              },
+                              &quot;f:machinePoolDefaults&quot;: {},
+                              &quot;f:machinePools&quot;: {
+                                &quot;.&quot;: {},
+                                &quot;k:{\&quot;name\&quot;:\&quot;pool1\&quot;}&quot;: {
+                                  &quot;.&quot;: {},
+                                  &quot;f:controlPlaneRole&quot;: {},
+                                  &quot;f:drainBeforeDelete&quot;: {},
+                                  &quot;f:dynamicSchemaSpec&quot;: {},
+                                  &quot;f:etcdRole&quot;: {},
+                                  &quot;f:machineConfigRef&quot;: {},
+                                  &quot;f:name&quot;: {},
+                                  &quot;f:quantity&quot;: {},
+                                  &quot;f:unhealthyNodeTimeout&quot;: {},
+                                  &quot;f:workerRole&quot;: {}
+                                }
+                              },
+                              &quot;f:machineSelectorConfig&quot;: {},
+                              &quot;f:networking&quot;: {},
+                              &quot;f:registries&quot;: {},
+                              &quot;f:upgradeStrategy&quot;: {
+                                &quot;.&quot;: {},
+                                &quot;f:controlPlaneConcurrency&quot;: {},
+                                &quot;f:controlPlaneDrainOptions&quot;: {
+                                  &quot;.&quot;: {},
+                                  &quot;f:deleteEmptyDirData&quot;: {},
+                                  &quot;f:disableEviction&quot;: {},
+                                  &quot;f:enabled&quot;: {},
+                                  &quot;f:force&quot;: {},
+                                  &quot;f:gracePeriod&quot;: {},
+                                  &quot;f:ignoreDaemonSets&quot;: {},
+                                  &quot;f:skipWaitForDeleteTimeoutSeconds&quot;: {},
+                                  &quot;f:timeout&quot;: {}
+                                },
+                                &quot;f:workerConcurrency&quot;: {},
+                                &quot;f:workerDrainOptions&quot;: {
+                                  &quot;.&quot;: {},
+                                  &quot;f:deleteEmptyDirData&quot;: {},
+                                  &quot;f:disableEviction&quot;: {},
+                                  &quot;f:enabled&quot;: {},
+                                  &quot;f:force&quot;: {},
+                           ...
+                
+                ... remainder of log omitted ...
+                </pre></p>
+<p><pre style="color:yellow;">     cons:warn❖</pre> <pre>[DEPRECATED] `this.$plugin` is deprecated and will be removed in a future version. Use `this.$extension` instead.</pre></p>
+<p><pre style="color:red;">    cy:request✘</pre> <pre style="color:grey;">DELETE https://localhost:8005/v3/cloudCredentials/cattle-global-data:cc-ltfg2
+                Status: 422 - Unprocessable Entity
+                Response body: {
+                  &quot;baseType&quot;: &quot;error&quot;,
+                  &quot;code&quot;: &quot;InvalidAction&quot;,
+                  &quot;message&quot;: &quot;Cloud credential is currently referenced by provisioning cluster e2e-test-1765913830843-rke2ec2cluster&quot;,
+                  &quot;status&quot;: 422,
+                  &quot;type&quot;: &quot;error&quot;
+                }</pre></p>
+<br>
+
+</body>
+</html>

--- a/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
+++ b/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail.po.ts
@@ -1,4 +1,4 @@
-import PagePo from '@/cypress/e2e/po/pages/page.po';
+import { BaseDetailPagePo } from '@/cypress/e2e/po/pages/base/base-detail-page.po';
 import MachinePoolsListPo from '@/cypress/e2e/po/lists/machine-pools-list.po';
 import ClusterConditionsListPo from '~/cypress/e2e/po/lists/cluster-conditions-list.po';
 import ClusterProvisioningLogPo from '~/cypress/e2e/po/lists/cluster-provisioning-log.po';
@@ -7,10 +7,11 @@ import ClusterSnapshotsListPo from '~/cypress/e2e/po/lists/cluster-snapshots-lis
 import TabbedPo from '~/cypress/e2e/po/components/tabbed.po';
 import ClusterRecentEventsListPo from '~/cypress/e2e/po/lists/cluster-recent-events-list.po';
 import DetailDrawer from '@/cypress/e2e/po/side-bars/detail-drawer.po';
+
 /**
  * Covers core functionality that's common to the dashboard's cluster detail pages
  */
-export default abstract class ClusterManagerDetailPagePo extends PagePo {
+export default abstract class ClusterManagerDetailPagePo extends BaseDetailPagePo {
   private static createPath(clusterId: string, clusterName: string, tab?: string) {
     const namespace = clusterName === 'local' ? 'fleet-local' : 'fleet-default';
 
@@ -45,8 +46,8 @@ export default abstract class ClusterManagerDetailPagePo extends PagePo {
     return this.self().get('code');
   }
 
-  machinePoolsList() {
-    return new MachinePoolsListPo(this.self().find('[data-testid="sortable-table-list-container"]'));
+  poolsList(tabId: 'machine' | 'node') {
+    return new MachinePoolsListPo(this.self().find(`#${ tabId }-pools [data-testid="sortable-table-list-container"]`));
   }
 
   conditionsList() {

--- a/cypress/e2e/po/lists/machine-pools-list.po.ts
+++ b/cypress/e2e/po/lists/machine-pools-list.po.ts
@@ -1,5 +1,7 @@
 import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
 import ResourceTablePo from '@/cypress/e2e/po/components/resource-table.po';
+import TooltipPo from '@/cypress/e2e/po/components/tooltip.po';
+import { GetOptions } from '@/cypress/e2e/po/components/component.po';
 
 export default class MachinePoolsListPo extends BaseResourceList {
   details(name: string, index: number) {
@@ -8,5 +10,26 @@ export default class MachinePoolsListPo extends BaseResourceList {
 
   downloadYamlButton() {
     return new ResourceTablePo(this.self()).downloadYamlButton();
+  }
+
+  machinePoolCount(poolName: string, count: number | RegExp, options?: GetOptions) {
+    return this.resourceTable().sortableTable().groupElementWithName(poolName)
+      .find('.group-header-buttons')
+      .contains(count, options);
+  }
+
+  scaleDownButton(poolName: string) {
+    return this.resourceTable().sortableTable().groupElementWithName(poolName)
+      .find('[data-testid="scale-down-button"]');
+  }
+
+  scaleUpButton(poolName: string) {
+    return this.resourceTable().sortableTable().groupElementWithName(poolName)
+      .find('[data-testid="scale-up-button"]');
+  }
+
+  scaleButtonTooltip(poolName: string, button: 'plus' | 'minus'): TooltipPo {
+    return new TooltipPo(this.resourceTable().sortableTable().groupElementWithName(poolName)
+      .find(`.group-header-buttons button .icon-${ button }`));
   }
 }

--- a/cypress/e2e/po/prompts/genericPrompt.po.ts
+++ b/cypress/e2e/po/prompts/genericPrompt.po.ts
@@ -1,6 +1,7 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 import CardPo from '@/cypress/e2e/po/components/card.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
 
 export default class GenericPrompt extends ComponentPo {
   card = new CardPo();
@@ -15,6 +16,10 @@ export default class GenericPrompt extends ComponentPo {
 
   labeledSelect(selector = '.labeled-select'): LabeledSelectPo {
     return new LabeledSelectPo(selector);
+  }
+
+  checkbox(selector = '[data-checkbox-ctrl]') {
+    return new CheckboxInputPo(this.self().get(selector));
   }
 
   clickActionButton(text: string) {

--- a/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
@@ -7,7 +7,7 @@ import { WorkloadsDeploymentsListPagePo } from '@/cypress/e2e/po/pages/explorer/
 import * as path from 'path';
 import * as jsyaml from 'js-yaml';
 import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
-import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT, VERY_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 import { FeatureFlagsPagePo } from '@/cypress/e2e/po/pages/global-settings/feature-flags.po';
 import LoadingPo from '@/cypress/e2e/po/components/loading.po';
 
@@ -84,7 +84,7 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
   it('data is populated in fleet cluster list and detail view', () => {
     ClusterManagerListPagePo.navTo();
     clusterList.waitForPage();
-    clusterList.list().state(clusterName).contains('Active', { timeout: 700000 });
+    clusterList.list().state(clusterName).contains('Active', VERY_LONG_TIMEOUT_OPT);
 
     // create gitrepo
     cy.createRancherResource('v1', 'fleet.cattle.io.gitrepos', gitRepoTargetAllClustersRequest(namespace, gitRepo, gitRepoUrl, branch, paths)).then(() => {

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -547,8 +547,8 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
       clusterDetail.selectTab(tabbedPo, '[data-testid="btn-node-pools"]');
 
       clusterDetail.waitForPage(undefined, 'node-pools');
-      clusterDetail.machinePoolsList().details('machine-', 2).should('be.visible');
-      clusterDetail.machinePoolsList().downloadYamlButton().should('be.disabled');
+      clusterDetail.poolsList('node').details('machine-', 2).should('be.visible');
+      clusterDetail.poolsList('node').downloadYamlButton().should('be.disabled');
     });
 
     it(`Show Configuration allows to edit config and view yaml for local cluster`, () => {

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -6,23 +6,23 @@ import ClusterManagerEditGenericPagePo from '@/cypress/e2e/po/edit/provisioning.
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import LoadingPo from '@/cypress/e2e/po/components/loading.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
-import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT, VERY_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 import { USERS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
+import { promptModal } from '@/cypress/e2e/po/prompts/shared/modalInstances.po';
 
 // will only run this in jenkins pipeline where cloud credentials are stored
-describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation: 'off', tags: ['@manager', '@adminUser', '@standardUser', '@jenkins'] }, () => {
+describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manager', '@adminUser', '@standardUser', '@jenkins'] }, () => {
   const clusterList = new ClusterManagerListPagePo();
   const loadingPo = new LoadingPo('.loading-indicator');
 
   let removeCloudCred = false;
   let cloudcredentialId = '';
-  let k8sVersion = '';
+  let latestK8sVersion = '';
   let olderK8sVersion = '';
   let clusterId = '';
 
   before(() => {
     cy.login();
-    HomePagePo.goTo();
 
     // clean up amazon cloud credentials
     cy.getRancherResource('v3', 'cloudcredentials', null, null).then((resp: Cypress.Response<any>) => {
@@ -43,6 +43,8 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
   });
 
   beforeEach(() => {
+    cy.login();
+    HomePagePo.goTo();
     cy.createE2EResourceName('rke2ec2cluster').as('rke2Ec2ClusterName');
     cy.createE2EResourceName('ec2cloudcredential').as('ec2CloudCredentialName');
   });
@@ -85,47 +87,51 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
     createRKE2ClusterPage.nameNsDescription().name().set(this.rke2Ec2ClusterName);
     createRKE2ClusterPage.nameNsDescription().description().set(`${ this.rke2Ec2ClusterName }-description`);
 
-    // Get kubernetes versions - use an older version for initial creation, then upgrade later
-    cy.wait('@getRke2Releases').then(({ response }) => {
-      expect(response.statusCode).to.eq(200);
-      const index1 = response.body.data.length - 1;
+    // Get kubernetes versions from the UI dropdown
+    // Index 0 is the "RKE2" header, so actual versions start at index 1
+    cy.wait('@getRke2Releases').its('response.statusCode').should('eq', 200);
+    createRKE2ClusterPage.basicsTab().kubernetesVersions().toggle();
+    createRKE2ClusterPage.basicsTab().kubernetesVersions().getOptions().then(($options) => {
+      // Ensure we have at least 3 options
+      expect($options.length).to.be.gt(2);
 
-      // Store the latest version for upgrade test
-      k8sVersion = response.body.data[index1].id;
-      cy.wrap(k8sVersion).as('k8sVersion');
+      // First RKE2 version (index 1) is the latest version
+      latestK8sVersion = Cypress.$($options[1]).text().trim();
+      cy.wrap(latestK8sVersion).as('latestK8sVersion');
 
-      // Use the older version for cluster creation
-      // This allows us to test the upgrade scenario
-      const index2 = index1 - 1;
-
-      olderK8sVersion = response.body.data[index2].id;
+      // Second RKE2 version (index 2) is the older version for cluster creation
+      olderK8sVersion = Cypress.$($options[2]).text().trim();
       cy.wrap(olderK8sVersion).as('olderK8sVersion');
+
+      cy.log(`latestK8sVersion: ${ latestK8sVersion }`);
+      cy.log(`olderK8sVersion: ${ olderK8sVersion }`);
+
+      // Set the k8s version
+      createRKE2ClusterPage.basicsTab().kubernetesVersions().clickOptionWithLabel(olderK8sVersion);
     });
 
-    cy.get<string>('@olderK8sVersion').then((version) => {
-      createRKE2ClusterPage.basicsTab().kubernetesVersions().toggle();
-      createRKE2ClusterPage.basicsTab().kubernetesVersions().clickOptionWithLabel(version);
+    // Set the network
+    createRKE2ClusterPage.machinePoolTab().networks().toggle();
+    createRKE2ClusterPage.machinePoolTab().networks().clickOptionWithLabel('default');
 
-      createRKE2ClusterPage.machinePoolTab().networks().toggle();
-      createRKE2ClusterPage.machinePoolTab().networks().clickOptionWithLabel('default');
+    // Create the cluster
+    cy.intercept('POST', 'v1/provisioning.cattle.io.clusters').as('createRke2Cluster');
+    createRKE2ClusterPage.create();
+    cy.wait('@createRke2Cluster').then(({ response }) => {
+      expect(response?.statusCode).to.eq(201);
+      expect(response?.body).to.have.property('kind', 'Cluster');
+      expect(response?.body.metadata).to.have.property('name', this.rke2Ec2ClusterName);
+      expect(response?.body.spec).to.have.property('kubernetesVersion').contains(olderK8sVersion);
+      clusterId = response?.body.id;
+    });
 
-      cy.intercept('POST', 'v1/provisioning.cattle.io.clusters').as('createRke2Cluster');
-      createRKE2ClusterPage.create();
-      cy.wait('@createRke2Cluster').then(({ response }) => {
-        expect(response?.statusCode).to.eq(201);
-        expect(response?.body).to.have.property('kind', 'Cluster');
-        expect(response?.body.metadata).to.have.property('name', this.rke2Ec2ClusterName);
-        expect(response?.body.spec).to.have.property('kubernetesVersion').contains(version);
-        clusterId = response?.body.id;
+    clusterList.waitForPage();
+    clusterList.list().state(this.rke2Ec2ClusterName).should('be.visible')
+      .and(($el) => {
+        const status = $el.text().trim();
+
+        expect(['Reconciling', 'Updating']).to.include(status);
       });
-      clusterList.waitForPage();
-      clusterList.list().state(this.rke2Ec2ClusterName).should('be.visible')
-        .and(($el) => {
-          const status = $el.text().trim();
-
-          expect(['Reconciling', 'Updating']).to.include(status);
-        });
-    });
   });
 
   it('can see details of cluster in cluster list', function() {
@@ -138,7 +144,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
 
     // check states
     clusterList.list().state(this.rke2Ec2ClusterName).should('contain.text', 'Updating');
-    clusterList.list().state(this.rke2Ec2ClusterName).contains('Active', { timeout: 700000 });
+    clusterList.list().state(this.rke2Ec2ClusterName).contains('Active', VERY_LONG_TIMEOUT_OPT);
 
     // check k8s version
     clusterList.list().version(this.rke2Ec2ClusterName).then((el) => {
@@ -164,13 +170,8 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
     clusterList.list().name(this.rke2Ec2ClusterName).click();
     clusterDetails.waitForPage(null, 'machine-pools');
     clusterDetails.resourceDetail().title().should('contain', this.rke2Ec2ClusterName);
-    clusterDetails.machinePoolsList().details(`${ this.rke2Ec2ClusterName }-pool1-`, 1).should('contain', 'Running');
 
     // check cluster details page > recent events
-    ClusterManagerListPagePo.navTo();
-    clusterList.waitForPage();
-    clusterList.goToDetailsPage(this.rke2Ec2ClusterName, '.cluster-link a');
-    clusterDetails.waitForPage(null, 'machine-pools');
     clusterDetails.selectTab(tabbedPo, '[data-testid="btn-events"]');
     clusterDetails.waitForPage(null, 'events');
     clusterDetails.recentEventsList().checkTableIsEmpty();
@@ -192,7 +193,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
 
     // Select the latest version for upgrade
     editClusterPage.basicsTab().kubernetesVersions().toggle();
-    editClusterPage.basicsTab().kubernetesVersions().clickOptionWithLabel(k8sVersion);
+    editClusterPage.basicsTab().kubernetesVersions().clickOptionWithLabel(latestK8sVersion);
 
     cy.intercept('PUT', `/v1/provisioning.cattle.io.clusters/fleet-default/${ this.rke2Ec2ClusterName }`).as('clusterUpdate');
     // Save the cluster to upgrade the Kubernetes version
@@ -212,16 +213,16 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
       expect(response?.statusCode).to.equal(200);
       expect(response?.body).to.have.property('kind', 'Cluster');
       expect(response?.body.metadata).to.have.property('name', this.rke2Ec2ClusterName);
-      expect(response?.body.spec).to.have.property('kubernetesVersion').contains(k8sVersion);
+      expect(response?.body.spec).to.have.property('kubernetesVersion').contains(latestK8sVersion);
     });
 
     clusterList.waitForPage();
     clusterList.list().state(this.rke2Ec2ClusterName).should('contain.text', 'Updating');
-    clusterList.list().state(this.rke2Ec2ClusterName).contains('Active', { timeout: 700000 });
+    clusterList.list().state(this.rke2Ec2ClusterName).contains('Active', VERY_LONG_TIMEOUT_OPT);
 
     // check k8s version
     clusterList.list().version(this.rke2Ec2ClusterName).then((el) => {
-      expect(el.text().trim()).contains(k8sVersion);
+      expect(el.text().trim()).contains(latestK8sVersion);
     });
 
     // Navigate back to edit page to verify older version is disabled in dropdown
@@ -229,7 +230,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
     editClusterPage.waitForPage('mode=edit', 'basic');
 
     // Verify current version is selected
-    editClusterPage.basicsTab().kubernetesVersions().checkContainsOptionSelected(k8sVersion);
+    editClusterPage.basicsTab().kubernetesVersions().checkContainsOptionSelected(latestK8sVersion);
 
     // Open dropdown and verify older version is disabled
     editClusterPage.basicsTab().kubernetesVersions().toggle();
@@ -258,7 +259,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
     ClusterManagerListPagePo.navTo();
     clusterList.waitForPage();
     clusterList.list().state(this.rke2Ec2ClusterName).should('contain.text', 'Updating');
-    clusterList.list().state(this.rke2Ec2ClusterName).contains('Active', { timeout: 700000 });
+    clusterList.list().state(this.rke2Ec2ClusterName).contains('Active', VERY_LONG_TIMEOUT_OPT);
 
     // check snapshot exist
     clusterList.goToDetailsPage(this.rke2Ec2ClusterName, '.cluster-link a');
@@ -266,6 +267,116 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
     clusterDetails.selectTab(tabbedPo, '[data-testid="btn-snapshots"]');
     clusterDetails.waitForPage(null, 'snapshots');
     clusterDetails.snapshotsList().checkSnapshotExist(`on-demand-${ this.rke2Ec2ClusterName }`);
+  });
+
+  it('can scale up a machine pool', function() {
+    // testing https://github.com/rancher/dashboard/issues/13285
+    const clusterDetails = new ClusterManagerDetailRke2AmazonEc2PagePo(undefined, this.rke2Ec2ClusterName);
+
+    ClusterManagerListPagePo.navTo();
+    clusterList.waitForPage();
+
+    // Navigate to cluster details page > machine pools
+    clusterList.list().name(this.rke2Ec2ClusterName).click();
+    clusterDetails.waitForPage(null, 'machine-pools');
+    clusterDetails.resourceDetail().title().should('contain', this.rke2Ec2ClusterName);
+
+    // Verify scaling buttons are present in the machine pools section
+    clusterDetails.poolsList('machine').resourceTable().sortableTable().groupByButtons(1)
+      .click();
+
+    // Check for scale up button (it should be enabled)
+    clusterDetails.poolsList('machine').scaleUpButton(`${ this.rke2Ec2ClusterName }-pool1`)
+      .should('be.visible')
+      .and('be.enabled');
+
+    // Hover scale up button - tooltip should read "Scale Pool Up"
+    clusterDetails.poolsList('machine').scaleButtonTooltip(`${ this.rke2Ec2ClusterName }-pool1`, 'plus')
+      .waitForTooltipWithText('Scale Pool Up');
+    clusterDetails.poolsList('machine').scaleButtonTooltip(`${ this.rke2Ec2ClusterName }-pool1`, 'plus')
+      .hideTooltip();
+
+    // Check for scale down button (it should be disabled initially)
+    clusterDetails.poolsList('machine').scaleDownButton(`${ this.rke2Ec2ClusterName }-pool1`)
+      .should('be.visible')
+      .and('be.disabled');
+
+    // Hover scale down button - tooltip should read "Scale Pool Down"
+    clusterDetails.poolsList('machine').scaleButtonTooltip(`${ this.rke2Ec2ClusterName }-pool1`, 'minus')
+      .waitForTooltipWithText('Scale Pool Down');
+    clusterDetails.poolsList('machine').scaleButtonTooltip(`${ this.rke2Ec2ClusterName }-pool1`, 'minus')
+      .hideTooltip();
+
+    cy.intercept('PUT', ` /v1/provisioning.cattle.io.clusters/fleet-default/${ this.rke2Ec2ClusterName }`).as('scaleUpMachineDeployment');
+    // Scale up the machine pool
+    clusterDetails.poolsList('machine').scaleUpButton(`${ this.rke2Ec2ClusterName }-pool1`)
+      .click();
+
+    cy.wait('@scaleUpMachineDeployment').its('response.statusCode').should('eq', 200);
+
+    // Verify the machine pool is scaled up to 2
+    clusterDetails.poolsList('machine').machinePoolCount(`${ this.rke2Ec2ClusterName }-pool1`, /^2$/, VERY_LONG_TIMEOUT_OPT);
+    clusterDetails.poolsList('machine').resourceTable().sortableTable().checkRowCount(false, 2, LONG_TIMEOUT_OPT);
+
+    // Verify the scale down button is now enabled (since we have 2 nodes)
+    clusterDetails.poolsList('machine').scaleDownButton(`${ this.rke2Ec2ClusterName }-pool1`)
+      .should('be.enabled');
+
+    // Verify the cluster is active
+    clusterDetails.resourceDetail().masthead().resourceStatus().contains('Active', VERY_LONG_TIMEOUT_OPT);
+    clusterDetails.poolsList('machine').resourceTable().sortableTable().checkRowCount(false, 2, MEDIUM_TIMEOUT_OPT);
+  });
+
+  it('can scale down a machine pool', function() {
+    // testing https://github.com/rancher/dashboard/issues/13285
+    // Set user preference to ensure the scale down confirmation modal always appears
+    cy.setUserPreference({ 'scale-pool-prompt': false });
+
+    const clusterDetails = new ClusterManagerDetailRke2AmazonEc2PagePo(undefined, this.rke2Ec2ClusterName);
+
+    ClusterManagerListPagePo.navTo();
+    clusterList.waitForPage();
+
+    // Navigate to cluster details page > machine pools
+    clusterList.list().name(this.rke2Ec2ClusterName).click();
+    clusterDetails.waitForPage(null, 'machine-pools');
+    clusterDetails.resourceDetail().title().should('contain', this.rke2Ec2ClusterName);
+
+    // Verify we have 2 nodes to start with (from the previous scale up test)
+    clusterDetails.poolsList('machine').resourceTable().sortableTable().groupByButtons(1)
+      .click();
+
+    clusterDetails.poolsList('machine').machinePoolCount(`${ this.rke2Ec2ClusterName }-pool1`, 2, MEDIUM_TIMEOUT_OPT);
+
+    // Verify the scale down button is enabled
+    clusterDetails.poolsList('machine').scaleDownButton(`${ this.rke2Ec2ClusterName }-pool1`)
+      .should('be.visible')
+      .and('be.enabled');
+
+    cy.intercept('PUT', `/v1/provisioning.cattle.io.clusters/fleet-default/${ this.rke2Ec2ClusterName }`).as('scaleDownMachineDeployment');
+
+    // Scale down the machine pool
+    clusterDetails.poolsList('machine').scaleDownButton(`${ this.rke2Ec2ClusterName }-pool1`)
+      .click();
+
+    // Handle the scale down confirmation dialog
+    promptModal().getBody().should('contain', 'You are attempting to delete the MachineDeployment');
+    promptModal().getBody().should('contain', `${ this.rke2Ec2ClusterName }-pool1`);
+    promptModal().clickActionButton('Confirm');
+
+    cy.wait('@scaleDownMachineDeployment').its('response.statusCode').should('eq', 200);
+
+    // Verify the machine pool is scaled down to 1
+    clusterDetails.poolsList('machine').machinePoolCount(`${ this.rke2Ec2ClusterName }-pool1`, /^1$/, MEDIUM_TIMEOUT_OPT);
+
+    // Verify the cluster is updating -> active
+    clusterDetails.resourceDetail().masthead().resourceStatus().contains('Updating');
+    clusterDetails.resourceDetail().masthead().resourceStatus().contains('Active', VERY_LONG_TIMEOUT_OPT);
+    clusterDetails.poolsList('machine').resourceTable().sortableTable().checkRowCount(false, 1, VERY_LONG_TIMEOUT_OPT);
+
+    // Verify the scale down button is now disabled (can't scale below 1)
+    clusterDetails.poolsList('machine').scaleDownButton(`${ this.rke2Ec2ClusterName }-pool1`)
+      .should('be.disabled');
   });
 
   it('can delete an Amazon EC2 RKE2 cluster', function() {
@@ -293,5 +404,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { testIsolation:
       //  delete cloud cred
       cy.deleteRancherResource('v3', 'cloudCredentials', cloudcredentialId);
     }
+
+    cy.setUserPreference({ 'scale-pool-prompt': null });
   });
 });

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-azure-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-azure-rke2.spec.ts
@@ -5,7 +5,7 @@ import ClusterManagerDetailRke2AzurePagePo from '@/cypress/e2e/po/detail/provisi
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import LoadingPo from '@/cypress/e2e/po/components/loading.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
-import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import { MEDIUM_TIMEOUT_OPT, VERY_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 
 // will only run this in jenkins pipeline where cloud credentials are stored
 describe('Deploy RKE2 cluster using node driver on Azure', { testIsolation: 'off', tags: ['@manager', '@adminUser', '@standardUser', '@jenkins'] }, () => {
@@ -170,7 +170,7 @@ describe('Deploy RKE2 cluster using node driver on Azure', { testIsolation: 'off
 
     // check states
     clusterList.list().state(this.rke2AzureClusterName).should('contain.text', 'Updating');
-    clusterList.list().state(this.rke2AzureClusterName).contains('Active', { timeout: 700000 });
+    clusterList.list().state(this.rke2AzureClusterName).contains('Active', VERY_LONG_TIMEOUT_OPT);
 
     // check k8s version
     clusterList.list().version(this.rke2AzureClusterName).then((el) => {
@@ -196,7 +196,7 @@ describe('Deploy RKE2 cluster using node driver on Azure', { testIsolation: 'off
     clusterList.list().name(this.rke2AzureClusterName).click();
     clusterDetails.waitForPage(null, 'machine-pools');
     clusterDetails.resourceDetail().title().should('contain', this.rke2AzureClusterName);
-    clusterDetails.machinePoolsList().details(`${ this.rke2AzureClusterName }-pool1-`, 1).should('contain', 'Running');
+    clusterDetails.poolsList('machine').details(`${ this.rke2AzureClusterName }-pool1-`, 1).should('contain', 'Running');
 
     // check cluster details page > recent events
     ClusterManagerListPagePo.navTo();
@@ -228,7 +228,7 @@ describe('Deploy RKE2 cluster using node driver on Azure', { testIsolation: 'off
     ClusterManagerListPagePo.navTo();
     clusterList.waitForPage();
     clusterList.list().state(this.rke2AzureClusterName).should('contain.text', 'Updating');
-    clusterList.list().state(this.rke2AzureClusterName).contains('Active', { timeout: 700000 });
+    clusterList.list().state(this.rke2AzureClusterName).contains('Active', VERY_LONG_TIMEOUT_OPT);
 
     // check snapshot exist
     clusterList.goToDetailsPage(this.rke2AzureClusterName, '.cluster-link a');

--- a/cypress/support/utils/timeouts.ts
+++ b/cypress/support/utils/timeouts.ts
@@ -17,3 +17,5 @@ export const RESTART_TIMEOUT_OPT = { timeout: 120000 };
  * Medium timeout to use when a test requires a little longer for something to change in the UI
  */
 export const MEDIUM_TIMEOUT_OPT = { timeout: 30000 };
+
+export const VERY_LONG_TIMEOUT_OPT = { timeout: 700000 };

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -893,6 +893,7 @@ export default {
                         :disabled="!group.ref.canScaleDownPool()"
                         type="button"
                         class="btn btn-sm role-secondary"
+                        data-testid="scale-down-button"
                         @click="toggleScaleDownModal($event, group.ref)"
                       >
                         <i class="icon icon-sm icon-minus" />
@@ -902,6 +903,7 @@ export default {
                         :disabled="!group.ref.canScaleUpPool()"
                         type="button"
                         class="btn btn-sm role-secondary ml-10"
+                        data-testid="scale-up-button"
                         @click="group.ref.scalePool(1)"
                       >
                         <i class="icon icon-sm icon-plus" />


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/1756

- Adds e2e coverage for scaling RKE2 Amazon EC2 machine pools - scale up/down, tooltip checks, row counts, active state.
- Fixes create/upgrade tests - Fixed flakiness caused by Kubernetes version mismatches by reading versions directly from the UI dropdown instead of the API.

<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="394" height="134" alt="image" src="https://github.com/user-attachments/assets/14167e9a-b762-4dbf-9d09-5eea474789f0" />


<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
