### PR TITLE
[17087] Changed to PR_EVENT_PATH to not use GITHUB_* reserved env var

### DIFF
--- a/.github/workflows/pr-gh-project-processor.yaml
+++ b/.github/workflows/pr-gh-project-processor.yaml
@@ -45,5 +45,5 @@ jobs:
       env:
         GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         PR_PROJECT: ${{ secrets.PR_PROJECT }}
-        GITHUB_EVENT_PATH: pr-gh-project-event/event.json
+        PR_EVENT_PATH: pr-gh-project-event/event.json
       run: node .github/workflows/scripts/pr-gh-project.js

--- a/.github/workflows/scripts/pr-gh-project.js
+++ b/.github/workflows/scripts/pr-gh-project.js
@@ -50,7 +50,11 @@ if (ghProjectId.length !== 2) {
 }
 
 // The event object
-const event = require(process.env.GITHUB_EVENT_PATH);
+// Note: We use PR_EVENT_PATH (not GITHUB_EVENT_PATH) because the latter is a
+// reserved GitHub Actions env var that always points to the workflow_run event,
+// which would shadow the custom value set in the workflow YAML.
+const path = require('path');
+const event = require(path.resolve(process.cwd(), process.env.PR_EVENT_PATH));
 
 function getReferencedIssues(body) {
   // https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17087
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Removed the usage of GITHUB_* flag

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- When running the process I saw that the GITHUB_ flag was not having the correct event on a two-stage flow. The value was not being added and was silently failing inside the script. When changing to a random ENV VAR it worked well.
- I believe this has not been working since it has been introduced, I tried to find cases where it worked but could not find 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- We will only be sure after it is merged, but it worked on my fork
- https://github.com/marcelofukumoto/dashboard/issues/91

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
