### PR TITLE
Ensure TestHub syncs PR changes

### DIFF
--- a/.github/workflows/testhub.yaml
+++ b/.github/workflows/testhub.yaml
@@ -23,6 +23,9 @@ on:
       - demilestoned
       - ready_for_review
       - converted_to_draft
+      - assigned
+      - unassigned
+
     branches:
       - 'master'
       - 'release-*'
@@ -73,7 +76,7 @@ jobs:
       TESTHUB_TOKEN: ${{ secrets.TESTHUB_TOKEN }}
 
     # Only run for pull_request events when env vars are configured
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     steps:
       - name: Sync PR info with TestHub
         # Continue even if this fails - we don't want to fail the workflow


### PR DESCRIPTION
Minor tweaks to the TestHub integration workflow to correct the name of the event so that PR changes are synced to the TestHub cache.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
