### PR TITLE
Automation - Prime replicaset test fixes

### DIFF
--- a/cypress/e2e/po/pages/explorer/workloads-replicasets.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads-replicasets.po.ts
@@ -14,6 +14,11 @@ export class WorkloadsReplicasetsListPagePo extends BaseListPagePo {
   constructor(clusterId = 'local') {
     super(WorkloadsReplicasetsListPagePo.createPath(clusterId));
   }
+
+  waitForListReady(): void {
+    this.list().resourceTable().sortableTable().checkVisible();
+    this.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+  }
 }
 
 export class WorkloadsReplicasetsEditPagePo extends BaseDetailPagePo {

--- a/cypress/e2e/po/prompts/ResourceSearchDialog.po.ts
+++ b/cypress/e2e/po/prompts/ResourceSearchDialog.po.ts
@@ -18,6 +18,10 @@ export default class ResourceSearchDialog extends ComponentPo {
     super('[data-testid="search-modal"]');
   }
 
+  waitForNoDialog(): Cypress.Chainable {
+    return this.self().should('not.exist');
+  }
+
   open() {
     cy.keyboardControls(CMD_K_KEY, 1);
   }

--- a/cypress/e2e/tests/pages/explorer2/workloads/replicasets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/replicasets.spec.ts
@@ -13,6 +13,7 @@ describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser'] }, () => {
       it('should not be able to rollback a replicaset', () => {
         // list view for replicasets
         const workloadsReplicasetsListPage = new WorkloadsReplicasetsListPagePo('local');
+        const resourceSearchDialog = new ResourceSearchDialog();
 
         workloadsReplicasetsListPage.goTo();
         workloadsReplicasetsListPage.waitForPage();
@@ -25,10 +26,9 @@ describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser'] }, () => {
           .set(replicasetName);
         workloadsDaemonsetsEditPage.containerImageInput().set('nginx');
         workloadsDaemonsetsEditPage.resourceDetail().createEditView().save();
-
-        ResourceSearchDialog.goToResource('ReplicaSets');
-
         workloadsReplicasetsListPage.waitForPage();
+        resourceSearchDialog.waitForNoDialog();
+        workloadsReplicasetsListPage.waitForListReady();
 
         workloadsReplicasetsListPage.list().resourceTable().sortableTable().rowElementWithName(replicasetName)
           .should('be.visible');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/qa-tasks#2266

Stabilizes the ReplicaSets Cypress test that validates rollback is unavailable by removing a flaky timing race caused by modal overlay transitions.

### Occurred changes and/or fixed issues

- Updated the ReplicaSets e2e spec to use page object waits before interacting with row actions.
- Added and used a list-page helper to wait until modal overlays are gone.
- Added and used a list readiness helper that waits for table visibility and loading completion.

### Areas or cases that should be tested
E2E

### Areas which could experience regressions
E2E

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
