### PR TITLE
[backport-2.13] Automation - Prime ingress tests maintenance

### DIFF
--- a/cypress/e2e/po/pages/explorer/ingress.po.ts
+++ b/cypress/e2e/po/pages/explorer/ingress.po.ts
@@ -68,19 +68,19 @@ export class IngressCreateEditPo extends BaseDetailPagePo {
   }
 
   setTargetServiceValueByLabel(arrayListIndex: number, value: string) {
-    const item = this.rulesList().arrayListItem(arrayListIndex);
-    const select = new LabeledSelectPo(item.find('.col:nth-of-type(2) .unlabeled-select'));
+    const select = new LabeledSelectPo(() => this.rulesList().arrayListItem(arrayListIndex).find('.col:nth-of-type(2) .unlabeled-select'));
 
     select.toggle();
     select.clickOptionWithLabel(value);
+    select.checkOptionSelected(value);
   }
 
   setPortValueByLabel(arrayListIndex: number, value: string) {
-    const item = this.rulesList().arrayListItem(arrayListIndex);
-    const select = new LabeledSelectPo(item.find('.col:nth-of-type(3) .unlabeled-select'));
+    const select = new LabeledSelectPo(() => this.rulesList().arrayListItem(arrayListIndex).find('.col:nth-of-type(3) .unlabeled-select'));
 
     select.toggle();
     select.clickOptionWithLabel(value);
+    select.checkOptionSelected(value);
   }
 
   certificatesList() {

--- a/cypress/e2e/tests/pages/explorer/service-discovery/ingress.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/service-discovery/ingress.spec.ts
@@ -29,7 +29,12 @@ describe('Ingresses', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] 
     // testing https://github.com/rancher/dashboard/issues/11086
     cy.get('@consoleWarn').should('not.be.calledWith', warnMsg);
 
-    cy.title().should('eq', 'Rancher - local - Ingresses');
+    cy.getRancherVersion().then((version) => {
+      const expectedTitle = version.RancherPrime === 'true' ? 'Rancher Prime - local - Ingresses' : 'Rancher - local - Ingresses';
+
+      cy.log(`Expected title is: ${ expectedTitle }`);
+      cy.title().should('eq', expectedTitle);
+    });
   });
 
   it('can open "Edit as YAML"', () => {
@@ -74,8 +79,6 @@ describe('Ingresses', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] 
 
     it('can select rules and certificates in Create mode', () => {
       cy.viewport(1440, 900);
-
-      cy.log('!!!!!!!!!!!!!!!!!!', namespace);
 
       ingressListPagePo.goTo();
       ingressListPagePo.waitForPage();
@@ -123,7 +126,7 @@ describe('Ingresses', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] 
       ingressCreatePagePo.setSecretNameValueByLabel(1, secretsNamesList[1]);
       ingressCreatePagePo.setHostValueByIndex(1, 'bar1');
 
-      ingressCreatePagePo.resourceDetail().createEditView().saveAndWaitForRequests('POST', 'v1/networking.k8s.io.ingresses')
+      ingressCreatePagePo.resourceDetail().createEditView().saveAndWaitForRequests('POST', '/v1/networking.k8s.io.ingresses')
         .then(({ response }) => {
           expect(response?.statusCode).to.eq(201);
           expect(response?.body.metadata).to.have.property('name', ingressName);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/qa-tasks#2263

This PR fixes E2E test failures and race conditions within the Ingress creation and evaluation tests in `ingress.spec.ts`

Specifically, it addresses the following findings:

- Title Assertion Failure on Prime
- Payload/Flaky Test Fix
- Detached DOM Error

### Occurred changes and/or fixed issues
Backport of github.com/rancher/dashboard/pull/16950 

### Areas or cases that should be tested
E2E

### Areas which could experience regressions
E2E

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
