### PR TITLE
Enable editing of custom claims for keycloak provider

### DIFF
--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -247,5 +247,55 @@ describe('oidc.vue', () => {
       expect(groupsClaim.exists()).toBe(true);
       expect(emailClaim.exists()).toBe(true);
     });
+
+    it('should render addCustomClaims and supportsGroupSearch  checkbox when provider is keycloak', async() => {
+      wrapper.vm.model.id = 'keycloakoidc';
+      await nextTick();
+
+      const addCustomClaimsCheckbox = wrapper.find('[data-testid="input-add-custom-claims"]');
+      const groupSearchCheckbox = wrapper.find('[data-testid="input-group-search"]');
+
+      expect(addCustomClaimsCheckbox.exists()).toBe(true);
+      expect(groupSearchCheckbox.exists()).toBe(true);
+    });
+
+    it('should render custom claims section when provider is keycloak and addCustomClaims is true', async() => {
+      wrapper.vm.model.id = 'keycloakoidc';
+      wrapper.vm.addCustomClaims = true;
+      await nextTick();
+
+      const nameClaim = wrapper.find('[data-testid="input-name-claim"]');
+      const groupsClaim = wrapper.find('[data-testid="input-groups-claim"]');
+      const emailClaim = wrapper.find('[data-testid="input-email-claim"]');
+
+      expect(nameClaim.exists()).toBe(true);
+      expect(groupsClaim.exists()).toBe(true);
+      expect(emailClaim.exists()).toBe(true);
+    });
+
+    it('should render both addCustomClaims and groupSearch checkboxes when provider is genericoidc', async() => {
+      wrapper.vm.model.id = 'genericoidc';
+      await nextTick();
+
+      const addCustomClaimsCheckbox = wrapper.find('[data-testid="input-add-custom-claims"]');
+      const groupSearchCheckbox = wrapper.find('[data-testid="input-group-search"]');
+
+      expect(addCustomClaimsCheckbox.exists()).toBe(true);
+      expect(groupSearchCheckbox.exists()).toBe(true);
+    });
+
+    it('should NOT render custom claims section when provider is keycloak and addCustomClaims is false', async() => {
+      wrapper.vm.model.id = 'keycloakoidc';
+      wrapper.vm.addCustomClaims = false;
+      await nextTick();
+
+      const nameClaim = wrapper.find('[data-testid="input-name-claim"]');
+      const groupsClaim = wrapper.find('[data-testid="input-groups-claim"]');
+      const emailClaim = wrapper.find('[data-testid="input-email-claim"]');
+
+      expect(nameClaim.exists()).toBe(false);
+      expect(groupsClaim.exists()).toBe(false);
+      expect(emailClaim.exists()).toBe(false);
+    });
   });
 });

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -155,6 +155,14 @@ export default {
       return this.model?.id === 'genericoidc';
     },
 
+    isKeycloak() {
+      return this.model?.id === 'keycloakoidc';
+    },
+
+    supportsCustomClaims() {
+      return this.isGenericOidc || this.isKeycloak;
+    },
+
     isLogoutAllSupported() {
       return this.model?.logoutAllSupported;
     },
@@ -275,7 +283,7 @@ export default {
     },
 
     willSave() {
-      if (this.isGenericOidc && !this.addCustomClaims) {
+      if (this.supportsCustomClaims && !this.addCustomClaims) {
         this.model.nameClaim = undefined;
         this.model.groupsClaim = undefined;
         this.model.emailClaim = undefined;
@@ -436,29 +444,27 @@ export default {
               :label="t('authConfig.oidc.pkce.label')"
               :tooltip="t('authConfig.oidc.pkce.tooltip')"
             />
-            <template v-if="isGenericOidc || supportsGroupSearch">
-              <Checkbox
-                v-if="supportsGroupSearch"
-                v-model:value="model.groupSearchEnabled"
-                data-testid="input-group-search"
-                :label="t('authConfig.oidc.groupSearch.label')"
-                :tooltip="t('authConfig.oidc.groupSearch.tooltip')"
-                :mode="mode"
-              />
-              <Checkbox
-                v-if="isGenericOidc"
-                v-model:value="addCustomClaims"
-                data-testid="input-add-custom-claims"
-                :label="t('authConfig.oidc.customClaims.enable.label')"
-                :tooltip="t('authConfig.oidc.customClaims.enable.tooltip')"
-                :mode="mode"
-              />
-            </template>
+            <Checkbox
+              v-if="supportsGroupSearch"
+              v-model:value="model.groupSearchEnabled"
+              data-testid="input-group-search"
+              :label="t('authConfig.oidc.groupSearch.label')"
+              :tooltip="t('authConfig.oidc.groupSearch.tooltip')"
+              :mode="mode"
+            />
+            <Checkbox
+              v-if="supportsCustomClaims"
+              v-model:value="addCustomClaims"
+              data-testid="input-add-custom-claims"
+              :label="t('authConfig.oidc.customClaims.enable.label')"
+              :tooltip="t('authConfig.oidc.customClaims.enable.tooltip')"
+              :mode="mode"
+            />
           </div>
         </div>
 
         <!-- Custom Claims -->
-        <template v-if="addCustomClaims && isGenericOidc">
+        <template v-if="addCustomClaims && supportsCustomClaims">
           <h4>{{ t('authConfig.oidc.customClaims.label') }}</h4>
           <div class="row mb-20">
             <div class="col span-6">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This enables the editing of custom claims for keycloak provider.

Fixes #16241
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Enable editing of custom claims for keycloak provider
- Add unit tests to assert new behavior

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

rancher/rancher#53465 contains fixes for custom userName claims in keycloak. This change requires that custom claims be enabled for keycloak as well as generic oidc.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Keycloak OIDC should render and save custom claims

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This change should be additive to the keycloak provider config form.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="1383" height="2521" alt="image" src="https://github.com/user-attachments/assets/dc9f7e7a-26da-4c15-af49-8979052f9113" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
