### PR TITLE
Default to `medium` for action menus

### DIFF
--- a/shell/components/ActionMenuShell.vue
+++ b/shell/components/ActionMenuShell.vue
@@ -97,7 +97,7 @@ const menuOptions = () => {
 <template>
   <rc-dropdown-menu
     :button-variant="buttonVariant || 'link'"
-    :button-size="buttonSize || 'small'"
+    :button-size="buttonSize || 'medium'"
     :button-aria-label="buttonAriaLabel"
     :dropdown-aria-label="dropdownAriaLabel"
     :options="menuOptions()"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16619
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- default to `medium` button size for action menu's instead of `small`

### Technical notes summary
- came in i think via https://github.com/rancher/dashboard/pull/16023

### Areas or cases that should be tested
- as per issue, list row height shouldn't be condensed 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
