### PR TITLE
Fixing several issues that stem from a race condition access issue around namespaces

### DIFF
--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/__tests__/identifying-fields.test.ts
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/__tests__/identifying-fields.test.ts
@@ -6,7 +6,12 @@ import { NAME as FLEET_NAME } from '@shell/config/product/fleet';
 
 const mockStore = {
   getters: {
-    productId: 'PRODUCT_ID', clusterId: 'CLUSTER_ID', 'type-map/optionsFor': jest.fn(), currentCluster: 'CLUSTER_ID'
+    productId:             'PRODUCT_ID',
+    clusterId:             'CLUSTER_ID',
+    'type-map/optionsFor': jest.fn(),
+    currentCluster:        'CLUSTER_ID',
+    currentStore:          () => 'cluster',
+    'cluster/canList':     () => true,
   }
 };
 const mockRoute = { params: { cluster: 'CLUSTER', namespace: 'NAMESPACE' } };
@@ -32,12 +37,24 @@ describe('composables: IdentifyingFields', () => {
       expect(result).toBeUndefined();
     });
 
-    it('should return a valid namespace row', () => {
+    it('should return a valid namespace row with ResourcePopover when user canList namespaces', () => {
+      mockStore.getters['cluster/canList'] = () => true;
       const resource = { namespace: 'NAMESPACE' };
       const result = useNamespace(resource);
 
       expect(result?.value.valueOverride?.props.type).toStrictEqual(NAMESPACE);
       expect(result?.value.valueOverride?.props.id).toStrictEqual(resource.namespace);
+      expect(result?.value.value).toStrictEqual(resource.namespace);
+      expect(result?.value.label).toStrictEqual('component.resource.detail.metadata.identifyingInformation.namespace');
+      expect(result?.value.valueDataTestid).toStrictEqual('masthead-subheader-namespace');
+    });
+
+    it('should return a plain text namespace row when user cannot canList namespaces', () => {
+      mockStore.getters['cluster/canList'] = () => false;
+      const resource = { namespace: 'NAMESPACE' };
+      const result = useNamespace(resource);
+
+      expect(result?.value.valueOverride).toBeUndefined();
       expect(result?.value.value).toStrictEqual(resource.namespace);
       expect(result?.value.label).toStrictEqual('component.resource.detail.metadata.identifyingInformation.namespace');
       expect(result?.value.valueDataTestid).toStrictEqual('masthead-subheader-namespace');

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/identifying-fields.ts
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/identifying-fields.ts
@@ -24,18 +24,26 @@ export const useNamespace = (resource: any): ComputedRef<Row> | undefined => {
   }
 
   return computed(() => {
-    return {
-      label:           i18n.t('component.resource.detail.metadata.identifyingInformation.namespace'),
-      value:           resourceValue.namespace,
-      valueDataTestid: 'masthead-subheader-namespace',
-      valueOverride:   {
-        component: markRaw(defineAsyncComponent(() => import('@shell/components/Resource/Detail/ResourcePopover/index.vue'))),
-        props:     {
-          type:           NAMESPACE,
-          id:             resourceValue.namespace,
-          detailLocation: resourceValue.namespaceLocation
-        }
+    const currentStore = store.getters['currentStore'](NAMESPACE);
+    const canList = store.getters[`${ currentStore }/canList`](NAMESPACE);
+
+    const label = i18n.t('component.resource.detail.metadata.identifyingInformation.namespace');
+    const value = resourceValue.namespace;
+    const valueDataTestid = 'masthead-subheader-namespace';
+    const valueOverride = canList ? {
+      component: markRaw(defineAsyncComponent(() => import('@shell/components/Resource/Detail/ResourcePopover/index.vue'))),
+      props:     {
+        type:           NAMESPACE,
+        id:             resourceValue.namespace,
+        detailLocation: resourceValue.namespaceLocation
       }
+    } : undefined;
+
+    return {
+      label,
+      value,
+      valueDataTestid,
+      valueOverride,
     };
   });
 };

--- a/shell/components/Resource/Detail/ResourcePopover/__tests__/index.test.ts
+++ b/shell/components/Resource/Detail/ResourcePopover/__tests__/index.test.ts
@@ -79,6 +79,18 @@ describe('component: ResourcePopover/index.vue', () => {
       expect(wrapper.find('.display').exists()).toBe(false);
     });
 
+    it('should show plain text and no PopoverCard when fetch fails', async() => {
+      mockClusterFind.mockRejectedValue(new Error('Not found'));
+      const wrapper = createWrapper(undefined, undefined, PopoverCardStub);
+
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.findComponent(PopoverCard).exists()).toBe(false);
+      expect(wrapper.text()).toBe('test-ns/test-pod');
+    });
+
     it('should fetch data using the default store', async() => {
       const wrapper = createWrapper();
 

--- a/shell/components/Resource/Detail/ResourcePopover/index.vue
+++ b/shell/components/Resource/Detail/ResourcePopover/index.vue
@@ -58,6 +58,7 @@ const actionInvoked = () => {
 
 <template>
   <PopoverCard
+    v-if="!fetch.error"
     class="resource-popover"
     :card-title="nameDisplay"
     fallback-focus="[data-testid='resource-popover-action-menu']"
@@ -104,6 +105,7 @@ const actionInvoked = () => {
       />
     </template>
   </PopoverCard>
+  <span v-else>{{ props.id }}</span>
 </template>
 
 <style lang="scss" scoped>

--- a/shell/models/__tests__/namespace.test.ts
+++ b/shell/models/__tests__/namespace.test.ts
@@ -187,6 +187,17 @@ describe('class Namespace', () => {
   it.todo('should set the resourceQuota as reactive Vue property');
   it.todo('should reset project with cleanForNew');
 
+  describe('hideDetailLocation', () => {
+    it('should not throw when currentProduct is undefined', () => {
+      const namespace = new Namespace({});
+
+      jest.spyOn(namespace, '$rootGetters', 'get').mockReturnValue({ currentProduct: undefined });
+
+      expect(() => namespace.hideDetailLocation).not.toThrow();
+      expect(namespace.hideDetailLocation).toBe(true);
+    });
+  });
+
   describe('glance', () => {
     it('should return projectGlance instead of namespace when namespace is in a project', () => {
       const t = jest.fn((key) => key);

--- a/shell/models/namespace.js
+++ b/shell/models/namespace.js
@@ -267,7 +267,9 @@ export default class Namespace extends SteveModel {
   }
 
   get hideDetailLocation() {
-    return !!this.$rootGetters['currentProduct'].hideNamespaceLocation;
+    const currentProduct = this.$rootGetters['currentProduct'];
+
+    return currentProduct ? !!currentProduct.hideNamespaceLocation : true;
   }
 
   get glance() {

--- a/shell/plugins/dashboard-store/__tests__/resource-class.test.ts
+++ b/shell/plugins/dashboard-store/__tests__/resource-class.test.ts
@@ -428,6 +428,33 @@ describe('class: Resource', () => {
     });
   });
 
+  describe('getter: _glance', () => {
+    it('should not throw when currentCluster or currentProduct is undefined', () => {
+      const resource = new Resource({
+        type:     'test',
+        metadata: { creationTimestamp: '2024-01-01T00:00:00Z' }
+      }, {
+        getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
+        dispatch:    jest.fn(),
+        rootGetters: {
+          'i18n/t':            (key: string) => key,
+          currentCluster:      undefined,
+          currentProduct:      undefined,
+          'type-map/labelFor': () => 'Test',
+        },
+      });
+
+      expect(() => resource._glance).not.toThrow();
+
+      const glance = resource._glance;
+      const namespaceItem = glance.find((item: any) => item.name === 'namespace');
+
+      expect(namespaceItem.formatter).toBeUndefined();
+      expect(namespaceItem.formatterOpts.to.cluster).toBeUndefined();
+      expect(namespaceItem.formatterOpts.to.product).toBeUndefined();
+    });
+  });
+
   describe('getter: detailPageAdditionalActions', () => {
     it('should return undefined by default', () => {
       const resource = new Resource({ type: 'test-type' }, {

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -1956,12 +1956,12 @@ export default class Resource {
       {
         name:          'namespace',
         label:         this.t('component.resource.detail.glance.namespace'),
-        formatter:     'Link',
+        formatter:     this.$rootGetters['currentProduct']?.id && this.$rootGetters['currentCluster']?.id ? 'Link' : undefined,
         formatterOpts: {
           to: {
             name:     `c-cluster-product-resource-id`,
-            product:  this.$rootGetters['currentProduct'].id,
-            cluster:  this.$rootGetters['currentCluster'].id,
+            product:  this.$rootGetters['currentProduct']?.id,
+            cluster:  this.$rootGetters['currentCluster']?.id,
             resource: this.type
           },
           row:     {},


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16442
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

The namespace `ResourcePopover` could crash when the user lacked permission to list namespaces or when `currentProduct`/`currentCluster` were unresolved due to a race condition.

### Technical notes summary

- `useNamespace` now evaluates `currentStore`/`canList` inside the `computed` so they remain reactive and aren't accessed before the store is ready. The popover is gated behind `canList`, falling back to plain text.
- `ResourcePopover` renders a plain text when its fetch fails
- Conditional check in `Namespace.hideDetailLocation` and `Resource._glance` for `currentProduct`/`currentCluster`

### Areas or cases that should be tested
The namespace popover on cluster pages immediately after the cluster was created.

- Reproducing was pretty inconsistent, you have to immediately visit the cluster detail page after creating it to repro.

### Areas which could experience regressions
- **Resource detail masthead** — namespace/project/workspace identifying fields
- **`ResourcePopover`** — the `v-if="!fetch.error"` guard affects all consumers, not just namespace
- **Glance panel** — `_glance` the conditional changes could affect other resources

### Screenshot/Video
If the request fails we default to showing the id of the resource we're attempting to show without a popover.

<img width="1126" height="497" alt="image" src="https://github.com/user-attachments/assets/cc1d2445-5476-4ba4-9c58-39098ff9e0d5" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
