### PR TITLE
[15961][fleet] Added option to create user id same as the gitops

### DIFF
--- a/shell/edit/__tests__/fleet.cattle.io.helmop.test.ts
+++ b/shell/edit/__tests__/fleet.cattle.io.helmop.test.ts
@@ -100,6 +100,49 @@ describe('view: fleet.cattle.io.helmop, mode: view', () => {
   });
 });
 
+describe('helmOp component lifecycle', () => {
+  it('should have registerBeforeHook method available and call updateBeforeSave', () => {
+    const helmOpOptions = {
+      metadata: {
+        name:      'test-helmop',
+        namespace: 'test-namespace',
+        labels:    {}
+      }
+    };
+
+    const wrapper = mount(HelmOpComponent, initHelmOp({ mode: _CREATE }, helmOpOptions));
+
+    // Mock registerBeforeHook to spy on calls
+    const mockRegisterBeforeHook = jest.fn();
+
+    wrapper.vm.registerBeforeHook = mockRegisterBeforeHook;
+
+    // Verify updateBeforeSave method exists
+    expect(typeof wrapper.vm.updateBeforeSave).toBe('function');
+
+    // Call the method that would be called during created lifecycle
+    wrapper.vm.registerBeforeHook(wrapper.vm.updateBeforeSave);
+
+    // Verify that registerBeforeHook was called with updateBeforeSave function
+    expect(mockRegisterBeforeHook).toHaveBeenCalledWith(wrapper.vm.updateBeforeSave);
+  });
+
+  it('should have doCreateSecrets method available for registerBeforeHook', () => {
+    const helmOpOptions = {
+      metadata: {
+        name:      'test-helmop',
+        namespace: 'test-namespace',
+        labels:    {}
+      }
+    };
+
+    const wrapper = mount(HelmOpComponent, initHelmOp({ mode: _CREATE }, helmOpOptions));
+
+    // Verify doCreateSecrets method exists
+    expect(typeof wrapper.vm.doCreateSecrets).toBe('function');
+  });
+});
+
 describe.each([
   _CREATE,
   _EDIT,
@@ -262,4 +305,58 @@ describe.each([
 
     expect(wrapper.vm.value.spec.downstreamResources).toStrictEqual([{ name: 'configMap2', kind: 'ConfigMap' }, { name: 'configMap3', kind: 'ConfigMap' }]);
   });
+
+  if (mode === _CREATE) {
+    it('should set created-by-user-id label when updateBeforeSave is called in CREATE mode', () => {
+      const mockCurrentUser = { id: 'user-123' };
+      const helmOpOptions = {
+        metadata: {
+          name:      'test-helmop',
+          namespace: 'test-namespace',
+          labels:    {}
+        }
+      };
+      const wrapper = mount(HelmOpComponent, initHelmOp({ mode, realMode: mode }, helmOpOptions));
+
+      // Ensure metadata.labels exists
+      if (!wrapper.vm.value.metadata.labels) {
+        wrapper.vm.value.metadata.labels = {};
+      }
+
+      // Mock the currentUser
+      (wrapper.vm as any).currentUser = mockCurrentUser;
+
+      // Call updateBeforeSave method
+      wrapper.vm.updateBeforeSave();
+
+      // Should set the created-by-user-id label in CREATE mode
+      expect(wrapper.vm.value.metadata.labels['fleet.cattle.io/created-by-user-id']).toBe('user-123');
+    });
+  } else {
+    it('should not set created-by-user-id label when updateBeforeSave is called in EDIT mode', () => {
+      const mockCurrentUser = { id: 'user-123' };
+      const helmOpOptions = {
+        metadata: {
+          name:      'test-helmop',
+          namespace: 'test-namespace',
+          labels:    {}
+        }
+      };
+      const wrapper = mount(HelmOpComponent, initHelmOp({ mode, realMode: mode }, helmOpOptions));
+
+      // Ensure metadata.labels exists
+      if (!wrapper.vm.value.metadata.labels) {
+        wrapper.vm.value.metadata.labels = {};
+      }
+
+      // Mock the currentUser
+      (wrapper.vm as any).currentUser = mockCurrentUser;
+
+      // Call updateBeforeSave method
+      wrapper.vm.updateBeforeSave();
+
+      // Should not set the label in EDIT mode
+      expect(wrapper.vm.value.metadata.labels['fleet.cattle.io/created-by-user-id']).toBeUndefined();
+    });
+  }
 });

--- a/shell/edit/fleet.cattle.io.helmop.vue
+++ b/shell/edit/fleet.cattle.io.helmop.vue
@@ -80,6 +80,7 @@ export default {
         type:        CONFIG_MAP
       }
     }, this.$store);
+    this.currentUser = await this.value.getCurrentUser();
   },
 
   data() {
@@ -405,6 +406,10 @@ export default {
 
     updateBeforeSave() {
       this.value.spec['correctDrift'] = { enabled: this.correctDriftEnabled };
+
+      if (this.mode === _CREATE) {
+        this.value.metadata.labels[FLEET_LABELS.CREATED_BY_USER_ID] = this.currentUser.id;
+      }
     },
 
     durationSeconds(value) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15961
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Copied implementation from gitops to helmops

**shell/edit/fleet.cattle.io.helmop.vue** - Changed just the registerBeforeHook and added the condition to only execute whenever is created to add the current user id
**shell/edit/__tests__/fleet.cattle.io.helmop.test.ts** - Added new tests to verify the integrity of the registerBeforeHook and the function as well that has been created, specially to see if _EDIT and _CREATE is properly separated

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- Copied same functionality from gitops
- Make sure the data doesnt change on edit, specially for new users
- Make sure the data is added correctly on creation

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Only HELMOPS is affected for any cases
- Nothing on the screen to show the information, just data

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Only HELMOPS is affected
- Regression could happen for places where the data is used and not mapped properly

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
PDF with the Test Cases and screenshot
Test Cases 15961.pdf

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
