### PR TITLE
Automation: Fix home page tests for prime builds

### DIFF
--- a/cypress/e2e/po/components/notification-center.po.ts
+++ b/cypress/e2e/po/components/notification-center.po.ts
@@ -63,6 +63,17 @@ export default class NotificationsCenterPo extends ComponentPo {
     return new NotificationPo(() => cy.get(selector).eq(index));
   }
 
+  /**
+   * Get a notification by selector name
+   * @param selectorName Selector name of the notification in the notification center
+   * @returns Notification
+   */
+  getNotificationByName(selectorName: string) {
+    const selector = `[data-testid^="notifications-center-item-${ selectorName }"]`;
+
+    return new NotificationPo(() => cy.get(selector));
+  }
+
   markAllRead() {
     cy.get('[data-testid="notifications-center-markall-read"]').click({ force: true });
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2192

- Adds a Prime-only test for SUSE Application Collection
- Uses getNotificationByName('release-notes') so the release-notes test works when notification order differs (Prime vs Community).
- Asserts correct Docs link for Prime vs Community.
- Tags Commercial Support test as `@noPrime` as its a community only test.
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
