### PR TITLE
[2.13.1] Added changes required to display hosted providers from exte…

### DIFF
--- a/shell/core/extension-manager-impl.js
+++ b/shell/core/extension-manager-impl.js
@@ -35,11 +35,11 @@ const createExtensionManager = (context) => {
    */
   function instantiateModelExtension($plugin, clz) {
     const context = {
-      dispatch: store.dispatch,
-      getters:  store.getters,
-      t:        store.getters['i18n/t'],
-      $axios,
-      $plugin,
+      dispatch:   store.dispatch,
+      getters:    store.getters,
+      t:          store.getters['i18n/t'],
+      $extension: $plugin,
+      $axios
     };
 
     return new clz(context);
@@ -455,7 +455,13 @@ const createExtensionManager = (context) => {
         try {
           const provisioner = context.$extension.getDynamic('provisioner', name);
 
-          return new provisioner({ ...context });
+          const defaults = {
+            isCreate: false,
+            isEdit:   false,
+            isView:   false
+          };
+
+          return new provisioner({ ...defaults, ...context });
         } catch (e) {
           console.error('Error loading provisioner(s) from extensions', e); // eslint-disable-line no-console
         }

--- a/shell/core/types-provisioning.ts
+++ b/shell/core/types-provisioning.ts
@@ -63,7 +63,7 @@ export interface ClusterProvisionerContext {
   /**
    * Definition of the extension
    */
-  $plugin: any,
+  $extension: any,
   /**
    * Function to retrieve a localised string
    */

--- a/shell/models/__tests__/provisioning.cattle.io.cluster.test.ts
+++ b/shell/models/__tests__/provisioning.cattle.io.cluster.test.ts
@@ -1,24 +1,29 @@
 import ProvCluster from '@shell/models/provisioning.cattle.io.cluster';
+jest.mock('@shell/utils/provider', () => ({
+  isHostedProvider: jest.fn().mockImplementation((context, provider) => {
+    return ['GKE', 'EKS', 'AKS'].includes(provider);
+  })
+}));
 
 describe('class ProvCluster', () => {
   const gkeClusterWithPrivateEndpoint = {
     clusterName: 'test',
     provisioner: 'GKE',
-    spec:        { rkeConfig: {} },
+    spec:        { },
     mgmt:        { spec: { gkeConfig: { privateClusterConfig: { enablePrivateEndpoint: true } } } }
   };
 
   const eksClusterWithPrivateEndpoint = {
     clusterName: 'test',
     provisioner: 'EKS',
-    spec:        { rkeConfig: {} },
+    spec:        {},
     mgmt:        { spec: { eksConfig: { privateAccess: true } } }
   };
 
   const aksClusterWithPrivateEndpoint = {
     clusterName: 'test',
     provisioner: 'AKS',
-    spec:        { rkeConfig: {} },
+    spec:        {},
     mgmt:        { spec: { aksConfig: { privateCluster: true } } }
   };
 
@@ -44,13 +49,115 @@ describe('class ProvCluster', () => {
         clusterData.provisioner
       );
 
-      expect(cluster.isRke2).toBe(expected);
+      expect(cluster.isRke2).toBe(false);
       expect(cluster.isHostedKubernetesProvider).toBe(expected);
       expect(cluster.isPrivateHostedProvider).toBe(expected);
       resetMocks();
     });
   });
+  describe('isImported', () => {
+    const testCases = [
+      {
+        description: 'should return false for a local cluster',
+        clusterData: { isLocal: true },
+        expected:    false
+      },
+      {
+        description: 'should return true for an imported k3s cluster',
+        clusterData: {
+          isLocal: false,
+          mgmt:    { status: { provider: 'k3s', driver: 'k3s' } }
+        },
+        expected: true
+      },
+      {
+        description: 'should return false for a provisioned k3s cluster',
+        clusterData: {
+          isLocal: false,
+          mgmt:    { status: { provider: 'k3s', driver: 'imported' } }
+        },
+        expected: false
+      },
+      {
+        description: 'should return true for an imported rke2 cluster',
+        clusterData: {
+          isLocal: false,
+          mgmt:    { status: { provider: 'rke2', driver: 'rke2' } }
+        },
+        expected: true
+      },
+      {
+        description: 'should return false for a provisioned rke2 cluster',
+        clusterData: {
+          isLocal: false,
+          mgmt:    { status: { provider: 'rke2', driver: 'imported' } }
+        },
+        expected: false
+      },
+      {
+        description: 'should return true for an imported hosted cluster',
+        clusterData: {
+          isLocal:                    false,
+          isHostedKubernetesProvider: true,
+          providerConfig:             { imported: true }
+        },
+        expected: true
+      },
+      {
+        description: 'should return false for a provisioned hosted cluster',
+        clusterData: {
+          isLocal:                    false,
+          isHostedKubernetesProvider: true,
+          providerConfig:             { imported: false }
+        },
+        expected: false
+      },
+      {
+        description: 'should return true for a generic imported cluster',
+        clusterData: {
+          isLocal:     false,
+          provisioner: 'imported'
+        },
+        expected: true
+      },
+      {
+        description: 'should return false for a generic provisioned cluster',
+        clusterData: {
+          isLocal:     false,
+          provisioner: 'rke2'
+        },
+        expected: false
+      }
+    ];
+    const resetMocks = () => {
+      // Clear all mock function calls:
+      jest.clearAllMocks();
+    };
 
+    it.each(testCases)('$description', ({ clusterData, expected }) => {
+      const cluster = new ProvCluster({});
+
+      // Mock getters
+      jest.spyOn(cluster, 'mgmt', 'get').mockReturnValue(
+        clusterData.mgmt
+      );
+      if (clusterData.isLocal !== undefined) {
+        jest.spyOn(cluster, 'isLocal', 'get').mockReturnValue(clusterData.isLocal);
+      }
+      if (clusterData.isHostedKubernetesProvider !== undefined) {
+        jest.spyOn(cluster, 'isHostedKubernetesProvider', 'get').mockReturnValue(clusterData.isHostedKubernetesProvider);
+      }
+      if (clusterData.providerConfig !== undefined) {
+        jest.spyOn(cluster, 'providerConfig', 'get').mockReturnValue(clusterData.providerConfig);
+      }
+      if (clusterData.provisioner !== undefined) {
+        jest.spyOn(cluster, 'provisioner', 'get').mockReturnValue(clusterData.provisioner);
+      }
+
+      expect(cluster.isImported).toBe(expected);
+      resetMocks();
+    });
+  });
   describe('hasError', () => {
     const conditionsWithoutError = [
       {

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -15,6 +15,7 @@ import { LINUX, WINDOWS } from '@shell/store/catalog';
 import { KONTAINER_TO_DRIVER } from './management.cattle.io.kontainerdriver';
 import { PINNED_CLUSTERS } from '@shell/store/prefs';
 import { copyTextToClipboard } from '@shell/utils/clipboard';
+import { isHostedProvider } from '@shell/utils/provider';
 
 const DEFAULT_BADGE_COLOR = '#707070';
 
@@ -171,9 +172,20 @@ export default class MgmtCluster extends SteveModel {
     return this.isCondition('Ready');
   }
 
+  get config() {
+    if (!this.spec?.[`${ this.provisioner }Config`]) {
+      const allKeys = Object.keys(this.spec);
+      const configKey = allKeys.find( (k) => k.endsWith('Config'));
+
+      return this.spec[configKey];
+    }
+
+    return this.spec?.[`${ this.provisioner }Config`];
+  }
+
   get kubernetesVersionRaw() {
     const fromStatus = this.status?.version?.gitVersion;
-    const fromSpec = this.spec?.[`${ this.provisioner }Config`]?.kubernetesVersion;
+    const fromSpec = this.config?.kubernetesVersion;
 
     return fromStatus || fromSpec;
   }
@@ -239,9 +251,15 @@ export default class MgmtCluster extends SteveModel {
   }
 
   get isHostedKubernetesProvider() {
-    const providers = ['AKS', 'EKS', 'GKE'];
+    const context = {
+      dispatch:   this.$dispatch,
+      getters:    this.$getters,
+      axios:      this.$axios,
+      $extension: this.$plugin,
+      t:          (...args) => this.t.apply(this, args),
+    };
 
-    return providers.includes(this.provisioner);
+    return isHostedProvider(context, this.provisioner);
   }
 
   get providerLogo() {

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -16,7 +16,7 @@ import jsyaml from 'js-yaml';
 import { defineAsyncComponent, markRaw } from 'vue';
 import stevePaginationUtils from '@shell/plugins/steve/steve-pagination-utils';
 import { PaginationFilterField, PaginationParamFilter } from '@shell/types/store/pagination.types';
-
+import { isHostedProvider } from '@shell/utils/provider';
 const RKE1_ALLOWED_ACTIONS = [
   'promptRemove',
   'openShell',
@@ -272,9 +272,26 @@ export default class ProvCluster extends SteveModel {
   }
 
   get isHostedKubernetesProvider() {
-    const providers = ['AKS', 'EKS', 'GKE'];
+    const context = {
+      dispatch:   this.$dispatch,
+      getters:    this.$getters,
+      axios:      this.$axios,
+      $extension: this.$plugin,
+      t:          (...args) => this.t.apply(this, args),
+    };
 
-    return providers.includes(this.provisioner);
+    return isHostedProvider(context, this.provisioner);
+  }
+
+  get providerConfig() {
+    if ( this.isRke2 ) {
+      return this.spec.rkeConfig;
+    }
+    if (this.mgmt && this.mgmt.config) {
+      return this.mgmt.config;
+    }
+
+    return null;
   }
 
   get isPrivateHostedProvider() {
@@ -314,13 +331,7 @@ export default class ProvCluster extends SteveModel {
 
     // imported KEv2
     // we can't rely on this.provisioner to determine imported-ness for these clusters, as it will return 'aks' 'eks' 'gke' for both provisioned and imported clusters
-    const kontainerConfigs = ['aksConfig', 'eksConfig', 'gkeConfig'];
-
-    const isImportedKontainer = kontainerConfigs.filter((key) => {
-      return this.mgmt?.spec?.[key]?.imported === true;
-    }).length;
-
-    if (isImportedKontainer) {
+    if (this.isHostedKubernetesProvider && !!this.providerConfig.imported) {
       return true;
     }
 

--- a/shell/pages/c/_cluster/explorer/index.vue
+++ b/shell/pages/c/_cluster/explorer/index.vue
@@ -222,7 +222,7 @@ export default {
     displayProvider() {
       const other = 'other';
 
-      let provider = this.currentCluster?.status?.provider || other;
+      let provider = this.currentCluster?.status?.provider || this.currentCluster?.status?.driver.toLowerCase() || other;
 
       if (provider === 'rke.windows') {
         provider = 'rkeWindows';
@@ -484,6 +484,13 @@ export default {
     hasNodes() {
       return this.nodes?.length > 0;
     },
+
+    kubernetesVersion() {
+      const base = this.currentCluster?.kubernetesVersionBase || '';
+      const extension = this.currentCluster?.kubernetesVersionExtension || '';
+
+      return `${ base }${ extension }`;
+    }
   },
 
   methods: {
@@ -661,11 +668,7 @@ export default {
       </div>
       <div data-testid="kubernetesVersion__label">
         <label>{{ t('glance.version') }}: </label>
-        <span>{{ currentCluster.kubernetesVersionBase }}</span>
-        <span
-          v-if="currentCluster.kubernetesVersionExtension"
-          style="font-size: 0.75em"
-        >{{ currentCluster.kubernetesVersionExtension }}</span>
+        <span>{{ kubernetesVersion }}</span>
       </div>
       <div
         v-if="hasNodes"

--- a/shell/pages/c/_cluster/manager/hostedprovider/index.vue
+++ b/shell/pages/c/_cluster/manager/hostedprovider/index.vue
@@ -9,6 +9,7 @@ import RcStatusBadge from '@components/Pill/RcStatusBadge/RcStatusBadge.vue';
 import { exceptionToErrorsArray } from '@shell/utils/error';
 import { isRancherPrime } from '@shell/config/version';
 import { stateDisplay, STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
+import { getHostedProviders } from '@shell/utils/provider';
 
 export default {
   name:       'HostedProviders',
@@ -66,13 +67,10 @@ export default {
         getters:    this.$store.getters,
         axios:      this.$store.$axios,
         $extension: this.$store.app.$extension,
-        t:          (...args) => this.t.apply(this, args),
-        isCreate:   this.isCreate,
-        isEdit:     this.isEdit,
-        isView:     this.isView,
+        t:          (...args) => this.t.apply(this, args)
       };
 
-      return this.$extension.getProviders(context);
+      getHostedProviders(context);
     },
     getSettings() {
       this.settingResource = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.KEV2_OPERATORS );
@@ -107,7 +105,7 @@ export default {
       }
     },
     async generateRows() {
-      this.rows = this.allProviders.filter((p) => p.group === 'hosted').map((p) => {
+      this.rows = this.allProviders.map((p) => {
         const active = p.id in this.settings ? this.settings[p.id] : true;
         const canNotPrime = p.prime && !this.prime;
         const canNotChangeSettings = !this.settingResource?.canUpdate;

--- a/shell/utils/__tests__/provider.test.ts
+++ b/shell/utils/__tests__/provider.test.ts
@@ -1,0 +1,98 @@
+import { getHostedProviders, isHostedProvider } from '../provider';
+import { ClusterProvisionerContext, IClusterProvisioner } from '@shell/core/types';
+
+const DEFAULT_CONTEXT = {
+  dispatch: {},
+  getters:  {},
+  axios:    {},
+  t:        (args: any) => args.join(' '),
+};
+
+const MOCK_PROVIDERS: IClusterProvisioner[] = [
+  { id: 'AKS', group: 'hosted' } as IClusterProvisioner,
+  { id: 'EKS', group: 'hosted' } as IClusterProvisioner,
+  { id: 'GKE', group: 'hosted' } as IClusterProvisioner,
+  { id: 'alibaba', group: 'hosted' } as IClusterProvisioner,
+  { id: 'other', group: 'other' } as IClusterProvisioner,
+];
+
+describe('utils/provider', () => {
+  describe('getHostedProviders', () => {
+    it('should return an empty array when context.$extension is undefined', () => {
+      const context = { ...DEFAULT_CONTEXT } as ClusterProvisionerContext;
+      const result = getHostedProviders(context);
+
+      expect(result).toStrictEqual([]);
+    });
+
+    it('should return hosted providers when context.$extension is defined', () => {
+      const context = {
+        ...DEFAULT_CONTEXT,
+        $extension: { getProviders: jest.fn().mockReturnValue(MOCK_PROVIDERS) }
+      } as unknown as ClusterProvisionerContext;
+
+      const result = getHostedProviders(context);
+
+      expect(result).toStrictEqual([
+        { id: 'AKS', group: 'hosted' },
+        { id: 'EKS', group: 'hosted' },
+        { id: 'GKE', group: 'hosted' },
+        { id: 'alibaba', group: 'hosted' },
+      ]);
+      expect(context.$extension.getProviders).toHaveBeenCalledWith(context);
+    });
+
+    it('should return an empty array if getProviders returns null', () => {
+      const context = {
+        ...DEFAULT_CONTEXT,
+        $extension: { getProviders: jest.fn().mockReturnValue(null) }
+      } as unknown as ClusterProvisionerContext;
+
+      const result = getHostedProviders(context);
+
+      expect(result).toStrictEqual([]);
+    });
+
+    it('should return an empty array if getProviders returns undefined', () => {
+      const context = {
+        ...DEFAULT_CONTEXT,
+        $extension: { getProviders: jest.fn().mockReturnValue(undefined) }
+      } as unknown as ClusterProvisionerContext;
+
+      const result = getHostedProviders(context);
+
+      expect(result).toStrictEqual([]);
+    });
+  });
+
+  describe('isHostedProvider', () => {
+    it('should return false if provisioner is not provided', () => {
+      const context = {
+        ...DEFAULT_CONTEXT,
+        $extension: { getProviders: jest.fn().mockReturnValue(MOCK_PROVIDERS) }
+      } as ClusterProvisionerContext;
+
+      expect(isHostedProvider(context, '')).toBe(false);
+      expect(isHostedProvider(context, undefined as any)).toBe(false);
+      expect(isHostedProvider(context, null as any)).toBe(false);
+    });
+
+    it('should return true only if provisioner is in the list of hosted providers', () => {
+      const context = {
+        ...DEFAULT_CONTEXT,
+        $extension: { getProviders: jest.fn().mockReturnValue(MOCK_PROVIDERS) }
+      } as ClusterProvisionerContext;
+
+      expect(isHostedProvider(context, 'AKS')).toBe(true);
+      expect(isHostedProvider(context, 'eks')).toBe(true);
+      expect(isHostedProvider(context, 'different')).toBe(false); // case-insensitive check
+      expect(isHostedProvider(context, 'other')).toBe(false); // case-insensitive check
+    });
+
+    it('should return false if there are no hosted providers', () => {
+      const context = { ...DEFAULT_CONTEXT, $extension: { getProviders: jest.fn().mockReturnValue([]) } } as ClusterProvisionerContext;
+
+      expect(isHostedProvider(context, 'prov1')).toBe(false);
+    });
+  });
+});

--- a/shell/utils/provider.ts
+++ b/shell/utils/provider.ts
@@ -1,0 +1,14 @@
+import { IClusterProvisioner, ClusterProvisionerContext } from '@shell/core/types';
+
+export function getHostedProviders(context: ClusterProvisionerContext) {
+  return context?.$extension?.getProviders(context)?.filter((p: IClusterProvisioner) => p.group === 'hosted') || [];
+}
+
+export function isHostedProvider(context: ClusterProvisionerContext, provisioner: string) {
+  if (!provisioner) {
+    return false;
+  }
+  const provisioners = new Set(getHostedProviders(context).map((p: IClusterProvisioner) => p.id.toLowerCase()));
+
+  return provisioners.has(provisioner.toLowerCase());
+}


### PR DESCRIPTION
…nsions

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16132 
<!-- Define findings related to the feature or bug issue. -->
Backport of https://github.com/rancher/dashboard/pull/16007

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Changed our model to get the list of hosted providers from extensions, instead of a hardcoded list
Fixed issues identified as part of alibaba testing:
in Cluster Explorer:

The Provider field is displayed as “Other” instead of “Alibaba Cloud.”
The Kubernetes version string shows inconsistent font size and spacing. The suffix aliyun.1 appears in a smaller font or different font face, and there is an extra space before the hyphen in the version — displayed as
Kubernetes Version: v1.34.1 -aliyun.1.
For Imported cluster:
On Cluster Management page cluster provider should be Imported for imported clusters, but it's missing

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested (please message me to get it setup)
Run as prime
Install Alibaba extension
Provision a new Alibaba cluster -> once provisioned -> Explore -> Provider should be shown as Alibaba Cloud, Kubernetes version should be one string of the same font
Import an existing Alibaba cluster -> on Cluster Management it should be identified as Imported Alibaba Cloud

###Areas which could experience regressions
No changes for existing built-in functionality should be visible, other than the K8s version.

This could affect other providers. We should validate that we still correctly identify at least one of each type of provisioned and imported clusters.
Hosted providers page could be affected by some minor changes, so we should check that it still loads
Clusters made of private hosted providers could be affected, we should check that we still identify them correctly.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
