### PR TITLE
Fixed harvester chart values not being set

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -978,8 +978,7 @@ export default {
         );
       }
 
-      Object.keys(this.versionInfo).forEach((key) => delete this.versionInfo[key]); // Invalidate cache such that version info relevant to selected kube version is updated
-
+      this.versionInfo = {}; // Invalidate cache such that version info relevant to selected kube version is updated
       // Allow time for addonNames to update... then fetch any missing addons
       this.$nextTick(() => this.initAddons());
       if (this.mode === _CREATE) {
@@ -1864,11 +1863,11 @@ export default {
             versionName: entry.version,
           });
 
-          this.set(this.versionInfo, chartName, res);
+          this.versionInfo[chartName] = res;
           const key = this.chartVersionKey(chartName);
 
           if (!this.userChartValues[key]) {
-            this.set(this.userChartValues, key, {});
+            this.userChartValues[key] = {};
           }
         } catch (e) {
           console.error(`Failed to fetch or process chart info for ${ chartName }`); // eslint-disable-line no-console
@@ -1940,7 +1939,7 @@ export default {
       const fromUser = this.userChartValuesTemp[name];
       const different = diff(fromChart, fromUser);
 
-      this.set(this.userChartValues, this.chartVersionKey(name), different);
+      this.userChartValues[this.chartVersionKey(name)] = different;
     }, 250, { leading: true }),
 
     initYamlEditor(name) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16857
<!-- Define findings related to the feature or bug issue. -->
As part of Traefik changes, I broke the logic around updating charts. This change revert it to the previous state.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Attempt to provision a harvester cluster.
Validate that request contains 'harvester-cloud-provider' configuration under spec.rkeConfig.chartValues

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
RKE2 and K3s provisioning could be affected. In particular, recently added Ingress configuration

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
