### PR TITLE
Fixed Ingress banner wrongfully shown on edit

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Ingress.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Ingress.vue
@@ -163,7 +163,7 @@ function selectIngress(id: string) {
     preconfigureTraefik();
   } else {
     emit('update:value', id);
-    if (id === TRAEFIK && isEdit) {
+    if (id === TRAEFIK && !!isEdit.value) {
       showTraefikBanner.value = true;
     }
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15950
<!-- Define findings related to the feature or bug issue. -->
Fixed "Before switching to Traefik, please review our migration documentation  Opens in a new tabto ensure your Ingress resources are updated to support Traefik’s configuration requirements." warning banner appearing on cluster creation.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
There was a typo in isEdit making the check wrong.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Go to create an RKE2 cluster -> Ingress
Switch between nginx and traefik a few times. the warning banner should not appear under the ingress selection cards.
It should till appear when switcihng between selections on edit.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None
### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
