### PR TITLE
fix(rc-dropdown): fix memory leak by removing pointerdown listener co…

### DIFF
--- a/shell/composables/useClickOutside.ts
+++ b/shell/composables/useClickOutside.ts
@@ -76,6 +76,6 @@ export const useClickOutside = <T extends OnClickOutsideOptions>(
 
   onBeforeUnmount(() => {
     window.removeEventListener('click', listener as any);
-    window.removeEventListener('pointerDown', setShouldListen);
+    window.removeEventListener('pointerdown', setShouldListen);
   });
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/16425

### Occurred changes and/or fixed issues

* Fixed a memory leak in the `useClickOutside` composable where a `pointerdown` event listener was added on mount but not removed on unmount due to an incorrect event name (`pointerDown`).

### Technical notes summary

* Corrected the `removeEventListener` call to use the exact same event name registered by `addEventListener`:

  * `addEventListener('pointerDown', ...)`
  * `removeEventListener('pointerDown', ...)` ✅

### Areas or cases that should be tested

* Dropdown behavior:

  * Open/close dropdown and ensure click-outside closes the menu as expected.
  
* High-churn list scenarios (repro for the leak):
    
  1. Create many pod that keeps restarting.  
  2. Navigate to event page.
  3. Observe that browser memory stabilizes and does not continuously grow.
  
* Local browser tested: **Chrome**

### Screenshot/Video

<img width="1853" height="816" alt="截屏2026-01-22 12 10 28" src="https://github.com/user-attachments/assets/c3c9e51f-8a73-40f1-83fd-be1035198005" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
