### PR TITLE
Fixed v2prov-capi.spec.ts -  modal overlay plus local distro check

### DIFF
--- a/cypress/e2e/tests/pages/manager/v2prov-capi.spec.ts
+++ b/cypress/e2e/tests/pages/manager/v2prov-capi.spec.ts
@@ -1,5 +1,6 @@
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import { qase } from '@/cypress/support/qase';
 
 import { mockCapiMgmtCluster, mockCapiProvCluster } from '@/cypress/e2e/blueprints/manager/v2prov-capi-cluster-mocks';
 
@@ -30,13 +31,21 @@ describe('Cluster List - v2 Provisioning CAPI Clusters', { tags: ['@manager', '@
     clusterList.waitForPage();
   });
 
-  it('should not allow editing CAPI cluster configs', () => {
-    clusterList.list().actionMenu(clusterName).getMenuItem('Edit Config').should('not.exist');
-    clusterList.list().actionMenu('local').getMenuItem('Edit Config').should('exist');
-  });
+  qase(18526, it('should not allow editing CAPI cluster configs', () => {
+    const capiActionMenu = clusterList.list().actionMenu(clusterName);
 
-  it('should not report a machine provider for CAPI clusters', () => {
+    capiActionMenu.getMenuItem('Edit Config').should('not.exist');
+
+    // Close the first row action menu so its overlay does not block subsequent row actions.
+    clusterList.list().actionMenuClose(clusterName);
+    cy.get('body').find('[dropdown-menu-collection]:visible').should('have.length', 0);
+
+    clusterList.list().actionMenu('local').getMenuItem('Edit Config').should('exist');
+  }));
+
+  qase(18528, it('should not report a machine provider for CAPI clusters', () => {
     clusterList.list().provider(clusterName).should('have.text', ' RKE2');
-    clusterList.list().provider('local').should('have.text', 'Local K3s');
-  });
+
+    clusterList.list().provider('local').invoke('text').should('match', /^Local (K3s|RKE2)$/);
+  }));
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
(https://github.com/rancher/qa-tasks/issues/2280)

### Occurred changes and/or fixed issues
Fixed modal overlay issue in test 'should not allow editing CAPI cluster configs'  and updated the test 'should not report a machine provider for CAPI clusters' to fetch cluster distros so that it's flexible for both RKE2 and K3s local clusters.

### Areas or cases that should be tested
Test v2prov-capi.spec.ts locally and in jenkins pipeline with both k3s and RKE2 local clusters


### Screenshot/Video
<img width="1740" height="988" alt="Screenshot 2026-03-27 at 00 09 02" src="https://github.com/user-attachments/assets/f8738f5f-766a-4e5e-b2a7-51cf0000cd75" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
