### PR TITLE
Fix markdown blockquote excessive spacing

### DIFF
--- a/shell/components/Markdown.vue
+++ b/shell/components/Markdown.vue
@@ -93,7 +93,7 @@ export default {
       color: rgb(101, 109, 118);
       border-left: 0.25em solid rgb(208, 215, 222);
       padding: 0 1em;
-      margin-bottom: 16px;
+      margin: 10px 8px 8px 8px;
     }
 
     table {


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Things have improved slightly since the issue was filed but the margins were a bit excessive. I'll attach a screenshot of what we have in master and what we have in his pr. If we're happy with master I'll just close the issue.

Fixes #11854
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Updated margins

### Technical notes summary
The `blockquote` is only styled in one location so it's not too hard to verify. You just need to find the appropriate charts.

### Areas or cases that should be tested
- [ ] Navigate to Cluster Explorer → Apps → Charts → Kasten
- [ ] Verify blockquote is positioned closer to the left edge and higher vertically

### Areas which could experience regressions
Same as above

### Screenshot/Video
Master:
<img width="645" height="546" alt="image" src="https://github.com/user-attachments/assets/10f4027a-fcde-444a-9dcc-e4bf013a7e19" />

PR:
<img width="642" height="374" alt="image" src="https://github.com/user-attachments/assets/694ad8d1-9383-4eaa-87ed-ac0fa13c1fe6" />


### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
