### PR TITLE
Fixes for ClusterRepo resources

### DIFF
--- a/cypress/e2e/po/edit/chart-repositories.po.ts
+++ b/cypress/e2e/po/edit/chart-repositories.po.ts
@@ -1,6 +1,7 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 import UnitInputPo from '@/cypress/e2e/po/components/unit-input.po';
+import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
 import AsyncButtonPo from '@/cypress/e2e/po/components/async-button.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import NameNsDescription from '@/cypress/e2e/po/components/name-ns-description.po';
@@ -83,8 +84,16 @@ export default class ChartRepositoriesCreateEditPo extends PagePo {
     return this.authSelectOrCreate('[data-testid="clusterrepo-auth-secret"]');
   }
 
-  refreshIntervalInput() {
-    return new UnitInputPo('[data-testid="clusterrepo-refresh-interval"]');
+  refreshIntervalInput() : LabeledInputPo {
+    return LabeledInputPo.byLabel(this.self(), 'Refresh Interval');
+  }
+
+  refreshIntervalUnits() : LabeledSelectPo {
+    return new LabeledSelectPo('[data-testid="clusterrepo-refresh-interval"]');
+  }
+
+  refreshIntervalEnabled() : CheckboxInputPo {
+    return new CheckboxInputPo('[data-testid="clusterrepo-refresh-interval"]');
   }
 
   saveAndWaitForRequests(method: string, url: string) {

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -82,13 +82,39 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     cy.contains(`${ this.repoName }-desc-edit`).should('be.visible');
   });
 
+  it('can modify refresh interval', function() {
+    ChartRepositoriesPagePo.navTo();
+    repositoriesPage.waitForPage();
+    repositoriesPage.list().actionMenu(this.repoName).getMenuItem('Edit Config').click();
+    repositoriesPage.createEditRepositories(this.repoName).waitForPage('mode=edit');
+    repositoriesPage.createEditRepositories().refreshIntervalEnabled().isChecked();
+    repositoriesPage.createEditRepositories().refreshIntervalInput().set(20);
+    repositoriesPage.createEditRepositories().refreshIntervalUnits().toggle();
+    repositoriesPage.createEditRepositories().refreshIntervalUnits().clickOptionWithLabel('mins');
+    repositoriesPage.createEditRepositories().saveAndWaitForRequests('PUT', `${ CLUSTER_REPOS_BASE_URL }/${ this.repoName }`).then((req) => {
+      expect(req.request.body.spec.refreshInterval).to.eq(20 * 60);
+    });
+    repositoriesPage.waitForPage();
+
+    // The interval should not trigger a refresh
+    repositoriesPage.list().details(this.repoName, 1).contains('Active').should('be.visible');
+    repositoriesPage.list().details(this.repoName, 2).click();
+    cy.contains('label', 'Refresh Interval')
+      .siblings('.value')
+      .should('contain.text', '20m');
+  });
+
   it('can disable automatic updates', function() {
     ChartRepositoriesPagePo.navTo();
     repositoriesPage.waitForPage();
     repositoriesPage.list().actionMenu(this.repoName).getMenuItem('Edit Config').click();
     repositoriesPage.createEditRepositories(this.repoName).waitForPage('mode=edit');
-    repositoriesPage.createEditRepositories().refreshIntervalInput().setValue('-1');
-    repositoriesPage.createEditRepositories().saveAndWaitForRequests('PUT', `${ CLUSTER_REPOS_BASE_URL }/${ this.repoName }`);
+    repositoriesPage.createEditRepositories().refreshIntervalEnabled().isChecked();
+    repositoriesPage.createEditRepositories().refreshIntervalEnabled().uncheck();
+    repositoriesPage.createEditRepositories().refreshIntervalInput().isDisabled();
+    repositoriesPage.createEditRepositories().saveAndWaitForRequests('PUT', `${ CLUSTER_REPOS_BASE_URL }/${ this.repoName }`).then((req) => {
+      expect(req.request.body.spec.refreshInterval).to.eq(-1);
+    });
     repositoriesPage.waitForPage();
 
     // The interval should not trigger a refresh
@@ -261,7 +287,7 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     repositoriesPage.createEditRepositories().nameNsDescription().description().set(`${ this.repoName }-description`);
     repositoriesPage.createEditRepositories().selectOciUrlCard();
     repositoriesPage.createEditRepositories().ociUrl().set(ociUrl);
-    repositoriesPage.createEditRepositories().refreshIntervalInput().setValue(refreshInterval);
+    repositoriesPage.createEditRepositories().refreshIntervalInput().set(refreshInterval);
     repositoriesPage.createEditRepositories().clusterRepoAuthSelectOrCreate().createBasicAuth('test', 'test');
     repositoriesPage.createEditRepositories().ociMinWaitInput().setValue(ociMinWait);
     // setting a value and removing it so in the intercept we test that the key(e.g. maxWait) is not included in the request

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -82,6 +82,21 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     cy.contains(`${ this.repoName }-desc-edit`).should('be.visible');
   });
 
