### PR TITLE
Remove unused tab references from ResourceTabs

### DIFF
--- a/shell/components/form/ResourceTabs/index.vue
+++ b/shell/components/form/ResourceTabs/index.vue
@@ -101,7 +101,6 @@ export default {
     return {
       eventSchema,
       EVENT,
-      selectedTab:    this.defaultTab,
       inStore,
       showConditions: false,
       paginationHeaders
@@ -245,7 +244,6 @@ export default {
     :default-tab="defaultTab"
     :resource="value"
     :use-hash="useHash"
-    @changed="tabChange"
   >
     <slot />
     <Tab


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves console warnings that are printed when rendering the ResourceTabs component by removing unused references to `tabChange` and `selectedTab`.

Fixes #16249 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Remove non-existent reference so `tabChange`
- Remove unused `selectedTab`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This warning was raised because we're attempting to invoke `tabChange`, which does not exist. I think that this inadvertently introduced from the outset. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

See the associated issue for details. This warning should not be printed to the console anymore.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This should have no effect on behavior. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
