### PR TITLE
Automation: Fix fleet clusters handle missing sub row

### DIFF
--- a/cypress/e2e/po/pages/fleet/fleet.cattle.io.cluster.po.ts
+++ b/cypress/e2e/po/pages/fleet/fleet.cattle.io.cluster.po.ts
@@ -65,6 +65,10 @@ export class FleetClusterDetailsPo extends BaseDetailPagePo {
   addAppButton() {
     return this.self().get('.btn').contains('Create App Bundle');
   }
+
+  clusterLabels(): Cypress.Chainable {
+    return this.self().find('.tag-data');
+  }
 }
 
 export class FleetClusterEditPo extends BaseDetailPagePo {

--- a/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
@@ -7,7 +7,7 @@ import { WorkloadsDeploymentsListPagePo } from '@/cypress/e2e/po/pages/explorer/
 import * as path from 'path';
 import * as jsyaml from 'js-yaml';
 import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
-import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT, VERY_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import { EXTRA_LONG_TIMEOUT_OPT, LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT, VERY_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 import { FeatureFlagsPagePo } from '@/cypress/e2e/po/pages/global-settings/feature-flags.po';
 import LoadingPo from '@/cypress/e2e/po/components/loading.po';
 
@@ -108,7 +108,7 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
     fleetClusterListPage.resourceTableDetails(clusterName, 2).should('be.visible');
     // check cluster state in fleet
     fleetClusterListPage.resourceTableDetails(clusterName, 1).contains('Not Ready', MEDIUM_TIMEOUT_OPT);
-    fleetClusterListPage.resourceTableDetails(clusterName, 1).contains('Active', LONG_TIMEOUT_OPT);
+    fleetClusterListPage.resourceTableDetails(clusterName, 1).contains('Active', EXTRA_LONG_TIMEOUT_OPT);
     // check Git Repos ready
     fleetClusterListPage.resourceTableDetails(clusterName, 3).should('have.text', '1');
     // check Helm Ops ready
@@ -117,12 +117,11 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
     fleetClusterListPage.resourceTableDetails(clusterName, 5).should('have.text', '2');
     // check resources: testing https://github.com/rancher/dashboard/issues/11154
     fleetClusterListPage.resourceTableDetails(clusterName, 6).contains( ' 7 ', MEDIUM_TIMEOUT_OPT);
-    // check cluster labels
-    fleetClusterListPage.list().resourceTable().sortableTable()
-      .subRows()
-      .should('contain.text', 'foo=bar');
 
     const fleetClusterDetailsPage = new FleetClusterDetailsPo(namespace, clusterName);
+
+    // check cluster labels
+    fleetClusterDetailsPage.clusterLabels().contains('foo: bar').should('be.visible');
 
     // go to cluster details in fleet
     fleetClusterListPage.goToDetailsPage(clusterName);
@@ -140,7 +139,7 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
     // check target
     fleetClusterDetailsPage.appBundlesList().resourceTableDetails(gitRepo, 5).contains('All');
     // check cluster resources
-    fleetClusterDetailsPage.appBundlesList().resourceTableDetails(gitRepo, 7).should('have.text', ' 1 ');
+    fleetClusterDetailsPage.appBundlesList().resourceTableDetails(gitRepo, 7).should('contain.text', '—');
   });
 
   it('check all tabs are available in the details view', () => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/qa-tasks#2268

<!-- Define findings related to the feature or bug issue. -->

This fix addresses an issue in fleet cluster automation where validation depended on the presence of a subRow, which is no longer used in newer versions.

The subRow field existed in version 2.11, but it has been removed starting from more recent versions (e.g., 2.14).

The previous validation logic incorrectly assumed the presence of this field, causing failures in cluster handling.

The validation has now been updated to properly handle the current data structure and no longer depends on subRow.

**Additionally:**

Extra wait time has been introduced to ensure the cluster has enough time to update and reflect its correct status before proceeding with further actions.

**Expected Result:**

- Cluster automation should no longer fail due to missing subRow.
- Status updates should be more reliable due to the added buffer time.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

**Rancher version 2.11**

<img width="1505" height="824" alt="Screenshot 2026-03-18 at 3 04 52 p m" src="https://github.com/user-attachments/assets/d3ee3c13-b7be-4a13-a288-856de4fa990a" />

**Rancher version 2.14**

<img width="1923" height="907" alt="Screenshot 2026-03-19 at 3 40 13 p m" src="https://github.com/user-attachments/assets/04ec443b-e4d1-44ff-999f-4fecf9dccdf3" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
