### PR TITLE
Support manually supplied nodes in NodeScheduling

### DIFF
--- a/shell/components/form/NodeScheduling.vue
+++ b/shell/components/form/NodeScheduling.vue
@@ -2,6 +2,7 @@
 import { mapGetters } from 'vuex';
 import { RadioGroup } from '@components/Form/Radio';
 import ResourceLabeledSelect from '@shell/components/form/ResourceLabeledSelect.vue';
+import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
 import NodeAffinity from '@shell/components/form/NodeAffinity.vue';
 import { HARVESTER_NAME as VIRTUAL } from '@shell/config/features';
 import { _VIEW } from '@shell/config/query-params';
@@ -18,6 +19,7 @@ const parseNode = (node: string | KubeNode) => typeof node === 'string' ? node :
 export default {
   components: {
     RadioGroup,
+    LabeledSelect,
     ResourceLabeledSelect,
     NodeAffinity,
   },
@@ -35,7 +37,7 @@ export default {
      */
     nodes: {
       type:    Array,
-      default: () => []
+      default: () => null
     },
 
     mode: {
@@ -218,14 +220,14 @@ export default {
       handler(nodeSelector) {
         // Harvester specific code should not live in rancher/dashboard components
         // This was brought into harvester/dashboard via https://github.com/harvester/dashboard/pull/342
-        // rancher/dashboard via https://github.com/rancher/dashboard/pull/6310
+        // and then rancher/dashboard via https://github.com/rancher/dashboard/pull/6310
         if (this.isHarvester && nodeSelector?.[HOSTNAME]) {
           this.selectNode = 'nodeSelector';
           const nodeName = nodeSelector[HOSTNAME];
 
           this.nodeName = nodeName;
 
-          const array = this.nodes.map((n) => n.value);
+          const array = this.nodes?.map((n) => n.value) || [];
 
           if (nodeName && !array.includes(nodeName)) {
             this.$store.dispatch('growl/error', {
@@ -259,7 +261,19 @@ export default {
     <template v-if="selectNode === 'nodeSelector'">
       <div class="row">
         <div class="col span-6">
+          <LabeledSelect
+            v-if="nodes"
+            v-model:value="nodeName"
+            :label="t('workload.scheduling.affinity.nodeName')"
+            :options="nodes || []"
+            :mode="mode"
+            :multiple="false"
+            :loading="loading"
+            :data-testid="'node-scheduling-nodeSelector'"
+            @update:value="update"
+          />
           <ResourceLabeledSelect
+            v-else
             v-model:value="nodeName"
             :label="t('workload.scheduling.affinity.nodeName')"
             :resource-type="NODE"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16918
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- NodeScheduling was updated in https://github.com/rancher/dashboard/pull/16428 to use the ResourceLabeledSelect. This dynamically handles the fetch of nodes to use
- However harvester still needs to pass through it's own node collection. The plumbing for this was broken

### Areas or cases that should be tested
- tested via building + loading current harvester/harvester-ui-extension into local docker
- dev load it into rancher
- validate broken
  - in non-harvester world workloads --> pods --> create --> Pod tab --> Node scheduling --> run on specific node --> node/s shown
  - in harvester world virtual machines --> create --> node schedling --> run virtual machine on specific node --> node/s NOT shown
- yarn link this branch's shell to the extensions shell, rebuild + serve
- refresh browser
- validate nodes shown
  - in non-harvester world workloads --> pods --> create --> Pod tab --> Node scheduling --> run on specific node --> node/s shown
  - in harvester world virtual machines --> create --> node schedling --> run virtual machine on specific node --> node/s shown
### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
