### PR TITLE
Automation - Pod scale fixes

### DIFF
--- a/cypress/e2e/po/components/Resource/Detail/Card/scaler.po.ts
+++ b/cypress/e2e/po/components/Resource/Detail/Card/scaler.po.ts
@@ -8,14 +8,14 @@ export default class ScalerPo extends ComponentPo {
   }
 
   getValue(): CypressChainable {
-    return this.self().get('[data-testid="scaler-value"]', LONG_TIMEOUT_OPT);
+    return cy.get(`${ this.selector } [data-testid="scaler-value"]`, LONG_TIMEOUT_OPT);
   }
 
   decreaseButton(): CypressChainable {
-    return this.self().get('[data-testid="scaler-decrease"]', LONG_TIMEOUT_OPT);
+    return cy.get(`${ this.selector } [data-testid="scaler-decrease"]`, LONG_TIMEOUT_OPT);
   }
 
   increaseButton(): CypressChainable {
-    return this.self().get('[data-testid="scaler-increase"]', LONG_TIMEOUT_OPT);
+    return cy.get(`${ this.selector } [data-testid="scaler-increase"]`, LONG_TIMEOUT_OPT);
   }
 }

--- a/cypress/e2e/po/components/Resource/Detail/Card/statusCard.po.ts
+++ b/cypress/e2e/po/components/Resource/Detail/Card/statusCard.po.ts
@@ -7,7 +7,7 @@ export default class CardPo extends ComponentPo {
   }
 
   private scaler() {
-    return new ScalerPo();
+    return new ScalerPo(`${ this.selector } [data-testid="scaler"]`);
   }
 
   scaleUp(): Cypress.Chainable {
@@ -19,7 +19,7 @@ export default class CardPo extends ComponentPo {
   }
 
   podsRunningTotal(): Cypress.Chainable {
-    return this.self().get('[data-testid="rc-counter-badge"]');
+    return cy.get(`${ this.selector } [data-testid="rc-counter-badge"]`);
   }
 
   replicaCount(): Cypress.Chainable {
@@ -27,10 +27,10 @@ export default class CardPo extends ComponentPo {
   }
 
   podsStatus(): Cypress.Chainable {
-    return this.self().find('.status-row .label');
+    return cy.get(`${ this.selector } .status-row .label`);
   }
 
   podsStatusCount(): Cypress.Chainable {
-    return this.self().find('[data-testid="rc-counter-badge"]');
+    return cy.get(`${ this.selector } [data-testid="rc-counter-badge"]`);
   }
 }

--- a/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
@@ -57,6 +57,10 @@ export class WorkloadDetailsPageBasePo extends BaseDetailPagePo {
     return new CardPo();
   }
 
+  title(): Cypress.Chainable {
+    return cy.get(`${ this.selector } h1`);
+  }
+
   deleteWithKubectl(name: string, namespace = 'default') {
     this.workload().deleteWithKubectl(name, namespace);
   }
@@ -93,7 +97,7 @@ export class WorkloadDetailsPageBasePo extends BaseDetailPagePo {
    * Wait until there's exactly one pods status count element
    */
   waitForSinglePodsStatusCount(): Cypress.Chainable {
-    return cy.get('[data-testid="rc-counter-badge"]').should('have.length', 1);
+    return this.podsStatusCount().should('have.length', 1, MEDIUM_TIMEOUT_OPT);
   }
 
   /**
@@ -121,13 +125,13 @@ export class WorkloadDetailsPageBasePo extends BaseDetailPagePo {
   }
 
   /**
-   * Wait for both scale up and down buttons to be enabled
+   * Wait for both scale up and down buttons to be enabled and visible
    */
   waitForScaleButtonsEnabled() {
-    this.podScaleUp().should('not.be.disabled');
-    this.podScaleDown().should('not.be.disabled');
-    this.podScaleUp().should('not.have.attr', 'aria-disabled', 'true');
-    this.podScaleDown().should('not.have.attr', 'aria-disabled', 'true');
+    this.podScaleUp().scrollIntoView().should('be.visible').and('not.be.disabled')
+      .should('not.have.attr', 'aria-disabled', 'true');
+    this.podScaleDown().scrollIntoView().should('be.visible').and('not.be.disabled')
+      .should('not.have.attr', 'aria-disabled', 'true');
 
     return this;
   }


### PR DESCRIPTION
### Summary
Fixes rancher/qa-tasks#2162

### Occurred changes and/or fixed issues
 Stabilized the pod scaling E2E test, which was frequently failing due to timing issues and UI re-renders. The primary issues were the default Kubernetes pod termination delay (30s) exceeding test timeouts and Cypress losing element references when Vue updated the status cards. I also added logic to make the test self-healing during retries with `testIsolation: off`.

### Technical notes summary
* Added `terminationGracePeriodSeconds: 0` to the test deployment spec. This forces pods to disappear immediately during scale-down, removing the 30s Kubernetes wait that was causing assertions to flake.
* Refactored the `Scaler` and `StatusCard` Page Objects to use fully scoped `cy.get()` selectors instead of chained `.find()` calls. This allows Cypress to automatically re-query the DOM and recover if Vue re-renders the component mid-assertion, preventing "detached from DOM" errors.
* Implemented dynamic intercepts that inspect the replicas count in the request payload. By aliasing requests specifically as `@scaleUp` or `@scaleDown`, the test now waits for the backend before verifying the UI.
* Added a reset block at the beginning of the test to ensure the workload starts at `1` replica. This prevents a scaled-up state from a previous failed attempt from breaking subsequent retries.

### Areas or cases that should be tested
CI

### Areas which could experience regressions
CI / Jenkins

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
