### PR TITLE
Wrap contents of `Masthead/latest.vue` in a div

### DIFF
--- a/shell/components/ResourceDetail/Masthead/latest.vue
+++ b/shell/components/ResourceDetail/Masthead/latest.vue
@@ -42,27 +42,29 @@ const store = useStore();
 </script>
 
 <template>
-  <TitleBar v-bind="titleBarProps" />
-  <Banner
-    v-if="bannerProps"
-    v-ui-context="{
-      store: store,
-      icon: 'icon-info',
-      hookable: true,
-      value: {
-        bannerProps,
-        resource: uiCtxResource
-      },
-      tag: '__details-state-banner',
-      description: 'Status Message'
-    }"
-    class="new state-banner"
-    v-bind="bannerProps"
-  />
-  <Metadata
-    v-bind="metadataProps"
-    class="mmt-4"
-  />
+  <div>
+    <TitleBar v-bind="titleBarProps" />
+    <Banner
+      v-if="bannerProps"
+      v-ui-context="{
+        store: store,
+        icon: 'icon-info',
+        hookable: true,
+        value: {
+          bannerProps,
+          resource: uiCtxResource
+        },
+        tag: '__details-state-banner',
+        description: 'Status Message'
+      }"
+      class="new state-banner"
+      v-bind="bannerProps"
+    />
+    <Metadata
+      v-bind="metadataProps"
+      class="mmt-4"
+    />
+  </div>
 </template>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves the warning `[Vue warn]: Runtime directive used on component with non-element root node. The directives will not function as intended.` by wrapping the contents of `shell/components/ResourceDetail/Masthead/latest.vue` in a `div`.

Fixes #16248 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Wrap contents of `Masthead/latest.vue` in a div

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The warning appears to be originating from `v-if` usage in `shell/components/ResourceDetail/Masthead/index.vue`:

https://github.com/rancher/dashboard/blob/bac4bc16aa0222115660a0b0d9b90cbb6712766b/shell/components/ResourceDetail/Masthead/index.vue#L47-L51

The Vue3 docs don't contain any warnings that I could find with regards to `v-if`/`v-show` usage on components with multiple root nodes. The best I could find while searching is a reddit thread that explains this behavior[^1]. 

[^1]: https://www.reddit.com/r/vuejs/comments/17036bb/vuejs_bug_with_vshow_and_multiple_root_element/

Full contents of the warning:

```
[Vue warn]: Runtime directive used on component with non-element root node. The directives will not function as intended. 
  at <Latest key=0 value= 
Object { id: "default/prak-test", type: "apps.deployment", links: {…}, apiVersion: "apps/v1", kind: "Deployment", metadata: {…}, spec: {…}, status: {…}, … }
 resourceSubtype=null > 
  at <Index key=0 resource="apps.deployment" value= 
Object { id: "default/prak-test", type: "apps.deployment", links: {…}, apiVersion: "apps/v1", kind: "Deployment", metadata: {…}, spec: {…}, status: {…}, … }
  ... > 
  at <Index class="outlet" > 
  at <ClusterResourceNamespaceId class="outlet" onVnodeUnmounted=fn<onVnodeUnmounted> ref=Ref< 
Proxy { <target>: {…}, <handler>: {…} }
 > > 
  at <RouterView key="/c/local/explorer/apps.deployment/default/prak-test" class="outlet" > 
  at <Default onVnodeUnmounted=fn<onVnodeUnmounted> ref=Ref< 
Proxy { <target>: {…}, <handler>: {…} }
 > > 
  at <RouterView> 
  at <App>
```

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

The masthead will need to render properly with the additional div in place. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Rendering of the masthead could change.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
