### PR TITLE
Automation: Jenkins - vai enabled

### DIFF
--- a/cypress/jenkins/cypress.config.jenkins.ts
+++ b/cypress/jenkins/cypress.config.jenkins.ts
@@ -81,7 +81,8 @@ export default defineConfig({
     username,
     password:            process.env.CATTLE_BOOTSTRAP_PASSWORD || process.env.TEST_PASSWORD,
     bootstrapPassword:   process.env.CATTLE_BOOTSTRAP_PASSWORD,
-    grepTags:            process.env.GREP_TAGS,
+    // Jenkins runs against Vai-enabled Rancher; exclude @noVai tests.
+    grepTags:            `${ process.env.GREP_TAGS }+-@noVai`,
     // the below env vars are only available to tests that run in Jenkins
     awsAccessKey:        process.env.AWS_ACCESS_KEY_ID,
     awsSecretKey:        process.env.AWS_SECRET_ACCESS_KEY,

--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -344,13 +344,11 @@ corral config vars set nodejs_version "${NODEJS_VERSION}"
 corral config vars set dashboard_repo "${DASHBOARD_REPO}"
 corral config vars set dashboard_branch "${DASHBOARD_BRANCH}"
 
-# Disable vai where it doesn't exist or is turn off by default
-case "${RANCHER_IMAGE_TAG}" in
-    "v2.7-head" | "v2.8-head" | "v2.9-head" )
-        CYPRESS_TAGS="${CYPRESS_TAGS}+-@noVai"
-        ;;
-    *)
-esac
+# Jenkins pipeline runs against Vai-enabled Rancher; append exclusion of @noVai tests
+# (e.g. priority/no-vai-setup.spec.ts which disables the Vai feature flag).
+if [[ -n "${CYPRESS_TAGS}" ]]; then
+  CYPRESS_TAGS="${CYPRESS_TAGS}+-@noVai"
+fi
 corral config vars set cypress_tags "${CYPRESS_TAGS}"
 
 # Save all values to a file for the Slack notification script


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2170

Exclude tests tagged with `@noVai` when running in Jenkins by appending +-`@noVai` to the Cypress tag filter to ensure Jenkins builds run against a Vai-enabled Rancher environment.

<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
