### PR TITLE
Add tests for OIDC Custom Claims and Custom Resource Quotas

### DIFF
--- a/cypress/e2e/po/edit/auth/genericOidc.po.ts
+++ b/cypress/e2e/po/edit/auth/genericOidc.po.ts
@@ -1,0 +1,67 @@
+import PagePo from '@/cypress/e2e/po/pages/page.po';
+import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
+import RadioGroupInputPo from '@/cypress/e2e/po/components/radio-group-input.po';
+import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
+import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
+
+export default class GenericOidcPo extends PagePo {
+  private static createPath(clusterId: string) {
+    return `/c/${ clusterId }/auth/config/genericoidc?mode=edit`;
+  }
+
+  constructor(clusterId: string) {
+    super(GenericOidcPo.createPath(clusterId));
+  }
+
+  enterClientId(id: string) {
+    return new LabeledInputPo('[data-testid="oidc-client-id"]').set(id);
+  }
+
+  enterClientSecret(secret: string) {
+    return new LabeledInputPo('[data-testid="oidc-client-secret"]').set(secret);
+  }
+
+  selectCustomEndpoint() {
+    return new RadioGroupInputPo('[data-testid="oidc-custom-endpoint"]').set(1);
+  }
+
+  enterRancherUrl(url: string) {
+    return new LabeledInputPo('[data-testid="oidc-rancher-url"]').set(url);
+  }
+
+  enterIssuer(url: string) {
+    return new LabeledInputPo('[data-testid="oidc-issuer"]').set(url);
+  }
+
+  enterAuthEndpoint(url: string) {
+    return new LabeledInputPo('[data-testid="oidc-auth-endpoint"]').set(url);
+  }
+
+  enableCustomClaims() {
+    return new CheckboxInputPo('[data-testid="input-add-custom-claims"]').set();
+  }
+
+  enterNameClaim(claim: string) {
+    return new LabeledInputPo('[data-testid="input-name-claim"]').set(claim);
+  }
+
+  enterGroupsClaim(claim: string) {
+    return new LabeledInputPo('[data-testid="input-groups-claim"]').set(claim);
+  }
+
+  enterEmailClaim(claim: string) {
+    return new LabeledInputPo('[data-testid="input-email-claim"]').set(claim);
+  }
+
+  saveButton(): AsyncButtonPo {
+    return new AsyncButtonPo('[data-testid="form-save"]', this.self());
+  }
+
+  save() {
+    return new AsyncButtonPo('[data-testid="form-save"]').click();
+  }
+
+  permissionsWarningBanner() {
+    return this.self().get('[data-testid="auth-provider-admin-permissions-warning-banner"]');
+  }
+}

--- a/cypress/e2e/po/pages/explorer/projects-namespaces.po.ts
+++ b/cypress/e2e/po/pages/explorer/projects-namespaces.po.ts
@@ -88,6 +88,18 @@ export class ProjectCreateEditPagePo extends BaseDetailPagePo {
     return selectPo.clickOption(optionIndex + 1);
   }
 
+  selectResourceTypeByLabel(label: string) {
+    const selectPo = new SelectPo(cy.get('[data-testid="projectrow-type-input"]'));
+
+    selectPo.toggle();
+
+    return selectPo.clickOptionWithLabel(label);
+  }
+
+  inputCustomType() {
+    return new LabeledInputPo(cy.get('[data-testid="projectrow-custom-type-input"]'));
+  }
+
   bannerError(n: number) {
     return this.self().getId(`error-banner${ n }`);
   }

--- a/cypress/e2e/po/pages/explorer/projects-namespaces.po.ts
+++ b/cypress/e2e/po/pages/explorer/projects-namespaces.po.ts
@@ -52,12 +52,12 @@ export class ProjectCreateEditPagePo extends BaseDetailPagePo {
     return this.self().getId('array-list-button');
   }
 
