### PR TITLE
Automation: Fix hosted provider bulk action error

### DIFF
--- a/cypress/e2e/tests/pages/manager/hosted-providers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/hosted-providers.spec.ts
@@ -1,6 +1,7 @@
 import HostedProvidersPagePo from '@/cypress/e2e/po/pages/cluster-manager/hosted-providers.po';
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po';
+import { qase } from '@/cypress/support/qase';
 
 describe('Hosted Providers', { testIsolation: 'off', tags: ['@manager', '@adminUser', '@provisioning'] }, () => {
   const providersPage = new HostedProvidersPagePo();
@@ -23,7 +24,7 @@ describe('Hosted Providers', { testIsolation: 'off', tags: ['@manager', '@adminU
     providersPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
   });
 
-  it('can deactivate provider', () => {
+  qase(16620, it('can deactivate provider', () => {
     const expected = {
       aks: false, eks: true, gke: true
     };
@@ -54,7 +55,7 @@ describe('Hosted Providers', { testIsolation: 'off', tags: ['@manager', '@adminU
     clusterList.createCluster();
     createCluster.waitForPage();
     createCluster.gridElementExistanceByName(AKS, 'not.exist');
-  });
+  }));
 
   it('can activate provider', () => {
     const expected = {
@@ -195,6 +196,9 @@ describe('Hosted Providers', { testIsolation: 'off', tags: ['@manager', '@adminU
     providersPage.list().resourceTable().sortableTable().rowSelectCtlWithName(GKE)
       .isChecked();
 
+    // Ensure no loading indicator is visible after interactions
+    providersPage.list().resourceTable().sortableTable()
+      .checkLoadingIndicatorNotVisible();
     cy.intercept('PUT', `v1/management.cattle.io.settings/kev2-operators`).as('updateProviders');
 
     providersPage.list().activate().click();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/qa-tasks#2277

After performing UI interactions, the test now verifies that no loading indicator is visible in the table. This helps ensure the interface has fully finished processing before continuing, reducing flakiness and improving test reliability.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="930" height="405" alt="Screenshot 2026-04-27 at 10 32 05 p m" src="https://github.com/user-attachments/assets/5984228a-5723-49bd-aad6-3b95b18e18a3" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
