### PR TITLE
create docs for prod registration

### DIFF
--- a/docusaurus/docs/extensions/api/nav/product-registration.md
+++ b/docusaurus/docs/extensions/api/nav/product-registration.md
@@ -1,6 +1,6 @@
 # Product Registration (Experimental)
 
-> Note: This API is experimental and may change in future releases. The existing [DSL-based product registration](./products.md) remains the default and recommended approach for production Extensions.
+> Note: This API is experimental and may change in future releases.
 
 ## Overview
 
@@ -32,14 +32,14 @@ Before diving in, here are the key terms used throughout this API. If you're not
 
 ## API Reference
 
-All methods are called on the `plugin` object in your Extension's `index.ts`.
+All methods are called on the `extension` object in your Extension's `index.ts`.
 
 ### `addProduct(productName)`
 
 The simplest way to register a product. Pass a string name and the product will be registered with a default empty page.
 
 ```ts
-plugin.addProduct('my-first-product');
+extension.addProduct('my-first-product');
 ```
 
 This is a convenience/bridge method useful for getting started. You can expand to the full API signatures below once you are ready to add custom pages.
@@ -89,11 +89,11 @@ The fastest way to get a product registered. This registers a product with a def
 import { importTypes } from '@rancher/auto-import';
 import { IPlugin } from '@shell/core/types';
 
