### PR TITLE
Automation: Reset ui-pl to real default – lowercase "rancher"

### DIFF
--- a/cypress/e2e/tests/pages/global-settings/branding.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/branding.spec.ts
@@ -491,7 +491,7 @@ describe('Branding', { testIsolation: 'off' }, () => {
         const resourceVersion = resp.body.metadata.resourceVersion;
 
         cy.setRancherResource('v1', 'management.cattle.io.settings', 'ui-pl', {
-          value:    `${ settings.privateLabel.original }`,
+          value:    `${ settings.privateLabel.original }`.toLowerCase(),
           metadata: { name: 'ui-pl', resourceVersion }
         });
       });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2226

Fixes three "has the correct title" tests.
The test failures were caused by the Branding spec’s Private label test. Its after() hook resets the ui-pl setting to the literal value "Rancher", which becomes the product name used in the document title. In a Rancher Prime environment the title then showed “Rancher - Global Settings - Settings” instead of “Rancher Prime - …”. Resetting the private label to the lowercased value ("rancher") makes the app use the real default product name (Rancher Prime) again, so the title tests pass.
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
