### PR TITLE
Remove `bg-` prefix from the state background

### DIFF
--- a/shell/components/Resource/Detail/ResourcePopover/index.vue
+++ b/shell/components/Resource/Detail/ResourcePopover/index.vue
@@ -32,7 +32,7 @@ const fetch = useFetch(async() => {
 });
 
 const stateBackground = computed(() => {
-  return fetch.value.data?.stateBackground?.replace('bg-', '') || 'unknown';
+  return fetch.value.data?.stateSimpleColor || 'unknown';
 });
 
 const resourceTypeLabel = computed(() => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves a console error by removing the `bg-` prefix from the state background.

Fixes #16267 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

Remove `bg-` prefix from the state background

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

It appears that the `stateBackground` is prefixed with a `bg-`

https://github.com/rancher/dashboard/blob/bac4bc16aa0222115660a0b0d9b90cbb6712766b/shell/plugins/dashboard-store/resource-class.js#L758-L760

While the status indicator expects no prefix:

https://github.com/rancher/dashboard/blob/bac4bc16aa0222115660a0b0d9b90cbb6712766b/pkg/rancher-components/src/components/utils/status.ts#L3-L28

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

See issue - there should be no error printed to the browser console when navigating to a deployment detail page. The status indicator should be correct.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Any valid status that contains `bg-` will have the matching string stripped.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="1043" height="631" alt="Image" src="https://github.com/user-attachments/assets/7f737a44-ae44-4597-9658-7babc262665a" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
