### PR TITLE
Fix target namespace for charts

### DIFF
--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -303,57 +303,6 @@ export default {
 
       this.fetchStoreChart();
 
-      if ( this.query.appNamespace && this.query.appName ) {
-        // First check the URL query for an app name and namespace.
-        // Use those values to check for a catalog app resource.
-        // If found, set the form to edit mode. If not, set the
-        // form to create mode.
-
-        try {
-          this.existing = await this.$store.dispatch('cluster/find', {
-            type: CATALOG.APP,
-            id:   `${ this.query.appNamespace }/${ this.query.appName }`,
-          });
-
-          await this.existing?.fetchValues(true);
-
-          this.mode = _EDIT;
-        } catch (e) {
-          this.mode = _CREATE;
-          this.existing = null;
-        }
-      } else if ( this.chart?.targetNamespace && this.chart?.targetName ) {
-        // If the app name and namespace values are not provided in the
-        // query, fall back on target values defined in the Helm chart itself.
-
-        // Ask to install a special chart with fixed namespace/name
-        // or edit it if there's an existing install.
-
-        try {
-          this.existing = await this.$store.dispatch('cluster/find', {
-            type: CATALOG.APP,
-            id:   `${ this.chart.targetNamespace }/${ this.chart.targetName }`,
-          });
-          this.mode = _EDIT;
-        } catch (e) {
-          this.mode = _CREATE;
-          this.existing = null;
-        }
-      } else if (this.chart) {
-        const matching = this.chart.matchingInstalledApps;
-
-        if (matching.length === 1) {
-          this.existing = matching[0];
-          this.mode = _EDIT;
-        } else {
-          this.mode = _CREATE;
-        }
-      } else {
-        // Regular create
-
-        this.mode = _CREATE;
-      }
-
       if ( !this.chart ) {
         return;
       }
@@ -417,6 +366,62 @@ export default {
         this.versionInfoError = e;
 
         console.error('Unable to fetch VersionInfo: ', e); // eslint-disable-line no-console
+      }
+
+      if ( this.query.appNamespace && this.query.appName ) {
+        // First check the URL query for an app name and namespace.
+        // Use those values to check for a catalog app resource.
+        // If found, set the form to edit mode. If not, set the
+        // form to create mode.
+
+        try {
+          this.existing = await this.$store.dispatch('cluster/find', {
+            type: CATALOG.APP,
+            id:   `${ this.query.appNamespace }/${ this.query.appName }`,
+          });
+
+          await this.existing?.fetchValues(true);
+
+          this.mode = _EDIT;
+        } catch (e) {
+          this.mode = _CREATE;
+          this.existing = null;
+        }
+      } else {
+        const targetNamespace = this.version?.annotations?.[CATALOG_ANNOTATIONS.NAMESPACE];
+        const targetName = this.version?.annotations?.[CATALOG_ANNOTATIONS.RELEASE_NAME];
+
+        if ( targetNamespace && targetName ) {
+          // If the app name and namespace values are not provided in the
+          // query, fall back on target values defined in the Helm chart itself.
+
+          // Ask to install a special chart with fixed namespace/name
+          // or edit it if there's an existing install.
+
+          try {
+            this.existing = await this.$store.dispatch('cluster/find', {
+              type: CATALOG.APP,
+              id:   `${ targetNamespace }/${ targetName }`,
+            });
+            this.mode = _EDIT;
+          } catch (e) {
+            this.mode = _CREATE;
+            this.existing = null;
+          }
+        } else if (this.chart) {
+          const matching = this.chart.matchingInstalledApps;
+
+          if (matching.length === 1) {
+            this.existing = matching[0];
+            this.mode = _EDIT;
+          } else {
+            this.mode = _CREATE;
+          }
+        } else {
+          // Regular create
+
+          this.mode = _CREATE;
+        }
       }
     }, // End of fetchChart
 

