### PR TITLE
Refactor ActionMenuShell to emit single action-invoked event

### DIFF
--- a/pkg/rancher-components/src/components/RcItemCard/RcItemCard.test.ts
+++ b/pkg/rancher-components/src/components/RcItemCard/RcItemCard.test.ts
@@ -187,7 +187,7 @@ describe('rcItemCard', () => {
     expect(icon.attributes('style')).toContain('color: red');
   });
 
-  it('emits custom action events correctly', async() => {
+  it('emits action-invoked event when action is triggered', async() => {
     const wrapper = mount(RcItemCard, {
       props: {
         ...baseProps,
@@ -198,12 +198,22 @@ describe('rcItemCard', () => {
       }
     });
 
-    const listeners = wrapper.vm.$.setupState.actionListeners;
+    // Simulate the action-invoked event being emitted from ActionMenu
+    const actionMenu = wrapper.findComponent({ name: 'ActionMenuShell' });
 
-    listeners.myActionA('payload-1');
-    listeners.myActionB('payload-2');
+    expect(actionMenu.exists()).toBe(true);
 
-    expect(wrapper.emitted('myActionA')?.[0]).toStrictEqual(['payload-1']);
-    expect(wrapper.emitted('myActionB')?.[0]).toStrictEqual(['payload-2']);
+    // Emit action-invoked event with payload
+    const payload = {
+      action: 'myActionA', actionData: { action: 'myActionA', label: 'Edit' }, event: new MouseEvent('click')
+    };
+
+    actionMenu.vm.$emit('action-invoked', payload);
+    await wrapper.vm.$nextTick();
+
+    const emitted = wrapper.emitted('action-invoked');
+
+    expect(emitted).toBeTruthy();
+    expect(emitted?.[0]).toStrictEqual([payload]);
   });
 });

--- a/pkg/rancher-components/src/components/RcItemCard/RcItemCard.vue
+++ b/pkg/rancher-components/src/components/RcItemCard/RcItemCard.vue
@@ -82,8 +82,8 @@ interface RcItemCardProps {
 
   /** Optional actions that will be displayed inside an action-menu
    *
-   * Each action should include an `action` name, which is emitted as a custom event when selected.
-   * To respond to the event, you must also register a matching event listener using the `@` syntax.
+   * Each action should include an `action` name, which is included in the payload
+   * of the 'action-invoked' event when the action is selected.
    *
    * Example:
    * <rc-item-card
@@ -94,8 +94,10 @@ interface RcItemCardProps {
    *       enabled: true
    *     }
    *   ]"
-   *   @focusSearch="focusSearch"
+   *   @action-invoked="handleActionInvoked"
    * />
+   *
+   * The handler receives a payload with { action: string, actionData: object, event: MouseEvent, ... }
    */
   actions?: DropdownOption[];
 
@@ -117,23 +119,9 @@ const props = defineProps<RcItemCardProps>();
 /**
  * Emits:
  * - 'card-click' when card is clicked or activated via keyboard.
- * - custom events defined in the `actions` prop, but only if the corresponding event listener is explicitly declared on the component.
+ * - 'action-invoked' when an action is selected from the action menu (only when `actions` prop is used).
  */
-const emit = defineEmits<{(e: 'card-click', value: ItemValue): void; (e: string, payload: unknown): void;}>();
-
-const actionListeners = computed(() => {
-  if (!props.actions) return {};
-
-  const listeners: Record<string, (payload: unknown) => void> = {};
-
-  for (const a of props.actions) {
-    if (a.action) {
-      listeners[a.action] = (payload: unknown) => emit(a.action, payload);
-    }
-  }
-
-  return listeners;
-});
+const emit = defineEmits<{(e: 'card-click', value?: ItemValue): void; (e: 'action-invoked', payload: unknown): void;}>();
 
 /**
  * Handles the card click while avoiding nested interactive elements
@@ -282,7 +270,7 @@ const cardMeta = computed(() => ({
                 <ActionMenu
                   data-testid="item-card-header-action-menu"
                   :custom-actions="actions"
-                  v-on="actionListeners"
+                  @action-invoked="(payload) => emit('action-invoked', payload)"
                 />
               </rc-item-card-action>
             </template>

--- a/shell/components/ActionMenu.vue
+++ b/shell/components/ActionMenu.vue
@@ -11,7 +11,7 @@ const SHOW = 'show';
 export default {
   name: 'ActionMenu',
 
-  emits: ['close'],
+  emits: ['close', 'action-invoked'],
 
   components: { IconOrSvg },
   props:      {
@@ -217,15 +217,14 @@ export default {
         // If the state of this component is controlled
         // by props instead of Vuex, we assume you wouldn't want
         // the mutation to have a dependency on Vuex either.
-        // So in that case we use events to execute actions instead.
-        // If an action list item is clicked, this
-        // component emits that event, then we assume the parent
-        // component will execute the action.
-        this.$emit(action.action, {
-          action,
+        // The parent component should handle the action based on the action property
+        // in the 'action-invoked' event payload.
+        this.$emit('action-invoked', {
+          action:     action.action,
+          actionData: action,
           event,
           ...args,
-          route: this.$route
+          route:      this.$route
         });
       } else {
         // If the state of this component is controlled

--- a/shell/components/ActionMenuShell.vue
+++ b/shell/components/ActionMenuShell.vue
@@ -30,7 +30,15 @@ const openChanged = (event: boolean) => {
   }
 };
 
-const emit = defineEmits<{(event: string, payload: any): void;(event: 'action-invoked'): void;}>();
+export interface ActionMenuSelection {
+  action: string;
+  actionData: any;
+  event: MouseEvent;
+  route: ReturnType<typeof useRoute>;
+  [key: string]: any;
+}
+
+const emit = defineEmits<{(event: 'action-invoked', payload?: ActionMenuSelection): void;}>();
 const route = useRoute();
 
 const execute = (action: any, event: MouseEvent, args?: any) => {
@@ -38,7 +46,15 @@ const execute = (action: any, event: MouseEvent, args?: any) => {
     return;
   }
 
-  emit('action-invoked');
+  const payload: ActionMenuSelection = {
+    action:     action.action,
+    actionData: action,
+    event,
+    ...args,
+    route,
+  };
+
+  emit('action-invoked', payload);
 
   // this will come from extensions...
   if (action.invoke) {
@@ -56,24 +72,7 @@ const execute = (action: any, event: MouseEvent, args?: any) => {
         fn.apply(this, [opts, resources]);
       }
     }
-  } else if (props.customActions) {
-    // If the state of this component is controlled
-    // by props instead of Vuex, we assume you wouldn't want
-    // the mutation to have a dependency on Vuex either.
-    // So in that case we use events to execute actions instead.
-    // If an action list item is clicked, this
-    // component emits that event, then we assume the parent
-    // component will execute the action.
-    emit(
-      action.action,
-      {
-        action,
-        event,
-        ...args,
-        route,
-      }
-    );
-  } else {
+  } else if (!props.customActions) {
     // If the state of this component is controlled
     // by Vuex, mutate the store when an action is clicked.
     const opts = { alt: isAlternate(event) };

--- a/shell/detail/management.cattle.io.oidcclient.vue
+++ b/shell/detail/management.cattle.io.oidcclient.vue
@@ -7,7 +7,7 @@ import { defineComponent } from 'vue';
 import CopyToClipboardText from '@shell/components/CopyToClipboardText.vue';
 import DateComponent from '@shell/components/formatter/Date.vue';
 import { RcItemCard } from '@components/RcItemCard';
-import ActionMenu from '@shell/components/ActionMenuShell.vue';
+import ActionMenu, { type ActionMenuSelection } from '@shell/components/ActionMenuShell.vue';
 import { Banner } from '@components/Banner';
 
 type SecretActionType = 'create-secret' | 'regen-secret' | 'remove-secret'
@@ -32,7 +32,6 @@ interface SecretManageData {
 const OIDC_SECRETS_NAMESPACE = 'cattle-oidc-client-secrets';
 
 export default defineComponent({
-  emits: ['regenerateSecret', 'removeSecret'],
 
   components: {
     CopyToClipboardText,
@@ -100,6 +99,19 @@ export default defineComponent({
   },
 
   methods: {
+    handleSecretAction(secret: SecretManageData, payload?: ActionMenuSelection) {
+      switch (payload?.action) {
+      case 'regenerateSecret':
+        this.promptSecretsModal(OIDC_CLIENT_SECRET_ACTION.REGEN, secret);
+        break;
+      case 'removeSecret':
+        this.promptSecretsModal(OIDC_CLIENT_SECRET_ACTION.REMOVE, secret);
+        break;
+      default:
+        console.warn(`Unknown secret action: ${ payload?.action }`); // eslint-disable-line no-console
+      }
+    },
+
     promptSecretsModal(actionType: SecretActionType, secret: SecretManageData) {
       this.errors = [];
 
@@ -320,8 +332,7 @@ export default defineComponent({
                 :data-testid="`oidc-client-secret-${i}-action-menu`"
                 :resource="secret"
                 :custom-actions="cardActions"
-                @regenerateSecret="promptSecretsModal(OIDC_CLIENT_SECRET_ACTION.REGEN, secret)"
-                @removeSecret="promptSecretsModal(OIDC_CLIENT_SECRET_ACTION.REMOVE, secret)"
+                @action-invoked="(payload) => handleSecretAction(secret, payload)"
               />
             </template>
           </rc-item-card>

--- a/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
+++ b/shell/edit/monitoring.coreos.com.alertmanagerconfig/index.vue
@@ -177,6 +177,21 @@ export default {
       this.alertmanagerConfigResource.spec.receivers = receiversMinusDeletedItem;
       // After saving the AlertmanagerConfig, the resource has been deleted.
       this.alertmanagerConfigResource.save(...arguments);
+    },
+    handleReceiverAction(payload) {
+      switch (payload?.action) {
+      case 'goToEdit':
+        this.goToEdit();
+        break;
+      case 'goToEditYaml':
+        this.goToEditYaml();
+        break;
+      case 'promptRemove':
+        this.promptRemove();
+        break;
+      default:
+        console.warn(`Unknown receiver action: ${ payload?.action }`); // eslint-disable-line no-console
+      }
     }
   }
 };
@@ -263,9 +278,7 @@ export default {
       :custom-target-element="actionMenuTargetElement"
       :custom-target-event="actionMenuTargetEvent"
       @close="receiverActionMenuIsOpen = false"
-      @goToEdit="goToEdit"
-      @goToEditYaml="goToEditYaml"
-      @promptRemove="promptRemove"
+      @action-invoked="handleReceiverAction"
     />
   </CruResource>
 </template>

--- a/shell/pages/c/_cluster/explorer/tools/index.vue
+++ b/shell/pages/c/_cluster/explorer/tools/index.vue
@@ -130,6 +130,28 @@ export default {
   },
 
   methods: {
+    handleCardAction(payload, card) {
+      switch (payload?.action) {
+      case 'upgrade':
+        this.upgrade(card.installedApp, card.rawChart);
+        break;
+      case 'downgrade':
+        this.downgrade(card.installedApp, card.rawChart);
+        break;
+      case 'edit':
+        this.edit(card.installedApp);
+        break;
+      case 'remove':
+        this.remove(card.installedApp, payload.event);
+        break;
+      case 'install':
+        this.install(card.rawChart);
+        break;
+      default:
+        console.warn(`Unknown card action: ${ payload?.action }`); // eslint-disable-line no-console
+      }
+    },
+
     getCardActions(card) {
       const { installedApp, rawChart } = card;
 
@@ -243,11 +265,7 @@ export default {
         :content="card.content"
         :actions="getCardActions(card)"
         :class="{ 'single-card': appChartCards.length === 1 }"
-        @upgrade="() => upgrade(card.installedApp, card.rawChart)"
-        @downgrade="() => downgrade(card.installedApp, card.rawChart)"
-        @edit="() => edit(card.installedApp)"
-        @remove="(payload) => remove(card.installedApp, payload.event)"
-        @install="() => install(card.rawChart)"
+        @action-invoked="(payload) => handleCardAction(payload, card)"
       >
         <template
           v-once

--- a/shell/pages/c/_cluster/monitoring/alertmanagerconfig/_alertmanagerconfigid/receiver.vue
+++ b/shell/pages/c/_cluster/monitoring/alertmanagerconfig/_alertmanagerconfigid/receiver.vue
@@ -210,11 +210,11 @@ export default {
     // and this method executes the action.
       this.$router.push(this.alertmanagerConfigResource.getEditReceiverYamlRoute(this.receiverValue.name, _EDIT));
     },
-    promptRemove(actionData) {
+    promptRemove(payload) {
       // 'promptRemove' is the exact name of an action for AlertmanagerConfig
       // and this method executes the action.
       // Get the name of the receiver to delete from the action info.
-      const nameOfReceiverToDelete = actionData.route.query.receiverName;
+      const nameOfReceiverToDelete = payload?.route?.query?.receiverName;
       // Remove it from the configuration of the parent AlertmanagerConfig
       // resource.
       const existingReceivers = this.alertmanagerConfigResource.spec.receivers || [];
@@ -226,6 +226,21 @@ export default {
       // After saving the AlertmanagerConfig, the resource has been deleted.
       this.alertmanagerConfigResource.save(...arguments);
       this.$router.push(this.alertmanagerConfigResource._detailLocation);
+    },
+    handleReceiverAction(payload) {
+      switch (payload?.action) {
+      case 'goToEdit':
+        this.goToEdit();
+        break;
+      case 'goToEditYaml':
+        this.goToEditYaml();
+        break;
+      case 'promptRemove':
+        this.promptRemove(payload);
+        break;
+      default:
+        console.warn(`Unknown receiver action: ${ payload?.action }`); // eslint-disable-line no-console
+      }
     },
     redirectToReceiverDetail(receiverName) {
       return this.alertmanagerConfigResource.getReceiverDetailLink(receiverName);
@@ -300,9 +315,7 @@ export default {
       :custom-target-element="actionMenuTargetElement"
       :custom-target-event="actionMenuTargetEvent"
       @close="receiverActionMenuIsOpen = false"
-      @goToEdit="goToEdit"
-      @goToEditYaml="goToEditYaml"
-      @promptRemove="promptRemove"
+      @action-invoked="handleReceiverAction"
     />
   </div>
 </template>

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -703,6 +703,44 @@ export default {
       });
     },
 
+    handleMenuAction(payload) {
+      switch (payload?.action) {
+      case 'devLoad':
+        this.showDeveloperLoadDialog();
+        break;
+      case 'manageRepos':
+        this.manageRepos();
+        break;
+      case 'addRancherRepos':
+        this.showAddExtensionReposDialog();
+        break;
+      case 'manageExtensionView':
+        this.manageExtensionView();
+        break;
+      default:
+        console.warn(`Unknown menu action: ${ payload?.action }`); // eslint-disable-line no-console
+      }
+    },
+
+    handlePluginCardAction(payload, card) {
+      switch (payload?.action) {
+      case 'uninstall':
+        this.showUninstallDialog(card.plugin, payload.event);
+        break;
+      case 'upgrade':
+        this.showInstallDialog(card.plugin, 'upgrade', payload.event);
+        break;
+      case 'downgrade':
+        this.showInstallDialog(card.plugin, 'downgrade', payload.event);
+        break;
+      case 'install':
+        this.showInstallDialog(card.plugin, 'install', payload.event);
+        break;
+      default:
+        console.warn(`Unknown plugin card action: ${ payload?.action }`); // eslint-disable-line no-console
+      }
+    },
+
     updateAddReposSetting() {
       // because of https://github.com/rancher/rancher/pull/45894 we need to consider other start values
       if (this.addExtensionReposBannerSetting?.value === 'true' || this.addExtensionReposBannerSetting?.value === '' || this.addExtensionReposBannerSetting?.value === undefined) {
@@ -920,10 +958,7 @@ export default {
             button-role="tertiary"
             :button-aria-label="t('plugins.labels.menu')"
             :custom-actions="menuActions"
-            @devLoad="showDeveloperLoadDialog"
-            @manageRepos="manageRepos"
-            @addRancherRepos="showAddExtensionReposDialog"
-            @manageExtensionView="manageExtensionView"
+            @action-invoked="handleMenuAction"
           />
         </div>
       </div>
@@ -1037,10 +1072,7 @@ export default {
             :actions="card.actions"
             :clickable="true"
             @card-click="showPluginDetail(card.plugin)"
-            @uninstall="({event}) => showUninstallDialog(card.plugin, event)"
-            @upgrade="({event}) => showInstallDialog(card.plugin, 'upgrade', event)"
-            @downgrade="({event}) => showInstallDialog(card.plugin, 'downgrade', event)"
-            @install="({event}) => showInstallDialog(card.plugin, 'install', event)"
+            @action-invoked="(payload) => handlePluginCardAction(payload, card)"
           >
             <template #item-card-sub-header>
               <AppChartCardSubHeader


### PR DESCRIPTION
## Summary
We wanted to refactor ActionMenuShell emits so we can avoid warnings caused by emitting new messages that weren't in the compile time template defintion of defineEmits().

Fixes #13553

## Occurred Changes/Fixed Issues
- Refactored `ActionMenuShell.vue` to emit a single `action-invoked` event with an `ActionMenuSelection` payload instead of dynamic events
- Updated the consumers of this interface.

## Technical Notes
- `ActionMenuSelection` interface provides: `action` (string name), `actionData` (full action object), `event` (MouseEvent), `route`
- The `action-invoked` event now fires for all action types (Vuex, custom, extension invoke)
- Existing consumers using `@action-invoked` without payload (e.g., `close`) continue to work since payload is optional

## Areas for Testing
- Extensions page: Test menu actions (Manage Repos, Add Rancher Repos, Manage Extension View, Developer Load)
- OIDC Client detail page: Test regenerate/remove secret actions on client secret cards
- Any component using RcItemCard with actions prop

## Regression Risk Areas
- ActionMenu behavior in SortableTable rows
- ResourcePopover action menu
- Any extension using ActionMenuShell with customActions

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
