### PR TITLE
[backport 2.14] - Fix e2e diagnostic tabbable uncaught exeption

### DIFF
--- a/cypress/e2e/tests/pages/generic/diagnostic.spec.ts
+++ b/cypress/e2e/tests/pages/generic/diagnostic.spec.ts
@@ -16,6 +16,7 @@ describe('Diagnostics Page', { tags: ['@generic', '@adminUser'] }, () => {
     // Ignore the focus-trap error that fires when the modal closes immediately
     // after the download is triggered (known cosmetic side-effect of the dialog)
     // Also the focus-trap error triggered when it can’t find any tabbable node inside its container
+    // This workaround is needed until we can update the focus-trap library to a version that has the fix for this issue https://github.com/rancher/dashboard/issues/17104
 
     cy.on('uncaught:exception', (err) => {
       if (err?.message?.includes('focus-trap') || err?.message?.includes('tabbable')) {

--- a/cypress/e2e/tests/pages/generic/diagnostic.spec.ts
+++ b/cypress/e2e/tests/pages/generic/diagnostic.spec.ts
@@ -2,6 +2,7 @@ import DiagnosticsPagePo from '@/cypress/e2e/po/pages/diagnostics.po';
 import * as path from 'path';
 
 const downloadsFolder = Cypress.config('downloadsFolder');
+const downloadedFilename = path.join(downloadsFolder, 'rancher-diagnostic-data.json');
 
 describe('Diagnostics Page', { tags: ['@generic', '@adminUser'] }, () => {
   beforeEach(() => {
@@ -9,6 +10,18 @@ describe('Diagnostics Page', { tags: ['@generic', '@adminUser'] }, () => {
   });
 
   it('User should be able to download the diagnostics package JSON', () => {
+    // Ignore the focus-trap error that fires when the modal closes immediately
+    // after the download is triggered (known cosmetic side-effect of the dialog)
+    // Also the focus-trap error triggered when it can’t find any tabbable node inside its container
+
+    cy.on('uncaught:exception', (err) => {
+      if (err.message.includes('focus-trap' ) || err.message.includes('tabbable')) {
+        return false;
+      }
+
+      return true;
+    });
+
     const diagnosticsPage = new DiagnosticsPagePo();
 
     diagnosticsPage.goTo();
@@ -19,10 +32,12 @@ describe('Diagnostics Page', { tags: ['@generic', '@adminUser'] }, () => {
     // modal button to actually trigger the download
     diagnosticsPage.downloadDiagnosticsModalActionBtn().click(true);
 
-    const downloadedFilename = path.join(downloadsFolder, 'rancher-diagnostic-data.json');
-
     cy.readFile(downloadedFilename).should('exist').then((file: any) => {
       expect(Object.keys(file).length).to.equal(4);
     });
+  });
+  afterEach(() => {
+    // Keep the downloads directory clean between tests.
+    cy.exec(`rm -f "${ downloadedFilename }"`, { failOnNonZeroExit: false });
   });
 });

--- a/cypress/e2e/tests/pages/generic/diagnostic.spec.ts
+++ b/cypress/e2e/tests/pages/generic/diagnostic.spec.ts
@@ -1,5 +1,6 @@
 import DiagnosticsPagePo from '@/cypress/e2e/po/pages/diagnostics.po';
 import * as path from 'path';
+import { qase } from '@/cypress/support/qase';
 
 const downloadsFolder = Cypress.config('downloadsFolder');
 const downloadedFilename = path.join(downloadsFolder, 'rancher-diagnostic-data.json');
@@ -9,7 +10,7 @@ describe('Diagnostics Page', { tags: ['@generic', '@adminUser'] }, () => {
     cy.login();
   });
 
-  it('User should be able to download the diagnostics package JSON', () => {
+  qase(1454, it('User should be able to download the diagnostics package JSON', () => {
     // Ignore the focus-trap error that fires when the modal closes immediately
     // after the download is triggered (known cosmetic side-effect of the dialog)
     // Also the focus-trap error triggered when it can’t find any tabbable node inside its container
@@ -35,7 +36,7 @@ describe('Diagnostics Page', { tags: ['@generic', '@adminUser'] }, () => {
     cy.readFile(downloadedFilename).should('exist').then((file: any) => {
       expect(Object.keys(file).length).to.equal(4);
     });
-  });
+  }));
   afterEach(() => {
     // Keep the downloads directory clean between tests.
     cy.exec(`rm -f "${ downloadedFilename }"`, { failOnNonZeroExit: false });

--- a/cypress/e2e/tests/pages/generic/diagnostic.spec.ts
+++ b/cypress/e2e/tests/pages/generic/diagnostic.spec.ts
@@ -16,7 +16,7 @@ describe('Diagnostics Page', { tags: ['@generic', '@adminUser'] }, () => {
     // Also the focus-trap error triggered when it can’t find any tabbable node inside its container
 
     cy.on('uncaught:exception', (err) => {
-      if (err.message.includes('focus-trap' ) || err.message.includes('tabbable')) {
+      if (err.message.includes('focus-trap') && err.message.includes('tabbable')) {
         return false;
       }
 
@@ -39,6 +39,6 @@ describe('Diagnostics Page', { tags: ['@generic', '@adminUser'] }, () => {
   }));
   afterEach(() => {
     // Keep the downloads directory clean between tests.
-    cy.exec(`rm -f "${ downloadedFilename }"`, { failOnNonZeroExit: false });
+    cy.deleteDownloadsFolder();
   });
 });

--- a/cypress/e2e/tests/pages/generic/diagnostic.spec.ts
+++ b/cypress/e2e/tests/pages/generic/diagnostic.spec.ts
@@ -18,7 +18,7 @@ describe('Diagnostics Page', { tags: ['@generic', '@adminUser'] }, () => {
     // Also the focus-trap error triggered when it can’t find any tabbable node inside its container
 
     cy.on('uncaught:exception', (err) => {
-      if (err.message.includes('focus-trap') && err.message.includes('tabbable')) {
+      if (err?.message?.includes('focus-trap') || err?.message?.includes('tabbable')) {
         return false;
       }
     });

--- a/cypress/e2e/tests/pages/generic/diagnostic.spec.ts
+++ b/cypress/e2e/tests/pages/generic/diagnostic.spec.ts
@@ -8,6 +8,8 @@ const downloadedFilename = path.join(downloadsFolder, 'rancher-diagnostic-data.j
 describe('Diagnostics Page', { tags: ['@generic', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
+    // Keep the downloads directory clean between tests.
+    cy.deleteDownloadsFolder();
   });
 
   qase(1454, it('User should be able to download the diagnostics package JSON', () => {
@@ -19,8 +21,6 @@ describe('Diagnostics Page', { tags: ['@generic', '@adminUser'] }, () => {
       if (err.message.includes('focus-trap') && err.message.includes('tabbable')) {
         return false;
       }
-
-      return true;
     });
 
     const diagnosticsPage = new DiagnosticsPagePo();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
(https://github.com/rancher/qa-tasks/issues/2270)

### Occurred changes and/or fixed issues
Added tabbable exception to cypress  `uncaught:exception` and added an aftereach hook to cleanup the test environment by deleting the downloaded file. Also, added the qase test ID.

### Areas or cases that should be tested
the `diagnostics.spec.ts`

### Areas which could experience regressions
Diagnostics page

### Screenshot/Video
<img width="1740" height="988" alt="Screenshot 2026-03-27 at 15 46 50" src="https://github.com/user-attachments/assets/e3d5afb1-9f5e-4b74-a1ce-cf0ff1166b1e" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
