### PR TITLE
[backport 2.13.3] Automation: Remove redundant click from project-ns test

### DIFF
--- a/cypress/e2e/tests/pages/explorer2/project-namespace.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/project-namespace.spec.ts
@@ -43,8 +43,7 @@ describe('Projects/Namespaces', { tags: ['@explorer2', '@adminUser'] }, () => {
           .name()
           .set(projectName);
         createProjectPage.resourceDetail().createEditView()
-          .create()
-          .click();
+          .create();
 
         cy.wait('@createProjectRequest').then(({ request }) => {
           expect(request.body.annotations['field.cattle.io/creator-principal-name']).to.equal('github://1234567890');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2178

Partial backport of https://github.com/rancher/dashboard/pull/16557
Test: Projects/Namespaces → `sets the creator principal id annotation when creating a project and using third-party auth`
Issue: The test called .create() and then chained .click(). In the page object, .create() already does createButton().click(), so the extra .click() was a second click on the same create button and was redundant and causing test to fail.
Solution: remove second click().
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
