### PR TITLE
Pod Security Admissions page visual tests

### DIFF
--- a/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
+++ b/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
@@ -166,3 +166,28 @@ describe('Pod Security Admissions', { testIsolation: 'off', tags: ['@manager', '
       });
   });
 });
+
+describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () => {
+  before(() => {
+    cy.login();
+    // Set theme to light
+    cy.setUserPreference({ theme: 'ui-light' });
+  });
+
+  it('should display Pod Security Admissions list page', () => {
+    const podSecurityAdmissionsPage = new PodSecurityAdmissionsPagePo();
+
+    PodSecurityAdmissionsPagePo.goTo('_');
+    podSecurityAdmissionsPage.checkIsCurrentPage();
+
+    podSecurityAdmissionsPage.list().resourceTable().sortableTable().checkVisible();
+    podSecurityAdmissionsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+    podSecurityAdmissionsPage.list().resourceTable().sortableTable().noRowsShouldNotExist();
+
+    // hide elements before taking percy snapshot
+    cy.hideElementBySelector('[data-testid="nav_header_showUserMenu"]', '[data-testid="type-count"]');
+
+    // takes percy snapshot.
+    cy.percySnapshot('Pod Security Admissions list page');
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/qa-tasks#1828

### Occurred changes and/or fixed issues
Adding the default visual test of the Pod Security Admissions page. 

### Technical notes summary
This one has always two rows populated by default. This test takes an snapshot of that state.

### Areas or cases that should be tested
CI

### Areas which could experience regressions
CI / Percy Dashboard

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
