### PR TITLE
Fix incorrect parent nullification in diff() when nested children exist

### DIFF
--- a/shell/utils/__tests__/object.test.ts
+++ b/shell/utils/__tests__/object.test.ts
@@ -210,6 +210,83 @@ describe('fx: diff', () => {
 
     expect(result).toStrictEqual(expected);
   });
+  it('should preserve nested object values when transitioning from empty object to populated object', () => {
+    const from = { parent: { child: { config: {} } } };
+    const to = {
+      parent: {
+        child: {
+          config: {
+            annotations: { hello: 'world' },
+            labels:      { key: 'value' }
+          }
+        }
+      }
+    };
+
+    const result = diff(from, to);
+    const expected = {
+      parent: {
+        child: {
+          config: {
+            annotations: { hello: 'world' },
+            labels:      { key: 'value' }
+          }
+        }
+      }
+    };
+
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('should preserve explicit empty object when clearing nested object values', () => {
+    const from = { parent: { child: { config: { annotations: { hello: 'world' } } } } };
+    const to = { parent: { child: { config: {} } } };
+
+    const result = diff(from, to);
+    const expected = { parent: { child: { config: {} } } };
+
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('should not emit nested empty objects when there are no differences', () => {
+    const from = { parent: { child: { config: { annotations: { hello: 'world' } } } } };
+    const to = { parent: { child: { config: { annotations: { hello: 'world' } } } } };
+
+    const result = diff(from, to);
+    const expected = {};
+
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('should correctly nullify nested keys when removed', () => {
+    const from = {
+      parent: {
+        child: {
+          config: {
+            annotations: { hello: 'world' },
+            labels:      { key: 'value' }
+          }
+        }
+      }
+    };
+    const to = { parent: { child: { config: { annotations: { hello: 'world' } } } } };
+
+    const result = diff(from, to);
+    const expected = { parent: { child: { config: { labels: { key: null } } } } };
+
+    expect(result).toStrictEqual(expected);
+  });
+
+  it('should not nullify child keys when parent object is updated', () => {
+    const from = { parent: { child: { config: {} } } };
+    const to = { parent: { child: { config: { annotations: { hello: 'world' } } } } };
+
+    const result = diff(from, to);
+    const expected = { parent: { child: { config: { annotations: { hello: 'world' } } } } };
+
+    expect(result).toStrictEqual(expected);
+    expect(result.parent.child.config).not.toHaveProperty('annotations', null);
+  });
 });
 
 describe('fx: definedKeys', () => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes  https://github.com/rancher/dashboard/issues/16414
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Currently the diff logic flattened nested keys and compared them as strings... When only nested children existed in the updated object, the parent key was incorrectly treated as missing and nullified... This resulted in valid nested updates being overwritten with null.(screenshot attached on the issue)
- The fix addresses the, parent keys are not treated as missing when nested descendants exist.
- preventNull behavior remain unchanged.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
