### PR TITLE
[backport 2.13.5] Automation: Resolve notification count and release notes navigation failures for prime builds

### DIFF
--- a/cypress/e2e/po/components/notification-center.po.ts
+++ b/cypress/e2e/po/components/notification-center.po.ts
@@ -84,4 +84,9 @@ export default class NotificationsCenterPo extends ComponentPo {
   checkCount(count: number) {
     return this.self().find('[data-testid="notifications-center-item"]').should('have.length', count);
   }
+
+  /** Assert at least `min` notifications (exact count may vary). */
+  checkCountAtLeast(min: number) {
+    return this.self().find('[data-testid="notifications-center-item"]').should('have.length.at.least', min);
+  }
 }

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -35,12 +35,12 @@ function goToHomePageAndSettle() {
   homeClusterList.resourceTable().sortableTable().rowElements().should((el) => expect(el).to.contain.text('There are no rows which match your search query.'));
 }
 
-// Prime shows an extra notification vs Community
+// Min items: Community 1, Prime 2. Count can be higher (dynamic new-release applies to Community and Prime).
 function assertHomeNotificationCount(nc: NotificationsCenterPo) {
   cy.getRancherVersion().then((version) => {
-    const expectedCount = version.RancherPrime === 'true' ? 2 : 1;
+    const minCount = version.RancherPrime === 'true' ? 2 : 1;
 
-    nc.checkCount(expectedCount);
+    nc.checkCountAtLeast(minCount);
   });
 }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2271

backport of https://github.com/rancher/dashboard/pull/17137
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
