### PR TITLE
Automation - Add timeout wrapping node blocks to prevent indefinite queue hangs

### DIFF
--- a/cypress/jenkins/Jenkinsfile
+++ b/cypress/jenkins/Jenkinsfile
@@ -8,6 +8,7 @@ def branch = "${env.BRANCH}" != 'null' && "${env.BRANCH}" != '' ? "${env.BRANCH}
 def testExecutionResult = null
 def testExitCode = null
 
+timeout(time: 270, unit: 'MINUTES') {
 node('harvester-vpn-1') {
   ansiColor('xterm') {
     withFolderProperties {
@@ -174,4 +175,5 @@ node('harvester-vpn-1') {
       }
     }
   }
+}
 }

--- a/cypress/jenkins/Jenkinsfile_multi
+++ b/cypress/jenkins/Jenkinsfile_multi
@@ -73,6 +73,7 @@ test_tags.eachWithIndex { String rancher_version, int i ->
     }
 }
 
+timeout(time: 45, unit: 'MINUTES') {
 node {
   ansiColor('xterm') {
     withFolderProperties {
@@ -125,9 +126,12 @@ node {
             }
           }
 
-          parallel batchBranches
+          timeout(time: 270, unit: 'MINUTES') {
+            parallel batchBranches
+          }
         }
       }
     }
   }
+}
 }


### PR DESCRIPTION
### Summary
Fixes #

`Jenkinsfile`: 270 min outer timeout (30 min queue + 240 min work). Inner 240 min timeout on Run Tests stage fires first during execution.

`Jenkinsfile_multi`: 45 min outer timeout for orchestrator node. 270 min per-batch timeout on parallel child builds.

### Areas or cases that should be tested
CI

### Areas which could experience regressions
CI

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
