### PR TITLE
Automation: update slack message status

### DIFF
--- a/cypress/jenkins/Jenkinsfile
+++ b/cypress/jenkins/Jenkinsfile
@@ -67,13 +67,13 @@ node {
                   sh 'cypress/jenkins/init.sh'
                 } catch (err) {
                   echo "Error: " + err
-                  currentBuild.result = 'FAILURE'
+                  currentBuild.result = 'UNSTABLE'
                   throw err
                 }
               }
             } catch (err) {
               echo "Pipeline aborted early: ${err}"
-              currentBuild.result = 'FAILURE'
+              currentBuild.result = 'UNSTABLE'
             } finally {
               stage('Grab Results') {
                 // Safe to run even if init.sh failed (scp fails gracefully)
@@ -93,7 +93,7 @@ node {
                         
                         def resultsContent = readFile('results.xml').trim()
                         if (resultsContent.contains('<failure')) {
-                            testExecutionResult = 'UNSTABLE'
+                            testExecutionResult = 'FAILURE'
                         } else if (resultsContent.contains('<testcase')) {
                             testExecutionResult = 'SUCCESS'
                         } else {
@@ -121,13 +121,13 @@ node {
                     if (resultsContent.contains('<testcase')) {
                         // Tests ran - check if they failed or passed
                         if (resultsContent.contains('<failure')) {
-                            testExecutionResult = 'UNSTABLE'
+                            testExecutionResult = 'FAILURE'
                         } else {
                             testExecutionResult = 'SUCCESS'
                         }
                     }
                 }
-                currentBuild.result = 'FAILURE'
+                currentBuild.result = 'UNSTABLE'
               }
               if ("${env.QASE_REPORT}".toLowerCase() == "true") {
                   try {
@@ -140,13 +140,17 @@ node {
                     }
                   } catch(err) {
                       echo "Error: " + err
-                      currentBuild.result = 'FAILURE'
+                      currentBuild.result = 'UNSTABLE'
                   }
               }
               
-              if (testExecutionResult == 'FAILURE' || testExecutionResult == 'UNSTABLE') {
+              // test failure -> FAILURE (Slack: FAILED)
+              // pipeline/env failure -> UNSTABLE
+              if (currentBuild.result == 'UNSTABLE' || testExecutionResult == 'FAILURE') {
                   if ("${env.SLACK_NOTIFICATION}".toLowerCase() != "false") {
-                      sh "cypress/jenkins/slack-notification.sh ${testExecutionResult}"
+                      withEnv(["SLACK_BUILD_STATUS=${testExecutionResult == 'FAILURE' ? 'FAILURE' : 'UNSTABLE'}"]) {
+                          sh 'cypress/jenkins/slack-notification.sh $SLACK_BUILD_STATUS'
+                      }
                   }
               }
             }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2191

Swap Slack failure status: 
- tests failed → FAILED
- pipeline/env failed → UNSTABLE

Pipeline and test results in the Jenkinsfile now set the status passed to the Slack script so test failures are reported as FAILED and pipeline/env failures as UNSTABLE.
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`