### PR TITLE
[backport 2.14.1] Automation: Stabilize Kubewarden install e2e test

### DIFF
--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -6,7 +6,7 @@ import RepositoriesPagePo from '@/cypress/e2e/po/pages/chart-repositories.po';
 import BannersPo from '@/cypress/e2e/po/components/banners.po';
 import ChartRepositoriesCreateEditPo from '@/cypress/e2e/po/edit/chart-repositories.po';
 import AppClusterRepoEditPo from '@/cypress/e2e/po/edit/catalog.cattle.io.clusterrepo.po';
-import { LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 import { CLUSTER_REPOS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
 import ResourceTablePo from '@/cypress/e2e/po/components/resource-table.po';
 import { GetOptions } from '@/cypress/e2e/po/components/component.po';
@@ -49,6 +49,50 @@ export default class ExtensionsPagePo extends PagePo {
 
   waitForTabs() {
     return this.extensionTabs.checkVisible(LONG_TIMEOUT_OPT);
+  }
+
+  /**
+   * Returns whether the given extension tab is present.
+   */
+  checkForExtensionTab(tab: 'available' | 'installed' | 'builtin'): Cypress.Chainable<boolean> {
+    this.waitForTabs();
+
+    return this.self().then((el) => {
+      return el.find(`[data-testid="btn-${ tab }"]`).length > 0;
+    });
+  }
+
+  /**
+   * Returns whether any card under the page root has a title containing `extensionName`
+   * Resolves to false when none match; does not assert failure.
+   */
+  checkForExtensionCardWithName(extensionName: string): Cypress.Chainable<boolean> {
+    this.waitForTabs();
+
+    return this.self(MEDIUM_TIMEOUT_OPT).then((el) => {
+      const header = el.find('[data-testid="item-card-header-title"]').filter((_, titleEl) => {
+        return Cypress.$(titleEl).text().includes(extensionName);
+      });
+
+      return header.length > 0;
+    });
+  }
+
+  /**
+   * Intercepts the cluster-repo install POST, installs `extensionName` from the Available tab through
+   * the modal, asserts a 2xx response, then completes the reload banner flow.
+   */
+  installExtensionFromCatalog(extensionName: string, clusterRepoName: string, interceptAlias: string): void {
+    cy.intercept('POST', `${ CLUSTER_REPOS_BASE_URL }/${ clusterRepoName }?action=install`).as(interceptAlias);
+
+    this.extensionTabAvailableClick();
+    this.waitForPage(null, 'available');
+    this.extensionCardInstallClick(extensionName);
+    this.installModal().checkVisible();
+    this.installModal().installButton().click();
+    cy.wait(`@${ interceptAlias }`, MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('be.oneOf', [200, 201]);
+    this.extensionReloadBanner().should('be.visible');
+    this.extensionReloadClick();
   }
 
   /**

--- a/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
@@ -4,10 +4,20 @@ import RepositoriesPagePo from '@/cypress/e2e/po/pages/chart-repositories.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import KubewardenExtensionPo from '@/cypress/e2e/po/pages/extensions/kubewarden.po';
 import { catchTargetPageException } from '@/cypress/support/utils/exception-utils';
+import { qase } from '@/cypress/support/qase';
 
 const extensionName = 'kubewarden';
 const gitRepoName = 'rancher-extensions';
 let removeExtensions = false;
+
+function verifyKubewardenInstalledDetails(extensionsPo: ExtensionsPagePo) {
+  extensionsPo.waitForTabs();
+  extensionsPo.extensionTabInstalledClick();
+  extensionsPo.waitForPage(null, 'installed');
+  extensionsPo.extensionCardClick(extensionName);
+  extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+  extensionsPo.extensionDetailsCloseClick();
+}
 
 describe('Kubewarden Extension', { tags: ['@extensions', '@adminUser'] }, () => {
   before(() => {
@@ -29,34 +39,37 @@ describe('Kubewarden Extension', { tags: ['@extensions', '@adminUser'] }, () => 
     cy.login();
   });
 
-  it('Should install Kubewarden extension', () => {
+  qase(1430, it('Should install Kubewarden extension', () => {
     const extensionsPo = new ExtensionsPagePo();
 
     extensionsPo.goTo();
     extensionsPo.waitForPage();
 
-    extensionsPo.extensionTabAvailableClick();
-    extensionsPo.waitForPage(null, 'available');
+    // Idempotent: no Installed tab → install Kubewarden from catalog (nothing installed yet).
+    // Installed tab → open it: Kubewarden card present → only assert details; absent → install
+    extensionsPo.checkForExtensionTab('installed').then((installedTabRendered) => {
+      if (!installedTabRendered) {
+        extensionsPo.installExtensionFromCatalog(extensionName, gitRepoName, 'kwInstall');
+        verifyKubewardenInstalledDetails(extensionsPo);
 
-    // click on install button on card
-    extensionsPo.extensionCardInstallClick(extensionName);
-    extensionsPo.installModal().checkVisible();
+        return;
+      }
+      extensionsPo.extensionTabInstalledClick();
+      extensionsPo.waitForPage(null, 'installed');
+      extensionsPo.checkForExtensionCardWithName(extensionName).then((kubewardenCardPresent) => {
+        if (kubewardenCardPresent) {
+          extensionsPo.extensionCardClick(extensionName);
+          extensionsPo.extensionDetailsTitle().should('contain', extensionName);
+          extensionsPo.extensionDetailsCloseClick();
+        } else {
+          extensionsPo.installExtensionFromCatalog(extensionName, gitRepoName, 'kwInstall');
+          verifyKubewardenInstalledDetails(extensionsPo);
+        }
+      });
+    });
+  }));
 
-    // click install
-    extensionsPo.installModal().installButton().click();
-
-    // check the extension reload banner and reload the page
-    extensionsPo.extensionReloadBanner().should('be.visible');
-    extensionsPo.extensionReloadClick();
-
-    // make sure extension card is in the installed tab
-    extensionsPo.extensionTabInstalledClick();
-    extensionsPo.extensionCardClick(extensionName);
-    extensionsPo.extensionDetailsTitle().should('contain', extensionName);
-    extensionsPo.extensionDetailsCloseClick();
-  });
-
-  it('Check Apps/Charts and Apps/Repo pages for route collisions', () => {
+  qase(1429, it('Check Apps/Charts and Apps/Repo pages for route collisions', () => {
     const chartsPage: ChartsPage = new ChartsPage();
 
     chartsPage.goTo();
@@ -68,9 +81,9 @@ describe('Kubewarden Extension', { tags: ['@extensions', '@adminUser'] }, () => 
     appRepoList.goTo('local', 'apps');
     appRepoList.waitForPage();
     cy.get('h1').contains('Repositories').should('exist');
-  });
+  }));
 
-  it('Side-nav should contain Kubewarden menu item', () => {
+  qase(1431, it('Side-nav should contain Kubewarden menu item', () => {
     const kubewardenPo = new KubewardenExtensionPo();
     const productMenu = new ProductNavPo();
 
@@ -81,9 +94,9 @@ describe('Kubewarden Extension', { tags: ['@extensions', '@adminUser'] }, () => 
 
     kubewardenNavItem.should('exist');
     kubewardenNavItem.click();
-  });
+  }));
 
-  it('Kubewarden dashboard view should exist', () => {
+  qase(1432, it('Kubewarden dashboard view should exist', () => {
     const kubewardenPo = new KubewardenExtensionPo();
 
     kubewardenPo.goTo();
@@ -91,14 +104,15 @@ describe('Kubewarden Extension', { tags: ['@extensions', '@adminUser'] }, () => 
 
     cy.get('h1').contains('Kubewarden').should('exist');
     cy.get('button').contains('Install Kubewarden').should('exist');
-  });
+  }));
 
-  it('Should uninstall Kubewarden', () => {
+  qase(1433, it('Should uninstall Kubewarden', () => {
     const extensionsPo = new ExtensionsPagePo();
 
     extensionsPo.goTo();
     extensionsPo.waitForPage();
 
+    extensionsPo.waitForTabs();
     extensionsPo.extensionTabInstalledClick();
 
     // click on uninstall button on card
@@ -114,7 +128,7 @@ describe('Kubewarden Extension', { tags: ['@extensions', '@adminUser'] }, () => 
     extensionsPo.extensionTabAvailableClick();
     extensionsPo.extensionCardClick(extensionName);
     extensionsPo.extensionDetailsTitle().should('contain', extensionName);
-  });
+  }));
 
   after(() => {
     if ( removeExtensions ) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2267

Backport of https://github.com/rancher/dashboard/pull/17115
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
