### PR TITLE
[16714][fleet] Change to only show workspace selector on list screen

### DIFF
--- a/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
@@ -484,8 +484,6 @@ describe('Fleet CLuster List - resources', { tags: ['@fleet', '@adminUser'] }, (
     // check table headers
     const expectedHeadersDetailsView = ['State', 'Name', 'Type', 'Source', 'Target', 'Clusters Ready', 'Resources', 'Age'];
 
-    headerPo.selectWorkspace(workspace);
-
     // Select flat list
     fleetClusterDetailsPage.appBundlesList().sortableTable().groupByButtons(0).click();
 

--- a/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
@@ -68,8 +68,6 @@ describe('Git Repo', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] }, (
         repo, branch, paths, helmRepoURLRegex
       } = gitRepoCreateRequest.spec;
 
-      headerPo.selectWorkspace(workspace);
-
       // Metadata step
       gitRepoCreatePage.resourceDetail().createEditView().nameNsDescription()
         .name()

--- a/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
@@ -60,6 +60,11 @@ describe('Git Repo', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] }, (
       cy.intercept('GET', '/v1/secrets?*').as('getSecrets');
       cy.intercept('GET', '/v1/secrets?*').as('getSecretsInitialLoad');
 
+      // Select the workspace from the list page before navigating to create
+      listPage.goTo();
+      listPage.waitForPage();
+      headerPo.selectWorkspace(workspace);
+
       gitRepoCreatePage.goTo();
       gitRepoCreatePage.waitForPage();
 

--- a/cypress/e2e/tests/pages/fleet/helmop.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/helmop.spec.ts
@@ -96,8 +96,6 @@ describe('Fleet HelmOps', { testIsolation: 'off', tags: ['@fleet', '@adminUser']
 
       helmOpCreatePage.waitForPage();
 
-      headerPo.selectWorkspace(workspace);
-
       // Metadata step
       helmOpCreatePage.resourceDetail().createEditView().nameNsDescription()
         .name()

--- a/cypress/e2e/tests/pages/fleet/resources/workspaces.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/resources/workspaces.spec.ts
@@ -1,3 +1,4 @@
+import { FleetApplicationListPagePo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
 import { FleetWorkspaceListPagePo, FleetWorkspaceCreateEditPo, FleetWorkspaceDetailsPo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.fleetworkspace.po';
 import { generateFleetWorkspacesDataSmall } from '@/cypress/e2e/blueprints/fleet/workspaces-get';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
@@ -415,10 +416,10 @@ describe('Workspaces', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] },
     });
 
     it('user sees custom workspace as an option in workspace selector', () => {
-      fleetWorkspacesListPage.goTo();
-      fleetWorkspacesListPage.waitForPage();
-      fleetWorkspacesListPage.list().resourceTable().sortableTable()
-        .noRowsShouldNotExist();
+      const appBundleListPage = new FleetApplicationListPagePo();
+
+      appBundleListPage.goTo();
+      appBundleListPage.waitForPage();
       headerPo.checkCurrentWorkspace(customWorkspace);
     });
 

--- a/cypress/e2e/tests/pages/fleet/resources/workspaces.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/resources/workspaces.spec.ts
@@ -1,5 +1,5 @@
-import { FleetApplicationListPagePo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
 import { FleetWorkspaceListPagePo, FleetWorkspaceCreateEditPo, FleetWorkspaceDetailsPo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.fleetworkspace.po';
+import { FleetApplicationListPagePo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
 import { generateFleetWorkspacesDataSmall } from '@/cypress/e2e/blueprints/fleet/workspaces-get';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import SortableTablePo from '@/cypress/e2e/po/components/sortable-table.po';

--- a/shell/components/CountBox.vue
+++ b/shell/components/CountBox.vue
@@ -3,6 +3,8 @@
 export default {
   name: 'CountBox',
 
+  emits: ['click'],
+
   props: {
     name: {
       type:     String,
@@ -17,6 +19,10 @@ export default {
       required: true
     },
     compact: {
+      type:    Boolean,
+      default: false
+    },
+    clickable: {
       type:    Boolean,
       default: false
     }
@@ -34,6 +40,12 @@ export default {
   methods: {
     customizePrimaryColorOpacity(opacity) {
       return `rgba(var(${ this.primaryColorVar }), ${ opacity })`;
+    },
+
+    handleClick() {
+      if (this.clickable) {
+        this.$emit('click');
+      }
     }
   }
 };
@@ -42,7 +54,9 @@ export default {
 <template>
   <div
     class="count-container"
+    :class="{ 'clickable': clickable }"
     :style="sideStyle"
+    @click="handleClick"
   >
     <div
       class="count"
@@ -61,6 +75,12 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+    .count-container {
+      &.clickable {
+        cursor: pointer;
+      }
+    }
+
     .count {
       $padding: 10px;
 

--- a/shell/components/__tests__/CountBox.test.ts
+++ b/shell/components/__tests__/CountBox.test.ts
@@ -1,0 +1,72 @@
+import { shallowMount } from '@vue/test-utils';
+import CountBox from '@shell/components/CountBox.vue';
+
+describe('component: CountBox', () => {
+  const defaultProps = {
+    name:            'Test',
+    count:           5,
+    primaryColorVar: '--sizzle-1',
+  };
+
+  describe('when clickable is false', () => {
+    it('should render as a div', () => {
+      const wrapper = shallowMount(CountBox, { props: defaultProps });
+
+      expect(wrapper.element.tagName).toBe('DIV');
+    });
+
+    it('should not have the clickable class', () => {
+      const wrapper = shallowMount(CountBox, { props: defaultProps });
+
+      expect(wrapper.classes()).not.toContain('clickable');
+    });
+
+    it('should not emit click event when clicked', async() => {
+      const wrapper = shallowMount(CountBox, { props: defaultProps });
+
+      await wrapper.trigger('click');
+
+      expect(wrapper.emitted('click')).toBeUndefined();
+    });
+  });
+
+  describe('when clickable is true', () => {
+    it('should have the clickable class', () => {
+      const wrapper = shallowMount(CountBox, {
+        props: {
+          ...defaultProps,
+          clickable: true,
+        },
+      });
+
+      expect(wrapper.classes()).toContain('clickable');
+    });
+
+    it('should emit click event when clicked', async() => {
+      const wrapper = shallowMount(CountBox, {
+        props: {
+          ...defaultProps,
+          clickable: true,
+        },
+      });
+
+      await wrapper.trigger('click');
+
+      expect(wrapper.emitted('click')).toHaveLength(1);
+    });
+  });
+
+  describe('display', () => {
+    it('should display the count', () => {
+      const wrapper = shallowMount(CountBox, { props: defaultProps });
+
+      expect(wrapper.find('h1').text()).toBe('5');
+    });
+
+    it('should display the name', () => {
+      const wrapper = shallowMount(CountBox, { props: defaultProps });
+
+      expect(wrapper.find('label').text()).toBe('Test');
+    });
+  });
+});

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -1,7 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import debounce from 'lodash/debounce';
-import { FLEET, MANAGEMENT, NORMAN, STEVE } from '@shell/config/types';
+import { MANAGEMENT, NORMAN, STEVE } from '@shell/config/types';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import { ucFirst } from '@shell/utils/string';
 import { isAlternate, isMac } from '@shell/utils/platform';
@@ -190,17 +190,9 @@ export default {
       // Don't show if the header is in 'simple' mode
       const notSimple = !this.simple;
       // One of these must be enabled, otherwise there's no component to show
-      const showWorkspace = this.currentProduct?.showWorkspaceSwitcher && !this.isWorkspacesPage;
-      const validFilterSettings = this.currentProduct?.showNamespaceFilter || showWorkspace;
+      const validFilterSettings = this.currentProduct?.showNamespaceFilter || this.showWorkspaceSwitcher;
 
       return validClusterOrProduct && notSimple && validFilterSettings;
-    },
-
-    /**
-     * Whether the current route is the Workspaces list page.
-     */
-    isWorkspacesPage() {
-      return this.$route?.params?.resource === FLEET.WORKSPACE;
     },
 
     /**
@@ -583,7 +575,7 @@ export default {
       >
         <NamespaceFilter v-if="clusterReady && currentProduct && (currentProduct.showNamespaceFilter || isExplorer)" />
         <WorkspaceSwitcher
-          v-else-if="clusterReady && currentProduct && currentProduct.showWorkspaceSwitcher && showWorkspaceSwitcher"
+          v-else-if="clusterReady && showWorkspaceSwitcher"
           :disabled="disableWorkspaceSwitcher"
         />
       </div>

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -1,7 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import debounce from 'lodash/debounce';
-import { MANAGEMENT, NORMAN, STEVE } from '@shell/config/types';
+import { FLEET, MANAGEMENT, NORMAN, STEVE } from '@shell/config/types';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import { ucFirst } from '@shell/utils/string';
 import { isAlternate, isMac } from '@shell/utils/platform';
@@ -189,10 +189,35 @@ export default {
                  (this.currentProduct && this.currentProduct.showWorkspaceSwitcher);
       // Don't show if the header is in 'simple' mode
       const notSimple = !this.simple;
-      // One of these must be enabled, otherwise t here's no component to show
-      const validFilterSettings = this.currentProduct?.showNamespaceFilter || this.currentProduct?.showWorkspaceSwitcher;
+      // One of these must be enabled, otherwise there's no component to show
+      const showNamespaceFilter = this.currentProduct?.showNamespaceFilter;
+      const showWorkspace = this.currentProduct?.showWorkspaceSwitcher && this.showWorkspaceSwitcherOnRoute;
+      const validFilterSettings = showNamespaceFilter || showWorkspace;
 
       return validClusterOrProduct && notSimple && validFilterSettings;
+    },
+
+    /**
+     * The workspace switcher should only be visible on list pages and not on the Workspaces page itself.
+     * Detail, edit and create pages should not show it.
+     */
+    showWorkspaceSwitcherOnRoute() {
+      // Hide on detail/edit pages (route has an id param)
+      if (this.$route?.params?.id) {
+        return false;
+      }
+
+      // Hide on create pages (route names end with '-create')
+      if (this.$route?.name?.endsWith('-create')) {
+        return false;
+      }
+
+      // Hide on the Workspaces list page
+      if (this.$route?.params?.resource === FLEET.WORKSPACE) {
+        return false;
+      }
+
+      return true;
     },
 
     featureRancherDesktop() {
@@ -556,7 +581,7 @@ export default {
         class="top"
       >
         <NamespaceFilter v-if="clusterReady && currentProduct && (currentProduct.showNamespaceFilter || isExplorer)" />
-        <WorkspaceSwitcher v-else-if="clusterReady && currentProduct && currentProduct.showWorkspaceSwitcher && showWorkspaceSwitcher" />
+        <WorkspaceSwitcher v-else-if="clusterReady && currentProduct && currentProduct.showWorkspaceSwitcher && showWorkspaceSwitcher && showWorkspaceSwitcherOnRoute" />
       </div>
       <div
         v-if="currentCluster && !simple"

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -190,34 +190,35 @@ export default {
       // Don't show if the header is in 'simple' mode
       const notSimple = !this.simple;
       // One of these must be enabled, otherwise there's no component to show
-      const showNamespaceFilter = this.currentProduct?.showNamespaceFilter;
-      const showWorkspace = this.currentProduct?.showWorkspaceSwitcher && this.showWorkspaceSwitcherOnRoute;
-      const validFilterSettings = showNamespaceFilter || showWorkspace;
+      const showWorkspace = this.currentProduct?.showWorkspaceSwitcher && !this.isWorkspacesPage;
+      const validFilterSettings = this.currentProduct?.showNamespaceFilter || showWorkspace;
 
       return validClusterOrProduct && notSimple && validFilterSettings;
     },
 
     /**
-     * The workspace switcher should only be visible on list pages and not on the Workspaces page itself.
-     * Detail, edit and create pages should not show it.
+     * Whether the current route is the Workspaces list page.
      */
-    showWorkspaceSwitcherOnRoute() {
-      // Hide on detail/edit pages (route has an id param)
+    isWorkspacesPage() {
+      return this.$route?.params?.resource === FLEET.WORKSPACE;
+    },
+
+    /**
+     * The workspace switcher should be disabled on detail, edit and create pages.
+     * Only list pages should allow changing the workspace.
+     */
+    disableWorkspaceSwitcher() {
+      // Disable on detail/edit pages (route has an id param)
       if (this.$route?.params?.id) {
-        return false;
+        return true;
       }
 
-      // Hide on create pages (route names end with '-create')
+      // Disable on create pages (route names end with '-create')
       if (this.$route?.name?.endsWith('-create')) {
-        return false;
+        return true;
       }
 
-      // Hide on the Workspaces list page
-      if (this.$route?.params?.resource === FLEET.WORKSPACE) {
-        return false;
-      }
-
-      return true;
+      return false;
     },
 
     featureRancherDesktop() {
@@ -581,7 +582,10 @@ export default {
         class="top"
       >
         <NamespaceFilter v-if="clusterReady && currentProduct && (currentProduct.showNamespaceFilter || isExplorer)" />
-        <WorkspaceSwitcher v-else-if="clusterReady && currentProduct && currentProduct.showWorkspaceSwitcher && showWorkspaceSwitcher && showWorkspaceSwitcherOnRoute" />
+        <WorkspaceSwitcher
+          v-else-if="clusterReady && currentProduct && currentProduct.showWorkspaceSwitcher && showWorkspaceSwitcher"
+          :disabled="disableWorkspaceSwitcher"
+        />
       </div>
       <div
         v-if="currentCluster && !simple"

--- a/shell/components/nav/WorkspaceSwitcher.vue
+++ b/shell/components/nav/WorkspaceSwitcher.vue
@@ -8,6 +8,13 @@ export default {
   name:       'WorkspaceSwitcher',
   components: { Select },
 
+  props: {
+    disabled: {
+      type:    Boolean,
+      default: false,
+    },
+  },
+
   computed: {
     ...mapState(['allWorkspaces', 'workspace', 'allNamespaces', 'defaultNamespace', 'getActiveNamespaces']),
 
@@ -94,6 +101,7 @@ export default {
       label="label"
       :options="options"
       :clearable="false"
+      :disabled="disabled"
       :reduce="(opt) => opt.value"
     />
     <!--button v-shortkey.once="['w']" class="hide" @shortkey="focus()" /-->
@@ -186,5 +194,10 @@ export default {
 
 .filter :deep() .unlabeled-select INPUT[type='search'] {
   padding: 7px;
+}
+
+.filter :deep() .unlabeled-select.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 </style>

--- a/shell/components/nav/__tests__/Header.test.ts
+++ b/shell/components/nav/__tests__/Header.test.ts
@@ -84,18 +84,18 @@ describe('component: Header', () => {
     });
   }
 
-  describe('showWorkspaceSwitcherOnRoute', () => {
-    it('should return true on a list page', () => {
+  describe('disableWorkspaceSwitcher', () => {
+    it('should return false on a list page', () => {
       const wrapper = createWrapper({
         name:   'c-cluster-fleet-application-resource',
         path:   '/c/local/fleet/application/fleet.cattle.io.gitrepo',
         params: { resource: 'fleet.cattle.io.gitrepo' },
       });
 
-      expect((wrapper.vm as any).showWorkspaceSwitcherOnRoute).toBe(true);
+      expect((wrapper.vm as any).disableWorkspaceSwitcher).toBe(false);
     });
 
-    it('should return false on a detail page (route has an id param)', () => {
+    it('should return true on a detail page (route has an id param)', () => {
       const wrapper = createWrapper({
         name:   'c-cluster-fleet-application-resource-namespace-id',
         path:   '/c/local/fleet/application/fleet.cattle.io.gitrepo/fleet-default/my-repo',
@@ -104,27 +104,27 @@ describe('component: Header', () => {
         },
       });
 
-      expect((wrapper.vm as any).showWorkspaceSwitcherOnRoute).toBe(false);
+      expect((wrapper.vm as any).disableWorkspaceSwitcher).toBe(true);
     });
 
-    it('should return false on a create page (route name ends with -create)', () => {
+    it('should return true on a create page (route name ends with -create)', () => {
       const wrapper = createWrapper({
         name:   'c-cluster-fleet-application-resource-create',
         path:   '/c/local/fleet/application/fleet.cattle.io.gitrepo/create',
         params: { resource: 'fleet.cattle.io.gitrepo' },
       });
 
-      expect((wrapper.vm as any).showWorkspaceSwitcherOnRoute).toBe(false);
+      expect((wrapper.vm as any).disableWorkspaceSwitcher).toBe(true);
     });
 
-    it('should return false on the application create page', () => {
+    it('should return true on the application create page', () => {
       const wrapper = createWrapper({
         name:   'c-cluster-fleet-application-create',
         path:   '/c/local/fleet/application/create',
         params: {},
       });
 
-      expect((wrapper.vm as any).showWorkspaceSwitcherOnRoute).toBe(false);
+      expect((wrapper.vm as any).disableWorkspaceSwitcher).toBe(true);
     });
 
     it('should return false on the Workspaces list page', () => {
@@ -134,20 +134,20 @@ describe('component: Header', () => {
         params: { resource: FLEET.WORKSPACE },
       });
 
-      expect((wrapper.vm as any).showWorkspaceSwitcherOnRoute).toBe(false);
+      expect((wrapper.vm as any).disableWorkspaceSwitcher).toBe(false);
     });
 
-    it('should return true on a non-workspace resource list page', () => {
+    it('should return false on a non-workspace resource list page', () => {
       const wrapper = createWrapper({
         name:   'c-cluster-fleet-application-resource',
         path:   '/c/local/fleet/application/fleet.cattle.io.cluster',
         params: { resource: 'fleet.cattle.io.cluster' },
       });
 
-      expect((wrapper.vm as any).showWorkspaceSwitcherOnRoute).toBe(true);
+      expect((wrapper.vm as any).disableWorkspaceSwitcher).toBe(false);
     });
 
-    it('should return false on an edit page (route has an id param)', () => {
+    it('should return true on an edit page (route has an id param)', () => {
       const wrapper = createWrapper({
         name:   'c-cluster-fleet-application-resource-namespace-id',
         path:   '/c/local/fleet/application/fleet.cattle.io.gitrepo/fleet-default/my-repo?mode=edit',
@@ -156,7 +156,7 @@ describe('component: Header', () => {
         },
       });
 
-      expect((wrapper.vm as any).showWorkspaceSwitcherOnRoute).toBe(false);
+      expect((wrapper.vm as any).disableWorkspaceSwitcher).toBe(true);
     });
   });
 
@@ -174,7 +174,7 @@ describe('component: Header', () => {
       expect((wrapper.vm as any).showFilter).toBe(true);
     });
 
-    it('should return false when showWorkspaceSwitcher is enabled but route is a detail page', () => {
+    it('should return true when showWorkspaceSwitcher is enabled on a detail page (switcher visible but disabled)', () => {
       const wrapper = createWrapper(
         {
           name:   'c-cluster-fleet-application-resource-namespace-id',
@@ -186,10 +186,10 @@ describe('component: Header', () => {
         { currentProduct: { showWorkspaceSwitcher: true } },
       );
 
-      expect((wrapper.vm as any).showFilter).toBe(false);
+      expect((wrapper.vm as any).showFilter).toBe(true);
     });
 
-    it('should return false when showWorkspaceSwitcher is enabled but route is a create page', () => {
+    it('should return true when showWorkspaceSwitcher is enabled on a create page (switcher visible but disabled)', () => {
       const wrapper = createWrapper(
         {
           name:   'c-cluster-fleet-application-resource-create',
@@ -199,10 +199,10 @@ describe('component: Header', () => {
         { currentProduct: { showWorkspaceSwitcher: true } },
       );
 
-      expect((wrapper.vm as any).showFilter).toBe(false);
+      expect((wrapper.vm as any).showFilter).toBe(true);
     });
 
-    it('should return false when showWorkspaceSwitcher is enabled but route is the Workspaces page', () => {
+    it('should return false when showWorkspaceSwitcher is enabled on the Workspaces page (switcher hidden)', () => {
       const wrapper = createWrapper(
         {
           name:   'c-cluster-fleet-application-resource',

--- a/shell/components/nav/__tests__/Header.test.ts
+++ b/shell/components/nav/__tests__/Header.test.ts
@@ -1,6 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
 import Header from '@shell/components/nav/Header.vue';
-import { FLEET } from '@shell/config/types';
 
 describe('component: Header', () => {
   const defaultStoreMock = {
@@ -130,8 +129,8 @@ describe('component: Header', () => {
     it('should return false on the Workspaces list page', () => {
       const wrapper = createWrapper({
         name:   'c-cluster-fleet-application-resource',
-        path:   `/c/local/fleet/application/${ FLEET.WORKSPACE }`,
-        params: { resource: FLEET.WORKSPACE },
+        path:   '/c/local/fleet/application/management.cattle.io.fleetworkspace',
+        params: { resource: 'management.cattle.io.fleetworkspace' },
       });
 
       expect((wrapper.vm as any).disableWorkspaceSwitcher).toBe(false);
@@ -202,14 +201,17 @@ describe('component: Header', () => {
       expect((wrapper.vm as any).showFilter).toBe(true);
     });
 
-    it('should return false when showWorkspaceSwitcher is enabled on the Workspaces page (switcher hidden)', () => {
+    it('should return false when showWorkspaceSwitcher is false in the store (e.g. Workspaces page)', () => {
       const wrapper = createWrapper(
         {
           name:   'c-cluster-fleet-application-resource',
-          path:   `/c/local/fleet/application/${ FLEET.WORKSPACE }`,
-          params: { resource: FLEET.WORKSPACE },
+          path:   '/c/local/fleet/application/management.cattle.io.fleetworkspace',
+          params: { resource: 'management.cattle.io.fleetworkspace' },
         },
-        { currentProduct: { showWorkspaceSwitcher: true } },
+        {
+          currentProduct:        { showWorkspaceSwitcher: true },
+          showWorkspaceSwitcher: false,
+        },
       );
 
       expect((wrapper.vm as any).showFilter).toBe(false);

--- a/shell/components/nav/__tests__/Header.test.ts
+++ b/shell/components/nav/__tests__/Header.test.ts
@@ -1,0 +1,233 @@
+import { shallowMount } from '@vue/test-utils';
+import Header from '@shell/components/nav/Header.vue';
+import { FLEET } from '@shell/config/types';
+
+describe('component: Header', () => {
+  const defaultStoreMock = {
+    getters: {
+      clusterReady:            false,
+      isExplorer:              false,
+      isRancher:               false,
+      currentCluster:          null,
+      currentProduct:          null,
+      rootProduct:             { name: 'fleet' },
+      backToRancherLink:       '',
+      backToRancherGlobalLink: '',
+      pageActions:             [],
+      isSingleProduct:         false,
+      isRancherInHarvester:    false,
+      showTopLevelMenu:        false,
+      showWorkspaceSwitcher:   true,
+      'management/schemaFor':  () => null,
+      'management/all':        () => [],
+      'rancher/schemaFor':     () => null,
+      'rancher/byId':          () => null,
+      'rancher/all':           () => [],
+      'auth/principalId':      'test',
+      'auth/enabled':          false,
+      'i18n/withFallback':     () => '',
+    },
+    dispatch: jest.fn(),
+    commit:   jest.fn(),
+  };
+
+  const defaultRouteMock = {
+    name:   'c-cluster-fleet-application-resource',
+    path:   '/c/local/fleet/application/fleet.cattle.io.gitrepo',
+    params: { resource: 'fleet.cattle.io.gitrepo' },
+  };
+
+  const defaultConfigMock = { rancherEnv: 'web' };
+
+  function createWrapper(routeOverride = {}, storeOverride = {}) {
+    const routeMock = {
+      ...defaultRouteMock,
+      ...routeOverride,
+    };
+
+    const storeMock = {
+      ...defaultStoreMock,
+      getters: {
+        ...defaultStoreMock.getters,
+        ...storeOverride,
+      },
+      dispatch: jest.fn(),
+      commit:   jest.fn(),
+    };
+
+    return shallowMount(Header as any, {
+      global: {
+        mocks: {
+          $store:     storeMock,
+          $route:     routeMock,
+          $config:    defaultConfigMock,
+          $extension: { getDynamic: jest.fn() },
+        },
+        stubs: {
+          'router-link':        { template: '<a><slot /></a>' },
+          BrandImage:           { template: '<span />' },
+          ClusterProviderIcon:  { template: '<span />' },
+          ClusterBadge:         { template: '<span />' },
+          TopLevelMenu:         { template: '<div />' },
+          NamespaceFilter:      { template: '<div />' },
+          WorkspaceSwitcher:    { template: '<div />' },
+          IconOrSvg:            { template: '<span />' },
+          AppModal:             { template: '<div />' },
+          NotificationCenter:   { template: '<div />' },
+          HeaderPageActionMenu: { template: '<div />' },
+          RcDropdown:           { template: '<div><slot /><slot name="dropdownCollection" /></div>' },
+          RcDropdownItem:       { template: '<div><slot /></div>' },
+          RcDropdownSeparator:  { template: '<hr />' },
+          RcDropdownTrigger:    { template: '<button><slot /></button>' },
+        },
+      },
+    });
+  }
+
+  describe('showWorkspaceSwitcherOnRoute', () => {
+    it('should return true on a list page', () => {
+      const wrapper = createWrapper({
+        name:   'c-cluster-fleet-application-resource',
+        path:   '/c/local/fleet/application/fleet.cattle.io.gitrepo',
+        params: { resource: 'fleet.cattle.io.gitrepo' },
+      });
+
+      expect((wrapper.vm as any).showWorkspaceSwitcherOnRoute).toBe(true);
+    });
+
+    it('should return false on a detail page (route has an id param)', () => {
+      const wrapper = createWrapper({
+        name:   'c-cluster-fleet-application-resource-namespace-id',
+        path:   '/c/local/fleet/application/fleet.cattle.io.gitrepo/fleet-default/my-repo',
+        params: {
+          resource: 'fleet.cattle.io.gitrepo', namespace: 'fleet-default', id: 'my-repo'
+        },
+      });
+
+      expect((wrapper.vm as any).showWorkspaceSwitcherOnRoute).toBe(false);
+    });
+
+    it('should return false on a create page (route name ends with -create)', () => {
+      const wrapper = createWrapper({
+        name:   'c-cluster-fleet-application-resource-create',
+        path:   '/c/local/fleet/application/fleet.cattle.io.gitrepo/create',
+        params: { resource: 'fleet.cattle.io.gitrepo' },
+      });
+
+      expect((wrapper.vm as any).showWorkspaceSwitcherOnRoute).toBe(false);
+    });
+
+    it('should return false on the application create page', () => {
+      const wrapper = createWrapper({
+        name:   'c-cluster-fleet-application-create',
+        path:   '/c/local/fleet/application/create',
+        params: {},
+      });
+
+      expect((wrapper.vm as any).showWorkspaceSwitcherOnRoute).toBe(false);
+    });
+
+    it('should return false on the Workspaces list page', () => {
+      const wrapper = createWrapper({
+        name:   'c-cluster-fleet-application-resource',
+        path:   `/c/local/fleet/application/${ FLEET.WORKSPACE }`,
+        params: { resource: FLEET.WORKSPACE },
+      });
+
+      expect((wrapper.vm as any).showWorkspaceSwitcherOnRoute).toBe(false);
+    });
+
+    it('should return true on a non-workspace resource list page', () => {
+      const wrapper = createWrapper({
+        name:   'c-cluster-fleet-application-resource',
+        path:   '/c/local/fleet/application/fleet.cattle.io.cluster',
+        params: { resource: 'fleet.cattle.io.cluster' },
+      });
+
+      expect((wrapper.vm as any).showWorkspaceSwitcherOnRoute).toBe(true);
+    });
+
+    it('should return false on an edit page (route has an id param)', () => {
+      const wrapper = createWrapper({
+        name:   'c-cluster-fleet-application-resource-namespace-id',
+        path:   '/c/local/fleet/application/fleet.cattle.io.gitrepo/fleet-default/my-repo?mode=edit',
+        params: {
+          resource: 'fleet.cattle.io.gitrepo', namespace: 'fleet-default', id: 'my-repo'
+        },
+      });
+
+      expect((wrapper.vm as any).showWorkspaceSwitcherOnRoute).toBe(false);
+    });
+  });
+
+  describe('showFilter', () => {
+    it('should return true on a list page when showWorkspaceSwitcher is enabled', () => {
+      const wrapper = createWrapper(
+        {
+          name:   'c-cluster-fleet-application-resource',
+          path:   '/c/local/fleet/application/fleet.cattle.io.gitrepo',
+          params: { resource: 'fleet.cattle.io.gitrepo' },
+        },
+        { currentProduct: { showWorkspaceSwitcher: true } },
+      );
+
+      expect((wrapper.vm as any).showFilter).toBe(true);
+    });
+
+    it('should return false when showWorkspaceSwitcher is enabled but route is a detail page', () => {
+      const wrapper = createWrapper(
+        {
+          name:   'c-cluster-fleet-application-resource-namespace-id',
+          path:   '/c/local/fleet/application/fleet.cattle.io.gitrepo/fleet-default/my-repo',
+          params: {
+            resource: 'fleet.cattle.io.gitrepo', namespace: 'fleet-default', id: 'my-repo'
+          },
+        },
+        { currentProduct: { showWorkspaceSwitcher: true } },
+      );
+
+      expect((wrapper.vm as any).showFilter).toBe(false);
+    });
+
+    it('should return false when showWorkspaceSwitcher is enabled but route is a create page', () => {
+      const wrapper = createWrapper(
+        {
+          name:   'c-cluster-fleet-application-resource-create',
+          path:   '/c/local/fleet/application/fleet.cattle.io.gitrepo/create',
+          params: { resource: 'fleet.cattle.io.gitrepo' },
+        },
+        { currentProduct: { showWorkspaceSwitcher: true } },
+      );
+
+      expect((wrapper.vm as any).showFilter).toBe(false);
+    });
+
+    it('should return false when showWorkspaceSwitcher is enabled but route is the Workspaces page', () => {
+      const wrapper = createWrapper(
+        {
+          name:   'c-cluster-fleet-application-resource',
+          path:   `/c/local/fleet/application/${ FLEET.WORKSPACE }`,
+          params: { resource: FLEET.WORKSPACE },
+        },
+        { currentProduct: { showWorkspaceSwitcher: true } },
+      );
+
+      expect((wrapper.vm as any).showFilter).toBe(false);
+    });
+
+    it('should return true when showNamespaceFilter is enabled regardless of route', () => {
+      const wrapper = createWrapper(
+        {
+          name:   'c-cluster-fleet-application-resource-namespace-id',
+          path:   '/c/local/fleet/application/fleet.cattle.io.gitrepo/fleet-default/my-repo',
+          params: {
+            resource: 'fleet.cattle.io.gitrepo', namespace: 'fleet-default', id: 'my-repo'
+          },
+        },
+        { currentCluster: { id: 'local' }, currentProduct: { showNamespaceFilter: true } },
+      );
+
+      expect((wrapper.vm as any).showFilter).toBe(true);
+    });
+  });
+});

--- a/shell/detail/__tests__/management.cattle.io.fleetworkspace.test.ts
+++ b/shell/detail/__tests__/management.cattle.io.fleetworkspace.test.ts
@@ -1,0 +1,128 @@
+import { shallowMount } from '@vue/test-utils';
+import DetailWorkspace from '@shell/detail/management.cattle.io.fleetworkspace.vue';
+import { FLEET } from '@shell/config/types';
+import { NAME as FLEET_NAME } from '@shell/config/product/fleet';
+import { BLANK_CLUSTER } from '@shell/store/store-types.js';
+
+describe('component: DetailWorkspace', () => {
+  const mockValue = {
+    id:     'fleet-default',
+    counts: {
+      gitRepos:      3,
+      helmOps:       2,
+      clusters:      5,
+      cluster:       5,
+      clusterGroup:  1,
+      clusterGroups: 1,
+    },
+  };
+
+  const mockRouter = { push: jest.fn() };
+
+  const defaultStore = {
+    commit:   jest.fn(),
+    dispatch: jest.fn(),
+    getters:  {
+      'i18n/t':       (key: string) => key,
+      'i18n/exists':  () => true,
+      currentProduct: { name: FLEET_NAME },
+    },
+  };
+
+  const createWrapper = (props = {}) => {
+    return shallowMount(DetailWorkspace, {
+      props:  { value: mockValue, ...props },
+      global: {
+        mocks: {
+          $store:  defaultStore,
+          $route:  { params: {} },
+          $router: mockRouter,
+        },
+        stubs: {
+          CountBox:     { template: '<div />', props: ['clickable', 'count', 'name', 'primaryColorVar'] },
+          ResourceTabs: { template: '<div />' },
+        },
+      },
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('applicationRoute', () => {
+    it('should return the fleet application route', () => {
+      const wrapper = createWrapper();
+
+      expect(wrapper.vm.applicationRoute).toStrictEqual({
+        name:   'c-cluster-fleet-application',
+        params: { cluster: BLANK_CLUSTER },
+      });
+    });
+  });
+
+  describe('clustersRoute', () => {
+    it('should return the fleet clusters list route', () => {
+      const wrapper = createWrapper();
+
+      expect(wrapper.vm.clustersRoute).toStrictEqual({
+        name:   'c-cluster-product-resource',
+        params: {
+          cluster:  BLANK_CLUSTER,
+          product:  FLEET_NAME,
+          resource: FLEET.CLUSTER,
+        },
+      });
+    });
+  });
+
+  describe('clusterGroupsRoute', () => {
+    it('should return the fleet cluster groups list route', () => {
+      const wrapper = createWrapper();
+
+      expect(wrapper.vm.clusterGroupsRoute).toStrictEqual({
+        name:   'c-cluster-product-resource',
+        params: {
+          cluster:  BLANK_CLUSTER,
+          product:  FLEET_NAME,
+          resource: FLEET.CLUSTER_GROUP,
+        },
+      });
+    });
+  });
+
+  describe('setWorkspaceAndNavigate', () => {
+    it('should commit updateWorkspace with the workspace id', () => {
+      const wrapper = createWrapper();
+      const route = wrapper.vm.applicationRoute;
+
+      wrapper.vm.setWorkspaceAndNavigate(route);
+
+      expect(defaultStore.commit).toHaveBeenCalledWith('updateWorkspace', {
+        value:   'fleet-default',
+        getters: defaultStore.getters,
+      });
+    });
+
+    it('should dispatch prefs/set with the workspace id', () => {
+      const wrapper = createWrapper();
+      const route = wrapper.vm.applicationRoute;
+
+      wrapper.vm.setWorkspaceAndNavigate(route);
+
+      expect(defaultStore.dispatch).toHaveBeenCalledWith('prefs/set', {
+        key:   expect.any(String),
+        value: 'fleet-default',
+      });
+    });
+
+    it('should navigate to the given route', () => {
+      const wrapper = createWrapper();
+      const route = wrapper.vm.clustersRoute;
+
+      wrapper.vm.setWorkspaceAndNavigate(route);
+
+      expect(mockRouter.push).toHaveBeenCalledWith(route);
+    });
+  });
+});

--- a/shell/detail/management.cattle.io.fleetworkspace.vue
+++ b/shell/detail/management.cattle.io.fleetworkspace.vue
@@ -4,6 +4,8 @@ import ResourceTabs from '@shell/components/form/ResourceTabs';
 import { SCOPE_NAMESPACE, SCOPE_CLUSTER } from '@shell/components/RoleBindings.vue';
 import { NAME as FLEET_NAME } from '@shell/config/product/fleet';
 import { FLEET } from '@shell/config/types';
+import { BLANK_CLUSTER } from '@shell/store/store-types.js';
+import { WORKSPACE } from '@shell/store/prefs';
 
 export default {
   name: 'DetailWorkspace',
@@ -34,6 +36,35 @@ export default {
       return this.t(`typeLabel."${ FLEET.HELM_OP }"`, { count: this.value.counts.helmOps });
     },
 
+    applicationRoute() {
+      return {
+        name:   'c-cluster-fleet-application',
+        params: { cluster: BLANK_CLUSTER }
+      };
+    },
+
+    clustersRoute() {
+      return {
+        name:   'c-cluster-product-resource',
+        params: {
+          cluster:  BLANK_CLUSTER,
+          product:  FLEET_NAME,
+          resource: FLEET.CLUSTER,
+        }
+      };
+    },
+
+    clusterGroupsRoute() {
+      return {
+        name:   'c-cluster-product-resource',
+        params: {
+          cluster:  BLANK_CLUSTER,
+          product:  FLEET_NAME,
+          resource: FLEET.CLUSTER_GROUP,
+        }
+      };
+    },
+
     SCOPE_NAMESPACE() {
       return SCOPE_NAMESPACE;
     },
@@ -46,6 +77,16 @@ export default {
       return FLEET_NAME;
     }
   },
+
+  methods: {
+    setWorkspaceAndNavigate(route) {
+      const workspaceId = this.value.id;
+
+      this.$store.commit('updateWorkspace', { value: workspaceId, getters: this.$store.getters });
+      this.$store.dispatch('prefs/set', { key: WORKSPACE, value: workspaceId });
+      this.$router.push(route);
+    }
+  }
 };
 </script>
 
@@ -58,6 +99,8 @@ export default {
             :count="value.counts.gitRepos"
             :name="gitRepoLabel"
             :primary-color-var="'--sizzle-3'"
+            :clickable="true"
+            @click="setWorkspaceAndNavigate(applicationRoute)"
           />
         </div>
         <div class="col span-3">
@@ -65,6 +108,8 @@ export default {
             :count="value.counts.helmOps"
             :name="helmOpsLabel"
             :primary-color-var="'--sizzle-3'"
+            :clickable="true"
+            @click="setWorkspaceAndNavigate(applicationRoute)"
           />
         </div>
         <div class="col span-3">
@@ -72,6 +117,8 @@ export default {
             :count="value.counts.clusters"
             :name="clustersLabel"
             :primary-color-var="'--sizzle-1'"
+            :clickable="true"
+            @click="setWorkspaceAndNavigate(clustersRoute)"
           />
         </div>
         <div class="col span-3">
@@ -79,6 +126,8 @@ export default {
             :count="value.counts.clusterGroups"
             :name="clusterGroupsLabel"
             :primary-color-var="'--sizzle-2'"
+            :clickable="true"
+            @click="setWorkspaceAndNavigate(clusterGroupsRoute)"
           />
         </div>
       </div>

--- a/shell/list/management.cattle.io.fleetworkspace.vue
+++ b/shell/list/management.cattle.io.fleetworkspace.vue
@@ -21,6 +21,14 @@ export default {
     }
   },
 
+  created() {
+    this.$store.dispatch('showWorkspaceSwitcher', false);
+  },
+
+  beforeUnmount() {
+    this.$store.dispatch('showWorkspaceSwitcher', true);
+  },
+
   async fetch() {
     try {
       await this.$fetchType(this.resource);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16714
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Changed the workspace selectors to be disabled on create/edit/view pages
- It only can be changed on list screens
- On the workspace it doesnt show
- Added a click on the card to navigate to the proper page and interact better with workspace selector

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- The check is done by the name id

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Fleet screens
- Views/Create/Edit should not show
- List should show
- List for Workspaces should not show

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<img width="1133" height="1111" alt="image" src="https://github.com/user-attachments/assets/00a18aec-b556-4e3e-896c-2271034ff2fa" />
<img width="1133" height="1111" alt="image" src="https://github.com/user-attachments/assets/d488710d-6263-48e2-ac64-47c6b3074ba3" />
<img width="1133" height="1111" alt="image" src="https://github.com/user-attachments/assets/d00df6d0-4148-4312-a3c8-263728b64219" />
<img width="1133" height="1111" alt="image" src="https://github.com/user-attachments/assets/393df3b4-a199-4826-a7d7-5a49a9f0703c" />



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
