### PR TITLE
We now hide the CruResourceFooter if we're looking at the _VIEW detail page.

### DIFF
--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -782,6 +782,7 @@ export default {
         </div>
         <slot name="form-footer">
           <CruResourceFooter
+            v-if="!isView"
             class="cru__footer"
             :mode="mode"
             :is-form="showAsForm"

--- a/shell/components/__tests__/CruResource.test.ts
+++ b/shell/components/__tests__/CruResource.test.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils';
 import CruResource from '@shell/components/CruResource.vue';
-import { _EDIT, _YAML } from '@shell/config/query-params';
+import { _CREATE, _EDIT, _VIEW, _YAML } from '@shell/config/query-params';
 import TextAreaAutoGrow from '@components/Form/TextArea/TextAreaAutoGrow.vue';
 
 describe('component: CruResource', () => {
@@ -169,6 +169,40 @@ describe('component: CruResource', () => {
     await textAreaField.trigger('keydown.enter', event);
 
     expect(event.preventDefault).toHaveBeenCalledWith();
+  });
+
+  it.each([
+    [_EDIT, true],
+    [_CREATE, true],
+    [_VIEW, false],
+  ])('should render CruResourceFooter when mode is %s: %s', (mode: string, shouldRender: boolean) => {
+    const wrapper = mount(CruResource, {
+      props: {
+        canYaml:  false,
+        mode,
+        resource: {}
+      },
+      global: {
+        mocks: {
+          $store: {
+            getters: {
+              currentStore:              () => 'current_store',
+              'current_store/schemaFor': jest.fn(),
+              'current_store/all':       jest.fn(),
+              'i18n/t':                  jest.fn(),
+              'i18n/exists':             jest.fn(),
+            },
+            dispatch: jest.fn(),
+          },
+          $route:  { query: { AS: _YAML } },
+          $router: { applyQuery: jest.fn() },
+        },
+      }
+    });
+
+    const footer = wrapper.find('.cru-resource-footer');
+
+    expect(footer.exists()).toBe(shouldRender);
   });
 
   it('should not prevent default events on keypress Enter', async() => {


### PR DESCRIPTION
…



<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16466
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Hide `CruResourceFooter` in `_VIEW` mode.

### Technical notes summary
N/A

### Areas or cases that should be tested

- Detail pages without a custom detail component (network policy should work).
- Create/edit pages: footer should still be visible.

### Areas which could experience regressions
- Create/edit pages.
- Components providing custom `form-footer` slot content (provisioning pages like rke2 or eks).


### Screenshot/Video
I first show the failure case then show the fix:

https://github.com/user-attachments/assets/f58aaf83-d5e2-46ae-ada0-ae05d673c3cd


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
