### PR TITLE
Fallback to rancherversion if fetching setting fails

### DIFF
--- a/shell/pages/about.vue
+++ b/shell/pages/about.vue
@@ -9,6 +9,7 @@ import { mapGetters } from 'vuex';
 import TabTitle from '@shell/components/TabTitle';
 import { PanelLocation, ExtensionPoint } from '@shell/core/types';
 import ExtensionPanel from '@shell/components/ExtensionPanel';
+import { getVersionInfo } from '@shell/utils/version';
 
 export default {
   components: {
@@ -30,7 +31,7 @@ export default {
   computed: {
     ...mapGetters(['releaseNotesUrl']),
     rancherVersion() {
-      return this.settings.find((s) => s.id === SETTING.VERSION_RANCHER);
+      return getVersionInfo(this.$store).fullVersion;
     },
     appName() {
       return getVendor();
@@ -124,7 +125,7 @@ export default {
           >
             {{ t("about.versions.rancher") }}
           </a>
-        </td><td>{{ rancherVersion.value }}</td>
+        </td><td>{{ rancherVersion }}</td>
       </tr>
       <tr v-if="dashboardVersion">
         <td>

--- a/shell/utils/version.js
+++ b/shell/utils/version.js
@@ -3,6 +3,7 @@ import semver from 'semver';
 import { MANAGEMENT } from '@shell/config/types';
 import { READ_WHATS_NEW, SEEN_WHATS_NEW } from '@shell/store/prefs';
 import { SETTING } from '@shell/config/settings';
+import { getVersionData } from '@shell/config/version';
 
 export function parse(str) {
   str = `${ str }`;
@@ -98,8 +99,10 @@ export function isDevBuild(version) {
 }
 
 export function getVersionInfo(store) {
-  const setting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.VERSION_RANCHER);
-  const fullVersion = setting?.value || 'unknown';
+  const fullVersion = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.VERSION_RANCHER)?.value ??
+    getVersionData()?.Version ??
+    'unknown';
+
   let displayVersion = fullVersion;
 
   const match = fullVersion.match(/^(.*)-([0-9a-f]{40})-(.*)$/);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds a fallback to attempt fetching the version from the `getVersionData()` util if the `server-version` setting fails.

Fixes #16610
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Fallback to rancherversion if fetching setting fails

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->



### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

See the issue for reproduction steps. The about page should display the correct version. Tables should still render the modern drop down menu when the setting is absent. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

About Page
Table Actions

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
