### PR TITLE
Quote ssp filter values if they contain a `-`

### DIFF
--- a/shell/plugins/steve/__tests__/steve-pagination-utils.test.ts
+++ b/shell/plugins/steve/__tests__/steve-pagination-utils.test.ts
@@ -477,6 +477,20 @@ describe('class StevePaginationUtils', () => {
       expect(result).toBe('filter=spec.containers.image~nginx&filter=metadata.name!=test');
     });
 
+    it.each([
+      ['test', 'test'],
+      ['-test', '"-test"'],
+      ['te-st', '"te-st"'],
+      ['test-', '"test-"'],
+    ])('should handle filter value %s with hyphens', (x, y) => {
+      const filters = [
+        new PaginationParamFilter({ fields: [new PaginationFilterField({ field: 'metadata.name', value: x })] }),
+      ];
+      const result = testStevePaginationUtils.convertPaginationParams({ schema, filters });
+
+      expect(result).toBe(`filter=metadata.name=${ y }`);
+    });
+
     it('should handle IN and NOT_IN operators', () => {
       const filters = [
         new PaginationParamFilter({

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -213,9 +213,9 @@ class StevePaginationUtils extends NamespaceProjectFilters {
    * Match
    * - a-z (case insensitive)
    * - 0-9
-   * - `-`, `_`, `.`
+   * - `_`, `.`
    */
-  static VALID_FIELD_VALUE_REGEX = /^[\w\-.]+$/;
+  static VALID_FIELD_VALUE_REGEX = /^[\w.]+$/;
 
   /**
    * Filtering with the vai cache supports specific fields


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16454
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- The UI will quote `filter` param values if they do not contain allowed chars
- This was selectively done to keep the length of the url down
  - specifically for times when it grew on systems with lots of namespaces and global filters like `Only User Namespaces` were fetched
  - that process now uses IN/NOT IN args and doesn't use the quotes
- Which means we can fix the issue of filter values starting with `-` failing by quoted them

Follows on from https://github.com/rancher/dashboard/pull/14409

### Areas or cases that should be tested
- Free text filter in any list, deployments in upstream cluster with `capi-controller-manager` / `-controller-manager` is a good one

### Areas which could experience regressions
- Global header row user / system filters

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
