### PR TITLE
Track a11y test count

### DIFF
--- a/cypress/support/plugins/accessibility/index.ts
+++ b/cypress/support/plugins/accessibility/index.ts
@@ -219,7 +219,7 @@ function registerHooks(on, config) {
 
     const data = {
       stats,
-      children: root
+      children: root.children
     };
 
     fs.writeFileSync(path.join(folder, 'accessibility.json'), JSON.stringify(data, null, 2));


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16430

### Occurred changes and/or fixed issues

This is a small improvement which changes the format of the custom accessibility json we generate so it includes some of the stats in terms of the number of accessibility tests we have. This is support future work to keep track of tests, accessibility etc.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
