### PR TITLE
EKS - Minor ui change to `ipFamily` section

### DIFF
--- a/pkg/eks/components/Networking.vue
+++ b/pkg/eks/components/Networking.vue
@@ -323,7 +323,7 @@ export default defineComponent({
       </div>
     </div>
     <div class="row">
-      <div class="col span-2">
+      <div class="col span-12">
         <RadioGroup
           :value="ipFamily"
           name="ip-family"
@@ -332,18 +332,19 @@ export default defineComponent({
           label-key="eks.ipFamily.label"
           :disabled="!isNewOrUnprovisioned"
           data-testid="eks-ip-family-radio"
+          :row="true"
           @update:value="$emit('update:ipFamily', $event)"
-        />
+        >
+          <template #label>
+            <h3>{{ t('eks.ipFamily.label') }}</h3>
+            <Banner
+              v-if="isNewOrUnprovisioned"
+              color="info"
+              :label="t('eks.ipFamily.banner')"
+            />
+          </template>
+        </RadioGroup>
       </div>
-    </div>
-    <div
-      v-if="isNewOrUnprovisioned"
-      class="row mb-10"
-    >
-      <Banner
-        color="info"
-        :label="t('eks.ipFamily.banner')"
-      />
     </div>
     <div class="row mb-10 mt-20">
       <div


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16407 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
As part of the work related to #16407 this PR addresses Ovi’s feedback on IP Family positioning:
- Moved the banner to sit under the title.
- Updated the options to a horizontal layout.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
n/a
### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
n/a
### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
n/a
### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
Before:
<img width="1582" height="327" alt="image" src="https://github.com/user-attachments/assets/b42f701d-a4ca-4210-add8-c70c7f2a574f" />

After:
<img width="1588" height="317" alt="image" src="https://github.com/user-attachments/assets/be0730ca-2c89-4a54-974e-ef25d6b0c6ba" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
