### PR TITLE
Add default-days to GitHub Actions dependency config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    default-days: 7
     open-pull-requests-limit: 5
     labels: ["component/dependencies"]
 
@@ -21,5 +22,6 @@ updates:
       - "/pkg/*"
     schedule:
       interval: "weekly"
+    default-days: 7
     open-pull-requests-limit: 5
     labels: ["area/dependencies"]


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Add a cooloff period before dependabot creates an update.

Does not apply to security releases (.....)

### Areas or cases that should be tested
- We should validate that new dependabot issues are all created from versions at least 5 days (ideally they are all 7-14 days old given schedule)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
