### PR TITLE
[backport 2.14] - CAPI modal overlay test fixes

### DIFF
--- a/cypress/e2e/po/components/action-menu.po.ts
+++ b/cypress/e2e/po/components/action-menu.po.ts
@@ -12,4 +12,8 @@ export default class ActionMenuPo extends ComponentPo {
   getMenuItem(name: string) {
     return this.self().find('[dropdown-menu-item]').contains(name);
   }
+
+  static checkNoActionMenuIsVisible() {
+    return cy.get('[dropdown-menu-collection]:visible').should('have.length', 0);
+  }
 }

--- a/cypress/e2e/po/lists/base-resource-list.po.ts
+++ b/cypress/e2e/po/lists/base-resource-list.po.ts
@@ -22,13 +22,6 @@ export default class BaseResourceList extends ComponentPo {
     return this.resourceTable().sortableTable().rowActionMenuClose(rowLabel);
   }
 
-  /**
-   * Asserts that no action menu dropdowns are currently visible
-   */
-  checkActionMenuNotVisible() {
-    return cy.get('body').find('[dropdown-menu-collection]:visible').should('have.length', 0);
-  }
-
   rowWithName(rowLabel: string) {
     return this.resourceTable().sortableTable().rowWithName(rowLabel);
   }

--- a/cypress/e2e/po/lists/base-resource-list.po.ts
+++ b/cypress/e2e/po/lists/base-resource-list.po.ts
@@ -22,6 +22,13 @@ export default class BaseResourceList extends ComponentPo {
     return this.resourceTable().sortableTable().rowActionMenuClose(rowLabel);
   }
 
+  /**
+   * Asserts that no action menu dropdowns are currently visible
+   */
+  checkActionMenuNotVisible() {
+    return cy.get('body').find('[dropdown-menu-collection]:visible').should('have.length', 0);
+  }
+
   rowWithName(rowLabel: string) {
     return this.resourceTable().sortableTable().rowWithName(rowLabel);
   }

