### PR TITLE
Add missing cypress `realHover` command type

### DIFF
--- a/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po.ts
+++ b/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po.ts
@@ -118,14 +118,14 @@ export class FleetGitRepoCreateEditPo extends BaseDetailPagePo {
   displayAlwaysKeepInformationMessage() {
     this.self().get('[data-testid="checkbox-info-icon"]').eq(0).as('always');
 
-    (cy.get('@always') as any).realHover();
+    cy.get('@always').realHover();
     cy.get('@always').should('have.attr', 'data-popper-shown');
   }
 
   displayPollingInvervalTimeInformationMessage() {
     this.self().get('[data-testid="checkbox-info-icon"]').eq(1).as('polling');
 
-    (cy.get('@polling') as any).realHover();
+    cy.get('@polling').realHover();
     cy.get('@polling').should('have.attr', 'data-popper-shown');
   }
 

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -220,6 +220,11 @@ declare global {
       shouldHaveCssVar(name: string, value: string);
 
       /**
+       * realHover event from cypress-real-events
+       */
+      realHover(): Chainable<Element>;
+
+      /**
        * Fetch the steve `revision` / timestamp of request
        */
       fetchRevision(): Chainable<string>;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