-  inputProjectLimit() {
-    return new LabeledInputPo(cy.get('[data-testid="projectrow-project-quota-input"]'));
+  inputProjectLimit(rowIndex = 0) {
+    return new LabeledInputPo(cy.get('[data-testid="projectrow-project-quota-input"]').eq(rowIndex));
   }
 
-  inputNamespaceDefaultLimit() {
-    return new LabeledInputPo(cy.get('[data-testid="projectrow-namespace-quota-input"]'));
+  inputNamespaceDefaultLimit(rowIndex = 0) {
+    return new LabeledInputPo(cy.get('[data-testid="projectrow-namespace-quota-input"]').eq(rowIndex));
   }
 
   tabContainerDefaultResourceLimit() {
@@ -80,24 +80,24 @@ export class ProjectCreateEditPagePo extends BaseDetailPagePo {
     return new LabeledInputPo(cy.get('[data-testid="memory-limit"]'));
   }
 
-  selectResourceType(optionIndex: number) {
-    const selectPo = new SelectPo(cy.get('[data-testid="projectrow-type-input"]'));
+  selectResourceType(optionIndex: number, rowIndex = 0) {
+    const selectPo = new SelectPo(cy.get('[data-testid="projectrow-type-input"]').eq(rowIndex));
 
     selectPo.toggle();
 
     return selectPo.clickOption(optionIndex + 1);
   }
 
-  selectResourceTypeByLabel(label: string) {
-    const selectPo = new SelectPo(cy.get('[data-testid="projectrow-type-input"]'));
+  selectResourceTypeByLabel(label: string, rowIndex = 0) {
+    const selectPo = new SelectPo(cy.get('[data-testid="projectrow-type-input"]').eq(rowIndex));
 
     selectPo.toggle();
 
     return selectPo.clickOptionWithLabel(label);
   }
 
-  inputCustomType() {
-    return new LabeledInputPo(cy.get('[data-testid="projectrow-custom-type-input"]'));
+  inputCustomType(rowIndex = 0) {
+    return new LabeledInputPo(cy.get('[data-testid="projectrow-custom-type-input"]').eq(rowIndex));
   }
 
   bannerError(n: number) {

--- a/cypress/e2e/tests/pages/explorer2/project-namespace.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/project-namespace.spec.ts
@@ -148,6 +148,61 @@ describe('Projects/Namespaces', { tags: ['@explorer2', '@adminUser'] }, () => {
         });
       });
 
+      it('sends only the last-written quota values when duplicate custom resource identifiers are posted', () => {
+        cy.get('@projectName').then((projectName) => {
+          projectsNamespacesPage.baseResourceList().masthead().create();
+          createProjectPage.resourceDetail().createEditView().nameNsDescription()
+            .name()
+            .set(projectName);
+          createProjectPage.tabResourceQuotas().click();
+
+          // Add first Custom resource row
+          createProjectPage.btnAddResource().click();
+          createProjectPage.selectResourceTypeByLabel('Custom', 0);
+          createProjectPage.inputCustomType(0).set('example.io/custom-resource');
+          createProjectPage.inputProjectLimit(0).set('5');
+          createProjectPage.inputNamespaceDefaultLimit(0).set('2');
+
+          // Add second Custom resource row with the same identifier
+          createProjectPage.btnAddResource().click();
+          createProjectPage.selectResourceTypeByLabel('Custom', 1);
+          createProjectPage.inputCustomType(1).set('example.io/custom-resource');
+          createProjectPage.inputProjectLimit(1).set('10');
+          createProjectPage.inputNamespaceDefaultLimit(1).set('4');
+
+          createProjectPage.resourceDetail().createEditView().create();
+
+          cy.wait('@createProjectRequest').then(({ request }) => {
+            // The duplicate identifier resolves to a single key; the last-written values win
+            expect(request.body.resourceQuota.limit.extended['example.io/custom-resource']).to.equal('10');
+            expect(request.body.namespaceDefaultResourceQuota.limit.extended['example.io/custom-resource']).to.equal('4');
+          });
+        });
+      });
+
+      it('sends a POST request without extended quota values when identifier is set but quota values are left empty', () => {
+        cy.get('@projectName').then((projectName) => {
+          projectsNamespacesPage.baseResourceList().masthead().create();
+          createProjectPage.resourceDetail().createEditView().nameNsDescription()
+            .name()
+            .set(projectName);
+          createProjectPage.tabResourceQuotas().click();
+
+          // Add a Custom resource row with only the identifier filled in; leave both limit fields empty
+          createProjectPage.btnAddResource().click();
+          createProjectPage.selectResourceTypeByLabel('Custom', 0);
+          createProjectPage.inputCustomType(0).set('example.io/custom-resource');
+
+          createProjectPage.resourceDetail().createEditView().create();
+
+          cy.wait('@createProjectRequest').then(({ request }) => {
+            // No limit values were entered so the extended object is absent from the request body
+            expect(request.body.resourceQuota.limit?.extended).to.equal(undefined);
+            expect(request.body.namespaceDefaultResourceQuota.limit?.extended).to.equal(undefined);
+          });
+        });
+      });
+
       afterEach(() => {
         cy.get<string>('@projectName').then((projectName) => {
           cy.deleteRancherResource('v3', 'projects', projectName, false);

--- a/cypress/e2e/tests/pages/explorer2/project-namespace.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/project-namespace.spec.ts
@@ -93,6 +93,7 @@ describe('Projects/Namespaces', { tags: ['@explorer2', '@adminUser'] }, () => {
         .set('test-1234');
       createProjectPage.tabResourceQuotas().click();
       createProjectPage.btnAddResource().click();
+      createProjectPage.selectResourceTypeByLabel('Custom');
       createProjectPage.inputCustomType().expectToBeEnabled();
     });
 

--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -257,6 +257,8 @@ describe('oidc.vue', () => {
 
       expect(addCustomClaimsCheckbox.exists()).toBe(true);
       expect(groupSearchCheckbox.exists()).toBe(true);
+      expect(addCustomClaimsCheckbox.find('input').element.disabled).toBe(false);
+      expect(groupSearchCheckbox.find('input').element.disabled).toBe(false);
     });
 
     it('should render custom claims section when provider is keycloak and addCustomClaims is true', async() => {
@@ -282,6 +284,8 @@ describe('oidc.vue', () => {
 
       expect(addCustomClaimsCheckbox.exists()).toBe(true);
       expect(groupSearchCheckbox.exists()).toBe(true);
+      expect(addCustomClaimsCheckbox.find('input').element.disabled).toBe(false);
+      expect(groupSearchCheckbox.find('input').element.disabled).toBe(false);
     });
 
     it('should NOT render custom claims section when provider is keycloak and addCustomClaims is false', async() => {
@@ -296,6 +300,19 @@ describe('oidc.vue', () => {
       expect(nameClaim.exists()).toBe(false);
       expect(groupsClaim.exists()).toBe(false);
       expect(emailClaim.exists()).toBe(false);
+    });
+
+    it.each([
+      ['cognito'],
+    ])('addCustomClaims and supportsGroupSearch fields do not exist for provider "%s"', async(providerId: string) => {
+      wrapper.setData({ model: { ...mockModel, id: providerId } });
+      await nextTick();
+
+      const addCustomClaimsCheckbox = wrapper.find('[data-testid="input-add-custom-claims"]');
+      const groupSearchCheckbox = wrapper.find('[data-testid="input-group-search"]');
+
+      expect(addCustomClaimsCheckbox.exists()).toBe(false);
+      expect(groupSearchCheckbox.exists()).toBe(false);
     });
   });
 });

--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -302,10 +302,8 @@ describe('oidc.vue', () => {
       expect(emailClaim.exists()).toBe(false);
     });
 
-    it.each([
-      ['cognito'],
-    ])('addCustomClaims and supportsGroupSearch fields do not exist for provider "%s"', async(providerId: string) => {
-      wrapper.setData({ model: { ...mockModel, id: providerId } });
+    it('addCustomClaims and supportsGroupSearch fields do not exist for provider cognito', async() => {
+      wrapper.setData({ model: { ...mockModel, id: 'cognito' } });
       await nextTick();
 
       const addCustomClaimsCheckbox = wrapper.find('[data-testid="input-add-custom-claims"]');

--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -145,6 +145,23 @@ describe('oidc.vue', () => {
 
         expect(saveButton.disabled).toBe(false);
       });
+
+      it('when addCustomClaims is enabled but claim fields are undefined', async() => {
+        wrapper.setData({
+          oidcUrls:        { url: validUrl, realm: validRealm },
+          oidcScope:       validScope.split(' '),
+          addCustomClaims: true,
+        });
+
+        wrapper.vm.model.nameClaim = undefined;
+        wrapper.vm.model.groupsClaim = undefined;
+        wrapper.vm.model.emailClaim = undefined;
+        await nextTick();
+
+        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+
+        expect(saveButton.disabled).toBe(false);
+      });
     });
 
     it('updates issuer endpoint when oidcUrls.url and oidcUrls.realm changes', async() => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds additional tests to increase coverage for the custom claims and custom resource quotas features.

Fixes #16889
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add e2e tests for custom resource quotas
- Update unit tests for OIDC
- Write e2e tests for OIDC custom claims

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

#16241 was reopened with the request to add additional tests:

- Add to the existing unit tests an assertion that the fields are enabled
- Add unit test to make sure that the fields addCustomClaims and supportsGroupSearch dont exist for any of the other OIDC providers
- Add e2e test that checks that the custom mapping values are successfully posted to the backend

I'm also including additional e2e tests to assert that the custom resource quotas save data properly.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

e2e & CI should pass.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

NA. Adding additional tests to increase coverage.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
