### PR TITLE
Fix charts status updates

### DIFF
--- a/shell/models/chart.js
+++ b/shell/models/chart.js
@@ -136,91 +136,87 @@ export default class Chart extends SteveModel {
    * @returns {Object} Card content object with `subHeaderItems`, `footerItems`, and `statuses` arrays.
    */
   get cardContent() {
-    if (!this._cardContent) {
-      const latestVersion = this.latestCompatibleVersion;
-      const subHeaderItems = [];
+    const latestVersion = this.latestCompatibleVersion;
+    const subHeaderItems = [];
 
-      if (latestVersion) {
-        const hasZeroTime = latestVersion.created === ZERO_TIME;
+    if (latestVersion) {
+      const hasZeroTime = latestVersion.created === ZERO_TIME;
 
-        subHeaderItems.push({
-          icon:        'icon-version-alt',
-          iconTooltip: { key: 'tableHeaders.version' },
-          label:       latestVersion.version
-        });
+      subHeaderItems.push({
+        icon:        'icon-version-alt',
+        iconTooltip: { key: 'tableHeaders.version' },
+        label:       latestVersion.version
+      });
 
-        const lastUpdatedItem = {
-          icon:        'icon-refresh-alt',
-          iconTooltip: { key: 'tableHeaders.lastUpdated' },
-          label:       hasZeroTime ? this.t('generic.na') : day(latestVersion.created).format('MMM D, YYYY')
-        };
-
-        if (hasZeroTime) {
-          lastUpdatedItem.labelTooltip = this.t('catalog.charts.appChartCard.subHeaderItem.missingVersionDate');
-        }
-
-        subHeaderItems.push(lastUpdatedItem);
-      }
-
-      const footerItems = [
-        {
-          type:         REPO,
-          icon:         'icon-repository-alt',
-          iconTooltip:  { key: 'tableHeaders.repoName' },
-          labels:       [this.repoNameDisplay],
-          labelTooltip: this.t('catalog.charts.findSimilar.message', { type: this.t('catalog.charts.findSimilar.types.repo') }, true)
-        }
-      ];
-
-      if (this.categories.length) {
-        footerItems.push( {
-          type:         CATEGORY,
-          icon:         'icon-category-alt',
-          iconTooltip:  { key: 'generic.category' },
-          labels:       this.categories,
-          labelTooltip: this.t('catalog.charts.findSimilar.message', { type: this.t('catalog.charts.findSimilar.types.category') }, true)
-        });
-      }
-
-      if (this.tags.length) {
-        footerItems.push({
-          type:         TAG,
-          icon:         'icon-tag-alt',
-          iconTooltip:  { key: 'generic.tags' },
-          labels:       this.tags,
-          labelTooltip: this.t('catalog.charts.findSimilar.message', { type: this.t('catalog.charts.findSimilar.types.tag') }, true)
-        });
-      }
-
-      const statuses = [];
-
-      if (this.deprecated) {
-        statuses.push({
-          icon: 'icon-alert-alt', color: 'error', tooltip: { key: 'generic.deprecated' }
-        });
-      }
-
-      if (this.upgradeable) {
-        statuses.push({
-          icon: 'icon-upgrade-alt', color: 'info', tooltip: { key: 'generic.upgradeable' }
-        });
-      }
-
-      if (this.isInstalled) {
-        const installedVersion = this.matchingInstalledApps[0]?.spec?.chart?.metadata?.version;
-
-        statuses.push({
-          icon: 'icon-confirmation-alt', color: 'success', tooltip: { text: `${ this.t('generic.installed') } (${ installedVersion })` }
-        });
-      }
-
-      this._cardContent = {
-        subHeaderItems,
-        footerItems,
-        statuses
+      const lastUpdatedItem = {
+        icon:        'icon-refresh-alt',
+        iconTooltip: { key: 'tableHeaders.lastUpdated' },
+        label:       hasZeroTime ? this.t('generic.na') : day(latestVersion.created).format('MMM D, YYYY')
       };
+
+      if (hasZeroTime) {
+        lastUpdatedItem.labelTooltip = this.t('catalog.charts.appChartCard.subHeaderItem.missingVersionDate');
+      }
+
+      subHeaderItems.push(lastUpdatedItem);
     }
 
-    return this._cardContent;
+    const footerItems = [
+      {
+        type:         REPO,
+        icon:         'icon-repository-alt',
+        iconTooltip:  { key: 'tableHeaders.repoName' },
+        labels:       [this.repoNameDisplay],
+        labelTooltip: this.t('catalog.charts.findSimilar.message', { type: this.t('catalog.charts.findSimilar.types.repo') }, true)
+      }
+    ];
+
+    if (this.categories.length) {
+      footerItems.push( {
+        type:         CATEGORY,
+        icon:         'icon-category-alt',
+        iconTooltip:  { key: 'generic.category' },
+        labels:       this.categories,
+        labelTooltip: this.t('catalog.charts.findSimilar.message', { type: this.t('catalog.charts.findSimilar.types.category') }, true)
+      });
+    }
+
+    if (this.tags.length) {
+      footerItems.push({
+        type:         TAG,
+        icon:         'icon-tag-alt',
+        iconTooltip:  { key: 'generic.tags' },
+        labels:       this.tags,
+        labelTooltip: this.t('catalog.charts.findSimilar.message', { type: this.t('catalog.charts.findSimilar.types.tag') }, true)
+      });
+    }
+
+    const statuses = [];
+
+    if (this.deprecated) {
+      statuses.push({
+        icon: 'icon-alert-alt', color: 'error', tooltip: { key: 'generic.deprecated' }
+      });
+    }
+
+    if (this.upgradeable) {
+      statuses.push({
+        icon: 'icon-upgrade-alt', color: 'info', tooltip: { key: 'generic.upgradeable' }
+      });
+    }
+
+    if (this.isInstalled) {
+      const installedVersion = this.matchingInstalledApps[0]?.spec?.chart?.metadata?.version;
+
+      statuses.push({
+        icon: 'icon-confirmation-alt', color: 'success', tooltip: { text: `${ this.t('generic.installed') } (${ installedVersion })` }
+      });
+    }
+
+    return {
+      subHeaderItems,
+      footerItems,
+      statuses
+    };
   }
 }

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -120,7 +120,6 @@ export default {
           }
         }
       ],
