### PR TITLE
Automation: Disable oidc setup test for prime builds

### DIFF
--- a/cypress/e2e/tests/priority/oidc-provider-setup.spec.ts
+++ b/cypress/e2e/tests/priority/oidc-provider-setup.spec.ts
@@ -10,7 +10,7 @@ const featureFlagsPage = new FeatureFlagsPagePo('local');
  * This test enables the OIDC Provider feature flag.
  * It's designed to run in Jenkins CI environment as part of the test setup process.
  */
-describe('Enable OIDC Provider', { testIsolation: 'off', tags: ['@jenkins', '@adminUser'] }, () => {
+describe('Enable OIDC Provider', { testIsolation: 'off', tags: ['@jenkins', '@noPrime', '@adminUser'] }, () => {
   before(() => {
     cy.login();
     HomePagePo.goTo();

--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -344,10 +344,17 @@ corral config vars set nodejs_version "${NODEJS_VERSION}"
 corral config vars set dashboard_repo "${DASHBOARD_REPO}"
 corral config vars set dashboard_branch "${DASHBOARD_BRANCH}"
 
-# Jenkins pipeline runs against Vai-enabled Rancher; append exclusion of @noVai tests
-# (e.g. priority/no-vai-setup.spec.ts which disables the Vai feature flag).
+# Exclude tagged E2E tests that don't apply to Rancher build:
+# - @noVai: Jenkins pipeline runs against Vai-enabled Rancher; skip tests that assume Vai is off
+#   (e.g. priority/no-vai-setup.spec.ts which disables the Vai feature flag).
+# - @noPrime: on Prime/alpha/latest, skip tests that assume non-Prime defaults
+#   (e.g. priority/oidc-provider-setup.spec.ts — OIDC Provider is already enabled on Prime).
 if [[ -n "${CYPRESS_TAGS}" ]]; then
-  CYPRESS_TAGS="${CYPRESS_TAGS}+-@noVai"
+  if [[ "${RANCHER_HELM_REPO}" == "rancher-prime" || "${RANCHER_HELM_REPO}" == "rancher-latest" || "${RANCHER_HELM_REPO}" == "rancher-alpha" ]]; then
+    CYPRESS_TAGS="${CYPRESS_TAGS}+-@noVai+-@noPrime"
+  else
+    CYPRESS_TAGS="${CYPRESS_TAGS}+-@noVai"
+  fi
 fi
 corral config vars set cypress_tags "${CYPRESS_TAGS}"
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2175

Skips the OIDC Provider setup E2E test when the Jenkins pipeline runs against Prime/alpha/latest Rancher builds, where the OIDC Provider feature is already enabled by default.
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
