### PR TITLE
Automation: Resolve notification count and release notes navigation failures for prime builds

### DIFF
--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -1,8 +1,10 @@
+import NotificationsCenterPo from '@/cypress/e2e/po/components/notification-center.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterManagerImportGenericPagePo from '@/cypress/e2e/po/extensions/imported/cluster-import-generic.po';
 import { PARTIAL_SETTING_THRESHOLD } from '@/cypress/support/utils/settings-utils';
 import { RANCHER_PAGE_EXCEPTIONS, catchTargetPageException } from '@/cypress/support/utils/exception-utils';
+import { qase } from '@/cypress/support/qase';
 
 const homePage = new HomePagePo();
 const homeClusterList = homePage.list();
@@ -33,8 +35,17 @@ function goToHomePageAndSettle() {
   homeClusterList.resourceTable().sortableTable().rowElements().should((el) => expect(el).to.contain.text('There are no rows which match your search query.'));
 }
 
+// Prime shows an extra notification vs Community
+function assertHomeNotificationCount(nc: NotificationsCenterPo) {
+  cy.getRancherVersion().then((version) => {
+    const expectedCount = version.RancherPrime === 'true' ? 2 : 1;
+
+    nc.checkCount(expectedCount);
+  });
+}
+
 describe('Home Page', () => {
-  it('Confirm correct number of settings requests made', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+  qase(3002, it('Confirm correct number of settings requests made', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
     cy.login();
 
     cy.intercept('GET', '/v1/management.cattle.io.settings?exclude=metadata.managedFields').as('settingsReq');
@@ -47,22 +58,22 @@ describe('Home Page', () => {
     // Yes this is bad, but want to ensure no other settings requests are made.
     cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
     cy.get('@settingsReq.all').should('have.length', 1);
-  });
+  }));
 
   describe('List', { testIsolation: 'off' }, () => {
     before(() => {
       cy.login();
     });
 
-    it('Validate home page with percy', { tags: ['@generic', '@adminUser'] }, () => {
+    qase(8563, it('Validate home page with percy', { tags: ['@generic', '@adminUser'] }, () => {
       // Navigate to home page and wait for page to be fully loaded.
       HomePagePo.goToAndWaitForGet();
 
       // #takes percy snapshot.
       cy.percySnapshot('Home Page');
-    });
+    }));
 
-    it('Can see that cluster details match those in Cluster Management page', { tags: ['@generic', '@adminUser'] }, () => {
+    qase(14900, it('Can see that cluster details match those in Cluster Management page', { tags: ['@generic', '@adminUser'] }, () => {
       /**
        * Get cluster details from the Home page
        * Verify that the cluster details match those on the Cluster Management page
@@ -96,9 +107,9 @@ describe('Home Page', () => {
       cy.get('@providerText').then((provider) => {
         provClusterList.list().details(clusterName, 4).should('contain.text', provider);
       });
-    });
+    }));
 
-    it('Can filter rows in the cluster list', { tags: ['@generic', '@adminUser'] }, () => {
+    qase(4109, it('Can filter rows in the cluster list', { tags: ['@generic', '@adminUser'] }, () => {
       /**
        * Filter rows in the cluster list
        */
@@ -114,9 +125,9 @@ describe('Home Page', () => {
       homeClusterList.name('local').should((el) => {
         expect(el).to.contain.text('local');
       });
-    });
+    }));
 
-    it('Should show cluster description information in the cluster list', { tags: ['@generic', '@adminUser'] }, () => {
+    qase(4108, it('Should show cluster description information in the cluster list', { tags: ['@generic', '@adminUser'] }, () => {
       // since I wasn't able to fully mock a list of clusters
       // the next best thing is to add a description to the current local cluster
       // testing https://github.com/rancher/dashboard/issues/10441
@@ -147,9 +158,9 @@ describe('Home Page', () => {
         .get('.cluster-description');
 
       desc.contains(longClusterDescription);
-    });
+    }));
 
-    it('check table headers are visible', { tags: ['@noVai', '@generic', '@adminUser'] }, () => {
+    qase(4107, it('check table headers are visible', { tags: ['@noVai', '@generic', '@adminUser'] }, () => {
       homePage.goTo();
       homePage.waitForPage();
 
@@ -164,7 +175,7 @@ describe('Home Page', () => {
 
           expect(text).to.eq(expectedHeaders[i]);
         });
-    });
+    }));
   });
 
   describe('Support Links', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
@@ -174,7 +185,7 @@ describe('Home Page', () => {
       HomePagePo.goTo();
     });
 
-    it('can click on Docs link', () => {
+    qase(1477, it('can click on Docs link', () => {
       catchTargetPageException(RANCHER_PAGE_EXCEPTIONS, 'https://ranchermanager.docs.rancher.com');
 
       homePage.supportLinks().should('have.length.at.least', 6);
@@ -189,9 +200,9 @@ describe('Home Page', () => {
           cy.url().should('include', expectedUrl);
         });
       });
-    });
+    }));
 
-    it('can click on Forums link', () => {
+    qase(1475, it('can click on Forums link', () => {
       catchTargetPageException('TenantFeatures', 'https://forums.suse.com');
 
       // click Forums link
@@ -200,41 +211,41 @@ describe('Home Page', () => {
       cy.origin('https://forums.suse.com', () => {
         cy.url().should('include', 'forums.suse.com/');
       });
-    });
+    }));
 
-    it('can click on Slack link', () => {
+    qase(1474, it('can click on Slack link', () => {
       // click Slack link
       homePage.clickSupportLink(2, true);
 
       cy.origin('https://slack.rancher.io', () => {
         cy.url().should('include', 'slack.rancher.io/');
       });
-    });
+    }));
 
-    it('can click on File an Issue link', () => {
+    qase(1478, it('can click on File an Issue link', () => {
       // click File an Issue link
       homePage.clickSupportLink(3, true);
 
       cy.origin('https://github.com', () => {
         cy.url().should('include', 'github.com/login');
       });
-    });
+    }));
 
-    it('can click on Get Started link', () => {
+    qase(1473, it('can click on Get Started link', () => {
       catchTargetPageException(RANCHER_PAGE_EXCEPTIONS);
 
       // click Get Started link
       homePage.clickSupportLink(4, true);
 
       cy.url().should('include', 'getting-started/overview');
-    });
+    }));
 
-    it('can click on Commercial Support link', { tags: '@noPrime' }, () => {
+    qase(1476, it('can click on Commercial Support link', { tags: '@noPrime' }, () => {
       // click Commercial Support link
       homePage.clickSupportLink(5);
 
       cy.url().should('include', '/support');
-    });
+    }));
 
     it('can click on SUSE Application Collection link', { tags: ['@jenkins', '@prime', '@scc'] }, () => {
       catchTargetPageException(RANCHER_PAGE_EXCEPTIONS);
@@ -252,7 +263,7 @@ describe('Home Page', () => {
       cy.login();
     });
 
-    it('has notification for release notes', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+    qase(9690, it('has notification for release notes', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
       cy.setUserPreference({ 'read-whatsnew': '' });
 
       goToHomePageAndSettle();
@@ -268,7 +279,8 @@ describe('Home Page', () => {
       nc.checkExists();
       nc.checkVisible();
       nc.checkHasUnread();
-      nc.checkCount(1);
+
+      assertHomeNotificationCount(nc);
 
       // Get the release notes notification - this is the first one on Community builds, second on Prime builds
       let item = nc.getNotificationByName('release-notes');
@@ -296,7 +308,7 @@ describe('Home Page', () => {
 
       nc.checkExists();
       nc.checkVisible();
-      nc.checkCount(1);
+      assertHomeNotificationCount(nc);
       nc.checkAllRead();
 
       // Now mark the notification as unread
@@ -309,9 +321,9 @@ describe('Home Page', () => {
       item.toggleRead();
       item.checkUnread();
       nc.checkHasUnread();
-    });
+    }));
 
-    it('Can toggle banner graphic', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+    qase(7009, it('Can toggle banner graphic', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
       goToHomePageAndSettle();
 
       // Banner graphic should be visible
@@ -327,14 +339,14 @@ describe('Home Page', () => {
       // Show the banner graphic
       homePage.toggleBanner();
       homePage.bannerGraphic().graphicBanner().should('exist');
-    });
+    }));
 
-    it('Can navigate to Home page', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+    qase(8910, it('Can navigate to Home page', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
       HomePagePo.navTo();
       homePage.waitForPage();
-    });
+    }));
 
-    it('Can use the Manage, Import Existing, and Create buttons', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+    qase(1427, it('Can use the Manage, Import Existing, and Create buttons', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
     /**
      * Click 'Manage' button and verify user lands on the Cluster Management page
      * Click on the Import Existing button and verify user lands on the cluster creation page in import mode
@@ -354,38 +366,42 @@ describe('Home Page', () => {
       HomePagePo.goToAndWaitForGet();
       homePage.createButton().click();
       genericCreateClusterPage.waitForPage();
-    });
+    }));
 
-    it('Can navigate to release notes page for latest Rancher version', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+    qase(2059, it('Can navigate to release notes page for latest Rancher version', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
       cy.setUserPreference({ 'read-whatsnew': '' });
       HomePagePo.navTo();
       homePage.waitForPage();
 
-      cy.getRancherResource('v1', 'management.cattle.io.settings', 'server-version').then((resp: Cypress.Response<any>) => {
-        const nc = homePage.notificationsCenter();
+      const nc = homePage.notificationsCenter();
 
-        // Open the notification centre
-        nc.toggle();
+      // Open the notification centre
+      nc.toggle();
 
-        nc.checkOpen();
-        nc.checkExists();
-        nc.checkVisible();
-        nc.checkCount(1);
+      nc.checkOpen();
+      nc.checkExists();
+      nc.checkVisible();
+      assertHomeNotificationCount(nc);
 
-        // Get the release notes notification
-        const item = nc.getNotificationByIndex(0);
+      const item = nc.getNotificationByName('release-notes');
 
-        item.checkExists();
+      item.checkExists();
 
+      cy.getRancherVersion().then((version) => {
         cy.window().then((win) => {
           cy.stub(win, 'open', () => {}).as('openReleaseNotes');
         });
 
         item.primaryActionButton().click();
 
-        cy.get('@openReleaseNotes').should('be.calledWith', 'https://github.com/rancher/rancher/releases/latest', '_blank');
+        cy.get('@openReleaseNotes').should((stub: any) => {
+          const [url, target] = stub.getCall(0).args;
+
+          expect(url).to.contain(version.RancherPrime === 'true' ? 'documentation.suse.com/cloudnative/rancher-manager' : 'github.com/rancher/rancher/releases');
+          expect(target).to.eq('_blank');
+        });
       });
-    });
+    }));
   });
 
   after(() => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2271

Rancher Prime the home notification center shows two items, not one, so the test now expects the right count per edition. The release-notes test no longer assumes index 0 or a GitHub-only URL; it picks the release-notes row and checks that window.open uses either GitHub or SUSE documentation
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
