### PR TITLE
Add the ability to customize the action buttons on detail pages

### DIFF
--- a/shell/components/Resource/Detail/TitleBar/__tests__/composables.test.ts
+++ b/shell/components/Resource/Detail/TitleBar/__tests__/composables.test.ts
@@ -16,13 +16,14 @@ jest.mock('vue-router', () => ({ useRoute: () => mockRoute }));
 
 describe('composables: TitleBar', () => {
   const resource = {
-    nameDisplay:       'RESOURCE_NAME',
-    namespace:         'RESOURCE_NAMESPACE',
-    type:              'RESOURCE_TYPE',
-    stateBackground:   'RESOURCE_STATE_BACKGROUND',
-    stateDisplay:      'RESOURCE_STATE_DISPLAY',
-    description:       'RESOURCE_DESCRIPTION',
-    showConfiguration: jest.fn(),
+    nameDisplay:                 'RESOURCE_NAME',
+    namespace:                   'RESOURCE_NAMESPACE',
+    type:                        'RESOURCE_TYPE',
+    stateBackground:             'RESOURCE_STATE_BACKGROUND',
+    stateDisplay:                'RESOURCE_STATE_DISPLAY',
+    description:                 'RESOURCE_DESCRIPTION',
+    showConfiguration:           jest.fn(),
+    detailPageAdditionalActions: undefined as any,
   };
   const labelFor = 'LABEL_FOR';
   const schema = { type: 'SCHEMA' };
@@ -53,5 +54,35 @@ describe('composables: TitleBar', () => {
 
     props.value.onShowConfiguration?.('callback');
     expect(resource.showConfiguration).toHaveBeenCalledTimes(1);
+  });
+
+  it('should include additionalActions from resource.detailPageAdditionalActions', async() => {
+    const additionalActions = [
+      {
+        label: 'Action 1', variant: 'secondary', onClick: jest.fn()
+      }
+    ];
+
+    resource.detailPageAdditionalActions = additionalActions;
+
+    mockStore.getters['currentStore'].mockImplementation(() => 'cluster');
+    mockStore.getters['cluster/schemaFor'].mockImplementation(() => schema);
+    mockStore.getters['type-map/labelFor'].mockImplementation(() => labelFor);
+
+    const props = useDefaultTitleBarProps(resource, ref(undefined));
+
+    expect(props.value.additionalActions).toStrictEqual(additionalActions);
+  });
+
+  it('should have undefined additionalActions when resource does not define detailPageAdditionalActions', async() => {
+    resource.detailPageAdditionalActions = undefined;
+
+    mockStore.getters['currentStore'].mockImplementation(() => 'cluster');
+    mockStore.getters['cluster/schemaFor'].mockImplementation(() => schema);
+    mockStore.getters['type-map/labelFor'].mockImplementation(() => labelFor);
+
+    const props = useDefaultTitleBarProps(resource, ref(undefined));
+
+    expect(props.value.additionalActions).toBeUndefined();
   });
 });

--- a/shell/components/Resource/Detail/TitleBar/composables.ts
+++ b/shell/components/Resource/Detail/TitleBar/composables.ts
@@ -36,7 +36,8 @@ export const useDefaultTitleBarProps = (resource: any, resourceSubtype?: Ref<str
         color: resourceValue.stateBackground,
         label: resourceValue.stateDisplay
       },
-      description: resourceValue.description,
+      description:       resourceValue.description,
+      additionalActions: resourceValue.detailPageAdditionalActions,
       onShowConfiguration
     };
   });

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -8,14 +8,21 @@ import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
 import RcButton from '@components/RcButton/RcButton.vue';
 import TabTitle from '@shell/components/TabTitle';
-import { computed, ref, watch } from 'vue';
+import { computed, ref, VueElement, watch } from 'vue';
 import { _CONFIG, AS } from '@shell/config/query-params';
 import { ExtensionPoint, PanelLocation } from '@shell/core/types';
 import ExtensionPanel from '@shell/components/ExtensionPanel.vue';
