### PR TITLE
[backport 2.13.4] Automation: Exclude ui-brand test and update home-links test for prime builds

### DIFF
--- a/cypress/e2e/tests/pages/global-settings/home-links.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/home-links.spec.ts
@@ -26,7 +26,13 @@ describe('Home Links', { testIsolation: 'off' }, () => {
     homeLinksPage.applyAndWait('/v1/management.cattle.io.settings/ui-custom-links', 200);
 
     HomePagePo.goTo();
-    homePage.supportLinks().should('have.length', 1).contains('Commercial Support');
+
+    // "SUSE Application Collection" for Rancher Prime, otherwise "Commercial Support"
+    cy.getRancherVersion().then((version) => {
+      const expectedValue = version.RancherPrime === 'true' ? 'SUSE Application Collection' : 'Commercial Support';
+
+      homePage.supportLinks().should('have.length', 1).contains(expectedValue);
+    });
 
     HomeLinksPagePo.navTo();
 

--- a/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
@@ -258,7 +258,7 @@ describe('Settings', { testIsolation: 'off' }, () => {
     resetSettings.push('ui-offline-preferred');
   });
 
-  it('can update ui-brand', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it('can update ui-brand', { tags: ['@noPrime', '@globalSettings', '@adminUser'] }, () => {
     // We probably want a better way to distinguish between rancher and suse logos. I'm doing this as part of the vue3 migration and trying to keep things as similar as possible.
     const rancherLogoWidth = 167;
     const suseRancherLogoWidth = 200;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2204
https://github.com/rancher/qa-tasks/issues/2206

Backport of https://github.com/rancher/dashboard/pull/16681

<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
