### PR TITLE
Fix text selection in namespace filter input

### DIFF
--- a/shell/components/__tests__/NamespaceFilter.test.ts
+++ b/shell/components/__tests__/NamespaceFilter.test.ts
@@ -244,4 +244,53 @@ describe('component: NamespaceFilter', () => {
 
     it.todo('should generate the options based on the Rancher resources');
   });
+
+  describe('given filter input text selection', () => {
+    it('should allow text selection by stopping mousedown propagation', async() => {
+      const wrapper = mount(NamespaceFilter, {
+        computed: {
+          filtered: () => [],
+          options:  () => [],
+          value:    () => [],
+        },
+        global: {
+          mocks: {
+            t:           (key: string) => key,
+            $store:      { getters: { 'i18n/t': () => '', namespaceFilterMode: () => undefined } },
+            $fetchState: { pending: false }
+          },
+          directives: {
+            'clean-tooltip': () => {},
+            shortkey:        () => {},
+          },
+          stubs: { RcButton: { template: '<button><slot /></button>' } },
+        }
+      });
+
+      // Open the dropdown to reveal the filter input
+      const dropdown = wrapper.find('[data-testid="namespaces-dropdown"]');
+
+      await dropdown.trigger('click');
+
+      // Find the filter input
+      const filterInput = wrapper.find('.ns-filter-input');
+
+      expect(filterInput.exists()).toBe(true);
+
+      // Trigger mousedown on the filter input and capture the event
+      const mousedownEvent = new MouseEvent('mousedown', {
+        bubbles:    true,
+        cancelable: true
+      });
+      const stopPropagationSpy = jest.spyOn(mousedownEvent, 'stopPropagation');
+
+      filterInput.element.dispatchEvent(mousedownEvent);
+
+      // Verify stopPropagation was called (which allows text selection)
+      expect(stopPropagationSpy).toHaveBeenCalledWith();
+
+      // Verify the default was NOT prevented (text selection should work)
+      expect(mousedownEvent.defaultPrevented).toBe(false);
+    });
+  });
 });

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -841,6 +841,7 @@ export default {
             tabindex="0"
             class="ns-filter-input"
             :aria-label="t('namespaceFilter.input')"
+            @mousedown.stop
             @click="focusFilter"
             @keydown="inputKeyHandler($event)"
           >


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary  
The parent container's @mousedown.prevent was blocking text selection in the filter input. Adding @mousedown.stop to the input prevents the event from bubbling up, allowing normal text selection behavior while preserving the dropdown's focus management.
  
 Fixes #12658

### Occurred changes and/or fixed issues

Users can now select text in the namespace filter input field using mouse interactions (double-click to select word, click-and-drag to select text).

### Technical notes summary
This adds`@mousedown.stop` on the input, preventing them from bubbling up to the parent `.ns-filter` container where `@mousedown.prevent` would block text selection.

**Important:** This change preserves the focus behavior fix introduced in ad2c555ea654750726961ad4516c2d9a16800ecf (PR #11762). 

### Areas or cases that should be tested
- Use the mouse to highlight text in the namespace filter
- Use the keyboard to highlight text in the namespace filter
- Clicking outside the dropdown still closes it
- Verify the focus behavior from #11683 is still working (no unwanted focus when clicking to open/close)

### Areas which could experience regressions

- **Namespace filter dropdown toggle behavior** - The dropdown should still open/close correctly when clicking the main dropdown area
- **Focus management** - The fix from #11683 should remain intact; clicking the dropdown should not cause unwanted focus issues
- **Keyboard navigation** - Tab/arrow key navigation within the namespace filter should remain unaffected


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
