### PR TITLE
Fix CodeMirror text wrapping for long strings

### DIFF
--- a/shell/components/CodeMirror.vue
+++ b/shell/components/CodeMirror.vue
@@ -330,9 +330,6 @@ export default {
         border-color: var(--primary-border);
       }
 
-      .CodeMirror-wrap pre {
-        word-break: break-word;
-      }
       .CodeMirror-code {
         .CodeMirror-line {
           &:not(:last-child)>span:after,
@@ -425,6 +422,10 @@ export default {
 
       .CodeMirror-gutters {
         background: inherit;
+      }
+
+      .CodeMirror-wrap pre {
+        word-break: break-word;
       }
     }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes # [harvester#9618](https://github.com/harvester/harvester/issues/9618), [harvester#9330](https://github.com/harvester/harvester/issues/9330)
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Fixed `CodeMirror text` wrapping for long strings. 
The CSS rule `word-break: break-word` was accidentally removed in commit [a125cf8495c](https://github.com/rancher/dashboard/commit/a125cf8495c), causing long unbroken strings to overflow horizontally instead of wrapping.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Restored .`CodeMirror-wrap pre { word-break: break-word; }` to the `.codemirror-container` block

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Provision Harvester cluster page

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
N/A

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/09eb2ed3-2eda-4013-b432-99aab3a62503

https://github.com/user-attachments/assets/dbf4fe01-2cbb-4108-a9cb-8334f260a5bb

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
