### PR TITLE
Fix a few low-hanging a11y issues from the a11y test report

### DIFF
--- a/cypress/e2e/tests/accessibility/shell.spec.ts
+++ b/cypress/e2e/tests/accessibility/shell.spec.ts
@@ -418,8 +418,7 @@ describe('Shell a11y testing', { tags: ['@adminUser', '@accessibility'] }, () =>
 
           cy.wait(2500); // eslint-disable-line cypress/no-unnecessary-waiting
 
-          // Scroll to bottom of explain panel - this helps hide any tooltip for the kubectl explain command which can interfere with accessibility checks
-          cy.get('.explain-panel').scrollTo('bottom');
+          cy.get('[data-testid="kubectl-explain-expand-all"]').click();
 
           cy.injectAxe();
 

--- a/cypress/e2e/tests/accessibility/shell.spec.ts
+++ b/cypress/e2e/tests/accessibility/shell.spec.ts
@@ -416,6 +416,8 @@ describe('Shell a11y testing', { tags: ['@adminUser', '@accessibility'] }, () =>
           slideIn.checkVisible();
           slideIn.waitforContent();
 
+          cy.wait(2500); // eslint-disable-line cypress/no-unnecessary-waiting
+
           // Scroll to bottom of explain panel - this helps hide any tooltip for the kubectl explain command which can interfere with accessibility checks
           cy.get('.explain-panel').scrollTo('bottom');
 

--- a/cypress/e2e/tests/accessibility/shell.spec.ts
+++ b/cypress/e2e/tests/accessibility/shell.spec.ts
@@ -416,6 +416,9 @@ describe('Shell a11y testing', { tags: ['@adminUser', '@accessibility'] }, () =>
           slideIn.checkVisible();
           slideIn.waitforContent();
 
+          // Scroll to bottom of explain panel - this helps hide any tooltip for the kubectl explain command which can interfere with accessibility checks
+          cy.get('.explain-panel').scrollTo('bottom');
+
           cy.injectAxe();
 
           cy.checkPageAccessibility();

--- a/pkg/kubectl-explain/components/SlideInPanel.vue
+++ b/pkg/kubectl-explain/components/SlideInPanel.vue
@@ -270,6 +270,7 @@ export default {
             class="icon icon-sort mr-10"
             role="button"
             :aria-label="t('kubectl-explain.expandAll')"
+            data-testid="kubectl-explain-expand-all"
             tabindex="0"
             @click="toggleAll()"
             @keydown.space.enter.stop.prevent="toggleAll()"

--- a/pkg/kubectl-explain/components/SlideInPanel.vue
+++ b/pkg/kubectl-explain/components/SlideInPanel.vue
@@ -209,6 +209,7 @@ export default {
       class="slide-in"
       :class="{ 'slide-in-open': isOpen }"
       :style="{ width, right, top, height }"
+      :aria-label="t('kubectl-explain.title')"
       data-testid="slide-in-panel-resource-explain"
     >
       <div

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6559,6 +6559,7 @@ sortableTable:
   resetFilters: Reset
   add: Add
   tableHeader:
+    actions: Actions
     noFilter: This column cannot be filtered by
     groupBy: Group by
     show: Show

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5889,6 +5889,7 @@ promptSlo:
     waiting: Logging Out
 
 promptRemove:
+  dialogAriaLabel: "Delete confirmation dialog"
   title: Are you sure?
   andOthers: |-
     {count, plural,

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1406,6 +1406,7 @@ catalog:
         description: HTTP(S) URL pointing to a Helm chart repository index
       oci: 
         title: OCI Repository
+        logo: OCI Repository Logo
         description: OCI-compliant registry hosting Helm charts as artifacts
       suseAppCollection: 
         title: SUSE App Collection

--- a/shell/components/AppModal.vue
+++ b/shell/components/AppModal.vue
@@ -91,7 +91,11 @@ export default defineComponent({
     focusTrapWatcherBasedVariable: {
       type:    Boolean,
       default: undefined,
-    }
+    },
+    title: {
+      type:    String,
+      default: '',
+    },
   },
   computed: {
     modalWidth(): string {
@@ -202,6 +206,7 @@ export default defineComponent({
           :class="customClass"
           class="modal-container"
           :style="modalStyles"
+          :aria-label="title"
           role="dialog"
           aria-modal="true"
           @click.stop

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -685,10 +685,10 @@ export default {
               >
                 <div
                   v-if="step.name === activeStep.name || step.hidden"
+                  :id="'step-container-' + step.name"
                   :key="step.name"
                   class="step-container__step"
                   :class="{'hide': step.name !== activeStep.name && step.hidden}"
-                  :id="'step-container-' + step.name"
                 >
                   <slot
                     :step="step"

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -688,6 +688,7 @@ export default {
                   :key="step.name"
                   class="step-container__step"
                   :class="{'hide': step.name !== activeStep.name && step.hidden}"
+                  :id="'step-container-' + step.name"
                 >
                   <slot
                     :step="step"

--- a/shell/components/PromptModal.vue
+++ b/shell/components/PromptModal.vue
@@ -71,6 +71,18 @@ export default {
     },
     modalName() {
       return this.modalData?.modalName;
+    },
+
+    /**
+     * When the component is a string, we can generate a title from the name of the component which we can then use for the aria-label attribute.
+     * For example, if the component is "MyComponentDialog", we generate a title of "My Component Dialog"
+     */
+    modalTitle() {
+      if (typeof this.modalData?.component === 'string') {
+        let name = this.modalData.component;
+
+        return name.replace(/([A-Z])/g, ' $1').trim()
+      }
     }
   },
 
@@ -124,6 +136,7 @@ export default {
     :custom-class="customClass"
     :styles="styles"
     :height="height"
+    :title="modalTitle"
     :trigger-focus-trap="true"
     :return-focus-selector="returnFocusSelector"
     :return-focus-first-iterable-node-selector="returnFocusFirstIterableNodeSelector"

--- a/shell/components/PromptModal.vue
+++ b/shell/components/PromptModal.vue
@@ -79,10 +79,11 @@ export default {
      */
     modalTitle() {
       if (typeof this.modalData?.component === 'string') {
-        let name = this.modalData.component;
-
-        return name.replace(/([A-Z])/g, ' $1').trim()
+        // Insert a space before all caps and trim any leading/trailing whitespace
+        return this.modalData.component.replace(/([A-Z])/g, ' $1').trim();
       }
+
+      return '';
     }
   },
 

--- a/shell/components/PromptRemove.vue
+++ b/shell/components/PromptRemove.vue
@@ -341,6 +341,7 @@ export default {
     custom-class="remove-modal"
     name="promptRemove"
     :width="400"
+    :title="t('promptRemove.dialogAriaLabel')"
     height="auto"
     styles="max-height: 100vh;"
     :trigger-focus-trap="true"

--- a/shell/components/Setting.vue
+++ b/shell/components/Setting.vue
@@ -13,6 +13,10 @@ export default {
   computed: {
     ...mapGetters({ t: 'i18n/t' }),
     ...mapGetters({ options: 'action-menu/optionsArray' }),
+
+    hasDescription() {
+      return !!this.t(`advancedSettings.descriptions.${ this.value.id }`);
+    }
   },
 };
 </script>
@@ -35,7 +39,9 @@ export default {
             class="modified"
           >{{ t('advancedSettings.modified') }}</span>
         </h1>
-        <h2>{{ t(`advancedSettings.descriptions.${value.id}`) }}</h2>
+        <h2 v-if="hasDescription">
+          {{ t(`advancedSettings.descriptions.${value.id}`) }}
+        </h2>
       </div>
       <div
         v-if="value.hasActions"

--- a/shell/components/SortableTable/THead.vue
+++ b/shell/components/SortableTable/THead.vue
@@ -361,7 +361,11 @@ export default {
       <th
         v-else-if="rowActions"
         :width="rowActionsWidth"
-      />
+      >
+        <span class="sr-only">
+          {{ t('sortableTable.tableHeader.actions') }}
+        </span>
+      </th>
     </tr>
   </thead>
 </template>

--- a/shell/components/Wizard.vue
+++ b/shell/components/Wizard.vue
@@ -358,7 +358,7 @@ export default {
 
                     :id="step.name"
                     :class="{step: true, active: step.name === activeStep.name, disabled: !isAvailable(step)}"
-                    role="presentation"
+                    role="listitem"
                   >
                     <span
                       :aria-controls="'step-container-' + step.name"

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -47,6 +47,11 @@ export default {
     highlightRoute: {
       type:    Boolean,
       default: true,
+    },
+
+    parentLabel: {
+      type:    String,
+      default: '',
     }
   },
 
@@ -100,6 +105,10 @@ export default {
 
     headerRoute() {
       return filterLocationValidParams(this.$router, this.group.children[0].route);
+    },
+
+    parentName() {
+      return this.depth > 0 ? `${ this.parentLabel }, ` : '';
     }
   },
 
@@ -261,7 +270,7 @@ export default {
         :class="{'active': highlightRoute && isOverview, 'noHover': !canCollapse || fixedOpen}"
         role="navigation"
         :tabindex="fixedOpen ? -1 : 0"
-        :aria-label="group.labelDisplay || group.label || ''"
+        :aria-label="`${ parentName }${ group.labelDisplay || group.label || '' }`"
         :aria-expanded="!canCollapse || isExpanded"
         :aria-controls="!canCollapse ? null : `group-${id}`"
         @click="groupSelected()"
@@ -351,6 +360,7 @@ export default {
             :group="child"
             :fixed-open="fixedOpen"
             :highlight-route="highlightRoute"
+            :parent-label="group.label"
             @selected="groupSelected($event)"
             @expand="expandGroup($event)"
             @close="close($event)"

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -259,7 +259,7 @@ export default {
         v-if="showHeader"
         class="header"
         :class="{'active': highlightRoute && isOverview, 'noHover': !canCollapse || fixedOpen}"
-        role="button"
+        role="navigation"
         :tabindex="fixedOpen ? -1 : 0"
         :aria-label="group.labelDisplay || group.label || ''"
         :aria-expanded="!canCollapse || isExpanded"

--- a/shell/components/nav/Pinned.vue
+++ b/shell/components/nav/Pinned.vue
@@ -36,7 +36,7 @@ export default {
     :aria-checked="!!pinned"
     class="pin icon"
     :class="{'icon-pin-outlined': !pinned, 'icon-pin': pinned}"
-    role="button"
+    role="checkbox"
     :aria-label="t('nav.ariaLabel.pinCluster', { cluster: cluster.label })"
     @click.stop.prevent="toggle"
     @keydown.enter.prevent="toggle"

--- a/shell/components/nav/WindowManager/panels/HorizontalPanel.vue
+++ b/shell/components/nav/WindowManager/panels/HorizontalPanel.vue
@@ -63,7 +63,7 @@ const {
         role="tab"
         :aria-selected="tab.id === activeTab[props.position]"
         :aria-label="tab.label"
-        :aria-controls="`panel-${tab.id}`"
+        :aria-controls="`wm-panel-body-${ props.position }-${ tab.id.replace(/[^a-zA-Z0-9_-]/g, '-') }`"
         tabindex="0"
         @click="setTabActive({ position: props.position, id: tab.id })"
         @keyup.enter.space="setTabActive({ position: props.position, id: tab.id })"

--- a/shell/edit/catalog.cattle.io.clusterrepo.vue
+++ b/shell/edit/catalog.cattle.io.clusterrepo.vue
@@ -67,7 +67,7 @@ export default {
       {
         id:      CLUSTER_REPO_TYPES.OCI_URL,
         header:  { title: { key: 'catalog.repo.target.oci.title' } },
-        image:   { src: requireAsset('@shell/assets/images/providers/oci-open-containers.svg'), alt: { key: 'catalog.repo.target.oci.title' } },
+        image:   { src: requireAsset('@shell/assets/images/providers/oci-open-containers.svg'), alt: { key: 'catalog.repo.target.oci.title.logo' } },
         content: { key: 'catalog.repo.target.oci.description' },
       },
     ];

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -227,7 +227,7 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
-  <main v-else>
+  <div v-else>
     <div
       v-if="chart"
       class="chart-header"
@@ -537,7 +537,7 @@ export default {
         </div>
       </aside>
     </div>
-  </main>
+  </div>
 </template>
 
 <style lang="scss" scoped>

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -227,7 +227,10 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
-  <div v-else>
+  <section
+    v-else
+    :aria-label="chart.chartNameDisplay"
+  >
     <div
       v-if="chart"
       class="chart-header"
@@ -374,6 +377,7 @@ export default {
       </div>
       <aside
         v-if="version"
+        :aria-label="t('catalog.chart.info.chartVersions.label')"
         class="chart-body__info"
       >
         <div class="chart-body__info-section">
@@ -537,7 +541,7 @@ export default {
         </div>
       </aside>
     </div>
-  </div>
+  </section>
 </template>
 
 <style lang="scss" scoped>

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -227,7 +227,7 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
-  <section
+  <region
     v-else
     :aria-label="chart.chartNameDisplay"
   >
@@ -541,7 +541,7 @@ export default {
         </div>
       </aside>
     </div>
-  </section>
+  </region>
 </template>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
### Summary
Contributes towards #17279

Addresses a number of accessibility (a11y) violations identified by the existing accessibility e2e test suite.

With these changes, total violation count is reduced from 222 to 116.

The goal was to tackle the low-hanging groups of violations and remove whole groups, regardless of severity. 

### Occurred changes and/or fixed issues

- **Missing/empty dialog titles** – `AppModal` now accepts a `title` prop that is applied as `aria-label` on the dialog container. `PromptModal` derives a human-readable title from the component name and passes it through; `PromptRemove` passes an explicit translated label.
- **Empty headings in Settings** – `Setting.vue` now guards the `<h2>` description element so it is only rendered when a translation key resolves to a non-empty string, preventing empty heading violations.
- **Screen reader header for the Actions column** – `SortableTable/THead` adds a visually-hidden `<span class="sr-only">` inside the actions `<th>` so the column has an accessible name.
- **Invalid `aria-controls` references** – `CruResource.vue` now sets an `id` on each step container (`step-container-<name>`) so that `aria-controls` in `Wizard.vue` resolves to a real element. `HorizontalPanel` likewise scopes `aria-controls` with the panel position to avoid ID collisions.
- **Incorrect ARIA roles in the Wizard** – Step list items were using `role="presentation"`, which suppressed them from the accessibility tree; changed to `role="listitem"`.
- **Duplicate aria-labels in nav groups** – Nested `Group` components (e.g. items under "More Resources") now receive their parent's label as a `parentLabel` prop so each header announces as `"<Parent>, <Child>"`, making labels unique and contextually meaningful.
- **Incorrect role on the pin toggle** – `Pinned.vue` used `role="button"` on a toggle that represents a checked/unchecked state; corrected to `role="checkbox"`.
- **Missing landmark label on chart page** – The chart detail page `<main>` was replaced with a labelled `<region>` and the chart info `<aside>` was given an `aria-label`.
- **OCI logo alt text** – The alt text key for the OCI repository logo was corrected to `catalog.repo.target.oci.logo` so it describes the image rather than repeating the section title.
- **Cypress a11y test fix** – The kubectl-explain slide-in panel test now waits for animations and expands content before running the axe scan - this avoids an issue with the tooltip remaining visible and causing a11y issues.

### Technical notes summary

- The `AppModal` `title` prop is intentionally optional (defaults to `''`) to avoid breaking existing usages; callers should supply it for any dialog that lacks a visible heading.
- `PromptModal`'s `modalTitle` computed property derives a title only when `modalData.component` is a string (a registered component name). Object-based component definitions fall through and produce an empty string, which is safe — those modals are expected to carry their own visible heading.
- `role="navigation"` on the collapsible nav group header is the correct landmark for a nav section toggle.

### Areas or cases that should be tested

Covered by the existing Cypress accessibility test suite (`cypress/e2e/tests/accessibility/shell.spec.ts`). No additional manual test steps required.

### Areas which could experience regressions

- Navigation sidebar collapsing/expanding behaviour
- Wizard / multi-step form navigation
- SortableTable column headers and sorting
- `PromptRemove` dialog (confirm delete flow)
- App/Helm chart detail page layout
- kubectl-explain slide-in panel

### Screenshot/Video

N/A — changes are non-visual (ARIA attributes, roles, and screen-reader-only text).

### A11y

After these changes, the a11y test report looks like this:

#### Accessibility Violations Summary

| Severity | Count |
|----------|-------|
| 🔴 Critical | 62 |
| 🟠 Serious | 37 |
| 🔵 Moderate | 17 |
| ⚪ Minor | 0 |
| **Total** | **116** |

#### Violations Detail

| Level | Violation | Count | Description |
|-------|-----------|-------|-------------|
| 🟠 Serious | `color-contrast` | 2 | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds |
| 🔵 Moderate | `heading-order` | 17 | Ensure the order of headings is semantically correct |
| 🔴 Critical | `aria-required-parent` | 51 | Ensure elements with an ARIA role that require parent roles are contained by them |
| 🔴 Critical | `aria-required-children` | 11 | Ensure elements with an ARIA role that require child roles contain them |
| 🟠 Serious | `listitem` | 34 | Ensure &lt;li&gt; elements are used semantically |
| 🟠 Serious | `nested-interactive` | 1 | Ensure interactive controls are not nested as they are not always announced by screen readers or can cause focus problems for assistive technologies |


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
