### PR TITLE
Automation - Adding instance type variable after corral logic split

### DIFF
--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -246,6 +246,7 @@ create_test_clusters() {
 # Create Rancher server
 # ============================================================================
 create_rancher_server() {
+  clean_corral config vars set instance_type "${AWS_INSTANCE_TYPE}"
   clean_corral config vars set aws_hostname_prefix "jenkins-${prefix_random}"
   clean_corral config vars set server_count "${SERVER_COUNT:-3}"
   clean_corral create --skip-cleanup --recreate --debug rancher "dist/aws-k3s-rancher-${K3S_KUBERNETES_VERSION}-${RANCHER_VERSION//v}-${CERT_MANAGER_VERSION}"


### PR DESCRIPTION
### Summary
Fixes https://github.com/rancher/dashboard/pull/17000

### Occurred changes and/or fixed issues

After splitting Rancher and clusters/nodes creation in the new Jenkins infra build logic, a variable was missed, making that specific Rancher with Clusters recurring runs fail.

### Areas or cases that should be tested
Jenkins

### Areas which could experience regressions
Jenkins

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
