### PR TITLE
[backport 2.13.3] Automation: Fix about page tests

### DIFF
--- a/cypress/e2e/po/side-bars/burger-side-menu.po.ts
+++ b/cypress/e2e/po/side-bars/burger-side-menu.po.ts
@@ -191,7 +191,7 @@ export default class BurgerMenuPo extends ComponentPo {
    * @returns {Cypress.Chainable}
    */
   about(): Cypress.Chainable {
-    return this.self().contains('About');
+    return this.self().find('[aria-label="About page link"]');
   }
 
   /**

--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -15,7 +15,7 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
     aboutPage.waitForPage();
   });
 
-  it('no Prime info when community', () => {
+  it('no Prime info when community', { tags: '@noPrime' }, () => {
     HomePagePo.goToAndWaitForGet();
     AboutPagePo.navTo();
     aboutPage.waitForPage();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2182

Backport of https://github.com/rancher/dashboard/pull/16566
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
