### PR TITLE
Add a label to RcItemCard actions

### DIFF
--- a/pkg/rancher-components/src/components/RcItemCard/RcItemCard.vue
+++ b/pkg/rancher-components/src/components/RcItemCard/RcItemCard.vue
@@ -159,9 +159,10 @@ const contentText = computed(() => labelText(props.content));
 const statusTooltips = computed(() => props.header.statuses?.map((status) => labelText(status.tooltip)) || []);
 
 const cardMeta = computed(() => ({
-  ariaLabel: props.clickable ? t('itemCard.ariaLabel.clickable', { cardTitle: labelText(props.header.title) }) : undefined,
-  tabIndex:  props.clickable ? '0' : undefined,
-  role:      props.clickable ? 'button' : undefined
+  ariaLabel:       props.clickable ? t('itemCard.ariaLabel.clickable', { cardTitle: labelText(props.header.title) }) : undefined,
+  tabIndex:        props.clickable ? '0' : undefined,
+  role:            props.clickable ? 'button' : undefined,
+  actionMenuLabel: props.actions && t('itemCard.actionMenu.label', { cardTitle: labelText(props.header.title) })
 }));
 
 </script>
@@ -269,6 +270,7 @@ const cardMeta = computed(() => ({
               <rc-item-card-action class="item-card-header-action-menu">
                 <ActionMenu
                   data-testid="item-card-header-action-menu"
+                  :button-aria-label="cardMeta.actionMenuLabel"
                   :custom-actions="actions"
                   @action-invoked="(payload) => emit('action-invoked', payload)"
                 />

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -3879,6 +3879,8 @@ istio:
 itemCard:
   ariaLabel:
     clickable: Click on card for {cardTitle}
+  actionMenu:
+    label: '{cardTitle} actions'
 jwt:
   title: JWT Authentication
   actions:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This improves the accessibility of RcItemCard by adding an aria label for the action dropdown menu. 

Fixes #16579
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add a label to RcItemCard actions

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The previous implementation would be announced as "Button Menu" by screen readers. This update makes it more clear which button is associated with any given card. For example, screen readers will now announce "Alerting Drivers actions", "Elemental actions", "Logging actions", etc... 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

With a screen reader active:

1. Navigate to Local Cluster Explorer => Cluster => Tools
2. Use the keyboard to navigate through each action associated with the cards rendered on page

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This should be providing more context to the buttons. If a card title is long or confusing, this approach could be unintuitive. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
