### PR TITLE
Use the svc DNS instead of the IP

### DIFF
--- a/shell/dialog/ExtensionCatalogInstallDialog.vue
+++ b/shell/dialog/ExtensionCatalogInstallDialog.vue
@@ -302,7 +302,7 @@ export default {
         });
 
         if (this.extensionSvc) {
-          this.extensionUrl = `http://${ this.extensionSvc.spec.clusterIP }:${ this.extensionSvc.spec.ports[0].port }`;
+          this.extensionUrl = `http://${ this.extensionSvc.metadata.name }.${ this.extensionSvc.metadata.namespace }.svc:${ this.extensionSvc.spec.ports[0].port }`;
         } else {
           throw new Error('Error fetching extension service');
         }


### PR DESCRIPTION
### Summary
Currently when importing an Extension Catalog, the catalog created points to the SVC IP directly. That IP can change if the SVC is recreated for whatever reason but pointing to the DNS entry will always work.

fixes #17171

### Occurred changes and/or fixed issues
No idea.

### Technical notes summary
Basically it is a K8s best practice to use the SVC DNS name instead of the IP as it may change.

### Areas or cases that should be tested
No idea.

### Areas which could experience regressions
No idea

### Screenshot/Video
<img width="1181" height="85" alt="image" src="https://github.com/user-attachments/assets/8b078c1a-cc83-4f58-8c7b-b5c972116531" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone 
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
