### PR TITLE
Repositories dynamic tooltip

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/AppChartCardFooter.vue
+++ b/shell/pages/c/_cluster/apps/charts/AppChartCardFooter.vue
@@ -3,10 +3,11 @@ import { reactive } from 'vue';
 import { RcItemCardAction } from '@components/RcItemCard';
 import { RcButton } from '@components/RcButton';
 import { isTruncated } from '@shell/utils/style';
-import { RcIcon } from '@components/RcIcon';
+import RcIcon from '@components/RcIcon/RcIcon.vue';
+import type { RcIconType } from '@components/RcIcon/types';
 
 interface FooterItem {
-  icon?: string;
+  icon?: RcIconType;
   iconTooltip?: { key?: string; text?: string };
   labels: string[];
   labelTooltip?: string;

--- a/shell/utils/style.ts
+++ b/shell/utils/style.ts
@@ -52,5 +52,8 @@ export function isTruncated(element: HTMLElement | null): boolean {
     return false;
   }
 
-  return element.scrollWidth > element.clientWidth || (element.scrollHeight - element.clientHeight > 1);
+  const isHorizontallyTruncated = element.scrollWidth > element.clientWidth;
+  const isVerticallyTruncated = element.scrollHeight - element.clientHeight > 1;
+
+  return isHorizontallyTruncated || isVerticallyTruncated;
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15661 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Added dynamic tooltips to `AppChartCardFooter` labels. When a label text is truncated, hovering over it will display a tooltip containing the full label text prepended to the base tooltip.

### Technical notes summary
- Created an `isTruncated` utility function in `shell/utils/style.ts` to detect if an HTML element's text overflows its container.
- Added `mouseenter` event listeners and element refs in `AppChartCardFooter.vue` to dynamically update the tooltip content based on the truncation state of the label elements.

### Areas or cases that should be tested
- Verify that hovering over truncated labels in the App Chart Card Footer displays the expanded text in the tooltip.
- Verify that non-truncated labels only show the default tooltip (if any) and do not show their own text in the tooltip.
- Tested on Chrome. Reviewers can test on Firefox or Safari.

### Areas which could experience regressions
- Tooltip behavior on App Chart Cards.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="975" height="515" alt="image" src="https://github.com/user-attachments/assets/58c96f3e-f47c-432e-b814-ba7b58de6a08" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