--- a/cypress/e2e/tests/pages/manager/v2prov-capi.spec.ts
+++ b/cypress/e2e/tests/pages/manager/v2prov-capi.spec.ts
@@ -31,17 +31,11 @@ describe('Cluster List - v2 Provisioning CAPI Clusters', { tags: ['@manager', '@
     clusterList.waitForPage();
   });
 
-  it('should not provide a link to capi cluster details', () => {
+  qase(18525, it('should not provide a link to capi cluster details', () => {
     clusterList.list().name(clusterName).find('a').should('not.exist');
     clusterList.list().name('local').find('a').should('exist');
-  });
+  }));
 
-  it('should show a message indicating that CAPI clusters are not editable', () => {
-    clusterList.capiWarningSubRow(clusterName)
-      .should('be.visible');
-    clusterList.capiWarningSubRow('Local')
-      .should('not.exist');
-  });
   qase(18526, it('should not allow editing CAPI cluster configs', () => {
     const capiActionMenu = clusterList.list().actionMenu(clusterName);
 
@@ -52,6 +46,13 @@ describe('Cluster List - v2 Provisioning CAPI Clusters', { tags: ['@manager', '@
     cy.get('body').find('[dropdown-menu-collection]:visible').should('have.length', 0);
 
     clusterList.list().actionMenu('local').getMenuItem('Edit Config').should('exist');
+  }));
+
+  qase(18527, it('should show a message indicating that CAPI clusters are not editable', () => {
+    clusterList.capiWarningSubRow(clusterName)
+      .should('be.visible');
+    clusterList.capiWarningSubRow('Local')
+      .should('not.exist');
   }));
 
   qase(18528, it('should not report a machine provider for CAPI clusters', () => {

--- a/cypress/e2e/tests/pages/manager/v2prov-capi.spec.ts
+++ b/cypress/e2e/tests/pages/manager/v2prov-capi.spec.ts
@@ -1,5 +1,6 @@
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import { qase } from '@/cypress/support/qase';
 
 import { mockCapiMgmtCluster, mockCapiProvCluster } from '@/cypress/e2e/blueprints/manager/v2prov-capi-cluster-mocks';
 
@@ -35,20 +36,27 @@ describe('Cluster List - v2 Provisioning CAPI Clusters', { tags: ['@manager', '@
     clusterList.list().name('local').find('a').should('exist');
   });
 
-  it('should not allow editing CAPI cluster configs', () => {
-    clusterList.list().actionMenu(clusterName).getMenuItem('Edit Config').should('not.exist');
-    clusterList.list().actionMenu('local').getMenuItem('Edit Config').should('exist');
-  });
-
   it('should show a message indicating that CAPI clusters are not editable', () => {
     clusterList.capiWarningSubRow(clusterName)
       .should('be.visible');
     clusterList.capiWarningSubRow('Local')
       .should('not.exist');
   });
+  qase(18526, it('should not allow editing CAPI cluster configs', () => {
+    const capiActionMenu = clusterList.list().actionMenu(clusterName);
 
-  it('should not report a machine provider for CAPI clusters', () => {
+    capiActionMenu.getMenuItem('Edit Config').should('not.exist');
+
+    // Close the first row action menu so its overlay does not block subsequent row actions.
+    clusterList.list().actionMenuClose(clusterName);
+    cy.get('body').find('[dropdown-menu-collection]:visible').should('have.length', 0);
+
+    clusterList.list().actionMenu('local').getMenuItem('Edit Config').should('exist');
+  }));
+
+  qase(18528, it('should not report a machine provider for CAPI clusters', () => {
     clusterList.list().provider(clusterName).should('have.text', ' RKE2');
-    clusterList.list().provider('local').should('have.text', 'Local K3s');
-  });
+
+    clusterList.list().provider('local').invoke('text').should('match', /^Local (K3s|RKE2)$/);
+  }));
 });

--- a/cypress/e2e/tests/pages/manager/v2prov-capi.spec.ts
+++ b/cypress/e2e/tests/pages/manager/v2prov-capi.spec.ts
@@ -43,7 +43,7 @@ describe('Cluster List - v2 Provisioning CAPI Clusters', { tags: ['@manager', '@
 
     // Close the first row action menu so its overlay does not block subsequent row actions.
     clusterList.list().actionMenuClose(clusterName);
-    cy.get('body').find('[dropdown-menu-collection]:visible').should('have.length', 0);
+    clusterList.list().checkActionMenuNotVisible();
 
     clusterList.list().actionMenu('local').getMenuItem('Edit Config').should('exist');
   }));

--- a/cypress/e2e/tests/pages/manager/v2prov-capi.spec.ts
+++ b/cypress/e2e/tests/pages/manager/v2prov-capi.spec.ts
@@ -1,5 +1,6 @@
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import ActionMenuPo from '@/cypress/e2e/po/components/action-menu.po';
 import { qase } from '@/cypress/support/qase';
 
 import { mockCapiMgmtCluster, mockCapiProvCluster } from '@/cypress/e2e/blueprints/manager/v2prov-capi-cluster-mocks';
@@ -43,7 +44,7 @@ describe('Cluster List - v2 Provisioning CAPI Clusters', { tags: ['@manager', '@
 
     // Close the first row action menu so its overlay does not block subsequent row actions.
     clusterList.list().actionMenuClose(clusterName);
-    clusterList.list().checkActionMenuNotVisible();
+    ActionMenuPo.checkNoActionMenuIsVisible();
 
     clusterList.list().actionMenu('local').getMenuItem('Edit Config').should('exist');
   }));


### PR DESCRIPTION
Fixes #
(https://github.com/rancher/qa-tasks/issues/2280)

Occurred changes and/or fixed issues
ATTENTION:
The test file in the original branch release-2.14 has 2 more tests that were already removed in the master branch: 'should not provide a link to capi cluster details' and 'should show a message indicating that CAPI clusters are not editable'. I removed them to be consistent to the file in master branch, let me know if I need to roll them back.

Fixed modal overlay issue in test 'should not allow editing CAPI cluster configs' and updated the test 'should not report a machine provider for CAPI clusters' to fetch cluster distros so that it's flexible for both RKE2 and K3s local clusters.

Areas or cases that should be tested
Test v2prov-capi.spec.ts locally and in jenkins pipeline with both k3s and RKE2 local clusters


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
