### PR TITLE
Fix findlabelSelector when vai enabled but resource type not supported

### DIFF
--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -554,7 +554,6 @@ export default {
    */
   async findLabelSelector(ctx, {
     type,
-    context,
     matching: {
       namespace,
       labelSelector
@@ -562,14 +561,10 @@ export default {
     opt
   }) {
     const { getters, dispatch } = ctx;
-    const args = {
-      id: type,
-      context,
-    };
 
     opt = opt || {};
 
-    if (getters[`paginationEnabled`]?.(args)) {
+    if (getters[`paginationEnabled`]?.()) {
       if (isLabelSelectorEmpty(labelSelector)) {
         throw new Error(`labelSelector must not be empty when using findLabelSelector (avoid fetching all resources)`);
       }

--- a/shell/utils/selector-typed.ts
+++ b/shell/utils/selector-typed.ts
@@ -110,7 +110,7 @@ export async function matching({
     return generateMatchingResponse([], inScopeCount || 0);
   }
 
-  if ($store.getters[`${ inStore }/paginationEnabled`]?.({ id: type })) {
+  if ($store.getters[`${ inStore }/paginationEnabled`]?.()) {
     if (isLabelSelectorEmpty(labelSelector) && (!!namespace && !safeNamespaces?.length)) {
       // no namespaces - ALL resources are candidates
       // no labels - return all candidates


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16621
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- When vai is enabled the old method of applying labelSelectors server-side is not supported
- At the moment though we use the old method if vai is enabled AND the resource is configured to use it
- This led to bugs where vai enabled, resource is not configured to use it --> old method 
- Now we don't check if the type supports ssp, we just check vai enabled
  - The supported flag is just something locally to enable us to easily manage resources that use ssp lists / other features
  - They're tracked in shell/plugins/steve/steve-pagination-utils.ts  PAGINATION_SETTINGS_STORE_DEFAULTS

### Technical notes summary
- This only affects two places, and only when supplied `type` is not SSP enabled
  - findLabelSelector
    - shell/dialog/ExtensionCatalogUninstallDialog.vue finding `catalog.cattle.io.clusterrepo`
    - shell/dialog/ScaleMachineDownDialog.vue finding `cluster.x-k8s.io.machineset`
    - _findRelationship --> findOwned --> shell/models/compliance.cattle.io.clusterscan.js getReports
  - shell/utils/selector-typed.ts `matching` fn
    - not used anywhere that supplies a type not SSP enabled

### Areas or cases that should be tested
- RKE2 scale down modal
  - Provision an RKE2 cluster with 3 pools, two with just a worker
  - Nav to cluster detail page, open dev tools
  - Confirm that http requests to fetch `cluster.x-k8s.io.machineset` return 1 result when...
    - for each machine in each worker pool click action menu --> `Scale down`.
    - a model should show which kicks off a request to fetch machinesets in that pool
    - the requests should return only the machine relevant to the pool 
- Compliance (replacement app for CIS Benchmark)
  - cluster tools --> install compliance app
  - load https://raw.githubusercontent.com/rancher/compliance-operator/refs/heads/main/tests/k3s-bench-test.yaml, copy url, apply yaml in target cluster
  - wait for scan to complete --> click on a scan --> Shows entries
  - Unrelated issue https://github.com/rancher/dashboard/issues/16735


### Areas which could experience regressions
  - Find two deployments with different amount of pods
  - Flick multiple times between the detail page of each deployment and ensure the Pods list contains the correct values
  - Also refresh on a detail page and ensure Pods list contains correct values

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
