### PR TITLE
Automation - Prime test cluster manager fixes

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -20,21 +20,24 @@ import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import { nodeDriveResponse } from '@/cypress/e2e/tests/pages/manager/mock-responses';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import LoadingPo from '@/cypress/e2e/po/components/loading.po';
-import { EXTRA_LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import {
+  VERY_LONG_TIMEOUT_OPT,
+  EXTRA_LONG_TIMEOUT_OPT,
+  MEDIUM_TIMEOUT_OPT,
+  RESTART_TIMEOUT_OPT
+} from '@/cypress/support/utils/timeouts';
 import HostedProvidersPagePo from '@/cypress/e2e/po/pages/cluster-manager/hosted-providers.po';
 import { USERS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
 
 // At some point these will come from somewhere central, then we can make tools to remove resources from this or all runs
-const runTimestamp = +new Date();
-const runPrefix = `e2e-test-${ runTimestamp }`;
+const createClusterTestName = (suffix: string) => `e2e-test-${ +new Date() }-create-${ suffix }`;
 
 // File specific consts
 const namespace = 'fleet-default';
 const type = 'provisioning.cattle.io.cluster';
 const importType = 'cluster';
-const clusterNamePartial = `${ runPrefix }-create`;
-const rke2CustomName = `${ clusterNamePartial }-rke2-custom`;
-const importGenericName = `${ clusterNamePartial }-import-generic`;
+let rke2CustomName = createClusterTestName('rke2-custom');
+let importGenericName = createClusterTestName('import-generic');
 let reenableAKS = false;
 let originalSettings = '[{"name":"aks","active":true},{"name":"alibaba","active":true},{"name":"eks","active":true},{"name":"gke","active":true}]';
 
@@ -110,13 +113,14 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
   describe('Created', () => {
     const createRKE2ClusterPage = new ClusterManagerCreateRke2CustomPagePo();
-    const detailRKE2ClusterPage = new ClusterManagerDetailRke2CustomPagePo(undefined, rke2CustomName);
+    const detailRKE2ClusterPage = () => new ClusterManagerDetailRke2CustomPagePo(undefined, rke2CustomName);
     const tabbedPo = new TabbedPo('[data-testid="tabbed-block"]');
 
     describe('RKE2 Custom', { tags: ['@jenkins', '@customCluster', '@provisioning'] }, () => {
-      const editCreatedClusterPage = new ClusterManagerEditRke2CustomPagePo(undefined, rke2CustomName);
+      const editCreatedClusterPage = () => new ClusterManagerEditRke2CustomPagePo(undefined, rke2CustomName);
 
-      it('can create new cluster', () => {
+      it('can create new cluster', { retries: 0 }, () => {
+        rke2CustomName = createClusterTestName('rke2-custom');
         cy.intercept('POST', `/v1/${ type }s`).as('createRequest');
         const request = {
           type,
@@ -128,7 +132,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
           // The test validate the warning when selecting none, but now this get back to calico.
           // A CNI is mandatory to get the cluster active otherwise manual intervention is needed or
           // the use of a cloud provider but that's not in scope.
-          spec: { rkeConfig: { machineGlobalConfig: { cni: 'calico', 'ingress-controller': 'ingress-nginx' }, machinePoolDefaults: { hostnameLengthLimit: 15 } } }
+          spec: { rkeConfig: { machineGlobalConfig: { cni: 'calico' }, machinePoolDefaults: { hostnameLengthLimit: 15 } } }
         };
 
         cy.userPreferences();
@@ -173,16 +177,21 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         cy.wait('@createRequest').then((intercept) => {
           // Issue with linter https://github.com/cypress-io/eslint-plugin-cypress/issues/3
           expect(isMatch(intercept.request.body, request)).to.equal(true);
+          expect(['ingress-nginx', 'traefik']).to.include(intercept.request.body.spec?.rkeConfig?.machineGlobalConfig?.['ingress-controller']);
         });
 
-        detailRKE2ClusterPage.waitForPage(undefined, 'registration');
+        detailRKE2ClusterPage().waitForPage(undefined, 'registration');
 
         createRKE2ClusterPage.activateInsecureRegistrationCommandFromUI().click();
         createRKE2ClusterPage.commandFromCustomClusterUI().then(($value) => {
           const registrationCommand = $value.text();
+          const customNodeKey = `${ Cypress.env('customNodeKey') || '' }`;
+          const decodedCustomNodeKey = customNodeKey.includes('BEGIN') ? customNodeKey : Cypress.Buffer.from(customNodeKey, 'base64').toString('utf8');
 
-          cy.exec(`echo ${ Cypress.env('customNodeKey') } | base64 -d > custom_node.key && chmod 600 custom_node.key`).then((result) => {
+          cy.writeFile('custom_node.key', decodedCustomNodeKey).then(() => {
             cy.log('Creating the custom_node.key');
+          });
+          cy.exec('chmod 600 custom_node.key').then((result) => {
             cy.log(result.stderr);
             cy.log(result.stdout);
             expect(result.code).to.eq(0);
@@ -201,7 +210,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         ClusterManagerListPagePo.navTo();
         clusterList.waitForPage();
         clusterList.list().state(rke2CustomName).should('contain.text', 'Updating');
-        clusterList.list().state(rke2CustomName).contains('Active', { timeout: 300000 }); // super long timeout needed for cluster provisioning to complete
+        clusterList.list().state(rke2CustomName).contains('Active', VERY_LONG_TIMEOUT_OPT); // super long timeout needed for cluster provisioning to complete
       });
 
       it('can copy config to clipboard', () => {
@@ -234,17 +243,18 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         clusterList.goTo();
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
 
-        editCreatedClusterPage.waitForPage('mode=edit', 'basic');
-        editCreatedClusterPage.nameNsDescription().description().set(rke2CustomName);
-        editCreatedClusterPage.save();
+        editCreatedClusterPage().waitForPage('mode=edit', 'basic');
+        editCreatedClusterPage().nameNsDescription().description().set(rke2CustomName);
+        editCreatedClusterPage().save();
 
         // We should be taken back to the list page if the save was successful
         clusterList.waitForPage();
 
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
 
-        editCreatedClusterPage.waitForPage('mode=edit', 'basic');
-        editCreatedClusterPage.nameNsDescription().description().self().should('have.value', rke2CustomName);
+        editCreatedClusterPage().waitForPage('mode=edit', 'basic');
+        editCreatedClusterPage().nameNsDescription().description().self()
+          .should('have.value', rke2CustomName);
       });
 
       it('will disable saving if an addon config has invalid data', () => {
@@ -274,15 +284,16 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         clusterList.goTo();
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit YAML').click();
 
-        editCreatedClusterPage.waitForPage('mode=edit&as=yaml');
-        editCreatedClusterPage.resourceDetail().resourceYaml().checkVisible();
+        editCreatedClusterPage().waitForPage('mode=edit&as=yaml');
+        editCreatedClusterPage().resourceDetail().resourceYaml().checkVisible();
       });
 
       it('can download KubeConfig', () => {
+        cy.deleteDownloadsFolder();
         clusterList.goTo();
         cy.intercept('POST', '/v1/ext.cattle.io.kubeconfigs').as('generateKubeconfig');
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Download KubeConfig').click();
-        cy.wait('@generateKubeconfig').its('response.statusCode').should('eq', 200);
+        cy.wait('@generateKubeconfig').its('response.statusCode').should('be.oneOf', [200, 201]);
 
         const downloadedFilename = path.join(downloadsFolder, `${ rke2CustomName }.yaml`);
 
@@ -291,8 +302,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
           const obj: any = jsyaml.load(buffer);
 
           // Basic checks on the downloaded YAML
-          expect(obj.clusters.length).to.equal(1);
-          expect(obj.clusters[0].name).to.equal(rke2CustomName);
+          expect(obj.clusters.some((cluster: { name: string }) => cluster.name === rke2CustomName)).to.equal(true);
           expect(obj.apiVersion).to.equal('v1');
           expect(obj.kind).to.equal('Config');
         });
@@ -322,16 +332,13 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         clusterList.sortableTable().rowElementWithName(rke2CustomName).should('exist', MEDIUM_TIMEOUT_OPT);
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Delete').click();
 
-        clusterList.sortableTable().rowNames('.cluster-link').then((rows: any) => {
-          const promptRemove = new PromptRemove();
+        const promptRemove = new PromptRemove();
 
-          promptRemove.confirm(rke2CustomName);
-          promptRemove.remove();
+        promptRemove.confirm(rke2CustomName);
+        promptRemove.remove();
 
-          clusterList.waitForPage();
-          clusterList.sortableTable().checkRowCount(false, rows.length - 1);
-          clusterList.sortableTable().rowNames('.cluster-link').should('not.contain', rke2CustomName);
-        });
+        clusterList.waitForPage();
+        clusterList.sortableTable().rowElementWithName(rke2CustomName).should('not.exist');
       });
     });
   });
@@ -344,6 +351,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
     describe('Generic', () => {
       it('can create new cluster', () => {
+        importGenericName = createClusterTestName('import-generic');
         cy.intercept('GET', `${ USERS_BASE_URL }?*`).as('getUsers');
         cy.intercept('POST', `/v3/${ importType }s`).as('importRequest');
 
@@ -393,7 +401,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
             expect(kubectlCommand).to.contain('--insecure');
             cy.log(kubectlCommand);
-            cy.exec(kubectlCommand, { failOnNonZeroExit: false }).then((result) => {
+            cy.exec(kubectlCommand, { failOnNonZeroExit: false, timeout: RESTART_TIMEOUT_OPT.timeout }).then((result) => {
               cy.log(result.stderr);
               cy.log(result.stdout);
               expect(result.code).to.eq(0);
@@ -479,16 +487,13 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         clusterList.sortableTable().bulkActionDropDownOpen();
         clusterList.sortableTable().bulkActionDropDownButton('Delete').click();
 
-        clusterList.sortableTable().rowNames('.cluster-link').then((rows: any) => {
-          const promptRemove = new PromptRemove();
+        const promptRemove = new PromptRemove();
 
-          promptRemove.confirm(importGenericName);
-          promptRemove.remove();
+        promptRemove.confirm(importGenericName);
+        promptRemove.remove();
 
-          clusterList.waitForPage();
-          clusterList.sortableTable().checkRowCount(false, rows.length - 1);
-          clusterList.sortableTable().rowNames('.cluster-link').should('not.contain', importGenericName);
-        });
+        clusterList.waitForPage();
+        clusterList.sortableTable().rowElementWithName(importGenericName).should('not.exist');
       });
     });
   });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/qa-tasks#2274

Stabilizes Cluster Manager E2E coverage by updating brittle assertions and aligning the spec with current Rancher behavior, especially around cluster create payloads, kubeconfig responses, and delete flows.

### Occurred changes and/or fixed issues

- Updated RKE2 create request validation to accept current ingress controller behavior while still asserting required payload fields.
- Made create-test naming retry-safe by generating unique runtime cluster names and using those names across dependent steps.
- Fixed kubeconfig download expectation to handle valid backend response variations and current kubeconfig content shape.
- Reworked delete and bulk-delete checks to validate row disappearance instead of relying on fragile row-count assumptions.
- Kept custom node key handling robust for both PEM and base64-provided values before SSH registration.
- Replaced hardcoded long exec timeout usage with shared timeout utility usage for consistency.
- Adjusted local timeout usage errors where option objects were passed incorrectly.
- Makes the test run only once, due to how the provisioning flow works retries will always fail. So make it fail early skipping the timeout waits.

### Areas or cases that should be tested
E2E

### Areas which could experience regressions
E2E

Staging Jenkins results:

Running: pages/manager/cluster-manager.spec.ts (51 of 127)

Cluster Manager
  ✓ deactivating a hosted provider should hide its card from the cluster creation page (19123ms)
  ✓ can navigate to Cluster Management Page
  ✓ can download YAML via bulk actions
  ✓ can download KubeConfig via bulk actions
  ✓ can connect to kubectl shell (6743ms)
  RKE2 providers
    ✓ should be able to access RKE2 cluster creation for provider Amazon EKS via url
    ✓ should be able to access RKE2 cluster creation for provider Azure AKS via url
    ✓ should be able to access RKE2 cluster creation for provider Google GKE via url
    ✓ should be able to access RKE2 cluster creation for provider Amazon EC2 via url
    ✓ should be able to access RKE2 cluster creation for provider Azure via url
    ✓ should be able to access RKE2 cluster creation for provider DigitalOcean via url
    ✓ should be able to access RKE2 cluster creation for provider Azure AKS via url
    ✓ should be able to access RKE2 cluster creation for provider Harvester via url
    ✓ should be able to access RKE2 cluster creation for provider Linode via url
    ✓ should be able to access RKE2 cluster creation for provider Azure via url
    ✓ should be able to access RKE2 cluster creation for provider VMware vSphere via url
    ✓ should be able to access RKE2 cluster creation for provider Custom via url
  Created
    RKE2 Custom
      ✓ can create new cluster (229079ms)
      ✓ can copy config to clipboard (9876ms)
      ✓ can edit cluster and see changes afterwards (10028ms)
      ✓ will disable saving if an addon config has invalid data (7433ms)
      ✓ can view cluster YAML editor
      ✓ can download KubeConfig
      ✓ can download YAML
      ✓ can delete cluster (8551ms)
  Imported
    Generic
      ✓ can create new cluster (65988ms)
      ✓ can edit imported cluster and see changes afterwards (13865ms)
      ✓ can delete cluster by bulk actions (7507ms)
  Cluster Details Page and Tabs
    ✓ can navigate to Cluster Conditions Page
    ✓ can navigate to Cluster Related Page
    ✓ can navigate to Cluster Provisioning Log Page
    ✓ can navigate to Cluster Machines Page
    ✓ Show Configuration allows to edit config and view yaml for local cluster
    ✓ can navigate to namespace from cluster detail view
  Local
    ✓ can open edit for local cluster (6686ms)
    ✓ can navigate to local cluster's explore product
  Credential Step
    should always show credentials for nutanix driver
      ✓ should show credential step when `addCloudCredential` is true
      ✓ should show credential step when `addCloudCredential` is false
    should always show credentials for oci driver
      ✓ should show credential step when `addCloudCredential` is true
      ✓ should show credential step when `addCloudCredential` is false
    should show on condition of addCloudCredential
      ✓ should show credential step when `addCloudCredential` is true
      ✓ should NOT show credential step when `addCloudCredential` is false

42 passing (8m)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
