### PR TITLE
Automation: Stabilize OIDC provider tests

### DIFF
--- a/cypress/e2e/po/pages/users-and-auth/oidc-client.po.ts
+++ b/cypress/e2e/po/pages/users-and-auth/oidc-client.po.ts
@@ -22,7 +22,7 @@ export default class OidcClientsPagePo extends PagePo {
     const sideNav = new ProductNavPo();
 
     BurgerMenuPo.burgerMenuNavToMenubyLabel('Users & Authentication');
-    sideNav.navToSideMenuGroupByLabel('Client Application');
+    sideNav.navToSideMenuEntryByLabel('OIDC Apps');
   }
 
   createOidcClient() {

--- a/cypress/e2e/tests/pages/users-and-auth/oidcProvider.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/oidcProvider.spec.ts
@@ -4,8 +4,10 @@ import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import { promptModal } from '@/cypress/e2e/po/prompts/shared/modalInstances.po';
 import OIDCClientDetailPo from '@/cypress/e2e/po/detail/management.cattle.io.oidcclient.po';
 import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import { qase } from '@/cypress/support/qase';
 
-describe('Rancher as an OIDC Provider', { testIsolation: 'off', tags: ['@globalSettings', '@adminUser'] }, () => {
+describe('Rancher as an OIDC Provider', { tags: ['@globalSettings', '@adminUser'] }, () => {
   const OIDC_CREATE_DATA = {
     APP_NAME: 'some-app-name',
     APP_DESC: 'some-app-desc',
@@ -35,15 +37,16 @@ describe('Rancher as an OIDC Provider', { testIsolation: 'off', tags: ['@globalS
   const oidcClientCreatePage = new OidcClientCreateEditPo(clusterId);
   const oidcClientEditPage = new OidcClientCreateEditPo(clusterId, OIDC_CREATE_DATA.APP_NAME, true);
 
-  before(() => {
+  beforeEach(() => {
     cy.login();
   });
 
-  it('should be able to create an OIDC client application', () => {
+  qase(9761, it('should be able to create an OIDC client application', () => {
     cy.intercept('POST', `/v1/management.cattle.io.oidcclients`).as('createRequest');
 
-    oidcClientsPage.goTo();
-    oidcClientsPage.waitForPage();
+    HomePagePo.goTo();
+    OidcClientsPagePo.navTo(); // Do not use goTo() here — deep link (going directly to the list page) makes the full-secret copy row behavior flaky.
+    oidcClientsPage.waitForUrlPathWithoutContext();
 
     // check title and list view
     oidcClientsPage.list().title().should('contain', 'OIDC Apps');
@@ -57,7 +60,7 @@ describe('Rancher as an OIDC Provider', { testIsolation: 'off', tags: ['@globalS
 
     // let's create an oidc client
     oidcClientsPage.createOidcClient();
-    oidcClientCreatePage.waitForPage();
+    oidcClientCreatePage.waitForUrlPathWithoutContext();
 
     oidcClientCreatePage.nameNsDescription().name().set(OIDC_CREATE_DATA.APP_NAME);
     oidcClientCreatePage.nameNsDescription().description().set(OIDC_CREATE_DATA.APP_DESC);
@@ -79,16 +82,16 @@ describe('Rancher as an OIDC Provider', { testIsolation: 'off', tags: ['@globalS
       expect(response?.body.spec.tokenExpirationSeconds).to.equal(OIDC_CREATE_DATA.TOKEN_EXP);
     });
 
-    oidcClientDetailPage.waitForPage();
+    oidcClientDetailPage.waitForUrlPathWithoutContext();
 
     oidcClientDetailPage.clientID().exists();
     oidcClientDetailPage.clientFullSecretCopy(0).exists();
 
     oidcClientDetailPage.clientID().copyToClipboard();
     oidcClientDetailPage.clientFullSecretCopy(0).copyToClipboard();
-  });
+  }));
 
-  it('should be able to edit an OIDC client application', () => {
+  qase(9762, it('should be able to edit an OIDC client application', () => {
     cy.intercept('PUT', `/v1/management.cattle.io.oidcclients/${ OIDC_CREATE_DATA.APP_NAME }`).as('editRequest');
 
     OidcClientsPagePo.goTo();
@@ -116,14 +119,18 @@ describe('Rancher as an OIDC Provider', { testIsolation: 'off', tags: ['@globalS
       expect(response?.body.spec.refreshTokenExpirationSeconds).to.equal(OIDC_EDIT_DATA.REF_TOKEN_EXP);
       expect(response?.body.spec.tokenExpirationSeconds).to.equal(OIDC_EDIT_DATA.TOKEN_EXP);
     });
-  });
+  }));
 
-  it('should be able to add a new secret for an OIDC provider', () => {
+  qase(9763, it('should be able to add a new secret for an OIDC provider', () => {
     cy.intercept('PUT', `/v1/management.cattle.io.oidcclients/${ OIDC_CREATE_DATA.APP_NAME }`).as('addNewSecret');
 
-    oidcClientDetailPage.goTo();
-    oidcClientDetailPage.waitForPage();
-
+    HomePagePo.goTo();
+    OidcClientsPagePo.navTo(); // Do not use goTo() here — deep link (going directly to the detail page) makes the full-secret copy row behavior flaky.
+    oidcClientsPage.waitForUrlPathWithoutContext();
+    oidcClientsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+    oidcClientsPage.list().resourceTable().sortableTable().noRowsShouldNotExist();
+    oidcClientsPage.list().resourceTable().goToDetailsPage(OIDC_CREATE_DATA.APP_NAME);
+    oidcClientDetailPage.waitForUrlPathWithoutContext();
     oidcClientDetailPage.addNewSecretBtnClick();
 
     // check data from network request
@@ -133,20 +140,25 @@ describe('Rancher as an OIDC Provider', { testIsolation: 'off', tags: ['@globalS
     });
 
     // Wait for the page to refresh and show the new secret with proper timeout
-    oidcClientDetailPage.waitForPage();
+    oidcClientDetailPage.waitForUrlPathWithoutContext();
 
     // Wait for the secret element to appear before trying to interact with it
     oidcClientDetailPage.clientFullSecretCopy(1).checkVisible();
 
     oidcClientDetailPage.clientFullSecretCopy(1).exists();
     oidcClientDetailPage.clientFullSecretCopy(1).copyToClipboard();
-  });
+  }));
 
-  it('should be able to regenerate a secret for an OIDC provider', () => {
+  qase(9764, it('should be able to regenerate a secret for an OIDC provider', () => {
     cy.intercept('PUT', `/v1/management.cattle.io.oidcclients/${ OIDC_CREATE_DATA.APP_NAME }`).as('regenSecret');
 
-    oidcClientDetailPage.goTo();
-    oidcClientDetailPage.waitForPage();
+    HomePagePo.goTo();
+    OidcClientsPagePo.navTo(); // Do not use goTo() here — deep link (going directly to the detail page) makes the full-secret copy row behavior flaky.
+    oidcClientsPage.waitForUrlPathWithoutContext();
+    oidcClientsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+    oidcClientsPage.list().resourceTable().sortableTable().noRowsShouldNotExist();
+    oidcClientsPage.list().resourceTable().goToDetailsPage(OIDC_CREATE_DATA.APP_NAME);
+    oidcClientDetailPage.waitForUrlPathWithoutContext();
 
     // let's regen the secret we've added the step before
     oidcClientDetailPage.secretCardActionMenuToggle(1);
@@ -163,9 +175,9 @@ describe('Rancher as an OIDC Provider', { testIsolation: 'off', tags: ['@globalS
 
     oidcClientDetailPage.clientFullSecretCopy(1).exists();
     oidcClientDetailPage.clientFullSecretCopy(1).copyToClipboard();
-  });
+  }));
 
-  it('should be able to delete a secret for an OIDC provider', () => {
+  qase(9765, it('should be able to delete a secret for an OIDC provider', () => {
     cy.intercept('PUT', `/v1/management.cattle.io.oidcclients/${ OIDC_CREATE_DATA.APP_NAME }`).as('deleteSecret');
 
     oidcClientDetailPage.goTo();
@@ -186,9 +198,9 @@ describe('Rancher as an OIDC Provider', { testIsolation: 'off', tags: ['@globalS
 
     // check that the card doesn't exist anymore
     cy.get('[data-testid="item-card-client-secret-2"]').should('not.exist');
-  });
+  }));
 
-  it('should be able to delete an OIDC client application', () => {
+  qase(9766, it('should be able to delete an OIDC client application', () => {
     cy.intercept('DELETE', `/v1/management.cattle.io.oidcclients/${ OIDC_CREATE_DATA.APP_NAME }`).as('deleteRequest');
 
     OidcClientsPagePo.goTo();
@@ -204,5 +216,5 @@ describe('Rancher as an OIDC Provider', { testIsolation: 'off', tags: ['@globalS
 
     oidcClientsPage.waitForPage();
     cy.contains(OIDC_CREATE_DATA.APP_NAME).should('not.exist');
-  });
+  }));
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2231

Updates the OIDC provider tests so they navigate to the OIDC Apps list page and navigate into the detail page from the resource table instead of using goTo() on the detail URL. Deep-linking to the detail page was tied to flaky behavior for the full-secret copy row (load-order / snapshot timing).
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="422" height="170" alt="image" src="https://github.com/user-attachments/assets/69198550-bb1e-45ac-bcc5-2c3e9b7ca118" />



<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
