### PR TITLE
Improve type generation of the i18n plugin

### DIFF
--- a/shell/composables/useI18n.ts
+++ b/shell/composables/useI18n.ts
@@ -11,7 +11,16 @@ let store: Store<any> | null = null;
  * @returns A translated string or the raw value if the raw parameter is set to true.
  */
 const t = (key: string, args?: unknown, raw?: boolean): string => {
-  return stringFor(store, key, args, raw);
+  if (!store) {
+    if (!!process.env.dev) {
+      // eslint-disable-next-line no-console
+      console.warn('useI18n: store not available');
+    }
+
+    return key;
+  }
+
+  return stringFor(store, key, args as any, raw);
 };
 
 export type I18n = { t: typeof t };

--- a/shell/package.json
+++ b/shell/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "author": "SUSE",
   "private": false,
+  "types": "types/shell/index.d.ts",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/shell/plugins/i18n.js
+++ b/shell/plugins/i18n.js
@@ -3,6 +3,14 @@ import { escapeHtml } from '../utils/string';
 import { watchEffect, ref, h } from 'vue';
 import { useStore } from 'vuex';
 
+/**
+ * @param {import('vuex').Store<any>} store
+ * @param {string} key
+ * @param {Record<string, any>} [args]
+ * @param {boolean} [raw]
+ * @param {boolean} [escapehtml]
+ * @returns {string}
+ */
 export function stringFor(store, key, args, raw = false, escapehtml = true) {
   const translation = store.getters['i18n/t'](key, args);
 

--- a/shell/scripts/typegen.sh
+++ b/shell/scripts/typegen.sh
@@ -29,6 +29,7 @@ ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/store/prefs.js --declaration --al
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/store/plugins.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/store > /dev/null
 
 # # plugins
+${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/plugins/i18n.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/ > /dev/null
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/plugins/dashboard-store/normalize.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/plugins/dashboard-store/ > /dev/null
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/plugins/dashboard-store/resource-class.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/plugins/dashboard-store/ > /dev/null
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/plugins/dashboard-store/classify.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/plugins/dashboard-store/ > /dev/null


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This updates the Rancher Shell type generation to include the i18n plugin.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add the i18n plugin to the typegen script
- Annotate `stringFor()` with a dostring to include types
- Fix typescript warnings in the `t()` function of `useI18n`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Kubewarden UI will fail with the following error when updating to the latest versions of `@rancher/shell`:

```
  ERROR in node_modules/@rancher/shell/composables/useI18n.ts:3:27
  TS7016: Could not find a declaration file for module '@shell/plugins/i18n'.
  '/home/phillip/Development/kubewarden-ui/node_modules/@rancher/shell/plugins/i18n.j
  s' implicitly has an 'any' type.
    If the '@rancher/shell' package actually exposes this module, try adding a new
  declaration (.d.ts) file containing `declare module '@shell/plugins/i18n';`
      1 | import { Store } from 'vuex';
      2 |
    > 3 | import { stringFor } from '@shell/plugins/i18n';
        |                           ^^^^^^^^^^^^^^^^^^^^^
      4 |
      5 | let store: Store<any> | null = null;
      6 | /**
```

This issue appears to be isolated to Kubewarden, but the root cause can be linked to kubewarden depending on later versions of typescript than shell and other extensions, so this failure could be linked to better type checking overall. 

There's also a risk that we will encounter these issues for other extensions in the future as we update dependencies in shell.

After updating the types for the i18n plugin, we received a new typescript warning:

```
ERROR in node_modules/@rancher/shell/composables/useI18n.ts:14:20
  TS2345: Argument of type 'Store<any> | null' is not assignable to parameter of type
  'Store<any>'.
    Type 'null' is not assignable to type 'Store<any>'.
      12 |  */
      13 | const t = (key: string, args?: unknown, raw?: boolean): string => {
    > 14 |   return stringFor(store, key, args, raw);
         |                    ^^^^^
      15 | };
      16 |
      17 | export type I18n = { t: typeof t };
```

I added some guards to ensure that the store is available before invoking `stringFor()`.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Publish an updated versions of shell to a local registry or link the package. Kubewarden should no longer show type errors. 

We will want to test with a few other extensions, but that should be covered by CI.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This adds better type support for the i18n plugin. Other extensions might rely on ill defined types and will need to updated accordingly to support the change. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
