### PR TITLE
Ensure Workload Pod Node Schedule selector correctly loads more results

### DIFF
--- a/shell/components/form/NodeScheduling.vue
+++ b/shell/components/form/NodeScheduling.vue
@@ -13,6 +13,8 @@ import { LabelSelectPaginationFunctionOptions } from '@shell/components/form/lab
 import { PaginationFilterEquality, PaginationParamFilter } from '@shell/types/store/pagination.types';
 import { KubeNode, KubeNodeTaint } from '@shell/types/resources/node';
 
+const parseNode = (node: string | KubeNode) => typeof node === 'string' ? node : node.id;
+
 export default {
   components: {
     RadioGroup,
@@ -63,21 +65,26 @@ export default {
 
     // Settings used by ResourceLabeledSelect when node pagination disabled
     const nodeSchedulingAllSettings: ResourceLabeledSelectSettings = {
-      updateResources(nodes: KubeNode[]) {
+      updateResources(nodes: (string | KubeNode)[]) {
         return nodes
           .filter((node) => {
+            if (typeof node === 'string') {
+              // Already passed check
+              return true;
+            }
+
             const taints = node.spec?.taints || [];
 
             return taints.every((taint: KubeNodeTaint) => !keys.includes(taint.key));
           })
-          .map((node) => node.id);
+          .map(parseNode);
       },
     };
 
     // Settings used by ResourceLabeledSelect when node pagination enabled
     const nodeSchedulingPaginationSettings: ResourceLabeledSelectPaginateSettings = {
-      updateResources(nodes) {
-        return nodes.map((node) => node.id);
+      updateResources(nodes: (string | KubeNode)[]) {
+        return nodes.map(parseNode);
       },
       requestSettings: (opts: LabelSelectPaginationFunctionOptions) => {
         const { filter } = opts.opts;


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16750
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- we parse nodes into id's and show that
- when we "load more" we parse the entries again
- some will already be ids, so just return without changing

### Technical notes summary
- also applied same fix to vai off world to be safe, however there's no load more there so we shouldn't be re-parsing content


### Areas or cases that should be tested
- as per issue
- note for devs - we can reduce the node count requirement by reducing `pageSize` in shell/components/form/labeled-select-utils/labeled-select-pagination.ts. So 5 nodes --> pageSize 3 --> load more will show

### Areas which could experience regressions
- vai off world

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
