### PR TITLE
Scale pods fix 2.13

### DIFF
--- a/cypress/e2e/po/components/Resource/Detail/Card/scaler.po.ts
+++ b/cypress/e2e/po/components/Resource/Detail/Card/scaler.po.ts
@@ -1,0 +1,21 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import { CypressChainable } from '@/cypress/e2e/po/po.types';
+import { LONG_TIMEOUT_OPT } from '~/cypress/support/utils/timeouts';
+
+export default class ScalerPo extends ComponentPo {
+  constructor(selector = '.plus-minus') {
+    super(selector);
+  }
+
+  getValue(): CypressChainable {
+    return this.self().find('.value', LONG_TIMEOUT_OPT);
+  }
+
+  decreaseButton(): CypressChainable {
+    return this.self().find('.icon-minus', LONG_TIMEOUT_OPT);
+  }
+
+  increaseButton(): CypressChainable {
+    return this.self().find('.icon-plus', LONG_TIMEOUT_OPT);
+  }
+}

--- a/cypress/e2e/po/components/Resource/Detail/Card/statusCard.po.ts
+++ b/cypress/e2e/po/components/Resource/Detail/Card/statusCard.po.ts
@@ -1,0 +1,36 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import ScalerPo from '@/cypress/e2e/po/components/Resource/Detail/Card/scaler.po';
+
+export default class CardPo extends ComponentPo {
+  constructor(selector = '.gauges__pods') {
+    super(selector);
+  }
+
+  private scaler() {
+    return new ScalerPo('.plus-minus');
+  }
+
+  scaleUp(): Cypress.Chainable {
+    return this.scaler().increaseButton();
+  }
+
+  scaleDown(): Cypress.Chainable {
+    return this.scaler().decreaseButton();
+  }
+
+  podsRunningTotal(): Cypress.Chainable {
+    return this.self().find('.count-gauge .data h1');
+  }
+
+  replicaCount(): Cypress.Chainable {
+    return this.scaler().getValue();
+  }
+
+  podsStatus(): Cypress.Chainable {
+    return this.self().find('.count-gauge .data label');
+  }
+
+  podsStatusCount(): Cypress.Chainable {
+    return this.self().find('.count-gauge .data h1');
+  }
+}

