### PR TITLE
[Backport 2.14.1] feat: add cpu model dropdown for harvester REK2 cluster provisioning

### DIFF
--- a/pkg/harvester-manager/l10n/en-us.yaml
+++ b/pkg/harvester-manager/l10n/en-us.yaml
@@ -60,3 +60,6 @@ harvesterManager:
     placeholder: 'Please select a VGPU'
     allocatable: allocatable
     allocatableUnknown: missing allocation info
+  cpuModel:
+    label: CPU Model
+    optionLabel: "{modelName} (Ready nodes: {count})"

--- a/pkg/harvester-manager/l10n/zh-hans.yaml
+++ b/pkg/harvester-manager/l10n/zh-hans.yaml
@@ -9,3 +9,6 @@ harvesterManager:
     loadError: 加载 Harvester 插件时出错
   rke:
     templateError: 模版格式不正确
+  cpuModel:
+    label: CPU 型号
+    optionLabel: "{modelName} (就绪节点: {count})"

--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -156,12 +156,13 @@ export default {
         }
 
         const res = await allHashSettled({
-          namespaces:   this.$store.dispatch('cluster/request', { url: `${ url }/${ NAMESPACE }s` }),
-          images:       this.$store.dispatch('cluster/request', { url: `${ url }/${ HCI.IMAGE }s` }),
-          configMaps:   this.$store.dispatch('cluster/request', { url: configMapsUrl }),
-          networks:     this.$store.dispatch('cluster/request', { url: `${ url }/k8s.cni.cncf.io.network-attachment-definitions` }),
-          storageClass: this.$store.dispatch('cluster/request', { url: `${ url }/${ STORAGE_CLASS }es` }),
-          settings:     this.$store.dispatch('cluster/request', { url: `${ url }/${ MANAGEMENT.SETTING }s` })
+          namespaces:     this.$store.dispatch('cluster/request', { url: `${ url }/${ NAMESPACE }s` }),
+          images:         this.$store.dispatch('cluster/request', { url: `${ url }/${ HCI.IMAGE }s` }),
+          configMaps:     this.$store.dispatch('cluster/request', { url: configMapsUrl }),
+          networks:       this.$store.dispatch('cluster/request', { url: `${ url }/k8s.cni.cncf.io.network-attachment-definitions` }),
+          storageClass:   this.$store.dispatch('cluster/request', { url: `${ url }/${ STORAGE_CLASS }es` }),
+          settings:       this.$store.dispatch('cluster/request', { url: `${ url }/${ MANAGEMENT.SETTING }s` }),
+          cpuModelConfig: this.$store.dispatch('cluster/request', { url: `${ url }/${ CONFIG_MAP }s/harvester-system/node-cpu-model-configuration` }),
         });
 
         for (const key of Object.keys(res)) {
@@ -190,6 +191,7 @@ export default {
         this.images = res.images.value?.data;
         this.storageClass = res.storageClass.value?.data;
         this.networks = res.networks.value?.data;
+        this.cpuModelConfigMap = res.cpuModelConfig.value?.data;
 
         let systemNamespaces = (res.settings.value?.data || []).filter((x) => x.id === SETTING.SYSTEM_NAMESPACES);
 
@@ -380,6 +382,7 @@ export default {
       vGpuDevices:        {},
       vGpusInit:          vGpus,
       vGpus,
+      cpuModelConfigMap:  null,
     };
   },
 
@@ -407,6 +410,49 @@ export default {
       set(neu) {
         this.images = neu;
       }
+    },
+
+    cpuModelOptions() {
+      const defaultOption = { label: this.t('generic.default'), value: '' };
+
+      if (!this.cpuModelConfigMap?.cpuModels) {
+        return [defaultOption];
+      }
+
+      let cpuModelsData;
+
+      try {
+        cpuModelsData = YAML.parse(this.cpuModelConfigMap.cpuModels);
+      } catch (e) {
+        return [defaultOption];
+      }
+
+      if (!cpuModelsData || typeof cpuModelsData !== 'object') {
+        return [defaultOption];
+      }
+
+      const options = [defaultOption];
+
+      const globalModels = cpuModelsData.globalModels || [];
+
+      globalModels.forEach((modelName) => {
+        options.push({ label: modelName, value: modelName });
+      });
+
+      const modelEntries = Object.entries(cpuModelsData.models || {});
+
+      modelEntries.sort((a, b) => a[0].localeCompare(b[0]));
+
+      modelEntries.forEach(([modelName, modelInfo]) => {
+        const readyCount = modelInfo.readyCount || 0;
+
+        options.push({
+          label: this.t('harvesterManager.cpuModel.optionLabel', { modelName, count: readyCount }),
+          value: modelName
+        });
+      });
+
+      return options;
     },
 
     networkOptions: {
@@ -1287,6 +1333,15 @@ export default {
             :mode="mode"
             :disabled="disabled"
             :placeholder="t('cluster.harvester.machinePool.reservedMemory.placeholder')"
+          />
+        </div>
+        <div class="col span-6">
+          <LabeledSelect
+            v-model:value="value.cpuModel"
+            :label="t('harvesterManager.cpuModel.label')"
+            :options="cpuModelOptions"
+            :mode="mode"
+            :disabled="disabled"
           />
         </div>
       </div>

--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -83,6 +83,7 @@ const SOURCE_TYPE = {
 };
 
 const VGPU_PREFIX = { NVIDIA: 'nvidia.com/' };
+const HARVESTER_CPU_MODEL = 'harvester-system/node-cpu-model-configuration';
 
 export default {
   name: 'ConfigComponentHarvester',
@@ -147,7 +148,8 @@ export default {
             filters: [
               PaginationParamFilter.createMultipleFields([
                 new PaginationFilterField({ field: `metadata.labels[${ HCI_ANNOTATIONS.CLOUD_INIT }]`, value: 'user' }),
-                new PaginationFilterField({ field: `metadata.labels[${ HCI_ANNOTATIONS.CLOUD_INIT }]`, value: 'network' })
+                new PaginationFilterField({ field: `metadata.labels[${ HCI_ANNOTATIONS.CLOUD_INIT }]`, value: 'network' }),
+                new PaginationFilterField({ field: 'id', value: HARVESTER_CPU_MODEL })
               ])
             ]
           });
@@ -156,13 +158,12 @@ export default {
         }
 
         const res = await allHashSettled({
-          namespaces:     this.$store.dispatch('cluster/request', { url: `${ url }/${ NAMESPACE }s` }),
-          images:         this.$store.dispatch('cluster/request', { url: `${ url }/${ HCI.IMAGE }s` }),
-          configMaps:     this.$store.dispatch('cluster/request', { url: configMapsUrl }),
-          networks:       this.$store.dispatch('cluster/request', { url: `${ url }/k8s.cni.cncf.io.network-attachment-definitions` }),
-          storageClass:   this.$store.dispatch('cluster/request', { url: `${ url }/${ STORAGE_CLASS }es` }),
-          settings:       this.$store.dispatch('cluster/request', { url: `${ url }/${ MANAGEMENT.SETTING }s` }),
-          cpuModelConfig: this.$store.dispatch('cluster/request', { url: `${ url }/${ CONFIG_MAP }s/harvester-system/node-cpu-model-configuration` }),
+          namespaces:   this.$store.dispatch('cluster/request', { url: `${ url }/${ NAMESPACE }s` }),
+          images:       this.$store.dispatch('cluster/request', { url: `${ url }/${ HCI.IMAGE }s` }),
+          configMaps:   this.$store.dispatch('cluster/request', { url: configMapsUrl }),
+          networks:     this.$store.dispatch('cluster/request', { url: `${ url }/k8s.cni.cncf.io.network-attachment-definitions` }),
+          storageClass: this.$store.dispatch('cluster/request', { url: `${ url }/${ STORAGE_CLASS }es` }),
+          settings:     this.$store.dispatch('cluster/request', { url: `${ url }/${ MANAGEMENT.SETTING }s` }),
         });
 
         for (const key of Object.keys(res)) {
@@ -191,7 +192,7 @@ export default {
         this.images = res.images.value?.data;
         this.storageClass = res.storageClass.value?.data;
         this.networks = res.networks.value?.data;
-        this.cpuModelConfigMap = res.cpuModelConfig.value?.data;
+        this.cpuModelConfigMap = this.genCpuModelConfigMap(res.configMaps.value?.data);
 
         let systemNamespaces = (res.settings.value?.data || []).filter((x) => x.id === SETTING.SYSTEM_NAMESPACES);
 
@@ -435,6 +436,8 @@ export default {
 
       const globalModels = cpuModelsData.globalModels || [];
 
+      globalModels.sort((a, b) => a[0].localeCompare(b[0]));
+
       globalModels.forEach((modelName) => {
         options.push({ label: modelName, value: modelName });
       });
@@ -620,6 +623,11 @@ export default {
 
   methods: {
     stringify,
+    genCpuModelConfigMap(configMaps = []) {
+      const cpuModelConfigMap = configMaps.find((cm) => cm.id === HARVESTER_CPU_MODEL);
+
+      return cpuModelConfigMap?.data || null;
+    },
     genCloudDataOptions(configMaps = [], type = 'user') {
       const valueMap = new Map();
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16724


### Occurred changes and/or fixed issues
backport https://github.com/rancher/dashboard/pull/17041 to release-2.14

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
Add CPU Model dropdown in harvester RKE2 provisioning create page

<img width="1468" height="801" alt="Screenshot 2026-04-08 at 5 36 03 PM" src="https://github.com/user-attachments/assets/c25fc417-2b13-419d-9232-3ba6af7e9304" />


The VM created on harvester
<img width="1455" height="813" alt="Screenshot 2026-04-08 at 5 50 11 PM" src="https://github.com/user-attachments/assets/eea482b3-fb6f-4280-948b-1d3811b5fe63" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
