### PR TITLE
Automation - Guard publishHTML against missing html/ directory

### DIFF
--- a/cypress/jenkins/Jenkinsfile
+++ b/cypress/jenkins/Jenkinsfile
@@ -128,13 +128,15 @@ node('harvester-vpn-1') {
                   } else {
                     testExecutionResult = null
                   }
-                  publishHTML(target: [allowMissing: true,
-                    alwaysLinkToLastBuild: true,
-                    keepAll: true,
-                    reportDir: 'html',
-                    reportFiles: 'index.html',
-                    reportName: 'html-report',
-                    reportTitles: 'Report'])
+                  if (fileExists('html')) {
+                    publishHTML(target: [allowMissing: true,
+                      alwaysLinkToLastBuild: true,
+                      keepAll: true,
+                      reportDir: 'html',
+                      reportFiles: 'index.html',
+                      reportName: 'html-report',
+                      reportTitles: 'Report'])
+                  }
                 }
               } catch (err) {
                 echo 'Error in Test Report stage: ' + err

--- a/cypress/jenkins/init.sh
+++ b/cypress/jenkins/init.sh
@@ -323,9 +323,25 @@ else
 
   # Copy results to workspace for Jenkins artifact collection
   dashboard_dir="${PLAYBOOK_DIR}/dashboard"
-  cp "${dashboard_dir}/results.xml" "${JENKINS_WORKSPACE}/" 2>/dev/null || true
+  copy_ok=true
+  cp "${dashboard_dir}/results.xml" "${JENKINS_WORKSPACE}/" 2>/dev/null || copy_ok=false
   mkdir -p "${JENKINS_WORKSPACE}/html"
-  cp -r "${dashboard_dir}/cypress/reports/html/"* "${JENKINS_WORKSPACE}/html/" 2>/dev/null || true
+  cp -r "${dashboard_dir}/cypress/reports/html/"* "${JENKINS_WORKSPACE}/html/" 2>/dev/null || copy_ok=false
+
+  # Warn only on a genuine container crash (all three must be true):
+  #   1. Artifact copy failed
+  #   2. Source results.xml doesn't exist (Cypress never finished)
+  #   3. Exit code is a known Docker crash signal, not a Cypress failure count
+  #     - 125=daemon error, 126=cannot invoke, 127=not found
+  #     - 134=SIGABRT, 137=SIGKILL/OOM, 139=SIGSEGV, 143=SIGTERM
+  crash=false
+  case "${cypress_exit}" in
+    125|126|127|134|137|139|143) crash=true ;;
+  esac
+
+  if [[ "${copy_ok}" == false && ! -f "${dashboard_dir}/results.xml" && "${crash}" == true ]]; then
+    echo "[init] WARNING: artifacts failed to copy — container likely crashed (exit ${cypress_exit})"
+  fi
 
   exit "${cypress_exit}"
 fi


### PR DESCRIPTION
### Summary
Fixes rancher/qa-tasks#1867

`publishHTML` throws an `ERROR` when the `html/` directory doesn't exist, even with `allowMissing: true`. This causes the Test Report stage to throw, which sets `testExecutionResult` to `null` and marks the build as `FAILURE` even when tests ran successfully.

Wrap `publishHTML` in a `fileExists('html')` check so a missing report directory no longer derails the build result.

Also track artifact copy failures in `init.sh` and only warn when the Cypress container exit code indicates a crash, not on normal test failures where the exit code is the count of failed tests.

### Areas or cases that should be tested
CI

### Areas which could experience regressions
CI

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
