### PR TITLE
Fix update-count warning

### DIFF
--- a/shell/components/form/ResourceTabs/composable.ts
+++ b/shell/components/form/ResourceTabs/composable.ts
@@ -39,10 +39,10 @@ export const useTabCountWatcher = () => {
 
 export const useTabCountUpdater = () => {
   const tabKey = randomStr();
-  const updateCount = inject<UpdateCountFn>(UPDATE_COUNT_PROVIDER_KEY);
+  const updateCount = inject<UpdateCountFn>(UPDATE_COUNT_PROVIDER_KEY, () => { });
 
   const updateTabCount = (count: number | undefined) => {
-    updateCount?.(tabKey, count);
+    updateCount(tabKey, count);
   };
 
   const clearTabCount = () => updateTabCount(undefined);


### PR DESCRIPTION
### Summary
fixes #16196
<!-- Define findings related to the feature or bug issue. -->

### Technical notes summary
Providing a default eliminates the warning. In the case we provide a noop default function.

### Areas or cases that should be tested
The /home page shouldn't emit the warning anymore and a defail page should still show tab counts properly.

### Areas which could experience regressions
See above

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
