### PR TITLE
Fixing the autoscroll feature for container logs

### DIFF
--- a/shell/components/Window/ContainerLogs.vue
+++ b/shell/components/Window/ContainerLogs.vue
@@ -306,6 +306,24 @@ export default {
       }
     },
 
+    onMouseDown() {
+      this.stopFollowing();
+    },
+
+    onMouseUp() {
+      const virtualList = this.$refs.virtualList;
+
+      if (!virtualList) {
+        return;
+      }
+
+      const isVirtualListScrolledToBottom = virtualList.getOffset() + virtualList.getClientSize() >= virtualList.getScrollSize();
+
+      if (isVirtualListScrolledToBottom) {
+        this.startFollowing();
+      }
+    },
+
     openContainerMenu() {
       this.isContainerMenuOpen = true;
     },
@@ -741,7 +759,6 @@ export default {
       <div
         ref="body"
         :class="{'logs-container': true, 'open': isOpen, 'closed': !isOpen, 'show-times': timestamps && filtered.length, 'wrap-lines': wrap}"
-        @wheel.passive="onMouseWheel"
       >
         <VirtualList
           v-show="filtered.length"
@@ -754,6 +771,9 @@ export default {
           :keeps="200"
           :bottom-threshold="200"
           @tobottom="onScrollToBottom"
+          @wheel.passive="onMouseWheel"
+          @mousedown="onMouseDown"
+          @mouseup="onMouseUp"
         />
         <template v-if="!filtered.length">
           <div v-if="search">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
fixes #13545
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Scrolling or clicking in the log container stops following; Follow button resumes it
- Auto-scroll no longer fights user input
- Fixed `[Vue warn]: Invalid prop: type check failed for prop "height"` on ContainerLogs

### Technical notes summary

- **Recursive scroll loop**: `vue3-virtual-scroll-list`'s `scrollToBottom()` spawns a recursive 3ms `setTimeout` that never terminates while the user is scrolling away. Replaced with a one-shot `scrollToOffset(getScrollSize())`.
- **`isFollowing` state**: Moved from a debounced `@scroll` handler (100ms stale window) to `@wheel.passive`/`@mousedown` listeners on the native `logs-container` div. The VirtualList component doesn't forward native events so listeners had to go on the parent element.
- **Watcher performance**: No longer using a watcher to update the scroll position, we now just update the scroll position when we add more lines.
- **`height` prop**: Declared `required: Number` in `ContainerLogs` but never used — removed.

### Areas or cases that should be tested
- Open a chatty pod's logs — container should auto-scroll to bottom
- Scroll with mouse wheel — auto-scroll stop
- Click inside the log container — auto-scroll stops
- Click Follow — jumps to bottom, auto-scroll resumes
- Open multiple log windows and confirm scroll state is independent per window
- `[Vue warn]: Invalid prop: type check failed for prop "height"` no longer in the console.

### Areas which could experience regressions
- ContainerLogs.vue

### Notes
You can make a chatty pod with
```
apiVersion: v1
kind: Pod
metadata:
  name: log-generator
  namespace: default
  labels:
    app: log-generator
spec:
  containers:
    - name: log-generator
      image: busybox
      command: ["/bin/sh", "-c"]
      args:
        - |
          i=0
          while true; do
            echo "$(date +%Y-%m-%dT%H:%M:%SZ) [INFO] Log entry $i - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore."
            i=$((i+1))
            sleep 0.01
          done
  restartPolicy: Never
```

And a less chatty pod to help verify the edge cases:

```
apiVersion: v1
kind: Pod
metadata:
  name: log-generator-slow
  namespace: default
  labels:
    app: log-generator-slow
spec:
  containers:
    - name: log-generator-slow
      image: busybox
      command: ["/bin/sh", "-c"]
      args:
        - |
          i=0; while true; do echo "$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ) level=info msg=\"Log entry number $i from log-generator-slow pod. request_id=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || echo $RANDOM) status=200 duration_ms=$((RANDOM % 500)) method=GET path=/api/v1/resource/$((RANDOM % 1000))\""; i=$((i + 1)); sleep 1; done
  restartPolicy: Never

```


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/a22fa072-f203-4d28-841f-c78c3f1d6a3a




### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
