### PR TITLE
Remove namespace filter options: Only Namespaced/Cluster Resources

### DIFF
--- a/cypress/e2e/tests/pages/explorer2/namespace-picker.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/namespace-picker.spec.ts
@@ -97,8 +97,8 @@ describe('Namespace picker', { testIsolation: 'off' }, () => {
       .should('be.visible');
   });
 
-  it('can select only one of the top 5 resource filters at a time', { tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {
-    // Verify that user can only select one of the first 5 options
+  it('can select only one of the top resource filters at a time', { tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {
+    // Verify that user can only select one of the special filter options
 
     namespacePicker.toggle();
 
@@ -115,16 +115,6 @@ describe('Namespace picker', { testIsolation: 'off' }, () => {
     // Select 'Only System Namespaces'
     namespacePicker.clickOptionByLabelAndWaitForRequest('Only System Namespaces');
     namespacePicker.isChecked('Only System Namespaces');
-    namespacePicker.checkIcon().should('have.length', 1);
-
-    // Select 'Only Namespaced Resources'
-    namespacePicker.clickOptionByLabelAndWaitForRequest('Only Namespaced Resources');
-    namespacePicker.isChecked('Only Namespaced Resources');
-    namespacePicker.checkIcon().should('have.length', 1);
-
-    // Select 'Only Cluster Resources'
-    namespacePicker.clickOptionByLabelAndWaitForRequest('Only Cluster Resources');
-    namespacePicker.isChecked('Only Cluster Resources');
     namespacePicker.checkIcon().should('have.length', 1);
   });
 

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -263,9 +263,7 @@ nav:
     resources: Resources
   ns:
     all: All Namespaces
-    clusterLevel: Only Cluster Resources
     namespace: "{name}"
-    namespaced: Only Namespaced Resources
     orphan: Not in a Project
     project: "Project: {name}"
     system: Only System Namespaces

--- a/shell/components/SideNav.vue
+++ b/shell/components/SideNav.vue
@@ -75,15 +75,6 @@ export default {
       }
     },
 
-    // Queue namespaceMode and namespaces
-    // Changes to namespaceMode can also change namespaces, so keep this simple and execute both in a shortened queue
-
-    namespaceMode(a, b) {
-      if ( a !== b ) {
-        this.queueUpdate();
-      }
-    },
-
     namespaces(a, b) {
       if ( !isEqual(a, b) ) {
         this.queueUpdate();
@@ -112,7 +103,7 @@ export default {
 
   computed: {
     ...mapState(['managementReady', 'clusterReady']),
-    ...mapGetters(['isStandaloneHarvester', 'productId', 'clusterId', 'currentProduct', 'rootProduct', 'isSingleProduct', 'namespaceMode', 'isExplorer', 'isVirtualCluster']),
+    ...mapGetters(['isStandaloneHarvester', 'productId', 'clusterId', 'currentProduct', 'rootProduct', 'isSingleProduct', 'isExplorer', 'isVirtualCluster']),
     ...mapGetters({ locale: 'i18n/selectedLocaleLabel', hasMultipleLocales: 'i18n/hasMultipleLocales' }),
     ...mapGetters('type-map', ['activeProducts']),
 

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -9,8 +9,6 @@ import {
   NAMESPACE_FILTER_ALL as ALL,
   NAMESPACE_FILTER_ALL_SYSTEM as ALL_SYSTEM,
   NAMESPACE_FILTER_ALL_ORPHANS as ALL_ORPHANS,
-  NAMESPACE_FILTER_NAMESPACED_YES as NAMESPACED_YES,
-  NAMESPACE_FILTER_NAMESPACED_NO as NAMESPACED_NO,
   createNamespaceFilterKey,
   NAMESPACE_FILTER_KINDS,
   NAMESPACE_FILTER_NS_FULL_PREFIX,
@@ -195,16 +193,6 @@ export default {
             id:    ALL_SYSTEM,
             kind:  NAMESPACE_FILTER_KINDS.SPECIAL,
             label: t('nav.ns.system'),
-          },
-          {
-            id:    NAMESPACED_YES,
-            kind:  NAMESPACE_FILTER_KINDS.SPECIAL,
-            label: t('nav.ns.namespaced'),
-          },
-          {
-            id:    NAMESPACED_NO,
-            kind:  NAMESPACE_FILTER_KINDS.SPECIAL,
-            label: t('nav.ns.clusterLevel'),
           },
         ];
 

--- a/shell/mixins/resource-fetch-api-pagination.js
+++ b/shell/mixins/resource-fetch-api-pagination.js
@@ -1,4 +1,4 @@
-import { NAMESPACE_FILTER_NAMESPACED_YES, NAMESPACE_FILTER_NAMESPACED_NO, NAMESPACE_FILTER_ALL } from '@shell/utils/namespace-filter';
+import { NAMESPACE_FILTER_ALL } from '@shell/utils/namespace-filter';
 import { NAMESPACE } from '@shell/config/types';
 import { ALL_NAMESPACES } from '@shell/store/prefs';
 import { mapGetters } from 'vuex';
@@ -265,13 +265,6 @@ export default {
 
           // If we're showing all... and not hiding system or obscure ns then don't go through filter process
           if (!allButHidingSystemResources) {
-            return;
-          }
-        }
-
-        // Transitioning to a ns filter that doesn't affect the list should be avoided
-        if (neu.length === 1) {
-          if ([NAMESPACE_FILTER_NAMESPACED_YES, NAMESPACE_FILTER_NAMESPACED_NO].includes(neu[0])) {
             return;
           }
         }

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -17,7 +17,7 @@ import { BY_TYPE } from '@shell/plugins/dashboard-store/classify';
 import Steve from '@shell/plugins/steve';
 import { STEVE_MODEL_TYPES } from '@shell/plugins/steve/getters';
 import { CLUSTER as CLUSTER_PREF, LAST_NAMESPACE, NAMESPACE_FILTERS, WORKSPACE } from '@shell/store/prefs';
-import { BOTH, CLUSTER_LEVEL, NAMESPACED } from '@shell/store/type-map';
+import { BOTH } from '@shell/store/type-map';
 import { filterBy, findBy } from '@shell/utils/array';
 import { ApiError, ClusterNotFoundError } from '@shell/utils/error';
 import { gcActions, gcGetters } from '@shell/utils/gc/gc-root-store';
@@ -25,9 +25,7 @@ import {
   NAMESPACE_FILTER_ALL_ORPHANS as ALL_ORPHANS,
   NAMESPACE_FILTER_ALL_SYSTEM as ALL_SYSTEM,
   NAMESPACE_FILTER_ALL_USER as ALL_USER,
-  NAMESPACE_FILTER_NAMESPACED_NO as NAMESPACED_NO,
   NAMESPACE_FILTER_NAMESPACED_PREFIX as NAMESPACED_PREFIX,
-  NAMESPACE_FILTER_NAMESPACED_YES as NAMESPACED_YES,
   splitNamespaceFilterKey,
   NAMESPACE_FILTER_NS_FULL_PREFIX,
 } from '@shell/utils/namespace-filter';
@@ -190,9 +188,7 @@ const getActiveNamespaces = (state, getters, readonly = false) => {
     .filter((ns) => product.hideSystemResources ? !ns.isSystem : true); // Filter out Fleet system namespaces
 
   // Retrieve all the filters selected by the user
-  const filters = state.namespaceFilters.filter(
-    (filters) => !!filters && !`${ filters }`.startsWith(NAMESPACED_PREFIX)
-  );
+  const filters = state.namespaceFilters;
 
   const activeNamespaces = {
     ...getActiveNamespacesCategories(getters, allowedNamespaces, filters),
@@ -403,7 +399,7 @@ export const getters = {
       return true;
     }
 
-    return state.namespaceFilters.filter((x) => !`${ x }`.startsWith(NAMESPACED_PREFIX)).length === 0;
+    return state.namespaceFilters.length === 0;
   },
 
   isMultipleNamespaces(state, getters) {
@@ -434,38 +430,10 @@ export const getters = {
    * Namespace/Project filter for the current cluster
    */
   namespaceFilters(state) {
-    const filters = state.namespaceFilters.filter((x) => !!x && !`${ x }`.startsWith(NAMESPACED_PREFIX));
-
-    return filters;
+    return state.namespaceFilters;
   },
 
-  namespaceMode(state, getters) {
-    const filters = state.namespaceFilters;
-    const product = getters['currentProduct'];
-
-    if ( !product?.showNamespaceFilter ) {
-      return BOTH;
-    }
-
-    // Explicitly asking
-    if ( filters.includes(NAMESPACED_YES) ) {
-      return NAMESPACED;
-    } else if ( filters.includes(NAMESPACED_NO) ) {
-      return CLUSTER_LEVEL;
-    }
-
-    const byKind = {};
-
-    for ( const filter of filters ) {
-      const type = filter.split('://', 2)[0];
-
-      byKind[type] = (byKind[type] || 0) + 1;
-    }
-
-    if ( byKind['project'] > 0 || byKind['ns'] > 0 ) {
-      return NAMESPACED;
-    }
-
+  namespaceMode() {
     return BOTH;
   },
 
@@ -663,7 +631,7 @@ export const mutations = {
    * Updates cluster specific ns settings, including the selected ns cache `activeNamespaceCache`
    */
   updateNamespaces(state, { filters, all, getters: optGetters }) {
-    state.namespaceFilters = filters.filter((x) => !!x);
+    state.namespaceFilters = filters.filter((x) => !!x && !`${ x }`.startsWith(NAMESPACED_PREFIX));
 
     if ( all ) {
       state.allNamespaces = all;

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -604,7 +604,6 @@ export const getters = {
       // - `used` matches the data types where there are more than 0 of them in the current set of namespaces.
       // - `all` matches all types.
       // - `favorite` matches starred types.
-      // namespaceMode: 'namespaced', 'cluster', or 'both'
       // namespaces: null means all, otherwise it will be an array of specific namespaces to include
       const isBasic = mode === TYPE_MODES.BASIC;
 
@@ -629,13 +628,6 @@ export const getters = {
 
         if ( typeObj.schema && getters.isIgnored(typeObj.schema) ) {
           // Skip ignored groups & types
-          continue;
-        }
-
-        const namespaced = typeObj.namespaced;
-
-        if ( (namespaceMode === NAMESPACED && !namespaced ) || (namespaceMode === CLUSTER_LEVEL && namespaced) ) {
-          // Skip types that are not the right namespace mode
           continue;
         }
 
@@ -712,7 +704,7 @@ export const getters = {
           mode:         typeObj.mode,
           exact:        typeObj.exact || false,
           'exact-path': typeObj['exact-path'] || false,
-          namespaced,
+          namespaced:   typeObj.namespaced,
           route:        filterLocationValidParams(rootState.$router, route),
           name:         typeObj.name,
           weight:       typeObj.weight || getters.typeWeightFor(typeObj.schema?.id || label, isBasic),

--- a/shell/utils/namespace-filter.js
+++ b/shell/utils/namespace-filter.js
@@ -10,8 +10,6 @@ export const NAMESPACE_FILTER_ALL_SYSTEM = `${ NAMESPACE_FILTER_ALL_PREFIX }://s
 export const NAMESPACE_FILTER_ALL_USER = `${ NAMESPACE_FILTER_ALL_PREFIX }://user`;
 export const NAMESPACE_FILTER_ALL_ORPHANS = `${ NAMESPACE_FILTER_ALL_PREFIX }://orphans`;
 export const NAMESPACE_FILTER_NAMESPACED_PREFIX = 'namespaced://';
-export const NAMESPACE_FILTER_NAMESPACED_YES = 'namespaced://true';
-export const NAMESPACE_FILTER_NAMESPACED_NO = 'namespaced://false';
 
 export const NAMESPACE_FILTER_KINDS = {
   DIVIDER:   'divider',

--- a/shell/utils/pagination-utils.ts
+++ b/shell/utils/pagination-utils.ts
@@ -5,8 +5,6 @@ import {
   NAMESPACE_FILTER_ALL_USER as ALL_USER,
   NAMESPACE_FILTER_ALL as ALL,
   NAMESPACE_FILTER_ALL_SYSTEM as ALL_SYSTEM,
-  NAMESPACE_FILTER_NAMESPACED_YES as NAMESPACED_YES,
-  NAMESPACE_FILTER_NAMESPACED_NO as NAMESPACED_NO,
   NAMESPACE_FILTER_KINDS,
   NAMESPACE_FILTER_NS_FULL_PREFIX,
   NAMESPACE_FILTER_P_FULL_PREFIX,
@@ -46,7 +44,7 @@ class PaginationUtils {
    *
    * This basically blocks 'Not in a Project'.. which would involve a projectsornamespaces param with every ns not in a project.
    */
-  readonly validNsProjectFilters = [ALL, ALL_SYSTEM, ALL_USER, ALL_SYSTEM, NAMESPACE_FILTER_KINDS.NAMESPACE, NAMESPACE_FILTER_KINDS.PROJECT, NAMESPACED_YES, NAMESPACED_NO];
+  readonly validNsProjectFilters = [ALL, ALL_SYSTEM, ALL_USER, ALL_SYSTEM, NAMESPACE_FILTER_KINDS.NAMESPACE, NAMESPACE_FILTER_KINDS.PROJECT];
 
   private getSettings({ rootGetters }: any): PaginationSettings {
     const perf = getPerformanceSetting(rootGetters);


### PR DESCRIPTION
# Not ready for review if you're peeking

### Summary
Fixes #7467

### Occurred changes and/or fixed issues
- Removed "Only Namespaced Resources" and "Only Cluster Resources" options from the namespace filter dropdown
- Cleaned up all associated filtering logic across the store, type-map, SideNav, and pagination utilities
- Stale user preferences containing these filter values are now stripped on load via the `updateNamespaces` mutation

### Technical notes summary
- **NamespaceFilter.vue**: Removed the two `NAMESPACED_YES`/`NAMESPACED_NO` dropdown entries and imports
- **namespace-filter.js**: Removed `NAMESPACE_FILTER_NAMESPACED_YES` and `NAMESPACE_FILTER_NAMESPACED_NO` constants; kept `NAMESPACE_FILTER_NAMESPACED_PREFIX` to strip stale prefs
- **store/index.js**: Simplified `namespaceMode` getter to always return `BOTH`; moved `namespaced://` prefix filtering into `updateNamespaces` mutation; removed redundant defensive filtering from `getActiveNamespaces`, `isAllNamespaces`, and `namespaceFilters` getters
- **store/type-map.js**: Removed `CLUSTER_LEVEL`/`NAMESPACED` namespace mode filtering in `getTree()` (was dead code since SideNav hardcodes `'both'`)
- **SideNav.vue**: Removed `namespaceMode` watcher and `mapGetters` entry
- **pagination-utils.ts**: Removed `NAMESPACED_YES`/`NAMESPACED_NO` from `validNsProjectFilters`
- **resource-fetch-api-pagination.js**: Removed early return that skipped pagination for namespaced/cluster-level filters

### Areas or cases that should be tested
- Namespace filter dropdown should show all options except "Only Namespaced Resources" and "Only Cluster Resources"
- Selecting "All Namespaces", "Only User Namespaces", "Only System Namespaces", individual projects, and individual namespaces should all work correctly
- Side navigation should display both namespaced and cluster-level resource types regardless of filter selection
- Resource search dialog (Ctrl/Cmd+K) should show all resource types
- Users who previously had "Only Namespaced Resources" or "Only Cluster Resources" selected should gracefully fall back to the default filter

### Areas which could experience regressions
- Namespace filtering behavior across all explorer pages
- Side navigation resource type visibility
- Server-side pagination namespace filter validation

### Screenshot/Video