+import { ButtonVariantNewProps, ButtonSizeNewProps } from '~/pkg/rancher-components/src/components/RcButton/types';
+import { isArray } from 'lodash';
 
 export interface Badge {
   color: 'bg-success' | 'bg-error' | 'bg-warning' | 'bg-info';
   label: string;
+}
+
+export interface AdditionalActionButton extends ButtonVariantNewProps, ButtonSizeNewProps {
+  label: string;
+  onClick: () => void;
 }
 
 export interface TitleBarProps {
@@ -27,6 +34,8 @@ export interface TitleBarProps {
   description?: string;
   badge?: Badge;
 
+  additionalActions?: VueElement | AdditionalActionButton[];
+
   // This should be replaced with a list of menu items we want to render.
   // I don't have the time right now to swap this out though.
   actionMenuResource?: any;
@@ -36,7 +45,7 @@ export interface TitleBarProps {
 
 <script setup lang="ts">
 const {
-  resource, resourceTypeLabel, resourceTo, resourceName, description, badge, onShowConfiguration,
+  additionalActions, resource, resourceTypeLabel, resourceTo, resourceName, description, badge, onShowConfiguration,
 } = defineProps<TitleBarProps>();
 
 const store = useStore();
@@ -55,6 +64,8 @@ watch(
     router.push({ query: { [AS]: currentView.value } });
   }
 );
+
+const showAdditionalActionButtons = computed(() => isArray(additionalActions));
 </script>
 
 <template>
@@ -89,12 +100,30 @@ watch(
         />
       </Title>
       <div class="actions">
-        <slot name="additional-actions" />
+        <slot name="additional-actions">
+          <template v-if="additionalActions">
+            <template v-if="showAdditionalActionButtons">
+              <RcButton
+                v-for="(actionButtonProps, i) in (additionalActions as AdditionalActionButton[])"
+                :key="`action-button-${i}`"
+                :variant="actionButtonProps.variant"
+                :size="actionButtonProps.size"
+                @click="actionButtonProps.onClick"
+              >
+                {{ actionButtonProps.label }}
+              </RcButton>
+            </template>
+            <component
+              :is="additionalActions"
+              v-else
+            />
+          </template>
+        </slot>
         <RcButton
           v-if="onShowConfiguration"
           :data-testid="showConfigurationDataTestId"
           class="show-configuration"
-          :primary="true"
+          variant="primary"
           size="large"
           :aria-label="i18n.t('component.resource.detail.titleBar.ariaLabel.showConfiguration', { resource: resourceName })"
           @click="() => emit('show-configuration', showConfigurationReturnFocusSelector)"
@@ -144,7 +173,12 @@ watch(
     margin-right: 10px;
   }
 
-  .show-configuration {
+  .actions {
+    display: flex;
+    align-items: center;
+  }
+
+  .show-configuration, &:deep() .actions button {
     margin-left: 16px;
   }
 

--- a/shell/plugins/dashboard-store/__tests__/resource-class.test.ts
+++ b/shell/plugins/dashboard-store/__tests__/resource-class.test.ts
@@ -429,4 +429,46 @@ describe('class: Resource', () => {
       expect(props.rows[1].label).toBe('component.resource.detail.card.insightsCard.rows.events');
     });
   });
+
+  describe('getter: detailPageAdditionalActions', () => {
+    it('should return undefined by default', () => {
+      const resource = new Resource({ type: 'test-type' }, {
+        getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
+        dispatch:    jest.fn(),
+        rootGetters: { 'i18n/t': jest.fn() },
+      });
+
+      expect(resource.detailPageAdditionalActions).toBeUndefined();
+    });
+
+    it('should allow subclasses to override and return button props array', () => {
+      class CustomResource extends Resource {
+        get detailPageAdditionalActions() {
+          return [
+            {
+              label: 'Action 1', variant: 'secondary', onClick: () => {}
+            },
+            {
+              label: 'Action 2', variant: 'primary', onClick: () => {}
+            }
+          ];
+        }
+      }
+
+      const resource = new CustomResource({ type: 'test-type' }, {
+        getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
+        dispatch:    jest.fn(),
+        rootGetters: { 'i18n/t': jest.fn() },
+      });
+
+      const actions = resource.detailPageAdditionalActions;
+
+      expect(Array.isArray(actions)).toBe(true);
+      expect(actions).toHaveLength(2);
+      expect(actions[0].label).toBe('Action 1');
+      expect(actions[0].variant).toBe('secondary');
+      expect(actions[1].label).toBe('Action 2');
+      expect(actions[1].variant).toBe('primary');
+    });
+  });
 });

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -1385,6 +1385,49 @@ export default class Resource {
     return this._detailLocation;
   }
 
