### PR TITLE
Create/Edit HPA - Don't fetch all workload types when SSP enabled

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3591,6 +3591,7 @@ hpa:
     last: Last Scale Time
     max: Maximum Replicas
     min: Minimum Replicas
+    targetReferenceType: Target Type
     targetReference: Target Reference
 
 import:
@@ -8363,6 +8364,11 @@ typeLabel:
     {count, plural,
       one { Role }
       other { Roles }
+    }
+  replicationcontroller: |-
+    {count, plural,
+      one { Replication Controller }
+      other { Replication Controllers }
     }
   scheduling.k8s.io.priorityclass: |-
     {count, plural,

--- a/shell/components/form/ResourceLabeledSelect.vue
+++ b/shell/components/form/ResourceLabeledSelect.vue
@@ -165,5 +165,16 @@ export default defineComponent({
     :paginate="paginateType"
     :multiple="$attrs.multiple || false"
     @update:value="$emit('update:value', $event)"
-  />
+  >
+    <template
+      v-for="(_, slot) in $slots"
+      :key="slot"
+      #[slot]="scope"
+    >
+      <slot
+        :name="slot"
+        v-bind="scope"
+      />
+    </template>
+  </LabeledSelect>
 </template>

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -81,7 +81,11 @@ export const RBAC = {
 
 export const WORKLOAD = 'workload';
 
-// The types that are aggregated into a "workload"
+/**
+ * Rancher Workload types
+ *
+ * The types that are aggregated into a "workload"
+ */
 export const WORKLOAD_TYPES = {
   DEPLOYMENT:             'apps.deployment',
   CRON_JOB:               'batch.cronjob',
@@ -92,15 +96,44 @@ export const WORKLOAD_TYPES = {
   REPLICATION_CONTROLLER: 'replicationcontroller',
 };
 
+/**
+ * Kube Workload Kinds
+ */
+export const WORKLOAD_KINDS = {
+  DEPLOYMENT:             'Deployment',
+  CRON_JOB:               'CronJob',
+  DAEMON_SET:             'DaemonSet',
+  JOB:                    'Job',
+  STATEFUL_SET:           'StatefulSet',
+  REPLICA_SET:            'ReplicaSet',
+  REPLICATION_CONTROLLER: 'ReplicationController',
+};
+
+/**
+ * Map Rancher Workload types to Kube Workload Kinds
+ */
 export const WORKLOAD_TYPE_TO_KIND_MAPPING = {
   // Each deployment creates a replicaset and the metrics are published for a replicaset.
-  [WORKLOAD_TYPES.DEPLOYMENT]:             'ReplicaSet',
-  [WORKLOAD_TYPES.CRON_JOB]:               'CronJob',
-  [WORKLOAD_TYPES.DAEMON_SET]:             'DaemonSet',
-  [WORKLOAD_TYPES.JOB]:                    'Job',
-  [WORKLOAD_TYPES.STATEFUL_SET]:           'StatefulSet',
-  [WORKLOAD_TYPES.REPLICA_SET]:            'ReplicaSet',
-  [WORKLOAD_TYPES.REPLICATION_CONTROLLER]: 'ReplicationController',
+  [WORKLOAD_TYPES.DEPLOYMENT]:             WORKLOAD_KINDS.DEPLOYMENT,
+  [WORKLOAD_TYPES.CRON_JOB]:               WORKLOAD_KINDS.CRON_JOB,
+  [WORKLOAD_TYPES.DAEMON_SET]:             WORKLOAD_KINDS.DAEMON_SET,
+  [WORKLOAD_TYPES.JOB]:                    WORKLOAD_KINDS.JOB,
+  [WORKLOAD_TYPES.STATEFUL_SET]:           WORKLOAD_KINDS.STATEFUL_SET,
+  [WORKLOAD_TYPES.REPLICA_SET]:            WORKLOAD_KINDS.REPLICA_SET,
+  [WORKLOAD_TYPES.REPLICATION_CONTROLLER]: WORKLOAD_KINDS.REPLICATION_CONTROLLER,
+};
+
+/**
+ * Map Kube Workload Kinds types to Rancher Workload
+ */
+export const WORKLOAD_KIND_TO_TYPE_MAPPING = {
+  [WORKLOAD_KINDS.DEPLOYMENT]:             WORKLOAD_TYPES.DEPLOYMENT,
+  [WORKLOAD_KINDS.CRON_JOB]:               WORKLOAD_TYPES.CRON_JOB,
+  [WORKLOAD_KINDS.DAEMON_SET]:             WORKLOAD_TYPES.DAEMON_SET,
+  [WORKLOAD_KINDS.JOB]:                    WORKLOAD_TYPES.JOB,
+  [WORKLOAD_KINDS.STATEFUL_SET]:           WORKLOAD_TYPES.STATEFUL_SET,
+  [WORKLOAD_KINDS.REPLICA_SET]:            WORKLOAD_TYPES.REPLICA_SET,
+  [WORKLOAD_KINDS.REPLICATION_CONTROLLER]: WORKLOAD_TYPES.REPLICATION_CONTROLLER,
 };
 
 export const METRICS_SUPPORTED_KINDS = [

--- a/shell/edit/autoscaling.horizontalpodautoscaler/index.vue
+++ b/shell/edit/autoscaling.horizontalpodautoscaler/index.vue
@@ -1,27 +1,52 @@
-<script>
+<script lang="ts">
 import CreateEditView from '@shell/mixins/create-edit-view';
 
-import CruResource from '@shell/components/CruResource';
+import CruResource from '@shell/components/CruResource.vue';
 import { LabeledInput } from '@components/Form/LabeledInput';
-import LabeledSelect from '@shell/components/form/LabeledSelect';
-import Labels from '@shell/components/form/Labels';
-import Loading from '@shell/components/Loading';
-import NameNsDescription from '@shell/components/form/NameNsDescription';
-import Tab from '@shell/components/Tabbed/Tab';
+import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
+import ResourceLabeledSelect from '@shell/components/form/ResourceLabeledSelect.vue';
+import Labels from '@shell/components/form/Labels.vue';
+import Loading from '@shell/components/Loading.vue';
+import NameNsDescription from '@shell/components/form/NameNsDescription.vue';
+import Tab from '@shell/components/Tabbed/Tab.vue';
 import Tabbed from '@shell/components/Tabbed';
-import MetricsRow from '@shell/edit/autoscaling.horizontalpodautoscaler/metrics-row';
-import ArrayListGrouped from '@shell/components/form/ArrayListGrouped';
-import { DEFAULT_RESOURCE_METRIC } from '@shell/edit/autoscaling.horizontalpodautoscaler/resource-metric';
+import MetricsRow from '@shell/edit/autoscaling.horizontalpodautoscaler/metrics-row.vue';
+import ArrayListGrouped from '@shell/components/form/ArrayListGrouped.vue';
+import { DEFAULT_RESOURCE_METRIC } from '@shell/edit/autoscaling.horizontalpodautoscaler/resource-metric.vue';
 import { Checkbox } from '@components/Form/Checkbox';
 
-import { API_SERVICE, SCALABLE_WORKLOAD_TYPES } from '@shell/config/types';
+import { API_SERVICE, SCALABLE_WORKLOAD_TYPES, WORKLOAD_KIND_TO_TYPE_MAPPING } from '@shell/config/types';
 import isEmpty from 'lodash/isEmpty';
 import find from 'lodash/find';
 import endsWith from 'lodash/endsWith';
-import { findBy } from '@shell/utils/array';
 import HpaScalingRule from '@shell/edit/autoscaling.horizontalpodautoscaler/hpa-scaling-rule.vue';
+import { ResourceLabeledSelectPaginateSettings, ResourceLabeledSelectSettings } from '@shell/types/components/resourceLabeledSelect';
+import { PaginationParam, PaginationParamFilter } from '@shell/types/store/pagination.types';
+import { LabelSelectPaginationFunctionOptions } from '@shell/components/form/labeled-select-utils/labeled-select.utils';
 
 const RESOURCE_METRICS_API_GROUP = 'metrics.k8s.io';
+
+/**
+ * HPA spec.scaleTargetRef
+ */
+interface OBJECT_REFERENCE {
+  apiVersion: string;
+  kind: string;
+  name: string;
+}
+
+type Workload = any;
+
+/**
+ * Update to type OBJECT_REFERENCE which can be stored directly as scaleTargetRef
+ */
+const mapWorkload = (workload: Workload | OBJECT_REFERENCE): OBJECT_REFERENCE => {
+  return {
+    kind:       workload.kind,
+    name:       workload.metadata?.name || workload.name,
+    apiVersion: workload.apiVersion,
+  };
+};
 
 export default {
   name: 'CruHPA',
@@ -35,6 +60,7 @@ export default {
     CruResource,
     LabeledInput,
     LabeledSelect,
+    ResourceLabeledSelect,
     Labels,
     Loading,
     NameNsDescription,
@@ -57,40 +83,45 @@ export default {
     },
   },
 
-  fetch() {
-    const promises = [this.loadAPIServices(), this.loadWorkloads()];
-
-    return Promise.all(promises);
+  async fetch() {
+    await this.loadAPIServices();
   },
 
   data() {
-    return { defaultResourceMetric: DEFAULT_RESOURCE_METRIC };
+    const sharedSettings = {
+      labelSelectOptions: {
+        'get-option-label': (opt: Workload) => opt?.name,
+        'option-key':       'name',
+      },
+    };
+
+    const paginateSettings: ResourceLabeledSelectPaginateSettings = {
+      ...sharedSettings,
+      updateResources: (resources) => {
+        return resources.map(mapWorkload);
+      },
+      requestSettings: this.pageRequestSettings
+    };
+
+    const allSettings: ResourceLabeledSelectSettings = {
+      ...sharedSettings,
+      updateResources: this.mapWorkloads,
+    };
+
+    const scalableWorkloadType = WORKLOAD_KIND_TO_TYPE_MAPPING[this.value?.spec?.scaleTargetRef?.kind] || Object.values(SCALABLE_WORKLOAD_TYPES)[0];
+
+    return {
+      defaultResourceMetric: DEFAULT_RESOURCE_METRIC,
+      paginateSettings,
+      allSettings,
+      scalableWorkloadType,
+      scalableWorkloadTypes: Object.values(SCALABLE_WORKLOAD_TYPES).map((v) => ({ label: this.t(`typeLabel."${ v }"`, { count: 1 }), value: v })),
+    };
   },
 
   computed: {
     allMetrics() {
       return this.value?.spec?.metrics;
-    },
-    allWorkloadsFiltered() {
-      return (
-        Object.values(SCALABLE_WORKLOAD_TYPES)
-          .flatMap((type) => this.$store.getters['cluster/all'](type))
-          .filter(
-            // Filter out anything that has an owner, which should probably be the one with the HPA
-            // For example ReplicaSets can be associated with a HPA (https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/#replicaset-as-a-horizontal-pod-autoscaler-target)
-            // but wouldn't make sense if it's owned by a deployment
-            (wl) => wl.metadata.namespace === this.value.metadata.namespace && !wl.ownedByWorkload
-          )
-      );
-    },
-    allWorkloadsMapped() {
-      return this.allWorkloadsFiltered
-      // Update to type OBJECT_REFERENCE which can be stored directly as scaleTargetRef
-        .map((workload) => ({
-          kind:       workload.kind,
-          name:       workload.metadata.name,
-          apiVersion: workload.apiVersion,
-        }));
     },
     allServices() {
       return this.$store.getters['cluster/all'](API_SERVICE);
@@ -107,17 +138,13 @@ export default {
       );
     },
     selectedTargetRef() {
-      const { scaleTargetRef: { name } } = this.value.spec;
-      const { allWorkloadsFiltered } = this;
-      const match = findBy(allWorkloadsFiltered, 'metadata.name', name);
-
-      return match ?? null;
+      return this.value?.spec?.scaleTargetRef;
     },
     hasScaleDownRules: {
       get() {
         return !!this.value.spec.behavior?.scaleDown;
       },
-      set(hasScaleDownRules) {
+      set(hasScaleDownRules: boolean) {
         if (hasScaleDownRules) {
           if (!this.value.spec.behavior) {
             this.value.spec['behavior'] = {};
@@ -134,7 +161,7 @@ export default {
       get() {
         return !!this.value.spec.behavior?.scaleUp;
       },
-      set(hasScaleUpRules) {
+      set(hasScaleUpRules: boolean) {
         if (hasScaleUpRules) {
           if (!this.value.spec.behavior) {
             this.value.spec['behavior'] = {};
@@ -147,6 +174,12 @@ export default {
         }
       }
     },
+    /**
+     * Unique id that when changes resets the state used to show candidate targets
+     */
+    targetResetKey() {
+      return `${ this.value.metadata.namespace }/${ this.scalableWorkloadType }`;
+    }
   },
 
   created() {
@@ -171,16 +204,56 @@ export default {
         metrics: [{ ...this.defaultResourceMetric }]
       };
     },
-    async loadWorkloads() {
-      await Promise.all(
-        Object.values(SCALABLE_WORKLOAD_TYPES).map((type) => this.$store.dispatch('cluster/findAll', { type })
-        )
-      );
-    },
     async loadAPIServices() {
       await this.$store.dispatch('cluster/findAll', { type: API_SERVICE });
     },
+
+    /**
+     * Fn of type @PaginateTypeOverridesFn
+     */
+    pageRequestSettings(opts: LabelSelectPaginationFunctionOptions): LabelSelectPaginationFunctionOptions {
+      const { opts: { filter } } = opts;
+
+      const filters: PaginationParam[] = [
+        PaginationParamFilter.createSingleField({
+          field: 'metadata.namespace', value: this.value.metadata.namespace, equals: true
+        }),
+      ];
+
+      if (!!filter) {
+        filters.push( PaginationParamFilter.createSingleField({
+          field: 'metadata.name', value: filter, equals: true, exact: false
+        }));
+      }
+
+      return {
+        ...opts,
+        classify:         false,
+        groupByNamespace: false,
+        sort:             [{ asc: true, field: 'metadata.name' }],
+        filters
+      };
+    },
+
+    /**
+     * Update to type OBJECT_REFERENCE which can be stored directly as scaleTargetRef
+     */
+    mapWorkload(workload: Workload | OBJECT_REFERENCE): OBJECT_REFERENCE {
+      return mapWorkload(workload);
+    },
+
+    mapWorkloads(workloads: Workload[]) {
+      return workloads
+        .filter((w) => w.metadata.namespace === this.value.metadata.namespace)
+        .map(mapWorkload);
+    }
   },
+
+  watch: {
+    targetResetKey() {
+      delete this.value.spec.scaleTargetRef;
+    },
+  }
 };
 </script>
 
@@ -196,7 +269,7 @@ export default {
       :resource="value"
       :validation-passed="true"
       :errors="errors"
-      @error="(e) => (errors = e)"
+      @error="(e: any) => (errors = e)"
       @finish="save"
       @cancel="done"
     >
@@ -219,17 +292,24 @@ export default {
           <div class="row mb-20">
             <div class="col span-6">
               <LabeledSelect
+                v-model:value="scalableWorkloadType"
+                :options="scalableWorkloadTypes"
+                :mode="mode"
+                :label="t('hpa.workloadTab.targetReferenceType')"
+                :required="true"
+              />
+            </div>
+            <div class="col span-6">
+              <ResourceLabeledSelect
+                :key="targetResetKey"
                 v-model:value="value.spec.scaleTargetRef"
-                :get-option-label="(opt) => opt.name"
                 :mode="mode"
                 :label="t('hpa.workloadTab.targetReference')"
-                :options="allWorkloadsMapped"
                 :required="true"
-              >
-                <template v-slot:option="option">
-                  {{ option.name }}<span class="pull-right">{{ option.kind }}</span>
-                </template>
-              </LabeledSelect>
+                :resource-type="scalableWorkloadType"
+                :paginated-resource-settings="paginateSettings"
+                :all-resources-settings="allSettings"
+              />
             </div>
           </div>
           <div class="row">
@@ -282,6 +362,7 @@ export default {
                 :mode="mode"
                 :metrics-available="resourceMetricsAvailable"
                 :referent="selectedTargetRef"
+                :namespace="value.metadata.namespace"
               />
             </template>
           </ArrayListGrouped>

--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -699,19 +699,19 @@ export default {
 
     const res = await dispatch('request', { opt, type });
 
-    await dispatch('load', { data: res, invalidatePageCache: opt.invalidatePageCache });
+    if (!opt.transient) {
+      await dispatch('load', { data: res, invalidatePageCache: opt.invalidatePageCache });
+    }
 
-    if ( opt.watch !== false ) {
+    if (!opt.transient && opt.watch !== false ) {
       dispatch('watch', createFindWatchArg({
         type, id, opt, res
       }));
     }
 
-    out = getters.byId(type, id);
-
     garbageCollect.gcUpdateLastAccessed(ctx, type);
 
-    return out;
+    return opt.transient ? await dispatch('create', res) : getters.byId(type, id);
   },
 
   /**


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16346

### Occurred changes and/or fixed issues
Remove the need to fetch all workload types to support the user just selecting one

Core Changes
- Split selection of HPA target resource from label select with ALL workloads ---> separate per-resource label select 
- Use resource label select instead of label select
  - handles ssp case
- Update metrics-row to fetch required resource instead of being passed in from cache
  - we no longer have the cache
- Add `transient` mode to find (as per findPage)
  - Fetches resource but does not cache it, just returns it
- This change also improves SSP disabled world, given we only fetch all of one TYPE

Improvements
- Convert create/edit hpa component to TS
- Much better typing and mapping between workload types and workload kinds

General Improvements
- Pass through templates from ResourceLabeledSelect to LabeledSelect (wasn't needed in the end but should be included)
  - we don't currently use this anywhere in code

### Areas or cases that should be tested
- For both SSP Enabled and Disabled all the below tests
- Create
  - User can select a namespace and target type and see the matching target resources
  - User can change namespace or target type, the target resource is reset and new resources are shown
- Edit
  - Target tab Target Type and Target Reference is initially populated correctly (even if type is not deployment)
- Create & Edit
  - Updating the target resource updates the reference found in the metrics tab
    - this should be possible to test by ensuring no warning message is shown(requires metrics server enabled)

### Areas which could experience regressions
- nothing outside of the above tests

### Screenshot/Video
<img width="1098" height="489" alt="image" src="https://github.com/user-attachments/assets/607dbb88-3c18-4b6c-838a-f3c37414972b" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
