### PR TITLE
Restrict Node Scheduling selection to worker nodes

### DIFF
--- a/shell/edit/workload/__tests__/index.test.ts
+++ b/shell/edit/workload/__tests__/index.test.ts
@@ -101,8 +101,8 @@ describe('component: Workload', () => {
       expect(result).toStrictEqual(newMessage);
     });
 
-    describe('workerNodes', () => {
-      it('should filter out nodes with control-plane or etcd taints', () => {
+    describe('secondaryResourceDataConfig', () => {
+      it('should filter out nodes with control-plane or etcd taints from workerNodes parsingFunc', () => {
         const allNodeObjects = [
           {
             id:   'node-1',
@@ -130,43 +130,9 @@ describe('component: Workload', () => {
           }
         ];
 
-        const mockedWorkloadMixinForWorkerNodes = {
-          ...baseMockedWorkloadMixin,
-          computed: { allNodeObjects: () => allNodeObjects }
-        };
-
-        const MockedWorkload = { ...Workload, mixins: [baseMockedValidationMixin, baseMockedCREMixin, mockedWorkloadMixinForWorkerNodes] };
-
-        const wrapper = shallowMount(MockedWorkload, {
-          props: {
-            value: {
-              metadata: {},
-              spec:     { template: {} }
-            },
-            params:        {},
-            fvFormIsValid: {}
-          },
-          global: {
-            mocks: {
-              $route:      { params: {}, query: {} },
-              $router:     { applyQuery: jest.fn() },
-              $fetchState: { pending: false },
-              $store:      {
-                getters: {
-                  'cluster/schemaFor': jest.fn(),
-                  'type-map/labelFor': jest.fn(),
-                  'i18n/t':            jest.fn(),
-                },
-              },
-            },
-            stubs: {
-              NameNsDescription: true,
-              CruResource:       true,
-            }
-          },
-        });
-
-        const result = (wrapper.vm as any).workerNodes;
+        const { data } = (Workload.mixins[2] as any).methods.secondaryResourceDataConfig.apply({ value: { metadata: { namespace: 'test' } } });
+        const workerNodesParsingFunc = data.node.applyTo.find((r: any) => r.var === 'workerNodes').parsingFunc;
+        const result = workerNodesParsingFunc(allNodeObjects);
 
         expect(result).toStrictEqual(['node-3', 'node-4', 'node-5', 'node-6']);
       });

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -22,24 +22,8 @@ export default {
   data() {
     return { selectedName: null, errors: [] };
   },
-  computed: {
-    ...mapGetters({ t: 'i18n/t' }),
-    workerNodes() {
-      const keys = [
-        `node-role.kubernetes.io/control-plane`,
-        `node-role.kubernetes.io/etcd`
-      ];
-
-      return this.allNodeObjects
-        .filter((node) => {
-          const taints = node?.spec?.taints || [];
-
-          return taints.every((taint) => !keys.includes(taint.key));
-        })
-        .map((node) => node.id);
-    }
-  },
-  methods: {
+  computed: { ...mapGetters({ t: 'i18n/t' }) },
+  methods:  {
     changed(tab) {
       const key = this.idKey;
 

--- a/shell/edit/workload/mixins/workload.js
+++ b/shell/edit/workload/mixins/workload.js
@@ -258,6 +258,7 @@ export default {
       secondaryResourceData:      this.secondaryResourceDataConfig(),
       namespacedConfigMaps:       [],
       allNodes:                   null,
+      workerNodes:                null,
       allNodeObjects:             [],
       namespacedSecrets:          [],
       imagePullNamespacedSecrets: [],
@@ -647,7 +648,24 @@ export default {
                 parsingFunc: (data) => {
                   return data.map((node) => node.id);
                 }
-              }
+              },
+              {
+                var:         'workerNodes',
+                parsingFunc: (data) => {
+                  const keys = [
+                    `node-role.kubernetes.io/control-plane`,
+                    `node-role.kubernetes.io/etcd`
+                  ];
+
+                  return data
+                    .filter((node) => {
+                      const taints = node?.spec?.taints || [];
+
+                      return taints.every((taint) => !keys.includes(taint.key));
+                    })
+                    .map((node) => node.id);
+                }
+              },
             ]
           },
           [SERVICE]: {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This restricts Node Scheduling selection to only worker nodes by forming a new collection of nodes that do not contain the `etc` or `control-plane` taint.

Fixes #16333
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Limit node scheduling dropdown to worker nodes
- Add unit tests for worker nodes computed

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

It appears that the taints are the primary method kubernetes uses to restrict workload scheduling[^1]. 

[^1]: https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Repro steps described in the issue. 

Confirm that this works with nodes that have multiple roles selected (e.g. etcd & worker). In my tests, I noted that the taint is omitted whenever worker is selected. This needs to be confirmed. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Node selection. Nodes cannot be selected if, for some reason, worker nodes can receive the etcd/control-plane taint.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
