### PR TITLE
fix(workload): clear nodeName when resetting node scheduling

### DIFF
--- a/shell/components/form/NodeScheduling.vue
+++ b/shell/components/form/NodeScheduling.vue
@@ -181,7 +181,7 @@ export default {
         :options="selectNodeOptions"
         :mode="mode"
         :data-testid="'node-scheduling-selectNode'"
-        @input="update"
+        @update:value="update"
       />
     </div>
     <template v-if="selectNode === 'nodeSelector'">
@@ -205,7 +205,7 @@ export default {
         v-model:value="nodeAffinity"
         :mode="mode"
         :data-testid="'node-scheduling-nodeAffinity'"
-        @input="update"
+        @update:value="update"
       />
     </template>
   </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/16126


### Occurred changes and/or fixed issues
The component emits update:value, not input, so @update:value works and @input doesn’t.

### To Reproduce
  1. Log in to Rancher
  2. Navigate to a cluster and open Workloads.
  3. Create or edit a Deployment/Workload.
  4. In the Node Scheduling section, select “Run pods on any available node” and save the workload.
  5. Edit the same workload again and change Node Scheduling to “Run pods on specific nodes”, select a node, and save.
  6. Edit the workload one more time and try to change Node Scheduling back to “Run pods on any available node” via the UI.

### Screenshot/Video

![Jietu20251204-下午25628-HD 2](https://github.com/user-attachments/assets/7c468408-51a4-47f0-ad03-898b074e0c87)



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