-export default function(plugin: IPlugin) {
-  importTypes(plugin);
-  plugin.metadata = require('./package.json');
+export default function(extension: IPlugin) {
+  importTypes(extension);
+  extension.metadata = require('./package.json');
 
-  plugin.addProduct('my-first-product');
+  extension.addProduct('my-first-product');
 }
 ```
 
@@ -107,9 +107,9 @@ import { importTypes } from '@rancher/auto-import';
 import { IPlugin } from '@shell/core/types';
 import { ProductSinglePage } from '@shell/core/plugin-types';
 
-export default function(plugin: IPlugin) {
-  importTypes(plugin);
-  plugin.metadata = require('./package.json');
+export default function(extension: IPlugin) {
+  importTypes(extension);
+  extension.metadata = require('./package.json');
 
   const product: ProductSinglePage = {
     name:      'my-dashboard',
@@ -118,7 +118,7 @@ export default function(plugin: IPlugin) {
     component: () => import('./pages/DashboardPage.vue')
   };
 
-  plugin.addProduct(product);
+  extension.addProduct(product);
 }
 ```
 
@@ -132,9 +132,9 @@ import { importTypes } from '@rancher/auto-import';
 import { IPlugin } from '@shell/core/types';
 import { ProductMetadata, ProductChildCustomPage } from '@shell/core/plugin-types';
 
-export default function(plugin: IPlugin) {
-  importTypes(plugin);
-  plugin.metadata = require('./package.json');
+export default function(extension: IPlugin) {
+  importTypes(extension);
+  extension.metadata = require('./package.json');
 
   const overviewPage: ProductChildCustomPage = {
     name:      'overview',
@@ -156,7 +156,7 @@ export default function(plugin: IPlugin) {
     icon:  'gear',
   };
 
-  plugin.addProduct(product, [overviewPage, settingsPage]);
+  extension.addProduct(product, [overviewPage, settingsPage]);
 }
 ```
 
@@ -170,9 +170,9 @@ import { importTypes } from '@rancher/auto-import';
 import { IPlugin } from '@shell/core/types';
 import { ProductMetadata, ProductChildResourcePage } from '@shell/core/plugin-types';
 
-export default function(plugin: IPlugin) {
-  importTypes(plugin);
-  plugin.metadata = require('./package.json');
+export default function(extension: IPlugin) {
+  importTypes(extension);
+  extension.metadata = require('./package.json');
 
   const clusterPage: ProductChildResourcePage = {
     type:   'provisioning.cattle.io.cluster',
@@ -196,7 +196,7 @@ export default function(plugin: IPlugin) {
     label: 'My Resources',
   };
 
-  plugin.addProduct(product, [clusterPage, nodePage]);
+  extension.addProduct(product, [clusterPage, nodePage]);
 }
 ```
 
@@ -214,9 +214,9 @@ import {
   ProductChildGroup
 } from '@shell/core/plugin-types';
 
-export default function(plugin: IPlugin) {
-  importTypes(plugin);
-  plugin.metadata = require('./package.json');
+export default function(extension: IPlugin) {
+  importTypes(extension);
+  extension.metadata = require('./package.json');
 
   // Pages for the "Monitoring" group
   const alertsPage: ProductChildCustomPage = {
@@ -251,7 +251,7 @@ export default function(plugin: IPlugin) {
     label: 'My Platform',
   };
 
-  plugin.addProduct(product, [overviewPage, monitoringGroup]);
+  extension.addProduct(product, [overviewPage, monitoringGroup]);
 }
 ```
 
@@ -265,9 +265,9 @@ import { importTypes } from '@rancher/auto-import';
 import { IPlugin } from '@shell/core/types';
 import { ProductChildCustomPage } from '@shell/core/plugin-types';
 
-export default function(plugin: IPlugin) {
-  importTypes(plugin);
-  plugin.metadata = require('./package.json');
+export default function(extension: IPlugin) {
+  importTypes(extension);
+  extension.metadata = require('./package.json');
 
   const customPage: ProductChildCustomPage = {
     name:      'my-custom-view',
@@ -276,7 +276,7 @@ export default function(plugin: IPlugin) {
   };
 
   // Add a page to the Cluster Explorer product
-  plugin.extendProduct('explorer', [customPage]);
+  extension.extendProduct('explorer', [customPage]);
 }
 ```
 

--- a/docusaurus/docs/extensions/api/nav/product-registration.md
+++ b/docusaurus/docs/extensions/api/nav/product-registration.md
@@ -1,0 +1,405 @@
+# Product Registration (Experimental)
+
+> Note: This API is experimental and may change in future releases. The existing [DSL-based product registration](./products.md) remains the default and recommended approach for production Extensions.
+
+## Overview
+
+The product registration API provides a simplified way to register products and pages in Rancher Dashboard Extensions. It replaces the need to manually configure routes and DSL functions (`product`, `virtualType`, `configureType`, `basicType`) — all of which are handled automatically under the hood.
+
+### When to use this API
+
+Use this API when you want to:
+
+- Quickly scaffold a new Extension product without dealing with routing boilerplate
+- Add custom pages or resource pages to a product with minimal configuration
+- Extend an existing Rancher Dashboard product (Explorer, Cluster Management, etc.) with new pages
+
+For full control over routing and DSL configuration, continue using the [existing approach](./products.md).
+
+> Note: For a set of copy-paste-ready examples covering common use cases, see [Product Registration Examples](../../usecases/product-registration-examples.md).
+
+## Terminology
+
+Before diving in, here are the key terms used throughout this API. If you're not familiar with the concepts of top-level and cluster-level products, check their definitions [here](../../api/concepts.md).
+
+| Term | Description |
+| --- | --- |
+| **Product** | A top-level view in Rancher Dashboard that adds a navigation entry into the top-level slide-in menu (e.g. Fleet, Cluster Management) |
+| **Custom page** | A page inside a product that renders a Vue component you provide. Equivalent to defining a `virtualType` in the DSL approach |
+| **Resource page** | A page inside a product that displays a Kubernetes resource type using Rancher's built-in list/detail/edit views. Equivalent to defining a `configureType` in the DSL approach |
+| **Group** | A collapsible folder/group in the product's side-menu that contains pages or other groups |
+| **Single page product** | A product with no side-menu — just one full-page Vue component |
+
+## API Reference
+
+All methods are called on the `plugin` object in your Extension's `index.ts`.
+
+### `addProduct(productName)`
+
+The simplest way to register a product. Pass a string name and the product will be registered with a default empty page.
+
+```ts
+plugin.addProduct('my-first-product');
+```
+
+This is a convenience/bridge method useful for getting started. You can expand to the full API signatures below once you are ready to add custom pages.
+
+### `addProduct(product, config)`
+
+Register a product with pages and side-menu navigation.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `product` | `ProductMetadata` | Product name, label, icon, and other metadata |
+| `config` | `ProductChildPage[]` or `ProductChildGroup[]` | Array of pages or groups that form the product's side-menu |
+
+### `addProduct(product)`
+
+Register a single page product (no side-menu).
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `product` | `ProductSinglePage` | Product metadata plus a `component` to render |
+
+### `extendProduct(product, config)`
+
+Add pages to an existing Rancher Dashboard product.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `product` | `StandardProductName` | One of: `'explorer'`, `'manager'`, `'settings'`, `'auth'` |
+| `config` | `ProductChildPage[]` or `ProductChildGroup[]` | Array of pages or groups to add to the product |
+
+## Usage
+
+> Note: We recommend building up configuration objects as separate `const` variables before passing them to `addProduct` or `extendProduct`. This gives you better TypeScript intellisense and autocomplete, and avoids some of the confusion when creating the objects directly in `addProduct` or `extendProduct`.
+
+### Quick start
+
+The fastest way to get a product registered. This registers a product with a default empty page:
+
+```ts
+// ./index.ts
+import { importTypes } from '@rancher/auto-import';
+import { IPlugin } from '@shell/core/types';
+
+export default function(plugin: IPlugin) {
+  importTypes(plugin);
+  plugin.metadata = require('./package.json');
+
+  plugin.addProduct('my-first-product');
+}
+```
+
+### Single page product
+
+A product that renders a single Vue component with no side-menu:
+
+```ts
+// ./index.ts
+import { importTypes } from '@rancher/auto-import';
+import { IPlugin } from '@shell/core/types';
+import { ProductSinglePage } from '@shell/core/plugin-types';
+
+export default function(plugin: IPlugin) {
+  importTypes(plugin);
+  plugin.metadata = require('./package.json');
+
+  const product: ProductSinglePage = {
+    name:      'my-dashboard',
+    label:     'My Dashboard',
+    icon:      'globe',
+    component: () => import('./pages/DashboardPage.vue')
+  };
+
+  plugin.addProduct(product);
+}
+```
+
+### Product with custom pages
+
+A product with multiple custom pages listed as side-menu entries:
+
+```ts
+// ./index.ts
+import { importTypes } from '@rancher/auto-import';
+import { IPlugin } from '@shell/core/types';
+import { ProductMetadata, ProductChildCustomPage } from '@shell/core/plugin-types';
+
+export default function(plugin: IPlugin) {
+  importTypes(plugin);
+  plugin.metadata = require('./package.json');
+
+  const overviewPage: ProductChildCustomPage = {
+    name:      'overview',
+    label:     'Overview',
+    component: () => import('./pages/OverviewPage.vue'),
+    weight:    2, // side-menu ordering (bigger number on top)
+  };
+
+  const settingsPage: ProductChildCustomPage = {
+    name:      'settings',
+    label:     'Settings',
+    component: () => import('./pages/SettingsPage.vue'),
+    weight:    1,
+  };
+
+  const product: ProductMetadata = {
+    name:  'my-app',
+    label: 'My App',
+    icon:  'gear',
+  };
+
+  plugin.addProduct(product, [overviewPage, settingsPage]);
+}
+```
+
+### Product with resource pages
+
+A product that displays Kubernetes resources using Rancher's built-in list/detail/edit views:
+
+```ts
+// ./index.ts
+import { importTypes } from '@rancher/auto-import';
+import { IPlugin } from '@shell/core/types';
+import { ProductMetadata, ProductChildResourcePage } from '@shell/core/plugin-types';
+
+export default function(plugin: IPlugin) {
+  importTypes(plugin);
+  plugin.metadata = require('./package.json');
+
+  const clusterPage: ProductChildResourcePage = {
+    type:   'provisioning.cattle.io.cluster',
+    weight: 2,
+    config: {
+      displayName: 'Clusters',
+      isCreatable: true,
+      isEditable:  true,
+      isRemovable: true,
+      canYaml:     true,
+    },
+  };
+
+  const nodePage: ProductChildResourcePage = {
+    type:   'management.cattle.io.node',
+    weight: 1,
+  };
+
+  const product: ProductMetadata = {
+    name:  'my-resources',
+    label: 'My Resources',
+  };
+
+  plugin.addProduct(product, [clusterPage, nodePage]);
+}
+```
+
+### Product with groups
+
+Organize pages into collapsible folder/groups in the side-menu:
+
+```ts
+// ./index.ts
+import { importTypes } from '@rancher/auto-import';
+import { IPlugin } from '@shell/core/types';
+import {
+  ProductMetadata,
+  ProductChildCustomPage,
+  ProductChildGroup
+} from '@shell/core/plugin-types';
+
+export default function(plugin: IPlugin) {
+  importTypes(plugin);
+  plugin.metadata = require('./package.json');
+
+  // Pages for the "Monitoring" group
+  const alertsPage: ProductChildCustomPage = {
+    name:      'alerts',
+    label:     'Alerts',
+    component: () => import('./pages/AlertsPage.vue'),
+  };
+
+  const metricsPage: ProductChildCustomPage = {
+    name:      'metrics',
+    label:     'Metrics',
+    component: () => import('./pages/MetricsPage.vue'),
+  };
+
+  const monitoringGroup: ProductChildGroup = {
+    name:     'monitoring',
+    label:    'Monitoring',
+    weight:   2,
+    children: [alertsPage, metricsPage],
+  };
+
+  // A standalone page outside any group
+  const overviewPage: ProductChildCustomPage = {
+    name:      'overview',
+    label:     'Overview',
+    component: () => import('./pages/OverviewPage.vue'),
+    weight:    3, // side-menu ordering (bigger number on top)
+  };
+
+  const product: ProductMetadata = {
+    name:  'my-platform',
+    label: 'My Platform',
+  };
+
+  plugin.addProduct(product, [overviewPage, monitoringGroup]);
+}
+```
+
+### Extending an existing product
+
+Add new pages to one of Rancher Dashboard's built-in products:
+
+```ts
+// ./index.ts
+import { importTypes } from '@rancher/auto-import';
+import { IPlugin } from '@shell/core/types';
+import { ProductChildCustomPage } from '@shell/core/plugin-types';
+
+export default function(plugin: IPlugin) {
+  importTypes(plugin);
+  plugin.metadata = require('./package.json');
+
+  const customPage: ProductChildCustomPage = {
+    name:      'my-custom-view',
+    label:     'My Custom View',
+    component: () => import('./pages/MyCustomView.vue'),
+  };
+
+  // Add a page to the Cluster Explorer product
+  plugin.extendProduct('explorer', [customPage]);
+}
+```
+
+The products available for extension are:
+
+| Name | Description |
+| --- | --- |
+| `'explorer'` | Cluster Explorer |
+| `'manager'` | Cluster Management |
+| `'settings'` | Global Settings |
+| `'auth'` | Authentication & API Keys |
+
+## Type Reference
+
+All types are importable from `@shell/core/plugin-types`:
+
+```ts
+import {
+  ProductMetadata,
+  ProductSinglePage,
+  ProductChildCustomPage,
+  ProductChildResourcePage,
+  ProductChildPage,
+  ProductChildGroup,
+  StandardProductName,
+} from '@shell/core/plugin-types';
+```
+
+### `ProductMetadata`
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `string` | Yes | Unique product identifier |
+| `label` | `string` | Yes* | Display label (* either `label` or `labelKey` is required) |
+| `labelKey` | `string` | Yes* | Translation key for the label |
+| `icon` | `string` | No | Icon name (based on [rancher icons](https://rancher.github.io/icons/)). Defaults to `'extension'` |
+| `weight` | `number` | No | Side-menu ordering (bigger number on top) |
+| `showClusterSwitcher` | `boolean` | No | Show the cluster switcher in navigation |
+| `showNamespaceFilter` | `boolean` | No | Show the namespace filter in the header |
+
+### `ProductSinglePage`
+
+Extends `ProductMetadata` with:
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `component` | `RouteComponent` | Yes | Vue component to render for the entire product |
+
+### `ProductChildCustomPage`
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `string` | Yes | Unique page identifier |
+| `label` | `string` | Yes* | Display label (* either `label` or `labelKey` is required) |
+| `labelKey` | `string` | Yes* | Translation key for the label |
+| `component` | `RouteComponent` | Yes | Vue component to render |
+| `weight` | `number` | No | Side-menu ordering (bigger number on top) |
+
+### `ProductChildResourcePage`
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `type` | `string` | Yes | Kubernetes resource type (e.g. `'provisioning.cattle.io.cluster'`) |
+| `weight` | `number` | No | Side-menu ordering (bigger number on top) |
+| `config` | `ConfigureTypeConfiguration` | No | Resource page options (creatable, editable, removable, etc.) |
+
+### `ProductChildGroup`
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `string` | Yes | Unique group identifier |
+| `label` | `string` | Yes* | Display label (* either `label` or `labelKey` is required) |
+| `labelKey` | `string` | Yes* | Translation key for the label |
+| `children` | `ProductChild[]` | Yes | Array of pages or nested groups |
+| `component` | `RouteComponent` | No | Optional component for the group's own page |
+| `weight` | `number` | No | Side-menu ordering (bigger number on top) |
+
+
+## Rules & Constraints
+
+When defining pages and groups in your product configuration, there are some important rules to keep in mind:
+
+### Page types are mutually exclusive
+
+A page item is either a **custom page** (has `component`) or a **resource page** (has `type`). Do not set both `type` and `component` on the same item. The API uses these properties to determine what kind of page to register:
+
+- `component` defined &rarr; registers a custom page (`virtualType`)
+- `type` defined &rarr; registers a resource page (`configureType`)
+
+### Resource pages cannot have children
+
+Only custom pages and groups can have `children`. A resource page (an item with `type`) cannot be turned into a group — it uses Rancher Dashboard's built-in list/detail/edit views and does not support child navigation.
+
+### Groups cannot have a `type` property
+
+A group (an item with `children`) cannot also have a `type` property. Groups are for organizing navigation — they do not display Kubernetes resources directly. Place resource pages as children of the group instead.
+
+### Group parents cannot have `component` when extending a product
+
+When using `extendProduct`, group parent items cannot specify a `component`. This is because of route matching conflicts with the existing product's routes. Place the component on a child page instead.
+
+When using `addProduct` for a new product, group parents *can* have a `component` — this renders as an overview page when the group header is clicked.
+
+### Naming requirements
+
+- Custom pages and groups require a `name` property (unique identifier used in routes)
+- Resource pages require a `type` property (the Kubernetes resource type)
+- Custom pages and groups require either `label` or `labelKey` (for display in the side-menu)
+- Resource pages do not need `label` or `labelKey` — Rancher Dashboard resolves the display name from the resource schema
+
+### Page names must be unique within a product
+
+Each custom page and group must have a unique `name` within the same product configuration. Registering two pages with the same `name` at the same level will throw an error at registration time.
+
+> Note: Pages with the same `name` in different groups are allowed, because the group prefix makes their resolved names different (e.g. `myapp-overview` and `myapp-admin-overview` are distinct).
+
+### Resource types must be unique within a product
+
+Each resource page `type` must appear only once in a product configuration. Registering the same Kubernetes resource type twice will throw an error at registration time.
+
+### Ordering and default routes
+
+- The first item in the config array (after ordering by `weight`) becomes the product's default landing route
+- For groups without a `component`, the default route falls through to the group's first child
+- Higher `weight` values place items higher in the side-menu (bigger number on top)
+- When no weights are specified, the array order determines the side-menu order

--- a/docusaurus/docs/extensions/api/nav/product-registration.md
+++ b/docusaurus/docs/extensions/api/nav/product-registration.md
@@ -374,12 +374,6 @@ Only custom pages and groups can have `children`. A resource page (an item with 
 
 A group (an item with `children`) cannot also have a `type` property. Groups are for organizing navigation — they do not display Kubernetes resources directly. Place resource pages as children of the group instead.
 
-### Group parents cannot have `component` when extending a product
-
-When using `extendProduct`, group parent items cannot specify a `component`. This is because of route matching conflicts with the existing product's routes. Place the component on a child page instead.
-
-When using `addProduct` for a new product, group parents *can* have a `component` — this renders as an overview page when the group header is clicked.
-
 ### Naming requirements
 
 - Custom pages and groups require a `name` property (unique identifier used in routes)

--- a/docusaurus/docs/extensions/usecases/product-registration-examples.md
+++ b/docusaurus/docs/extensions/usecases/product-registration-examples.md
@@ -1,0 +1,399 @@
+# Product Registration Examples (Experimental)
+
+> Note: These examples use the experimental product registration API, which may change in future releases. For the current stable approach, see [Extension as a top-level product](./top-level-product.md) and [Extension as a cluster-level product](./cluster-level-product.md).
+
+This page provides a set of copy-paste-ready examples for common product registration use cases. Each example is self-contained and shows the complete `index.ts` for an Extension.
+
+For a detailed explanation of each API method and its types, see the [Product Registration API reference](../api/nav/product-registration.md).
+
+## Quick start: empty product
+
+Register a product with a single call. Useful for bootstrapping a new Extension before adding real pages:
+
+```ts
+// ./index.ts
+import { importTypes } from '@rancher/auto-import';
+import { IPlugin } from '@shell/core/types';
+
+export default function(plugin: IPlugin) {
+  importTypes(plugin);
+  plugin.metadata = require('./package.json');
+
+  plugin.addProduct('my-first-product');
+}
+```
+
+**Result:** A product named "my-first-product" appears in the top-level slide-in menu with a default empty page.
+
+---
+
+## Single page product
+
+A product that shows one full-page component with no side-menu. Good for dashboards or settings screens:
+
+```ts
+// ./index.ts
+import { importTypes } from '@rancher/auto-import';
+import { IPlugin } from '@shell/core/types';
+import { ProductSinglePage } from '@shell/core/plugin-types';
+
+export default function(plugin: IPlugin) {
+  importTypes(plugin);
+  plugin.metadata = require('./package.json');
+
+  const product: ProductSinglePage = {
+    name:      'status-board',
+    label:     'Status Board',
+    icon:      'globe',
+    component: () => import('./pages/StatusBoard.vue'),
+  };
+
+  plugin.addProduct(product);
+}
+```
+
+**Result:** A product with a single full-page view and no side-menu.
+
+---
+
+## Multiple custom pages
+
+A product with several custom pages listed as side-menu entries:
+
+```ts
+// ./index.ts
+import { importTypes } from '@rancher/auto-import';
+import { IPlugin } from '@shell/core/types';
+import {
+  ProductMetadata,
+  ProductChildCustomPage
+} from '@shell/core/plugin-types';
+
+export default function(plugin: IPlugin) {
+  importTypes(plugin);
+  plugin.metadata = require('./package.json');
+
+  const overviewPage: ProductChildCustomPage = {
+    name:      'overview',
+    label:     'Overview',
+    component: () => import('./pages/Overview.vue'),
+    weight:    3,
+  };
+
+  const usersPage: ProductChildCustomPage = {
+    name:      'users',
+    label:     'Users',
+    component: () => import('./pages/Users.vue'),
+    weight:    2,
+  };
+
+  const logsPage: ProductChildCustomPage = {
+    name:      'logs',
+    label:     'Logs',
+    component: () => import('./pages/Logs.vue'),
+    weight:    1,
+  };
+
+  const product: ProductMetadata = {
+    name:  'my-app',
+    label: 'My App',
+    icon:  'gear',
+  };
+
+  plugin.addProduct(product, [overviewPage, usersPage, logsPage]);
+}
+```
+
+**Result:** A product with three pages in the side-menu, ordered by weight (bigger number on top).
+
+---
+
+## Resource pages (Kubernetes resources)
+
+A product that uses Rancher Dashboard's built-in list/detail/edit views for Kubernetes resource types:
+
+```ts
+// ./index.ts
+import { importTypes } from '@rancher/auto-import';
+import { IPlugin } from '@shell/core/types';
+import {
+  ProductMetadata,
+  ProductChildResourcePage
+} from '@shell/core/plugin-types';
+
+export default function(plugin: IPlugin) {
+  importTypes(plugin);
+  plugin.metadata = require('./package.json');
+
+  const clusterPage: ProductChildResourcePage = {
+    type:   'provisioning.cattle.io.cluster',
+    weight: 2,
+    config: {
+      displayName: 'Clusters',
+      isCreatable: true,
+      isEditable:  true,
+      isRemovable: true,
+      canYaml:     true,
+      showState:   true,
+      showAge:     true,
+    },
+  };
+
+  const secretsPage: ProductChildResourcePage = {
+    type:   'secret',
+    weight: 1,
+  };
+
+  const product: ProductMetadata = {
+    name:  'cluster-tools',
+    label: 'Cluster Tools',
+  };
+
+  plugin.addProduct(product, [clusterPage, secretsPage]);
+}
+```
+
+**Result:** A product with two resource pages. Clicking a resource in the side-menu shows Rancher's standard list view; clicking a row opens the detail view.
+
+---
+
+## Mixed pages: custom + resource
+
+Combine custom pages and resource pages in the same product:
+
+```ts
+// ./index.ts
+import { importTypes } from '@rancher/auto-import';
+import { IPlugin } from '@shell/core/types';
+import {
+  ProductMetadata,
+  ProductChildCustomPage,
+  ProductChildResourcePage
+} from '@shell/core/plugin-types';
+
+export default function(plugin: IPlugin) {
+  importTypes(plugin);
+  plugin.metadata = require('./package.json');
+
+  const dashboardPage: ProductChildCustomPage = {
+    name:      'dashboard',
+    label:     'Dashboard',
+    component: () => import('./pages/Dashboard.vue'),
+    weight:    3,
+  };
+
+  const clusterPage: ProductChildResourcePage = {
+    type:   'provisioning.cattle.io.cluster',
+    weight: 2,
+  };
+
+  const settingsPage: ProductChildCustomPage = {
+    name:      'settings',
+    label:     'Settings',
+    component: () => import('./pages/Settings.vue'),
+    weight:    1,
+  };
+
+  const product: ProductMetadata = {
+    name:  'my-platform',
+    label: 'My Platform',
+  };
+
+  plugin.addProduct(product, [dashboardPage, clusterPage, settingsPage]);
+}
+```
+
+---
+
+## Pages organized in groups
+
+Use groups to create collapsible folder/groups in the side-menu:
+
+```ts
+// ./index.ts
+import { importTypes } from '@rancher/auto-import';
+import { IPlugin } from '@shell/core/types';
+import {
+  ProductMetadata,
+  ProductChildCustomPage,
+  ProductChildGroup
+} from '@shell/core/plugin-types';
+
+export default function(plugin: IPlugin) {
+  importTypes(plugin);
+  plugin.metadata = require('./package.json');
+
+  // Standalone page (outside any group)
+  const homePage: ProductChildCustomPage = {
+    name:      'home',
+    label:     'Home',
+    component: () => import('./pages/Home.vue'),
+    weight:    10,
+  };
+
+  // "Monitoring" group with two pages
+  const alertsPage: ProductChildCustomPage = {
+    name:      'alerts',
+    label:     'Alerts',
+    component: () => import('./pages/Alerts.vue'),
+  };
+
+  const metricsPage: ProductChildCustomPage = {
+    name:      'metrics',
+    label:     'Metrics',
+    component: () => import('./pages/Metrics.vue'),
+  };
+
+  const monitoringGroup: ProductChildGroup = {
+    name:     'monitoring',
+    label:    'Monitoring',
+    weight:   5,
+    children: [alertsPage, metricsPage],
+  };
+
+  // "Admin" group with two pages
+  const usersPage: ProductChildCustomPage = {
+    name:      'users',
+    label:     'Users',
+    component: () => import('./pages/Users.vue'),
+  };
+
+  const rolesPage: ProductChildCustomPage = {
+    name:      'roles',
+    label:     'Roles',
+    component: () => import('./pages/Roles.vue'),
+  };
+
+  const adminGroup: ProductChildGroup = {
+    name:     'admin',
+    label:    'Administration',
+    weight:   1,
+    children: [usersPage, rolesPage],
+  };
+
+  const product: ProductMetadata = {
+    name:  'my-platform',
+    label: 'My Platform',
+  };
+
+  plugin.addProduct(product, [homePage, monitoringGroup, adminGroup]);
+}
+```
+
+**Result:** The side-menu will look like:
+
+```
+Home
+▾ Monitoring
+    Alerts
+    Metrics
+▾ Administration
+    Users
+    Roles
+```
+
+---
+
+## Group with its own page
+
+A group can have its own component that renders when the group header is clicked, instead of navigating to the first child:
+
+```ts
+const monitoringGroup: ProductChildGroup = {
+  name:      'monitoring',
+  label:     'Monitoring',
+  component: () => import('./pages/MonitoringOverview.vue'), // group's own page
+  children:  [alertsPage, metricsPage],
+};
+```
+
+**Result:** Clicking "Monitoring" in the side-menu shows the `MonitoringOverview` component. Expanding the group reveals the child pages.
+
+---
+
+## Extending Cluster Explorer
+
+Add a standalone custom page to the Cluster Explorer product:
+
+```ts
+// ./index.ts
+import { importTypes } from '@rancher/auto-import';
+import { IPlugin } from '@shell/core/types';
+import { ProductChildCustomPage } from '@shell/core/plugin-types';
+
+export default function(plugin: IPlugin) {
+  importTypes(plugin);
+  plugin.metadata = require('./package.json');
+
+  const customPage: ProductChildCustomPage = {
+    name:      'cost-analysis',
+    label:     'Cost Analysis',
+    component: () => import('./pages/CostAnalysis.vue'),
+  };
+
+  plugin.extendProduct('explorer', [customPage]);
+}
+```
+
+Or, to add pages inside a group:
+
+```ts
+// ./index.ts
+import { importTypes } from '@rancher/auto-import';
+import { IPlugin } from '@shell/core/types';
+import {
+  ProductChildCustomPage,
+  ProductChildGroup
+} from '@shell/core/plugin-types';
+
+export default function(plugin: IPlugin) {
+  importTypes(plugin);
+  plugin.metadata = require('./package.json');
+
+  const costPage: ProductChildCustomPage = {
+    name:      'cost-analysis',
+    label:     'Cost Analysis',
+    component: () => import('./pages/CostAnalysis.vue'),
+  };
+
+  const usagePage: ProductChildCustomPage = {
+    name:      'usage-report',
+    label:     'Usage Report',
+    component: () => import('./pages/UsageReport.vue'),
+  };
+
+  const insightsGroup: ProductChildGroup = {
+    name:     'insights',
+    label:    'Insights',
+    children: [costPage, usagePage],
+  };
+
+  plugin.extendProduct('explorer', [insightsGroup]);
+}
+```
+
+The products available for extension are: `'explorer'`, `'manager'`, `'settings'`, and `'auth'`.
+
+---
+
+## Using translation keys instead of labels
+
+For i18n support, use `labelKey` instead of `label`. The key will be resolved from your Extension's translation files:
+
+```ts
+const product: ProductMetadata = {
+  name:     'my-app',
+  labelKey: 'product.myApp.label',
+  icon:     'gear',
+};
+
+const overviewPage: ProductChildCustomPage = {
+  name:      'overview',
+  labelKey:  'product.myApp.overview',
+  component: () => import('./pages/Overview.vue'),
+};
+
+plugin.addProduct(product, [overviewPage]);
+```
+
+> Note: See the [Localization documentation](../advanced/localization.md) for details on setting up translation files.

--- a/docusaurus/docs/extensions/usecases/product-registration-examples.md
+++ b/docusaurus/docs/extensions/usecases/product-registration-examples.md
@@ -15,11 +15,11 @@ Register a product with a single call. Useful for bootstrapping a new Extension 
 import { importTypes } from '@rancher/auto-import';
 import { IPlugin } from '@shell/core/types';
 
-export default function(plugin: IPlugin) {
-  importTypes(plugin);
-  plugin.metadata = require('./package.json');
+export default function(extension: IPlugin) {
+  importTypes(extension);
+  extension.metadata = require('./package.json');
 
-  plugin.addProduct('my-first-product');
+  extension.addProduct('my-first-product');
 }
 ```
 
@@ -37,9 +37,9 @@ import { importTypes } from '@rancher/auto-import';
 import { IPlugin } from '@shell/core/types';
 import { ProductSinglePage } from '@shell/core/plugin-types';
 
-export default function(plugin: IPlugin) {
-  importTypes(plugin);
-  plugin.metadata = require('./package.json');
+export default function(extension: IPlugin) {
+  importTypes(extension);
+  extension.metadata = require('./package.json');
 
   const product: ProductSinglePage = {
     name:      'status-board',
@@ -48,7 +48,7 @@ export default function(plugin: IPlugin) {
     component: () => import('./pages/StatusBoard.vue'),
   };
 
-  plugin.addProduct(product);
+  extension.addProduct(product);
 }
 ```
 
@@ -69,9 +69,9 @@ import {
   ProductChildCustomPage
 } from '@shell/core/plugin-types';
 
-export default function(plugin: IPlugin) {
-  importTypes(plugin);
-  plugin.metadata = require('./package.json');
+export default function(extension: IPlugin) {
+  importTypes(extension);
+  extension.metadata = require('./package.json');
 
   const overviewPage: ProductChildCustomPage = {
     name:      'overview',
@@ -100,7 +100,7 @@ export default function(plugin: IPlugin) {
     icon:  'gear',
   };
 
-  plugin.addProduct(product, [overviewPage, usersPage, logsPage]);
+  extension.addProduct(product, [overviewPage, usersPage, logsPage]);
 }
 ```
 
@@ -121,9 +121,9 @@ import {
   ProductChildResourcePage
 } from '@shell/core/plugin-types';
 
-export default function(plugin: IPlugin) {
-  importTypes(plugin);
-  plugin.metadata = require('./package.json');
+export default function(extension: IPlugin) {
+  importTypes(extension);
+  extension.metadata = require('./package.json');
 
   const clusterPage: ProductChildResourcePage = {
     type:   'provisioning.cattle.io.cluster',
@@ -149,7 +149,7 @@ export default function(plugin: IPlugin) {
     label: 'Cluster Tools',
   };
 
-  plugin.addProduct(product, [clusterPage, secretsPage]);
+  extension.addProduct(product, [clusterPage, secretsPage]);
 }
 ```
 
@@ -171,9 +171,9 @@ import {
   ProductChildResourcePage
 } from '@shell/core/plugin-types';
 
-export default function(plugin: IPlugin) {
-  importTypes(plugin);
-  plugin.metadata = require('./package.json');
+export default function(extension: IPlugin) {
+  importTypes(extension);
+  extension.metadata = require('./package.json');
 
   const dashboardPage: ProductChildCustomPage = {
     name:      'dashboard',
@@ -199,7 +199,7 @@ export default function(plugin: IPlugin) {
     label: 'My Platform',
   };
 
-  plugin.addProduct(product, [dashboardPage, clusterPage, settingsPage]);
+  extension.addProduct(product, [dashboardPage, clusterPage, settingsPage]);
 }
 ```
 
@@ -219,9 +219,9 @@ import {
   ProductChildGroup
 } from '@shell/core/plugin-types';
 
-export default function(plugin: IPlugin) {
-  importTypes(plugin);
-  plugin.metadata = require('./package.json');
+export default function(extension: IPlugin) {
+  importTypes(extension);
+  extension.metadata = require('./package.json');
 
   // Standalone page (outside any group)
   const homePage: ProductChildCustomPage = {
@@ -276,7 +276,7 @@ export default function(plugin: IPlugin) {
     label: 'My Platform',
   };
 
-  plugin.addProduct(product, [homePage, monitoringGroup, adminGroup]);
+  extension.addProduct(product, [homePage, monitoringGroup, adminGroup]);
 }
 ```
 
@@ -321,9 +321,9 @@ import { importTypes } from '@rancher/auto-import';
 import { IPlugin } from '@shell/core/types';
 import { ProductChildCustomPage } from '@shell/core/plugin-types';
 
-export default function(plugin: IPlugin) {
-  importTypes(plugin);
-  plugin.metadata = require('./package.json');
+export default function(extension: IPlugin) {
+  importTypes(extension);
+  extension.metadata = require('./package.json');
 
   const customPage: ProductChildCustomPage = {
     name:      'cost-analysis',
@@ -331,7 +331,7 @@ export default function(plugin: IPlugin) {
     component: () => import('./pages/CostAnalysis.vue'),
   };
 
-  plugin.extendProduct('explorer', [customPage]);
+  extension.extendProduct('explorer', [customPage]);
 }
 ```
 
@@ -346,9 +346,9 @@ import {
   ProductChildGroup
 } from '@shell/core/plugin-types';
 
-export default function(plugin: IPlugin) {
-  importTypes(plugin);
-  plugin.metadata = require('./package.json');
+export default function(extension: IPlugin) {
+  importTypes(extension);
+  extension.metadata = require('./package.json');
 
   const costPage: ProductChildCustomPage = {
     name:      'cost-analysis',
@@ -368,7 +368,7 @@ export default function(plugin: IPlugin) {
     children: [costPage, usagePage],
   };
 
-  plugin.extendProduct('explorer', [insightsGroup]);
+  extension.extendProduct('explorer', [insightsGroup]);
 }
 ```
 
@@ -393,7 +393,7 @@ const overviewPage: ProductChildCustomPage = {
   component: () => import('./pages/Overview.vue'),
 };
 
-plugin.addProduct(product, [overviewPage]);
+extension.addProduct(product, [overviewPage]);
 ```
 
 > Note: See the [Localization documentation](../advanced/localization.md) for details on setting up translation files.

--- a/docusaurus/extensionSidebar.js
+++ b/docusaurus/extensionSidebar.js
@@ -170,6 +170,11 @@ const sidebars = {
               ]
             },
             'api/common',
+            {
+              type:  'doc',
+              id:    'api/nav/product-registration',
+              label: 'Product Registration (Experimental)',
+            },
           ]
         },
         {
@@ -242,7 +247,12 @@ const sidebars = {
             'usecases/top-level-product',
             'usecases/cluster-level-product',
             'usecases/node-driver',
-            'usecases/hosted-provider'
+            'usecases/hosted-provider',
+            {
+              type:  'doc',
+              id:    'usecases/product-registration-examples',
+              label: 'Product Registration Examples (Experimental)',
+            },
           ]
         },
         'known-issues',

--- a/shell/core/__tests__/plugin-products.test.ts
+++ b/shell/core/__tests__/plugin-products.test.ts
@@ -966,28 +966,6 @@ describe('pluginProduct', () => {
         new PluginProduct(mockPlugin, productMetadata, badConfig);
       }).toThrow('forEach');
     });
-
-    it('should throw when extending standard product and group parent has component', () => {
-      const mockPlugin = createMockPlugin();
-      const config: ProductChildGroup[] = [
-        {
-          name:      'parent-group',
-          label:     'Parent Group',
-          component: { name: 'GroupComponent' },
-          children:  [
-            {
-              name:      'child',
-              label:     'Child',
-              component: { name: 'ChildComponent' },
-            },
-          ],
-        },
-      ];
-
-      expect(() => {
-        new PluginProduct(mockPlugin, StandardProductNames.EXPLORER, config);
-      }).toThrow('When extending an existing product, group parent items cannot have a component because of route matching conflicts.');
-    });
   });
 
   describe('state verification', () => {
@@ -3154,6 +3132,13 @@ describe('pluginProduct', () => {
         virtualType:         jest.fn(),
         configureType:       jest.fn(),
         weightType:          jest.fn(),
+        headers:             jest.fn(),
+        hideBulkActions:     jest.fn(),
+        spoofedType:         jest.fn(),
+        mapGroup:            jest.fn(),
+        ignoreGroup:         jest.fn(),
+        mapType:             jest.fn(),
+        ignoreType:          jest.fn(),
       };
 
       jest.spyOn(mockPlugin, 'DSL').mockReturnValue(mockDSL);
@@ -3182,6 +3167,13 @@ describe('pluginProduct', () => {
         virtualType:         jest.fn(),
         configureType:       jest.fn(),
         weightType:          jest.fn(),
+        headers:             jest.fn(),
+        hideBulkActions:     jest.fn(),
+        spoofedType:         jest.fn(),
+        mapGroup:            jest.fn(),
+        ignoreGroup:         jest.fn(),
+        mapType:             jest.fn(),
+        ignoreType:          jest.fn(),
       };
 
       jest.spyOn(mockPlugin, 'DSL').mockReturnValue(mockDSL);
@@ -3206,6 +3198,13 @@ describe('pluginProduct', () => {
         virtualType:         jest.fn(),
         configureType:       jest.fn(),
         weightType:          jest.fn(),
+        headers:             jest.fn(),
+        hideBulkActions:     jest.fn(),
+        spoofedType:         jest.fn(),
+        mapGroup:            jest.fn(),
+        ignoreGroup:         jest.fn(),
+        mapType:             jest.fn(),
+        ignoreType:          jest.fn(),
       };
 
       jest.spyOn(mockPlugin, 'DSL').mockReturnValue(mockDSL);
@@ -3486,27 +3485,6 @@ describe('pluginProduct', () => {
 
         expect(groupRoute).toBeDefined();
         expect(groupRoute[0].name).toStrictEqual(expect.stringContaining('monitoring'));
-      });
-
-      it('should throw when extending a product with a group that has a component', () => {
-        const mockPlugin = createMockPlugin();
-
-        const childPage: ProductChildCustomPage = {
-          name:      'child',
-          label:     'Child',
-          component: { name: 'ChildComponent' },
-        };
-
-        const groupWithComponent: ProductChildGroup = {
-          name:      'my-group',
-          label:     'My Group',
-          component: { name: 'GroupOverview' },
-          children:  [childPage],
-        };
-
-        expect(() => {
-          new PluginProduct(mockPlugin, StandardProductNames.EXPLORER, [groupWithComponent]);
-        }).toThrow('group parent items cannot have a component');
       });
     });
 

--- a/shell/core/__tests__/plugin-products.test.ts
+++ b/shell/core/__tests__/plugin-products.test.ts
@@ -1,7 +1,8 @@
 import { PluginProduct } from '@shell/core/plugin-products';
 import {
   ProductMetadata, ProductSinglePage, ProductChildPage,
-  ProductChildGroup, StandardProductNames
+  ProductChildGroup, ProductChildCustomPage, ProductChildResourcePage,
+  ProductChild, StandardProductNames
 } from '@shell/core/plugin-types';
 import { IExtension } from '@shell/core/types';
 
@@ -891,9 +892,9 @@ describe('pluginProduct', () => {
       pluginProduct.apply(mockPlugin, mockStore);
 
       // Verify default route points to the group's component page (not first child)
-      // When a group has a component, it should route to that component, not the first child
+      // When a group has a component, the route includes the group's name for proper side-menu highlighting
       expect(mockDSL.product).toHaveBeenCalledWith(
-        expect.objectContaining({ to: expect.objectContaining({ name: 'groupwithpage-group' }) })
+        expect.objectContaining({ to: expect.objectContaining({ name: 'groupwithpage-settings' }) })
       );
 
       // Verify virtualType was still created for the group component
@@ -3214,6 +3215,618 @@ describe('pluginProduct', () => {
       pluginProduct.apply(mockPlugin, mockStore);
 
       expect(productCalls[0][0]).toStrictEqual(expect.objectContaining({ name: 'myproduct' }));
+    });
+  });
+
+  describe('documentation examples', () => {
+    describe('quick start: string convenience method', () => {
+      it('should create a new product from just a string name', () => {
+        const mockPlugin = createMockPlugin();
+        const pluginProduct = PluginProduct.fromName(mockPlugin, 'my-first-product');
+
+        expect(pluginProduct.newProduct).toBe(true);
+        expect(mockPlugin._registerTopLevelProduct).toHaveBeenCalledTimes(1);
+        expect(mockPlugin.addRoute).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('single page product', () => {
+      it('should create a product with a single page component and no config', () => {
+        const mockPlugin = createMockPlugin();
+        const product: ProductSinglePage = {
+          name:      'my-dashboard',
+          label:     'My Dashboard',
+          icon:      'globe',
+          component: { name: 'DashboardPage' },
+        };
+
+        const pluginProduct = new PluginProduct(mockPlugin, product, []);
+
+        expect(pluginProduct.newProduct).toBe(true);
+        expect(mockPlugin._registerTopLevelProduct).toHaveBeenCalledTimes(1);
+        expect(mockPlugin.addRoute).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('product with custom pages', () => {
+      it('should register routes for each custom page', () => {
+        const mockPlugin = createMockPlugin();
+
+        const overviewPage: ProductChildCustomPage = {
+          name:      'overview',
+          label:     'Overview',
+          component: { name: 'OverviewPage' },
+          weight:    2,
+        };
+
+        const settingsPage: ProductChildCustomPage = {
+          name:      'settings',
+          label:     'Settings',
+          component: { name: 'SettingsPage' },
+          weight:    1,
+        };
+
+        const product: ProductMetadata = {
+          name:  'my-app',
+          label: 'My App',
+          icon:  'gear',
+        };
+
+        const pluginProduct = new PluginProduct(mockPlugin, product, [overviewPage, settingsPage]);
+
+        expect(pluginProduct.newProduct).toBe(true);
+        expect(mockPlugin._registerTopLevelProduct).toHaveBeenCalledTimes(1);
+        expect(mockPlugin.addRoute).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('product with resource pages', () => {
+      it('should register resource CRUD routes for resource page items', () => {
+        const mockPlugin = createMockPlugin();
+
+        const clusterPage: ProductChildResourcePage = {
+          type:   'provisioning.cattle.io.cluster',
+          weight: 2,
+          config: {
+            displayName: 'Clusters',
+            isCreatable: true,
+            isEditable:  true,
+            isRemovable: true,
+            canYaml:     true,
+          },
+        };
+
+        const nodePage: ProductChildResourcePage = {
+          type:   'management.cattle.io.node',
+          weight: 1,
+        };
+
+        const product: ProductMetadata = {
+          name:  'my-resources',
+          label: 'My Resources',
+        };
+
+        const pluginProduct = new PluginProduct(mockPlugin, product, [clusterPage, nodePage]);
+
+        expect(pluginProduct.newProduct).toBe(true);
+        // Resource routes are only added once (shared CRUD routes) - mock generates list + detail = 2
+        expect(mockPlugin.addRoute).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    describe('product with groups', () => {
+      it('should register routes for a product with groups and standalone pages', () => {
+        const mockPlugin = createMockPlugin();
+
+        const alertsPage: ProductChildCustomPage = {
+          name:      'alerts',
+          label:     'Alerts',
+          component: { name: 'AlertsPage' },
+        };
+
+        const metricsPage: ProductChildCustomPage = {
+          name:      'metrics',
+          label:     'Metrics',
+          component: { name: 'MetricsPage' },
+        };
+
+        const monitoringGroup: ProductChildGroup = {
+          name:     'monitoring',
+          label:    'Monitoring',
+          weight:   2,
+          children: [alertsPage, metricsPage],
+        };
+
+        const overviewPage: ProductChildCustomPage = {
+          name:      'overview',
+          label:     'Overview',
+          component: { name: 'OverviewPage' },
+          weight:    3,
+        };
+
+        const product: ProductMetadata = {
+          name:  'my-platform',
+          label: 'My Platform',
+        };
+
+        const config: ProductChild[] = [overviewPage, monitoringGroup];
+        const pluginProduct = new PluginProduct(mockPlugin, product, config);
+
+        expect(pluginProduct.newProduct).toBe(true);
+        expect(mockPlugin._registerTopLevelProduct).toHaveBeenCalledTimes(1);
+        // 1 standalone page + 1 group parent route + 2 group children routes = 4
+        expect(mockPlugin.addRoute).toHaveBeenCalledTimes(4);
+      });
+    });
+
+    describe('extending an existing product', () => {
+      it('should extend explorer with a custom page', () => {
+        const mockPlugin = createMockPlugin();
+
+        const customPage: ProductChildCustomPage = {
+          name:      'my-custom-view',
+          label:     'My Custom View',
+          component: { name: 'MyCustomView' },
+        };
+
+        const pluginProduct = new PluginProduct(mockPlugin, StandardProductNames.EXPLORER, [customPage]);
+
+        expect(pluginProduct.newProduct).toBe(false);
+        expect(mockPlugin._registerTopLevelProduct).not.toHaveBeenCalled();
+        expect(mockPlugin.addRoute).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('mixed pages: custom + resource', () => {
+      it('should register routes for both custom pages and resource pages together', () => {
+        const mockPlugin = createMockPlugin();
+
+        const dashboardPage: ProductChildCustomPage = {
+          name:      'dashboard',
+          label:     'Dashboard',
+          component: { name: 'Dashboard' },
+          weight:    3,
+        };
+
+        const clusterPage: ProductChildResourcePage = {
+          type:   'provisioning.cattle.io.cluster',
+          weight: 2,
+        };
+
+        const settingsPage: ProductChildCustomPage = {
+          name:      'settings',
+          label:     'Settings',
+          component: { name: 'Settings' },
+          weight:    1,
+        };
+
+        const product: ProductMetadata = {
+          name:  'my-platform',
+          label: 'My Platform',
+        };
+
+        const config: ProductChild[] = [dashboardPage, clusterPage, settingsPage];
+        const pluginProduct = new PluginProduct(mockPlugin, product, config);
+
+        expect(pluginProduct.newProduct).toBe(true);
+        // 2 custom page routes + resource CRUD routes (list + detail = 2 from mock) = 4
+        expect(mockPlugin.addRoute).toHaveBeenCalledTimes(4);
+        // Verify addRoute was called for both custom pages and resource routes
+        const routeCalls = (mockPlugin.addRoute as jest.Mock).mock.calls;
+        const hasCustomRoutes = routeCalls.some((call) => call[0]?.name?.includes('dashboard'));
+        const hasResourceRoutes = routeCalls.some((call) => call[0]?.name?.includes('provisioning.cattle.io.cluster'));
+
+        expect(hasCustomRoutes).toBe(true);
+        expect(hasResourceRoutes).toBe(true);
+      });
+    });
+
+    describe('group with its own page', () => {
+      it('should register a route for the group page itself and its children', () => {
+        const mockPlugin = createMockPlugin();
+
+        const alertsPage: ProductChildCustomPage = {
+          name:      'alerts',
+          label:     'Alerts',
+          component: { name: 'AlertsPage' },
+        };
+
+        const metricsPage: ProductChildCustomPage = {
+          name:      'metrics',
+          label:     'Metrics',
+          component: { name: 'MetricsPage' },
+        };
+
+        const monitoringGroup: ProductChildGroup = {
+          name:      'monitoring',
+          label:     'Monitoring',
+          component: { name: 'MonitoringOverview' },
+          children:  [alertsPage, metricsPage],
+        };
+
+        const product: ProductMetadata = {
+          name:  'my-platform',
+          label: 'My Platform',
+        };
+
+        const pluginProduct = new PluginProduct(mockPlugin, product, [monitoringGroup]);
+
+        expect(pluginProduct.newProduct).toBe(true);
+        // 1 group parent route (with component) + 2 children routes = 3
+        expect(mockPlugin.addRoute).toHaveBeenCalledTimes(3);
+      });
+
+      it('should generate a route with the group name for proper side-menu highlighting', () => {
+        const mockPlugin = createMockPlugin();
+
+        const childPage: ProductChildCustomPage = {
+          name:      'child',
+          label:     'Child',
+          component: { name: 'ChildComponent' },
+        };
+
+        const monitoringGroup: ProductChildGroup = {
+          name:      'monitoring',
+          label:     'Monitoring',
+          component: { name: 'MonitoringOverview' },
+          children:  [childPage],
+        };
+
+        const product: ProductMetadata = {
+          name:  'my-platform',
+          label: 'My Platform',
+        };
+
+        new PluginProduct(mockPlugin, product, [monitoringGroup]);
+
+        // The group's own route should include the group name in the route name
+        // This ensures the side-menu can highlight the correct item
+        const routeCalls = (mockPlugin.addRoute as jest.Mock).mock.calls;
+        const groupRoute = routeCalls.find((call) => call[0]?.name?.includes('monitoring'));
+
+        expect(groupRoute).toBeDefined();
+        expect(groupRoute[0].name).toStrictEqual(expect.stringContaining('monitoring'));
+      });
+
+      it('should throw when extending a product with a group that has a component', () => {
+        const mockPlugin = createMockPlugin();
+
+        const childPage: ProductChildCustomPage = {
+          name:      'child',
+          label:     'Child',
+          component: { name: 'ChildComponent' },
+        };
+
+        const groupWithComponent: ProductChildGroup = {
+          name:      'my-group',
+          label:     'My Group',
+          component: { name: 'GroupOverview' },
+          children:  [childPage],
+        };
+
+        expect(() => {
+          new PluginProduct(mockPlugin, StandardProductNames.EXPLORER, [groupWithComponent]);
+        }).toThrow('group parent items cannot have a component');
+      });
+    });
+
+    describe('extending Cluster Explorer', () => {
+      it('should extend explorer with a standalone page', () => {
+        const mockPlugin = createMockPlugin();
+
+        const customPage: ProductChildCustomPage = {
+          name:      'cost-analysis',
+          label:     'Cost Analysis',
+          component: { name: 'CostAnalysis' },
+        };
+
+        const pluginProduct = new PluginProduct(mockPlugin, StandardProductNames.EXPLORER, [customPage]);
+
+        expect(pluginProduct.newProduct).toBe(false);
+        expect(mockPlugin.addRoute).toHaveBeenCalledTimes(1);
+      });
+
+      it('should extend explorer with a group containing multiple pages', () => {
+        const mockPlugin = createMockPlugin();
+
+        const costPage: ProductChildCustomPage = {
+          name:      'cost-analysis',
+          label:     'Cost Analysis',
+          component: { name: 'CostAnalysis' },
+        };
+
+        const usagePage: ProductChildCustomPage = {
+          name:      'usage-report',
+          label:     'Usage Report',
+          component: { name: 'UsageReport' },
+        };
+
+        const insightsGroup: ProductChildGroup = {
+          name:     'insights',
+          label:    'Insights',
+          children: [costPage, usagePage],
+        };
+
+        const pluginProduct = new PluginProduct(mockPlugin, StandardProductNames.EXPLORER, [insightsGroup]);
+
+        expect(pluginProduct.newProduct).toBe(false);
+        // 1 group parent route + 2 child routes = 3
+        expect(mockPlugin.addRoute).toHaveBeenCalledTimes(3);
+      });
+    });
+
+    describe('translation keys instead of labels', () => {
+      it('should accept labelKey instead of label for product and pages', () => {
+        const mockPlugin = createMockPlugin();
+
+        const product: ProductMetadata = {
+          name:     'my-app',
+          labelKey: 'product.myApp.label',
+          icon:     'gear',
+        };
+
+        const overviewPage: ProductChildCustomPage = {
+          name:      'overview',
+          labelKey:  'product.myApp.overview',
+          component: { name: 'OverviewPage' },
+        };
+
+        const pluginProduct = new PluginProduct(mockPlugin, product, [overviewPage]);
+
+        expect(pluginProduct.newProduct).toBe(true);
+        expect(mockPlugin._registerTopLevelProduct).toHaveBeenCalledTimes(1);
+        expect(mockPlugin.addRoute).toHaveBeenCalledTimes(1);
+      });
+
+      it('should register labelKey on virtualType during apply', () => {
+        const mockPlugin = createMockPlugin();
+        const mockStore = createMockStore();
+        const virtualTypeCalls: any[] = [];
+        const mockDSL = {
+          product:             jest.fn(),
+          basicType:           jest.fn(),
+          labelGroup:          jest.fn(),
+          setGroupDefaultType: jest.fn(),
+          weightGroup:         jest.fn(),
+          virtualType:         jest.fn((...args: any[]) => virtualTypeCalls.push(args)),
+          configureType:       jest.fn(),
+          weightType:          jest.fn(),
+        };
+
+        (mockPlugin.DSL as jest.Mock).mockReturnValue(mockDSL);
+
+        const product: ProductMetadata = {
+          name:     'my-app',
+          labelKey: 'product.myApp.label',
+        };
+
+        const overviewPage: ProductChildCustomPage = {
+          name:      'overview',
+          labelKey:  'product.myApp.overview',
+          component: { name: 'OverviewPage' },
+        };
+
+        const pluginProduct = new PluginProduct(mockPlugin, product, [overviewPage]);
+
+        pluginProduct.apply(mockPlugin, mockStore);
+
+        expect(virtualTypeCalls).toHaveLength(1);
+        expect(virtualTypeCalls[0][0]).toStrictEqual(expect.objectContaining({ labelKey: 'product.myApp.overview' }));
+      });
+    });
+
+    describe('duplicate page name detection', () => {
+      it('should throw when two custom pages have the same name in a new product', () => {
+        const mockPlugin = createMockPlugin();
+        const mockStore = createMockStore();
+        const mockDSL = {
+          product:             jest.fn(),
+          basicType:           jest.fn(),
+          labelGroup:          jest.fn(),
+          setGroupDefaultType: jest.fn(),
+          weightGroup:         jest.fn(),
+          virtualType:         jest.fn(),
+          configureType:       jest.fn(),
+          weightType:          jest.fn(),
+        };
+
+        (mockPlugin.DSL as jest.Mock).mockReturnValue(mockDSL);
+
+        const page1: ProductChildCustomPage = {
+          name:      'overview',
+          label:     'Overview',
+          component: { name: 'Page1' },
+        };
+
+        const page2: ProductChildCustomPage = {
+          name:      'overview',
+          label:     'Overview Duplicate',
+          component: { name: 'Page2' },
+        };
+
+        const product: ProductMetadata = {
+          name:  'my-app',
+          label: 'My App',
+        };
+
+        const pluginProduct = new PluginProduct(mockPlugin, product, [page1, page2]);
+
+        expect(() => {
+          pluginProduct.apply(mockPlugin, mockStore);
+        }).toThrow('Duplicate page name "overview"');
+      });
+
+      it('should not throw when pages with the same name are in different groups (different resolved names)', () => {
+        const mockPlugin = createMockPlugin();
+        const mockStore = createMockStore();
+        const mockDSL = {
+          product:             jest.fn(),
+          basicType:           jest.fn(),
+          labelGroup:          jest.fn(),
+          setGroupDefaultType: jest.fn(),
+          weightGroup:         jest.fn(),
+          virtualType:         jest.fn(),
+          configureType:       jest.fn(),
+          weightType:          jest.fn(),
+        };
+
+        (mockPlugin.DSL as jest.Mock).mockReturnValue(mockDSL);
+
+        // Same page name 'overview' but in different groups produces different resolved names
+        const standalonePage: ProductChildCustomPage = {
+          name:      'cost-analysis',
+          label:     'Cost Analysis',
+          component: { name: 'CostAnalysis1' },
+        };
+
+        const groupChildPage: ProductChildCustomPage = {
+          name:      'cost-analysis',
+          label:     'Cost Analysis',
+          component: { name: 'CostAnalysis2' },
+        };
+
+        const group: ProductChildGroup = {
+          name:     'insights',
+          label:    'Insights',
+          children: [groupChildPage],
+        };
+
+        const product: ProductMetadata = {
+          name:  'my-app',
+          label: 'My App',
+        };
+
+        const config: ProductChild[] = [standalonePage, group];
+        const pluginProduct = new PluginProduct(mockPlugin, product, config);
+
+        // Different groups produce different resolved names (myapp-cost-analysis vs myapp-insights-cost-analysis)
+        expect(() => {
+          pluginProduct.apply(mockPlugin, mockStore);
+        }).not.toThrow();
+      });
+
+      it('should throw when two resource pages have the same type', () => {
+        const mockPlugin = createMockPlugin();
+        const mockStore = createMockStore();
+        const mockDSL = {
+          product:             jest.fn(),
+          basicType:           jest.fn(),
+          labelGroup:          jest.fn(),
+          setGroupDefaultType: jest.fn(),
+          weightGroup:         jest.fn(),
+          virtualType:         jest.fn(),
+          configureType:       jest.fn(),
+          weightType:          jest.fn(),
+        };
+
+        (mockPlugin.DSL as jest.Mock).mockReturnValue(mockDSL);
+
+        const resource1: ProductChildResourcePage = { type: 'provisioning.cattle.io.cluster' };
+
+        const resource2: ProductChildResourcePage = { type: 'provisioning.cattle.io.cluster' };
+
+        const product: ProductMetadata = {
+          name:  'my-app',
+          label: 'My App',
+        };
+
+        const pluginProduct = new PluginProduct(mockPlugin, product, [resource1, resource2]);
+
+        expect(() => {
+          pluginProduct.apply(mockPlugin, mockStore);
+        }).toThrow('Duplicate resource type "provisioning.cattle.io.cluster"');
+      });
+
+      it('should not throw when pages have different names', () => {
+        const mockPlugin = createMockPlugin();
+        const mockStore = createMockStore();
+        const mockDSL = {
+          product:             jest.fn(),
+          basicType:           jest.fn(),
+          labelGroup:          jest.fn(),
+          setGroupDefaultType: jest.fn(),
+          weightGroup:         jest.fn(),
+          virtualType:         jest.fn(),
+          configureType:       jest.fn(),
+          weightType:          jest.fn(),
+        };
+
+        (mockPlugin.DSL as jest.Mock).mockReturnValue(mockDSL);
+
+        const page1: ProductChildCustomPage = {
+          name:      'overview',
+          label:     'Overview',
+          component: { name: 'Page1' },
+        };
+
+        const page2: ProductChildCustomPage = {
+          name:      'settings',
+          label:     'Settings',
+          component: { name: 'Page2' },
+        };
+
+        const product: ProductMetadata = {
+          name:  'my-app',
+          label: 'My App',
+        };
+
+        const pluginProduct = new PluginProduct(mockPlugin, product, [page1, page2]);
+
+        expect(() => {
+          pluginProduct.apply(mockPlugin, mockStore);
+        }).not.toThrow();
+      });
+    });
+
+    describe('group with component route naming', () => {
+      it('should include the group name in the virtualType route for side-menu highlighting', () => {
+        const mockPlugin = createMockPlugin();
+        const mockStore = createMockStore();
+        const virtualTypeCalls: any[] = [];
+        const mockDSL = {
+          product:             jest.fn(),
+          basicType:           jest.fn(),
+          labelGroup:          jest.fn(),
+          setGroupDefaultType: jest.fn(),
+          weightGroup:         jest.fn(),
+          virtualType:         jest.fn((...args: any[]) => virtualTypeCalls.push(args)),
+          configureType:       jest.fn(),
+          weightType:          jest.fn(),
+        };
+
+        (mockPlugin.DSL as jest.Mock).mockReturnValue(mockDSL);
+
+        const childPage: ProductChildCustomPage = {
+          name:      'alerts',
+          label:     'Alerts',
+          component: { name: 'AlertsPage' },
+        };
+
+        const monitoringGroup: ProductChildGroup = {
+          name:      'monitoring',
+          label:     'Monitoring',
+          component: { name: 'MonitoringOverview' },
+          children:  [childPage],
+        };
+
+        const product: ProductMetadata = {
+          name:  'my-app',
+          label: 'My App',
+        };
+
+        const pluginProduct = new PluginProduct(mockPlugin, product, [monitoringGroup]);
+
+        pluginProduct.apply(mockPlugin, mockStore);
+
+        // Find the virtualType call for the group (has exact + overview flags)
+        const groupVirtualType = virtualTypeCalls.find((call) => call[0].exact === true && call[0].overview === true);
+
+        expect(groupVirtualType).toBeDefined();
+        // The route name should contain the group name 'monitoring', not a generic 'group'
+        expect(groupVirtualType[0].route.name).toStrictEqual(expect.stringContaining('monitoring'));
+        // It should NOT be a generic route without the group name
+        expect(groupVirtualType[0].route.name).not.toBe('myapp-c-cluster');
+      });
     });
   });
 });

--- a/shell/core/plugin-products-base.ts
+++ b/shell/core/plugin-products-base.ts
@@ -321,10 +321,6 @@ export abstract class BasePluginProduct {
           this.surfaceError('Group items cannot have a "type" property - only custom pages can have groups.');
         }
 
-        if (child.component && !this.isNewProduct) {
-          this.surfaceError('When extending an existing product, group parent items cannot have a component because of route matching conflicts.');
-        }
-
         let route;
 
         if (!child.component) {

--- a/shell/core/plugin-products-base.ts
+++ b/shell/core/plugin-products-base.ts
@@ -25,6 +25,8 @@ export abstract class BasePluginProduct {
 
   protected addedResourceRoutes = false;
 
+  protected registeredPageNames: Set<string> = new Set();
+
   protected DSLMethods: any;
 
   protected config: ProductChild[];
@@ -199,15 +201,19 @@ export abstract class BasePluginProduct {
             }
           } else {
             // Group with component - route to the group page itself
-            defaultRoute = pluginProductsHelpers.generateVirtualTypeRoute(this.name, undefined, {
-              omitPath: true, component: firstConfig.component, extendProduct: !this.isNewProduct
-            });
+            const groupAsPage: ProductChildCustomPage = {
+              name: firstConfig.name, label: firstConfig.label || firstConfig.labelKey || firstConfig.name, component: firstConfig.component
+            };
+
+            defaultRoute = pluginProductsHelpers.generateVirtualTypeRoute(this.name, groupAsPage, { omitPath: true, extendProduct: !this.isNewProduct });
           }
         } else if (firstConfig.component) {
           // Group with component but no children - route to the group page itself
-          defaultRoute = pluginProductsHelpers.generateVirtualTypeRoute(this.name, undefined, {
-            omitPath: true, component: firstConfig.component, extendProduct: !this.isNewProduct
-          });
+          const groupAsPage: ProductChildCustomPage = {
+            name: firstConfig.name, label: firstConfig.label || firstConfig.labelKey || firstConfig.name, component: firstConfig.component
+          };
+
+          defaultRoute = pluginProductsHelpers.generateVirtualTypeRoute(this.name, groupAsPage, { omitPath: true, extendProduct: !this.isNewProduct });
         }
       } else if (isProductChildWithType(firstConfig)) {
         // Simple configureType page (resource page)
@@ -248,6 +254,13 @@ export abstract class BasePluginProduct {
       const name = `${ parentName }-${ item.name }`;
       const finalName = groupNaming ? `${ parentName }-${ groupNaming }-${ item.name }` : name;
 
+      // Check for duplicate page names within the same product
+      if (this.registeredPageNames.has(finalName)) {
+        this.surfaceError(`Duplicate page name "${ item.name }" - each page must have a unique name within a product`);
+      }
+
+      this.registeredPageNames.add(finalName);
+
       const virtualTypeConfig: VirtualTypeConfiguration = {
         label:      item.label,
         labelKey:   item.labelKey,
@@ -261,7 +274,15 @@ export abstract class BasePluginProduct {
       if (isProductChildGroup(item)) {
         virtualTypeConfig.exact = true;
         virtualTypeConfig.overview = true;
-        virtualTypeConfig.route = pluginProductsHelpers.generateVirtualTypeRoute(parentName, undefined, { extendProduct: !this.isNewProduct });
+        // Pass group metadata as pageChild so the route gets a unique path segment (e.g. /product/c/:cluster/groupName)
+        // Without this, the route would be identical to the product root and side-menu highlighting would fail
+        const groupAsPage: ProductChildCustomPage = {
+          name:      item.name,
+          label:     item.label || item.labelKey || item.name,
+          component: item.component as ProductChildCustomPage['component']
+        };
+
+        virtualTypeConfig.route = pluginProductsHelpers.generateVirtualTypeRoute(parentName, groupAsPage, { extendProduct: !this.isNewProduct });
       } else {
         virtualTypeConfig.route = pluginProductsHelpers.generateVirtualTypeRoute(parentName, item, { extendProduct: !this.isNewProduct });
       }
@@ -270,6 +291,14 @@ export abstract class BasePluginProduct {
     } else if (isProductChildWithType(item)) {
       // Page with a "type" specified maps to a configureType
       const typeValue = item.type;
+
+      // Check for duplicate resource type within the same product
+      if (this.registeredPageNames.has(typeValue)) {
+        this.surfaceError(`Duplicate resource type "${ typeValue }" - each resource type must be unique within a product`);
+      }
+
+      this.registeredPageNames.add(typeValue);
+
       const route = pluginProductsHelpers.generateConfigureTypeRoute(parentName, item, { extendProduct: !this.isNewProduct });
 
       const configureTypeConfig: ConfigureTypeConfiguration = {
@@ -316,7 +345,14 @@ export abstract class BasePluginProduct {
 
           route = pluginProductsHelpers.generateVirtualTypeRoute(parentName, pageForRoute, { extendProduct: !this.isNewProduct });
         } else {
-          route = pluginProductsHelpers.generateVirtualTypeRoute(parentName, undefined, { component: child.component, extendProduct: !this.isNewProduct });
+          // Pass group metadata as pageChild so the route gets a unique path segment
+          const groupAsPage: ProductChildCustomPage = {
+            name:      child.name,
+            label:     child.label || child.labelKey || child.name,
+            component: child.component
+          };
+
+          route = pluginProductsHelpers.generateVirtualTypeRoute(parentName, groupAsPage, { component: child.component, extendProduct: !this.isNewProduct });
         }
 
         // add the route for the group page/parent

--- a/shell/core/plugin-products-base.ts
+++ b/shell/core/plugin-products-base.ts
@@ -2,7 +2,7 @@ import { IExtension } from '@shell/core/types';
 import {
   ProductChild, ProductMetadata,
   ConfigureTypeConfiguration, VirtualTypeConfiguration,
-  ProductChildCustomPage
+  ProductChildCustomPage, VueRouteComponent, OverviewPageRoutingMetadata
 } from '@shell/core/plugin-types';
 import EmptyProductPage from '@shell/components/EmptyProductPage.vue';
 import pluginProductsHelpers from '@shell/core/plugin-products-helpers';
@@ -68,6 +68,13 @@ export abstract class BasePluginProduct {
       // update config with reordered children
       this.config = reorderedChildren;
     }
+  }
+
+  /**
+   * Generates data for group overview page routing
+   */
+  protected generateMetadataForGroupOverviewPageRouting(name: string, component: VueRouteComponent): OverviewPageRoutingMetadata {
+    return { name, component };
   }
 
   /**
@@ -200,20 +207,12 @@ export abstract class BasePluginProduct {
               defaultRoute = pluginProductsHelpers.generateVirtualTypeRoute(this.name, entryChild, { omitPath: true, extendProduct: !this.isNewProduct });
             }
           } else {
-            // Group with component - route to the group page itself
-            const groupAsPage: ProductChildCustomPage = {
-              name: firstConfig.name, label: firstConfig.label || firstConfig.labelKey || firstConfig.name, component: firstConfig.component
-            };
-
-            defaultRoute = pluginProductsHelpers.generateVirtualTypeRoute(this.name, groupAsPage, { omitPath: true, extendProduct: !this.isNewProduct });
+            // Group with component - route to the group overview page (which will render the group's component and side-menu)
+            defaultRoute = pluginProductsHelpers.generateVirtualTypeRoute(this.name, this.generateMetadataForGroupOverviewPageRouting(firstConfig.name, firstConfig.component), { omitPath: true, extendProduct: !this.isNewProduct });
           }
         } else if (firstConfig.component) {
           // Group with component but no children - route to the group page itself
-          const groupAsPage: ProductChildCustomPage = {
-            name: firstConfig.name, label: firstConfig.label || firstConfig.labelKey || firstConfig.name, component: firstConfig.component
-          };
-
-          defaultRoute = pluginProductsHelpers.generateVirtualTypeRoute(this.name, groupAsPage, { omitPath: true, extendProduct: !this.isNewProduct });
+          defaultRoute = pluginProductsHelpers.generateVirtualTypeRoute(this.name, this.generateMetadataForGroupOverviewPageRouting(firstConfig.name, firstConfig.component), { omitPath: true, extendProduct: !this.isNewProduct });
         }
       } else if (isProductChildWithType(firstConfig)) {
         // Simple configureType page (resource page)
@@ -275,14 +274,7 @@ export abstract class BasePluginProduct {
         virtualTypeConfig.exact = true;
         virtualTypeConfig.overview = true;
         // Pass group metadata as pageChild so the route gets a unique path segment (e.g. /product/c/:cluster/groupName)
-        // Without this, the route would be identical to the product root and side-menu highlighting would fail
-        const groupAsPage: ProductChildCustomPage = {
-          name:      item.name,
-          label:     item.label || item.labelKey || item.name,
-          component: item.component as ProductChildCustomPage['component']
-        };
-
-        virtualTypeConfig.route = pluginProductsHelpers.generateVirtualTypeRoute(parentName, groupAsPage, { extendProduct: !this.isNewProduct });
+        virtualTypeConfig.route = pluginProductsHelpers.generateVirtualTypeRoute(parentName, this.generateMetadataForGroupOverviewPageRouting(item.name, item.component as ProductChildCustomPage['component']), { extendProduct: !this.isNewProduct });
       } else {
         virtualTypeConfig.route = pluginProductsHelpers.generateVirtualTypeRoute(parentName, item, { extendProduct: !this.isNewProduct });
       }
@@ -345,14 +337,7 @@ export abstract class BasePluginProduct {
 
           route = pluginProductsHelpers.generateVirtualTypeRoute(parentName, pageForRoute, { extendProduct: !this.isNewProduct });
         } else {
-          // Pass group metadata as pageChild so the route gets a unique path segment
-          const groupAsPage: ProductChildCustomPage = {
-            name:      child.name,
-            label:     child.label || child.labelKey || child.name,
-            component: child.component
-          };
-
-          route = pluginProductsHelpers.generateVirtualTypeRoute(parentName, groupAsPage, { component: child.component, extendProduct: !this.isNewProduct });
+          route = pluginProductsHelpers.generateVirtualTypeRoute(parentName, this.generateMetadataForGroupOverviewPageRouting(child.name, child.component), { component: child.component, extendProduct: !this.isNewProduct });
         }
 
         // add the route for the group page/parent

--- a/shell/core/plugin-products-helpers.ts
+++ b/shell/core/plugin-products-helpers.ts
@@ -1,6 +1,7 @@
 import {
   RouteRecordRawWithParams, ProductChildGroup, ProductChild,
-  ProductChildCustomPage, ProductChildResourcePage, ProductRegistrationRouteGenerationOptions
+  ProductChildCustomPage, ProductChildResourcePage, ProductRegistrationRouteGenerationOptions,
+  OverviewPageRoutingMetadata
 } from '@shell/core/plugin-types';
 import { BLANK_CLUSTER } from '@shell/store/store-types';
 
@@ -62,7 +63,7 @@ class PluginProductsHelpers {
   }
 
   // VIRTUAL TYPE ROUTES
-  generateVirtualTypeRoute(parentName: string, pageChild: ProductChildCustomPage | undefined, options: ProductRegistrationRouteGenerationOptions = {}): RouteRecordRawWithParams {
+  generateVirtualTypeRoute(parentName: string, pageChild: ProductChildCustomPage | OverviewPageRoutingMetadata | undefined, options: ProductRegistrationRouteGenerationOptions = {}): RouteRecordRawWithParams {
     if (options.extendProduct) {
       return this.generateVirtualTypeRouteForExistingProduct(parentName, pageChild, options);
     } else {
@@ -71,7 +72,7 @@ class PluginProductsHelpers {
   }
 
   // VIRTUAL TYPE ROUTES - CLUSTER LEVEL EXTENSION
-  private generateVirtualTypeRouteForExistingProduct(parentName: string, pageChild: ProductChildCustomPage | undefined, options: ProductRegistrationRouteGenerationOptions = {}): RouteRecordRawWithParams {
+  private generateVirtualTypeRouteForExistingProduct(parentName: string, pageChild: ProductChildCustomPage | OverviewPageRoutingMetadata | undefined, options: ProductRegistrationRouteGenerationOptions = {}): RouteRecordRawWithParams {
     const { component, omitPath } = options;
     const name = pageChild ? `c-cluster-${ parentName }-${ pageChild.name }` : `c-cluster-${ parentName }`;
     const path = pageChild ? `c/:cluster/${ parentName }/${ pageChild.name }` : `c/:cluster/${ parentName }`;
@@ -95,7 +96,7 @@ class PluginProductsHelpers {
   }
 
   // VIRTUAL TYPE ROUTES - TOP LEVEL EXTENSION
-  private generateVirtualTypeRouteForNewProduct(parentName: string, pageChild: ProductChildCustomPage | undefined, options: ProductRegistrationRouteGenerationOptions = {}): RouteRecordRawWithParams {
+  private generateVirtualTypeRouteForNewProduct(parentName: string, pageChild: ProductChildCustomPage | OverviewPageRoutingMetadata | undefined, options: ProductRegistrationRouteGenerationOptions = {}): RouteRecordRawWithParams {
     const { component, omitPath } = options;
     const name = pageChild ? `${ parentName }-c-cluster-${ pageChild.name }` : `${ parentName }-c-cluster`;
     const path = pageChild ? `${ parentName }/c/:cluster/${ pageChild.name }` : `${ parentName }/c/:cluster`;

--- a/shell/core/plugin-types.ts
+++ b/shell/core/plugin-types.ts
@@ -151,11 +151,26 @@ export type ConfigureTypeConfiguration = {
 }
 
 /**
+ * Represents a Vue component or an async function that resolves to a Vue component, used for route components in product configuration
+ */
+export type VueRouteComponent = RouteComponent | Async<RouteComponent>;
+
+/**
+ * Metadata for route generation to a product overview page
+ */
+export type OverviewPageRoutingMetadata = {
+  /** Name of the overview page */
+  name: string;
+  /** Component to render for the overview page */
+  component: VueRouteComponent;
+}
+
+/**
  * Represents a custom page with a component
  */
 export type ProductChildCustomPage = ProductChildMetadata & {
   /** Component to render for this custom page */
-  component: RouteComponent | Async<RouteComponent>;
+  component: VueRouteComponent;
   /** Optional configuration for the page */
   config?: VirtualTypeConfiguration;
 };
@@ -189,7 +204,7 @@ export type ProductChild = ProductChildGroup | ProductChildPage; // eslint-disab
  * Represents a group of child pages in a product configuration
  */
 export type ProductChildGroup = ProductChildMetadata & {
-  component?: RouteComponent | Async<RouteComponent>;
+  component?: VueRouteComponent;
   children: ProductChild[];
   /** Default child to navigate to */
   default?: string;
@@ -218,5 +233,5 @@ export type ProductMetadata = Omit<ProductOptions, 'name' | 'label' | 'labelKey'
  */
 export type ProductSinglePage = ProductMetadata & {
   /** Component to render for this product (single page product) */
-  component: RouteComponent | Async<RouteComponent>;
+  component: VueRouteComponent;
 };

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -5,7 +5,7 @@ import { PaginationSettingsStores } from '@shell/types/resources/settings';
 import type {
   ProductMetadata, ProductSinglePage,
   StandardProductName, RouteRecordRawWithParams, ProductChildGroup,
-  ProductChildPage
+  ProductChildPage, ProductChild
 } from './plugin-types';
 
 // Cluster Provisioning types
@@ -665,6 +665,7 @@ export interface IExtension {
    */
   addProduct(product: ProductMetadata, config: ProductChildGroup[]): void;
   addProduct(product: ProductMetadata, config: ProductChildPage[]): void;
+  addProduct(product: ProductMetadata, config: ProductChild[]): void;
 
   /**
    * Add a product to the sidebar, without children (no side menu, single page only)
@@ -695,6 +696,7 @@ export interface IExtension {
    */
   extendProduct(product: StandardProductName | string, config: ProductChildGroup[]): void;
   extendProduct(product: StandardProductName | string, config: ProductChildPage[]): void;
+  extendProduct(product: StandardProductName | string, config: ProductChild[]): void;
 
   /**
    * Add a locale to the i18n store


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17165 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- create docs for the new product registration (work done in https://github.com/rancher/dashboard/pull/16352)
- fix issue where duplicated resource page inside the same product was being highlighted in both places
- fix issue where group page did not have a defined route name
- removed error throwing that prevented having a group with an overview page when extending an existing product (bug is not there anymore)

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

**One can see the high level topics approached** (for more details, check the markdown files)
<img width="1588" height="1097" alt="Screenshot 2026-04-15 at 14 39 17" src="https://github.com/user-attachments/assets/11a9a2af-747e-4dd9-9030-fe099809e1bf" />
<img width="1588" height="1097" alt="Screenshot 2026-04-15 at 14 39 22" src="https://github.com/user-attachments/assets/37f97411-f7f4-404b-8102-ac7a22b7c634" />
<img width="1588" height="1097" alt="Screenshot 2026-04-15 at 14 39 34" src="https://github.com/user-attachments/assets/e5187ad4-3cde-4f91-9a7c-bcc4a8bea807" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
