### PR TITLE
[backport 2.13.3] Automation: Disable oidc setup test for prime builds

### DIFF
--- a/cypress/e2e/tests/priority/oidc-provider-setup.spec.ts
+++ b/cypress/e2e/tests/priority/oidc-provider-setup.spec.ts
@@ -10,7 +10,7 @@ const featureFlagsPage = new FeatureFlagsPagePo('local');
  * This test enables the OIDC Provider feature flag.
  * It's designed to run in Jenkins CI environment as part of the test setup process.
  */
-describe('Enable OIDC Provider', { testIsolation: 'off', tags: ['@jenkins', '@adminUser'] }, () => {
+describe('Enable OIDC Provider', { testIsolation: 'off', tags: ['@jenkins', '@noPrime', '@adminUser'] }, () => {
   before(() => {
     cy.login();
     HomePagePo.goTo();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2175

Backport of https://github.com/rancher/dashboard/pull/16565
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
