### PR TITLE
Add `cooldown` param for specifying `default-days`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    default-days: 7
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels: ["component/dependencies"]
 
@@ -22,6 +23,7 @@ updates:
       - "/pkg/*"
     schedule:
       interval: "weekly"
-    default-days: 7
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels: ["area/dependencies"]


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This is an attempt to correct the cooldown period for dependabot:

```
Your .github/dependabot.yml contained invalid details

Dependabot encountered the following error when parsing your .github/dependabot.yml:

The property '#/updates/0/' contains additional properties ["default-days"] outside of the schema when none are allowed
The property '#/updates/1/' contains additional properties ["default-days"] outside of the schema when none are allowed

Please update the config file to conform with Dependabot's specification.

[Learn more](https://docs.github.com/en/code-security/concepts/supply-chain-security/about-dependabot-version-updates)
```

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add `cooldown` param for specifying `default-days`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This is a follow-up to #17139

You can see the reported error by navigating to Insights => Dependency Graph => Dependabot in github.

The docs imply that `default-days` needs to be defined as a param of `cooldown`: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Same as the previous attempt, we should validate that new dependabot issues are all created from versions at least 5 days (ideally they are all 7-14 days old given schedule)

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

NA

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
