### PR TITLE
Changed label when scaling down machine deployment

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5806,6 +5806,7 @@ promptForceRemove:
 
 promptScaleMachineDown:
   attemptingToRemove: "You are attempting to delete {count} {type}"
+  attemptingToScaleDown: "You are attempting to scale down {type}"
   retainedMachine1: At least one Machine must exist for roles Control Plane and Etcd.
   retainedMachine2: <b>{ name }</b> will remain
   scaling: |-

--- a/shell/dialog/ScalePoolDownDialog.vue
+++ b/shell/dialog/ScalePoolDownDialog.vue
@@ -26,7 +26,7 @@ export default {
     };
   },
   computed: {
-    machinenName() {
+    machineName() {
       const name = this.resources.length > 0 ? this.resources[0]?.id?.split('/')[1] : '';
 
       return name;
@@ -81,7 +81,7 @@ export default {
     <template #body>
       <div class="pl-10 pr-10">
         <div>
-          {{ t('promptRemove.attemptingToRemove', { type }) }} <b>{{ machinenName }}</b>
+          {{ t('promptScaleMachineDown.attemptingToScaleDown', { type }) }} <b>{{ machineName }}</b>
         </div>
         <div>
           <Checkbox


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16495 
<!-- Define findings related to the feature or bug issue. -->
Changed the label when scaling down machine deployment from "You are attempting to delete the MachineDeployment X" to "You are attempting to scale down MachineDeployment X"

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Changed the string.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Create an RKE2 cluster with 2 nodes in one pool
Go to that cluster's detail page.
Click on the minus button for the pool -> new message should be displayed
try to scale down specific node -> old message should be shown

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
https://github.com/user-attachments/assets/975d9bea-700d-4bad-be02-a136af718175

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
