### PR TITLE
Fixed ingress config on older migrated cluster

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Basics.vue
@@ -12,7 +12,7 @@ import { LEGACY } from '@shell/store/features';
 import semver from 'semver';
 import Ingress from '@shell/edit/provisioning.cattle.io.cluster/tabs/Ingress';
 import {
-  HARVESTER, RKE2_INGRESS_NGINX, RKE2_TRAEFIK, INGRESS_CONTROLLER, INGRESS_NGINX
+  HARVESTER, RKE2_INGRESS_NGINX, RKE2_TRAEFIK, INGRESS_CONTROLLER, INGRESS_NGINX, INGRESS_NONE
 } from '@shell/edit/provisioning.cattle.io.cluster/shared';
 
 export default {
@@ -173,7 +173,17 @@ export default {
     },
     ingressController: {
       get() {
-        return this.serverConfig && this.serverConfig[INGRESS_CONTROLLER] ? this.serverConfig[INGRESS_CONTROLLER] : INGRESS_NGINX ;
+        if (this.serverConfig) {
+          if (this.serverConfig[INGRESS_CONTROLLER]) {
+            return this.serverConfig[INGRESS_CONTROLLER];
+          } else {
+            if (this.serverConfig.disable && this.serverConfig.disable.includes(RKE2_INGRESS_NGINX)) {
+              return INGRESS_NONE;
+            }
+          }
+        }
+
+        return INGRESS_NGINX;
       },
 
       set(neu) {

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Ingress.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Ingress.vue
@@ -48,7 +48,7 @@ const isEdit = computed(() => mode === _EDIT);
 const showTraefikBanner = ref<Boolean>(false);
 const traefikMerged = ref(initYamlEditor(traefikChart));
 const nginxMerged = ref(initYamlEditor(nginxChart));
-const showConfig = ref<Boolean>(!!versionInfo[traefikChart] || !!versionInfo[nginxChart]);
+const showConfig = computed(() => !!versionInfo[traefikChart] || !!versionInfo[nginxChart]);
 
 const ingressSelection = computed(() => {
   if (Array.isArray(value) ) {
@@ -90,7 +90,13 @@ const ingressEnabled = computed({
     if (!val) {
       emit('update:value', INGRESS_NONE);
     } else {
-      emit('update:value', TRAEFIK);
+      if (traefikSupported) {
+        emit('update:value', TRAEFIK);
+      } else if (nginxSupported) {
+        emit('update:value', INGRESS_NGINX);
+      } else {
+        emit('update:value', INGRESS_NONE);
+      }
     }
   }
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16892
<!-- Define findings related to the feature or bug issue. -->
Previously, I was checking if nginx is supported based on the ability to disable nginx in version's server args. For older version, we do not have server args, which was leading to nginx option being missed. This also prevents us from fetching ingress charts.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Now if the version is too old, and the required configuration is missing, we assume that cluster is using ingress nginx.
I also hid additional configuration in this scenario.
The info banner recommending traefik migration has also been removed in this case, since we cannot tell if traefik is supported.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The assumption made here:
- We did not get the current version when we calculated allValidRke2Versions, so we do not know what is supported
- The cluster k8s version hasn't been upgraded yet, so ingress is not explicitly set yet.
Since https://github.com/rancher/dashboard/issues/16577 we explicitly set ingress controller on version upgrade.

This implies that if ingress is not disabled, NGINX is used

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
We need to test that edit works correctly for both older clusters and new clusters.
Please reach out to me or Izaac for a cluster that has been migrated from 2.12.
For older migrated clusters:
If the k8s version is not supported by Rancher, default to NGINX being selected (unless explicitly disabled) and hide traefik, dual mode, and chart configuration (ports and yaml)
If k8s version is new enough, editing should support all three options.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Provisioning new clusters could be affected
Editing a cluster that is on an older version and had nginx disabled could be affected.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
