### PR TITLE
Automation - Avoid 'Directory not empty' race when removing dashboard dir

### DIFF
--- a/cypress/jenkins/Jenkinsfile
+++ b/cypress/jenkins/Jenkinsfile
@@ -41,7 +41,8 @@ node('harvester-vpn-1') {
               stage('Pre-Clean') {
                 sh """#!/bin/bash
                   set +x
-                  sudo rm -rf "\${HOME}/dashboard" 2>/dev/null || true
+                  mv "\${HOME}/dashboard" "\${HOME}/dashboard.old.\$\$" 2>/dev/null || true
+                  rm -rf "\${HOME}/dashboard.old."* 2>/dev/null &
                   rm -f "\${HOME}/.env" 2>/dev/null || true
                   rm -rf "\${HOME}/.corral" 2>/dev/null || true
                   docker rm -f \$(docker ps -aq --filter ancestor=dashboard-test) 2>/dev/null || true
@@ -103,8 +104,9 @@ node('harvester-vpn-1') {
                   set +x
                   # Remove credentials file
                   rm -f "\${HOME}/.env" || true
-                  # Remove cloned dashboard (may have root-owned files from Docker)
-                  sudo rm -rf "\${HOME}/dashboard" || true
+                  # Remove cloned dashboard (move-then-delete avoids NFS/overlayfs race)
+                  mv "\${HOME}/dashboard" "\${HOME}/dashboard.old.\$\$" 2>/dev/null || true
+                  rm -rf "\${HOME}/dashboard.old."* 2>/dev/null || true
                   # Remove corral config to prevent stale vars leaking between runs
                   rm -rf "\${HOME}/.corral" || true
                   # Remove stale Docker containers and image

--- a/cypress/jenkins/run.sh
+++ b/cypress/jenkins/run.sh
@@ -53,7 +53,9 @@ build_image() {
 
 	echo "Cloning ${target_branch}$([ "${target_branch}" != "master" ] && echo ', overlaying CI from master')"
 
-	sudo rm -rf "${HOME}"/dashboard
+	# Move-then-delete avoids "Directory not empty" race on NFS/overlayfs
+	mv "${HOME}/dashboard" "${HOME}/dashboard.old.$$" 2>/dev/null || true
+	rm -rf "${HOME}/dashboard.old."* 2>/dev/null &
 	git clone -b "${target_branch}" \
 		"${GITHUB_URL}${DASHBOARD_REPO}" "${HOME}"/dashboard
 


### PR DESCRIPTION
### Summary

Fixes rancher/qa-tasks#1867

### Occurred changes and/or fixed issues

Replace `sudo rm -rf ~/dashboard` with an atomic mv-then-delete pattern. On NFS or overlayfs, `rm -rf` can race against open file handles (e.g. from Docker mounts or node processes), causing `ENOTEMPTY` on core-js and similar deeply nested `node_modules` directories.

The `mv` is atomic on the same filesystem, so the clone can proceed immediately while the old directory is cleaned up in the background.

### Areas or cases that should be tested
CI/Jenkins

### Areas which could experience regressions
CI/Jenkins

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
