### PR TITLE
[backport 2.13.5] Automation: Stabilize OIDC provider tests

### DIFF
--- a/cypress/e2e/po/pages/users-and-auth/oidc-client.po.ts
+++ b/cypress/e2e/po/pages/users-and-auth/oidc-client.po.ts
@@ -22,7 +22,7 @@ export default class OidcClientsPagePo extends PagePo {
     const sideNav = new ProductNavPo();
 
     BurgerMenuPo.burgerMenuNavToMenubyLabel('Users & Authentication');
-    sideNav.navToSideMenuGroupByLabel('Client Application');
+    sideNav.navToSideMenuEntryByLabel('OIDC Apps');
   }
 
   createOidcClient() {

--- a/cypress/e2e/tests/pages/users-and-auth/oidcProvider.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/oidcProvider.spec.ts
@@ -3,8 +3,9 @@ import OidcClientCreateEditPo from '~/cypress/e2e/po/edit/management.cattle.io.o
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import { promptModal } from '@/cypress/e2e/po/prompts/shared/modalInstances.po';
 import OIDCClientDetailPo from '@/cypress/e2e/po/detail/management.cattle.io.oidcclient.po';
+import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 
-describe('Rancher as an OIDC Provider', { testIsolation: 'off', tags: ['@globalSettings', '@adminUser'] }, () => {
+describe('Rancher as an OIDC Provider', { tags: ['@globalSettings', '@adminUser'] }, () => {
   const OIDC_CREATE_DATA = {
     APP_NAME: 'some-app-name',
     APP_DESC: 'some-app-desc',
@@ -34,15 +35,16 @@ describe('Rancher as an OIDC Provider', { testIsolation: 'off', tags: ['@globalS
   const oidcClientCreatePage = new OidcClientCreateEditPo(clusterId);
   const oidcClientEditPage = new OidcClientCreateEditPo(clusterId, OIDC_CREATE_DATA.APP_NAME, true);
 
-  before(() => {
+  beforeEach(() => {
     cy.login();
   });
 
   it('should be able to create an OIDC client application', () => {
     cy.intercept('POST', `/v1/management.cattle.io.oidcclients`).as('createRequest');
 
-    oidcClientsPage.goTo();
-    oidcClientsPage.waitForPage();
+    HomePagePo.goTo();
+    OidcClientsPagePo.navTo(); // Do not use goTo() here — deep link (going directly to the list page) makes the full-secret copy row behavior flaky.
+    oidcClientsPage.waitForUrlPathWithoutContext();
 
     // check title and list view
     oidcClientsPage.list().title().should('contain', 'OIDC Apps');
@@ -56,7 +58,7 @@ describe('Rancher as an OIDC Provider', { testIsolation: 'off', tags: ['@globalS
 
     // let's create an oidc client
     oidcClientsPage.createOidcClient();
-    oidcClientCreatePage.waitForPage();
+    oidcClientCreatePage.waitForUrlPathWithoutContext();
 
     oidcClientCreatePage.nameNsDescription().name().set(OIDC_CREATE_DATA.APP_NAME);
     oidcClientCreatePage.nameNsDescription().description().set(OIDC_CREATE_DATA.APP_DESC);
@@ -78,7 +80,7 @@ describe('Rancher as an OIDC Provider', { testIsolation: 'off', tags: ['@globalS
       expect(response?.body.spec.tokenExpirationSeconds).to.equal(OIDC_CREATE_DATA.TOKEN_EXP);
     });
 
-    oidcClientDetailPage.waitForPage();
+    oidcClientDetailPage.waitForUrlPathWithoutContext();
 
     oidcClientDetailPage.clientID().exists();
     oidcClientDetailPage.clientFullSecretCopy(0).exists();
@@ -120,9 +122,13 @@ describe('Rancher as an OIDC Provider', { testIsolation: 'off', tags: ['@globalS
   it('should be able to add a new secret for an OIDC provider', () => {
     cy.intercept('PUT', `/v1/management.cattle.io.oidcclients/${ OIDC_CREATE_DATA.APP_NAME }`).as('addNewSecret');
 
-    oidcClientDetailPage.goTo();
-    oidcClientDetailPage.waitForPage();
-
+    HomePagePo.goTo();
+    OidcClientsPagePo.navTo(); // Do not use goTo() here — deep link (going directly to the detail page) makes the full-secret copy row behavior flaky.
+    oidcClientsPage.waitForUrlPathWithoutContext();
+    oidcClientsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+    oidcClientsPage.list().resourceTable().sortableTable().noRowsShouldNotExist();
+    oidcClientsPage.list().resourceTable().goToDetailsPage(OIDC_CREATE_DATA.APP_NAME);
+    oidcClientDetailPage.waitForUrlPathWithoutContext();
     oidcClientDetailPage.addNewSecretBtnClick();
 
     // check data from network request
@@ -138,8 +144,13 @@ describe('Rancher as an OIDC Provider', { testIsolation: 'off', tags: ['@globalS
   it('should be able to regenerate a secret for an OIDC provider', () => {
     cy.intercept('PUT', `/v1/management.cattle.io.oidcclients/${ OIDC_CREATE_DATA.APP_NAME }`).as('regenSecret');
 
-    oidcClientDetailPage.goTo();
-    oidcClientDetailPage.waitForPage();
+    HomePagePo.goTo();
+    OidcClientsPagePo.navTo(); // Do not use goTo() here — deep link (going directly to the detail page) makes the full-secret copy row behavior flaky.
+    oidcClientsPage.waitForUrlPathWithoutContext();
+    oidcClientsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+    oidcClientsPage.list().resourceTable().sortableTable().noRowsShouldNotExist();
+    oidcClientsPage.list().resourceTable().goToDetailsPage(OIDC_CREATE_DATA.APP_NAME);
+    oidcClientDetailPage.waitForUrlPathWithoutContext();
 
     // let's regen the secret we've added the step before
     oidcClientDetailPage.secretCardActionMenuToggle(1);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2231

Backport of https://github.com/rancher/dashboard/pull/17032

<!-- Define findings related to the feature or bug issue. -->


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
