### PR TITLE
Fix issue with fetching the namespace key

### DIFF
--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -305,7 +305,7 @@ export default {
         namespace.value = toRef(props.forceNamespace);
         updateNamespace(namespace);
       } else if (props.namespaceKey) {
-        namespace.value = get(v, props.namespaceKey);
+        namespace.value = get(v.value, props.namespaceKey);
       } else {
         namespace.value = metadata?.namespace;
       }

--- a/shell/components/form/__tests__/NameNsDescription.test.ts
+++ b/shell/components/form/__tests__/NameNsDescription.test.ts
@@ -87,6 +87,48 @@ describe('component: NameNsDescription', () => {
     expect(wrapper.emitted().isNamespaceNew?.[0][0]).toBe(true);
   });
 
+  it('should set the namespace using the namespaceKey prop', () => {
+    const namespaceName = 'custom-namespace';
+    const store = createStore({
+      getters: {
+        allowedNamespaces:   () => () => ({ [namespaceName]: true }),
+        currentStore:        () => () => 'cluster',
+        'cluster/schemaFor': () => jest.fn()
+      }
+    });
+
+    const wrapper = mount(NameNsDescription, {
+      props: {
+        value: {
+          setAnnotation: jest.fn(),
+          metadata:      {},
+          value:         { metadata: { namespace: namespaceName } }
+        },
+        mode:         'create',
+        namespaceKey: 'value.metadata.namespace',
+      },
+      global: {
+        provide: { store },
+        mocks:   {
+          $store: {
+            dispatch: jest.fn(),
+            getters:  {
+              namespaces:                         jest.fn(),
+              'customizations/getPreviewCluster': {
+                ready:   true,
+                isLocal: false,
+                badge:   {},
+              },
+              'i18n/t': jest.fn(),
+            },
+          },
+        },
+      },
+    });
+
+    expect((wrapper.vm as any).namespace).toBe(namespaceName);
+  });
+
   it('renders the name input with the expected value', () => {
     const namespaceName = 'test';
     const store = createStore({


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This ensure that the `v` ref is properly accessed using `v.value` when attempting to get the namespace via key. 

Fixes #16342
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Access the `v` ref using `v.value` when fetching the namespace key
- Unit test the change

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

A ref was originally being passed to the `get()` method, the value was unable to be read and this returned `undefined`. The namespace will be set to "Default" when the `get()` method returns `undefined`.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

See issue and kubewarden: https://github.com/rancher/kubewarden-ui/issues/1387#issuecomment-3723140304

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This should be resolving a previous regression. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="1360" height="1150" alt="image" src="https://github.com/user-attachments/assets/12d5e4d5-fbbd-40e3-a52c-cc2d334db520" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
