### PR TITLE
Fix masthead's create title for project secrets

### DIFF
--- a/shell/models/secret.js
+++ b/shell/models/secret.js
@@ -496,7 +496,10 @@ export default class Secret extends SteveModel {
    * is this a project scoped secret
    */
   get isProjectScoped() {
-    const isProjectScopedRelated = !!this.metadata.labels?.[UI_PROJECT_SECRET]; // is this a project scoped secret .... or also a cloned project scoped secret
+    /**
+     * is this a project scoped secret .... or also a cloned project scoped secret
+     */
+    const isProjectScopedRelated = !!this.metadata.labels?.[UI_PROJECT_SECRET];
 
     return isProjectScopedRelated && !this.isProjectSecretCopy && this.$rootGetters['isRancher'];
   }
@@ -584,18 +587,18 @@ export default class Secret extends SteveModel {
   }
 
   get listLocation() {
-    if (!this.isProjectScoped) {
-      return super.listLocation;
+    if (this.hasProjectScopedUrlQueryParam || this.isProjectScoped) {
+      return {
+        name:   'c-cluster-product-resource',
+        params: {
+          product:  this.$rootGetters['productId'],
+          cluster:  this.$rootGetters['clusterId'],
+          resource: VIRTUAL_TYPES.PROJECT_SECRETS,
+        }
+      };
     }
 
-    return {
-      name:   'c-cluster-product-resource',
-      params: {
-        product:  this.$rootGetters['productId'],
-        cluster:  this.$rootGetters['clusterId'],
-        resource: VIRTUAL_TYPES.PROJECT_SECRETS,
-      }
-    };
+    return super.listLocation;
   }
 
   get hasProjectScopedUrlQueryParam() {
@@ -612,14 +615,7 @@ export default class Secret extends SteveModel {
 
   get parentLocationOverride() {
     if (this.hasProjectScopedUrlQueryParam || this.isProjectScoped) {
-      return {
-        name:   'c-cluster-product-resource',
-        params: {
-          product:  this.$rootGetters['productId'],
-          cluster:  this.$rootGetters['clusterId'],
-          resource: VIRTUAL_TYPES.PROJECT_SECRETS,
-        }
-      };
+      return this.listLocation;
     }
 
     return super.parentLocationOverride;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14779 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Fixed an issue where a wrong title was displayed on the create page for project secrets.

### Technical notes summary
- The `ResourceDetail` component was remapping `projectsecret` to `secret` (via `options.resource` configured in `shell/config/product/explorer.js`) *before* the Masthead component received the resource type. This caused the Masthead to look up the label for `secret`.
- I updated `ResourceDetail/index.vue` to capture the `mastheadResourceType` (specifically for `projectsecret`) from the route *before* this remapping occurs and pass it explicitly to the `<Masthead>` component.
- I updated `Masthead/legacy.vue` to handle cases where a schema definition is missing for the provided resource ID (which happens for `projectsecret`). It now returns a fallback object `{ id: this.resource }` in the `schema` computed property, ensuring that `labelFor` and translation lookups function correctly.
- Added unit tests.

### Areas or cases that should be tested
- **Create Project Secret:** Navigate to **Explorer > Storage > Project Secrets**. Click "Create". Verify the page title says "Project Secret: Create" and clicking on it redirects you the Project Secrets list page.
- **Edit Project Secret:** Edit an existing Project Secret. Verify the page title says "Edit Project Secret" (or just "Project Secret: <name>"). Note: The Edit/View pages for downstream cluster's PSS is broken, there's an open PR to fix it, but you can test this on the local cluster.
- **Standard Secrets:** Navigate to **Explorer > Storage > Secrets**. Create and Edit standard secrets. Verify the titles remain "Secret: Create" and clicking on it redirects you the Secrets list page.

### Areas which could experience regressions
- The `schema` computed property in `legacy.vue` is used by other parts of the Masthead. While the fix targets missing schemas, verify that standard resources with valid schemas still load their full schema correctly and that header renders properly.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/b6dc8cb8-faff-420a-a454-bdd71d1870a9


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
