### PR TITLE
Automation - Remove global timeout to prevent jobs cancels downstream

### DIFF
--- a/cypress/jenkins/Jenkinsfile_multi
+++ b/cypress/jenkins/Jenkinsfile_multi
@@ -73,7 +73,6 @@ test_tags.eachWithIndex { String rancher_version, int i ->
     }
 }
 
-timeout(time: 45, unit: 'MINUTES') {
 node {
   ansiColor('xterm') {
     withFolderProperties {
@@ -133,5 +132,4 @@ node {
       }
     }
   }
-}
 }


### PR DESCRIPTION
### Summary

Parent job's 45-min timeout was killing children mid-run. Removed it. Each batch already has a 270-min timeout, and children have their own. No need for the outer one to choke long runs.

### Technical notes summary
Removed `timeout(time: 300, unit: 'MINUTES')`

### Areas or cases that should be tested
CI

### Areas which could experience regressions
CI

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
