### PR TITLE
[backport 2.13] - Automation cypress/support/qase.ts from master

### DIFF
--- a/cypress/support/qase.ts
+++ b/cypress/support/qase.ts
@@ -1,0 +1,37 @@
+/* global Mocha */
+/* eslint-disable no-console */
+let qaseImport: any;
+
+try {
+  // Try to use the qase function from the reporter if available
+  // This is the recommended way for cypress-qase-reporter 3.0.0+
+  qaseImport = require('cypress-qase-reporter/mocha').qase;
+} catch (e) {
+  // Fallback to custom implementation if the import fails
+}
+
+/**
+ * Custom wrapper for Qase ID integration.
+ * If the official reporter is available, it delegates to it.
+ * Otherwise, it appends the Qase ID to the test title manually.
+ */
+export const qase = (caseId: number | number[], test: Mocha.Test): Mocha.Test => {
+  if (qaseImport) {
+    try {
+      return qaseImport(caseId, test);
+    } catch (e) {
+      console.warn('Qase reporter import failed at runtime, falling back to manual title update.');
+    }
+  }
+
+  // Custom fallback implementation
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!test || !test.title) {
+    return test;
+  }
+  const caseIds = Array.isArray(caseId) ? caseId : [caseId];
+
+  test.title = `${ test.title } (Qase ID: ${ caseIds.join(',') })`;
+
+  return test;
+};


### PR DESCRIPTION
Adds the Qase test-case ID wrapper so cherry-picked tests that use `qase()` compile without modification. No dependencies added and falls back to a harmless title decorator when `cypress-qase-reporter` is not installed.

### Summary
Fixes rancher/qa-tasks#1867 

Backport `cypress/support/qase.ts` from master to allow cherry-picking tests that use `qase()` wrappers without modification.

qase.ts exports a single function that wraps Mocha's `it()` to associate test cases with Qase IDs. At runtime it tries to 
`require('cypress-qase-reporter/mocha')` if the package is present and configured, results are reported to the Qase API. If not, it catches the error silently and falls back to appending `(Qase ID: 9761)` to the test title, which is a harmless no-op.

This adds no dependencies, no `package.json` or `yarn.lock` changes. The file only uses `require()` and the Mocha.Test type already bundled with Cypress. Since `cypress-qase-reporter` isn't installed on release branches the require() always fails gracefully, and since GH Actions workflows don't set `QASE_REPORT=true` there is no behavior change to existing tests.

Without this file, any cherry-pick from master that imports `@/cypress/support/qase` fails to compile on the release branch. Adding it once removes that friction permanently.

### Areas or cases that should be tested
CI

### Areas which could experience regressions
CI

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