-      appCardsCache:      {},
       selectedSortOption: CATALOG_SORT_OPTIONS.RECOMMENDED,
       sortOptions:        [
         { kind: 'group', label: this.t('catalog.charts.sort.prefix') },
@@ -280,26 +279,19 @@ export default {
     appChartCards() {
       const charts = this.filteredCharts.slice(0, this.visibleChartsCount);
 
-      return charts.map((chart) => {
-        if (!this.appCardsCache[chart.id]) {
-          // Cache the converted value. We're caching chart.cardContent anyway, so no need to worry about showing updates to state
-          this.appCardsCache[chart.id] = {
-            id:     chart.id,
-            pill:   chart.featured ? { label: { key: 'generic.shortFeatured' }, tooltip: { key: 'generic.featured' } } : undefined,
-            header: {
-              title:    { text: chart.chartNameDisplay },
-              statuses: chart.cardContent.statuses
-            },
-            subHeaderItems: chart.cardContent.subHeaderItems,
-            image:          { src: chart.latestCompatibleVersion.icon, alt: { text: this.t('catalog.charts.iconAlt', { app: get(chart, 'chartNameDisplay') }) } },
-            content:        { text: chart.chartDescription },
-            footerItems:    chart.cardContent.footerItems,
-            rawChart:       chart
-          };
-        }
-
-        return this.appCardsCache[chart.id];
-      });
+      return charts.map((chart) => ({
+        id:     chart.id,
+        pill:   chart.featured ? { label: { key: 'generic.shortFeatured' }, tooltip: { key: 'generic.featured' } } : undefined,
+        header: {
+          title:    { text: chart.chartNameDisplay },
+          statuses: chart.cardContent.statuses
+        },
+        subHeaderItems: chart.cardContent.subHeaderItems,
+        image:          { src: chart.latestCompatibleVersion.icon, alt: { text: this.t('catalog.charts.iconAlt', { app: get(chart, 'chartNameDisplay') }) } },
+        content:        { text: chart.chartDescription },
+        footerItems:    chart.cardContent.footerItems,
+        rawChart:       chart
+      }));
     },
 
     clusterId() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14774 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Removed the caching logic for chart card data. This change ensures chart statuses (e.g., "Installed") update immediately, fixing a side-effect where a page refresh was required. The caching was originally implemented for performance, but it is no longer necessary due to several subsequent optimizations made to the charts page:

- [Tooltips](https://github.com/rancher/dashboard/issues/15781)
- [Lazy loading](https://github.com/rancher/dashboard/issues/16040)
- [LazyImage component](https://github.com/rancher/dashboard/issues/14905)

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Removed the caching logic in:

- `shell/pages/c/_cluster/apps/charts/index.vue`
- `shell/models/chart.js`

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Go to the charts page and install a version of a chart that's not the latest, then come back to the charts page without refreshing the page, you should be able to see the installed and upgradeable icons on the card.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
The primary focus of testing should be to verify that these changes do not introduce a performance regression on the charts page.

1.  Add a repository that hosts a large number of charts. The Bitnami repo is a good candidate: `https://charts.bitnami.com/bitnami`

2.  Navigate to the charts page and assess performance while:
  * Scrolling rapidly through the entire list of charts.
  * Applying and clearing various filters from the side panel.
  * Typing a search query into the filter box.

The page should remain responsive. Scrolling should be smooth, and filters should apply without a noticeable lag. The overall performance should be on par with the master branch.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
https://github.com/user-attachments/assets/19475d81-bc75-47af-acb2-c084b4d74ff3

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
