### PR TITLE
[backport-2.13] Automation - Prime preferences landing page fixes

### DIFF
--- a/cypress/e2e/po/pages/preferences.po.ts
+++ b/cypress/e2e/po/pages/preferences.po.ts
@@ -85,6 +85,18 @@ export default class PreferencesPagePo extends PagePo {
     return new RadioGroupInputPo('[data-testid="prefs__landingPagePreference"]');
   }
 
+  customPageOptionsDropdown(): LabeledSelectPo {
+    return new LabeledSelectPo('.custom-page-options');
+  }
+
+  expectThemeOptionSelected(theme = 'auto') {
+    this.themeButtons().isSelected(theme);
+  }
+
+  expectClusterOptionExists(clusterName = 'local') {
+    this.customPageOptionsDropdown().self().should('contain', clusterName);
+  }
+
   checkLangDomElement(label: string) {
     return cy.get(label).should('exist');
   }

--- a/cypress/e2e/tests/pages/user-menu/preferences.spec.ts
+++ b/cypress/e2e/tests/pages/user-menu/preferences.spec.ts
@@ -426,7 +426,7 @@ describe('User can update their preferences', () => {
 
   // You want this to be last, there's some issues with logging in and logging out without sessions
 
-  function testLandingPageOption(key: { index: string, value: string, page: string}) {
+  function testLandingPageOption(key: { index: string, value: string, page: string, checkCluster?: string}) {
     /*
     Select each radio button and verify its highlighted
     Validate http request's payload & response contain correct values per selection
@@ -436,7 +436,27 @@ describe('User can update their preferences', () => {
 
     prefPage.goTo();
     prefPage.landingPageRadioBtn().checkVisible();
-    cy.intercept('PUT', 'v1/userpreferences/*').as(`prefUpdate${ key.value }`);
+
+    // Check if the dropdown exists before doing anything for the 'specific cluster' option
+    if (key.checkCluster) {
+      // Ensure the clusters fetch has completed and the Select component has populated
+      // with 'local' before we try to select the radio button.
+      prefPage.expectClusterOptionExists(key.checkCluster);
+    }
+
+    cy.intercept('PUT', 'v1/userpreferences/*', (req) => {
+      let body = req.body;
+
+      if (typeof body === 'string') {
+        try {
+          body = JSON.parse(body);
+        } catch (e) { }
+      }
+
+      if (body?.data?.['after-login-route'] === key.value) {
+        req.alias = `prefUpdate${ key.value }`;
+      }
+    });
     prefPage.landingPageRadioBtn().set(parseInt(key.index));
     cy.wait(`@prefUpdate${ key.value }`).then(({ request, response }) => {
       expect(response?.statusCode).to.eq(200);
@@ -482,7 +502,7 @@ describe('User can update their preferences', () => {
 
   it('Can select login landing page - specific cluster', { tags: ['@userMenu', '@adminUser'] }, () => {
     testLandingPageOption({ // This option only works when there is an existing local cluster
-      index: '2', value: '{\"name\":\"c-cluster\",\"params\":{\"cluster\":\"local\"}}', page: '/explore'
+      index: '2', value: '{\"name\":\"c-cluster\",\"params\":{\"cluster\":\"local\"}}', page: '/explore', checkCluster: 'local'
     });
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/qa-tasks#2281

Fix flaky Cypress E2E tests for the User Preferences login landing page.

### Occurred changes and/or fixed issues
Bakcport of https://github.com/rancher/dashboard/pull/16953


### Areas or cases that should be tested
E2E

### Areas which could experience regressions
E2E

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
