### PR TITLE
Fixed version upgrade for imported GKE

### DIFF
--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -190,7 +190,6 @@ export default defineComponent({
       const liveNormanCluster = await this.value.findNormanCluster();
 
       this.normanCluster = await store.dispatch(`rancher/clone`, { resource: liveNormanCluster });
-      this.originalVersion = this.normanCluster?.gkeConfig?.kubernetesVersion;
     } else {
       if (this.isImport) {
         this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...cloneDeep(defaultImportedCluster) }, { root: true });
@@ -204,6 +203,8 @@ export default defineComponent({
     // ensure any fields editable through this UI that have been altered in aws are shown here - see syncUpstreamConfig jsdoc for details
     if (!this.isNewOrUnprovisioned) {
       syncUpstreamConfig('gke', this.normanCluster);
+      // kubernetesVersion is null on imported cluster until this point
+      this.originalVersion = this.normanCluster?.gkeConfig?.kubernetesVersion;
     }
 
     if (!this.isImport) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #12250 
<!-- Define findings related to the feature or bug issue. -->
normanCluster.gkeConfig had kubernetesVersion set to null for imported cluster before it was synced with Upstream config. This meant that originalVersion was also null and we were not able to determine which minor is next
 
### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Moved the logic to set originalVersion after a sync with upstream. At that point, kubernetesVersion is defined and can be used.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
i don't think this case can be covered by unit tests, and we do not have existing e2e tests for the imported GKE cluster, so given the size of the change, I think manual testing is appropriate.
1. Create a GKE cluster outside of Rancher. Choose k8s version 1.32 or below
2. Import it into Rancher
3. Validate that only versions 1.33 are selectable

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1587" height="752" alt="Screenshot 2026-01-15 at 3 03 58 PM" src="https://github.com/user-attachments/assets/13b4bdf0-1165-4de8-83ee-0e302c8bc0a9" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
