### PR TITLE
[Github workflow] Creation of qa automation tasks 

### DIFF
--- a/.github/workflows/automation-candidate.yaml
+++ b/.github/workflows/automation-candidate.yaml
@@ -1,12 +1,9 @@
-# create an automation task in qa-tasks repo of an issue when "/automation-candidate" is commented or labeled
+# create an automation task in qa-tasks repo of an issue when label "candidate-automation" is added
 name: Create issue for QA automation 
 
 run-name: "Create issue for QA automation  ${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
 
 on:
-  issue_comment:
-    types:
-      - created
   issues:
     types:
       - labeled    
@@ -19,39 +16,15 @@ jobs:
       issues: write
       id-token: write
     runs-on: ubuntu-latest
-    if: |
-      (github.event_name == 'issue_comment' && (contains(github.event.comment.body, '/automation') || contains(github.event.comment.body, '/ac') || contains(github.event.comment.body, '/automation-candidate'))) ||
-      (github.event_name == 'issues' && github.event.label.name == 'candidate-automation')
+    if: github.event_name == 'issues' && github.event.label.name == 'candidate-automation'
     steps:
-      - name: Check org membership
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if gh api repos/${GITHUB_REPOSITORY}/collaborators/${GITHUB_ACTOR} --silent > /dev/null 2>&1; then
-              echo "${GITHUB_ACTOR} is a member"
-              echo "is_member=true" >> $GITHUB_ENV
-          else
-              echo "${GITHUB_ACTOR} is not a member of ${GITHUB_REPOSITORY_OWNER}" >> $GITHUB_STEP_SUMMARY
-              echo "is_member=false" >> $GITHUB_ENV
-          fi
-
-      - name: Notify non-member
-        if: env.is_member == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ORIGINAL_ISSUE_URL: ${{ github.event.issue.html_url }}
-        run: |
-          gh issue comment ${ORIGINAL_ISSUE_URL} --body "User @${GITHUB_ACTOR} is not a collaborator on this repository. No QA automation issue was created."
-
       - name: Read QA secrets
-        if: env.is_member == 'true'
         uses: rancher-eio/read-vault-secrets@main
         with:
           secrets: |
             github/token/rancher--qa-tasks--issues--write token | QA_GH_TOKEN
 
       - name: Create QA automation issue
-        if: env.is_member == 'true'
         env:
           GH_TOKEN: ${{ env.QA_GH_TOKEN }}
           ORIGINAL_ISSUE_NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
Fixes https://github.com/rancher/qa-tasks/issues/2164

### Summary

This is a github workflow that is triggered every time a contributor of the dashboard repo labels an issue from the `rancher/dashboard` repo with the 'candidate-automation' label, or comments in this issue one of the strings '/ac', '/automation-candidate ', or '/automation'. The purpose of this workflow is to automate the creation of issues in the `rancher/qa-tasks` repo to track automated test coverage efforts corresponding to the original issue. This workflow is mainly intended to be used by the QA team during QA Reviews, but it can be triggered by any contributors to the `rancher/dashboard` repo, as soon as they identify that the issue is an automation candidate for the qa team to add automated e2e tests. 

### Areas or cases that should be tested

- Being a member of the rancher/dashboard repo and triggering the workflow by adding the 'candidate-automation' label, and verifying that the issue gets created in the 'rancher/qa-tasks' repo
- Being a member of the rancher/dashboard repo and triggering the workflow by commenting '/ac', and verifying that the issue gets created in the 'rancher/qa-tasks' repo.
- Being a member of the rancher/dashboard repo and triggering the workflow by commenting '/automation-candidate', and verifying that the issue gets created in the 'rancher/qa-tasks' repo.
- Being a member of the rancher/dashboard repo and triggering the workflow by commenting '/automation', and verifying that the issue gets created in the 'rancher/qa-tasks' repo.
- Not being a member of the rancher/dashboard repo and triggering the workflow by commenting or labelling the issue, and verifying that the issue does NOT get created in the 'rancher/qa-tasks' repo, and that the github-bot correctly comments in the original issue body that the workflow fails to create the issue because the user is not a member of the dashboard repo.
- [Optional]: Being a member of the rancher/dashboard repo and triggering the workflow locally with an expired token to induce a generic workflow failure and verifying that the issue does NOT get created in the 'rancher/qa-tasks' repo, and that the github-bot correctly comments in the original issue body that the workflow fails to create the issue because of a generic workflow failure.

### Areas which could experience regressions
Maybe other existing github workflows.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

