### PR TITLE
[Automation] - Use --frozen-lockfile for CI yarn install

### DIFF
--- a/cypress/jenkins/run.sh
+++ b/cypress/jenkins/run.sh
@@ -98,7 +98,7 @@ build_image() {
 	# This skips the full dashboard monorepo (Vue, webpack, @rancher/components)
 	cd cypress
 	echo "Installing deps from $(pwd)/package.json"
-	yarn install
+	yarn install --frozen-lockfile
 	cd ..
 
 	# Symlink so Cypress 11 can resolve ts-node/typescript from the project root


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17120

Adding the `--frozen-lockfile` parameter to yarn install. `run.sh` runs in docker as part of Jenkins pipelines.

### Areas or cases that should be tested
CI

### Areas which could experience regressions
CI


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
