### PR TITLE
Automation: Fix browser title tests for prime builds

### DIFF
--- a/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
@@ -56,7 +56,11 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
   it('has the correct title', () => {
     ClusterDashboardPagePo.navTo();
 
-    cy.title().should('eq', 'Rancher - local - Cluster Dashboard');
+    cy.getRancherVersion().then((version) => {
+      const expectedTitle = version.RancherPrime === 'true' ? 'Rancher Prime - local - Cluster Dashboard' : 'Rancher - local - Cluster Dashboard';
+
+      cy.title().should('eq', expectedTitle);
+    });
   });
 
   it('shows fleet controller status', () => {

--- a/cypress/e2e/tests/pages/explorer2/storage/configmap.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/configmap.spec.ts
@@ -14,7 +14,11 @@ describe('ConfigMap', { testIsolation: 'off', tags: ['@explorer2', '@adminUser']
     configMapListPage.goTo();
     configMapListPage.baseResourceList().masthead().title().should('include', `ConfigMaps`);
 
-    cy.title().should('eq', 'Rancher - local - ConfigMaps');
+    cy.getRancherVersion().then((version) => {
+      const expectedTitle = version.RancherPrime === 'true' ? 'Rancher Prime - local - ConfigMaps' : 'Rancher - local - ConfigMaps';
+
+      cy.title().should('eq', expectedTitle);
+    });
   });
 
   it('creates a configmap and displays it in the list', () => {

--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -110,7 +110,7 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     });
   });
 
-  it('has the correct title for Prime users and should display banner on main extensions screen EVEN IF setting is empty string', () => {
+  it('has the correct title for Prime users and should display banner on main extensions screen EVEN IF setting is empty string', { tags: '@noPrime' }, () => {
     cy.getRancherResource('v3', 'setting', 'display-add-extension-repos-banner', null).then((resp: Cypress.Response<any>) => {
       const notFound = resp.status === 404;
       const requiredValue = resp.body?.value === '';

--- a/cypress/e2e/tests/pages/fleet/dashboard.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/dashboard.spec.ts
@@ -31,7 +31,11 @@ describe('Fleet Dashboard', { tags: ['@fleet', '@adminUser', '@jenkins'] }, () =
 
     fleetDashboardPage.fleetDashboardEmptyState().should('be.visible');
 
-    cy.title().should('eq', 'Rancher - Continuous Delivery - Dashboard');
+    cy.getRancherVersion().then((version) => {
+      const expectedTitle = version.RancherPrime === 'true' ? 'Rancher Prime - Continuous Delivery - Dashboard' : 'Rancher - Continuous Delivery - Dashboard';
+
+      cy.title().should('eq', expectedTitle);
+    });
   });
 
   it('Get Started button takes you to the correct page', () => {

--- a/cypress/e2e/tests/pages/global-settings/settings.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings.spec.ts
@@ -159,7 +159,11 @@ describe('Settings', { testIsolation: 'off' }, () => {
   it('has the correct title', { tags: ['@globalSettings', '@adminUser'] }, () => {
     SettingsPagePo.navTo();
 
-    cy.title().should('eq', 'Rancher - Global Settings - Settings');
+    cy.getRancherVersion().then((version) => {
+      const expectedTitle = version.RancherPrime === 'true' ? 'Rancher Prime - Global Settings - Settings' : 'Rancher - Global Settings - Settings';
+
+      cy.title().should('eq', expectedTitle);
+    });
   });
 
   it('has the correct banner text', { tags: ['@globalSettings', '@adminUser'] }, () => {

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -121,6 +121,7 @@ declare global {
         wait?: number,
       }): Chainable;
 
+      getRancherVersion(): Chainable<any>;
       getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode?: number): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: any): Chainable;
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any, failOnStatusCode?: boolean): Chainable;

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -427,6 +427,25 @@ Cypress.Commands.add('requestBase64Image', (url: string) => {
 });
 
 /**
+ * Get Rancher version info from /rancherversion (includes RancherPrime for product type).
+ */
+Cypress.Commands.add('getRancherVersion', () => {
+  return cy.request({
+    method:  'GET',
+    url:     `${ Cypress.env('api') }/rancherversion`,
+    headers: {
+      'x-api-csrf': token.value,
+      Accept:       'application/json'
+    },
+    failOnStatusCode: false
+  }).then((resp) => {
+    expect(resp.status).to.eq(200);
+
+    return JSON.parse(resp.body);
+  });
+});
+
+/**
  * Get a v3 / v1 resource
  * url is constructed based if resourceId is supplied or not
  */


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2186

E2E tests that assert the browser title were failing on Rancher Prime because they expected `Rancher - ...` while Prime uses `Rancher Prime - ...`. This PR makes those tests aware of Rancher version type so they pass on both Rancher and Rancher Prime.
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
