### PR TITLE
Added the ability to remove namespaces from projects entirely, not just move them between projects.

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4620,7 +4620,7 @@ moveModal:
   description: 'You are moving the following namespaces:'
   moveButtonLabel: Move
   targetProject: Target Project
-  noProject: None (remove from project)
+  noProject: None (remove from any project)
 
 nameNsDescription:
   name:

--- a/shell/dialog/__tests__/MoveNamespaceDialog.test.ts
+++ b/shell/dialog/__tests__/MoveNamespaceDialog.test.ts
@@ -2,6 +2,7 @@ import { shallowMount, VueWrapper } from '@vue/test-utils';
 import MoveNamespaceDialog from '@shell/dialog/MoveNamespaceDialog.vue';
 
 const t = (key: string): string => key;
+const NONE_VALUE = ' ';
 
 describe('component: MoveNamespaceDialog', () => {
   let wrapper: VueWrapper<any>;
@@ -78,7 +79,7 @@ describe('component: MoveNamespaceDialog', () => {
       const options = wrapper.vm.projectOptions;
 
       expect(options[0]).toStrictEqual({
-        value: '',
+        value: NONE_VALUE,
         label: 'moveModal.noProject'
       });
     });
@@ -119,20 +120,45 @@ describe('component: MoveNamespaceDialog', () => {
       expect(projectValues).not.toContain('p-abc123');
       expect(projectValues).toContain('p-def456');
     });
+
+    it('should NOT include "None" option when some namespaces are not in a project', async() => {
+      const namespaceInProject = createMockNamespace('p-abc123');
+      const namespaceNotInProject = createMockNamespace(null);
+
+      wrapper = mountComponent({ resources: [namespaceInProject, namespaceNotInProject] });
+      await wrapper.vm.$options.fetch.call(wrapper.vm);
+
+      const options = wrapper.vm.projectOptions;
+      const optionValues = options.map((o: any) => o.value);
+
+      expect(optionValues).not.toContain(NONE_VALUE);
+    });
+
+    it('should NOT include "None" option when no namespaces are in a project', async() => {
+      const namespace = createMockNamespace(null);
+
+      wrapper = mountComponent({ resources: [namespace] });
+      await wrapper.vm.$options.fetch.call(wrapper.vm);
+
+      const options = wrapper.vm.projectOptions;
+      const optionValues = options.map((o: any) => o.value);
+
+      expect(optionValues).not.toContain(NONE_VALUE);
+    });
   });
 
   describe('targetProject default value', () => {
     it('should default to empty string (None option)', () => {
       wrapper = mountComponent();
 
-      expect(wrapper.vm.targetProject).toBe('');
+      expect(wrapper.vm.targetProject).toBeNull();
     });
   });
 
   describe('move button disabled state', () => {
-    it('should be enabled when targetProject is empty string (None)', () => {
+    it('should be enabled when targetProject is NONE_VALUE (None)', () => {
       wrapper = mountComponent();
-      wrapper.vm.targetProject = '';
+      wrapper.vm.targetProject = NONE_VALUE;
 
       // The button should be enabled when targetProject !== null
       expect(wrapper.vm.targetProject === null).toBe(false);
@@ -147,13 +173,13 @@ describe('component: MoveNamespaceDialog', () => {
   });
 
   describe('move method', () => {
-    it('should clear labels and annotations when targetProject is empty (None)', async() => {
+    it('should clear labels and annotations when targetProject is NONE_VALUE (None)', async() => {
       const namespace = createMockNamespace('p-abc123');
 
       wrapper = mountComponent({ resources: [namespace] });
       await wrapper.vm.$options.fetch.call(wrapper.vm);
 
-      wrapper.vm.targetProject = '';
+      wrapper.vm.targetProject = NONE_VALUE;
 
       const finish = jest.fn();
 
@@ -190,7 +216,7 @@ describe('component: MoveNamespaceDialog', () => {
       wrapper = mountComponent({ resources: [namespace1, namespace2] });
       await wrapper.vm.$options.fetch.call(wrapper.vm);
 
-      wrapper.vm.targetProject = '';
+      wrapper.vm.targetProject = NONE_VALUE;
 
       const finish = jest.fn();
 
@@ -211,7 +237,7 @@ describe('component: MoveNamespaceDialog', () => {
       wrapper = mountComponent({ resources: [namespace] });
       await wrapper.vm.$options.fetch.call(wrapper.vm);
 
-      wrapper.vm.targetProject = '';
+      wrapper.vm.targetProject = NONE_VALUE;
 
       const finish = jest.fn();
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11128
<!-- Define findings related to the feature or bug issue. -->
Added the ability to remove namespaces from projects entirely, not just move them between projects. Previously, the "Move" action on namespaces only allowed moving to another project. Now users can select "None (remove from project)" to disassociate a namespace from any project.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Added "None (remove from project)" option to the target project dropdown in the Move Namespace dialog
- When "None" is selected, the `field.cattle.io/projectId` label and annotation are cleared from the namespace
- Added unit tests for the new functionality

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Select a namespace that is currently in a project, click "Move", verify "None (remove from project)" appears as the first option and is selected by default
2. Click "Move" with "None" selected - verify namespace is removed from the project (no longer appears under that project in the UI)
3. Select a different project from the dropdown and click "Move" - verify namespace moves to the new project (existing functionality still works)
4. Test bulk selection: select multiple namespaces from the same project, click "Move", select "None", verify all are removed from the project

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Moving namespaces between projects (existing functionality)
- Bulk move operations for namespaces
- Namespace list filtering by project (namespaces removed from projects should appear in "Not in a Project" group)
- Project resource counts (should decrease when namespace is removed)


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
