### PR TITLE
Resolving an issue where extensions that are loaded in old version of rancher would should the new detail page.

### DIFF
--- a/shell/composables/useIsNewDetailPageEnabled.test.ts
+++ b/shell/composables/useIsNewDetailPageEnabled.test.ts
@@ -1,0 +1,98 @@
+import { useIsNewDetailPageEnabled } from '@shell/composables/useIsNewDetailPageEnabled';
+
+const mockStore: any = { getters: {} };
+const mockRoute: any = { query: {} };
+
+jest.mock('vuex', () => ({ useStore: () => mockStore }));
+jest.mock('vue-router', () => ({ useRoute: () => mockRoute }));
+
+const mockGetVersionInfo = jest.fn(() => ({ fullVersion: '2.12.0' }));
+
+jest.mock('@shell/utils/version', () => ({ getVersionInfo: (...args: any[]) => mockGetVersionInfo(...args) }));
+
+describe('useIsNewDetailPageEnabled', () => {
+  beforeEach(() => {
+    mockRoute.query = {};
+    mockGetVersionInfo.mockReturnValue({ fullVersion: '2.12.0' });
+  });
+
+  describe('version gating', () => {
+    it('should return false when version is below 2.12.0', () => {
+      mockGetVersionInfo.mockReturnValue({ fullVersion: '2.11.9' });
+      const result = useIsNewDetailPageEnabled();
+
+      expect(result.value).toBe(false);
+    });
+
+    it('should return false when version is 2.10.0', () => {
+      mockGetVersionInfo.mockReturnValue({ fullVersion: '2.10.0' });
+      const result = useIsNewDetailPageEnabled();
+
+      expect(result.value).toBe(false);
+    });
+
+    it('should return true when version is exactly 2.12.0 and no legacy query', () => {
+      mockGetVersionInfo.mockReturnValue({ fullVersion: '2.12.0' });
+      const result = useIsNewDetailPageEnabled();
+
+      expect(result.value).toBe(true);
+    });
+
+    it('should return true when version is above 2.12.0', () => {
+      mockGetVersionInfo.mockReturnValue({ fullVersion: '2.13.0' });
+      const result = useIsNewDetailPageEnabled();
+
+      expect(result.value).toBe(true);
+    });
+
+    it('should return false when version is undefined', () => {
+      mockGetVersionInfo.mockReturnValue({ fullVersion: undefined });
+      const result = useIsNewDetailPageEnabled();
+
+      expect(result.value).toBe(false);
+    });
+
+    it('should return false when version is null', () => {
+      mockGetVersionInfo.mockReturnValue({ fullVersion: null });
+      const result = useIsNewDetailPageEnabled();
+
+      expect(result.value).toBe(false);
+    });
+
+    it('should handle pre-release version strings', () => {
+      mockGetVersionInfo.mockReturnValue({ fullVersion: 'v2.12.1-rc1' });
+      const result = useIsNewDetailPageEnabled();
+
+      expect(result.value).toBe(true);
+    });
+  });
+
+  describe('legacy query param (with version >= 2.12.0)', () => {
+    it('should return true when no legacy query param is present', () => {
+      const result = useIsNewDetailPageEnabled();
+
+      expect(result.value).toBe(true);
+    });
+
+    it('should return false when legacy query param is "true"', () => {
+      mockRoute.query = { legacy: 'true' };
+      const result = useIsNewDetailPageEnabled();
+
+      expect(result.value).toBe(false);
+    });
+
+    it('should return true when legacy query param is "false"', () => {
+      mockRoute.query = { legacy: 'false' };
+      const result = useIsNewDetailPageEnabled();
+
+      expect(result.value).toBe(true);
+    });
+
+    it('should return true when legacy query param has an unexpected value', () => {
+      mockRoute.query = { legacy: 'something' };
+      const result = useIsNewDetailPageEnabled();
+
+      expect(result.value).toBe(true);
+    });
+  });
+});

--- a/shell/composables/useIsNewDetailPageEnabled.ts
+++ b/shell/composables/useIsNewDetailPageEnabled.ts
@@ -1,6 +1,9 @@
 import { useRoute } from 'vue-router';
 import { LEGACY } from '@shell/config/query-params';
 import { computed } from 'vue';
+import { getVersionInfo } from '@shell/utils/version';
+import semver from 'semver';
+import { useStore } from 'vuex';
 
 const enabledByDefault = true;
 
@@ -8,6 +11,15 @@ export const useIsNewDetailPageEnabled = () => {
   const route = useRoute();
 
   return computed(() => {
+    const store = useStore();
+    const { fullVersion } = getVersionInfo(store);
+
+    const coerced = semver.coerce(fullVersion) || { version: '0.0.0' };
+
+    if (!semver.gte(coerced.version, '2.12.0')) {
+      return false;
+    }
+
     if (enabledByDefault) {
       return route?.query?.[LEGACY] !== 'true';
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Add version gating to the new detail page feature so it is only enabled for Rancher >= 2.12.0.

Fixes #16913
<!-- Define findings related to the feature or bug issue. -->



### Occurred changes and/or fixed issues
- See summary

### Technical notes summary
This is another instance of https://github.com/rancher/dashboard/issues/15590#issuecomment-4004509540 biting us. The new ResourceDetail in shell is getting copied and used in the previous versions of rancher via the extension. The primary rendering artifact is caused by using the old translations instead of the ones included in the copied shell.

Almost all new components which may get used in an extension will have to use some sort of gating mechanism if we continue to expect the support matrix to have backwards compatibility. (i.e. an extension using @shell/rancher that was released when 2.12 was being developed expecting it to work on 2.11 or 2.10).

### Areas or cases that should be tested
- Verify the new detail page is **not** available when connected to a Rancher server running < 2.12.0 
- Verify the new detail page **is** available on Rancher >= 2.12.0.

**Note:** this is a pain to test with the dev servers. It might make sense to test this with an rc release of shell and an extension that uses that rc release.

### Areas which could experience regressions
- See above

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
