### PR TITLE
Automation: Drive version assertions from index API

### DIFF
--- a/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
@@ -148,6 +148,11 @@ describe('Chart Details Page', { tags: ['@explorer', '@adminUser'] }, () => {
   const chartName = 'Logging';
   let chartPage: ChartPage;
 
+  before(() => {
+    cy.login();
+    cy.setUserPreference({ 'show-pre-release': true }); // Show pre-release versions
+  });
+
   beforeEach(() => {
     cy.intercept('GET', `${ CLUSTER_REPOS_BASE_URL }/**`).as('fetchChartData');
 
@@ -194,5 +199,9 @@ describe('Chart Details Page', { tags: ['@explorer', '@adminUser'] }, () => {
         chartPage.showMoreVersions().should('not.exist');
       }
     });
+  });
+
+  after(() => { // Reset user preference
+    cy.setUserPreference({ 'show-pre-release': false });
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2225

The number of versions shown in the UI depends on the Rancher setup (e.g. 4 in Rancher Prime, 30+ in Rancher community). The test now uses the chart index API (rancher-charts?link=index) to get the real rancher-logging version count and asserts the UI shows 7 with “show more” when there are more than 7, or all versions when there are 7 or fewer.

### Screenshots
<img width="1911" height="848" alt="Screenshot 2026-02-19 at 3 42 38 PM" src="https://github.com/user-attachments/assets/daf02a71-e64d-4734-9b0a-a85ee94bd962" />

<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
