### PR TITLE
fix error being swallowed when trying to initialize plugin

### DIFF
--- a/shell/core/__tests__/extension-manager-impl.test.js
+++ b/shell/core/__tests__/extension-manager-impl.test.js
@@ -299,6 +299,28 @@ describe('extension Manager', () => {
       delete window[pluginId];
     });
 
+    it('surfaces the plugin id and original error message when initialization fails', async() => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const pluginId = 'surface-error-plugin';
+      const originalError = new Error('something went wrong');
+      const mockPluginInit = jest.fn().mockImplementation(() => {
+        throw originalError;
+      });
+
+      window[pluginId] = { default: mockPluginInit };
+
+      const loadPromise = manager.loadAsync(pluginId, 'test.js');
+      const script = document.head.querySelector(`script[id="${ pluginId }"]`);
+
+      script.onload();
+
+      await expect(loadPromise).rejects.toThrow(`Could not initialize plugin ${ pluginId } - ${ originalError.message }`);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(`Could not initialize plugin ${ pluginId }`, originalError);
+
+      consoleErrorSpy.mockRestore();
+      delete window[pluginId];
+    });
+
     it('rejects if script load fails', async() => {
       const pluginId = 'fail-plugin';
       const loadPromise = manager.loadAsync(pluginId, 'bad-url.js');

--- a/shell/core/extension-manager-impl.js
+++ b/shell/core/extension-manager-impl.js
@@ -124,7 +124,9 @@ export const createExtensionManager = (context) => {
           } catch (e) {
             delete plugins[id];
 
-            return reject(new Error('Could not initialize plugin'));
+            console.error(`Could not initialize plugin ${ id }`, e); // eslint-disable-line no-console
+
+            return reject(new Error(`Could not initialize plugin ${ id } - ${ e?.message }`));
           }
 
           // Load all of the types etc from the plugin


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16973 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix error being swallowed when trying to initialize plugin

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
