### PR TITLE
Changed mechanism to see if hosted provider extension is prime only

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2726,7 +2726,6 @@ cruResource:
 providers:
   hosted: 
     title: Hosted Providers
-    prime: Prime only
     warning: Disabling providers will make any clusters that use them uneditable
 drivers:
   kontainer:

--- a/shell/core/extension-manager-impl.js
+++ b/shell/core/extension-manager-impl.js
@@ -306,7 +306,7 @@ export const createExtensionManager = (context) => {
 
     // Apply the plugin based on its metadata
     applyPlugin(plugin) {
-      // Types
+    // Types
       Object.keys(plugin.types).forEach((typ) => {
         Object.keys(plugin.types[typ]).forEach((name) => {
           this.register(typ, name, plugin.types[typ][name]);
@@ -459,9 +459,11 @@ export const createExtensionManager = (context) => {
     getProviders(context) {
       // Custom Providers from extensions - initialize each with the store and the i18n service
       // Wrap in try ... catch, to prevent errors in an extension breaking the page
+
       const extensions = context.$extension.listDynamic('provisioner').map((name) => {
         try {
           const provisioner = context.$extension.getDynamic('provisioner', name);
+
           const defaults = {
             isCreate: false,
             isEdit:   false,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15972 

Removed checks for "prime"ness from Hosted Providers page.
<!-- Define findings related to the feature or bug issue. -->
After adding gates on extension installation, checking for prime on Hosted providers page became redundant. To simplify code management, we decided to remove the check alltogether.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Removed all mentions of prime.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Hosted providers page
Install Alibaba extension. 
Check that 'prime only' label is no longer shown. 
Note: there is a bug in ali-ui that makes extension show up on cluster creation even if it was disabled here. That is unrelated to this issue

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