--- a/shell/pages/c/_cluster/apps/charts/__tests__/install.test.ts
+++ b/shell/pages/c/_cluster/apps/charts/__tests__/install.test.ts
@@ -1,0 +1,91 @@
+
+import { mount } from '@vue/test-utils';
+import Install from '@shell/pages/c/_cluster/apps/charts/install.vue';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
+
+describe('page: Install', () => {
+  it('should use version annotations for target namespace and name', async() => {
+    const mockStore = {
+      dispatch: jest.fn((action) => {
+        if (action === 'cluster/create') {
+          return Promise.resolve({ metadata: { namespace: '', name: '' } });
+        }
+
+        return Promise.resolve();
+      }),
+      getters: {
+        'catalog/inStore':         'cluster',
+        'features/get':            () => false,
+        defaultNamespace:          'default',
+        'i18n/withFallback':       (key: string) => key,
+        'type-map/hasCustomChart': () => false,
+        'cluster/all':             () => [],
+        'cluster/byId':            () => null,
+        'management/all':          () => [],
+        'prefs/get':               () => {},
+        'catalog/charts':          [],
+        'wm/byId':                 () => null,
+        'i18n/t':                  (key: string) => key,
+      }
+    };
+
+    const wrapper = mount(Install, {
+      global: {
+        mocks: {
+          $store:      mockStore,
+          $route:      { query: {} },
+          $fetchState: { pending: false },
+          t:           (key: string) => key,
+        },
+        stubs: {
+          Loading:             true,
+          Wizard:              true,
+          Banner:              true,
+          Checkbox:            true,
+          LabeledInput:        true,
+          LabeledSelect:       true,
+          NameNsDescription:   true,
+          Tabbed:              true,
+          Questions:           true,
+          YamlEditor:          true,
+          ResourceCancelModal: true,
+          UnitInput:           true,
+          TypeDescription:     true,
+          LazyImage:           true,
+          ChartReadme:         true,
+          ButtonGroup:         true,
+        }
+      },
+      data() {
+        return {
+          version: {
+            annotations: {
+              [CATALOG_ANNOTATIONS.NAMESPACE]:    'custom-ns',
+              [CATALOG_ANNOTATIONS.RELEASE_NAME]: 'custom-name',
+            }
+          },
+          chart: {
+            targetNamespace: 'wrong-ns',
+            targetName:      'wrong-name',
+            versions:        []
+          },
+          query: { versionName: '1.0.0' }
+        };
+      }
+    });
+
+    // Mock methods from mixins
+    jest.spyOn((wrapper.vm as any), 'fetchChart').mockImplementation().mockResolvedValue(undefined);
+    jest.spyOn((wrapper.vm as any), 'fetchAutoInstallInfo').mockImplementation().mockResolvedValue(undefined);
+    jest.spyOn((wrapper.vm as any), 'getClusterRegistry').mockImplementation().mockResolvedValue(undefined);
+    jest.spyOn((wrapper.vm as any), 'getGlobalRegistry').mockImplementation().mockResolvedValue(undefined);
+    jest.spyOn((wrapper.vm as any), 'loadValuesComponent').mockImplementation().mockResolvedValue(undefined);
+    jest.spyOn((wrapper.vm as any), 'updateStepOneReady').mockImplementation();
+
+    // Trigger fetch
+    await Install.fetch.call(wrapper.vm);
+
+    expect(wrapper.vm.forceNamespace).toBe('custom-ns');
+    expect(wrapper.vm.value.metadata.name).toBe('custom-name');
+  });
+});

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -166,10 +166,10 @@ export default {
     } else if (this.$route.query[FROM_CLUSTER] === _FLAGGED) {
       /* For Fleet, use the fleet-default namespace. */
       this.forceNamespace = DEFAULT_WORKSPACE;
-    } else if ( this.chart?.targetNamespace ) {
+    } else if ( this.version?.annotations?.[CATALOG_ANNOTATIONS.NAMESPACE] ) {
       /* If a target namespace is defined in the chart,
       set the target namespace as default. */
-      this.forceNamespace = this.chart.targetNamespace;
+      this.forceNamespace = this.version.annotations[CATALOG_ANNOTATIONS.NAMESPACE];
     } else if ( this.query.appNamespace ) {
       /* If a namespace is defined in the URL query,
        use that namespace as default. */
@@ -219,13 +219,13 @@ export default {
         The target name indicates the name of the cluster
         group that the chart is meant to be installed in.
       */
-      if ( this.chart?.targetName ) {
+      if ( this.version?.annotations?.[CATALOG_ANNOTATIONS.RELEASE_NAME] ) {
         /*
           Set the name of the chartInstallAction
           to the name of the cluster group
           where the chart should be installed.
         */
-        this.value.metadata.name = this.chart.targetName;
+        this.value.metadata.name = this.version.annotations[CATALOG_ANNOTATIONS.RELEASE_NAME];
         this.nameDisabled = true;
       } else if ( this.query.appName ) {
         this.value.metadata.name = this.query.appName;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16368 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Fixed an issue where the chart installation/upgrade process relied on the chart's latest version target namespace instead of the target namespace defined in the specifically selected version.
- This ensures that when installing a specific version of a chart that has a different target namespace than the latest version, the correct namespace is used for creation or existing app detection.

### Technical notes summary
- Refactored `fetchChart` in `shell/mixins/chart.js` to fetch the specific version information **before** determining if the app is already installed.
- Updated the logic to prioritize `version.annotations['catalog.cattle.io/namespace']` and `version.annotations['catalog.cattle.io/release-name']` over `chart.targetNamespace` and `chart.targetName`.
- Updated `shell/pages/c/_cluster/apps/charts/install.vue` to set `this.forceNamespace` and `this.value.metadata.name` based on the selected version's annotations.
- Added unit tests in `shell/pages/c/_cluster/apps/charts/__tests__/install.test.ts` and `shell/mixins/__tests__/chart.test.ts` to verify the namespace resolution logic.

### Areas or cases that should be tested
1.  **Add the Repository:**
    *   Go to **Apps & Marketplace** -> **Repositories**.
    *   Click **Create**.
    *   Target: `https://rancher.github.io/turtles`
    *   Click **Create**.

2.  **Test Older Version (0.24.3):**
    *   Go to **Apps & Marketplace** -> **Charts**.
    *   Find **Rancher Turtles**.
    *   Click on the chart card.
    *   In the **Chart Versions** sidebar, select **0.24.3**.
    *   Click **Install**.
    *   Proceed through the wizard steps and click **Install** to start the process.
    *   **Verify:** If the installation starts and opens the terminal window, check the executed command. It **MUST** include:
        `--namespace=rancher-turtles-system`

3.  **Test Latest Version:**
    *   Go back to **Apps & Marketplace** -> **Charts** -> **Rancher Turtles**.
    *   Select the **latest** version 
    *   Click **Install** (or Upgrade if you managed to install the previous one).
    *   Proceed to the installation execution.
    *   **Verify:** Check the executed command in the terminal window. It **MUST** include:
        `--namespace=cattle-turtles-system`

Note: The actual success of the installation does not matter for this test; we are verifying that the UI targets the correct namespace for each version.

### Areas which could experience regressions

- Since the order of operations in `fetchChart` changed (fetching version before checking for existing app), verify that the dashboard still correctly identifies when an app is already installed versus a new install, especially for charts without fixed namespaces.
- Test installing a standard chart (no fixed namespace) to ensure no regressions.
- Test upgrading an existing app

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
