### PR TITLE
fixed release notes test and flakiness caused by test isolation

### DIFF
--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -4,9 +4,10 @@ import DiagnosticsPagePo from '@/cypress/e2e/po/pages/diagnostics.po';
 
 const aboutPage = new AboutPagePo();
 
-describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
-  before(() => {
+describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+  beforeEach(() => {
     cy.login();
+    aboutPage.goTo();
   });
 
   it('can navigate to About page', () => {
@@ -16,15 +17,12 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
   });
 
   it('no Prime info when community', { tags: '@noPrime' }, () => {
-    HomePagePo.goToAndWaitForGet();
-    AboutPagePo.navTo();
     aboutPage.waitForPage();
 
     aboutPage.rancherPrimeInfo().should('not.exist');
   });
 
   it('can navigate to Diagnostics page', () => {
-    AboutPagePo.navTo();
     aboutPage.waitForPage();
     aboutPage.diagnosticsBtn().click();
 
@@ -37,9 +35,16 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
     AboutPagePo.navTo();
     aboutPage.waitForPage();
 
-    aboutPage.clickVersionLink('View release notes');
-    cy.origin('https://github.com/rancher/rancher', () => {
-      cy.url().should('include', 'https://github.com/rancher/rancher/releases/tag/');
+    cy.getRancherVersion().then((version) => {
+      const isPrime = version.RancherPrime === 'true';
+      const expectedOrigin = isPrime ? 'https://documentation.suse.com' : 'https://github.com';
+      const expectedPath = isPrime ? '/cloudnative/rancher-manager/latest/en/release-notes' : '/rancher/rancher/releases/tag/';
+
+      aboutPage.clickVersionLink('View release notes');
+      cy.origin(expectedOrigin, { args: { expectedPath } }, ({ expectedPath }) => {
+        cy.location('pathname').should('include', expectedPath);
+        cy.get('body').should('be.visible');
+      });
     });
   });
 

--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -7,7 +7,6 @@ const aboutPage = new AboutPagePo();
 describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
   beforeEach(() => {
     cy.login();
-    aboutPage.goTo();
   });
 
   it('can navigate to About page', () => {
@@ -17,12 +16,13 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
   });
 
   it('no Prime info when community', { tags: '@noPrime' }, () => {
+    aboutPage.goTo();
     aboutPage.waitForPage();
-
     aboutPage.rancherPrimeInfo().should('not.exist');
   });
 
   it('can navigate to Diagnostics page', () => {
+    aboutPage.goTo();
     aboutPage.waitForPage();
     aboutPage.diagnosticsBtn().click();
 
@@ -31,10 +31,9 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
     diagnosticsPo.waitForPage();
   });
 
-  it('can View release notes', () => {
-    AboutPagePo.navTo();
+  it('can View release notes', { tags: '@prime' }, () => {
+    aboutPage.goTo();
     aboutPage.waitForPage();
-
     cy.getRancherVersion().then((version) => {
       const isPrime = version.RancherPrime === 'true';
       const expectedOrigin = isPrime ? 'https://documentation.suse.com' : 'https://github.com';
@@ -42,8 +41,7 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
 
       aboutPage.clickVersionLink('View release notes');
       cy.origin(expectedOrigin, { args: { expectedPath } }, ({ expectedPath }) => {
-        cy.location('pathname').should('include', expectedPath);
-        cy.get('body').should('be.visible');
+        cy.url().should('include', expectedPath);
       });
     });
   });
@@ -51,6 +49,7 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
   describe('Versions', () => {
     beforeEach(() => {
       aboutPage.goTo();
+      aboutPage.waitForPage();
     });
 
     it('can see rancher version', () => {
@@ -64,28 +63,28 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
 
     it('can navigate to /rancher/rancher', () => {
       aboutPage.clickVersionLink('Rancher');
-      cy.origin('https://github.com/rancher/rancher', () => {
+      cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/rancher');
       });
     });
 
     it('can navigate to /rancher/dashboard', () => {
       aboutPage.clickVersionLink('Dashboard');
-      cy.origin('https://github.com/rancher/dashboard', () => {
+      cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/dashboard');
       });
     });
 
     it('can navigate to /rancher/helm', () => {
       aboutPage.clickVersionLink('Helm');
-      cy.origin('https://github.com/rancher/helm', () => {
+      cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/helm');
       });
     });
 
     it('can navigate to /rancher/machine', () => {
       aboutPage.clickVersionLink('Machine');
-      cy.origin('https://github.com/rancher/machine', () => {
+      cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/machine');
       });
     });
@@ -98,6 +97,7 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
     // workaround to make the following CLI tests work https://github.com/cypress-io/cypress/issues/8089#issuecomment-1585159023
     beforeEach(() => {
       aboutPage.goTo();
+      aboutPage.waitForPage();
       cy.intercept('GET', 'https://releases.rancher.com/cli2/**').as('download');
     });
 
@@ -157,7 +157,6 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
     }
 
     beforeEach(() => {
-      cy.login();
       interceptVersionAndSetToPrime().as('rancherVersion');
     });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
https://github.com/rancher/qa-tasks/issues/2269

### Occurred changes and/or fixed issues
Enabled Test Isolation to remove flakiness in the Versions test suite and updated the 'can View release notes' test to reflect the prime release notes url

### Areas or cases that should be tested
The `about.spec.ts` tests


### Screenshot/Video
All tests passing locally with node version v20.17.0
<img width="1740" height="988" alt="Screenshot 2026-03-26 at 21 00 03" src="https://github.com/user-attachments/assets/2471fa75-198e-4ae4-b6bc-2f4c0084d4f9" />




### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
