### PR TITLE
Automation: Fix registries tests for prime builds

### DIFF
--- a/cypress/e2e/tests/pages/manager/registries.spec.ts
+++ b/cypress/e2e/tests/pages/manager/registries.spec.ts
@@ -40,8 +40,12 @@ describe('Registries for RKE2', { tags: ['@manager', '@adminUser'] }, () => {
 
     // navigate to Registries tab
     createCustomClusterPage.clusterConfigurationTabs().clickTabWithSelector('#registry');
-    // enable registry
-    createCustomClusterPage.registries().enableRegistryCheckbox().set();
+    // enable registry (checkbox is on by default in Prime; only set when not Prime)
+    cy.getRancherVersion().then((version) => {
+      if (version.RancherPrime !== 'true') {
+        createCustomClusterPage.registries().enableRegistryCheckbox().set();
+      }
+    });
     createCustomClusterPage.registries().enableRegistryCheckbox().isChecked();
     createCustomClusterPage.registries().showAdvanced().should('be.visible');
     // disable registry
@@ -71,8 +75,13 @@ describe('Registries for RKE2', { tags: ['@manager', '@adminUser'] }, () => {
     createCustomClusterPage.nameNsDescription().name().set(this.clusterName);
     // navigate to Registries tab
     createCustomClusterPage.clusterConfigurationTabs().clickTabWithSelector('#registry');
-    // enable registry
-    createCustomClusterPage.registries().enableRegistryCheckbox().set();
+    // enable registry (checkbox is on by default in Prime; only set when not Prime)
+    cy.getRancherVersion().then((version) => {
+      if (version.RancherPrime !== 'true') {
+        createCustomClusterPage.registries().enableRegistryCheckbox().set();
+      }
+    });
+    createCustomClusterPage.registries().enableRegistryCheckbox().isChecked();
     // add host
     createCustomClusterPage.registries().addRegistryHost(registryHost);
     // click show advanced
@@ -136,8 +145,13 @@ describe('Registries for RKE2', { tags: ['@manager', '@adminUser'] }, () => {
     createCustomClusterPage.nameNsDescription().name().set(this.clusterName2);
     // navigate to Registries tab
     createCustomClusterPage.clusterConfigurationTabs().clickTabWithSelector('#registry');
-    // enable registry
-    createCustomClusterPage.registries().enableRegistryCheckbox().set();
+    // enable registry (checkbox is on by default in Prime; only set when not Prime)
+    cy.getRancherVersion().then((version) => {
+      if (version.RancherPrime !== 'true') {
+        createCustomClusterPage.registries().enableRegistryCheckbox().set();
+      }
+    });
+    createCustomClusterPage.registries().enableRegistryCheckbox().isChecked();
     // add host
     createCustomClusterPage.registries().addRegistryHost(registryHost);
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2230

Fixes 3 registries tests by:
Only call set() on the “Enable cluster scoped container registry” checkbox when not running Rancher Prime, since in Prime the checkbox is on by default and calling set() was toggling it off and breaking the three registries specs.
<!-- Define findings related to the feature or bug issue. -->

### Screenshots
<img width="1290" height="208" alt="image" src="https://github.com/user-attachments/assets/2f398ca7-1580-4a36-a0fc-d2c4da9990ea" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
