### PR TITLE
refactor: get CPU model from existing configmaps

### DIFF
--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -41,6 +41,7 @@ import { isEqual } from 'lodash';
 import { FilterArgs, PaginationFilterField, PaginationParamFilter } from '@shell/types/store/pagination.types';
 
 const STORAGE_NETWORK = 'storage-network.settings.harvesterhci.io';
+const HARVESTER_CPU_MODEL = 'harvester-system/node-cpu-model-configuration';
 
 // init qemu guest agent
 export const QGA_JSON = {
@@ -144,7 +145,8 @@ export default {
             filters: [
               PaginationParamFilter.createMultipleFields([
                 new PaginationFilterField({ field: `metadata.labels[${ HCI_ANNOTATIONS.CLOUD_INIT }]`, value: 'user' }),
-                new PaginationFilterField({ field: `metadata.labels[${ HCI_ANNOTATIONS.CLOUD_INIT }]`, value: 'network' })
+                new PaginationFilterField({ field: `metadata.labels[${ HCI_ANNOTATIONS.CLOUD_INIT }]`, value: 'network' }),
+                new PaginationFilterField({ field: 'id', value: HARVESTER_CPU_MODEL })
               ])
             ]
           });
@@ -153,13 +155,12 @@ export default {
         }
 
         const res = await allHashSettled({
-          namespaces:     this.$store.dispatch('cluster/request', { url: `${ url }/${ NAMESPACE }s` }),
-          images:         this.$store.dispatch('cluster/request', { url: `${ url }/${ HCI.IMAGE }s` }),
-          configMaps:     this.$store.dispatch('cluster/request', { url: configMapsUrl }),
-          networks:       this.$store.dispatch('cluster/request', { url: `${ url }/k8s.cni.cncf.io.network-attachment-definitions` }),
-          storageClass:   this.$store.dispatch('cluster/request', { url: `${ url }/${ STORAGE_CLASS }es` }),
-          settings:       this.$store.dispatch('cluster/request', { url: `${ url }/${ MANAGEMENT.SETTING }s` }),
-          cpuModelConfig: this.$store.dispatch('cluster/request', { url: `${ url }/${ CONFIG_MAP }s/harvester-system/node-cpu-model-configuration` }),
+          namespaces:   this.$store.dispatch('cluster/request', { url: `${ url }/${ NAMESPACE }s` }),
+          images:       this.$store.dispatch('cluster/request', { url: `${ url }/${ HCI.IMAGE }s` }),
+          configMaps:   this.$store.dispatch('cluster/request', { url: configMapsUrl }),
+          networks:     this.$store.dispatch('cluster/request', { url: `${ url }/k8s.cni.cncf.io.network-attachment-definitions` }),
+          storageClass: this.$store.dispatch('cluster/request', { url: `${ url }/${ STORAGE_CLASS }es` }),
+          settings:     this.$store.dispatch('cluster/request', { url: `${ url }/${ MANAGEMENT.SETTING }s` })
         });
 
         for (const key of Object.keys(res)) {
@@ -188,7 +189,7 @@ export default {
         this.images = res.images.value?.data;
         this.storageClass = res.storageClass.value?.data;
         this.networks = res.networks.value?.data;
-        this.cpuModelConfigMap = res.cpuModelConfig.value?.data;
+        this.cpuModelConfigMap = this.genCpuModelConfigMap(res.configMaps.value?.data);
 
         let systemNamespaces = (res.settings.value?.data || []).filter((x) => x.id === SETTING.SYSTEM_NAMESPACES);
 
@@ -409,6 +410,8 @@ export default {
 
       const globalModels = cpuModelsData.globalModels || [];
 
+      globalModels.sort((a, b) => a[0].localeCompare(b[0]));
+
       globalModels.forEach((modelName) => {
         options.push({ label: modelName, value: modelName });
       });
@@ -617,6 +620,11 @@ export default {
 
   methods: {
     stringify,
+    genCpuModelConfigMap(configMaps = []) {
+      const cpuModelConfigMap = configMaps.find((cm) => cm.id === HARVESTER_CPU_MODEL);
+
+      return cpuModelConfigMap?.data || null;
+    },
     genCloudDataOptions(configMaps = [], type = 'user') {
       const valueMap = new Map();
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16187


### Occurred changes and/or fixed issues
refactor: get CPU model from existing configmaps.  https://github.com/rancher/dashboard/pull/17161#issuecomment-4235350235


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<img width="1465" height="800" alt="Screenshot 2026-04-14 at 1 22 33 PM" src="https://github.com/user-attachments/assets/c8b79bd2-90e8-4fc5-bbbf-b2de17832617" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
