### PR TITLE
Removing the state column from the kubeconfig list page

### DIFF
--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -202,7 +202,6 @@ export function init(store) {
   ]);
 
   headers(EXT.KUBECONFIG, [
-    STATE,
     {
       name:      'clusters',
       labelKey:  'tableHeaders.clusters',


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16842
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Removes the State column

### Areas or cases that should be tested
Verify the kubeconfig list page no longer has the state column.

### Areas which could experience regressions
See above

### Screenshot/Video
<img width="1070" height="560" alt="image" src="https://github.com/user-attachments/assets/d8c56876-bded-498f-bc24-5f36e23fb417" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
