### PR TITLE
Automation: Fix cluster list machines assertion for Prime builds

### DIFF
--- a/cypress/e2e/po/lists/provisioning.cattle.io.cluster.po.ts
+++ b/cypress/e2e/po/lists/provisioning.cattle.io.cluster.po.ts
@@ -42,7 +42,8 @@ export default class ProvClusterListPo extends BaseResourceList {
   }
 
   machines(clusterName: string) {
-    return this.resourceTable().sortableTable().rowWithName(clusterName).column(5);
+    return this.resourceTable().sortableTable().rowWithName(clusterName)
+      .get('.col-machine-summary-graph');
   }
 
   explore(clusterName: string) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2229

Use a class-based selector for the machines cell instead of a column index, so the test works when the Autoscaler column is present. On Prime, the autoscaler feature is on by default, which adds that column and shifts the machines column index and broke the assertion.
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video

<img width="1549" height="696" alt="Screenshot 2026-02-20 at 3 04 33 PM" src="https://github.com/user-attachments/assets/feb58a85-69ab-412d-abe2-4b668399e377" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
