### PR TITLE
Ensure SSP filter values of `false` are not ignored

### DIFF
--- a/shell/plugins/steve/__tests__/steve-pagination-utils.test.ts
+++ b/shell/plugins/steve/__tests__/steve-pagination-utils.test.ts
@@ -502,5 +502,21 @@ describe('class StevePaginationUtils', () => {
 
       expect(result).toBe('filter=metadata.name IN (test1,test2)&filter=metadata.namespace NOTIN (ns1,ns2)');
     });
+
+    it.each([
+      [null, '""'],
+      [undefined, '""'],
+      [false, 'false'],
+      [true, 'true'],
+      [0, '0'],
+      [1, '1'],
+    ])('should handle falsy filter value %s', (x: any, y) => {
+      const filters = [
+        new PaginationParamFilter({ fields: [new PaginationFilterField({ field: 'metadata.name', value: x })] }),
+      ];
+      const result = testStevePaginationUtils.convertPaginationParams({ schema, filters });
+
+      expect(result).toBe(`filter=metadata.name=${ y }`);
+    });
   });
 });

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -596,10 +596,11 @@ class StevePaginationUtils extends NamespaceProjectFilters {
               if ([PaginationFilterEquality.IN, PaginationFilterEquality.NOT_IN].includes(equality)) {
                 safeValue = `(${ field.value })`;
               } else {
-                const encodedValue = encodeURIComponent(field.value || '');
+                const booleanSafeValue = typeof field.value === 'undefined' || field.value === null ? '' : field.value;
+                const encodedValue = encodeURIComponent(booleanSafeValue);
 
-                if (StevePaginationUtils.VALID_FIELD_VALUE_REGEX.test(field.value || '')) {
-                  // Does not contain any protected characters, send as is
+                if (StevePaginationUtils.VALID_FIELD_VALUE_REGEX.test(booleanSafeValue)) {
+                  // All characters safe, send as is
                   safeValue = encodedValue;
                 } else {
                   // Contains protected characters, wrap in quotes to ensure backend doesn't fail


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16394
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Issue
  - When `hide-local-cluster` setting is enabled the UI will filter it out via spec.internal=false
  - However [changes in 2.12.0 ](https://github.com/rancher/dashboard/pull/14772/changes#diff-989fea5e5d8e75bc1e36242ecfa4cb7d5504e4db5b8a0cb7af2b511e4985a764R512) meant filter values of false were converted to an empty string
  - So we were filtering clusters on spec.internal is an empty string, which meant no clusters were shown
- Fix
  - filter was fine (see shell/utils/cluster.js paginationFilterHiddenLocalCluster spec.internal filter for example)
  - fix is to not convert `false` to an empty string

### Areas or cases that should be tested
- Import some clusters (don't need to be registered)
- Confirm that the side bar shows local and imported clusters
- Global Settings --> Settings --> enable `hide-local-cluster`
- Refresh
- Confirm that the side bar ONLY contains the imported clusters (no local)

### Areas which could experience regressions
- showing any type of cluster in the side bar

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
