### PR TITLE
Jenkins: Skip chart e2e tests when charts are filtered by catalog (2.14)

### DIFF
--- a/cypress/e2e/po/pages/explorer/charts/install-charts.po.ts
+++ b/cypress/e2e/po/pages/explorer/charts/install-charts.po.ts
@@ -54,6 +54,10 @@ export class InstallChartPage extends PagePo {
     return this;
   }
 
+  footerControls() {
+    return cy.get('#wizard-footer-controls');
+  }
+
   chartName() {
     return this.self().get('[data-testid="NameNsDescriptionNameInput"]');
   }

--- a/cypress/e2e/po/pages/explorer/cluster-tools.po.ts
+++ b/cypress/e2e/po/pages/explorer/cluster-tools.po.ts
@@ -28,7 +28,7 @@ export default class ClusterToolsPagePo extends PagePo {
   }
 
   featureChartCards() {
-    return cy.get('[data-testid="tools-app-chart-cards"]').find('[data-testid*="item-card-"]');
+    return cy.get('[data-testid="tools-app-chart-cards"]').find('[data-testid*="item-card-cluster"]');
   }
 
   getCardByName(name: string): RcItemCardPo {

--- a/cypress/e2e/tests/navigation/side-nav/product-side-nav-highlighting.spec.ts
+++ b/cypress/e2e/tests/navigation/side-nav/product-side-nav-highlighting.spec.ts
@@ -6,6 +6,7 @@ import UsersPo from '@/cypress/e2e/po/pages/users-and-auth/users.po';
 import RolesPo from '@/cypress/e2e/po/pages/users-and-auth/roles.po';
 import ClusterProjectMembersPo from '@/cypress/e2e/po/pages/explorer/cluster-project-members.po';
 import { BLANK_CLUSTER } from '@shell/store/store-types.js';
+import { runTestWhenChartAvailable } from '@/cypress/support/commands/rancher-api-commands';
 
 Cypress.config();
 describe('Side navigation: Highlighting ', { tags: ['@navigation', '@adminUser'] }, () => {
@@ -19,6 +20,7 @@ describe('Side navigation: Highlighting ', { tags: ['@navigation', '@adminUser']
 
   beforeEach(() => {
     cy.login();
+    cy.setUserPreference({ 'show-pre-release': true }, true); // Show pre-release versions so charts with only -rc versions appear on Charts page
     HomePagePo.goTo();
   });
 
@@ -36,25 +38,27 @@ describe('Side navigation: Highlighting ', { tags: ['@navigation', '@adminUser']
     productNavPo.activeNavItem().should('equal', 'Cluster and Project Members');
   });
 
-  it('Chart and sub-pages are highlighted correctly', () => {
-    HomePagePo.goTo();
-    chartsPage.goTo();
+  it('Chart and sub-pages are highlighted correctly', function() {
+    runTestWhenChartAvailable(CHART.repo, CHART.id, this, () => {
+      HomePagePo.goTo();
+      chartsPage.goTo();
 
-    const productNavPo = new ProductNavPo();
+      const productNavPo = new ProductNavPo();
 
-    productNavPo.visibleNavTypes().eq(0).should('be.visible').click()
-      .then((link) => {
-        cy.url().should('equal', link.prop('href'));
-      });
-    productNavPo.activeNavItem().should('equal', 'Charts');
+      productNavPo.visibleNavTypes().eq(0).should('be.visible').click()
+        .then((link) => {
+          cy.url().should('equal', link.prop('href'));
+        });
+      productNavPo.activeNavItem().should('equal', 'Charts');
 
-    // Go to install page
-    chartsPage.clickChart(CHART.name);
-    chartPage.waitForChartPage(CHART.repo, CHART.id);
-    productNavPo.activeNavItem().should('equal', 'Charts');
+      // Go to install page
+      chartsPage.clickChart(CHART.name);
+      chartPage.waitForChartPage(CHART.repo, CHART.id);
+      productNavPo.activeNavItem().should('equal', 'Charts');
 
-    chartPage.goToInstall();
-    productNavPo.activeNavItem().should('equal', 'Charts');
+      chartPage.goToInstall();
+      productNavPo.activeNavItem().should('equal', 'Charts');
+    });
   });
 
   it('User Retention highlighting', () => {
@@ -83,5 +87,9 @@ describe('Side navigation: Highlighting ', { tags: ['@navigation', '@adminUser']
     roles.tabs().clickTabWithName(CLUSTER);
     roles.list(CLUSTER).rowWithName('Cluster Owner').checkExists();
     productNavPo.activeNavItem().should('equal', 'Role Templates');
+  });
+
+  after(() => {
+    cy.setUserPreference({ 'show-pre-release': false });
   });
 });

--- a/cypress/e2e/tests/pages/charts/chart-install-wizard.spec.ts
+++ b/cypress/e2e/tests/pages/charts/chart-install-wizard.spec.ts
@@ -2,6 +2,7 @@ import { ChartPage } from '@/cypress/e2e/po/pages/explorer/charts/chart.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import { InstallChartPage } from '@/cypress/e2e/po/pages/explorer/charts/install-charts.po';
 import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import { runTestWhenChartAvailable } from '@/cypress/support/commands/rancher-api-commands';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import ChartInstalledAppsListPagePo from '@/cypress/e2e/po/pages/chart-installed-apps.po';
@@ -27,6 +28,7 @@ describe('Charts Wizard', { testIsolation: 'off', tags: ['@charts', '@adminUser'
 
   before(() => {
     cy.login();
+    cy.setUserPreference({ 'show-pre-release': true }, true); // Show pre-release versions so charts with only -rc versions appear on Charts page
     HomePagePo.goTo();
   });
 
@@ -77,43 +79,45 @@ describe('Charts Wizard', { testIsolation: 'off', tags: ['@charts', '@adminUser'
     const chartName = 'Rancher Backups';
     const customRegistry = 'my.custom.registry:5000';
 
-    it('should persist custom registry when changing chart version', () => {
-      const installedAppsPage = new ChartInstalledAppsListPagePo('local', 'apps');
+    it('should persist custom registry when changing chart version', function() {
+      runTestWhenChartAvailable('rancher-charts', 'rancher-backup', this, () => {
+        const installedAppsPage = new ChartInstalledAppsListPagePo('local', 'apps');
 
-      // We need to install the chart first to have the versions selector show up later when we come back to the install page
-      ChartPage.navTo(null, chartName);
-      chartPage.waitForChartHeader(chartName, MEDIUM_TIMEOUT_OPT);
-      chartPage.goToInstall();
-      installChartPage.nextPage();
+        // We need to install the chart first to have the versions selector show up later when we come back to the install page
+        ChartPage.navTo(null, chartName);
+        chartPage.waitForChartHeader(chartName, MEDIUM_TIMEOUT_OPT);
+        chartPage.goToInstall();
+        installChartPage.nextPage();
 
-      cy.intercept('POST', '/v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install').as('installApp');
-      installChartPage.installChart();
-      namespacePicker.toggle();
-      namespacePicker.clickOptionByLabel('All Namespaces');
-      namespacePicker.isChecked('All Namespaces');
-      namespacePicker.closeDropdown();
-      installedAppsPage.waitForInstallCloseTerminal('installApp', ['rancher-backup', 'rancher-backup-crd']);
+        cy.intercept('POST', '/v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install').as('installApp');
+        installChartPage.installChart();
+        namespacePicker.toggle();
+        namespacePicker.clickOptionByLabel('All Namespaces');
+        namespacePicker.isChecked('All Namespaces');
+        namespacePicker.closeDropdown();
+        installedAppsPage.waitForInstallCloseTerminal('installApp', ['rancher-backup', 'rancher-backup-crd']);
 
-      ChartPage.navTo(null, chartName);
-      chartPage.waitForChartHeader(chartName, MEDIUM_TIMEOUT_OPT);
-      chartPage.goToInstall();
+        ChartPage.navTo(null, chartName);
+        chartPage.waitForChartHeader(chartName, MEDIUM_TIMEOUT_OPT);
+        chartPage.goToInstall();
 
-      // The version selector should now be visible
-      installChartPage.chartVersionSelector().self().should('be.visible');
+        // The version selector should now be visible
+        installChartPage.chartVersionSelector().self().should('be.visible');
 
-      installChartPage.customRegistryCheckbox().set();
+        installChartPage.customRegistryCheckbox().set();
 
-      // Enter custom registry
-      installChartPage.customRegistryInput().self().should('be.visible');
-      installChartPage.customRegistryInput().set(customRegistry);
+        // Enter custom registry
+        installChartPage.customRegistryInput().self().should('be.visible');
+        installChartPage.customRegistryInput().set(customRegistry);
 
-      // Change chart version
-      installChartPage.chartVersionSelector().toggle();
-      installChartPage.chartVersionSelector().clickOption(2);
+        // Change chart version
+        installChartPage.chartVersionSelector().toggle();
+        installChartPage.chartVersionSelector().clickOption(2);
 
-      // Verify custom registry is still there
-      installChartPage.customRegistryCheckbox().isChecked();
-      installChartPage.customRegistryInput().self().should('have.value', customRegistry);
+        // Verify custom registry is still there
+        installChartPage.customRegistryCheckbox().isChecked();
+        installChartPage.customRegistryInput().self().should('have.value', customRegistry);
+      });
     });
 
     after('clean up', () => {
@@ -125,5 +129,9 @@ describe('Charts Wizard', { testIsolation: 'off', tags: ['@charts', '@adminUser'
       cy.createRancherResource('v1', `catalog.cattle.io.apps/${ chartNamespace }/${ chartCrd }?action=uninstall`, '{}');
       cy.updateNamespaceFilter('local', 'none', '{"local":["all://user"]}');
     });
+  });
+
+  after(() => {
+    cy.setUserPreference({ 'show-pre-release': false });
   });
 });

--- a/cypress/e2e/tests/pages/charts/compliance.spec.ts
+++ b/cypress/e2e/tests/pages/charts/compliance.spec.ts
@@ -5,10 +5,12 @@ import { MEDIUM_TIMEOUT_OPT, LONG_TIMEOUT_OPT } from '@/cypress/support/utils/ti
 import Kubectl from '@/cypress/e2e/po/components/kubectl.po';
 import { CompliancePo, ComplianceListPo } from '~/cypress/e2e/po/other-products/compliance.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
+import { runTestWhenChartAvailable } from '@/cypress/support/commands/rancher-api-commands';
 
 describe('Charts', { testIsolation: 'off', tags: ['@charts', '@adminUser'] }, () => {
   before(() => {
     cy.login();
+    cy.setUserPreference({ 'show-pre-release': true }, true); // Show pre-release versions so charts with only -rc versions appear on Charts page
     HomePagePo.goTo();
   });
 
@@ -17,78 +19,80 @@ describe('Charts', { testIsolation: 'off', tags: ['@charts', '@adminUser'] }, ()
     const chartPage = new ChartPage();
 
     describe('YAML view', () => {
-      beforeEach(() => {
-        ChartPage.navTo(null, 'Rancher Compliance');
-        chartPage.waitForChartHeader('Rancher Compliance', MEDIUM_TIMEOUT_OPT);
-        chartPage.goToInstall();
-        installChartPage.nextPage().editYaml();
-      });
-
       describe('UI Elements', () => {
-        it('Footer controls should sticky to bottom', () => {
-          cy.get('#wizard-footer-controls').should('be.visible');
+        it('Footer controls should sticky to bottom', function() {
+          runTestWhenChartAvailable('rancher-charts', 'rancher-compliance', this, () => {
+            ChartPage.navTo(null, 'Rancher Compliance');
+            chartPage.waitForChartHeader('Rancher Compliance', MEDIUM_TIMEOUT_OPT);
+            chartPage.goToInstall();
+            installChartPage.nextPage().editYaml();
 
-          cy.get('#wizard-footer-controls').then(($el) => {
-            const elementRect = $el[0].getBoundingClientRect();
-            const viewportHeight = Cypress.config('viewportHeight');
-            const pageHeight = Cypress.$(cy.state('window')).height();
+            cy.get('#wizard-footer-controls').should('be.visible');
 
-            expect(elementRect.bottom).to.eq(pageHeight);
-            expect(elementRect.bottom).to.eq(viewportHeight);
+            cy.get('#wizard-footer-controls').then(($el) => {
+              const elementRect = $el[0].getBoundingClientRect();
+              const viewportHeight = Cypress.config('viewportHeight');
+              const pageHeight = Cypress.$(cy.state('window')).height();
+
+              expect(elementRect.bottom).to.eq(pageHeight);
+              expect(elementRect.bottom).to.eq(viewportHeight);
+            });
           });
         });
       });
     });
 
     describe('Compliance Chart setup', () => {
-      it('Complete install and a Scan is created', () => {
-        cy.updateNamespaceFilter('local', 'none', '{"local":[]}');
-        const kubectl = new Kubectl();
-        const compliance = new CompliancePo();
-        const complianceList = new ComplianceListPo();
-        const sideNav = new ProductNavPo();
-        const terminal = new Kubectl();
+      it('Complete install and a Scan is created', function() {
+        runTestWhenChartAvailable('rancher-charts', 'rancher-compliance', this, () => {
+          cy.updateNamespaceFilter('local', 'none', '{"local":[]}');
+          const kubectl = new Kubectl();
+          const compliance = new CompliancePo();
+          const complianceList = new ComplianceListPo();
+          const sideNav = new ProductNavPo();
+          const terminal = new Kubectl();
 
-        ChartPage.navTo(null, 'Rancher Compliance');
-        chartPage.waitForChartHeader('Rancher Compliance', MEDIUM_TIMEOUT_OPT);
-        chartPage.goToInstall();
+          ChartPage.navTo(null, 'Rancher Compliance');
+          chartPage.waitForChartHeader('Rancher Compliance', MEDIUM_TIMEOUT_OPT);
+          chartPage.goToInstall();
 
-        installChartPage.nextPage();
+          installChartPage.nextPage();
 
-        cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install').as('chartInstall');
-        installChartPage.installChart();
-        cy.wait('@chartInstall').its('response.statusCode').should('eq', 201);
-        kubectl.waitForTerminalStatus('Disconnected');
+          cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install').as('chartInstall');
+          installChartPage.installChart();
+          cy.wait('@chartInstall').its('response.statusCode').should('eq', 201);
+          kubectl.waitForTerminalStatus('Disconnected');
 
-        kubectl.closeTerminal();
+          kubectl.closeTerminal();
 
-        sideNav.navToSideMenuGroupByLabel('Compliance');
-        complianceList.waitForPage();
+          sideNav.navToSideMenuGroupByLabel('Compliance');
+          complianceList.waitForPage();
 
-        // Compliance does not come with any profiles, so create one
+          // Compliance does not come with any profiles, so create one
 
-        // Open terminal
-        terminal.openTerminal(LONG_TIMEOUT_OPT);
+          // Open terminal
+          terminal.openTerminal(LONG_TIMEOUT_OPT);
 
-        // kubectl commands
-        terminal.executeCommand(`apply -f https://raw.githubusercontent.com/rancher/compliance-operator/refs/heads/main/tests/k3s-bench-test.yaml`);
+          // kubectl commands
+          terminal.executeCommand(`apply -f https://raw.githubusercontent.com/rancher/compliance-operator/refs/heads/main/tests/k3s-bench-test.yaml`);
 
-        terminal.closeTerminal();
+          terminal.closeTerminal();
 
-        complianceList.createScan();
-        compliance.waitForPage();
-        compliance.cruResource().saveAndWaitForRequests('POST', 'v1/compliance.cattle.io.clusterscans')
-          .then(({ response }) => {
-            expect(response?.statusCode).to.eq(201);
-            expect(response?.body).to.have.property('type', 'compliance.cattle.io.clusterscan');
-            expect(response?.body.metadata).to.have.property('name');
-            expect(response?.body.metadata).to.have.property('generateName', 'scan-');
-          });
-        complianceList.waitForPage();
-        complianceList.checkVisible();
+          complianceList.createScan();
+          compliance.waitForPage();
+          compliance.cruResource().saveAndWaitForRequests('POST', 'v1/compliance.cattle.io.clusterscans')
+            .then(({ response }) => {
+              expect(response?.statusCode).to.eq(201);
+              expect(response?.body).to.have.property('type', 'compliance.cattle.io.clusterscan');
+              expect(response?.body.metadata).to.have.property('name');
+              expect(response?.body.metadata).to.have.property('generateName', 'scan-');
+            });
+          complianceList.waitForPage();
+          complianceList.checkVisible();
 
-        complianceList.list().resourceTable().checkVisible();
-        complianceList.list().resourceTable().sortableTable().checkRowCount(false, 2);
+          complianceList.list().resourceTable().checkVisible();
+          complianceList.list().resourceTable().sortableTable().checkRowCount(false, 2);
+        });
       });
 
       after('clean up', () => {
@@ -101,5 +105,9 @@ describe('Charts', { testIsolation: 'off', tags: ['@charts', '@adminUser'] }, ()
         cy.updateNamespaceFilter('local', 'none', '{"local":["all://user"]}');
       });
     });
+  });
+
+  after(() => {
+    cy.setUserPreference({ 'show-pre-release': false });
   });
 });

--- a/cypress/e2e/tests/pages/charts/compliance.spec.ts
+++ b/cypress/e2e/tests/pages/charts/compliance.spec.ts
@@ -27,9 +27,9 @@ describe('Charts', { testIsolation: 'off', tags: ['@charts', '@adminUser'] }, ()
             chartPage.goToInstall();
             installChartPage.nextPage().editYaml();
 
-            cy.get('#wizard-footer-controls').should('be.visible');
+            installChartPage.footerControls().should('be.visible');
 
-            cy.get('#wizard-footer-controls').then(($el) => {
+            installChartPage.footerControls().then(($el) => {
               const elementRect = $el[0].getBoundingClientRect();
               const viewportHeight = Cypress.config('viewportHeight');
               const pageHeight = Cypress.$(cy.state('window')).height();

--- a/cypress/e2e/tests/pages/charts/logging.spec.ts
+++ b/cypress/e2e/tests/pages/charts/logging.spec.ts
@@ -11,6 +11,7 @@ import ChartInstalledAppsListPagePo from '@/cypress/e2e/po/pages/chart-installed
 import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 import { CLUSTER_APPS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
 import CardPo from '~/cypress/e2e/po/components/card.po';
+import { runTestWhenChartAvailable } from '@/cypress/support/commands/rancher-api-commands';
 
 describe('Logging Chart', { testIsolation: 'off', tags: ['@charts', '@adminUser'] }, () => {
   const kubectl = new Kubectl();
@@ -25,6 +26,8 @@ describe('Logging Chart', { testIsolation: 'off', tags: ['@charts', '@adminUser'
 
   before(() => {
     cy.login();
+    cy.updateNamespaceFilter('local', 'none', '{"local":[]}');
+    cy.setUserPreference({ 'show-pre-release': true }, true); // Show pre-release versions so charts with only -rc versions appear on Charts page
     HomePagePo.goTo();
 
     cy.createE2EResourceName('logging-flow').then((name) => {
@@ -36,131 +39,135 @@ describe('Logging Chart', { testIsolation: 'off', tags: ['@charts', '@adminUser'
     });
   });
 
-  it('is installed and a rule created', () => {
-    cy.updateNamespaceFilter('local', 'none', '{"local":[]}');
-    const installChartPage = new InstallChartPage();
-    const chartPage = new ChartPage();
-    const sideNav = new ProductNavPo();
-    const loggingOutputList = new LoggingClusteroutputListPagePo();
-    const loggingOutputEdit = new LoggingClusterOutputCreateEditPagePo('local');
+  it('is installed and a rule created', function() {
+    runTestWhenChartAvailable('rancher-charts', 'rancher-logging', this, () => {
+      const installChartPage = new InstallChartPage();
+      const chartPage = new ChartPage();
+      const sideNav = new ProductNavPo();
+      const loggingOutputList = new LoggingClusteroutputListPagePo();
+      const loggingOutputEdit = new LoggingClusterOutputCreateEditPagePo('local');
 
-    cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install').as('chartInstall');
-    ChartPage.navTo(null, 'Logging');
-    chartPage.waitForChartHeader('Logging', { timeout: 20000 });
-    chartPage.waitForPage();
-    chartPage.goToInstall();
-    installChartPage.nextPage();
-    installChartPage.installChart();
+      cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install').as('chartInstall');
+      ChartPage.navTo(null, 'Logging');
+      chartPage.waitForChartHeader('Logging', { timeout: 20000 });
+      chartPage.waitForPage();
+      chartPage.goToInstall();
+      installChartPage.nextPage();
+      installChartPage.installChart();
 
-    cy.wait('@chartInstall', { timeout: 10000 }).its('response.statusCode').should('eq', 201);
-    kubectl.waitForTerminalStatus('Disconnected');
-    kubectl.closeTerminal();
+      cy.wait('@chartInstall', { timeout: 10000 }).its('response.statusCode').should('eq', 201);
+      kubectl.waitForTerminalStatus('Disconnected');
+      kubectl.closeTerminal();
 
-    LoggingClusteroutputListPagePo.navTo();
-    loggingOutputList.waitForPage();
-    loggingOutputList.baseResourceList().masthead().create();
-    loggingOutputEdit.waitForPage();
-    loggingOutputEdit.resourceDetail().createEditView().nameNsDescription().name()
-      .set(outputName);
-    loggingOutputEdit.target().set('random.domain.site');
-    loggingOutputEdit.resourceDetail().createEditView().saveAndWaitForRequests('POST', '/v1/logging.banzaicloud.io.clusteroutputs')
-      .then(({ response }) => {
-        expect(response?.statusCode).to.eq(201);
-        expect(response?.body.metadata).to.have.property('name', outputName);
-      });
-    loggingOutputList.waitForPage();
-    loggingOutputList.baseResourceList().resourceTable().sortableTable().rowElementWithName(outputName)
-      .should('exist');
+      LoggingClusteroutputListPagePo.navTo();
+      loggingOutputList.waitForPage();
+      loggingOutputList.baseResourceList().masthead().create();
+      loggingOutputEdit.waitForPage();
+      loggingOutputEdit.resourceDetail().createEditView().nameNsDescription().name()
+        .set(outputName);
+      loggingOutputEdit.target().set('random.domain.site');
+      loggingOutputEdit.resourceDetail().createEditView().saveAndWaitForRequests('POST', '/v1/logging.banzaicloud.io.clusteroutputs')
+        .then(({ response }) => {
+          expect(response?.statusCode).to.eq(201);
+          expect(response?.body.metadata).to.have.property('name', outputName);
+        });
+      loggingOutputList.waitForPage();
+      loggingOutputList.baseResourceList().resourceTable().sortableTable().rowElementWithName(outputName)
+        .should('exist');
 
-    sideNav.navToSideMenuEntryByLabel('ClusterFlow');
-    loggingFlowList.baseResourceList().masthead().create();
-    loggingFlowCreate.waitForPage();
-    loggingFlowCreate.resourceDetail().createEditView()
-      .nameNsDescription().name()
-      .set(flowName);
-    loggingFlowCreate.resourceDetail().tabs().clickTabWithSelector('[data-testid="btn-outputs"]');
-    loggingFlowCreate.waitForPage(null, 'outputs');
-    loggingFlowCreate.outputSelector().toggle();
-    loggingFlowCreate.outputSelector().clickOptionWithLabel(outputName);
+      sideNav.navToSideMenuEntryByLabel('ClusterFlow');
+      loggingFlowList.baseResourceList().masthead().create();
+      loggingFlowCreate.waitForPage();
+      loggingFlowCreate.resourceDetail().createEditView()
+        .nameNsDescription().name()
+        .set(flowName);
+      loggingFlowCreate.resourceDetail().tabs().clickTabWithSelector('[data-testid="btn-outputs"]');
+      loggingFlowCreate.waitForPage(null, 'outputs');
+      loggingFlowCreate.outputSelector().toggle();
+      loggingFlowCreate.outputSelector().clickOptionWithLabel(outputName);
 
-    // Configure namespaces during creation
-    // testing https://github.com/rancher/dashboard/issues/13845
-    loggingFlowCreate.resourceDetail().tabs().clickTabWithSelector('[data-testid="btn-match"]');
-    loggingFlowCreate.waitForPage(null, 'match');
-    const namespaces = ['fleet-default', 'cattle-system'];
+      // Configure namespaces during creation
+      // testing https://github.com/rancher/dashboard/issues/13845
+      loggingFlowCreate.resourceDetail().tabs().clickTabWithSelector('[data-testid="btn-match"]');
+      loggingFlowCreate.waitForPage(null, 'match');
+      const namespaces = ['fleet-default', 'cattle-system'];
 
-    loggingFlowCreate.setNamespaceValueByLabel(0, namespaces);
-    loggingFlowCreate.resourceDetail().createEditView().saveAndWaitForRequests('POST', '/v1/logging.banzaicloud.io.clusterflows')
-      .then(({ response }) => {
-        expect(response?.statusCode).to.eq(201);
-        expect(response?.body.metadata).to.have.property('name', flowName);
-        expect(response?.body.spec.match[0].select.namespaces[0]).to.contain(namespaces[0]);
-        expect(response?.body.spec.match[0].select.namespaces[1]).to.equal(namespaces[1]);
-      });
-    loggingFlowList.waitForPage();
-    loggingFlowList.list().resourceTable().sortableTable().rowElementWithName(flowName)
-      .should('exist');
-    loggingFlowList.list().resourceTable().goToDetailsPage(flowName);
-    const loggingFlowDetail = new LoggingClusterFlowDetailPagePo('local', 'cattle-logging-system', flowName);
+      loggingFlowCreate.setNamespaceValueByLabel(0, namespaces);
+      loggingFlowCreate.resourceDetail().createEditView().saveAndWaitForRequests('POST', '/v1/logging.banzaicloud.io.clusterflows')
+        .then(({ response }) => {
+          expect(response?.statusCode).to.eq(201);
+          expect(response?.body.metadata).to.have.property('name', flowName);
+          expect(response?.body.spec.match[0].select.namespaces[0]).to.contain(namespaces[0]);
+          expect(response?.body.spec.match[0].select.namespaces[1]).to.equal(namespaces[1]);
+        });
+      loggingFlowList.waitForPage();
+      loggingFlowList.list().resourceTable().sortableTable().rowElementWithName(flowName)
+        .should('exist');
+      loggingFlowList.list().resourceTable().goToDetailsPage(flowName);
+      const loggingFlowDetail = new LoggingClusterFlowDetailPagePo('local', 'cattle-logging-system', flowName);
 
-    loggingFlowDetail.ruleItem(0).should('be.visible');
+      loggingFlowDetail.ruleItem(0).should('be.visible');
+    });
   });
 
   // testing https://github.com/rancher/dashboard/issues/4849
-  it('can uninstall both chart and crd at once', () => {
-    cy.intercept('GET', `${ CLUSTER_APPS_BASE_URL }?*`).as('getCharts');
+  it('can uninstall both chart and crd at once', function() {
+    runTestWhenChartAvailable('rancher-charts', 'rancher-logging', this, () => {
+      cy.intercept('GET', `${ CLUSTER_APPS_BASE_URL }?*`).as('getCharts');
 
-    const clusterTools = new ClusterToolsPagePo('local');
-    const installedAppsPage = new ChartInstalledAppsListPagePo('local', 'apps');
+      const clusterTools = new ClusterToolsPagePo('local');
+      const installedAppsPage = new ChartInstalledAppsListPagePo('local', 'apps');
 
-    installedAppsPage.goTo('local', 'apps');
-    installedAppsPage.waitForPage();
-    cy.wait('@getCharts', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
-    installedAppsPage.appsList().checkVisible(MEDIUM_TIMEOUT_OPT);
-    installedAppsPage.appsList().sortableTable().checkLoadingIndicatorNotVisible();
-    installedAppsPage.appsList().sortableTable().noRowsShouldNotExist();
-    installedAppsPage.appsList().resourceTableDetails(chartApp, 1).should('exist');
-    installedAppsPage.appsList().resourceTableDetails(chartCrd, 1).should('exist');
+      installedAppsPage.goTo('local', 'apps');
+      installedAppsPage.waitForPage();
+      cy.wait('@getCharts', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
+      installedAppsPage.appsList().checkVisible(MEDIUM_TIMEOUT_OPT);
+      installedAppsPage.appsList().sortableTable().checkLoadingIndicatorNotVisible();
+      installedAppsPage.appsList().sortableTable().noRowsShouldNotExist();
+      installedAppsPage.appsList().resourceTableDetails(chartApp, 1).should('exist');
+      installedAppsPage.appsList().resourceTableDetails(chartCrd, 1).should('exist');
 
-    clusterTools.goTo();
-    clusterTools.waitForPage();
-    cy.wait('@getCharts', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
-    clusterTools.deleteChart(chartAppDisplayName);
+      clusterTools.goTo();
+      clusterTools.waitForPage();
+      cy.wait('@getCharts', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
+      clusterTools.deleteChart(chartAppDisplayName);
 
-    const promptRemove = new PromptRemove();
+      const promptRemove = new PromptRemove();
 
-    cy.intercept('POST', `${ CLUSTER_APPS_BASE_URL }/cattle-logging-system/rancher-logging?action=uninstall`).as('chartUninstall');
-    cy.intercept('POST', `${ CLUSTER_APPS_BASE_URL }/cattle-logging-system/rancher-logging-crd?action=uninstall`).as('crdUninstall');
-    promptRemove.checkbox().shouldContainText('Delete the CRD associated with this app');
+      cy.intercept('POST', `${ CLUSTER_APPS_BASE_URL }/cattle-logging-system/rancher-logging?action=uninstall`).as('chartUninstall');
+      cy.intercept('POST', `${ CLUSTER_APPS_BASE_URL }/cattle-logging-system/rancher-logging-crd?action=uninstall`).as('crdUninstall');
+      promptRemove.checkbox().shouldContainText('Delete the CRD associated with this app');
 
-    promptRemove.checkbox().set();
-    promptRemove.checkbox().isChecked();
-    promptRemove.remove();
+      promptRemove.checkbox().set();
+      promptRemove.checkbox().isChecked();
+      promptRemove.remove();
 
-    const card = new CardPo();
+      const card = new CardPo();
 
-    card.checkNotExists(MEDIUM_TIMEOUT_OPT);
-    cy.wait('@chartUninstall').its('response.statusCode').should('eq', 201);
-    cy.wait('@crdUninstall').its('response.statusCode').should('eq', 201);
+      card.checkNotExists(MEDIUM_TIMEOUT_OPT);
+      cy.wait('@chartUninstall').its('response.statusCode').should('eq', 201);
+      cy.wait('@crdUninstall').its('response.statusCode').should('eq', 201);
 
-    kubectl.waitForTerminalStatus('Disconnected', MEDIUM_TIMEOUT_OPT);
-    kubectl.closeTerminalByTabName('Uninstall cattle-logging-system:rancher-logging');
-    kubectl.waitForTerminalStatus('Disconnected', MEDIUM_TIMEOUT_OPT);
-    kubectl.closeTerminalByTabName('Uninstall cattle-logging-system:rancher-logging-crd');
+      kubectl.waitForTerminalStatus('Disconnected', MEDIUM_TIMEOUT_OPT);
+      kubectl.closeTerminalByTabName('Uninstall cattle-logging-system:rancher-logging');
+      kubectl.waitForTerminalStatus('Disconnected', MEDIUM_TIMEOUT_OPT);
+      kubectl.closeTerminalByTabName('Uninstall cattle-logging-system:rancher-logging-crd');
 
-    installedAppsPage.goTo('local', 'apps');
-    installedAppsPage.waitForPage();
-    cy.wait('@getCharts', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
-    installedAppsPage.appsList().checkVisible(MEDIUM_TIMEOUT_OPT);
-    installedAppsPage.appsList().sortableTable().checkLoadingIndicatorNotVisible();
-    installedAppsPage.appsList().sortableTable().noRowsShouldNotExist();
-    installedAppsPage.appsList().sortableTable().rowNames('.col-link-detail', MEDIUM_TIMEOUT_OPT)
-      .should('not.contain', chartApp);
-    // CRD removal may take time to reflect in the UI, so we conditionally wait until it's gone
-    installedAppsPage.appsList().sortableTable().waitForListItemRemoval('.col-link-detail', chartCrd, MEDIUM_TIMEOUT_OPT);
+      installedAppsPage.goTo('local', 'apps');
+      installedAppsPage.waitForPage();
+      cy.wait('@getCharts', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
+      installedAppsPage.appsList().checkVisible(MEDIUM_TIMEOUT_OPT);
+      installedAppsPage.appsList().sortableTable().checkLoadingIndicatorNotVisible();
+      installedAppsPage.appsList().sortableTable().noRowsShouldNotExist();
+      installedAppsPage.appsList().sortableTable().rowNames('.col-link-detail', MEDIUM_TIMEOUT_OPT)
+        .should('not.contain', chartApp);
+      // CRD removal may take time to reflect in the UI, so we conditionally wait until it's gone
+      installedAppsPage.appsList().sortableTable().waitForListItemRemoval('.col-link-detail', chartCrd, MEDIUM_TIMEOUT_OPT);
+    });
   });
 
   after('clean up', () => {
+    cy.setUserPreference({ 'show-pre-release': false });
     cy.createRancherResource('v1', `catalog.cattle.io.apps/${ chartNamespace }/${ chartApp }?action=uninstall`, '{}', false);
     cy.createRancherResource('v1', `catalog.cattle.io.apps/${ chartNamespace }/${ chartCrd }?action=uninstall`, '{}', false);
     cy.updateNamespaceFilter('local', 'none', '{"local":["all://user"]}');

--- a/cypress/e2e/tests/pages/charts/monitoring-istio.spec.ts
+++ b/cypress/e2e/tests/pages/charts/monitoring-istio.spec.ts
@@ -8,6 +8,7 @@ import { PrometheusTab } from '@/cypress/e2e/po/pages/explorer/charts/tabs/prome
 import { GrafanaTab } from '@/cypress/e2e/po/pages/explorer/charts/tabs/grafana-tab.po';
 // import { AlertingTab } from '@/cypress/e2e/po/pages/explorer/charts/tabs/alerting-tab.po';
 import { LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import { runTestWhenChartAvailable } from '@/cypress/support/commands/rancher-api-commands';
 // import { DEFAULT_GRAFANA_STORAGE_SIZE } from '@shell/config/types.js';
 
 describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
@@ -25,7 +26,12 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
 
   before(() => {
     cy.login();
+    cy.setUserPreference({ 'show-pre-release': true }, true); // Show pre-release versions so charts with only -rc versions appear on Charts page
     cy.viewport(1280, 720);
+  });
+
+  after(() => {
+    cy.setUserPreference({ 'show-pre-release': false });
   });
 
   // after(() => {
@@ -63,54 +69,56 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
         cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install').as('prometheusChartCreation');
       });
 
-      it('Prometheus and Grafana should have all relavant storage options and Storage Class inputs', () => {
-        const tabbedOptions = new TabbedPo();
+      it('Prometheus and Grafana should have all relavant storage options and Storage Class inputs', function() {
+        runTestWhenChartAvailable(CHART.repo, CHART.id, this, () => {
+          const tabbedOptions = new TabbedPo();
 
-        ChartPage.navTo(null, 'Monitoring');
-        chartPage.waitForChartPage(CHART.repo, CHART.id);
-        chartPage.goToInstall();
-        installChart.waitForChartPage(CHART.repo, CHART.id);
+          ChartPage.navTo(null, 'Monitoring');
+          chartPage.waitForChartPage(CHART.repo, CHART.id);
+          chartPage.goToInstall();
+          installChart.waitForChartPage(CHART.repo, CHART.id);
 
-        // Check Grafana has all storage options: https://github.com/rancher/dashboard/issues/11540
-        const grafana = new GrafanaTab();
+          // Check Grafana has all storage options: https://github.com/rancher/dashboard/issues/11540
+          const grafana = new GrafanaTab();
 
-        installChart.nextPage().selectTab(tabbedOptions, grafana.tabID());
-        installChart.waitForChartPage(CHART.repo, CHART.id);
-        grafana.storageOptions().getAllOptions().should('have.length', 4);
-        grafana.storageOptions().isChecked(0); // Disabled by default
+          installChart.nextPage().selectTab(tabbedOptions, grafana.tabID());
+          installChart.waitForChartPage(CHART.repo, CHART.id);
+          grafana.storageOptions().getAllOptions().should('have.length', 4);
+          grafana.storageOptions().isChecked(0); // Disabled by default
 
-        const options = ['Disabled', 'Enable With Existing PVC', 'Enable with PVC Template', 'Enable with StatefulSet Template'];
+          const options = ['Disabled', 'Enable With Existing PVC', 'Enable with PVC Template', 'Enable with StatefulSet Template'];
 
-        options.forEach((option, index) => {
-          grafana.storageOptions().getOptionByIndex(index).should('have.text', option);
+          options.forEach((option, index) => {
+            grafana.storageOptions().getOptionByIndex(index).should('have.text', option);
+          });
+
+          // Check Grafana has storage class input: https://github.com/rancher/dashboard/issues/11539
+          grafana.storageOptions().set(2);
+          grafana.storageClass().checkExists();
+          grafana.storageClass().toggle();
+          grafana.storageClass().clickOptionWithLabel(storageClass);
+          grafana.storageClass().checkOptionSelected(storageClass);
+
+          grafana.storageOptions().set(3);
+          grafana.storageClass().checkExists();
+          grafana.storageClass().toggle();
+          grafana.storageClass().clickOptionWithLabel(storageClass);
+          grafana.storageClass().checkOptionSelected(storageClass);
+
+          // Check Prometheus has storage class input: https://github.com/rancher/dashboard/issues/11539
+          installChart.selectTab(tabbedOptions, prometheus.tabID());
+          installChart.waitForChartPage(CHART.repo, CHART.id);
+
+          prometheus.scrollToTabBottom();
+
+          prometheus.persistentStorage().checkVisible();
+          prometheus.persistentStorage().set();
+
+          prometheus.storageClass().checkExists();
+          prometheus.storageClass().toggle();
+          prometheus.storageClass().clickOptionWithLabel(storageClass);
+          prometheus.storageClass().checkOptionSelected(storageClass);
         });
-
-        // Check Grafana has storage class input: https://github.com/rancher/dashboard/issues/11539
-        grafana.storageOptions().set(2);
-        grafana.storageClass().checkExists();
-        grafana.storageClass().toggle();
-        grafana.storageClass().clickOptionWithLabel(storageClass);
-        grafana.storageClass().checkOptionSelected(storageClass);
-
-        grafana.storageOptions().set(3);
-        grafana.storageClass().checkExists();
-        grafana.storageClass().toggle();
-        grafana.storageClass().clickOptionWithLabel(storageClass);
-        grafana.storageClass().checkOptionSelected(storageClass);
-
-        // Check Prometheus has storage class input: https://github.com/rancher/dashboard/issues/11539
-        installChart.selectTab(tabbedOptions, prometheus.tabID());
-        installChart.waitForChartPage(CHART.repo, CHART.id);
-
-        prometheus.scrollToTabBottom();
-
-        prometheus.persistentStorage().checkVisible();
-        prometheus.persistentStorage().set();
-
-        prometheus.storageClass().checkExists();
-        prometheus.storageClass().toggle();
-        prometheus.storageClass().clickOptionWithLabel(storageClass);
-        prometheus.storageClass().checkOptionSelected(storageClass);
       });
 
       // NOTE: Test disabled until we have a reliable way of waiting for the installation process to complete.

--- a/cypress/e2e/tests/pages/charts/opa-gatekeeper.spec.ts
+++ b/cypress/e2e/tests/pages/charts/opa-gatekeeper.spec.ts
@@ -60,9 +60,9 @@ describe('Charts', { testIsolation: 'off', tags: ['@charts', '@adminUser'] }, ()
             chartPage.goToInstall();
             installChartPage.nextPage().editYaml();
 
-            cy.get('#wizard-footer-controls').should('be.visible');
+            installChartPage.footerControls().should('be.visible');
 
-            cy.get('#wizard-footer-controls').then(($el) => {
+            installChartPage.footerControls().then(($el) => {
               const elementRect = $el[0].getBoundingClientRect();
               const viewportHeight = Cypress.config('viewportHeight');
               const pageHeight = Cypress.$(cy.state('window')).height();

--- a/cypress/e2e/tests/pages/charts/opa-gatekeeper.spec.ts
+++ b/cypress/e2e/tests/pages/charts/opa-gatekeeper.spec.ts
@@ -3,43 +3,47 @@ import OpaGatekeeperPo from '@/cypress/e2e/po/other-products/opa-gatekeeper';
 import { ChartPage } from '@/cypress/e2e/po/pages/explorer/charts/chart.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import { InstallChartPage } from '@/cypress/e2e/po/pages/explorer/charts/install-charts.po';
+import { runTestWhenChartAvailable } from '@/cypress/support/commands/rancher-api-commands';
 
 describe('Charts', { testIsolation: 'off', tags: ['@charts', '@adminUser'] }, () => {
   before(() => {
     cy.login();
+    cy.setUserPreference({ 'show-pre-release': true }, true); // Show pre-release versions so charts with only -rc versions appear on Charts page
     HomePagePo.goTo();
   });
 
   describe('OPA Gatekeeper resources', () => {
-    it('should check conditions related to issue #4600 (template w/ create btn + edit constraints w/ save btn)', () => {
-      // all intercepts needed to mock install of OPA-Gatekeeper
-      generateOpaGatekeeperForLocalCluster();
+    it('should check conditions related to issue #4600 (template w/ create btn + edit constraints w/ save btn)', function() {
+      runTestWhenChartAvailable('rancher-charts', 'rancher-gatekeeper', this, () => {
+        // all intercepts needed to mock install of OPA-Gatekeeper
+        generateOpaGatekeeperForLocalCluster();
 
-      const opaGatekeeper = new OpaGatekeeperPo('local');
+        const opaGatekeeper = new OpaGatekeeperPo('local');
 
-      opaGatekeeper.goTo();
-      opaGatekeeper.waitForPage();
+        opaGatekeeper.goTo();
+        opaGatekeeper.waitForPage();
 
-      opaGatekeeper.navToSideMenuEntryByLabel('Template');
-      opaGatekeeper.waitForPage();
+        opaGatekeeper.navToSideMenuEntryByLabel('Template');
+        opaGatekeeper.waitForPage();
 
-      opaGatekeeper.createFromYaml().should('exist');
+        opaGatekeeper.createFromYaml().should('exist');
 
-      opaGatekeeper.navToSideMenuEntryByLabel('Constraints');
-      opaGatekeeper.waitForPage();
+        opaGatekeeper.navToSideMenuEntryByLabel('Constraints');
+        opaGatekeeper.waitForPage();
 
-      opaGatekeeper.create().click();
-      opaGatekeeper.waitForPage();
+        opaGatekeeper.create().click();
+        opaGatekeeper.waitForPage();
 
-      opaGatekeeper.selectContraintSubtype('k8sallowedrepos').click();
-      opaGatekeeper.saveCreateForm().expectToBeEnabled();
+        opaGatekeeper.selectContraintSubtype('k8sallowedrepos').click();
+        opaGatekeeper.saveCreateForm().expectToBeEnabled();
 
-      opaGatekeeper.navToSideMenuEntryByLabel('Constraints');
-      opaGatekeeper.create().click();
-      opaGatekeeper.waitForPage();
+        opaGatekeeper.navToSideMenuEntryByLabel('Constraints');
+        opaGatekeeper.create().click();
+        opaGatekeeper.waitForPage();
 
-      opaGatekeeper.selectContraintSubtype('k8srequiredlabels').click();
-      opaGatekeeper.saveCreateForm().expectToBeEnabled();
+        opaGatekeeper.selectContraintSubtype('k8srequiredlabels').click();
+        opaGatekeeper.saveCreateForm().expectToBeEnabled();
+      });
     });
   });
 
@@ -48,27 +52,31 @@ describe('Charts', { testIsolation: 'off', tags: ['@charts', '@adminUser'] }, ()
     const chartPage = new ChartPage();
 
     describe('YAML view', () => {
-      beforeEach(() => {
-        ChartPage.navTo(null, 'OPA Gatekeeper');
-        chartPage.waitForPage('repo-type=cluster&repo=rancher-charts&chart=rancher-gatekeeper');
-        chartPage.goToInstall();
-        installChartPage.nextPage().editYaml();
-      });
-
       describe('UI Elements', () => {
-        it('Footer controls should sticky to bottom', () => {
-          cy.get('#wizard-footer-controls').should('be.visible');
+        it('Footer controls should sticky to bottom', function() {
+          runTestWhenChartAvailable('rancher-charts', 'rancher-gatekeeper', this, () => {
+            ChartPage.navTo(null, 'OPA Gatekeeper');
+            chartPage.waitForPage('repo-type=cluster&repo=rancher-charts&chart=rancher-gatekeeper');
+            chartPage.goToInstall();
+            installChartPage.nextPage().editYaml();
 
-          cy.get('#wizard-footer-controls').then(($el) => {
-            const elementRect = $el[0].getBoundingClientRect();
-            const viewportHeight = Cypress.config('viewportHeight');
-            const pageHeight = Cypress.$(cy.state('window')).height();
+            cy.get('#wizard-footer-controls').should('be.visible');
 
-            expect(elementRect.bottom).to.eq(pageHeight);
-            expect(elementRect.bottom).to.eq(viewportHeight);
+            cy.get('#wizard-footer-controls').then(($el) => {
+              const elementRect = $el[0].getBoundingClientRect();
+              const viewportHeight = Cypress.config('viewportHeight');
+              const pageHeight = Cypress.$(cy.state('window')).height();
+
+              expect(elementRect.bottom).to.eq(pageHeight);
+              expect(elementRect.bottom).to.eq(viewportHeight);
+            });
           });
         });
       });
     });
+  });
+
+  after(() => {
+    cy.setUserPreference({ 'show-pre-release': false });
   });
 });

--- a/cypress/e2e/tests/pages/charts/rancher-backup.spec.ts
+++ b/cypress/e2e/tests/pages/charts/rancher-backup.spec.ts
@@ -5,6 +5,7 @@ import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import { InstallChartPage } from '@/cypress/e2e/po/pages/explorer/charts/install-charts.po';
+import { runTestWhenChartAvailable } from '@/cypress/support/commands/rancher-api-commands';
 
 const STORAGE_CLASS_RESOURCE = 'storage.k8s.io.storageclasses';
 
@@ -14,6 +15,7 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
 
     before(() => {
       cy.login();
+      cy.setUserPreference({ 'show-pre-release': true }, true); // Show pre-release versions so charts with only -rc versions appear on Charts page
       HomePagePo.goTo();
     });
 
@@ -31,50 +33,56 @@ describe('Charts', { tags: ['@charts', '@adminUser'] }, () => {
         cy.deleteRancherResource('v1', STORAGE_CLASS_RESOURCE, 'test-no-annotations');
       });
 
-      it('Should auto-select default storage class', () => {
-        ChartPage.navTo(null, 'Rancher Backups');
-        chartPage.waitForPage('repo-type=cluster&repo=rancher-charts&chart=rancher-backup');
+      it('Should auto-select default storage class', function() {
+        runTestWhenChartAvailable('rancher-charts', 'rancher-backup', this, () => {
+          ChartPage.navTo(null, 'Rancher Backups');
+          chartPage.waitForPage('repo-type=cluster&repo=rancher-charts&chart=rancher-backup');
 
-        const installPage = new InstallChartPage();
+          const installPage = new InstallChartPage();
 
-        chartPage.goToInstall();
-        installPage.nextPage();
-        cy.wait('@storageClasses', { timeout: 10000 }).its('response.statusCode').should('eq', 200);
-        cy.wait('@persistentVolumes', { timeout: 10000 }).its('response.statusCode').should('eq', 200);
+          chartPage.goToInstall();
+          installPage.nextPage();
+          cy.wait('@storageClasses', { timeout: 10000 }).its('response.statusCode').should('eq', 200);
+          cy.wait('@persistentVolumes', { timeout: 10000 }).its('response.statusCode').should('eq', 200);
 
-        installPage.waitForPage('repo-type=cluster&repo=rancher-charts&chart=rancher-backup');
+          installPage.waitForPage('repo-type=cluster&repo=rancher-charts&chart=rancher-backup');
 
-        // Scroll into view - scroll to bottom of view
-        cy.get('.main-layout > .outlet > .outer-container').scrollTo('bottom');
+          // Scroll into view - scroll to bottom of view
+          cy.get('.main-layout > .outlet > .outer-container').scrollTo('bottom');
 
-        // Select the 'Use an existing storage class' option
-        const storageOptions = new RadioGroupInputPo('[chart="[chart: cluster/rancher-charts/rancher-backup]"]');
+          // Select the 'Use an existing storage class' option
+          const storageOptions = new RadioGroupInputPo('[chart="[chart: cluster/rancher-charts/rancher-backup]"]');
 
-        // Check that the control exists
-        storageOptions.checkExists();
+          // Check that the control exists
+          storageOptions.checkExists();
 
-        storageOptions.set(2);
+          storageOptions.set(2);
 
-        // Scroll into view - scroll to bottom of view
-        cy.get('.main-layout > .outlet > .outer-container').scrollTo('bottom');
+          // Scroll into view - scroll to bottom of view
+          cy.get('.main-layout > .outlet > .outer-container').scrollTo('bottom');
 
-        // Verify that the drop-down exists and has the default storage class selected
-        const select = new LabeledSelectPo('[data-testid="backup-chart-select-existing-storage-class"]');
+          // Verify that the drop-down exists and has the default storage class selected
+          const select = new LabeledSelectPo('[data-testid="backup-chart-select-existing-storage-class"]');
 
-        select.checkExists();
-        select.toggle();
-        select.clickOptionWithLabel('test-default-storage-class'); // in k3s there's a different default storage class (local-path)
-        select.checkOptionSelected('test-default-storage-class');
+          select.checkExists();
+          select.toggle();
+          select.clickOptionWithLabel('test-default-storage-class'); // in k3s there's a different default storage class (local-path)
+          select.checkOptionSelected('test-default-storage-class');
 
-        // Verify that changing tabs doesn't reset the last selected storage class option
-        installPage.editYaml();
-        const tabbedOptions = new TabbedPo();
+          // Verify that changing tabs doesn't reset the last selected storage class option
+          installPage.editYaml();
+          const tabbedOptions = new TabbedPo();
 
-        installPage.editOptions(tabbedOptions, '[data-testid="button-group-child-0"]');
+          installPage.editOptions(tabbedOptions, '[data-testid="button-group-child-0"]');
 
-        select.checkExists();
-        select.checkOptionSelected('test-default-storage-class');
+          select.checkExists();
+          select.checkOptionSelected('test-default-storage-class');
+        });
       });
+    });
+
+    after(() => {
+      cy.setUserPreference({ 'show-pre-release': false });
     });
   });
 });

--- a/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/charts.spec.ts
@@ -3,81 +3,86 @@ import { ChartPage } from '@/cypress/e2e/po/pages/explorer/charts/chart.po';
 import { CLUSTER_REPOS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
 import ReposListPagePo from '@/cypress/e2e/po/pages/chart-repositories.po';
 import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import { runTestWhenChartAvailable } from '@/cypress/support/commands/rancher-api-commands';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 
 const chartsPage = new ChartsPage();
+const chartPage = new ChartPage();
 
 describe('Apps/Charts', { tags: ['@explorer', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.intercept('GET', `${ CLUSTER_REPOS_BASE_URL }/**`).as('fetchChartData');
 
     cy.login();
+    cy.setUserPreference({ 'show-pre-release': true }, true); // Show pre-release versions so charts with only -rc versions appear on Charts page
     chartsPage.goTo();
     chartsPage.waitForPage();
   });
 
-  it('Charts have expected icons', () => {
-    chartsPage.resetAllFilters();
-    chartsPage.checkChartGenericIcon('Alerting Driver', false);
-    chartsPage.checkChartGenericIcon('Rancher Compliance', false);
-    chartsPage.checkChartGenericIcon('Logging', false);
+  it('Charts have expected icons', function() {
+    runTestWhenChartAvailable('rancher-charts', 'rancher-alerting-drivers', this, () => {
+      chartsPage.resetAllFilters();
+      chartsPage.checkChartGenericIcon('Alerting Driver', false);
+      chartsPage.checkChartGenericIcon('Rancher Compliance', false);
+      chartsPage.checkChartGenericIcon('Logging', false);
+    });
   });
 
-  it('should call fetch when route query changes with valid parameters', () => {
-    const chartName = 'Logging';
+  it('should call fetch when route query changes with valid parameters', function() {
+    runTestWhenChartAvailable('rancher-charts', 'rancher-logging', this, () => {
+      const chartName = 'Logging';
 
-    cy.wait('@fetchChartData', MEDIUM_TIMEOUT_OPT);
-    cy.get('@fetchChartData.all').should('have.length.at.least', 3);
+      cy.wait('@fetchChartData', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
+      cy.get('@fetchChartData.all').should('have.length.at.least', 3);
 
-    chartsPage.getChartByName(chartName)
-      .checkExists()
-      .scrollIntoView()
-      .should('be.visible')
-      .click();
+      ChartPage.navTo(null, chartName);
+      chartPage.waitForChartHeader(chartName);
 
-    const chartPage = new ChartPage();
+      // Set up intercept for the network request triggered by $fetch
+      cy.intercept('GET', `**${ CLUSTER_REPOS_BASE_URL }/**`).as('fetchChartDataAfterSelect');
 
-    chartPage.waitForPage();
+      // Select the first active version link when there is more than one version
+      chartPage.versions().its('length').then((length) => {
+        if (length > 1) {
+          chartPage.versionLinks()
+            .first()
+            .then((firstVersion) => {
+              chartPage.selectVersion(firstVersion.text());
 
-    // Set up intercept for the network request triggered by $fetch
-    cy.intercept('GET', `**${ CLUSTER_REPOS_BASE_URL }/**`).as('fetchChartDataAfterSelect');
-
-    // Select the first active version link
-    chartPage.versionLinks()
-      .first()
-      .then((firstVersion) => {
-        chartPage.selectVersion(firstVersion.text());
-
-        cy.wait('@fetchChartDataAfterSelect').its('response.statusCode').should('eq', 200);
+              cy.wait('@fetchChartDataAfterSelect').its('response.statusCode').should('eq', 200);
+            });
+        }
       });
+    });
   });
 
-  it('should not call fetch when navigating back to charts page', () => {
-    const chartName = 'Logging';
+  it('should not call fetch when navigating back to charts page', function() {
+    runTestWhenChartAvailable('rancher-charts', 'rancher-logging', this, () => {
+      const chartName = 'Logging';
 
-    cy.wait('@fetchChartData', MEDIUM_TIMEOUT_OPT);
-    cy.get('@fetchChartData.all').should('have.length.at.least', 3);
+      cy.wait('@fetchChartData', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
+      cy.get('@fetchChartData.all').should('have.length.at.least', 3);
 
-    chartsPage.getChartByName(chartName)
-      .checkExists()
-      .scrollIntoView()
-      .should('be.visible')
-      .click();
+      ChartPage.navTo(null, chartName);
+      chartPage.waitForChartHeader(chartName);
 
-    const chartPage = new ChartPage();
+      // Navigate back to the charts page
+      cy.go('back');
+      chartsPage.waitForPage();
 
-    chartPage.waitForPage();
+      // Set up intercept after navigating back
+      cy.intercept('GET', `**${ CLUSTER_REPOS_BASE_URL }/**`).as('fetchChartDataAfterBack');
 
-    // Navigate back to the charts page
-    cy.go('back');
-    chartsPage.waitForPage();
-
-    // Set up intercept after navigating back
-    cy.intercept('GET', `**${ CLUSTER_REPOS_BASE_URL }/**`).as('fetchChartDataAfterBack');
-
-    cy.get('@fetchChartDataAfterBack.all').should('have.length', 0);
+      cy.get('@fetchChartDataAfterBack.all').should('have.length', 0);
+    });
   });
 
   it('A disabled repo should NOT be listed on the list of repository filters', () => {
+    const CHART = {
+      name: 'Partners',
+      id:   'rancher-partner-charts',
+    };
+
     // go to repository page and disable a repo
     const appRepoList = new ReposListPagePo('local', 'apps');
 
@@ -91,14 +96,17 @@ describe('Apps/Charts', { tags: ['@explorer', '@adminUser'] }, () => {
     // check enabled repos are listed but the disabled repo is not
     chartsPage.getFilterOptionByName('Rancher').checkExists();
     chartsPage.getFilterOptionByName('RKE2').checkExists();
-    chartsPage.getAllOptionsByGroupName('Repository').contains('Partners')
+    chartsPage.getAllOptionsByGroupName('Repository').contains(CHART.name)
       .should('not.exist');
 
     // re-enable the disabled repo
     appRepoList.goTo('local', 'apps');
-    appRepoList.waitForGoTo(`${ CLUSTER_REPOS_BASE_URL }?*`);
+    appRepoList.waitForPage();
     appRepoList.sortableTable().checkLoadingIndicatorNotVisible();
     appRepoList.list().actionMenu('Partners').getMenuItem('Enable').click();
+    cy.waitForRepositoryDownload('v1', 'catalog.cattle.io.clusterrepos', CHART.id);
+    cy.waitForResourceState('v1', 'catalog.cattle.io.clusterrepos', CHART.id);
+    appRepoList.list().state(CHART.name).should('contain', 'Active');
   });
 
   it('should display empty state properly', () => {
@@ -142,62 +150,63 @@ describe('Apps/Charts', { tags: ['@explorer', '@adminUser'] }, () => {
       chartsPage.chartCards().should('have.length', totalCharts);
     });
   });
+
+  after(() => {
+    cy.setUserPreference({ 'show-pre-release': false });
+  });
 });
 
 describe('Chart Details Page', { tags: ['@explorer', '@adminUser'] }, () => {
   const chartName = 'Logging';
-  let chartPage: ChartPage;
-
-  before(() => {
-    cy.login();
-    cy.setUserPreference({ 'show-pre-release': true }); // Show pre-release versions
-  });
 
   beforeEach(() => {
     cy.intercept('GET', `${ CLUSTER_REPOS_BASE_URL }/**`).as('fetchChartData');
 
     cy.login();
-    chartsPage.goTo();
-    chartsPage.waitForPage();
-
-    cy.wait('@fetchChartData', MEDIUM_TIMEOUT_OPT);
-    cy.get('@fetchChartData.all').should('have.length.at.least', 3);
-
-    chartsPage.getChartByName(chartName)
-      .checkExists()
-      .scrollIntoView()
-      .should('be.visible')
-      .click();
-
-    chartPage = new ChartPage();
-    chartPage.waitForPage();
+    cy.setUserPreference({ 'show-pre-release': true }, true); // Show pre-release versions
+    HomePagePo.goTo();
   });
 
-  it('should navigate to the correct repository page', () => {
-    chartPage.repoLink().click();
-    cy.url().should('include', '/c/local/apps/catalog.cattle.io.clusterrepo/rancher-charts');
+  it('should navigate to the correct repository page', function() {
+    runTestWhenChartAvailable('rancher-charts', 'rancher-logging', this, () => {
+      ChartPage.navTo(null, chartName);
+      chartPage.waitForChartHeader(chartName);
+
+      chartPage.repoLink().click();
+      cy.url().should('include', '/c/local/apps/catalog.cattle.io.clusterrepo/rancher-charts');
+    });
   });
 
-  it('should navigate to the charts list with the correct filters when a keyword is clicked', () => {
-    chartPage.keywords().first().click();
-    chartsPage.waitForPage();
-    cy.url().should('include', 'q=logging');
+  it('should navigate to the charts list with the correct filters when a keyword is clicked', function() {
+    runTestWhenChartAvailable('rancher-charts', 'rancher-logging', this, () => {
+      ChartPage.navTo(null, chartName);
+      chartPage.waitForChartHeader(chartName);
+
+      chartPage.keywords().first().click();
+      chartsPage.waitForPage();
+      cy.url().should('include', 'q=logging');
+    });
   });
 
-  it('should show more versions when the button is clicked (when there are more than 7 versions)', () => {
-    cy.getRancherResource('v1', 'catalog.cattle.io.clusterrepos', 'rancher-charts?link=index').then((res: any) => {
-      const entries = res.body.entries;
-      const rancherLoggingVersions = entries['rancher-logging'];
-      const totalCount = rancherLoggingVersions.length;
+  it('should show more versions when the button is clicked (when there are more than 7 versions)', function() {
+    runTestWhenChartAvailable('rancher-charts', 'rancher-logging', this, () => {
+      ChartPage.navTo(null, chartName);
+      chartPage.waitForChartHeader(chartName);
 
-      if (totalCount > 7) {
-        chartPage.versions().should('have.length', 7);
-        chartPage.showMoreVersions().should('be.visible').click();
-        chartPage.versions().should('have.length', totalCount);
-      } else {
-        chartPage.versions().should('have.length', totalCount);
-        chartPage.showMoreVersions().should('not.exist');
-      }
+      cy.getRancherResource('v1', 'catalog.cattle.io.clusterrepos', 'rancher-charts?link=index').then((res: any) => {
+        const entries = res.body.entries;
+        const rancherLoggingVersions = entries['rancher-logging'];
+        const totalCount = rancherLoggingVersions.length;
+
+        if (totalCount > 7) {
+          chartPage.versions().should('have.length', 7);
+          chartPage.showMoreVersions().should('be.visible').click();
+          chartPage.versions().should('have.length', totalCount);
+        } else {
+          chartPage.versions().should('have.length', totalCount);
+          chartPage.showMoreVersions().should('not.exist');
+        }
+      });
     });
   });
 

--- a/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/repositories.spec.ts
@@ -3,6 +3,7 @@ import AppClusterRepoEditPo from '@/cypress/e2e/po/edit/catalog.cattle.io.cluste
 import { ChartPage } from '@/cypress/e2e/po/pages/explorer/charts/chart.po';
 import { ChartsPage } from '@/cypress/e2e/po/pages/explorer/charts/charts.po';
 import { CLUSTER_REPOS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
+import { runTestWhenChartAvailable } from '@/cypress/support/commands/rancher-api-commands';
 
 describe('Apps', () => {
   describe('Repositories', { tags: ['@explorer', '@adminUser'] }, () => {
@@ -162,55 +163,63 @@ describe('Apps', () => {
 
       beforeEach(() => {
         cy.login();
+        cy.setUserPreference({ 'show-pre-release': true }, true); // Show pre-release versions so charts with only -rc versions appear on Charts page
 
         appRepoList.goTo(clusterId, 'apps');
         appRepoList.waitForPage();
       });
 
-      it('Repo Refresh results in correct api requests', () => {
-        // Root request to the Rancher helm chart repo
-        cy.intercept('GET', `${ CLUSTER_REPOS_BASE_URL }/rancher-charts?*`).as('rancherCharts1');
+      it('Repo Refresh results in correct api requests', function() {
+        runTestWhenChartAvailable('rancher-charts', 'rancher-backup', this, () => {
+          // Root request to the Rancher helm chart repo
+          cy.intercept('GET', `${ CLUSTER_REPOS_BASE_URL }/rancher-charts?*`).as('rancherCharts1');
 
-        // Nav to a summary page for a specific chart
-        chartsPage.goTo();
-        chartsPage.resetAllFilters();
+          // Nav to a summary page for a specific chart
+          chartsPage.goTo();
+          chartsPage.resetAllFilters();
 
-        chartsPage.clickChart('Rancher Backups');
-        chartPage.waitForPage();
+          chartsPage.clickChart('Rancher Backups');
 
-        // The repo charts should have been fetched
-        cy.wait('@rancherCharts1').its('request.url').should('include', 'link=index');
-        // The specific version of the chart should be fetched
-        cy.wait('@rancherCharts1').its('request.url').should('include', 'version=');
+          chartPage.waitForPage();
 
-        // Nav to any other page
-        ReposListPagePo.navTo(clusterId, 'apps');
-        appRepoList.waitForPage();
+          // The repo charts should have been fetched
+          cy.wait('@rancherCharts1').its('request.url').should('include', 'link=index');
+          // The specific version of the chart should be fetched
+          cy.wait('@rancherCharts1').its('request.url').should('include', 'version=');
 
-        // Nav back to the summary page for a specific chart
-        // Note we're intercepting a more precise url here to avoid any icon requests made from the charts list
-        cy.intercept('GET', `${ CLUSTER_REPOS_BASE_URL }/rancher-charts?link=info&chartName=rancher-backup&version=*`, cy.spy().as('rancherCharts2'));
-        ChartPage.navTo(clusterId, 'Rancher Backups');
-        chartPage.waitForPage('repo-type=cluster&repo=rancher-charts&chart=rancher-backup');
-        // The specific version of the chart (and any other) should NOT be fetched
-        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
-        cy.get('@rancherCharts2').should('not.have.been.called');
+          // Nav to any other page
+          ReposListPagePo.navTo(clusterId, 'apps');
+          appRepoList.waitForPage();
 
-        // Nav to the helm chart repo page
-        ReposListPagePo.navTo(clusterId, 'apps');
-        appRepoList.waitForPage();
+          // Nav back to the summary page for a specific chart
+          // Note we're intercepting a more precise url here to avoid any icon requests made from the charts list
+          cy.intercept('GET', `${ CLUSTER_REPOS_BASE_URL }/rancher-charts?link=info&chartName=rancher-backup&version=*`, cy.spy().as('rancherCharts2'));
+          ChartPage.navTo(clusterId, 'Rancher Backups');
+          chartPage.waitForPage('repo-type=cluster&repo=rancher-charts&chart=rancher-backup');
+          // The specific version of the chart (and any other) should NOT be fetched
+          cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+          cy.get('@rancherCharts2').should('not.have.been.called');
 
-        // Refresh the Rancher repo (clears caches)
-        cy.intercept('GET', `${ CLUSTER_REPOS_BASE_URL }/rancher-charts?*`).as('rancherCharts3');
-        appRepoList.list().refreshRepo('Rancher');
-        // The charts should immediately update
-        cy.wait('@rancherCharts3').its('request.url').should('include', '?link=index');
+          // Nav to the helm chart repo page
+          ReposListPagePo.navTo(clusterId, 'apps');
+          appRepoList.waitForPage();
 
-        // Nav to the summary page for a specific chart
-        ChartPage.navTo(clusterId, 'Rancher Backups');
-        chartPage.waitForPage('repo-type=cluster&repo=rancher-charts&chart=rancher-backup');
-        // The specific version of the chart should be fetched (as the cache was cleared)
-        cy.wait('@rancherCharts3').its('request.url').should('include', 'version=');
+          // Refresh the Rancher repo (clears caches)
+          cy.intercept('GET', `${ CLUSTER_REPOS_BASE_URL }/rancher-charts?*`).as('rancherCharts3');
+          appRepoList.list().refreshRepo('Rancher');
+          // The charts should immediately update
+          cy.wait('@rancherCharts3').its('request.url').should('include', '?link=index');
+
+          // Nav to the summary page for a specific chart
+          ChartPage.navTo(clusterId, 'Rancher Backups');
+          chartPage.waitForPage('repo-type=cluster&repo=rancher-charts&chart=rancher-backup');
+          // The specific version of the chart should be fetched (as the cache was cleared)
+          cy.wait('@rancherCharts3').its('request.url').should('include', 'version=');
+        });
+      });
+
+      after(() => {
+        cy.setUserPreference({ 'show-pre-release': false });
       });
     });
   });

--- a/cypress/e2e/tests/pages/explorer2/cluster-tools.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/cluster-tools.spec.ts
@@ -2,6 +2,7 @@ import ClusterToolsPagePo from '@/cypress/e2e/po/pages/explorer/cluster-tools.po
 import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dashboard.po';
 import { InstallChartPage } from '@/cypress/e2e/po/pages/explorer/charts/install-charts.po';
 import { CLUSTER_APPS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
+import { runTestWhenChartAvailable } from '@/cypress/support/commands/rancher-api-commands';
 import Kubectl from '@/cypress/e2e/po/components/kubectl.po';
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
@@ -21,63 +22,72 @@ describe('Cluster Tools', { tags: ['@explorer2', '@adminUser'] }, () => {
     clusterDashboard.waitForPage();
     clusterDashboard.navToSideMenuEntryByLabel('Tools');
     clusterTools.waitForPage();
-    clusterTools.featureChartCards().should('have.length.gte', 10);
+
+    cy.getClusterToolsChartCount().then((expectedCount) => {
+      clusterTools.featureChartCards().should('have.length', expectedCount);
+    });
   });
 
-  it('can deploy chart successfully', () => {
-    clusterTools.goTo();
-    clusterTools.waitForPage();
-    clusterTools.getChartVersion('Alerting Drivers').invoke('text').then((el) => {
-      const chartVersion = el.trim();
+  it('can deploy chart successfully', function() {
+    runTestWhenChartAvailable('rancher-charts', 'rancher-alerting-drivers', this, () => {
+      clusterTools.goTo();
+      clusterTools.waitForPage();
+      clusterTools.getChartVersion('Alerting Drivers').invoke('text').then((el) => {
+        const chartVersion = el.trim();
 
-      const chartType = 'rancher-alerting-drivers';
-      const installAlertingDriversPage = `repo-type=cluster&repo=rancher-charts&chart=${ chartType }&version=${ chartVersion }&tools`;
-      const installCharts = new InstallChartPage();
+        const chartType = 'rancher-alerting-drivers';
+        const installAlertingDriversPage = `repo-type=cluster&repo=rancher-charts&chart=${ chartType }&version=${ chartVersion }&tools`;
+        const installCharts = new InstallChartPage();
 
-      clusterTools.goToInstall('Alerting Drivers');
-      installCharts.waitForPage(installAlertingDriversPage);
-      installCharts.nextPage();
+        clusterTools.goToInstall('Alerting Drivers');
+        installCharts.waitForPage(installAlertingDriversPage);
+        installCharts.nextPage();
 
-      cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install').as('chartInstall');
-      installCharts.installChart();
-      cy.wait('@chartInstall').its('response.statusCode').should('eq', 201);
+        cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install').as('chartInstall');
+        installCharts.installChart();
+        cy.wait('@chartInstall').its('response.statusCode').should('eq', 201);
+        clusterTools.waitForPage();
+        kubectl.waitForTerminalStatus('Connected');
+        kubectl.waitForTerminalStatus('Disconnected', MEDIUM_TIMEOUT_OPT);
+      });
+    });
+  });
+
+  it('can edit chart successfully', function() {
+    runTestWhenChartAvailable('rancher-charts', 'rancher-alerting-drivers', this, () => {
+      clusterTools.goTo();
+      clusterTools.waitForPage();
+      clusterTools.editChart('Alerting Drivers');
+
+      const installChart = new InstallChartPage();
+
+      installChart.nextPage();
+
+      cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=upgrade').as('chartUpdate');
+      installChart.installChart();
+      cy.wait('@chartUpdate').its('response.statusCode').should('eq', 201);
       clusterTools.waitForPage();
       kubectl.waitForTerminalStatus('Connected');
       kubectl.waitForTerminalStatus('Disconnected', MEDIUM_TIMEOUT_OPT);
     });
   });
 
-  it('can edit chart successfully', () => {
-    clusterTools.goTo();
-    clusterTools.waitForPage();
-    clusterTools.editChart('Alerting Drivers');
+  it('can uninstall chart successfully', function() {
+    runTestWhenChartAvailable('rancher-charts', 'rancher-alerting-drivers', this, () => {
+      clusterTools.goTo();
+      clusterTools.waitForPage();
+      clusterTools.deleteChart('Alerting Drivers');
 
-    const installChart = new InstallChartPage();
+      const promptRemove = new PromptRemove();
 
-    installChart.nextPage();
+      promptRemove.checkbox().checkNotExists();
 
-    cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=upgrade').as('chartUpdate');
-    installChart.installChart();
-    cy.wait('@chartUpdate').its('response.statusCode').should('eq', 201);
-    clusterTools.waitForPage();
-    kubectl.waitForTerminalStatus('Connected');
-    kubectl.waitForTerminalStatus('Disconnected', MEDIUM_TIMEOUT_OPT);
-  });
-
-  it('can uninstall chart successfully', () => {
-    clusterTools.goTo();
-    clusterTools.waitForPage();
-    clusterTools.deleteChart('Alerting Drivers');
-
-    const promptRemove = new PromptRemove();
-
-    promptRemove.checkbox().checkNotExists();
-
-    cy.intercept('POST', `${ CLUSTER_APPS_BASE_URL }/default/rancher-alerting-drivers?action=uninstall`).as('chartUninstall');
-    promptRemove.remove();
-    cy.wait('@chartUninstall').its('response.statusCode').should('eq', 201);
-    // we can't check that the initial state is connected... as the supporting socket can connect and disconnect quicker than we can show the window
-    // kubectl.waitForTerminalStatus('Connected');
-    kubectl.waitForTerminalStatus('Disconnected');
+      cy.intercept('POST', `${ CLUSTER_APPS_BASE_URL }/default/rancher-alerting-drivers?action=uninstall`).as('chartUninstall');
+      promptRemove.remove();
+      cy.wait('@chartUninstall').its('response.statusCode').should('eq', 201);
+      // we can't check that the initial state is connected... as the supporting socket can connect and disconnect quicker than we can show the window
+      // kubectl.waitForTerminalStatus('Connected');
+      kubectl.waitForTerminalStatus('Disconnected');
+    });
   });
 });

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -132,6 +132,8 @@ declare global {
       waitForResourceState(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, resourceState?: string, retries?: number): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1' | 'k8s', resourceType: string, resourceId: string, failOnStatusCode?: boolean): Chainable;
       getClusterIdByName(clusterName: string): Chainable<string>;
+      checkChartPresence(repoName: string, chartKey: string): Chainable<{ inFiltered: boolean, inUnfiltered: boolean }>;
+      getClusterToolsChartCount(repoName?: string): Chainable<number>;
       deleteNodeTemplate(nodeTemplateId: string, timeout?: number, failOnStatusCode?: boolean)
       /**
        * Delete a namespace and wait for it to 404. Helpful when the ns contains many resources
@@ -162,7 +164,7 @@ declare global {
       tableRowsPerPageAndNamespaceFilter(rows: number, clusterName: string, groupBy: string, namespaceFilter: string)
       tableRowsPerPageAndPreferences(rows: number, preferences: { clusterName: string, groupBy: string, namespaceFilter: string, allNamespaces?: string}, iteration?: number)
 
-      setUserPreference(prefs: any);
+      setUserPreference(prefs: any, verify?: boolean, retries?: number);
 
       /**
        * update namespace filter

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -1222,7 +1222,8 @@ Cypress.Commands.add('tableRowsPerPageAndNamespaceFilter', (rows: number, cluste
 });
 
 // Update the user preferences by over-writing the given preference
-Cypress.Commands.add('setUserPreference', (prefs: any) => {
+// If verify is true, the command will wait for the preferences to be updated and verify that the values are correct
+Cypress.Commands.add('setUserPreference', (prefs: any, verify = false, retries = 5) => {
   return cy.getRancherResource('v1', 'userpreferences').then((resp: Cypress.Response<any>) => {
     const update = resp.body.data[0];
 
@@ -1233,7 +1234,29 @@ Cypress.Commands.add('setUserPreference', (prefs: any) => {
 
     delete update.links;
 
-    return cy.setRancherResource('v1', 'userpreferences', update.id, update);
+    return cy.setRancherResource('v1', 'userpreferences', update.id, update)
+      .then((putResp: Cypress.Response<any>) => {
+        if (!verify) {
+          return putResp;
+        }
+
+        return cy.waitForRancherResource('v1', 'userpreferences', update.id, (getResp: any) => {
+          const responseData = getResp?.body?.data ?? getResp?.body ?? {};
+
+          return Object.entries(prefs).every(([key, value]) => {
+            const actual = responseData[key];
+
+            return actual === value || String(actual) === String(value);
+          });
+        }, retries)
+          .then((success) => {
+            if (!success) {
+              return cy.log(`setUserPreference: Failed to verify preferences ${ JSON.stringify(prefs) } after ${ retries } retries (non-fatal)`).then(() => putResp);
+            }
+
+            return cy.log('setUserPreference: Successfully verified preferences', prefs).then(() => putResp);
+          });
+      });
   });
 });
 
@@ -1439,3 +1462,107 @@ Cypress.Commands.add('applyDefaultTestTheme', () => {
       });
     });
 });
+
+const CATALOG_TYPE = 'catalog.cattle.io/type';
+const CLUSTER_TOOL = 'cluster-tool';
+const EXPERIMENTAL = 'catalog.cattle.io/experimental';
+
+/**
+ * Returns the expected number of cluster tool charts for the cluster tools page.
+ * Counts charts from the filtered rancher-charts index that have the cluster-tool type,
+ * are not experimental, and are not deprecated (matching the UI's filterAndArrangeCharts logic).
+ */
+Cypress.Commands.add('getClusterToolsChartCount', (repoName = 'rancher-charts') => {
+  const baseUrl = `${ Cypress.env('api') }/v1/catalog.cattle.io.clusterrepos/${ repoName }`;
+
+  const headers = {
+    'x-api-csrf': token.value,
+    Accept:       'application/json',
+  };
+
+  return cy.request({
+    method: 'GET',
+    url:    `${ baseUrl }?link=index`,
+    headers,
+  }).then((resp) => {
+    const entries = resp.body?.entries || {};
+    let count = 0;
+
+    for (const [, versions] of Object.entries(entries)) {
+      const chart = Array.isArray(versions) ? versions[0] : versions;
+
+      if (!chart?.annotations) {
+        continue;
+      }
+
+      const isClusterTool = chart.annotations[CATALOG_TYPE] === CLUSTER_TOOL;
+      const isExperimental = !!chart.annotations[EXPERIMENTAL];
+      const isDeprecated = !!chart.deprecated;
+
+      if (isClusterTool && !isExperimental && !isDeprecated) {
+        count++;
+      }
+    }
+
+    return count;
+  });
+});
+
+/**
+ * Checks whether a chart is present in the filtered catalog index (what the UI uses).
+ *
+ * `link=index` => Rancher applies catalog filtering based on chart annotations/constraints
+ * `skipFilter=true` => bypasses Rancher filtering so we can confirm the chart exists in the index at all.
+ */
+Cypress.Commands.add('checkChartPresence', (repoName: string, chartKey: string) => {
+  const baseUrl = `${ Cypress.env('api') }/v1/catalog.cattle.io.clusterrepos/${ repoName }`;
+
+  const headers = {
+    'x-api-csrf': token.value,
+    Accept:       'application/json',
+  };
+
+  return cy.request({
+    method: 'GET',
+    url:    `${ baseUrl }?link=index`,
+    headers,
+  }).then((filteredResp) => {
+    const inFiltered = Boolean(filteredResp.body?.entries?.[chartKey]);
+
+    return cy.request({
+      method: 'GET',
+      url:    `${ baseUrl }?link=index&skipFilter=true`,
+      headers,
+    }).then((unfilteredResp) => {
+      const inUnfiltered = Boolean(unfilteredResp.body?.entries?.[chartKey]);
+
+      return { inFiltered, inUnfiltered };
+    });
+  });
+});
+
+/**
+ * Runs the given callback only when the chart is available in the filtered catalog index.
+ * Skips the test when the chart exists in the catalog but is filtered out intentionally (e.g. based on k8s or Rancher annotations).
+ * Throws when the chart is missing from the unfiltered index (publishing/sync issue).
+ */
+export function runTestWhenChartAvailable(
+  repo: string,
+  chartKey: string,
+  mochaContext: { skip: () => void },
+  callback: () => void
+) {
+  cy.checkChartPresence(repo, chartKey).then(({ inFiltered, inUnfiltered }) => {
+    if (!inUnfiltered) {
+      throw new Error(`Chart '${ chartKey }' is missing from the unfiltered catalog index. This looks like a publishing/sync issue, not due to version compatibility filtering.`);
+    }
+
+    if (!inFiltered) {
+      cy.log(`Skipping: chart '${ chartKey }' is intentionally hidden from the filtered catalog index`);
+
+      return mochaContext.skip();
+    }
+
+    callback();
+  });
+}

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -1246,15 +1246,13 @@ Cypress.Commands.add('setUserPreference', (prefs: any, verify = false, retries =
           return Object.entries(prefs).every(([key, value]) => {
             const actual = responseData[key];
 
-            return actual === value || String(actual) === String(value);
+            return String(actual) === String(value);
           });
         }, retries)
           .then((success) => {
-            if (!success) {
-              return cy.log(`setUserPreference: Failed to verify preferences ${ JSON.stringify(prefs) } after ${ retries } retries (non-fatal)`).then(() => putResp);
-            }
+            const msg = success ? `Successfully verified preferences ${ JSON.stringify(prefs) }` : `Failed to verify preferences ${ JSON.stringify(prefs) } after ${ retries } retries (non-fatal)`;
 
-            return cy.log('setUserPreference: Successfully verified preferences', prefs).then(() => putResp);
+            return cy.log(`setUserPreference: ${ msg }`).then(() => putResp);
           });
       });
   });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2255, https://github.com/rancher/qa-tasks/issues/2256, https://github.com/rancher/qa-tasks/issues/2257, https://github.com/rancher/qa-tasks/issues/2258, https://github.com/rancher/qa-tasks/issues/2259, https://github.com/rancher/qa-tasks/issues/2260, https://github.com/rancher/qa-tasks/issues/2261, https://github.com/rancher/qa-tasks/issues/2264
 

Stabilizes chart-related E2E tests when the catalog hides charts by design (e.g. version / annotation filtering) and when only pre-release chart versions exist.

Problem: Some charts are deliberately hidden on the Charts page because of **chart annotations** (and related catalog rules). Others disappear from the list when the user has not enabled `Include Prerelease Versions` (show-pre-release): the raw Helm index can still include those charts, but the UI only shows a filtered catalog. Our tests used to assume every chart in the index would appear on Charts, which led to false failures when a chart was correctly hidden (by annotations or by that preference).

Fixes:
1. Adds custom command `runTestWhenChartAvailable` which skips the test when the chart exists in the unfiltered index but not in the filtered one (intentional catalog filtering). If the chart appears in the filtered index, the test runs as usual.
2. Enables `Include Prerelease Versions` user preference so that chart-related specs set show-pre-release before opening the Charts catalog, so charts that only have pre-release versions are not hidden by default UI behavior.
3. Extends setUserPreference with an optional verify flag: after the PUT, it retries GETs until the stored preferences match the requested values; if they still do not match after the retries, it logs a failure message and continues the test (helps surface timing/sync issues without failing the run on verification alone).
4. Resolves flakiness in various Charts tests

<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
