### PR TITLE
Fix long secret values causing page horizontal scroll

### DIFF
--- a/shell/components/DetailText.vue
+++ b/shell/components/DetailText.vue
@@ -167,11 +167,11 @@ export default {
     <h5
       v-if="labelKey"
       v-t="labelKey"
-      v-clean-tooltip="itemLabel"
+      v-clean-tooltip="{content: itemLabel, popperClass: 'detail-text-tooltip'}"
     />
     <h5
       v-else-if="label"
-      v-clean-tooltip="label"
+      v-clean-tooltip="{content: label, popperClass: 'detail-text-tooltip'}"
     >
       {{ label }}
     </h5>
@@ -209,6 +209,7 @@ export default {
     <template v-if="!isBinary && !jsonStr && isLong && !expanded">
       <a
         href="#"
+        class="more-characters"
         @click.prevent="expand"
       >{{ plusMore }}</a>
     </template>
@@ -298,5 +299,19 @@ export default {
 .monospace {
   white-space: pre-wrap;
   word-wrap: break-all
+}
+
+.more-characters {
+  margin-top: 8px;
+  display: inline-block;
+}
+</style>
+
+<style lang="scss">
+// The global styles for tooltips are in dashboard/shell/assets/styles/global/_tooltip.scss.
+// I don't want to make this change for all tooltips since there's 149 instances as of writing this
+// so I'm adding a global style here that's scoped to the class we're adding to the tooltips we have in this component.
+.detail-text-tooltip.v-popper__popper.v-popper--theme-tooltip {
+  overflow-wrap: anywhere;
 }
 </style>


### PR DESCRIPTION
## Summary
- Long opaque secrets now display with a horizontal scrollbar within their container instead of causing page-level horizontal scroll
- Uses `contain: inline-size` to constrain the container width and `overflow-x: auto` on the concealed content

Fixes #16408


### Occurred changes and/or fixed issues
- Handled overflow better
- Added some spacing between the action header and the buttons so they buttons don't overlap the text,

### Areas or cases that should be tested
- Create an opaque secret with a very long value (300+ characters, no spaces)
- View the secret detail page
- Verify the secret container stays within the page bounds
- Verify a horizontal scrollbar appears on the concealed content row
- Verify short secrets display normally without a scrollbar

A secret you can use
```apiVersion: v1
kind: Secret
metadata:
  name: test-long-secret
type: Opaque
data:
  short-key: c2hvcnQgdmFsdWU=
  long-key: YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ejAxMjM0NTY3ODlBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWmFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6MDEyMzQ1Njc4OUFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5ejAxMjM0NTY3ODlBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWg==
```


### Areas which could experience regressions
Displaying or editing various secret types.

### Screenshot/Video

https://github.com/user-attachments/assets/6f5d5047-c57f-4eb0-be66-e6b4f0c8df2c



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
