### PR TITLE
Prevent node/machine vertical tabs from changing order

### DIFF
--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po.ts
@@ -45,7 +45,7 @@ export default class ClusterManagerCreateEKSPagePo extends ClusterManagerCreateR
   }
 
   getNodeGroup() {
-    return new LabeledInputPo('[data-testid="eks-nodegroup-name"]');
+    return new LabeledInputPo(() => cy.get('[data-testid="eks-nodegroup-name"]:visible'));
   }
 
   getNodeRole() {

--- a/cypress/e2e/tests/pages/manager/eks-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/eks-cluster-provisioning.spec.ts
@@ -2,6 +2,7 @@ import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import LoadingPo from '@/cypress/e2e/po/components/loading.po';
 import ClusterManagerCreateEKSPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-eks.po';
+import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import * as eksDefaultSettings from '@/cypress/e2e/blueprints/cluster_management/eks-default-settings';
 import RadioGroupInputPo from '~/cypress/e2e/po/components/radio-group-input.po';
 
@@ -186,6 +187,35 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
 
     clusterList.waitForPage();
     clusterList.list().state(this.eksClusterName).should('contain.text', 'Provisioning');
+  });
+
+  it('can re-name node pools without changing the order in which they are displayed in the UI', () => {
+    const tabbedPo = new TabbedPo('[data-testid="tabbed"]');
+
+    tabbedPo.tabNames().then((initialTabNames) => {
+      const normalizedInitialTabNames = initialTabNames.map((name) => name.trim());
+
+      tabbedPo.self().find('[data-testid="tab-list-add"]').click();
+
+      tabbedPo.tabNames().then((tabNamesAfterAdd) => {
+        const normalizedTabNamesAfterAdd = tabNamesAfterAdd.map((name) => name.trim());
+        const lastTabAfterAdd = normalizedTabNamesAfterAdd[normalizedTabNamesAfterAdd.length - 1];
+
+        expect(normalizedTabNamesAfterAdd.length).to.eq(normalizedInitialTabNames.length + 1);
+        expect(lastTabAfterAdd).to.not.eq('');
+
+        tabbedPo.clickNthTab(2);
+        createEKSClusterPage.getNodeGroup().set('aaa');
+
+        tabbedPo.tabNames().then((tabNamesAfterRename) => {
+          const normalizedTabNamesAfterRename = tabNamesAfterRename.map((name) => name.trim());
+          const lastTabAfterRename = normalizedTabNamesAfterRename[normalizedTabNamesAfterRename.length - 1];
+
+          expect(normalizedTabNamesAfterRename.length).to.eq(normalizedTabNamesAfterAdd.length);
+          expect(lastTabAfterRename).to.eq('aaa');
+        });
+      });
+    });
   });
 
   after('clean up', () => {

--- a/pkg/aks/components/Config.vue
+++ b/pkg/aks/components/Config.vue
@@ -899,6 +899,7 @@ export default defineComponent({
         <Tab
           v-for="(pool, i) in nodePools"
           :key="i"
+          :weight="-1 * idx"
           :name="pool._id || pool.name"
           :label="pool.name || t('aks.nodePools.notNamed')"
           :error="!poolIsValid(pool)"

--- a/pkg/eks/components/CruEKS.vue
+++ b/pkg/eks/components/CruEKS.vue
@@ -710,6 +710,7 @@ export default defineComponent({
           <Tab
             v-for="(node, i) in nodeGroups"
             :key="i"
+            :weight="-1 * i"
             :label="node.nodegroupName || t('eks.nodeGroups.unnamed')"
             :name="`${node.nodegroupName} ${i}`"
           >

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -788,6 +788,7 @@ export default defineComponent({
           <Tab
             v-for="(pool) in nodePools"
             :key="pool._id"
+            :weight="-1 * idx"
             :name="pool._id || pool.name"
             :label="pool.name || t('gke.notNamed')"
             :error="pool._minMaxValid===false || pool._nameUnique===false"

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -2522,6 +2522,7 @@ export default {
               <Tab
                 v-if="!obj.remove"
                 :key="obj.id"
+                :weight="-1 * idx"
                 :name="obj.id"
                 :label="obj.pool.name || '(Not Named)'"
                 :show-header="false"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17122
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
I'm not sure when we _ever_ want tabs jumping around but I was reluctant to change the default behavior in Tabbed because it appeared to be implemented intentionally. This approach seems less likely to introduce regressions, but I could be persuaded changing Tabbed is more correct.

### Areas or cases that should be tested
EKS, GKE, AKS, rke2/k3s node driver clusters (anything but "generic" type) should be tested following steps described in the linked issue

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
