### PR TITLE
Automation: Restore product default theme after Percy tests

### DIFF
--- a/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
@@ -523,4 +523,8 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
     // takes percy snapshot.
     cy.percySnapshot('fleet clusters list page');
   });
+
+  after(() => {
+    cy.restoreProductDefaultTestTheme();
+  });
 });

--- a/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
@@ -419,6 +419,7 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
     cy.login();
     cy.applyDefaultTestTheme();
   });
+
   it('should display continuous delivery page git repo', () => {
     const gitRepoList = new FleetGitRepoListPagePo();
 
@@ -429,5 +430,9 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
     cy.hideElementBySelector('[data-testid="nav_header_showUserMenu"]', '[data-testid="type-count"]');
     // takes percy snapshot.
     cy.percySnapshot('Continuous Delivery Page - git repos');
+  });
+
+  after(() => {
+    cy.restoreProductDefaultTestTheme();
   });
 });

--- a/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cloud-credential.spec.ts
@@ -347,4 +347,8 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
     // takes percy snapshot.
     cy.percySnapshot('empty cloud credential creation page');
   });
+
+  after(() => {
+    cy.restoreProductDefaultTestTheme();
+  });
 });

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -829,6 +829,7 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
     cy.login();
     cy.applyDefaultTestTheme();
   });
+
   it('should display cluster manager page', () => {
     const clusterList = new ClusterManagerListPagePo();
 
@@ -843,5 +844,9 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
     cy.hideElementBySelector('[data-testid="nav_header_showUserMenu"]', 'td.col-live-date span.live-date');
     // takes percy snapshot.
     cy.percySnapshot('cluster manager list page');
+  });
+
+  after(() => {
+    cy.restoreProductDefaultTestTheme();
   });
 });

--- a/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
+++ b/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
@@ -267,4 +267,8 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
       }
     });
   });
+
+  after(() => {
+    cy.restoreProductDefaultTestTheme();
+  });
 });

--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -385,4 +385,8 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
     // takes percy snapshot.
     cy.percySnapshot('kontainer drivers list page');
   });
+
+  after(() => {
+    cy.restoreProductDefaultTestTheme();
+  });
 });

--- a/cypress/e2e/tests/pages/manager/machines.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machines.spec.ts
@@ -151,4 +151,8 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
     // takes percy snapshot.
     cy.percySnapshot('machines list page');
   });
+
+  after(() => {
+    cy.restoreProductDefaultTestTheme();
+  });
 });

--- a/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
+++ b/cypress/e2e/tests/pages/manager/pod-security-admissions.spec.ts
@@ -189,4 +189,8 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
     // takes percy snapshot.
     cy.percySnapshot('Pod Security Admissions list page');
   });
+
+  after(() => {
+    cy.restoreProductDefaultTestTheme();
+  });
 });

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -123,6 +123,7 @@ declare global {
         wait?: number,
       }): Chainable;
       applyDefaultTestTheme(): Chainable<any>;
+      restoreProductDefaultTestTheme(): Chainable<any>;
       getRancherVersion(): Chainable<any>;
       getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode?: number): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: any): Chainable;

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -1445,3 +1445,29 @@ Cypress.Commands.add('applyDefaultTestTheme', () => {
       });
     });
 });
+
+/**
+ * Restores `ui-brand` to the product default: suse for Rancher Prime, modern for Community.
+ * Clears the forced `ui-light` user preference so the session matches normal defaults.
+ */
+Cypress.Commands.add('restoreProductDefaultTestTheme', () => {
+  cy.getRancherVersion().then((version: { RancherPrime?: string }) => {
+    const uiBrand = version.RancherPrime === 'true' ? 'suse' : 'modern';
+
+    cy.setRancherResource('v3', 'settings', 'ui-brand', { value: uiBrand })
+      .then((response: Cypress.Response<{ value?: string }>) => {
+        Cypress.log({
+          name:    'setRancherResource',
+          message: `Rancher UI brand restored to: ${ response.body?.value || uiBrand }`
+        });
+      });
+
+    cy.setUserPreference({ theme: '' })
+      .then(() => {
+        Cypress.log({
+          name:    'setUserPreference',
+          message: 'User theme preference cleared (product default)'
+        });
+      });
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2262, https://github.com/rancher/qa-tasks/issues/2265, https://github.com/rancher/qa-tasks/issues/2273

Issue: `cy.applyDefaultTestTheme()` was forcing the modern ui-brand in eight Percy specs without restoring it, so Rancher Prime stayed on community branding and the UI showed plain “Rancher” instead of “Rancher Prime”—which broke title assertions.
Fix: Added `cy.restoreProductDefaultTestTheme()` so visual tests put ui-brand and theme back to defaults: `suse` on Prime and `modern` on community, and clear the forced ui-light preference. Wired it into each Percy suite’s after hook.
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
