### PR TITLE
Add exclusion rules for issue grooming workflow

### DIFF
--- a/.github/workflows/daily-issue-grooming.md
+++ b/.github/workflows/daily-issue-grooming.md
@@ -42,12 +42,50 @@ defined at the bottom of these instructions.
 
 ---
 
+## Exclusion Rules — Skip without grooming
+
+Before applying the Grooming Decision Model to any issue, check whether it falls into an exclusion
+category. If it does, **skip it immediately — take no action, post no comment, apply no labels** —
+and log it as described below.
+
+### Excluded label check
+
+Skip the issue if it carries **any** of the following labels:
+
+- `RFD`
+- `kind/question`
+- `bot/skip-grooming`
+
+### Backport issue check
+
+Skip the issue if **any** of the following conditions are true:
+
+- The issue title matches the pattern `[backport ...]` (e.g. `[backport v2.14.1] Some title`).
+- The issue was authored by `rancher-ui-project-bot`.
+
+### Logging skipped issues
+
+Whenever an issue is skipped due to an exclusion rule, output a single line to the workflow log in
+this format so skipped issues are traceable:
+
+```
+[skip] #{issue_number} — {reason}
+```
+
+Where `{reason}` is one of:
+
+- `excluded label: {label_name}`
+- `backport issue`
+
+---
+
 ## Queue A — New issues to groom
 
 1. List all open issues in this repository that were **created in the last 24 hours**.
 2. Skip any entry that is a pull request.
-3. Skip any issue that already carries the label `bot/ready-for-triage` or `needs-info`.
-4. For each remaining issue, evaluate it against the **Grooming Decision Model** below.
+3. Skip any issue that matches the **Exclusion Rules** above; log each skipped issue.
+4. Skip any issue that already carries the label `bot/ready-for-triage` or `needs-info`.
+5. For each remaining issue, evaluate it against the **Grooming Decision Model** below.
 
    - If `is_groomed` is **true**:
      - Post a comment using this exact format:
@@ -92,13 +130,14 @@ Keep track of every issue number you process in Queue A so Queue B can skip them
 1. List all open issues in this repository that are labeled `needs-info` **and** were updated in
    the last 24 hours.
 2. Skip any entry that is a pull request.
-3. Skip any issue whose number was already processed in Queue A during this run.
-4. For each remaining issue, retrieve its full comment list and find the **last comment posted by
+3. Skip any issue that matches the **Exclusion Rules** above; log each skipped issue.
+4. Skip any issue whose number was already processed in Queue A during this run.
+5. For each remaining issue, retrieve its full comment list and find the **last comment posted by
    the bot** (`github-actions[bot]`).
-5. Apply the **activity guard**: if the last comment on the issue (overall) was posted by the bot
+6. Apply the **activity guard**: if the last comment on the issue (overall) was posted by the bot
    AND `issue.updated_at` ≤ `last_bot_comment.created_at` + 30 minutes, skip this issue — there
    has been no meaningful user activity since the bot last commented.
-6. For issues that pass the activity guard, re-evaluate them against the **Grooming Decision
+7. For issues that pass the activity guard, re-evaluate them against the **Grooming Decision
    Model** below, treating the content of the last bot comment as the previous questions that were
    asked.
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds new exclusion rules for the daily issue grooming workflow.

Fixes #17004 

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Skips issues with `RFD`, `kind/question`, or `bot/skip-grooming` labels
- Skips backport issues
- Logs each skipped issue

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

For this iteration, I'm opting to keep the current approach of specifying the rules like we have previously defined them. Once we have settled on a good set of rules for which issues to exclude, we can then migrate to a more deterministic approach.  

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

We will need to manually run the daily issue grooming workflow/monitor daily runs.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

I think that this change is low risk, but we will need to monitor the daily workflow to ensure that it is behaving as expected.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
