### PR TITLE
Automation: Fix html publisher in Jenkins

### DIFF
--- a/cypress/jenkins/cypress.config.jenkins.ts
+++ b/cypress/jenkins/cypress.config.jenkins.ts
@@ -124,7 +124,9 @@ export default defineConfig({
       require('cypress-terminal-report/src/installLogsPrinter')(on, {
         outputRoot:           `${ config.projectRoot }/browser-logs/`,
         outputTarget:         { 'out.html': 'html' },
-        logToFilesOnAfterRun: true,
+        // Disabled in Jenkins config only to prevent conflict with cypress-mochawesome-reporter's after:run hook
+        // Both plugins use after:run; this prevents Cypress from exiting before HTML reports are generated
+        logToFilesOnAfterRun: false,
         printLogsToConsole:   'never',
         // printLogsToFile:      'always', // default prints on failures
       });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2147

Problem: `cypress-terminal-report` with `logToFilesOnAfterRun: true` conflicted with `cypress-mochawesome-reporter`'s `after:run` hook. When tests failed, Cypress exited before HTML generation completed. Regression introduced in PR #14962 

Fix: Disabled `logToFilesOnAfterRun` in Jenkins config to prevent the hook conflict.
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
