### PR TITLE
[Automation] - Addng visual test of the Cluster Drivers page

### DIFF
--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -285,3 +285,27 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     }
   });
 });
+
+describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () => {
+  before(() => {
+    cy.login();
+    // Set theme to light
+    cy.setUserPreference({ theme: 'ui-light' });
+  });
+
+  it('should display kontainer drivers list page', () => {
+    const driversPage = new KontainerDriversPagePo();
+
+    KontainerDriversPagePo.goTo('_');
+    driversPage.checkIsCurrentPage();
+
+    driversPage.list().resourceTable().sortableTable().checkVisible();
+    driversPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+    driversPage.list().resourceTable().sortableTable().noRowsShouldNotExist();
+
+    // hide elements before taking percy snapshot
+    cy.hideElementBySelector('[data-testid="nav_header_showUserMenu"]', '[data-testid="type-count"]');
+    // takes percy snapshot.
+    cy.percySnapshot('kontainer drivers list page');
+  });
+});


### PR DESCRIPTION
### Summary

Fixes rancher/qa-tasks#1826


### Occurred changes and/or fixed issues
Adding visual test of `c/_/manager/kontainerDriver` Clusters Drivers page.

### Technical notes summary

Percy accuracy is locked at 100%. Sidebar counters and the avatar are the only hidden elements.

### Areas or cases that should be tested
CI

### Areas which could experience regressions
CI / Percy Visual testing.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
