### PR TITLE
Replace deprecated RcButton boolean props with variant/size

### DIFF
--- a/pkg/rancher-components/src/components/Pill/RcTag/RcTag.vue
+++ b/pkg/rancher-components/src/components/Pill/RcTag/RcTag.vue
@@ -16,7 +16,7 @@ const emit = defineEmits(['close']);
     <slot name="default" />
     <RcButton
       v-if="props.showClose"
-      ghost
+      variant="ghost"
       :aria-label="props.closeAriaLabel"
       @click="emit('close')"
     >

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownMenu.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownMenu.vue
@@ -26,8 +26,8 @@ const hasOptions = (options: DropdownOption[]) => {
     @update:open="(e: boolean) => emit('update:open', e)"
   >
     <rc-dropdown-trigger
-      :[buttonVariant]="true"
-      :[buttonSize]="true"
+      :variant="buttonVariant"
+      :size="buttonSize"
       :data-testid="dataTestid"
       :aria-label="buttonAriaLabel"
     >

--- a/pkg/rancher-components/src/components/RcDropdown/types.ts
+++ b/pkg/rancher-components/src/components/RcDropdown/types.ts
@@ -1,6 +1,6 @@
 import { Ref, ref } from 'vue';
 import type { RcButtonType } from '@components/RcButton';
-import { ButtonVariantProps, ButtonSizeProps } from '@components/RcButton/types';
+import { ButtonVariant, ButtonSize } from '@components/RcButton/types';
 
 export type DropdownContext = {
   handleKeydown: () => void;
@@ -41,8 +41,8 @@ export type DropdownOption = {
 
 export type RcDropdownMenuComponentProps = {
   options: DropdownOption[];
-  buttonVariant?: keyof ButtonVariantProps;
-  buttonSize?: keyof ButtonSizeProps;
+  buttonVariant?: ButtonVariant;
+  buttonSize?: ButtonSize;
   buttonAriaLabel?: string;
   dropdownAriaLabel?: string;
   dataTestid?: string;

--- a/pkg/rancher-prime/pages/Registration.vue
+++ b/pkg/rancher-prime/pages/Registration.vue
@@ -159,7 +159,7 @@ onMounted(async() => {
           class="mt-20"
         />
         <RcButton
-          secondary
+          variant="secondary"
           class="mt-20"
           data-testid="registration-offline-visit-scc"
           :disabled="isRegistered || isRegistering"

--- a/shell/components/ActionMenuShell.vue
+++ b/shell/components/ActionMenuShell.vue
@@ -5,7 +5,7 @@ import { useRoute } from 'vue-router';
 
 import { isAlternate } from '@shell/utils/platform';
 import { RcDropdownMenu } from '@components/RcDropdown';
-import { ButtonVariantProps, ButtonSizeProps } from '@components/RcButton/types';
+import { ButtonVariant, ButtonSize } from '@components/RcButton/types';
 import { DropdownOption } from '@components/RcDropdown/types';
 
 defineOptions({ inheritAttrs: false });
@@ -13,8 +13,8 @@ defineOptions({ inheritAttrs: false });
 const store = useStore();
 
 type RcDropdownMenuComponentProps = {
-  buttonVariant?: keyof ButtonVariantProps;
-  buttonSize?: keyof ButtonSizeProps;
+  buttonVariant?: ButtonVariant;
+  buttonSize?: ButtonSize;
   buttonAriaLabel?: string;
   dropdownAriaLabel?: string;
   dataTestid?: string;

--- a/shell/components/DynamicContent/DynamicContentCloseButton.vue
+++ b/shell/components/DynamicContent/DynamicContentCloseButton.vue
@@ -18,8 +18,8 @@ const markRead = () => {
 </script>
 <template>
   <RcButton
-    ghost
-    small
+    variant="ghost"
+    size="small"
     :aria-label="t('dynamicContent.action.close')"
     tabindex="0"
     @click="markRead()"

--- a/shell/components/LocaleSelector.vue
+++ b/shell/components/LocaleSelector.vue
@@ -79,7 +79,7 @@ export default {
       >
         <rc-dropdown-trigger
           data-testid="locale-selector"
-          link
+          variant="link"
           class="baseline locale-selector-btn"
           :aria-label="t('locale.menu')"
         >

--- a/shell/components/fleet/FleetClusterTargets/index.vue
+++ b/shell/components/fleet/FleetClusterTargets/index.vue
@@ -427,16 +427,16 @@ export default {
             @update:value="updateMatchExpressions(i, $event, selector.key)"
           />
           <RcButton
-            small
-            link
+            size="small"
+            variant="link"
             @click="removeMatchExpressions(selector.key)"
           >
             <i class="icon icon-x" />
           </RcButton>
         </div>
         <RcButton
-          small
-          secondary
+          size="small"
+          variant="secondary"
           class="mmt-4"
           @click="addMatchExpressions"
         >

--- a/shell/components/fleet/FleetGitRepoPaths.vue
+++ b/shell/components/fleet/FleetGitRepoPaths.vue
@@ -335,8 +335,8 @@ export default {
             </h4>
             <RcButton
               v-if="!isView"
-              small
-              link
+              size="small"
+              variant="link"
               @click="removePaths(i)"
             >
               <i class="icon icon-x" />

--- a/shell/components/fleet/FleetValuesFrom.vue
+++ b/shell/components/fleet/FleetValuesFrom.vue
@@ -276,8 +276,8 @@ export default {
     <RcButton
       v-if="!isView"
       ref="add-button"
-      small
-      secondary
+      size="small"
+      variant="secondary"
       class="mmt-6"
       data-testid="fleet-values-from-add"
       @click="addValueFrom"

--- a/shell/components/formatter/Autoscaler.vue
+++ b/shell/components/formatter/Autoscaler.vue
@@ -46,8 +46,8 @@ const stopPropagation = (event: Event) => {
       >
         <RcButton
           v-if="row.canPauseResumeAutoscaler"
-          secondary
-          small
+          variant="secondary"
+          size="small"
           class="action"
           @click="() => {props.row.toggleAutoscalerRunner(); close()}"
         >

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -689,8 +689,8 @@ export default {
           :aria-label="t('nav.userMenu.label')"
         >
           <rc-dropdown-trigger
-            ghost
-            small
+            variant="ghost"
+            size="small"
             data-testid="nav_header_showUserMenu"
             :aria-label="t('nav.userMenu.button.label')"
           >

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -785,8 +785,8 @@ export default {
           <!-- block user from removing the last selection if ns forced filtering is on -->
           <RcButton
             v-if="!namespaceFilterMode || value.length > 1"
-            small
-            ghost
+            size="small"
+            variant="ghost"
             class="ns-chip-button"
             :data-testid="`namespaces-values-close-${j}`"
             :aria-label="t('namespaceFilter.removeNamespace', { name: ns.label })"
@@ -847,8 +847,8 @@ export default {
           >
           <RcButton
             v-if="hasFilter"
-            small
-            ghost
+            size="small"
+            variant="ghost"
             class="ns-filter-clear"
             :aria-label="t('namespaceFilter.button.clearFilter')"
             @click="clearFilter"
@@ -870,8 +870,8 @@ export default {
         </div>
         <RcButton
           v-else
-          small
-          ghost
+          size="small"
+          variant="ghost"
           class="ns-clear"
           :aria-label="t('namespaceFilter.button.clear')"
           @click="clear"

--- a/shell/components/nav/NotificationCenter/index.vue
+++ b/shell/components/nav/NotificationCenter/index.vue
@@ -36,7 +36,7 @@ const open = (opened: boolean) => {
     @update:open="open"
   >
     <rc-dropdown-trigger
-      tertiary
+      variant="tertiary"
       data-testid="notifications-center"
       :aria-label="t('nav.notifications.button.label')"
     >

--- a/shell/pages/c/_cluster/explorer/EventsTable.vue
+++ b/shell/pages/c/_cluster/explorer/EventsTable.vue
@@ -170,8 +170,8 @@ export default {
         <rc-dropdown-trigger
           data-testid="events-list-row-count-menu-toggle"
           :aria-label="t('glance.changeEventsListRowCount')"
-          ghost
-          small
+          variant="ghost"
+          size="small"
         >
           <i class="icon icon-gear" />
         </rc-dropdown-trigger>

--- a/shell/pages/c/_cluster/fleet/index.vue
+++ b/shell/pages/c/_cluster/fleet/index.vue
@@ -499,8 +499,8 @@ export default {
             @update:value="viewMode = $event"
           />
           <RcButton
-            small
-            ghost
+            size="small"
+            variant="ghost"
             data-testid="fleet-dashboard-expand-all"
             class="collapse-all-btn"
             @click="toggleCardAll(allCardsExpanded ? 'collapse' : 'expand')"
@@ -585,8 +585,8 @@ export default {
               :data-testid="'expand-button'"
             >
               <RcButton
-                small
-                ghost
+                size="small"
+                variant="ghost"
                 :aria-label="`workspace-expand-btn-${ workspace.id }`"
                 :data-testid="`workspace-expand-btn-${ workspace.id }`"
                 @click="toggleCard(workspace.id)"
@@ -652,7 +652,7 @@ export default {
               class="create-button"
             >
               <RcButton
-                small
+                size="small"
                 @click="createResource(workspace.id)"
               >
                 {{ t('fleet.application.intro.add') }}

--- a/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
+++ b/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
@@ -349,7 +349,7 @@ export default {
                   v-for="btn in panelActions"
                   :key="btn.action"
                   class="mmr-3 mmb-3"
-                  :[btn.role]="true"
+                  :variant="btn.role"
                   @click="onButtonClick(btn)"
                 >
                   <i :class="['icon', btn.icon, 'mmr-2']" />{{ btn.label }}


### PR DESCRIPTION
### Summary
Fixes #16468
Replace deprecated RcButton boolean props with new `variant` and `size` props.

### Occurred changes and/or fixed issues
- Replaced boolean props (`primary`, `secondary`, `ghost`, `link`, `small`) with `variant="x"` and `size="x"`
- Fixed `RcDropdownMenu` dynamic binding pattern `:[buttonVariant]="true"` → `:variant="buttonVariant"`
- Updated related TypeScript types in `RcDropdown/types.ts` and `ActionMenuShell.vue`

### Technical notes summary
- Root cause of most warnings was `RcDropdownMenu.vue` using deprecated dynamic boolean binding for every action menu
- Updated type definitions from `keyof ButtonVariantProps` to `ButtonVariant` to align with new prop API

### Areas or cases that should be tested
- Action menus on any list page (deployments, pods, etc.) - should show no RELATED console warnings
- Namespace filter dropdown buttons
- Fleet dashboard expand/collapse buttons
- Plugin info panel actions

### Areas which could experience regressions
See above

### Screenshot/Video
<img width="1223" height="1342" alt="image" src="https://github.com/user-attachments/assets/6555c462-b612-4240-9e58-573629baa2f3" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
