### PR TITLE
Removing the defineEmits/Props from imports and removed defineEmits fom non-setup locations.

### DIFF
--- a/pkg/rancher-components/src/components/RcDropdown/useDropdownContext.ts
+++ b/pkg/rancher-components/src/components/RcDropdown/useDropdownContext.ts
@@ -1,8 +1,6 @@
-import { ref, provide, nextTick, defineEmits } from 'vue';
+import { ref, provide, nextTick, EmitFn } from 'vue';
 import { useDropdownCollection } from './useDropdownCollection';
 import { RcButtonType } from '@components/RcButton';
-
-const rcDropdownEmits = defineEmits(['update:open']);
 
 /**
  * Composable that provides the context for a dropdown menu. Includes methods
@@ -13,7 +11,7 @@ const rcDropdownEmits = defineEmits(['update:open']);
  * @returns Dropdown context methods and state. Used for programmatic
  * interactions and setting focus.
  */
-export const useDropdownContext = (emit: typeof rcDropdownEmits) => {
+export const useDropdownContext = (emit: EmitFn<['update:open']>) => {
   const {
     dropdownItems,
     firstDropdownItem,

--- a/shell/components/fleet/FleetSecretSelector.vue
+++ b/shell/components/fleet/FleetSecretSelector.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ref, computed, defineProps, defineEmits } from 'vue';
+import { ref, computed } from 'vue';
 import { _EDIT } from '@shell/config/query-params';
 import { TYPES } from '@shell/models/secret';
 import { SECRET } from '@shell/config/types';

--- a/shell/components/nav/WindowManager/panels/TabBodyContainer.vue
+++ b/shell/components/nav/WindowManager/panels/TabBodyContainer.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script setup>
-import { onMounted, defineProps, defineEmits } from 'vue';
+import { onMounted } from 'vue';
 
 /**
  * This component serves as a container for the body of a tab within a window manager panel.

--- a/shell/composables/useLabeledFormElement.ts
+++ b/shell/composables/useLabeledFormElement.ts
@@ -1,5 +1,6 @@
 import {
-  ref, computed, ComputedRef, Ref, defineEmits
+  ref, computed, ComputedRef, Ref,
+  EmitFn
 } from 'vue';
 import { _VIEW, _EDIT } from '@shell/config/query-params';
 
@@ -72,9 +73,7 @@ export const labeledFormElementProps = {
   }
 };
 
-const labeledFormElementEmits = defineEmits(['update:validation']);
-
-export const useLabeledFormElement = (props: LabeledFormElementProps, emit: typeof labeledFormElementEmits): UseLabeledFormElement => {
+export const useLabeledFormElement = (props: LabeledFormElementProps, emit: EmitFn<['update:validation']>): UseLabeledFormElement => {
   const raised = ref(props.mode === _VIEW || !!`${ props.value }`);
   const focused = ref(false);
   const blurred = ref<number | null>(null);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
fixes #16197
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Fixing some of our console warnings.

### Technical notes summary
- We no longer need to import some of the defineEmits/Props methods because they're now macros.
- We needed to change how we specify an emits type in some of our components to use the types instead of calling the function.

### Areas or cases that should be tested
List pages, drop down menus, fleet secret selector and the window manager (console).

### Areas which could experience regressions
List pages, drop down menus, fleet secret selector and the window manager (console).

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
