### PR TITLE
Strip quotes from auth and upload-cloud versions

### DIFF
--- a/.github/workflows/build-and-upload.yaml
+++ b/.github/workflows/build-and-upload.yaml
@@ -50,12 +50,12 @@ jobs:
 
       - name: Apply gcs auth
         # https://github.com/google-github-actions/auth
-        uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           credentials_json: "${{ env.GOOGLE_AUTH }}"
 
       - name: Upload build
-        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3'
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3
         # https://github.com/google-github-actions/upload-cloud-storage
         with:
           path: ${{steps.build-hosted.outputs.BUILD_HOSTED_DIR}}
@@ -95,12 +95,12 @@ jobs:
 
       - name: Apply gcs auth
         # https://github.com/google-github-actions/auth
-        uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           credentials_json: "${{ env.GOOGLE_AUTH }}"
 
       - name: Upload tar
-        uses: 'google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3'
+        uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3'
         with:
           path: ${{steps.build-embedded.outputs.BUILD_EMBEDED_TGZ}}
           # Example - https://releases.rancher.com/ui/2.8.0.tar.gz


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This strips the quotes from the version strings for `google-github-actions/auth` and `google-github-actions/upload-cloud-storage`.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Strip quotes from auth and upload-cloud versions

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This is a follow-up to #17002

The single quotes originally included the version comment, causing workflows to fail:

```
Error: Unable to resolve action `google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3`, unable to find version `7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3`. Unable to resolve action `google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3`, unable to find version `6397bd7208e18d13ba2619ee21b9873edc94427a # v3`
```

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

CI build and upload: https://github.com/rancher/dashboard/actions/runs/23607819656/job/68756529101

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

NA

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
