### PR TITLE
Unpin the rancher backend for e2e tests now that the backend is fixed

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -9,7 +9,7 @@
         "rancher-image": {
           "namespace": "rancher",
           "name": "rancher",
-          "tag": "v2.15-a5b2d1827f563747ddd896e81af8aada5d8c57e7-head"
+          "tag": "head"
         }
       },
       "rancher-rancher-repo": {


### PR DESCRIPTION
Unpin the rancher backend for e2e tests now that the backend is fixed

Originally pinned here: https://github.com/rancher/dashboard/pull/17240/changes

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
