### PR TITLE
Automation: Add option to disable slack notification

### DIFF
--- a/cypress/jenkins/Jenkinsfile
+++ b/cypress/jenkins/Jenkinsfile
@@ -123,8 +123,12 @@ node {
             
             // Send Slack notification on failure or unstable builds
             if (currentBuild.result == 'FAILURE' || currentBuild.result == 'UNSTABLE') {
-                echo "Sending Slack notification for ${currentBuild.result} build"
-                sh "cypress/jenkins/slack-notification.sh ${currentBuild.result}"
+                if ("${env.SLACK_NOTIFICATION}".toLowerCase() != "false") {
+                    echo "Sending Slack notification for ${currentBuild.result} build"
+                    sh "cypress/jenkins/slack-notification.sh ${currentBuild.result}"
+                } else {
+                    echo "Slack notification disabled (see jenkins-job-builder/qa-ui-tests.yml)"
+                }
             } else {
                 echo "Build successful, no Slack notification needed"
             }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2136

Added support to disable Slack notifications via the SLACK_NOTIFICATION environment variable (set to false in jenkins-job-builder/qa-ui-tests.yml). This enables debugging and testing of Jenkins pipeline issues without sending notifications.

Associated JJB pr: https://github.com/rancherlabs/jenkins-job-builder/pull/980
<!-- Define findings related to the feature or bug issue. -->


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