+  /**
+   * Override this getter to provide additional action buttons or a custom component
+   * for the detail page title bar.
+   *
+   * @returns {undefined|object|Array} A Vue component definition, an array of RcButton props, or undefined
+   *
+   * @example
+   * // Using an array of button props with the new variant/size props
+   * get detailPageAdditionalActions() {
+   *   return [
+   *     { label: 'Action 1', variant: 'secondary', onClick: () => this.doAction1() },
+   *     { label: 'Action 2', variant: 'primary', size: 'large', onClick: () => this.doAction2() }
+   *   ];
+   * }
+   *
+   * @example
+   * // Using defineComponent with h() render function for custom rendering
+   * import { defineComponent, h } from 'vue';
+   * import RcButton from '@components/RcButton/RcButton.vue';
+   *
+   * get detailPageAdditionalActions() {
+   *   return defineComponent({
+   *     render() {
+   *       return h(RcButton, {
+   *         variant: 'primary',
+   *         onClick: () => console.log('clicked')
+   *       }, () => 'Click Me');
+   *     }
+   *   });
+   * }
+   *
+   * @example
+   * // Using dynamic import for a custom component
+   * import { defineAsyncComponent } from 'vue';
+   *
+   * get detailPageAdditionalActions() {
+   *   return defineAsyncComponent(() => import('@shell/components/MyCustomActions.vue'));
+   * }
+   */
+  get detailPageAdditionalActions() {
+    return undefined;
+  }
+
   goToDetail() {
     this.currentRouter().push(this.detailLocation);
   }


### PR DESCRIPTION
### Summary
Add the ability to customize the action buttons on detail pages

- Here are the new [methods ](https://github.com/rancher/dashboard/pull/16448/changes#diff-556a64885b5b143ac11818032a24b1514e630153c62223800f288f124a22adf5)
- Here's my preferred [method](https://github.com/rancher/dashboard/blob/master/shell/detail/fleet.cattle.io.helmop.vue#L131-L138)

Fixes #15061

### Occurred changes and/or fixed issues
- Added `detailPageAdditionalActions` getter to `resource-class.js`
- Added `additionalActions` prop to TitleBar (supports button props array or Vue components)
- Updated composables to pass actions from resource

### Areas or cases that should be tested
- The various methods documented here https://github.com/rancher/dashboard/pull/16448/changes#diff-556a64885b5b143ac11818032a24b1514e630153c62223800f288f124a22adf5

Here's a patch if you'd like to try one of the methods:
```curl -sL https://gist.githubusercontent.com/codyrancher/920cbd2835e3e05129d1a7876b9054e5/raw/6629f515fe4430d1bafb71b4cad4cf90316b5856/namespace.patch | git apply```

### Areas which could experience regressions
- Detail page title bar layout
- Existing `additional-actions` slot usage  (i.e. [fleet.cattle.io.helmop.vue](https://github.com/rancher/dashboard/blob/master/shell/detail/fleet.cattle.io.helmop.vue#L131-L138))

### Screenshot/Video
<img width="957" height="433" alt="image" src="https://github.com/user-attachments/assets/7b53218f-0c1d-44cd-96d0-e4691e7b3d04" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
