### PR TITLE
Fix TestHub PR Sync Job

### DIFF
--- a/.github/workflows/testhub.yaml
+++ b/.github/workflows/testhub.yaml
@@ -13,7 +13,7 @@ on:
       - completed
 
   # Trigger on PR events to sync PR info (don't need all events)
-  pull_request:
+  pull_request_target:
     types:
       - edited
       - closed
@@ -23,6 +23,9 @@ on:
       - demilestoned
       - ready_for_review
       - converted_to_draft
+    branches:
+      - 'master'
+      - 'release-*'
 
 jobs:
   # Job to register completed test runs with TestHub


### PR DESCRIPTION
Fixes the TestHub PR sync job - this has to run as pull_request_target in order to have access to the repository secrets.

It does not clone any other branches, so there should be no risk in doing this.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
