### PR TITLE
Automation - Prime ingress tests maintenance

### DIFF
--- a/cypress/e2e/po/pages/explorer/ingress.po.ts
+++ b/cypress/e2e/po/pages/explorer/ingress.po.ts
@@ -68,19 +68,19 @@ export class IngressCreateEditPo extends BaseDetailPagePo {
   }
 
   setTargetServiceValueByLabel(arrayListIndex: number, value: string) {
-    const item = this.rulesList().arrayListItem(arrayListIndex);
-    const select = new LabeledSelectPo(item.find('.col:nth-of-type(2) .unlabeled-select'));
+    const select = new LabeledSelectPo(() => this.rulesList().arrayListItem(arrayListIndex).find('.col:nth-of-type(2) .unlabeled-select'));
 
     select.toggle();
     select.clickOptionWithLabel(value);
+    select.checkOptionSelected(value);
   }
 
   setPortValueByLabel(arrayListIndex: number, value: string) {
-    const item = this.rulesList().arrayListItem(arrayListIndex);
-    const select = new LabeledSelectPo(item.find('.col:nth-of-type(3) .unlabeled-select'));
+    const select = new LabeledSelectPo(() => this.rulesList().arrayListItem(arrayListIndex).find('.col:nth-of-type(3) .unlabeled-select'));
 
     select.toggle();
     select.clickOptionWithLabel(value);
+    select.checkOptionSelected(value);
   }
 
   certificatesList() {

--- a/cypress/e2e/tests/pages/explorer/service-discovery/ingress.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/service-discovery/ingress.spec.ts
@@ -29,7 +29,12 @@ describe('Ingresses', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] 
     // testing https://github.com/rancher/dashboard/issues/11086
     cy.get('@consoleWarn').should('not.be.calledWith', warnMsg);
 
-    cy.title().should('eq', 'Rancher - local - Ingresses');
+    cy.getRancherVersion().then((version) => {
+      const expectedTitle = version.RancherPrime === 'true' ? 'Rancher Prime - local - Ingresses' : 'Rancher - local - Ingresses';
+
+      cy.log(`Expected title is: ${ expectedTitle }`);
+      cy.title().should('eq', expectedTitle);
+    });
   });
 
   it('can open "Edit as YAML"', () => {
@@ -74,8 +79,6 @@ describe('Ingresses', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] 
 
     it('can select rules and certificates in Create mode', () => {
       cy.viewport(1440, 900);
-
-      cy.log('!!!!!!!!!!!!!!!!!!', namespace);
 
       ingressListPagePo.goTo();
       ingressListPagePo.waitForPage();
@@ -252,13 +255,18 @@ describe('Ingresses', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] 
       ingressCreatePagePo.setTargetServiceValueByLabel(0, headlessServiceName);
       ingressCreatePagePo.setPortValueByLabel(0, '8080');
 
-      ingressCreatePagePo.resourceDetail().createEditView().saveAndWaitForRequests('POST', 'v1/networking.k8s.io.ingresses')
+      ingressCreatePagePo.resourceDetail().createEditView().saveAndWaitForRequests('POST', '/v1/networking.k8s.io.ingresses')
         .then(({ response }) => {
           expect(response?.statusCode).to.eq(201);
           expect(response?.body.metadata).to.have.property('name', ingressHeadlessName);
 
-          expect(response?.body.spec.rules[0]).to.have.property('host', 'example-headless.com');
-          const path = response?.body.spec.rules[0].http.paths[0];
+          const rule = response?.body?.spec?.rules?.[0];
+
+          expect(rule).to.have.property('host', 'example-headless.com');
+          expect(rule).to.have.property('http');
+          expect(rule.http.paths).to.be.an('array').with.length.greaterThan(0);
+
+          const path = rule.http.paths[0];
 
           expect(path).to.have.property('pathType', 'ImplementationSpecific');
           expect(path.backend.service).to.deep.include({
@@ -273,6 +281,12 @@ describe('Ingresses', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] 
       ingressListPagePo.list().resourceTable().sortableTable().rowWithName(ingressHeadlessName)
         .column(1)
         .should('contain.text', 'Active');
+    });
+
+    after('clean up namespaced resources', () => {
+      if (namespace) {
+        cy.deleteNamespace([namespace]);
+      }
     });
   });
 
@@ -351,7 +365,5 @@ describe('Ingresses', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] 
 
   after('clean up', () => {
     cy.updateNamespaceFilter(cluster, 'none', '{"local":["all://user"]}');
-
-    cy.deleteNamespace([namespace]);
   });
 });


### PR DESCRIPTION
### Summary
Fixes rancher/qa-tasks#2263

This PR fixes E2E test failures and race conditions within the Ingress creation and evaluation tests in `ingress.spec.ts`

Specifically, it addresses the following findings:

- Title Assertion Failure on Prime
- Payload/Flaky Test Fix
- Detached DOM Error

### Occurred changes and/or fixed issues

Title Assertion Failure on Prime: Navigation expectations were hardcoded to standard Rancher, causing assertions to fail on Rancher Prime builds. It now correctly scopes the expected page title depending on the environment.

Payload/Flaky Test Fix: Test executions were occasionally out-pacing Vue reactivity. Cypress was hitting the save button before the UI had fully updated the underlying payload, resulting in malformed network requests mapped to `http.paths`. This is mitigated using deterministic element assertions.

Detached DOM Error: Rapid re-renders from the `LabeledSelect` dropdown options were causing Cypress's underlying subject cache to detach from the DOM, requiring a switch to lazy-evaluated queries in the Page Object models (`() => ...`) queries in the Page Objects.

### Technical notes summary
Used `cy.getRancherVersion()` in `ingress.spec.ts`  to dynamically dictate the expected page title depending on whether the test is running against a regular Rancher environment (`version.RancherPrime === 'true'`).

Deterministic Cypress assertions (`.checkOptionSelected(value)`). This tells Cypress to automatically retry and wait until the DOM physically reflects the selected Vue data before attempting to run the `saveAndWaitForRequests`step.

Refactored `ingress.po.ts` setters `setTargetServiceValueByLabel` and `setPortValueByLabel` to pass a lazy-evaluating function (`() => this.rulesList()...`) into the `LabeledSelectPo` constructor rather than a static jQuery reference. This guarantees that `checkOptionSelected` queries the fresh DOM tree rather than looking at cached dropdown elements that get detached during Vue render ticks.

### Areas or cases that should be tested
E2E tests

### Areas which could experience regressions
E2E tests

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
