### PR TITLE
Improving the visuals of the CopyToClipboard implementations

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -30,6 +30,7 @@ generic:
   comma: ', '
   copy: Copy
   copyToClipboard: Copy text to Clipboard
+  copyValueToClipboard: 'Copy {value} to Clipboard'
   copiedToClipboard: Text copied to Clipboard
   create: Create
   created: Created

--- a/shell/components/CopyToClipboard.vue
+++ b/shell/components/CopyToClipboard.vue
@@ -38,7 +38,35 @@ export default {
     success-label="Copied!"
     error-label="Error Copying"
     v-bind="$attrs"
+    :success-color="$attrs['action-color'] || 'role-primary'"
+    :waiting-color="$attrs['action-color'] || 'role-primary'"
     :delay="2000"
     @click="clicked"
   />
 </template>
+
+<style lang="scss" scoped>
+.icon-btn {
+  min-height: 24px;
+  min-width: 24px;
+  justify-content: center;
+}
+
+.bg-transparent {
+  &:active {
+    background-color: var(--primary-keyboard-focus);
+    color: var(--primary-text);
+  }
+
+  &:focus-visible {
+    @include focus-outline;
+  }
+}
+
+.role-primary {
+  &:active {
+    background-color: var(--primary-keyboard-focus);
+    color: var(--primary-text);
+  }
+}
+</style>

--- a/shell/components/CopyToClipboardText.vue
+++ b/shell/components/CopyToClipboardText.vue
@@ -75,6 +75,10 @@ export default {
       }
     }
 
+    &:active {
+      color: var(--primary-keyboard-focus);
+    }
+
     &.copied {
       pointer-events: none;
       color: var(--success);

--- a/shell/edit/auth/github-app-steps.vue
+++ b/shell/edit/auth/github-app-steps.vue
@@ -49,6 +49,7 @@ defineProps<{
             <CopyToClipboard
               label-as="tooltip"
               :text="tArgs.serverUrl"
+              :aria-label="t('generic.copyValueToClipboard', { value: tArgs.serverUrl })"
               class="icon-btn"
               action-color="bg-transparent"
             />
@@ -67,6 +68,7 @@ defineProps<{
             <CopyToClipboard
               :text="t(`authConfig.${name}.form.callback.value`, tArgs, true)"
               label-as="tooltip"
+              :aria-label="t('generic.copyValueToClipboard', { value: t(`authConfig.${name}.form.callback.value`, tArgs, true) })"
               class="icon-btn"
               action-color="bg-transparent"
             />

--- a/shell/edit/auth/github-steps.vue
+++ b/shell/edit/auth/github-steps.vue
@@ -40,6 +40,7 @@ defineProps<{
             <b>{{ t(`authConfig.${name}.form.homepage.label`) }}</b>: {{ tArgs.serverUrl }} <CopyToClipboard
               label-as="tooltip"
               :text="tArgs.serverUrl"
+              :aria-label="t('generic.copyValueToClipboard', { value: tArgs.serverUrl })"
               class="icon-btn"
               action-color="bg-transparent"
             />
@@ -49,6 +50,7 @@ defineProps<{
             <b>{{ t(`authConfig.${name}.form.callback.label`) }}</b>: {{ tArgs.serverUrl }} <CopyToClipboard
               :text="tArgs.serverUrl"
               label-as="tooltip"
+              :aria-label="t('generic.copyValueToClipboard', { value: tArgs.serverUrl })"
               class="icon-btn"
               action-color="bg-transparent"
             />


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14105

### Occurred changes and/or fixed issues
Fixed color, size and aria issues regarding the copy to clipboard buttons on the node list and github auth pages.

### Technical notes summary
N/A

### Areas or cases that should be tested
- Tab to copy icons on the Nodes list (IP column) and press Enter/Space
- GitHub Auth Provider config page
- Test both light and dark themes.
- Verify screen reader announces "Copy [value] to Clipboard" on auth page buttons.

### Areas which could experience regressions
- Account api keys page - copy host or token
- Secret detail page - copy the secret
- Azuread auth provider - copy reply url

*We could be more exhaustive but I don't think it's necessary*

### Screenshot/Video

https://github.com/user-attachments/assets/e3963e1e-4c97-4ba3-b9e5-94d48de36a5a


https://github.com/user-attachments/assets/ac7fc04b-dde3-497d-98ba-a198f29d09bc



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
