### PR TITLE
Fix: Handle undefined metrics in HPA detail view

### DIFF
--- a/shell/detail/autoscaling.horizontalpodautoscaler/index.vue
+++ b/shell/detail/autoscaling.horizontalpodautoscaler/index.vue
@@ -52,9 +52,9 @@ export default {
         // The format is different between 'Resource' metrics and others.
         // See for examples: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#appendix-horizontal-pod-autoscaler-status-conditions
         if (metricType !== 'resource') {
-          currentMatch = findBy(currentMetrics, `${ metricType }.metric.name`, metricValue.metric.name);
+          currentMatch = findBy(currentMetrics, `${ metricType }.metric.name`, metricValue?.metric?.name);
         } else {
-          currentMatch = findBy(currentMetrics, 'resource.name', metric.resource.name);
+          currentMatch = findBy(currentMetrics, 'resource.name', metric.resource?.name);
         }
 
         const current = currentMatch ? get(currentMatch, `${ camelCase(metric.type) }.current`) : null;


### PR DESCRIPTION
### Summary
  Fixes rancher/dashboard#16171

  ### Occurred changes and/or fixed issues
  When viewing an HPA (Horizontal Pod Autoscaler) with custom metrics (Pods, External, or Object types), the dashboard throws a TypeError and displays nothing. Users must resort to using `kubectl describe hpa` to see the metrics.

  **Root Cause:**
  The `mappedMetrics` computed property in the HPA detail view attempts to access nested properties (`metricValue.metric.name` and `metric.resource.name`) without null/undefined checks. When the API returns a metric with a `type` field but missing the corresponding nested property, accessing `.name` throws:
  TypeError: Cannot read properties of undefined (reading 'name')

  **Changes Made:**
  - Added optional chaining to `metricValue?.metric?.name` at line 55 (custom metrics)
  - Added optional chaining to `metric.resource?.name` at line 57 (resource metrics)
  - Added test suite "with malformed metrics" to validate graceful handling
  - Tests ensure no TypeError is thrown and null values are handled correctly

  ### Technical notes summary
  The fix uses optional chaining (`?.`) to safely access nested properties, following the existing pattern already used at line 72 in the same file (`metricValue?.metric?.name ?? null`). This is a minimal, defensive coding approach that:
  - Maintains backward compatibility with valid metrics
  - Gracefully handles malformed or incomplete metric data
  - Follows established patterns in the codebase
  - Has no performance impact (optional chaining is syntactic sugar)

  ### Areas or cases that should be tested
  Manual testing:
  1. View an HPA with custom Pods metrics
  2. View an HPA with External metrics (e.g., from Prometheus)
  3. View an HPA with Object metrics
  4. View an HPA with standard Resource metrics (CPU/Memory)
  5. View an HPA with mixed metric types
  6. Verify browser console shows no errors
  7. Verify metrics display correctly (or show null gracefully if malformed)

  Automated testing:
  - Unit tests added for malformed metrics scenarios
  - Existing tests verify valid metrics still work correctly

  ### Areas which could experience regressions
  - HPA detail page metric rendering (`/shell/detail/autoscaling.horizontalpodautoscaler/index.vue`)
  - HPA list view display
  - Other components that consume HPA metric data (unlikely, as this is view-only)

  ### Screenshot/Video
  Not applicable - this is a JavaScript error fix with no UI changes. The UI behavior remains the same for valid metrics and now gracefully handles invalid data.

  ### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`