### PR TITLE
Fix login background preview cross-fallback between light/dark modes

### DIFF
--- a/cypress/e2e/tests/pages/global-settings/branding.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/branding.spec.ts
@@ -270,7 +270,7 @@ describe('Branding', { testIsolation: 'off' }, () => {
     });
   });
 
-  it('Login Background', { tags: ['@globalSettings', '@adminUser'] }, () => {
+  it('Login Background (Dark)', { tags: ['@globalSettings', '@adminUser'] }, () => {
     const prefPage = new PreferencesPagePo();
 
     BrandingPagePo.navTo();
@@ -279,22 +279,18 @@ describe('Branding', { testIsolation: 'off' }, () => {
     brandingPage.customLoginBackgroundCheckbox().hasAppropriateWidth();
     brandingPage.customLoginBackgroundCheckbox().hasAppropriateHeight();
 
-    // Upload Light Background
-    brandingPage.uploadButton('Upload Light Background')
-      .selectFile('cypress/e2e/blueprints/branding/backgrounds/login-landscape-light.svg', { force: true });
-
-    // Upload Dark Background
+    // Upload only Dark Background
     brandingPage.uploadButton('Upload Dark Background')
       .selectFile('cypress/e2e/blueprints/branding/backgrounds/login-landscape-dark.svg', { force: true });
 
     // Apply
-    brandingPage.applyAndWait('/v1/management.cattle.io.settings/ui-login-background-light', 200);
+    brandingPage.applyAndWait('/v1/management.cattle.io.settings/ui-login-background-dark', 200);
 
-    // Banner Preview
+    // Only dark preview should be visible, light preview should not exist
     brandingPage.loginBackgroundPreview('dark').scrollIntoView().should('be.visible');
-    brandingPage.loginBackgroundPreview('light').scrollIntoView().should('be.visible');
+    brandingPage.loginBackgroundPreview('light').should('not.exist');
 
-    // Set dashboard theme to Dark and check login page for updated background in dark mode
+    // Set dashboard theme to Dark and check login page for updated background
     PreferencesPagePo.navTo();
     prefPage.themeButtons().checkVisible();
     cy.intercept('PUT', 'v1/userpreferences/*').as('prefUpdateDark');
@@ -313,7 +309,12 @@ describe('Branding', { testIsolation: 'off' }, () => {
     cy.login();
     HomePagePo.goToAndWaitForGet();
 
-    // Set dashboard theme to Dark and check login page for updated background in light mode
+    // Reset
+    BrandingPagePo.navTo();
+    brandingPage.customLoginBackgroundCheckbox().set();
+    brandingPage.applyAndWait('/v1/management.cattle.io.settings/ui-login-background-dark', 200);
+
+    // Set theme back to Light
     PreferencesPagePo.navTo();
     prefPage.themeButtons().checkVisible();
     cy.intercept('PUT', 'v1/userpreferences/*').as('prefUpdateLight');
@@ -323,7 +324,29 @@ describe('Branding', { testIsolation: 'off' }, () => {
       expect(request.body.data).to.have.property('theme', '"ui-light"');
       expect(response?.body.data).to.have.property('theme', '"ui-light"');
     });
+  });
 
+  it('Login Background (Light)', { tags: ['@globalSettings', '@adminUser'] }, () => {
+    BrandingPagePo.navTo();
+
+    // Ensure login background customization is disabled to clear any leftover dark config
+    brandingPage.customLoginBackgroundCheckbox().uncheck();
+    brandingPage.applyAndWait('/v1/management.cattle.io.settings/ui-login-background-dark', 200);
+
+    brandingPage.customLoginBackgroundCheckbox().set();
+
+    // Upload only Light Background
+    brandingPage.uploadButton('Upload Light Background')
+      .selectFile('cypress/e2e/blueprints/branding/backgrounds/login-landscape-light.svg', { force: true });
+
+    // Apply
+    brandingPage.applyAndWait('/v1/management.cattle.io.settings/ui-login-background-light', 200);
+
+    // Only light preview should be visible, dark preview should not exist
+    brandingPage.loginBackgroundPreview('light').scrollIntoView().should('be.visible');
+    brandingPage.loginBackgroundPreview('dark').should('not.exist');
+
+    // Verify login page shows the light background
     cy.fixture('branding/backgrounds/login-landscape-light.svg', 'base64').then((expectedBase64) => {
       loginPage.goTo();
       loginPage.loginBackgroundImage().should('be.visible').and('have.attr', 'src', `data:image/svg+xml;base64,${ expectedBase64 }`);

--- a/shell/pages/c/_cluster/settings/brand.vue
+++ b/shell/pages/c/_cluster/settings/brand.vue
@@ -440,14 +440,14 @@ export default {
             />
           </div>
           <SimpleBox
-            v-if="uiLoginBackgroundLight || uiLoginBackgroundDark"
+            v-if="uiLoginBackgroundLight"
             class="theme-light mb-10"
           >
             <label class="text-muted">{{ t('branding.loginBackground.lightPreview') }}</label>
             <img
               class="img-preview"
               data-testid="branding-login-background-light-preview"
-              :src="uiLoginBackgroundLight ? uiLoginBackgroundLight : uiLoginBackgroundDark"
+              :src="uiLoginBackgroundLight"
             >
           </SimpleBox>
         </div>
@@ -465,14 +465,14 @@ export default {
             />
           </div>
           <SimpleBox
-            v-if="uiLoginBackgroundDark || uiLoginBackgroundLight"
+            v-if="uiLoginBackgroundDark"
             class="theme-dark  mb-10"
           >
             <label class="text-muted">{{ t('branding.loginBackground.darkPreview') }}</label>
             <img
               class="img-preview"
               data-testid="branding-login-background-dark-preview"
-              :src="uiLoginBackgroundDark ? uiLoginBackgroundDark : uiLoginBackgroundLight"
+              :src="uiLoginBackgroundDark"
             >
           </SimpleBox>
         </div>


### PR DESCRIPTION
### Summary
Fixes #17085

### Occurred changes and/or fixed issues
Login background image preview in the branding settings page no longer shows a cross-fallback between light and dark modes. Each preview now only appears when its own image is set, accurately reflecting the actual login page behavior.

### Technical notes summary
- Removed `||` conditions and ternary fallbacks in the login background preview `v-if` and `:src` bindings in `brand.vue`
- Split the single Cypress `Login Background` test into two separate tests (`Dark` and `Light`), each uploading only one image and asserting that the other preview does not exist

### Areas or cases that should be tested
- Upload only a dark login background image and verify the light preview does not appear
- Upload only a light login background image and verify the dark preview does not appear
- Upload both and verify both previews appear correctly
- Verify the actual login page displays the correct background for each theme

### Areas which could experience regressions
- Branding settings page login background preview section

### Screenshot/Video
<img width="1816" height="1004" alt="image" src="https://github.com/user-attachments/assets/272cc5cd-d0ed-414c-b321-f3b1550555f9" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`