### PR TITLE
Adding private registry to cloud provider imported clusters

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -265,7 +265,7 @@ export default defineComponent({
     },
 
     isImportedCluster() {
-      return this.isImport || !!this.config?.imported;
+      return this.isImport || this.value.isImported;
     },
     /**
      * fv mixin accepts a rootObject in rules but doesn't seem to like that the norman cluster isn't yet defined when the rule set is defined so we're ignoring that and passing in the key we want validated here

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -22,6 +22,7 @@ import Loading from '@shell/components/Loading.vue';
 import Config from './Config.vue';
 import Import from './Import.vue';
 
+import PrivateRegistry from '@shell/components/form/PrivateRegistry.vue';
 import ClusterMembershipEditor, { canViewClusterMembershipEditor } from '@shell/components/form/Members/ClusterMembershipEditor.vue';
 import type { AKSDiskType, AKSNodePool, AKSPoolMode, AKSConfig } from '../types/index';
 import {
@@ -89,6 +90,7 @@ const defaultCluster = {
   labels:                  {},
   annotations:             {},
   windowsPreferedCluster:  false,
+  importedConfig:          { privateRegistryURL: null },
 };
 
 export const NETWORKING_AUTH_MODES = {
@@ -110,6 +112,7 @@ export default defineComponent({
     Labels,
     Accordion,
     Banner,
+    PrivateRegistry,
     Loading,
     Config,
     Import
@@ -176,6 +179,9 @@ export default defineComponent({
         this.normanCluster.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
       }
     }
+    if (!this.normanCluster.importedConfig) {
+      this.normanCluster.importedConfig = {};
+    }
     if (this.isImport) {
       this.normanCluster.aksConfig = cloneDeep(importedDefaultAksConfig);
       this.config = this.normanCluster.aksConfig;
@@ -204,7 +210,7 @@ export default defineComponent({
 
     return {
       NETWORKING_AUTH_MODES,
-      normanCluster:    { name: '' } as any,
+      normanCluster:    { name: '', importedConfig: { privateRegistryURL: null } } as any,
       nodePools:        [] as AKSNodePool[],
       config:           { } as AKSConfig,
       membershipUpdate: {} as any,
@@ -225,10 +231,18 @@ export default defineComponent({
       {
         path:  'clusterName',
         rules: ['importedName']
+      },
+      {
+        path:  'normanCluster.importedConfig.privateRegistryURL',
+        rules: ['registryUrl']
       }
       ] : [{
         path:  'name',
         rules: ['nameRequired', 'clusterNameChars', 'clusterNameStartEnd', 'clusterNameLength'],
+      },
+      {
+        path:  'normanCluster.importedConfig.privateRegistryURL',
+        rules: ['registryUrl']
       }],
     };
   },
@@ -248,6 +262,10 @@ export default defineComponent({
 
     isImport() {
       return this.$route?.query?.mode === _IMPORT;
+    },
+
+    isImportedCluster() {
+      return this.isImport || !!this.config?.imported;
     },
     /**
      * fv mixin accepts a rootObject in rules but doesn't seem to like that the norman cluster isn't yet defined when the rule set is defined so we're ignoring that and passing in the key we want validated here
@@ -526,6 +544,18 @@ export default defineComponent({
         <Labels
           v-model:value="normanCluster"
           :mode="mode"
+        />
+      </Accordion>
+      <Accordion
+        v-if="isImportedCluster"
+        class="mb-20"
+        title-key="cluster.tabs.registry"
+        data-testid="registries-accordion"
+      >
+        <PrivateRegistry
+          v-model:value="normanCluster.importedConfig.privateRegistryURL"
+          :mode="mode"
+          :rules="fvGetAndReportPathRules('normanCluster.importedConfig.privateRegistryURL')"
         />
       </Accordion>
     </div>

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -23,6 +23,7 @@ import Config from './Config.vue';
 import Import from './Import.vue';
 
 import PrivateRegistry from '@shell/components/form/PrivateRegistry.vue';
+import { privateRegistryRequired } from '@shell/utils/validators/private-registry';
 import ClusterMembershipEditor, { canViewClusterMembershipEditor } from '@shell/components/form/Members/ClusterMembershipEditor.vue';
 import type { AKSDiskType, AKSNodePool, AKSPoolMode, AKSConfig } from '../types/index';
 import {
@@ -179,9 +180,10 @@ export default defineComponent({
         this.normanCluster.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
       }
     }
-    if (!this.normanCluster.importedConfig) {
+    if (this.value?.id && this.isImportedCluster && !this.normanCluster.importedConfig) {
       this.normanCluster.importedConfig = {};
     }
+    this.privateRegistryEnabled = !!this.normanCluster.importedConfig?.privateRegistryURL;
     if (this.isImport) {
       this.normanCluster.aksConfig = cloneDeep(importedDefaultAksConfig);
       this.config = this.normanCluster.aksConfig;
@@ -210,11 +212,12 @@ export default defineComponent({
 
     return {
       NETWORKING_AUTH_MODES,
-      normanCluster:    { name: '', importedConfig: { privateRegistryURL: null } } as any,
-      nodePools:        [] as AKSNodePool[],
-      config:           { } as AKSConfig,
-      membershipUpdate: {} as any,
-      originalVersion:  '',
+      normanCluster:          { name: '', importedConfig: { privateRegistryURL: null } } as any,
+      nodePools:              [] as AKSNodePool[],
+      config:                 { } as AKSConfig,
+      membershipUpdate:       {} as any,
+      originalVersion:        '',
+      privateRegistryEnabled: false,
 
       supportedVersionRange,
       locationOptions: [] as string[],
@@ -233,17 +236,17 @@ export default defineComponent({
         rules: ['importedName']
       },
       {
-        path:  'normanCluster.importedConfig.privateRegistryURL',
-        rules: ['registryUrl']
+        path:  'privateRegistry',
+        rules: ['privateRegistryRequired']
       }
       ] : [{
         path:  'name',
         rules: ['nameRequired', 'clusterNameChars', 'clusterNameStartEnd', 'clusterNameLength'],
       },
-      {
-        path:  'normanCluster.importedConfig.privateRegistryURL',
-        rules: ['registryUrl']
-      }],
+      ...(this.value?.isImported ? [{
+        path:  'privateRegistry',
+        rules: ['privateRegistryRequired']
+      }] : [])],
     };
   },
 
@@ -274,11 +277,12 @@ export default defineComponent({
 
     fvExtraRules() {
       return {
-        nameRequired:        requiredInCluster(this, 'nameNsDescription.name.label', 'normanCluster.name'),
-        clusterNameChars:    clusterNameChars(this),
-        clusterNameStartEnd: clusterNameStartEnd(this),
-        clusterNameLength:   clusterNameLength(this),
-        importedName:        requiredInCluster(this, 'aks.clusterToRegister', 'config.clusterName'),
+        nameRequired:            requiredInCluster(this, 'nameNsDescription.name.label', 'normanCluster.name'),
+        clusterNameChars:        clusterNameChars(this),
+        clusterNameStartEnd:     clusterNameStartEnd(this),
+        clusterNameLength:       clusterNameLength(this),
+        importedName:            requiredInCluster(this, 'aks.clusterToRegister', 'config.clusterName'),
+        privateRegistryRequired: privateRegistryRequired(this),
       };
     },
 
@@ -554,8 +558,9 @@ export default defineComponent({
       >
         <PrivateRegistry
           v-model:value="normanCluster.importedConfig.privateRegistryURL"
+          v-model:enabled="privateRegistryEnabled"
           :mode="mode"
-          :rules="fvGetAndReportPathRules('normanCluster.importedConfig.privateRegistryURL')"
+          :rules="fvGetAndReportPathRules('privateRegistry')"
         />
       </Accordion>
     </div>

--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -242,11 +242,10 @@ export default defineComponent({
       ] : [{
         path:  'name',
         rules: ['nameRequired', 'clusterNameChars', 'clusterNameStartEnd', 'clusterNameLength'],
-      },
-      ...(this.value?.isImported ? [{
+      }, {
         path:  'privateRegistry',
         rules: ['privateRegistryRequired']
-      }] : [])],
+      }],
     };
   },
 

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -347,7 +347,7 @@ export default defineComponent({
     },
 
     isImportedCluster(): boolean {
-      return this.isImport || !!this.config?.imported;
+      return this.isImport || this.value.isImported;
     },
 
     fvExtraRules(): {[key:string]: Function} {

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -18,6 +18,7 @@ import Tab from '@shell/components/Tabbed/Tab.vue';
 import Tabbed from '@shell/components/Tabbed/index.vue';
 import Accordion from '@components/Accordion/Accordion.vue';
 import Banner from '@components/Banner/Banner.vue';
+import PrivateRegistry from '@shell/components/form/PrivateRegistry.vue';
 import ClusterMembershipEditor, { canViewClusterMembershipEditor } from '@shell/components/form/Members/ClusterMembershipEditor.vue';
 import Loading from '@shell/components/Loading.vue';
 
@@ -53,6 +54,7 @@ const DEFAULT__IMPORT_CLUSTER = {
   windowsPreferedCluster:              false,
   fleetAgentDeploymentCustomization:   {},
   clusterAgentDeploymentCustomization: {},
+  importedConfig:                      { privateRegistryURL: null },
   eksConfig:                           {
     amazonCredentialSecret: '',
     displayName:            '',
@@ -109,6 +111,7 @@ export default defineComponent({
     Config,
     Networking,
     LabeledInput,
+    PrivateRegistry,
     ClusterMembershipEditor,
     Labels,
     Tabbed,
@@ -162,6 +165,10 @@ export default defineComponent({
       }
     }
 
+    if (!this.normanCluster.importedConfig) {
+      this.normanCluster.importedConfig = {};
+    }
+
     if (!this.isImport) {
       if (!this.normanCluster.eksConfig) {
         this.normanCluster['eksConfig'] = { ...DEFAULT_EKS_CONFIG } as any as EKSConfig;
@@ -201,7 +208,7 @@ export default defineComponent({
     return {
       isImport,
       cloudCredentialId: '',
-      normanCluster:     { name: '' } as unknown as NormanCluster,
+      normanCluster:     { name: '', importedConfig: { privateRegistryURL: null } } as unknown as NormanCluster,
       nodeGroups:        [] as EKSNodeGroup[],
       config:            { } as EKSConfig,
       membershipUpdate:  {} as {newBindings: any[], removedBindings: any[], save: Function},
@@ -214,6 +221,10 @@ export default defineComponent({
       {
         path:  'displayName',
         rules: ['displayNameRequired'],
+      },
+      {
+        path:  'normanCluster.importedConfig.privateRegistryURL',
+        rules: ['registryUrl']
       }
       ] : [{
         path:  'name',
@@ -259,6 +270,10 @@ export default defineComponent({
       {
         path:  'nodeGroupsRequired',
         rules: ['nodeGroupsRequired']
+      },
+      {
+        path:  'normanCluster.importedConfig.privateRegistryURL',
+        rules: ['registryUrl']
       }
       ],
 
@@ -320,7 +335,8 @@ export default defineComponent({
           group['version'] = neu;
         }
       });
-    }
+    },
+
   },
 
   computed: {
@@ -328,6 +344,10 @@ export default defineComponent({
 
     fetchState(): {pending: boolean} {
       return this.$fetchState;
+    },
+
+    isImportedCluster(): boolean {
+      return this.isImport || !!this.config?.imported;
     },
 
     fvExtraRules(): {[key:string]: Function} {
@@ -865,6 +885,18 @@ export default defineComponent({
         <Labels
           v-model:value="normanCluster"
           :mode="mode"
+        />
+      </Accordion>
+      <Accordion
+        v-if="isImportedCluster"
+        class="mb-20"
+        title-key="cluster.tabs.registry"
+        data-testid="registries-accordion"
+      >
+        <PrivateRegistry
+          v-model:value="normanCluster.importedConfig.privateRegistryURL"
+          :mode="mode"
+          :rules="fvGetAndReportPathRules('normanCluster.importedConfig.privateRegistryURL')"
         />
       </Accordion>
     </div>

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -31,6 +31,7 @@ import AccountAccess from './AccountAccess.vue';
 import Import from './Import.vue';
 
 import EKSValidators from '../util/validators';
+import { privateRegistryRequired } from '@shell/utils/validators/private-registry';
 import { CREATOR_PRINCIPAL_ID } from '@shell/config/labels-annotations';
 import { formatAWSError } from '@shell/utils/error';
 
@@ -165,9 +166,10 @@ export default defineComponent({
       }
     }
 
-    if (!this.normanCluster.importedConfig) {
+    if (this.value?.id && this.isImportedCluster && !this.normanCluster.importedConfig) {
       this.normanCluster.importedConfig = {};
     }
+    this.privateRegistryEnabled = !!this.normanCluster.importedConfig?.privateRegistryURL;
 
     if (!this.isImport) {
       if (!this.normanCluster.eksConfig) {
@@ -207,13 +209,14 @@ export default defineComponent({
 
     return {
       isImport,
-      cloudCredentialId: '',
-      normanCluster:     { name: '', importedConfig: { privateRegistryURL: null } } as unknown as NormanCluster,
-      nodeGroups:        [] as EKSNodeGroup[],
-      config:            { } as EKSConfig,
-      membershipUpdate:  {} as {newBindings: any[], removedBindings: any[], save: Function},
-      originalVersion:   '',
-      fvFormRuleSets:    isImport ? [{
+      cloudCredentialId:      '',
+      normanCluster:          { name: '', importedConfig: { privateRegistryURL: null } } as unknown as NormanCluster,
+      nodeGroups:             [] as EKSNodeGroup[],
+      config:                 { } as EKSConfig,
+      membershipUpdate:       {} as {newBindings: any[], removedBindings: any[], save: Function},
+      originalVersion:        '',
+      privateRegistryEnabled: false,
+      fvFormRuleSets:         isImport ? [{
         path:  'name',
         rules: ['nameRequired'],
       },
@@ -223,8 +226,8 @@ export default defineComponent({
         rules: ['displayNameRequired'],
       },
       {
-        path:  'normanCluster.importedConfig.privateRegistryURL',
-        rules: ['registryUrl']
+        path:  'privateRegistry',
+        rules: ['privateRegistryRequired']
       }
       ] : [{
         path:  'name',
@@ -271,10 +274,10 @@ export default defineComponent({
         path:  'nodeGroupsRequired',
         rules: ['nodeGroupsRequired']
       },
-      {
-        path:  'normanCluster.importedConfig.privateRegistryURL',
-        rules: ['registryUrl']
-      }
+      ...(this.value?.isImported ? [{
+        path:  'privateRegistry',
+        rules: ['privateRegistryRequired']
+      }] : [])
       ],
 
       loadingInstanceTypes:   false,
@@ -372,6 +375,7 @@ export default defineComponent({
         if (!this.config?.imported) {
           out.nodeGroupsRequired = EKSValidators.nodeGroupsRequired(this);
         }
+        out.privateRegistryRequired = privateRegistryRequired(this as any);
       }
 
       return out;
@@ -895,8 +899,9 @@ export default defineComponent({
       >
         <PrivateRegistry
           v-model:value="normanCluster.importedConfig.privateRegistryURL"
+          v-model:enabled="privateRegistryEnabled"
           :mode="mode"
-          :rules="fvGetAndReportPathRules('normanCluster.importedConfig.privateRegistryURL')"
+          :rules="fvGetAndReportPathRules('privateRegistry')"
         />
       </Accordion>
     </div>

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -274,10 +274,10 @@ export default defineComponent({
         path:  'nodeGroupsRequired',
         rules: ['nodeGroupsRequired']
       },
-      ...(this.value?.isImported ? [{
+      {
         path:  'privateRegistry',
         rules: ['privateRegistryRequired']
-      }] : [])
+      }
       ],
 
       loadingInstanceTypes:   false,

--- a/pkg/eks/components/__tests__/CruEKS.test.ts
+++ b/pkg/eks/components/__tests__/CruEKS.test.ts
@@ -281,6 +281,18 @@ describe('eKS provisioning form', () => {
     expect(registriesAccordion.exists()).toBe(false);
   });
 
+  it('should not show the registries accordion when editing a non-imported cluster', async() => {
+    const wrapper = shallowMount(CruEKS, {
+      propsData: { value: { isImported: false }, mode: 'edit' },
+      ...requiredSetup()
+    });
+
+    await setCredential(wrapper, { ...DEFAULT_EKS_CONFIG } as EKSConfig);
+    const registriesAccordion = wrapper.find('[data-testid="registries-accordion"]');
+
+    expect(registriesAccordion.exists()).toBe(false);
+  });
+
   it('should fetch ssh keys from the aws api and save response as list of keypair KeyNames', async() => {
     const setup = requiredSetup();
 

--- a/pkg/eks/components/__tests__/CruEKS.test.ts
+++ b/pkg/eks/components/__tests__/CruEKS.test.ts
@@ -235,6 +235,52 @@ describe('eKS provisioning form', () => {
     expect(wrapper.vm.fvUnreportedValidationErrors).toStrictEqual([]);
   });
 
+  it('should show the registries accordion when the mode is import', async() => {
+    const setup = {
+      global: {
+        mocks: {
+          $store:      mockedStore({ value: '<=1.27.x' }),
+          $route:      { query: { mode: 'import' } },
+          $fetchState: {},
+        },
+        stubs: { CruResource: false, Accordion: false }
+      }
+    };
+    const wrapper = shallowMount(CruEKS, {
+      propsData: { value: {}, mode: 'create' },
+      ...setup
+    });
+
+    await setCredential(wrapper);
+    const registriesAccordion = wrapper.find('[data-testid="registries-accordion"]');
+
+    expect(registriesAccordion.exists()).toBe(true);
+  });
+
+  it('should show the registries accordion when editing an imported cluster', async() => {
+    const wrapper = shallowMount(CruEKS, {
+      propsData: { value: {}, mode: 'edit' },
+      ...requiredSetup()
+    });
+
+    await setCredential(wrapper, { ...DEFAULT_EKS_CONFIG, imported: true } as EKSConfig);
+    const registriesAccordion = wrapper.find('[data-testid="registries-accordion"]');
+
+    expect(registriesAccordion.exists()).toBe(true);
+  });
+
+  it('should not show the registries accordion for a non-imported cluster', async() => {
+    const wrapper = shallowMount(CruEKS, {
+      propsData: { value: {}, mode: 'create' },
+      ...requiredSetup()
+    });
+
+    await setCredential(wrapper);
+    const registriesAccordion = wrapper.find('[data-testid="registries-accordion"]');
+
+    expect(registriesAccordion.exists()).toBe(false);
+  });
+
   it('should fetch ssh keys from the aws api and save response as list of keypair KeyNames', async() => {
     const setup = requiredSetup();
 

--- a/pkg/eks/components/__tests__/CruEKS.test.ts
+++ b/pkg/eks/components/__tests__/CruEKS.test.ts
@@ -213,7 +213,7 @@ describe('eKS provisioning form', () => {
 
   it('should NOT show an error nor prevent saving if no node groups are defined in an IMPORTED cluster', async() => {
     const wrapper = mount(CruEKS, {
-      propsData: { value: {}, mode: 'edit' },
+      propsData: { value: { isImported: true }, mode: 'edit' },
       ...requiredSetup(),
       shallow:   true,
     });
@@ -259,7 +259,7 @@ describe('eKS provisioning form', () => {
 
   it('should show the registries accordion when editing an imported cluster', async() => {
     const wrapper = shallowMount(CruEKS, {
-      propsData: { value: {}, mode: 'edit' },
+      propsData: { value: { isImported: true }, mode: 'edit' },
       ...requiredSetup()
     });
 

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -19,6 +19,7 @@ import Accordion from '@components/Accordion/Accordion.vue';
 import Banner from '@components/Banner/Banner.vue';
 import Loading from '@shell/components/Loading.vue';
 
+import PrivateRegistry from '@shell/components/form/PrivateRegistry.vue';
 import ClusterMembershipEditor, { canViewClusterMembershipEditor } from '@shell/components/form/Members/ClusterMembershipEditor.vue';
 import type { GKEConfig, GKENodePool } from '@shell/components/google/types';
 import AccountAccess from '@shell/components/google/AccountAccess.vue';
@@ -133,6 +134,7 @@ const defaultImportedCluster = {
   enableNetworkPolicy:    false,
   windowsPreferedCluster: false,
   name:                   '',
+  importedConfig:         { privateRegistryURL: null },
   gkeConfig:              {
     imported:               true,
     clusterName:            '',
@@ -155,6 +157,7 @@ export default defineComponent({
     Networking,
     GKENodePoolComponent,
     Config,
+    PrivateRegistry,
     ClusterMembershipEditor,
     Labels,
     Tabbed,
@@ -198,6 +201,9 @@ export default defineComponent({
       if (!this.$store.getters['auth/principalId'].includes('local://')) {
         this.normanCluster.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
       }
+    }
+    if (!this.normanCluster.importedConfig) {
+      this.normanCluster.importedConfig = {};
     }
     // ensure any fields editable through this UI that have been altered in aws are shown here - see syncUpstreamConfig jsdoc for details
     if (!this.isNewOrUnprovisioned) {
@@ -246,7 +252,7 @@ export default defineComponent({
 
     return {
       isImport,
-      normanCluster:    { name: '' } as any,
+      normanCluster:    { name: '', importedConfig: { privateRegistryURL: null } } as any,
       nodePools:        [] as GKENodePool[],
       config:           { } as GKEConfig,
       membershipUpdate: {} as any,
@@ -265,6 +271,9 @@ export default defineComponent({
       }, {
         path:  'importName',
         rules: ['importNameRequired']
+      }, {
+        path:  'normanCluster.importedConfig.privateRegistryURL',
+        rules: ['registryUrl']
       }] : [
         {
           path:  'diskSizeGb',
@@ -310,6 +319,10 @@ export default defineComponent({
           path:  'clusterIpv4Cidr',
           rules: ['clusterIpv4CidrFormat']
         },
+        {
+          path:  'normanCluster.importedConfig.privateRegistryURL',
+          rules: ['registryUrl']
+        },
       ],
       isAuthenticated: false,
 
@@ -337,6 +350,10 @@ export default defineComponent({
 
   computed: {
     ...mapGetters({ t: 'i18n/t' }),
+
+    isImportedCluster() {
+      return this.isImport || !!this.config?.imported;
+    },
 
     /**
      * fv mixin accepts a rootObject in rules but doesn't seem to like that the norman cluster isn't yet defined when the rule set is defined so we're ignoring that and passing in the key we want validated here
@@ -571,6 +588,7 @@ export default defineComponent({
     'config.region'() {
       this.debouncedLoadGCPData();
     },
+
   },
 
   methods: {
@@ -915,6 +933,18 @@ export default defineComponent({
         <Labels
           v-model:value="normanCluster"
           :mode="mode"
+        />
+      </Accordion>
+      <Accordion
+        v-if="isImportedCluster"
+        class="mb-20"
+        title-key="cluster.tabs.registry"
+        data-testid="registries-accordion"
+      >
+        <PrivateRegistry
+          v-model:value="normanCluster.importedConfig.privateRegistryURL"
+          :mode="mode"
+          :rules="fvGetAndReportPathRules('normanCluster.importedConfig.privateRegistryURL')"
         />
       </Accordion>
     </div>

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -20,6 +20,7 @@ import Banner from '@components/Banner/Banner.vue';
 import Loading from '@shell/components/Loading.vue';
 
 import PrivateRegistry from '@shell/components/form/PrivateRegistry.vue';
+import { privateRegistryRequired } from '@shell/utils/validators/private-registry';
 import ClusterMembershipEditor, { canViewClusterMembershipEditor } from '@shell/components/form/Members/ClusterMembershipEditor.vue';
 import type { GKEConfig, GKENodePool } from '@shell/components/google/types';
 import AccountAccess from '@shell/components/google/AccountAccess.vue';
@@ -202,9 +203,10 @@ export default defineComponent({
         this.normanCluster.annotations[CREATOR_PRINCIPAL_ID] = this.$store.getters['auth/principalId'];
       }
     }
-    if (!this.normanCluster.importedConfig) {
+    if (this.value?.id && this.isImportedCluster && !this.normanCluster.importedConfig) {
       this.normanCluster.importedConfig = {};
     }
+    this.privateRegistryEnabled = !!this.normanCluster.importedConfig?.privateRegistryURL;
     // ensure any fields editable through this UI that have been altered in aws are shown here - see syncUpstreamConfig jsdoc for details
     if (!this.isNewOrUnprovisioned) {
       syncUpstreamConfig('gke', this.normanCluster);
@@ -252,12 +254,13 @@ export default defineComponent({
 
     return {
       isImport,
-      normanCluster:    { name: '', importedConfig: { privateRegistryURL: null } } as any,
-      nodePools:        [] as GKENodePool[],
-      config:           { } as GKEConfig,
-      membershipUpdate: {} as any,
-      originalVersion:  '',
-      defaultImageType: GKEImageTypes[0],
+      normanCluster:          { name: '', importedConfig: { privateRegistryURL: null } } as any,
+      nodePools:              [] as GKENodePool[],
+      config:                 { } as GKEConfig,
+      membershipUpdate:       {} as any,
+      originalVersion:        '',
+      defaultImageType:       GKEImageTypes[0],
+      privateRegistryEnabled: false,
       supportedVersionRange,
 
       loadingMachineTypes:     false,
@@ -272,8 +275,8 @@ export default defineComponent({
         path:  'importName',
         rules: ['importNameRequired']
       }, {
-        path:  'normanCluster.importedConfig.privateRegistryURL',
-        rules: ['registryUrl']
+        path:  'privateRegistry',
+        rules: ['privateRegistryRequired']
       }] : [
         {
           path:  'diskSizeGb',
@@ -319,10 +322,10 @@ export default defineComponent({
           path:  'clusterIpv4Cidr',
           rules: ['clusterIpv4CidrFormat']
         },
-        {
-          path:  'normanCluster.importedConfig.privateRegistryURL',
-          rules: ['registryUrl']
-        },
+        ...(this.value?.isImported ? [{
+          path:  'privateRegistry',
+          rules: ['privateRegistryRequired']
+        }] : []),
       ],
       isAuthenticated: false,
 
@@ -362,10 +365,11 @@ export default defineComponent({
 
     fvExtraRules() {
       return {
-        clusterNameChars:    clusterNameChars(this),
-        clusterNameStartEnd: clusterNameStartEnd(this),
-        nameRequired:        requiredInCluster(this, 'nameNsDescription.name.label', 'name'),
-        importNameRequired:  requiredInCluster(this, 'nameNsDescription.name.label', 'gkeConfig.clusterName'),
+        clusterNameChars:        clusterNameChars(this),
+        clusterNameStartEnd:     clusterNameStartEnd(this),
+        nameRequired:            requiredInCluster(this, 'nameNsDescription.name.label', 'name'),
+        importNameRequired:      requiredInCluster(this, 'nameNsDescription.name.label', 'gkeConfig.clusterName'),
+        privateRegistryRequired: privateRegistryRequired(this),
 
         masterIpv4CidrBlockRequired: () => {
           if (!this.isAuthenticated) {
@@ -943,8 +947,9 @@ export default defineComponent({
       >
         <PrivateRegistry
           v-model:value="normanCluster.importedConfig.privateRegistryURL"
+          v-model:enabled="privateRegistryEnabled"
           :mode="mode"
-          :rules="fvGetAndReportPathRules('normanCluster.importedConfig.privateRegistryURL')"
+          :rules="fvGetAndReportPathRules('privateRegistry')"
         />
       </Accordion>
     </div>

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -322,10 +322,10 @@ export default defineComponent({
           path:  'clusterIpv4Cidr',
           rules: ['clusterIpv4CidrFormat']
         },
-        ...(this.value?.isImported ? [{
+        {
           path:  'privateRegistry',
           rules: ['privateRegistryRequired']
-        }] : []),
+        },
       ],
       isAuthenticated: false,
 

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -352,7 +352,7 @@ export default defineComponent({
     ...mapGetters({ t: 'i18n/t' }),
 
     isImportedCluster() {
-      return this.isImport || !!this.config?.imported;
+      return this.isImport || this.value.isImported;
     },
 
     /**

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -414,7 +414,9 @@ export default defineComponent({
 </script>
 
 <template>
+  <Loading v-if="$fetchState.pending" />
   <CruResource
+    v-else
     :resource="value"
     :mode="mode"
     :can-yaml="false"
@@ -424,11 +426,7 @@ export default defineComponent({
     @error="e=>errors=e"
     @finish="save"
   >
-    <Loading
-      v-if="$fetchState.pending"
-      mode="relative"
-    />
-    <div v-else>
+    <div>
       <div>
         <Banner
           v-if="harvesterLocation"

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -28,6 +28,7 @@ import { AGENT_CONFIGURATION_TYPES, SETTING } from '@shell/config/settings';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
 import genericImportedClusterValidators from '../util/validators';
 import PrivateRegistry from '@shell/components/form/PrivateRegistry.vue';
+import { privateRegistryRequired } from '@shell/utils/validators/private-registry';
 import { IMPORTED_CLUSTER_VERSION_MANAGEMENT } from '@shell/config/labels-annotations';
 import cloneDeep from 'lodash/cloneDeep';
 import { VERSION_MANAGEMENT_DEFAULT } from '@pkg/imported/util/shared.ts';
@@ -88,6 +89,7 @@ export default defineComponent({
     } else {
       this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...cloneDeep(defaultCluster) }, { root: true });
     }
+    this.privateRegistryEnabled = !!this.normanCluster?.importedConfig?.privateRegistryURL;
     if (!this.isRKE1) {
       await this.initVersionManagement();
     }
@@ -124,6 +126,7 @@ export default defineComponent({
       // When disabling clusterAgentDeploymentCustomization, we need to replace the whole object
       needsReplace:                             false,
       clusterAgentDefaultPriorityClassHash:     SETTING.CLUSTER_AGENT_DEFAULT_PRIORITY_CLASS,
+      privateRegistryEnabled:                   false,
       fvFormRuleSets:                           [{
         path:  'name',
         rules: ['clusterNameRequired', 'clusterNameChars', 'clusterNameStartEnd', 'clusterNameLength'],
@@ -134,8 +137,8 @@ export default defineComponent({
         path:  'controlPlaneConcurrency',
         rules: ['controlPlaneConcurrencyRule']
       }, {
-        path:  'normanCluster.importedConfig.privateRegistryURL',
-        rules: ['registryUrl']
+        path:  'privateRegistry',
+        rules: ['privateRegistryRequired']
       }
       ],
       AGENT_CONFIGURATION_TYPES,
@@ -156,6 +159,7 @@ export default defineComponent({
         clusterNameLength:           genericImportedClusterValidators.clusterNameLength(this),
         workerConcurrencyRule:       genericImportedClusterValidators.workerConcurrency(this),
         controlPlaneConcurrencyRule: genericImportedClusterValidators.controlPlaneConcurrency(this),
+        privateRegistryRequired:     privateRegistryRequired(this),
       };
     },
 
@@ -415,7 +419,7 @@ export default defineComponent({
     :mode="mode"
     :can-yaml="false"
     :done-route="doneRoute"
-    :errors="errors"
+    :errors="fvUnreportedValidationErrors"
     :validation-passed="fvFormIsValid"
     @error="e=>errors=e"
     @finish="save"
@@ -598,8 +602,9 @@ export default defineComponent({
       >
         <PrivateRegistry
           v-model:value="normanCluster.importedConfig.privateRegistryURL"
+          v-model:enabled="privateRegistryEnabled"
           :mode="mode"
-          :rules="fvGetAndReportPathRules('normanCluster.importedConfig.privateRegistryURL')"
+          :rules="fvGetAndReportPathRules('privateRegistry')"
           checkbox-test-id="private-registry-enable-checkbox"
           input-test-id="private-registry-url"
         />

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -27,7 +27,7 @@ import { AGENT_CONFIGURATION_TYPES, SETTING } from '@shell/config/settings';
 
 import NameNsDescription from '@shell/components/form/NameNsDescription';
 import genericImportedClusterValidators from '../util/validators';
-import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
+import PrivateRegistry from '@shell/components/form/PrivateRegistry.vue';
 import { IMPORTED_CLUSTER_VERSION_MANAGEMENT } from '@shell/config/labels-annotations';
 import cloneDeep from 'lodash/cloneDeep';
 import { VERSION_MANAGEMENT_DEFAULT } from '@pkg/imported/util/shared.ts';
@@ -45,7 +45,7 @@ export default defineComponent({
   name: 'CruImported',
 
   components: {
-    Basics, ACE, LabeledInput, Loading, CruResource, KeyValue, NameNsDescription, Accordion, Banner, ClusterMembershipEditor, Labels, Checkbox, SchedulingCustomization
+    Basics, ACE, Loading, CruResource, KeyValue, NameNsDescription, Accordion, Banner, ClusterMembershipEditor, Labels, Checkbox, SchedulingCustomization, PrivateRegistry
   },
 
   mixins: [CreateEditView, FormValidation],
@@ -84,7 +84,6 @@ export default defineComponent({
         this.normanCluster.importedConfig = {};
       }
 
-      this.showPrivateRegistryInput = !!this.normanCluster?.importedConfig?.privateRegistryURL;
       this.getVersions();
     } else {
       this.normanCluster = await store.dispatch('rancher/create', { type: NORMAN.CLUSTER, ...cloneDeep(defaultCluster) }, { root: true });
@@ -108,7 +107,6 @@ export default defineComponent({
 
   data() {
     return {
-      showPrivateRegistryInput:                 false,
       normanCluster:                            { name: '', importedConfig: { privateRegistryURL: null } },
       loadingVersions:                          false,
       membershipUpdate:                         {},
@@ -407,16 +405,7 @@ export default defineComponent({
         }
       }
     },
-  },
-
-  watch: {
-    showPrivateRegistryInput(value) {
-      if (!value) {
-        this.normanCluster.importedConfig.privateRegistryURL = null;
-      }
-    }
   }
-
 });
 </script>
 
@@ -607,27 +596,12 @@ export default defineComponent({
         data-testid="registries-accordion"
         :open-initially="false"
       >
-        <Banner
-          color="info"
-          class="mt-0"
-        >
-          {{ t('cluster.privateRegistry.importedDescription') }}
-        </Banner>
-        <Checkbox
-          v-model:value="showPrivateRegistryInput"
-          class="mb-20"
-          :mode="mode"
-          :label="t('cluster.privateRegistry.label')"
-          data-testid="private-registry-enable-checkbox"
-        />
-        <LabeledInput
-          v-if="showPrivateRegistryInput"
+        <PrivateRegistry
           v-model:value="normanCluster.importedConfig.privateRegistryURL"
           :mode="mode"
           :rules="fvGetAndReportPathRules('normanCluster.importedConfig.privateRegistryURL')"
-          label-key="catalog.chart.registry.custom.inputLabel"
-          data-testid="private-registry-url"
-          :placeholder="t('catalog.chart.registry.custom.placeholder')"
+          checkbox-test-id="private-registry-enable-checkbox"
+          input-test-id="private-registry-url"
         />
       </Accordion>
       <Accordion

--- a/shell/components/form/PrivateRegistry.vue
+++ b/shell/components/form/PrivateRegistry.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import Banner from '@components/Banner/Banner.vue';
+import { Checkbox } from '@components/Form/Checkbox';
+import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
+
+const props = defineProps<{
+  value?: string | null;
+  mode?: string;
+  rules?: Function[];
+  checkboxTestId?: string;
+  inputTestId?: string;
+}>();
+
+const emit = defineEmits<{
+  'update:value': [val: string | null];
+}>();
+
+const showInput = ref(!!props.value);
+
+watch(showInput, (neu) => {
+  if (!neu) {
+    emit('update:value', null);
+  }
+});
+
+watch(() => props.value, (neu) => {
+  if (!!neu && !showInput.value) {
+    showInput.value = true;
+  }
+});
+
+const onInput = (val: string) => {
+  emit('update:value', val);
+};
+</script>
+
+<template>
+  <Banner
+    color="info"
+    class="mt-0"
+    label-key="cluster.privateRegistry.importedDescription"
+  />
+  <Checkbox
+    v-model:value="showInput"
+    class="mb-20"
+    :mode="mode"
+    :label="t('cluster.privateRegistry.label')"
+    :data-testid="checkboxTestId"
+  />
+  <LabeledInput
+    v-if="showInput"
+    :value="value as string"
+    :mode="mode"
+    :rules="rules"
+    label-key="catalog.chart.registry.custom.inputLabel"
+    :data-testid="inputTestId"
+    :placeholder="t('catalog.chart.registry.custom.placeholder')"
+    @update:value="onInput"
+  />
+</template>

--- a/shell/components/form/PrivateRegistry.vue
+++ b/shell/components/form/PrivateRegistry.vue
@@ -6,6 +6,7 @@ import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 
 const props = defineProps<{
   value?: string | null;
+  enabled?: boolean;
   mode?: string;
   rules?: Function[];
   checkboxTestId?: string;
@@ -14,12 +15,22 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'update:value': [val: string | null];
+  'update:enabled': [val: boolean];
 }>();
 
 const showInput = ref(!!props.value);
 
-watch(showInput, (neu) => {
-  if (!neu) {
+watch(() => props.enabled, (neu) => {
+  if (typeof neu === 'boolean' && neu !== showInput.value) {
+    showInput.value = neu;
+  }
+});
+
+watch(showInput, (neu, old) => {
+  if (neu !== props.enabled) {
+    emit('update:enabled', neu);
+  }
+  if (!neu && old && props.value) {
     emit('update:value', null);
   }
 });
@@ -29,10 +40,6 @@ watch(() => props.value, (neu) => {
     showInput.value = true;
   }
 });
-
-const onInput = (val: string) => {
-  emit('update:value', val);
-};
 </script>
 
 <template>
@@ -53,9 +60,10 @@ const onInput = (val: string) => {
     :value="value as string"
     :mode="mode"
     :rules="rules"
+    :required="true"
     label-key="catalog.chart.registry.custom.inputLabel"
     :data-testid="inputTestId"
     :placeholder="t('catalog.chart.registry.custom.placeholder')"
-    @update:value="onInput"
+    @update:value="(val) => emit('update:value', val)"
   />
 </template>

--- a/shell/components/form/__tests__/PrivateRegistry.test.ts
+++ b/shell/components/form/__tests__/PrivateRegistry.test.ts
@@ -1,0 +1,133 @@
+import { shallowMount } from '@vue/test-utils';
+import PrivateRegistry from '@shell/components/form/PrivateRegistry.vue';
+import { Checkbox } from '@components/Form/Checkbox';
+import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
+
+const defaultMocks = {
+  $store: {
+    getters: {
+      'i18n/t': (text: string) => text,
+      t:        (text: string) => text,
+    }
+  }
+};
+
+const mountPrivateRegistry = (props = {}) => {
+  return shallowMount(PrivateRegistry, {
+    props: {
+      mode: 'edit',
+      ...props
+    },
+    global: { mocks: defaultMocks }
+  });
+};
+
+describe('privateRegistry', () => {
+  it('should render the info banner', () => {
+    const wrapper = mountPrivateRegistry();
+    const banner = wrapper.find('[color="info"]');
+
+    expect(banner.exists()).toBe(true);
+  });
+
+  it('should render the enable checkbox', () => {
+    const wrapper = mountPrivateRegistry();
+    const checkbox = wrapper.findComponent(Checkbox);
+
+    expect(checkbox.exists()).toBe(true);
+  });
+
+  it('should not show the URL input when no value is provided', () => {
+    const wrapper = mountPrivateRegistry();
+
+    expect(wrapper.findComponent(LabeledInput).exists()).toBe(false);
+  });
+
+  it('should show the URL input when a value is provided', () => {
+    const wrapper = mountPrivateRegistry({ value: 'registry.example.com' });
+
+    expect(wrapper.findComponent(LabeledInput).exists()).toBe(true);
+  });
+
+  it('should show the URL input when checkbox is checked', async() => {
+    const wrapper = mountPrivateRegistry();
+
+    expect(wrapper.findComponent(LabeledInput).exists()).toBe(false);
+
+    const checkbox = wrapper.findComponent(Checkbox);
+
+    await checkbox.vm.$emit('update:value', true);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent(LabeledInput).exists()).toBe(true);
+  });
+
+  it('should emit update:value with null when checkbox is unchecked', async() => {
+    const wrapper = mountPrivateRegistry({ value: 'registry.example.com' });
+
+    const checkbox = wrapper.findComponent(Checkbox);
+
+    await checkbox.vm.$emit('update:value', false);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('update:value')).toHaveLength(1);
+    expect(wrapper.emitted('update:value')![0]).toStrictEqual([null]);
+  });
+
+  it('should emit update:value when the URL input changes', async() => {
+    const wrapper = mountPrivateRegistry({ value: 'registry.example.com' });
+    const input = wrapper.findComponent(LabeledInput);
+
+    await input.vm.$emit('update:value', 'new-registry.example.com');
+
+    expect(wrapper.emitted('update:value')).toHaveLength(1);
+    expect(wrapper.emitted('update:value')![0]).toStrictEqual(['new-registry.example.com']);
+  });
+
+  it('should auto-enable the checkbox when value changes from null to a string', async() => {
+    const wrapper = mountPrivateRegistry();
+
+    expect(wrapper.findComponent(LabeledInput).exists()).toBe(false);
+
+    await wrapper.setProps({ value: 'registry.example.com' });
+
+    expect(wrapper.findComponent(LabeledInput).exists()).toBe(true);
+  });
+
+  it('should pass rules to the URL input', () => {
+    const mockRule = jest.fn();
+    const wrapper = mountPrivateRegistry({
+      value: 'registry.example.com',
+      rules: [mockRule]
+    });
+    const input = wrapper.findComponent(LabeledInput);
+
+    expect(input.attributes('rules')).toBeDefined();
+  });
+
+  it('should apply custom data-testid to checkbox when provided', () => {
+    const wrapper = mountPrivateRegistry({ checkboxTestId: 'my-checkbox' });
+    const checkbox = wrapper.findComponent(Checkbox);
+
+    expect(checkbox.attributes('data-testid')).toBe('my-checkbox');
+  });
+
+  it('should apply custom data-testid to input when provided', () => {
+    const wrapper = mountPrivateRegistry({
+      value:       'registry.example.com',
+      inputTestId: 'my-input'
+    });
+    const input = wrapper.findComponent(LabeledInput);
+
+    expect(input.attributes('data-testid')).toBe('my-input');
+  });
+
+  it('should not set data-testid when not provided', () => {
+    const wrapper = mountPrivateRegistry({ value: 'registry.example.com' });
+    const checkbox = wrapper.findComponent(Checkbox);
+    const input = wrapper.findComponent(LabeledInput);
+
+    expect(checkbox.attributes('data-testid')).toBeUndefined();
+    expect(input.attributes('data-testid')).toBeUndefined();
+  });
+});

--- a/shell/utils/validators/__tests__/private-registry.test.ts
+++ b/shell/utils/validators/__tests__/private-registry.test.ts
@@ -1,0 +1,72 @@
+import { privateRegistryRequired } from '@shell/utils/validators/private-registry';
+
+const makeCtx = (overrides: any = {}) => ({
+  t:                      jest.fn((key: string, params?: any) => (params ? `${ key }:${ JSON.stringify(params) }` : key)),
+  privateRegistryEnabled: false,
+  normanCluster:          { importedConfig: { privateRegistryURL: null } },
+  isImportedCluster:      true,
+  ...overrides,
+});
+
+describe('privateRegistryRequired', () => {
+  it('should return undefined when the cluster is not imported', () => {
+    const ctx = makeCtx({ isImportedCluster: false, privateRegistryEnabled: true });
+    const rule = privateRegistryRequired(ctx);
+
+    expect(rule()).toBeUndefined();
+  });
+
+  it('should default isImportedCluster to true when the property is omitted', () => {
+    const ctx = makeCtx({ isImportedCluster: undefined, privateRegistryEnabled: true });
+    const rule = privateRegistryRequired(ctx);
+
+    expect(rule()).toStrictEqual('validation.required:{"key":"cluster.privateRegistry.label"}');
+  });
+
+  it('should return undefined when the registry toggle is off', () => {
+    const ctx = makeCtx({ privateRegistryEnabled: false });
+    const rule = privateRegistryRequired(ctx);
+
+    expect(rule()).toBeUndefined();
+  });
+
+  it('should return a required error when enabled but the url is empty', () => {
+    const ctx = makeCtx({
+      privateRegistryEnabled: true,
+      normanCluster:          { importedConfig: { privateRegistryURL: '' } },
+    });
+    const rule = privateRegistryRequired(ctx);
+
+    expect(rule()).toStrictEqual('validation.required:{"key":"cluster.privateRegistry.label"}');
+  });
+
+  it('should return a required error when normanCluster.importedConfig is missing', () => {
+    const ctx = makeCtx({
+      privateRegistryEnabled: true,
+      normanCluster:          {},
+    });
+    const rule = privateRegistryRequired(ctx);
+
+    expect(rule()).toStrictEqual('validation.required:{"key":"cluster.privateRegistry.label"}');
+  });
+
+  it('should return a format error when enabled and the url is malformed', () => {
+    const ctx = makeCtx({
+      privateRegistryEnabled: true,
+      normanCluster:          { importedConfig: { privateRegistryURL: 'goober' } },
+    });
+    const rule = privateRegistryRequired(ctx);
+
+    expect(rule()).toStrictEqual('cluster.privateRegistry.privateRegistryUrlError');
+  });
+
+  it('should return undefined when enabled and the url is valid', () => {
+    const ctx = makeCtx({
+      privateRegistryEnabled: true,
+      normanCluster:          { importedConfig: { privateRegistryURL: 'registry.io:5000' } },
+    });
+    const rule = privateRegistryRequired(ctx);
+
+    expect(rule()).toBeUndefined();
+  });
+});

--- a/shell/utils/validators/__tests__/private-registry.test.ts
+++ b/shell/utils/validators/__tests__/private-registry.test.ts
@@ -16,8 +16,12 @@ describe('privateRegistryRequired', () => {
     expect(rule()).toBeUndefined();
   });
 
-  it('should default isImportedCluster to true when the property is omitted', () => {
-    const ctx = makeCtx({ isImportedCluster: undefined, privateRegistryEnabled: true });
+  it('should default isImportedCluster to true when the property is absent from the context', () => {
+    const ctx: any = {
+      t:                      jest.fn((key: string, params?: any) => (params ? `${ key }:${ JSON.stringify(params) }` : key)),
+      privateRegistryEnabled: true,
+      normanCluster:          { importedConfig: { privateRegistryURL: null } },
+    };
     const rule = privateRegistryRequired(ctx);
 
     expect(rule()).toStrictEqual('validation.required:{"key":"cluster.privateRegistry.label"}');

--- a/shell/utils/validators/private-registry.ts
+++ b/shell/utils/validators/private-registry.ts
@@ -10,7 +10,8 @@ interface PrivateRegistryRuleContext {
 
 export function privateRegistryRequired(ctx: PrivateRegistryRuleContext) {
   return () => {
-    const isImported = ctx.isImportedCluster ?? true;
+    // Check existence using `in` rather than direct access to avoid Vue's render-time warning
+    const isImported = 'isImportedCluster' in ctx ? !!ctx.isImportedCluster : true;
 
     if (!isImported || !ctx.privateRegistryEnabled) {
       return undefined;

--- a/shell/utils/validators/private-registry.ts
+++ b/shell/utils/validators/private-registry.ts
@@ -1,0 +1,27 @@
+import { Translation } from '@shell/types/t';
+import formRulesGenerator from '@shell/utils/validators/formRules';
+
+interface PrivateRegistryRuleContext {
+  t: Translation;
+  privateRegistryEnabled: boolean;
+  normanCluster: { importedConfig?: { privateRegistryURL?: string | null } } | null;
+  isImportedCluster?: boolean;
+}
+
+export function privateRegistryRequired(ctx: PrivateRegistryRuleContext) {
+  return () => {
+    const isImported = ctx.isImportedCluster ?? true;
+
+    if (!isImported || !ctx.privateRegistryEnabled) {
+      return undefined;
+    }
+    const url = ctx.normanCluster?.importedConfig?.privateRegistryURL;
+
+    if (!url) {
+      return ctx.t('validation.required', { key: ctx.t('cluster.privateRegistry.label') });
+    }
+    const { registryUrl } = formRulesGenerator(ctx.t, { key: ctx.t('cluster.privateRegistry.label') });
+
+    return (registryUrl as (val: string) => string | undefined)(url);
+  };
+}


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
We already had the private registry for generic import clusters, this generalizes the component and uses it in the imported cloud provider clusters.

Fixes #14916
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Create a new component, used it in each of these cluster types.

### Technical notes summary
- Assuming same `spec` structure for each cluster.

### Areas or cases that should be tested
- I verified in generic and eks, I don't have access to gke or aks yet but once I do I'll verify there as well.
- Verify private registry component when creating and editing the following imported clusters:
    - GKE
    - AKS
    - EKS
    - Generic

### Areas which could experience regressions
- See above

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/f2b2616a-abf1-45ab-86ac-8793577ac500


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
