### PR TITLE
fix(workload): force refetch of worload pods everytime

### DIFF
--- a/shell/detail/workload/index.vue
+++ b/shell/detail/workload/index.vue
@@ -54,7 +54,7 @@ export default {
     };
 
     if (this.podSchema) {
-      hash.pods = this.value.fetchPods();
+      hash.pods = await this.value.fetchPods(true);
     }
 
     if (this.serviceSchema) {

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -553,7 +553,7 @@ export default class Workload extends WorkloadService {
     }
   }
 
-  async fetchPods() {
+  async fetchPods(force = false) {
     if (this.podMatchExpression) {
       return this.$dispatch('findLabelSelector', {
         type:     POD,
@@ -561,6 +561,7 @@ export default class Workload extends WorkloadService {
           namespace:     this.metadata.namespace,
           labelSelector: { matchExpressions: this.podMatchExpression },
         },
+        force, //forces the store to refetch
       });
     }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/16131
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
added a force refetch on fetchPods() and a await call when calling fetchPods()

**To Reproduce**
<!--Steps to reproduce the behavior-->
1.  Navigate to Workloads
2. Click on Deployments
3. Select a Deployment
4. Browser back
5. Select the same deployment

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
