### PR TITLE
Automation: Exclude prime tests on community builds

### DIFF
--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -349,11 +349,12 @@ corral config vars set dashboard_branch "${DASHBOARD_BRANCH}"
 #   (e.g. priority/no-vai-setup.spec.ts which disables the Vai feature flag).
 # - @noPrime: on Prime/alpha/latest, skip tests that assume non-Prime defaults
 #   (e.g. priority/oidc-provider-setup.spec.ts — OIDC Provider is already enabled on Prime).
+# - @prime: on community builds, skip tests that are Prime-only.
 if [[ -n "${CYPRESS_TAGS}" ]]; then
   if [[ "${RANCHER_HELM_REPO}" == "rancher-prime" || "${RANCHER_HELM_REPO}" == "rancher-latest" || "${RANCHER_HELM_REPO}" == "rancher-alpha" ]]; then
     CYPRESS_TAGS="${CYPRESS_TAGS}+-@noVai+-@noPrime"
   else
-    CYPRESS_TAGS="${CYPRESS_TAGS}+-@noVai"
+    CYPRESS_TAGS="${CYPRESS_TAGS}+-@noVai+-@prime"
   fi
 fi
 corral config vars set cypress_tags "${CYPRESS_TAGS}"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2198

Add `+-@prime` to CYPRESS_TAGS in the init script when RANCHER_HELM_REPO is a community repo so community builds skip tests that are Prime-only.
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
