### PR TITLE
[16870][fleet] Change the targetClusters logic to consider nameDisplay as 2n…

### DIFF
--- a/shell/components/fleet/FleetClusterTargets/index.vue
+++ b/shell/components/fleet/FleetClusterTargets/index.vue
@@ -159,7 +159,7 @@ export default {
     clustersOptions() {
       return this.allClusters
         .filter((x) => x.metadata.namespace === this.namespace && !isHarvesterCluster(x))
-        .map((x) => ({ label: x.nameDisplay, value: x.metadata.name }));
+        .map((x) => ({ label: x.nameDisplay, value: x.nameDisplay }));
     },
 
     clusterGroupsOptions() {

--- a/shell/components/fleet/FleetClusterTargets/index.vue
+++ b/shell/components/fleet/FleetClusterTargets/index.vue
@@ -124,6 +124,15 @@ export default {
         this.update();
       }
     },
+
+    allClusters(clusters: any[]) {
+      if (clusters.length) {
+        // Resolve metadata.name values to nameDisplay for UI display
+        this.selectedClusters = this.selectedClusters.map(
+          (name) => this.resolveClusterDisplayName(name)
+        );
+      }
+    },
   },
 
   computed: {
@@ -350,6 +359,14 @@ export default {
       }
 
       return undefined;
+    },
+
+    resolveClusterDisplayName(name: string): string {
+      const cluster = this.allClusters.find(
+        (c: any) => c.metadata.namespace === this.namespace && c.metadata.name === name
+      );
+
+      return cluster ? cluster.nameDisplay : name;
     },
 
     reset() {

--- a/shell/models/fleet-application.js
+++ b/shell/models/fleet-application.js
@@ -105,7 +105,7 @@ export default class FleetApplication extends SteveModel {
 
     for (const tgt of this.spec.targets) {
       if (tgt.clusterName) {
-        const cluster = findBy(clusters, 'metadata.name', tgt.clusterName);
+        const cluster = findBy(clusters, 'metadata.name', tgt.clusterName) || findBy(clusters, 'nameDisplay', tgt.clusterName);
 
         if (cluster) {
           addObject(out, cluster);

--- a/shell/models/fleet.cattle.io.bundle.js
+++ b/shell/models/fleet.cattle.io.bundle.js
@@ -47,7 +47,7 @@ export default class FleetBundle extends SteveModel {
 
     for (const tgt of this.spec.targets) {
       if (tgt.clusterName) {
-        const cluster = findBy(clusters, 'metadata.name', tgt.clusterName);
+        const cluster = findBy(clusters, 'metadata.name', tgt.clusterName) || findBy(clusters, 'nameDisplay', tgt.clusterName);
 
         if (cluster) {
           addObject(out, cluster);


### PR DESCRIPTION
…d option

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16870
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
3 changed logics:

1. **`clustersOptions` uses `nameDisplay` as the value** - The cluster selector options now use `nameDisplay` for both `label` and `value`, so the UI consistently works with display names.
2. **`displayName` is resolved from `metadata.name` on load** - When loading existing targets from the YAML (via `fromTargets`), the `allClusters` watcher resolves any `metadata.name` values (e.g., `c-p2bmg`) in `selectedClusters` to their corresponding `nameDisplay` (e.g., `test-k3s`), so the `LabeledSelect` can match them against the options.
3. **Model `targetClusters` getters use `nameDisplay` lookup** - In `fleet-application.js`, the `findBy` uses a fallback: `findBy(clusters, 'metadata.name', tgt.clusterName) || findBy(clusters, 'nameDisplay', tgt.clusterName)`. In `fleet.cattle.io.bundle.js`, it uses `findBy(clusters, 'nameDisplay', tgt.clusterName)`. This ensures clusters are found regardless of whether the stored `clusterName` is a `metadata.name` or a `nameDisplay`.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- displayName already considers not having the label for displayName and use the metadata.name or the id instead.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Target clusters on AppBundle creation — select clusters, verify `nameDisplay` appears in the selector tags
- Target clusters on AppBundle edit — existing targets with `metadata.name` in the YAML should resolve to `nameDisplay` in the UI
- AppBundle resources list — the "targeted clusters" column should show the correct clusters
- Clusters with no `CLUSTER_DISPLAY_NAME` label — `nameDisplay` falls back to `metadata.name`, should still match correctly
- Clusters with a `CLUSTER_DISPLAY_NAME` label different from `metadata.name` — the display name should appear in the UI, and the resource should still resolve correctly

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
