### PR TITLE
Remove a deprecated warning we were getting on ResourceTable pages.

### DIFF
--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -427,7 +427,7 @@ export default {
     },
 
     _applicableExtensionTableHooks() {
-      if (this.$store.$plugin?.getUIConfig) {
+      if (this.$store.$extension?.getUIConfig) {
         const extensionTableHooks = getApplicableExtensionEnhancements(this, ExtensionPoint.TABLE, TableLocation.RESOURCE, this.$route);
 
         return extensionTableHooks;


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Just swap from $plugin to $extension in order to get rid of this warning.

<img width="775" height="76" alt="image" src="https://github.com/user-attachments/assets/cbab5f96-027e-4857-8706-07654667fc08" />




Question, do you think we can remove [this ](https://github.com/rancher/dashboard/blob/master/shell/store/index.js#L776)reference now too? 

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
The objects are identical and have the same methods so this is fairly low risk.

### Areas or cases that should be tested
List pages can be used to verify this change.

### Areas which could experience regressions
See above

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
