### PR TITLE
Auth Providers - Handle cases where driver scopes are an array

### DIFF
--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -266,7 +266,16 @@ export const actions = {
     }
 
     if (driver?.scopes) {
-      scopes = [joinStringList(scopes[0], driver.scopes)];
+      // In some cases, driver scopes can be an array. We need to convert this
+      // to a string that can be parsed by `joinStringList()`
+      try {
+        const driverScopes = Array.isArray(driver.scopes) ? driver.scopes.join(' ') : driver.scopes;
+
+        scopes = [joinStringList(scopes[0], driverScopes)];
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to join driver scopes', error);
+      }
     }
 
     let url = removeParam(redirectUrl, GITHUB_SCOPE);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves an issue with Azure AD auth, where joining scopes can fail if they are returned as an array instead of string.

Fixes #16656 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Handle cases where driver scopes are an array

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Some Auth Providers, like Azure AD, can return driver scopes as an array. The array needs to be converted to a string so that the scopes can be parsed properly.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Authenticating with the following auth providers:

- Azure AD
- Keycloak OIDC

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Other auth providers could fail if the data is structured in an unexpected way. We are guarding against this by wrapping the driver scopes in a try..catch block.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
