### PR TITLE
Automation: Fix cloud creds tests 

### DIFF
--- a/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
@@ -314,6 +314,7 @@ describe('Cloud Credential', { tags: ['@manager', '@adminUser'] }, () => {
   });
 
   after(() => {
+    cy.login(); // this is needed to avoid getting "Unauthorized 401: must authenticate" error
     for (let i = 0; i < doCreatedCloudCredsIds.length; i++) {
       cy.deleteRancherResource('v3', `cloudcredentials`, doCreatedCloudCredsIds[i]);
     }

--- a/cypress/e2e/tests/pages/manager/cloud-credentials.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credentials.spec.ts
@@ -1,8 +1,9 @@
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import CloudCredentialsPagePo from '@/cypress/e2e/po/pages/cluster-manager/cloud-credentials.po';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 
 // will only run this in jenkins pipeline where cloud credentials are stored
-describe('Cloud Credentials', { testIsolation: 'off', tags: ['@manager', '@jenkins', '@adminUser', '@standardUser'] }, () => {
+describe('Cloud Credentials', { tags: ['@manager', '@jenkins', '@adminUser', '@standardUser'] }, () => {
   const cloudCredentialsPage = new CloudCredentialsPagePo();
   let cloudcredentialId = '';
 
@@ -19,11 +20,13 @@ describe('Cloud Credentials', { testIsolation: 'off', tags: ['@manager', '@jenki
   });
 
   beforeEach(() => {
+    cy.login();
+    HomePagePo.goTo(); // this is needed to ensure we have a valid authentication session
     cy.createE2EResourceName('cloudCredential').as('cloudCredentialName');
   });
 
   it('can see error when authentication fails', function() {
-    CloudCredentialsPagePo.navTo();
+    cloudCredentialsPage.goTo();
     cloudCredentialsPage.waitForPage();
     cloudCredentialsPage.create();
     cloudCredentialsPage.createEditCloudCreds().waitForPage();
@@ -39,7 +42,8 @@ describe('Cloud Credentials', { testIsolation: 'off', tags: ['@manager', '@jenki
   });
 
   it('can create aws cloud credentials', function() {
-    CloudCredentialsPagePo.navTo();
+    cloudCredentialsPage.goTo();
+    cloudCredentialsPage.waitForPage();
     cloudCredentialsPage.create();
     cloudCredentialsPage.createEditCloudCreds().waitForPage();
     cloudCredentialsPage.createEditCloudCreds().cloudServiceOptions().selectSubTypeByIndex(0).click();
@@ -71,7 +75,8 @@ describe('Cloud Credentials', { testIsolation: 'off', tags: ['@manager', '@jenki
   });
 
   it('can edit cloud credentials', function() {
-    CloudCredentialsPagePo.navTo();
+    cloudCredentialsPage.goTo();
+    cloudCredentialsPage.waitForPage();
     cloudCredentialsPage.list().actionMenu(this.cloudCredentialName).getMenuItem('Edit Config').click();
     cloudCredentialsPage.createEditCloudCreds(cloudcredentialId).waitForPage('mode=edit');
     // Testing issue https://github.com/rancher/dashboard/issues/10424
@@ -89,7 +94,8 @@ describe('Cloud Credentials', { testIsolation: 'off', tags: ['@manager', '@jenki
   });
 
   it('can clone cloud credentials', function() {
-    CloudCredentialsPagePo.navTo();
+    cloudCredentialsPage.goTo();
+    cloudCredentialsPage.waitForPage();
     cloudCredentialsPage.list().actionMenu(`${ this.cloudCredentialName }-description-edit`).getMenuItem('Clone').click();
     cloudCredentialsPage.createEditCloudCreds(cloudcredentialId).waitForPage('mode=clone');
     cloudCredentialsPage.createEditCloudCreds().nameNsDescription().name().set(`${ this.cloudCredentialName }-clone`);
@@ -105,8 +111,8 @@ describe('Cloud Credentials', { testIsolation: 'off', tags: ['@manager', '@jenki
   });
 
   it('can delete cloud credentials', function() {
-    CloudCredentialsPagePo.navTo();
-
+    cloudCredentialsPage.goTo();
+    cloudCredentialsPage.waitForPage();
     // delete clone cloud credential
     cloudCredentialsPage.list().actionMenu(`${ this.cloudCredentialName }-clone`).getMenuItem('Delete').click();
     const promptRemove = new PromptRemove();
@@ -122,8 +128,8 @@ describe('Cloud Credentials', { testIsolation: 'off', tags: ['@manager', '@jenki
   });
 
   it('can delete cloud credentials via bulk actions', function() {
-    CloudCredentialsPagePo.navTo();
-
+    cloudCredentialsPage.goTo();
+    cloudCredentialsPage.waitForPage();
     // delete original cloud credential
     cloudCredentialsPage.list().resourceTable().sortableTable().rowSelectCtlWithName(`${ this.cloudCredentialName }-name-edit`)
       .set();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2199

Two fixes: 
- Fix Cloud Credentials e2e test failures by enabling test isolation. With this change, each test runs on a fresh browser state, and tests are no longer failing.
- `afterAll' hook is failing with \"message\": \"Unauthorized 401: must authenticate\"". Added `cy.login` within the hook to authenticate.
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
