### PR TITLE
Automation - Update cluster manager conditions assertion to check "Created" instead of "Ready"

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -531,7 +531,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
       clusterDetail.selectTab(tabbedPo, '[data-testid="btn-conditions"]');
 
       clusterDetail.waitForPage(undefined, 'conditions');
-      clusterDetail.conditionsList().details('Ready', 1).should('include.text', 'True');
+      clusterDetail.conditionsList().details('Created', 1).should('include.text', 'True');
     });
 
     it('can navigate to Cluster Related Page', () => {


### PR DESCRIPTION
### Summary
Fixes #

Fixes the Cypress E2E test for the Cluster Manager conditions tab by updating the assertion to verify the Created condition status instead of Ready

### Areas or cases that should be tested
CI

### Areas which could experience regressions
CI


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
