### PR TITLE
Fixing a problem where the `more actions` buttons didn't align on the projects/namespaces list page.

### DIFF
--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -593,15 +593,12 @@ export default {
 
 .project-namespaces {
   & :deep() {
-    .project-namespaces-table table {
-      table-layout: fixed;
-    }
-
     .project-name {
       line-height: 30px;
     }
 
     .project-bar {
+      contain: inline-size;
       display: flex;
       flex-direction: row;
       justify-content: space-between;


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16796
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

`table-layout: fixed` forced the action column to 40px instead of the 53px it naturally grows to on other list pages.

Example:
<img width="1449" height="423" alt="image" src="https://github.com/user-attachments/assets/32fd8faf-3204-4933-b78e-fcbbb8f95427" />


### Technical notes summary

- Removed`table-layout: fixed` so the columns could resize.
- Switched to `contain: inline-size` to account for large project name over flow. Originally resolved in this [PR](https://github.com/rancher/dashboard/pull/10295).

### Areas or cases that should be tested

- Project/Namespaces list page now has the more actions buttons aligned.
- Projects with large names still truncate. - See the screenshot below for an example

Long name in case it helps:
```
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
```

### Areas which could experience regressions
- Projects with large names


### Screenshot/Video
<img width="1876" height="1350" alt="image" src="https://github.com/user-attachments/assets/1dacbb36-9986-47e5-bddb-39d075267dd2" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
