### PR TITLE
Change how we hide the copytoclipboard component so it's not visible when banners are added

### DIFF
--- a/shell/assets/styles/base/_variables.scss
+++ b/shell/assets/styles/base/_variables.scss
@@ -42,6 +42,8 @@ $z-indexes: (
 
   cruFooter: 19,
 
+  copyToClipboard: 20,
+
   loadingMain: 51,
 
   slide-in: 52,

--- a/shell/components/Resource/Detail/CopyToClipboard.vue
+++ b/shell/components/Resource/Detail/CopyToClipboard.vue
@@ -70,8 +70,7 @@ const onClick = (ev: MouseEvent) => {
         border-color: var(--success-border);
         color: var(--success-text);
 
-        transition: all 0.25s;
-        transition-timing-function: ease;
+        transition: background-color 0.25s ease, border-color 0.25s ease, color 0.25s ease;
     }
 
     &:focus-visible {

--- a/shell/components/Resource/Detail/Metadata/KeyValueRow.vue
+++ b/shell/components/Resource/Detail/Metadata/KeyValueRow.vue
@@ -77,12 +77,15 @@ const previewId = randomStr();
   position: relative;
   padding: 0;
 
+  $topShift: -6px;
+  $topShiftHidden: -100vh; //100% of the viewport
+
   .copy-to-clipboard {
     position: fixed;
 
     right: -20px;
-    top: -6px;
-    z-index: 20px;
+    top: $topShiftHidden;
+    z-index: z-index('copyToClipboard');
   }
 
   &, .btn, .rc-tag {
@@ -126,13 +129,16 @@ const previewId = randomStr();
       }
 
       & + .copy-to-clipboard {
+        // This is how we "hide" the component but still allow it to be visible to accessibility (tab focus)
         position: absolute;
+        top: $topShift;
       }
     }
 
     .copy-to-clipboard:focus-visible, .copy-to-clipboard:hover {
+      // This is how we "hide" the component but still allow it to be visible to accessibility (tab focus)
       position: absolute;
-
+      top: $topShift;
     }
 
     .btn:has(+ .copy-to-clipboard:focus-visible), .btn:has(+ .copy-to-clipboard:hover)  {


### PR DESCRIPTION




<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16864
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Change the amount we're shifting the component off screen
- Add some comments
- Fix a z-index issue I spotted.

### Technical notes summary
Ultimately this issue comes about because we're running into some difficulty caused by packing in a fair amount of intractability in a small area and we end up having to make some compromises to support accessibility vs code simplicity.

This would never occur if we could just hide the clipboard components when appropriate but this breaks tab focus if we do.

To account for this we hide the component by shifting it off screen (previously above the viewport) but the banner caused the clipboard button to shift down. This now shifts it to the right 



### Areas or cases that should be tested
- Mouse navigation around the annotation/label rows in the detail page
- Same for keyboard navigation
- Multiline top banner

### Areas which could experience regressions
See above

### Screenshot/Video
<img width="1386" height="706" alt="image" src="https://github.com/user-attachments/assets/dac59609-e493-454b-bf5c-04566272ce20" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
