### PR TITLE
Only check if resource is listable if there's not a custom list component

### DIFF
--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -87,11 +87,14 @@ export default {
   },
 
   beforeMount() {
-    const inStore = this.$store.getters['currentStore'](this.resource);
-    const canList = this.$store.getters[`${ inStore }/canList`](this.resource);
+    if (!this.hasListComponent) {
+      // If a list doesn't have a list component confirm via schema that the resource is listable
+      const inStore = this.$store.getters['currentStore'](this.resource);
+      const canList = this.$store.getters[`${ inStore }/canList`](this.resource);
 
-    if (!canList) {
-      this.$store.dispatch('loadingError', new Error(this.t('nav.failWhale.resourceListNotListable', { resource: this.schema.id }, true)));
+      if (!canList) {
+        this.$store.dispatch('loadingError', new Error(this.t('nav.failWhale.resourceListNotListable', { resource: this.schema?.id || this.resource || 'unknown' }, true)));
+      }
     }
   },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16818
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- We now check that the list can be fetched before showing it
- However lists can have their own components which can do whatever they want (for example if there's no proper schema)
- In harvester this is happening
  - NETWORK_ATTACHMENT is virtual, but has not underlying schema
  - it has it's own list component
  - we try to fetch the schema and check it can be listed
  - there's no schema so it can't
  - we try to show not listable error but use schema.id, so is aborted + error shown in logs
- Fix is to 
  - Ensure we only check if listable if the resource does not contain it's own list component

### Technical notes summary
- Came in via https://github.com/rancher/dashboard/pull/16398
- resources that cannot be listed, for example
  - "ext.cattle.io.passwordchangerequest",
  - "authorization.k8s.io.subjectaccessreview",
  - "authorization.k8s.io.selfsubjectrulesreview",
  - "authorization.k8s.io.selfsubjectaccessreview",
  - "binding",
  - "authentication.k8s.io.tokenreview",
  - "ext.cattle.io.groupmembershiprefreshrequest",
  - "authentication.k8s.io.selfsubjectreview",
  - "authorization.k8s.io.localsubjectaccessreview",
  - "ext.cattle.io.selfuser"

### Areas or cases that should be tested
- Navigating directly to these resources via url (Example /c/local/explorer/authentication.k8s.io.selfsubjectreview)
  - Now - show an error
- In harvester extension yarn link to code from this PR, login and go to Networks --> IP Pools
  - There should not be the error from issue
  - The list should correctly show

### Areas which could experience regressions
- Navigate to any list, both inside and outside of `More Resources`


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
