### PR TITLE
Fix failing harvester e2e tests

### DIFF
--- a/cypress/e2e/po/components/labeled-select.po.ts
+++ b/cypress/e2e/po/components/labeled-select.po.ts
@@ -52,6 +52,15 @@ export default class LabeledSelectPo extends ComponentPo {
   }
 
   /**
+   * As per `getOptions` but returns actual string values instead of elements
+   */
+  getOptionsAsStrings(): Cypress.Chainable<string[]> {
+    return this.getOptions().then((options) => {
+      return options.toArray().map((option) => option.textContent.trim());
+    });
+  }
+
+  /**
    * Check dropdown is open
    * @returns
    */

--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -1,5 +1,4 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
-import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import ActionMenuPo from '@/cypress/e2e/po/components/action-menu.po';
 import NameNsDescriptionPo from '@/cypress/e2e/po/components/name-ns-description.po';
@@ -11,6 +10,7 @@ import { LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 import { CLUSTER_REPOS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
 import ResourceTablePo from '@/cypress/e2e/po/components/resource-table.po';
 import { GetOptions } from '@/cypress/e2e/po/components/component.po';
+import InstallExtensionDialog from '@/cypress/e2e/po/prompts/installExtensionDialog.po';
 
 export default class ExtensionsPagePo extends PagePo {
   static url = '/c/local/uiplugins'
@@ -158,32 +158,8 @@ export default class ExtensionsPagePo extends PagePo {
   }
 
   // ------------------ extension install modal ------------------
-  extensionInstallModal() {
-    return this.self().get('[data-testid="install-extension-modal"]');
-  }
-
-  installModalSelectVersionLabel(label: string): Cypress.Chainable {
-    const selectVersion = new LabeledSelectPo(this.extensionInstallModal().getId('install-ext-modal-select-version'));
-
-    selectVersion.toggle();
-
-    return selectVersion.setOptionAndClick(label);
-  }
-
-  installModalSelectVersionClick(optionIndex: number): Cypress.Chainable {
-    const selectVersion = new LabeledSelectPo(this.extensionInstallModal().getId('install-ext-modal-select-version'));
-
-    selectVersion.toggle();
-
-    return selectVersion.clickOption(optionIndex);
-  }
-
-  installModalCancelClick(): Cypress.Chainable {
-    return this.extensionInstallModal().getId('install-ext-modal-cancel-btn').click();
-  }
-
-  installModalInstallClick(): Cypress.Chainable {
-    return this.extensionInstallModal().getId('install-ext-modal-install-btn').click();
+  installModal() {
+    return new InstallExtensionDialog();
   }
 
   // ------------------ extension uninstall modal ------------------

--- a/cypress/e2e/po/prompts/installExtensionDialog.po.ts
+++ b/cypress/e2e/po/prompts/installExtensionDialog.po.ts
@@ -1,0 +1,35 @@
+import DialogPo from '@/cypress/e2e/po/components/dialog.po';
+import AsyncButtonPo from '~/cypress/e2e/po/components/async-button.po';
+import LabeledSelectPo from '~/cypress/e2e/po/components/labeled-select.po';
+
+export default class InstallExtensionDialog extends DialogPo {
+  public versionLabelSelect() {
+    return new LabeledSelectPo(this.self().getId('install-ext-modal-select-version'));
+  }
+
+  selectVersionLabel(label: string): Cypress.Chainable {
+    const selectVersion = this.versionLabelSelect();
+
+    selectVersion.toggle();
+
+    return selectVersion.setOptionAndClick(label);
+  }
+
+  selectVersionClick(optionIndex: number, toggle = true): Cypress.Chainable {
+    const selectVersion = this.versionLabelSelect();
+
+    if (toggle) {
+      selectVersion.toggle();
+    }
+
+    return selectVersion.clickOption(optionIndex);
+  }
+
+  cancelButton() {
+    return this.self().getId('install-ext-modal-cancel-btn');
+  }
+
+  installButton() {
+    return new AsyncButtonPo(this.self().getId('install-ext-modal-install-btn'));
+  }
+}

--- a/cypress/e2e/tests/extensions/elemental/elemental.spec.ts
+++ b/cypress/e2e/tests/extensions/elemental/elemental.spec.ts
@@ -50,11 +50,11 @@ describe('Extensions Compatibility spec', { tags: ['@elemental', '@adminUser'] }
 
     // click on install button on card
     extensionsPo.extensionCardInstallClick(EXTENSION_NAME);
-    extensionsPo.extensionInstallModal().should('be.visible');
+    extensionsPo.installModal().checkVisible();
 
     // select version and click install
-    extensionsPo.installModalSelectVersionLabel(EXTENSION_VERSION);
-    extensionsPo.installModalInstallClick();
+    extensionsPo.installModal().selectVersionLabel(EXTENSION_VERSION);
+    extensionsPo.installModal().installButton().click();
 
     // let's check the extension reload banner and reload the page
     extensionsPo.extensionReloadBanner().should('be.visible', MEDIUM_TIMEOUT_OPT);

--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -292,11 +292,11 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
 
     // click on install button on card
     extensionsPo.extensionCardInstallClick(EXTENSION_NAME);
-    extensionsPo.extensionInstallModal().should('be.visible');
+    extensionsPo.installModal().checkVisible();
 
     // select version and click install
-    extensionsPo.installModalSelectVersionClick(2);
-    extensionsPo.installModalInstallClick();
+    extensionsPo.installModal().selectVersionClick(2);
+    extensionsPo.installModal().installButton().click();
     cy.wait('@installExtension').its('response.statusCode').should('eq', 201);
 
     // let's check the extension reload banner and reload the page
@@ -339,7 +339,7 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
 
     // click on update button on card
     extensionsPo.extensionCardUpdateClick(EXTENSION_NAME);
-    extensionsPo.installModalInstallClick();
+    extensionsPo.installModal().installButton().click();
     cy.wait('@upgradeExtension').its('response.statusCode').should('eq', 201);
 
     // let's check the extension reload banner and reload the page
@@ -365,7 +365,7 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     // click on the rollback button on card
     // this will rollback to the immediate previous version
     extensionsPo.extensionCardRollbackClick(EXTENSION_NAME);
-    extensionsPo.installModalInstallClick();
+    extensionsPo.installModal().installButton().click();
 
     // let's check the extension reload banner and reload the page
     extensionsPo.extensionReloadBanner().should('be.visible');
@@ -389,10 +389,10 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
 
     // click on install button on card
     extensionsPo.extensionCardInstallClick(DISABLED_CACHE_EXTENSION_NAME);
-    extensionsPo.extensionInstallModal().should('be.visible');
+    extensionsPo.installModal().checkVisible();
 
     // click install
-    extensionsPo.installModalInstallClick();
+    extensionsPo.installModal().installButton().click();
 
     // let's check the extension reload banner and reload the page
     extensionsPo.extensionReloadBanner().should('be.visible');
@@ -438,8 +438,8 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
 
     // Install unauthenticated extension
     extensionsPo.extensionCardInstallClick(UNAUTHENTICATED_EXTENSION_NAME);
-    extensionsPo.extensionInstallModal().should('be.visible');
-    extensionsPo.installModalInstallClick();
+    extensionsPo.installModal().checkVisible();
+    extensionsPo.installModal().installButton().click();
 
     // let's check the extension reload banner and reload the page
     extensionsPo.extensionReloadBanner().should('be.visible');

--- a/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
@@ -40,10 +40,10 @@ describe('Kubewarden Extension', { tags: ['@extensions', '@adminUser'] }, () => 
 
     // click on install button on card
     extensionsPo.extensionCardInstallClick(extensionName);
-    extensionsPo.extensionInstallModal().should('be.visible');
+    extensionsPo.installModal().checkVisible();
 
     // click install
-    extensionsPo.installModalInstallClick();
+    extensionsPo.installModal().installButton().click();
 
     // check the extension reload banner and reload the page
     extensionsPo.extensionReloadBanner().should('be.visible');

--- a/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
+++ b/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
@@ -120,11 +120,11 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
 
     // click on install button on card
     extensionsPo.extensionCardInstallClick(harvesterGitRepoName);
-    extensionsPo.extensionInstallModal().should('be.visible');
+    extensionsPo.installModal().checkVisible();
 
     // select latest version and click install
-    extensionsPo.installModalSelectVersionClick(1);
-    extensionsPo.installModalInstallClick();
+    extensionsPo.installModal().selectVersionClick(1);
+    extensionsPo.installModal().installButton().click();
     cy.wait('@installHarvesterExtension').its('response.statusCode').should('eq', 201);
     extensionsPo.waitForPage(null, 'installed');
 
@@ -187,21 +187,18 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
     extensionsPo.waitForPage(null, 'available', MEDIUM_TIMEOUT_OPT);
     extensionsPo.loading().should('not.exist');
 
-    // get harvester extension versions
-    cy.getRancherResource('v1', 'catalog.cattle.io.clusterrepos/harvester?link=index').then((resp: Cypress.Response<any>) => {
-      const fetchedVersions = resp?.body.entries.harvester.map((item: any) => item.version);
-
-      cy.wrap(fetchedVersions).as('harvesterVersions');
-    });
-
     // click on install button on card
     extensionsPo.extensionCardInstallClick(harvesterGitRepoName);
-    extensionsPo.extensionInstallModal().should('be.visible');
+    extensionsPo.installModal().checkVisible();
 
-    cy.get('@harvesterVersions').then((versions) => {
+    // Note - We can't fetch version from `catalog.cattle.io.clusterrepos/harvester?link=index` given it won't filter out invalid extensions
+    // for example in rancher 2.12 the harvester 1.7.0 extension is invalid... however still returned... resulting in expected versions that don't exist as valid options
+
+    extensionsPo.installModal().versionLabelSelect().toggle();
+    extensionsPo.installModal().versionLabelSelect().getOptionsAsStrings().then((versions) => {
       // select older version and click install
-      extensionsPo.installModalSelectVersionClick(2);
-      extensionsPo.installModalInstallClick();
+      extensionsPo.installModal().selectVersionClick(2, false);
+      extensionsPo.installModal().installButton().click();
       cy.wait('@installHarvesterExtension').its('response.statusCode').should('eq', 201);
       extensionsPo.waitForPage(null, 'installed');
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- the harvester upgrade extension e2e test was failing due to a mismatch of versions
- failing test was fetching extension versions via api and then expecting them to match extension version options offered to user
- this was not the case, as the api does not filter out invalid extensions
  - rancher 2.12 is not compatible with harvester 1.7.0

### Occurred changes and/or fixed issues
- get versions from options we show user instead of api
- also spun out install extension dialog into a po

### Technical notes summary
- once merged i'll forward port to ensure future branches won't fail when harvester doesn't support them

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
