### PR TITLE
Automation: Fix support tests for prime builds

### DIFF
--- a/cypress/e2e/po/pages/get-support.po.ts
+++ b/cypress/e2e/po/pages/get-support.po.ts
@@ -60,4 +60,12 @@ export default class SupportPagePo extends PagePo {
       .invoke('removeAttr', 'target')
       .click();
   }
+
+  clickSccLink() {
+    return this.self().get('a[href="https://scc.suse.com"]').then((el) => {
+      expect(el).to.have.attr('target');
+    })
+      .invoke('removeAttr', 'target')
+      .click();
+  }
 }

--- a/cypress/e2e/po/side-bars/burger-side-menu.po.ts
+++ b/cypress/e2e/po/side-bars/burger-side-menu.po.ts
@@ -206,7 +206,7 @@ export default class BurgerMenuPo extends ComponentPo {
    * @returns {Cypress.Chainable}
    */
   support(): Cypress.Chainable {
-    return this.self().contains('Get Support');
+    return this.self().find('[aria-label="Support page link"]');
   }
 
   /**

--- a/cypress/e2e/tests/pages/generic/get-support.spec.ts
+++ b/cypress/e2e/tests/pages/generic/get-support.spec.ts
@@ -30,7 +30,7 @@ describe('Support Page', () => {
       supportPage.waitForPage();
     });
 
-    it('can click on Suse Rancher Support link', () => {
+    it('can click on Suse Rancher Support link', { tags: '@noPrime' }, () => {
       catchTargetPageException(RANCHER_PAGE_EXCEPTIONS, 'https://www.rancher.com/');
 
       supportPage.clickExternalSupportLinks(0);
@@ -40,7 +40,7 @@ describe('Support Page', () => {
       });
     });
 
-    it('can click on Contact us for pricing link', () => {
+    it('can click on Contact us for pricing link', { tags: '@noPrime' }, () => {
       catchTargetPageException(RANCHER_PAGE_EXCEPTIONS, 'https://www.rancher.com/pricing');
 
       supportPage.clickExternalSupportLinks(1);
@@ -50,14 +50,30 @@ describe('Support Page', () => {
       });
     });
 
+    it('can click on Suse Customer Center link', { tags: ['@jenkins', '@prime'] }, () => {
+      catchTargetPageException(RANCHER_PAGE_EXCEPTIONS, 'https://scc.suse.com/');
+
+      supportPage.clickSccLink();
+
+      cy.origin('https://scc.suse.com/', () => {
+        cy.url().should('include', 'scc.suse.com/');
+      });
+    });
+
     it('can click on Docs link', () => {
       catchTargetPageException(RANCHER_PAGE_EXCEPTIONS, 'https://ranchermanager.docs.rancher.com');
 
-      supportPage.supportLinks().should('have.length', 5);
+      supportPage.supportLinks().should('have.length.at.least', 5);
       supportPage.clickSupportLink(0, true);
 
-      cy.origin('https://ranchermanager.docs.rancher.com', () => {
-        cy.url().should('include', 'ranchermanager.docs.rancher.com');
+      // Doc link differs between Rancher Prime and Community
+      cy.getRancherVersion().then((version) => {
+        const expectedOrigin = version.RancherPrime === 'true' ? 'https://documentation.suse.com' : 'https://ranchermanager.docs.rancher.com';
+        const expectedUrl = version.RancherPrime === 'true' ? 'documentation.suse.com/cloudnative/rancher-manager' : 'ranchermanager.docs.rancher.com';
+
+        cy.origin(expectedOrigin, { args: { expectedUrl } }, ({ expectedUrl }) => {
+          cy.url().should('include', expectedUrl);
+        });
       });
     });
 
@@ -94,6 +110,16 @@ describe('Support Page', () => {
       // click Get Started link
       supportPage.clickSupportLink(4, true);
       cy.url().should('include', 'getting-started/overview');
+    });
+
+    it('can click on SUSE Application Collection link', { tags: ['@jenkins', '@prime'] }, () => {
+      catchTargetPageException(RANCHER_PAGE_EXCEPTIONS);
+
+      // click SUSE Application Collection link
+      supportPage.clickSupportLink(5, true);
+      cy.origin('https://apps.rancher.io/', () => {
+        cy.url().should('include', 'apps.rancher.io/');
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2189

Fixes E2E failures for the Get Support page and related flows on Rancher Prime by aligning selectors, link counts, and asserting the correct docs link for Prime vs Community.. 
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
