### PR TITLE
[2.13] Improved error handling around loading WebGL

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -101,14 +101,14 @@ jobs:
       # 2. call it here
       # 3. call it from `a11y-test` as well
 
-      - name: Install Chrome 143 
-        run: |
-          sudo apt-get install -y wget libu2f-udev
-          cd /tmp
-          wget -q http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_143.0.7499.192-1_amd64.deb
-          sudo dpkg -i google-chrome-stable_143.0.7499.192-1_amd64.deb
-          sudo apt-get install -y --allow-downgrades ./google-chrome-stable_143.0.7499.192-1_amd64.deb
-          google-chrome --version
+      # - name: Install Chrome 143 
+      #   run: |
+      #     sudo apt-get install -y wget libu2f-udev
+      #     cd /tmp
+      #     wget -q http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_143.0.7499.192-1_amd64.deb
+      #     sudo dpkg -i google-chrome-stable_143.0.7499.192-1_amd64.deb
+      #     sudo apt-get install -y --allow-downgrades ./google-chrome-stable_143.0.7499.192-1_amd64.deb
+      #     google-chrome --version
 
       - name: Download e2e build
         uses:  actions/download-artifact@v5
@@ -174,14 +174,14 @@ jobs:
       - name: Setup env
         uses: ./.github/actions/setup
 
-      - name: Install Chrome 143
-        run: |
-          sudo apt-get install -y wget libu2f-udev
-          cd /tmp
-          wget -q http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_143.0.7499.192-1_amd64.deb
-          sudo dpkg -i google-chrome-stable_143.0.7499.192-1_amd64.deb
-          sudo apt-get install -y --allow-downgrades ./google-chrome-stable_143.0.7499.192-1_amd64.deb
-          google-chrome --version
+      # - name: Install Chrome 143
+      #   run: |
+      #     sudo apt-get install -y wget libu2f-udev
+      #     cd /tmp
+      #     wget -q http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_143.0.7499.192-1_amd64.deb
+      #     sudo dpkg -i google-chrome-stable_143.0.7499.192-1_amd64.deb
+      #     sudo apt-get install -y --allow-downgrades ./google-chrome-stable_143.0.7499.192-1_amd64.deb
+      #     google-chrome --version
 
       - name: Download e2e build
         uses:  actions/download-artifact@v5

--- a/cypress/e2e/po/components/kubectl.po.ts
+++ b/cypress/e2e/po/components/kubectl.po.ts
@@ -7,7 +7,6 @@ export default class Kubectl extends ComponentPo {
   }
 
   readonly kubeCommand: string = 'kubectl'
-  readonly terminalRow: string = '.xterm-link-layer'
 
   openTerminal(options?: GetOptions) {
     cy.get('#btn-kubectl').click();
@@ -32,21 +31,31 @@ export default class Kubectl extends ComponentPo {
     this.self().contains('.active .status', status, options);
   }
 
+  terminalRow() {
+    return this.self().then(($el) => {
+      // Depending on if we could load webGL, this will change
+      if ($el.find('.xterm-cursor-layer').length > 0) {
+        return $el.find('.xterm-cursor-layer');
+      }
+
+      return $el.find('.xterm-link-layer');
+    });
+  }
+
   /**
    *
    * @param command Kube command without the 'kubectl'
    * @returns executeCommand for method chanining
    */
   executeCommand(command: string, wait = 3000) {
-    this.self().get(this.terminalRow).type(`${ this.kubeCommand } ${ command }{enter}`);
+    this.terminalRow().type(`${ this.kubeCommand } ${ command }{enter}`);
     cy.wait(wait);
 
     return this;
   }
 
   executeMultilineCommand(jsonObject: Object, wait = 3000) {
-    this.self()
-      .get(this.terminalRow)
+    this.terminalRow()
       .type(`kubectl apply -f - <<EOF{enter}`)
       .type(`${ jsyaml.dump(jsonObject) }{enter}`)
       .type(`EOF{enter}`)

--- a/shell/components/Window/ContainerShell.vue
+++ b/shell/components/Window/ContainerShell.vue
@@ -172,8 +172,11 @@ export default {
         await this.$store.dispatch('cluster/find', { type: NODE, id: nodeId });
       }
     } catch {}
-
-    await this.setupTerminal();
+    try {
+      await this.setupTerminal();
+    } catch (e) {
+      this.errorMsg = e;
+    }
     await this.connect();
 
     clearInterval(this.keepAliveTimer);
@@ -234,26 +237,20 @@ export default {
 
       this.fitAddon = new addons.fit.FitAddon();
       this.searchAddon = new addons.search.SearchAddon();
-
-      try {
-        this.webglAddon = new addons.webgl.WebglAddon();
-      } catch (e) {
-        // Some browsers (Safari) don't support the webgl renderer, so don't use it.
-        this.webglAddon = null;
-        this.canvasAddon = new addons.canvas.CanvasAddon();
-      }
-
       terminal.loadAddon(this.fitAddon);
       terminal.loadAddon(this.searchAddon);
       terminal.loadAddon(new addons.weblinks.WebLinksAddon());
       terminal.open(this.$refs.xterm);
 
-      if (this.webglAddon) {
+      try {
+        this.webglAddon = new addons.webgl.WebglAddon();
         terminal.loadAddon(this.webglAddon);
-      } else {
+      } catch (e) {
+        // Some browsers (Safari) don't support the webgl renderer, so don't use it.
+        this.webglAddon = null;
+        this.canvasAddon = new addons.canvas.CanvasAddon();
         terminal.loadAddon(this.canvasAddon);
       }
-
       this.fit();
       this.flush();
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16496
Backport of https://github.com/rancher/dashboard/pull/16458
If we couldn't load WebGL2 when initializing shell, it would become disconnected and unusable.
"Error: WebGL2 not supported null" was thrown in the console.

### Occurred changes and/or fixed issues
This PR adds some error handling to catch the errors if we were unable to load WebGL

### Technical notes summary
Areas or cases that should be tested
Disable WebGL2 in your browser.
Check that you are still able to use Kubectl shell

### Areas which could experience regressions
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