--- a/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads/workloads.po.ts
@@ -11,6 +11,7 @@ import ContainerMountPathPo from '@/cypress/e2e/po/components/workloads/containe
 import { WorkloadType } from '@shell/types/fleet';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import CardPo from '@/cypress/e2e/po/components/Resource/Detail/Card/statusCard.po';
 
 export class WorkloadDetailsPageBasePo extends BaseDetailPagePo {
   static url: string;
@@ -53,6 +54,18 @@ export class WorkloadDetailsPageBasePo extends BaseDetailPagePo {
     return new WorkloadPagePo();
   }
 
+  private card() {
+    return new CardPo();
+  }
+
+  title(): Cypress.Chainable {
+    return cy.get(`${ this.selector } h1`);
+  }
+
+  mastheadTitle(): Cypress.Chainable {
+    return cy.get('.resource-name.masthead-resource-title');
+  }
+
   deleteWithKubectl(name: string, namespace = 'default') {
     this.workload().deleteWithKubectl(name, namespace);
   }
@@ -62,23 +75,34 @@ export class WorkloadDetailsPageBasePo extends BaseDetailPagePo {
   }
 
   podScaleUp(): Cypress.Chainable {
-    return this.self().find('.btn-sm .icon-plus');
+    return this.card().scaleUp();
   }
 
   podScaleDown(): Cypress.Chainable {
-    return this.self().find('.btn-sm .icon-minus');
+    return this.card().scaleDown();
   }
 
   podsRunningTotal(): Cypress.Chainable {
-    return this.self().find('.count-gauge h1').first();
+    return this.card().podsRunningTotal();
   }
 
   replicaCount(): Cypress.Chainable {
-    return this.self().find('.plus-minus .value');
+    return this.card().replicaCount();
   }
 
-  gaugesPods(): Cypress.Chainable {
-    return this.self().find('.gauges__pods');
+  podsStatus(): Cypress.Chainable {
+    return this.card().podsStatus();
+  }
+
+  podsStatusCount(): Cypress.Chainable {
+    return this.card().podsStatusCount();
+  }
+
+  /**
+   * Wait until there's exactly one pods status count element
+   */
+  waitForSinglePodsStatusCount(): Cypress.Chainable {
+    return this.podsStatusCount().should('have.length', 1, MEDIUM_TIMEOUT_OPT);
   }
 
   /**
@@ -106,13 +130,13 @@ export class WorkloadDetailsPageBasePo extends BaseDetailPagePo {
   }
 
   /**
-   * Wait for both scale up and down buttons to be enabled
+   * Wait for both scale up and down buttons to be enabled and visible
    */
   waitForScaleButtonsEnabled() {
-    this.podScaleUp().should('not.be.disabled');
-    this.podScaleDown().should('not.be.disabled');
-    this.podScaleUp().should('not.have.attr', 'aria-disabled', 'true');
-    this.podScaleDown().should('not.have.attr', 'aria-disabled', 'true');
+    this.podScaleUp().scrollIntoView().should('be.visible').and('not.be.disabled')
+      .should('not.have.attr', 'aria-disabled', 'true');
+    this.podScaleDown().scrollIntoView().should('be.visible').and('not.be.disabled')
+      .should('not.have.attr', 'aria-disabled', 'true');
 
     return this;
   }

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -62,11 +62,12 @@ describe('Deployments', { testIsolation: 'off', tags: ['@explorer2'] }, () => {
             metadata:   { name: scaleTestNamespace }
           }));
 
-          const scaleDeployment = createTesDeployment(scaleTestDeploymentId);
+          const scaleDeployment: any = createTesDeployment(scaleTestDeploymentId);
 
           // Use the dynamic namespace
           scaleDeployment.metadata.namespace = scaleTestNamespace;
           scaleDeployment.spec.template.spec.containers[0].image = SMALL_CONTAINER.image;
+          scaleDeployment.spec.template.spec.terminationGracePeriodSeconds = 0;
 
           scaleTestDeploymentName = scaleDeployment.metadata.name;
 
@@ -97,27 +98,54 @@ describe('Deployments', { testIsolation: 'off', tags: ['@explorer2'] }, () => {
     });
 
     it('Should be able to scale the number of pods', () => {
-      const workloadDetailsPage = new WorkloadsDeploymentsDetailsPagePo(scaleTestDeploymentName, localCluster, 'apps.deployment', scaleTestNamespace);
+      cy.waitForResourceState('v1', 'apps.deployments', `${ scaleTestNamespace }/${ scaleTestDeploymentName }`);
+      const workloadDetailsPage = new WorkloadsDeploymentsDetailsPagePo(scaleTestDeploymentName, localCluster, 'apps.deployment' as any, scaleTestNamespace);
+
+      // Intercept scaling calls and alias them based on the desired replica count in the request body
+      cy.intercept('PUT', `/v1/apps.deployments/${ scaleTestNamespace }/${ scaleTestDeploymentName }`, (req) => {
+        if (req.body.spec?.replicas === 2) {
+          req.alias = 'scaleUp';
+        } else if (req.body.spec?.replicas === 1) {
+          req.alias = 'scaleDown';
+        }
+      });
 
       workloadDetailsPage.goTo();
       workloadDetailsPage.waitForDetailsPage(scaleTestDeploymentName);
 
+      // Reset replicas to 1 to handle test retries with testIsolation off
+      workloadDetailsPage.replicaCount().invoke('text').then((text) => {
+        const count = parseInt(text.trim());
+
+        if (count > 1) {
+          workloadDetailsPage.podScaleDown().should('be.visible').click({ force: true });
+          workloadDetailsPage.mastheadTitle().click();
+          cy.wait('@scaleDown');
+        }
+      });
+
       workloadDetailsPage.replicaCount().should('contain', '1', MEDIUM_TIMEOUT_OPT);
 
-      workloadDetailsPage.podScaleUp().click();
-
-      workloadDetailsPage.waitForScaleButtonsEnabled();
-      workloadDetailsPage.waitForPendingOperationsToComplete();
+      // Scale Up
+      workloadDetailsPage.podScaleUp().should('be.visible').click({ force: true });
+      workloadDetailsPage.mastheadTitle().click();
+      cy.wait('@scaleUp').its('response.statusCode').should('eq', 200);
 
       workloadDetailsPage.replicaCount().should('contain', '2', MEDIUM_TIMEOUT_OPT);
 
-      // Verify pod status shows healthy scaling state
-      workloadDetailsPage.gaugesPods().should('be.visible', MEDIUM_TIMEOUT_OPT)
+      // Verify pod status shows healthy scaling state using PO methods
+      workloadDetailsPage.podsStatus()
+        .should('be.visible')
         .should('contain.text', 'Running');
 
-      workloadDetailsPage.podScaleDown().click();
-      workloadDetailsPage.waitForScaleButtonsEnabled();
-      workloadDetailsPage.waitForPendingOperationsToComplete();
+      workloadDetailsPage.podsStatusCount()
+        .should('be.visible')
+        .should('contain', '2');
+
+      // Scale Down
+      workloadDetailsPage.podScaleDown().should('be.visible').click({ force: true });
+      workloadDetailsPage.mastheadTitle().click();
+      cy.wait('@scaleDown').its('response.statusCode').should('eq', 200);
 
       workloadDetailsPage.replicaCount().should('contain', '1', MEDIUM_TIMEOUT_OPT);
     });


### PR DESCRIPTION
### Summary
Fixes rancher/qa-tasks#2162

**Note**: The implementation diverges significantly from version 2.14 to accommodate the specific UI structure and selector conventions present in the 2.13 branch.

### Occurred changes and/or fixed issues
Stabilized the pod scaling E2E test, which was frequently failing due to timing issues and UI re-renders. The primary issues were the default. Kubernetes _pod termination delay_ (30s) exceeding test timeouts and Cypress losing element references when Vue updated the status cards. I also added logic to make the test self-healing during retries with `testIsolation: off`.

### Technical notes summary
* Added `terminationGracePeriodSeconds: 0` to the test deployment spec. This forces pods to disappear immediately during scale-down, removing the 30s Kubernetes wait that was causing assertions to flake.
* Introduced new Scaler and StatusCard Page Objects (following the architectural pattern from master) using chained command paths (cy.get().find()). By providing fresh command chains instead of storing element references, Cypress can automatically re-evaluate the entire DOM path during retries. This allows the tests to recover if Vue re-renders the component mid-assertion, effectively preventing 'detached from DOM' errors.
* Implemented dynamic intercepts that inspect the replicas count in the request payload. By aliasing requests specifically as `@scaleUp` or `@scaleDown`, the test now waits for the backend before verifying the UI.
* Added a reset block at the beginning of the test to ensure the workload starts at `1` replica. This prevents a scaled-up state from a previous failed attempt from breaking subsequent retries.

### Areas or cases that should be tested
CI

### Areas which could experience regressions
CI / Jenkins

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
