### PR TITLE
refactor: move HarvesterServiceAddOnConfig.vue to pkg/harvester-manager

### DIFF
--- a/pkg/harvester-manager/components/HarvesterServiceAddOnConfig.vue
+++ b/pkg/harvester-manager/components/HarvesterServiceAddOnConfig.vue
@@ -1,9 +1,8 @@
 <script>
 import { mapGetters } from 'vuex';
 import semver from 'semver';
-
 import LabeledSelect from '@shell/components/form/LabeledSelect';
-import { _CREATE } from '@shell/config/query-params';
+import { _CREATE, _EDIT } from '@shell/config/query-params';
 import { get } from '@shell/utils/object';
 import { HCI as HCI_LABELS_ANNOTATIONS } from '@shell/config/labels-annotations';
 import { SERVICE } from '@shell/config/types';
@@ -19,32 +18,20 @@ const HARVESTER_ADD_ON_CONFIG = [{
   default:      ''
 }];
 
+const HARVESTER_CLOUD_PROVIDER = 'harvester-cloud-provider';
+
 export default {
+  name: 'HarvesterServiceAddOnConfig',
+
   components: { LabeledSelect },
 
   props: {
-    mode: {
-      type:    String,
-      default: _CREATE,
-    },
-
-    value: {
+    resource: {
       type:    Object,
       default: () => {
         return {};
       }
     },
-
-    registerBeforeHook: {
-      type:    Function,
-      default: null
-    },
-  },
-
-  created() {
-    if (this.registerBeforeHook) {
-      this.registerBeforeHook(this.willSave, 'harvesterWillSave');
-    }
   },
 
   async fetch() {
@@ -61,19 +48,15 @@ export default {
   },
 
   data() {
+    const annotations = this.resource?.metadata?.annotations || {};
+
     const harvesterAddOnConfig = {};
 
     HARVESTER_ADD_ON_CONFIG.forEach((c) => {
-      harvesterAddOnConfig[c.variableName] = this.value.metadata.annotations[c.key] || c.default;
+      harvesterAddOnConfig[c.variableName] = annotations[c.key] || c.default;
     });
 
-    let showShareIP;
-
-    if (this.value.metadata.annotations[HCI_LABELS_ANNOTATIONS.PRIMARY_SERVICE]) {
-      showShareIP = true;
-    } else {
-      showShareIP = false;
-    }
+    const showShareIP = !!annotations[HCI_LABELS_ANNOTATIONS.PRIMARY_SERVICE];
 
     return {
       ...harvesterAddOnConfig,
@@ -84,6 +67,10 @@ export default {
 
   computed: {
     ...mapGetters(['allowedNamespaces', 'namespaces', 'currentCluster']),
+
+    currentMode() {
+      return this.$route?.query?.mode === _EDIT ? _EDIT : _CREATE;
+    },
 
     ipamOptions() {
       return [{
@@ -96,7 +83,7 @@ export default {
     },
 
     portOptions() {
-      const ports = this.value?.spec?.ports || [];
+      const ports = this.resource?.spec?.ports || [];
 
       return ports.filter((p) => p.port && p.protocol === 'TCP').map((p) => p.port) || [];
     },
@@ -111,7 +98,7 @@ export default {
         const ingress = s?.status?.loadBalancer?.ingress || [];
 
         return ingress.length > 0 &&
-                !s?.metadata?.annotations?.['cloudprovider.harvesterhci.io/primary-service'] &&
+                !s?.metadata?.annotations?.[HCI_LABELS_ANNOTATIONS.PRIMARY_SERVICE] &&
                 s.spec?.type === 'LoadBalancer' &&
                 namespaces[s.metadata.namespace];
       });
@@ -125,12 +112,13 @@ export default {
 
       if (kubernetesVersionExtension.startsWith('+rke2')) {
         const charts = ((this.rke2Versions?.data || []).find((v) => v.id === kubernetesVersion) || {}).charts;
-        let ccmVersion = charts?.['harvester-cloud-provider']?.version || '';
+        let ccmVersion = charts?.[HARVESTER_CLOUD_PROVIDER]?.version || '';
 
         if (ccmVersion.endsWith('00')) {
           ccmVersion = ccmVersion.slice(0, -2);
         }
 
+        // check since share IP is only supported in ccm version 0.2.0 and above
         return semver.satisfies(ccmVersion, '>=0.2.0');
       } else {
         return true;
@@ -138,28 +126,36 @@ export default {
     },
   },
 
+  watch: {
+    ipam() {
+      this.syncAnnotations();
+    },
+
+    sharedService() {
+      this.syncAnnotations();
+    },
+
+    showShareIP() {
+      this.syncAnnotations();
+    }
+  },
+
   methods: {
-    willSave() {
-      const errors = [];
-
-      if (this.showShareIP) {
-        if (!this.sharedService) {
-          errors.push(this.t('validation.required', { key: this.t('servicesPage.harvester.shareIP.label') }, true));
-        }
+    syncAnnotations() {
+      if (!this.resource?.metadata) {
+        return;
       }
 
-      if (errors.length > 0) {
-        return Promise.reject(errors);
-      }
+      this.resource.metadata.annotations = this.resource.metadata.annotations || {};
 
       HARVESTER_ADD_ON_CONFIG.forEach((c) => {
-        this.value.metadata.annotations[c.key] = String(get(this, c.variableName));
+        this.resource.metadata.annotations[c.key] = String(get(this, c.variableName));
       });
 
       if (this.showShareIP) {
-        delete this.value.metadata.annotations[HCI_LABELS_ANNOTATIONS.CLOUD_PROVIDER_IPAM];
+        delete this.resource.metadata.annotations[HCI_LABELS_ANNOTATIONS.CLOUD_PROVIDER_IPAM];
       } else {
-        delete this.value.metadata.annotations[HCI_LABELS_ANNOTATIONS.PRIMARY_SERVICE];
+        delete this.resource.metadata.annotations[HCI_LABELS_ANNOTATIONS.PRIMARY_SERVICE];
       }
     },
 
@@ -171,36 +167,34 @@ export default {
 </script>
 
 <template>
-  <div>
-    <div class="row mt-30">
-      <div class="col span-6">
-        <LabeledSelect
-          v-if="showShareIP"
-          v-model:value="sharedService"
-          :mode="mode"
-          :options="serviceOptions"
-          :label="t('servicesPage.harvester.shareIP.label')"
-          :disabled="mode === 'edit'"
-        />
-        <LabeledSelect
-          v-else
-          v-model:value="ipam"
-          :mode="mode"
-          :options="ipamOptions"
-          :label="t('servicesPage.harvester.ipam.label')"
-          :disabled="mode === 'edit'"
-        />
-        <div
-          v-if="mode === 'create'"
-          class="mt-10"
+  <div class="row mt-30">
+    <div class="col span-6">
+      <LabeledSelect
+        v-if="showShareIP"
+        v-model:value="sharedService"
+        :mode="currentMode"
+        :options="serviceOptions"
+        :label="t('servicesPage.harvester.shareIP.label')"
+        :disabled="currentMode === 'edit'"
+      />
+      <LabeledSelect
+        v-else
+        v-model:value="ipam"
+        :mode="currentMode"
+        :options="ipamOptions"
+        :label="t('servicesPage.harvester.ipam.label')"
+        :disabled="currentMode === 'edit'"
+      />
+      <div
+        v-if="currentMode === 'create'"
+        class="mt-10"
+      >
+        <a
+          role="button"
+          @click="toggleShareIP"
         >
-          <a
-            role="button"
-            @click="toggleShareIP"
-          >
-            {{ showShareIP ? t('servicesPage.harvester.useIpam.label') : t('servicesPage.harvester.useShareIP.label') }}
-          </a>
-        </div>
+          {{ showShareIP ? t('servicesPage.harvester.useIpam.label') : t('servicesPage.harvester.useShareIP.label') }}
+        </a>
       </div>
     </div>
   </div>

--- a/pkg/harvester-manager/index.ts
+++ b/pkg/harvester-manager/index.ts
@@ -1,5 +1,5 @@
 import { importTypes } from '@rancher/auto-import';
-import { IPlugin } from '@shell/core/types';
+import { IPlugin, TabLocation } from '@shell/core/types';
 
 // Init the package
 export default function(plugin: IPlugin) {
@@ -13,4 +13,34 @@ export default function(plugin: IPlugin) {
   plugin.metadata.icon = require('./icon.svg');
 
   plugin.addProduct(require('./config/harvester-manager'));
+
+  plugin.addTab(
+    TabLocation.RESOURCE_CREATE_PAGE,
+    {
+      resource: ['service'],
+      context:  { showHarvesterAddOnConfig: 'true' }
+    },
+    {
+      name:       'add-on-config',
+      labelKey:   'servicesPage.harvester.title',
+      weight:     -1,
+      showHeader: true,
+      component:  () => import('./components/HarvesterServiceAddOnConfig.vue')
+    }
+  );
+
+  plugin.addTab(
+    TabLocation.RESOURCE_EDIT_PAGE,
+    {
+      resource: ['service'],
+      context:  { showHarvesterAddOnConfig: 'true' }
+    },
+    {
+      name:       'add-on-config',
+      labelKey:   'servicesPage.harvester.title',
+      weight:     -1,
+      showHeader: true,
+      component:  () => import('./components/HarvesterServiceAddOnConfig.vue')
+    }
+  );
 }

--- a/shell/components/Tabbed/index.vue
+++ b/shell/components/Tabbed/index.vue
@@ -76,6 +76,12 @@ export default {
       type:    Boolean,
       default: true,
     },
+
+    extensionParams: {
+      type:    Object,
+      default: null,
+    },
+
     /**
      * Inherited global identifier prefix for tests
      * Define a term based on the parent component to avoid conflicts on multiple components

--- a/shell/edit/service.vue
+++ b/shell/edit/service.vue
@@ -18,7 +18,6 @@ import { ucFirst } from '@shell/utils/string';
 import CruResource from '@shell/components/CruResource';
 import { Banner } from '@components/Banner';
 import Labels from '@shell/components/form/Labels';
-import HarvesterServiceAddOnConfig from '@shell/components/HarvesterServiceAddOnConfig';
 import { clone } from '@shell/utils/object';
 import { POD, CAPI, HCI } from '@shell/config/types';
 import { matching } from '@shell/utils/selector-typed';
@@ -58,7 +57,6 @@ export default {
     Tab,
     Tabbed,
     UnitInput,
-    HarvesterServiceAddOnConfig,
   },
 
   mixins: [CreateEditView, FormValidation],
@@ -350,8 +348,10 @@ export default {
 
     <Tabbed
       :side-tabs="true"
+      :resource="value"
       :use-hash="useTabbedHash"
       :default-tab="defaultTab"
+      :extension-params="{ showHarvesterAddOnConfig: String(showHarvesterAddOnConfig) }"
     >
       <Tab
         v-if="checkTypeIs('ExternalName')"
@@ -470,18 +470,6 @@ export default {
             />
           </div>
         </div>
-      </Tab>
-      <Tab
-        v-if="showHarvesterAddOnConfig"
-        name="add-on-config"
-        :label="t('servicesPage.harvester.title')"
-        :weight="-1"
-      >
-        <HarvesterServiceAddOnConfig
-          :mode="mode"
-          :value="value"
-          :register-before-hook="registerBeforeHook"
-        />
       </Tab>
       <Tab
         v-if="!checkTypeIs('ExternalName') && !checkTypeIs('Headless')"


### PR DESCRIPTION
### Summary
Fixes #7774 


### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
Move HarvesterServiceAddOnConfig.vue out of shell, put into pkg/harvester-manager/components.
- refactor [HarvesterServiceAddOnConfig.vue](https://github.com/rancher/dashboard/pull/16997/changes#diff-af126d984d5b427ce43bf44fd5f8b018c1f4af45dad77bf9561ce28cbbd0829c) and change prop to resource as Tabbed gives extension tab this [prop](https://github.com/rancher/dashboard/blob/e87094530d4394538c501ed3e4a9f7c623796859/shell/components/Tabbed/index.vue#L431).
- Use plugin.addTab() to add HarvesterServiceAddOnConfig.vue into service create/edit page.

### Areas or cases that should be tested
`Add-on Config` tab only appears in cluster provisioned by harvester.
Service Discovery - > Service -> Create -> Load Balancer

 If choose below option, set annotation
- DHCP : `cloudprovider.harvesterhci.io/ipam: dhcp`
- Pool : `cloudprovider.harvesterhci.io/ipam: pool`
- Share IP : `cloudprovider.harvesterhci.io/primary-service: [option]`

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video


https://github.com/user-attachments/assets/5b640fde-663f-4250-a792-2589c90eeecc



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