+  it('can disable automatic updates', function() {
+    ChartRepositoriesPagePo.navTo();
+    repositoriesPage.waitForPage();
+    repositoriesPage.list().actionMenu(this.repoName).getMenuItem('Edit Config').click();
+    repositoriesPage.createEditRepositories(this.repoName).waitForPage('mode=edit');
+    repositoriesPage.createEditRepositories().refreshIntervalInput().setValue('-1');
+    repositoriesPage.createEditRepositories().saveAndWaitForRequests('PUT', `${ CLUSTER_REPOS_BASE_URL }/${ this.repoName }`);
+    repositoriesPage.waitForPage();
+
+    // The interval should not trigger a refresh
+    repositoriesPage.list().details(this.repoName, 1).contains('Active').should('be.visible');
+    repositoriesPage.list().details(this.repoName, 2).click();
+    cy.contains('label', 'Refresh Interval').should('have.value', 'Disabled');
+  });
+
   it('can clone a repository', function() {
     ChartRepositoriesPagePo.navTo();
     repositoriesPage.waitForPage();

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -94,7 +94,9 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     // The interval should not trigger a refresh
     repositoriesPage.list().details(this.repoName, 1).contains('Active').should('be.visible');
     repositoriesPage.list().details(this.repoName, 2).click();
-    cy.contains('label', 'Refresh Interval').should('have.value', 'Disabled');
+    cy.contains('label', 'Refresh Interval')
+      .siblings('.value')
+      .should('contain.text', 'Disabled');
   });
 
   it('can clone a repository', function() {

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1441,7 +1441,6 @@ catalog:
     refreshInterval:
       label: Refresh Interval
       placeholder: 'default: {value}'
-      tooltip: Using any negative value disables periodic updates
     error:
       refresh: Error refreshing repository
   tools:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1440,7 +1440,7 @@ catalog:
           placeholder: 'default: 5'
     refreshInterval:
       label: Refresh Interval
-      placeholder: 'default: {value} {units}'
+      placeholder: 'default: {value}'
       tooltip: Using any negative value disables periodic updates
     error:
       refresh: Error refreshing repository

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1440,7 +1440,8 @@ catalog:
           placeholder: 'default: 5'
     refreshInterval:
       label: Refresh Interval
-      placeholder: 'default: {hours}'
+      placeholder: 'default: {value} {units}'
+      tooltip: Using any negative value disables periodic updates
     error:
       refresh: Error refreshing repository
   tools:

--- a/shell/components/form/InputWithSelect.vue
+++ b/shell/components/form/InputWithSelect.vue
@@ -72,6 +72,11 @@ export default {
       default: false,
     },
 
+    selectDisabled: {
+      type:    Boolean,
+      default: false,
+    },
+
     textValue: {
       type:    [String, Number],
       default: '',
@@ -144,7 +149,7 @@ export default {
       :options="options"
       :searchable="false"
       :clearable="false"
-      :disabled="disabled || isView"
+      :disabled="disabled || selectDisabled || isView"
       :taggable="taggable"
       :create-option="(name) => ({ label: name, value: name })"
       :multiple="false"
@@ -160,7 +165,7 @@ export default {
       v-model:value="selected"
       :options="options"
       :searchable="searchable"
-      :disabled="disabled || isView"
+      :disabled="disabled || selectDisabled || isView"
       :clearable="false"
       class="in-input"
       :taggable="taggable"

--- a/shell/edit/catalog.cattle.io.clusterrepo.vue
+++ b/shell/edit/catalog.cattle.io.clusterrepo.vue
@@ -5,6 +5,7 @@ import Footer from '@shell/components/form/Footer';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
 import Labels from '@shell/components/form/Labels';
+import InputWithSelect from '@shell/components/form/InputWithSelect';
 import SelectOrCreateAuthSecret from '@shell/components/form/SelectOrCreateAuthSecret';
 import Banner from '@components/Banner/Banner.vue';
 import { Checkbox } from '@components/Form/Checkbox';
@@ -18,6 +19,18 @@ import { RcItemCard } from '@components/RcItemCard';
 import { _CREATE, _EDIT, TARGET, _VIEW } from '@shell/config/query-params';
 import { RcIconType } from '@components/RcIcon/types';
 import { requireAsset } from '@shell/utils/require-asset';
+import { secondsToLargestUnit } from '@shell/utils/time';
+
+function unitToSecondsMultiplier(unit: string) {
+  switch (unit) {
+  case 'day': return 86400;
+  case 'hour': return 3600;
+  case 'min': return 60;
+  default: return 1; // seconds
+  }
+}
+
+const defaultRefreshIntervalUnits = 'hour';
 
 export default {
   name: 'CruCatalogRepo',
@@ -34,6 +47,7 @@ export default {
     Banner,
     Checkbox,
     UnitInput,
+    InputWithSelect,
     RcItemCard,
   },
 
@@ -82,6 +96,21 @@ export default {
       });
     }
 
+    let refreshInterval = this.value?.spec?.refreshInterval || null;
+    const refreshIntervalDisabled = refreshInterval < 0;
+    let refreshIntervalUnits = defaultRefreshIntervalUnits;
+    const refreshIntervalUnitOptions = ['sec', 'min', 'hour', 'day'].map(
+      (unit) => ({ value: unit, label: this.t(`unit.${ unit }`, { count: 2 /* use plural */ }) }));
+
+    if (refreshIntervalDisabled) {
+      refreshInterval = null;
+    } else if (refreshInterval > 0) {
+      const { units, value } = secondsToLargestUnit(refreshInterval);
+
+      refreshInterval = value;
+      refreshIntervalUnits = units;
+    }
+
     return {
       CLUSTER_REPO_TYPES,
       AUTH_TYPE,
@@ -97,6 +126,10 @@ export default {
       clusterRepoTargets,
       previousName:        '',
       previousDescription: '',
+      refreshInterval,
+      refreshIntervalDisabled,
+      refreshIntervalUnits,
+      refreshIntervalUnitOptions,
     };
   },
 
@@ -108,6 +141,8 @@ export default {
       // Trigger onTargetChange to properly initialize form fields for the selected target
       this.onTargetChange(targetFromQuery);
     }
+
+    this.registerBeforeHook(this.applyRefreshIntervalOnSave);
   },
 
   computed: {
@@ -128,6 +163,20 @@ export default {
   },
 
   methods: {
+    positiveNumberValidator(val, key) {
+      // Explicit null is accepted, do not show warning after loading default value, only when we tried to be modified
+      if (val === null) {
+        return null;
+      }
+
+      const n = Number(val);
+
+      if (!Number.isFinite(n) || n <= 0) {
+        return this.t('validation.number.isPositive', { key });
+      }
+
+      return null; // valid
+    },
     onTargetChange(clusterRepoType) {
       // reset input fields when switching options
       const oldClusterRepoType = this.clusterRepoType;
@@ -174,15 +223,43 @@ export default {
 
       this.value.spec.exponentialBackOffValues[key] = Number(newVal);
     },
-    updateRefreshInterval(newVal) {
-      // when user removes the value we don't send refreshInterval along with the payload
-      if (newVal === null) {
+    onRefreshIntervalInput({ selected, text }) { // InputWithSelect emits "update:value" with { selected, text }
+      if (this.refreshIntervalDisabled) {
+        return;
+      }
+
+      const units = selected;
+      let refreshInterval = text;
+
+      if (refreshInterval === '' && this.refreshInterval !== refreshInterval) {
+        // HACK: Validation treats explicit null differently, omitting the warning.
+        // This code tries to detect the manual "deletion" case, and avoid showing the warning.
+        // Note: the components converts any non-numeric input to an empty string, so we only receive text='' here
+        refreshInterval = null;
+      }
+
+      // Keep UI up-to-date
+      this.refreshInterval = refreshInterval;
+      this.refreshIntervalUnits = units;
+
+      if (refreshInterval === '' || refreshInterval === null || refreshInterval === undefined) {
         delete this.value.spec.refreshInterval;
+        this.refreshIntervalUnits = defaultRefreshIntervalUnits;
 
         return;
       }
 
-      this.value.spec.refreshInterval = newVal;
+      // Convert input to seconds
+      this.value.spec.refreshInterval = Number(refreshInterval) * unitToSecondsMultiplier(units);
+    },
+    applyRefreshIntervalOnSave() {
+      if (this.refreshIntervalDisabled || this.refreshInterval < 0) {
+        this.value.spec.refreshInterval = -1;
+      } else if (this.refreshInterval === 0) {
+        delete this.value.spec.refreshInterval;
+      }
+
+      return Promise.resolve();
     },
     resetGitRepoValues() {
       delete this.value.spec['gitRepo'];
@@ -281,7 +358,7 @@ export default {
             data-testid="clusterrepo-git-repo-input"
           />
         </div>
-        <div class="col span-3">
+        <div class="col span-2">
           <LabeledInput
             v-model:value.trim="value.spec.gitBranch"
             :sub-label="!value.spec.gitBranch ? t('catalog.repo.gitBranch.defaultMessage', null, true) : undefined"
@@ -335,19 +412,36 @@ export default {
       </div>
 
       <div
-        class="col span-3"
+        class="col span-4"
         data-testid="clusterrepo-refresh-interval"
       >
-        <UnitInput
-          v-model:value.trim="value.spec.refreshInterval"
-          :label="t('catalog.repo.refreshInterval.label')"
-          :mode="mode"
-          :min="-1"
-          :suffix="t('suffix.sec')"
-          :placeholder="t('catalog.repo.refreshInterval.placeholder', { value: value.defaultRefreshIntervalHours, units: value.defaultRefreshIntervalHours > 1 ? 'hours' : 'hour' })"
-          :tooltip="t('catalog.repo.refreshInterval.tooltip')"
-          @update:value="updateRefreshInterval($event)"
-        />
+        <div class="refresh-interval-row">
+          <div class="refresh-interval-input">
+            <InputWithSelect
+              :text-value="refreshInterval"
+              :min="1"
+              :text-rules="[(val) => positiveNumberValidator(val, 'refreshInterval')]"
+              :select-disabled="refreshInterval == null || refreshInterval === ''"
+              :select-value="refreshIntervalUnits"
+              :select-before-text="false"
+              :searchable="false"
+              :text-label="t('catalog.repo.refreshInterval.label')"
+              :mode="mode"
+              type="number"
+              :options="refreshIntervalUnitOptions"
+              :disabled="refreshIntervalDisabled || isView"
+              :placeholder="t('catalog.repo.refreshInterval.placeholder', { value: value.defaultRefreshIntervalHours })"
+              @update:value="onRefreshIntervalInput"
+            />
+          </div>
+          <div class="refresh-interval-toggle">
+            <Checkbox
+              v-model:value="refreshIntervalDisabled"
+              :mode="mode"
+              :label="t('generic.disabled')"
+            />
+          </div>
+        </div>
       </div>
     </div>
 
@@ -477,5 +571,30 @@ export default {
   width: 100%;
   height: max-content;
   overflow: hidden;
+}
+.refresh-interval-row {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--gap-md);
+}
+.refresh-interval-input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+/* Increase unit selector size to make text visible */
+.refresh-interval-input :deep(.in-input) {
+  width: clamp(100px, 30%, 120px) !important; /* tweak numbers to taste */
+  min-width: 0 !important;
+  flex: 0 0 auto;
+}
+/* Ensure the text portion uses the remaining space */
+.refresh-interval-input :deep(.input-string) {
+  flex: 1 1 auto;
+  min-width: 0;
+  width: auto !important;
+}
+.refresh-interval-toggle {
+  flex: 0 0 auto;
+  padding-bottom: 2px;
 }
 </style>

--- a/shell/edit/catalog.cattle.io.clusterrepo.vue
+++ b/shell/edit/catalog.cattle.io.clusterrepo.vue
@@ -342,9 +342,10 @@ export default {
           v-model:value.trim="value.spec.refreshInterval"
           :label="t('catalog.repo.refreshInterval.label')"
           :mode="mode"
-          min="0"
-          :suffix="t('unit.hour', { count: value.spec.refreshInterval })"
-          :placeholder="t('catalog.repo.refreshInterval.placeholder', { hours: clusterRepoType === CLUSTER_REPO_TYPES.OCI_URL ? 24 : 6 })"
+          :min="-1"
+          :suffix="t('suffix.sec')"
+          :placeholder="t('catalog.repo.refreshInterval.placeholder', { value: value.defaultRefreshIntervalHours, units: value.defaultRefreshIntervalHours > 1 ? 'hours' : 'hour' })"
+          :tooltip="t('catalog.repo.refreshInterval.tooltip')"
           @update:value="updateRefreshInterval($event)"
         />
       </div>

--- a/shell/edit/catalog.cattle.io.clusterrepo.vue
+++ b/shell/edit/catalog.cattle.io.clusterrepo.vue
@@ -110,6 +110,7 @@ export default {
       refreshInterval = value;
       refreshIntervalUnits = units;
     }
+    const refreshIntervalUpdatesEnabled = !refreshIntervalDisabled;
 
     return {
       CLUSTER_REPO_TYPES,
@@ -127,7 +128,7 @@ export default {
       previousName:        '',
       previousDescription: '',
       refreshInterval,
-      refreshIntervalDisabled,
+      refreshIntervalUpdatesEnabled,
       refreshIntervalUnits,
       refreshIntervalUnitOptions,
     };
@@ -224,7 +225,7 @@ export default {
       this.value.spec.exponentialBackOffValues[key] = Number(newVal);
     },
     onRefreshIntervalInput({ selected, text }) { // InputWithSelect emits "update:value" with { selected, text }
-      if (this.refreshIntervalDisabled) {
+      if (!this.refreshIntervalUpdatesEnabled) {
         return;
       }
 
@@ -253,7 +254,7 @@ export default {
       this.value.spec.refreshInterval = Number(refreshInterval) * unitToSecondsMultiplier(units);
     },
     applyRefreshIntervalOnSave() {
-      if (this.refreshIntervalDisabled || this.refreshInterval < 0) {
+      if (!this.refreshIntervalUpdatesEnabled || this.refreshInterval < 0) {
         this.value.spec.refreshInterval = -1;
       } else if (this.refreshInterval === 0) {
         delete this.value.spec.refreshInterval;
@@ -429,16 +430,16 @@ export default {
               :mode="mode"
               type="number"
               :options="refreshIntervalUnitOptions"
-              :disabled="refreshIntervalDisabled || isView"
+              :disabled="!refreshIntervalUpdatesEnabled || isView"
               :placeholder="t('catalog.repo.refreshInterval.placeholder', { value: value.defaultRefreshIntervalHours })"
               @update:value="onRefreshIntervalInput"
             />
           </div>
           <div class="refresh-interval-toggle">
             <Checkbox
-              v-model:value="refreshIntervalDisabled"
+              v-model:value="refreshIntervalUpdatesEnabled"
               :mode="mode"
-              :label="t('generic.disabled')"
+              :label="t('generic.enabled')"
             />
           </div>
         </div>

--- a/shell/models/catalog.cattle.io.clusterrepo.js
+++ b/shell/models/catalog.cattle.io.clusterrepo.js
@@ -1,6 +1,7 @@
 import { parse } from '@shell/utils/url';
 import { CATALOG } from '@shell/config/labels-annotations';
 import { insertAt } from '@shell/utils/array';
+import { formatDuration } from '@shell/utils/time';
 import { CLUSTER_REPO_APPCO_AUTH_GENERATE_NAME, CATALOG as CATALOG_TYPE } from '@shell/config/types';
 import { colorForState, stateDisplay } from '@shell/plugins/dashboard-store/resource-class';
 import { _CREATE } from '@shell/config/query-params';
@@ -218,6 +219,24 @@ export default class ClusterRepo extends SteveModel {
     return this.spec?.gitBranch || '(default)';
   }
 
+  get defaultRefreshIntervalHours() {
+    return this.isOciType ? 24 : 1;
+  }
+
+  get defaultRefreshInterval() {
+    return 60 * 60 * this.defaultRefreshIntervalHours;
+  }
+
+  get refreshInterval() {
+    const value = this.spec?.refreshInterval || this.defaultRefreshInterval;
+
+    if (value === -1) {
+      return 'Disabled';
+    }
+
+    return formatDuration(value);
+  }
+
   get details() {
     return [
       {
@@ -229,6 +248,10 @@ export default class ClusterRepo extends SteveModel {
         content:       this.status.downloadTime,
         formatter:     'LiveDate',
         formatterOpts: { addSuffix: true },
+      },
+      {
+        label:   'Refresh Interval',
+        content: this.refreshInterval,
       },
     ];
   }

--- a/shell/models/catalog.cattle.io.clusterrepo.js
+++ b/shell/models/catalog.cattle.io.clusterrepo.js
@@ -231,7 +231,7 @@ export default class ClusterRepo extends SteveModel {
     const value = this.spec?.refreshInterval || this.defaultRefreshInterval;
 
     if (value === -1) {
-      return 'Disabled';
+      return this.t('generic.disabled');
     }
 
     return formatDuration(value);
@@ -250,7 +250,7 @@ export default class ClusterRepo extends SteveModel {
         formatterOpts: { addSuffix: true },
       },
       {
-        label:   'Refresh Interval',
+        label:   this.t('catalog.repo.refreshInterval.label'),
         content: this.refreshInterval,
       },
     ];

--- a/shell/utils/__tests__/time.test.ts
+++ b/shell/utils/__tests__/time.test.ts
@@ -1,5 +1,5 @@
 import { DATE_FORMAT, TIME_FORMAT } from '@shell/store/prefs';
-import { dateTimeFormat, isMissingDate } from '@shell/utils/time';
+import { dateTimeFormat, isMissingDate, formatDuration } from '@shell/utils/time';
 import { type Store } from 'vuex';
 import { ZERO_TIME } from '@shell/config/types';
 
@@ -40,5 +40,15 @@ describe('function: dateTimeFormat', () => {
     const formattedDate = dateTimeFormat(undefined, store);
 
     expect(formattedDate).toBe('');
+  });
+});
+
+describe('function: formatDuration', () => {
+  it('should format durations correctly', () => {
+    expect(formatDuration(30)).toBe('30s');
+    expect(formatDuration(126)).toBe('2m 6s');
+    expect(formatDuration(3610)).toBe('1h 10s');
+    expect(formatDuration(86520)).toBe('1d 2m');
+    expect(formatDuration(100000)).toBe('1d 3h 46m 40s');
   });
 });

--- a/shell/utils/__tests__/time.test.ts
+++ b/shell/utils/__tests__/time.test.ts
@@ -1,5 +1,5 @@
 import { DATE_FORMAT, TIME_FORMAT } from '@shell/store/prefs';
-import { dateTimeFormat, isMissingDate, formatDuration } from '@shell/utils/time';
+import { dateTimeFormat, isMissingDate, formatDuration, secondsToLargestUnit } from '@shell/utils/time';
 import { type Store } from 'vuex';
 import { ZERO_TIME } from '@shell/config/types';
 
@@ -50,5 +50,30 @@ describe('function: formatDuration', () => {
     expect(formatDuration(3610)).toBe('1h 10s');
     expect(formatDuration(86520)).toBe('1d 2m');
     expect(formatDuration(100000)).toBe('1d 3h 46m 40s');
+  });
+});
+
+describe('function: secondsToLargestUnit', () => {
+  it.each([
+    [1, { units: 'sec', value: 1 }],
+    [59, { units: 'sec', value: 59 }],
+    [60, { units: 'min', value: 1 }],
+    [61, { units: 'sec', value: 61 }],
+    [3600, { units: 'hour', value: 1 }],
+    [3660, { units: 'min', value: 61 }],
+    [3661, { units: 'sec', value: 3661 }],
+    [86400, { units: 'day', value: 1 }],
+    [90000, { units: 'hour', value: 25 }],
+  ])('given %p seconds, returns %p', (seconds, expected) => {
+    expect(secondsToLargestUnit(seconds)).toStrictEqual(expected);
+  });
+
+  it('prefers the largest unit when multiple are evenly divisible', () => {
+    // 172800 divisible by day/hour/min: should choose day
+    expect(secondsToLargestUnit(172800)).toStrictEqual({ units: 'day', value: 2 });
+  });
+
+  it('handles 0 seconds', () => {
+    expect(secondsToLargestUnit(0)).toStrictEqual({ units: 'sec', value: 0 });
   });
 });

--- a/shell/utils/time.ts
+++ b/shell/utils/time.ts
@@ -129,6 +129,26 @@ export function elapsedTime(seconds: any) {
 }
 
 /**
+ * Formats duration into days, hours, minutes and seconds components
+ * @param seconds Date string to format
+ * @returns Formatted duration string
+ */
+export function formatDuration(seconds: number): string {
+  const d = Math.trunc(seconds / 86400);
+  const h = Math.trunc((seconds % 86400) / 3600);
+  const m = Math.trunc((seconds % 3600) / 60);
+  const s = seconds % 60;
+
+  return [
+    { unit: 'd', value: d },
+    { unit: 'h', value: h },
+    { unit: 'm', value: m },
+    { unit: 's', value: s },
+  ].filter((e) => !!e.value)
+    .map((e) => `${ e.value }${ e.unit }`).join(' ');
+}
+
+/**
    * Format date and time using user preferences
    * @param value Date string to format
    * @returns Formatted date string

--- a/shell/utils/time.ts
+++ b/shell/utils/time.ts
@@ -134,6 +134,10 @@ export function elapsedTime(seconds: any) {
  * returns { units: string, value: number }
  */
 export function secondsToLargestUnit(seconds: number) {
+  if (seconds <= 0) {
+    return { units: 'sec', value: seconds };
+  }
+
   for (const x of [
     { units: 'day', multiplier: 86400 },
     { units: 'hour', multiplier: 3600 },

--- a/shell/utils/time.ts
+++ b/shell/utils/time.ts
@@ -129,6 +129,25 @@ export function elapsedTime(seconds: any) {
 }
 
 /**
+ * Converts seconds to the largest unit that applies evenly, otherwise keeps seconds
+ * @param seconds
+ * returns { units: string, value: number }
+ */
+export function secondsToLargestUnit(seconds: number) {
+  for (const x of [
+    { units: 'day', multiplier: 86400 },
+    { units: 'hour', multiplier: 3600 },
+    { units: 'min', multiplier: 60 },
+  ]) {
+    if (seconds % x.multiplier === 0) {
+      return { units: x.units, value: seconds / x.multiplier };
+    }
+  }
+
+  return { units: 'sec', value: seconds };
+}
+
+/**
  * Formats duration into days, hours, minutes and seconds components
  * @param seconds Date string to format
  * @returns Formatted duration string


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Fixes #16852

Misc fixes/improvements discovered while working with ClusterRepos.

### Occurred changes and/or fixed issues

- Fixes "Refresh Interval" units.
- Fixes default value for git-based resources (1 instead of 6 hours).
- Adds a new human-readable "Refresh Interval" to the details page.
- Adds support for disabling periodic updates (rancher/rancher#54124).

### Areas or cases that should be tested

Displaying/editing ClusteRepos, for which I've added unit/e2e tests.

### Areas which could experience regressions

Editing ClusterRepo refreshInterval should really honour the value being submitted.

### Screenshot/Video

<details>
<summary>Details</summary>

-----

Default input box, shows correct unix and default value:

<img width="499" height="88" alt="Screenshot 2026-03-17 at 16 18 02" src="https://github.com/user-attachments/assets/ff4665fe-66a2-4ad9-acdc-6bc5893d2a7f" />

-----

New tooltip:
<img width="508" height="115" alt="Screenshot 2026-03-17 at 16 17 56" src="https://github.com/user-attachments/assets/890199c8-9983-4968-8509-6857ed36a49e" />

-----

New data in details page (blank value):
<img width="315" height="176" alt="Screenshot 2026-03-18 at 17 14 07" src="https://github.com/user-attachments/assets/c38b98ca-1bf2-4a20-9bd7-b00973692cbb" />

-----

Shows disabled if `-1`:
<img width="342" height="179" alt="Screenshot 2026-03-18 at 17 14 22" src="https://github.com/user-attachments/assets/9bcec3ee-3e9e-4ba3-80ca-1c6c2ac10dcc" />

-----

</details>

### Checklist
- [X] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [X] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [X] The PR template has been filled out
- [X] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [X] The PR has a reviewer assigned
- [X] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [X] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
