### PR TITLE
Override rootDir in ts-loader's compilerOptions with the actual app root

### DIFF
--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -143,7 +143,7 @@ const instrumentCode = (config) => {
   }
 };
 
-const getLoaders = (SHELL_ABS) => [
+const getLoaders = (SHELL_ABS, dir) => [
   // no fallback for pre-2013 browsers https://caniuse.com/webworkers
   {
     test:    /web-worker.[a-z-]+.js/i,
@@ -199,7 +199,8 @@ const getLoaders = (SHELL_ABS) => [
           appendTsxSuffixTo: [
             '\\.vue$'
           ],
-          configFile: path.join(SHELL_ABS, 'tsconfig.json')
+          configFile:      path.join(SHELL_ABS, 'tsconfig.json'),
+          compilerOptions: { rootDir: dir }
         }
       }
     ]
@@ -580,7 +581,7 @@ module.exports = function(dir, appConfig = {}) {
 
       config.resolve.symlinks = false;
       processShellFiles(config, SHELL_ABS);
-      config.module.rules.push(...getLoaders(SHELL_ABS));
+      config.module.rules.push(...getLoaders(SHELL_ABS, dir));
       instrumentCode(config);
       preserveWhitespace(config);
     },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves the CI failure for Validate Plugin Build System by explicitly setting the `rootDir` for ts-loader to the actual application root. 

Fixes #17118
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Override rootDir in ts-loader's compilerOptions with the actual app root

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This fix overrides shell's `rootdir` tsconfig property by passing `dir` to `getLoaders` and setting the `rootDir` for the ts-loader options, helping to ensure that all source files in extensions are in scope. 

I'm still working to understand the root cause of this regression in CI. Attempts to reproduce the behavior in earlier commits nets the same result as what we see in CI today, but we know that CI was passing last week. I will update this PR and the associated issue with more details when I better understand what caused the regression.  

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

  - Run `shell/scripts/test-plugins-build.sh` locally and confirm it completes without the TS6059 error
  - Build a standalone extension generated by the extension creator. Run `yarn build` and `yarn build-pkg <name>` and confirm both succeed
  - Build Dashboard and confirm no regressions in the normal build

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

  - Extension creator builds - any regression would manifest as a compile error in freshly generated extension apps
  - `getLoaders` is also used when building Dashboard. `dir` in this context is the repo root, so existing files should remain in scope
  - Packages built within the dashboard repo (anything under `pkg/`) pass `dir` as the repo root

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
