### PR TITLE
Removed authorized endpoint for local cluster

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -599,7 +599,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
       editLocalClusterPage.accordion(2, 'K3S Options').should('be.visible'); // for K3S local cluster its K3S Options
       editLocalClusterPage.accordion(3, 'Member Roles').scrollIntoView().should('be.visible');
       editLocalClusterPage.accordion(4, 'Labels and Annotations').scrollIntoView().should('be.visible');
-      editLocalClusterPage.accordion(5, 'Networking').scrollIntoView().should('not.be.visible');
+      editLocalClusterPage.accordion(5, 'Networking').should('not.be.visible');
       editLocalClusterPage.accordion(6, 'Registries').scrollIntoView().should('be.visible');
       editLocalClusterPage.accordion(7, 'Advanced').scrollIntoView().should('be.visible');
 

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -599,7 +599,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
       editLocalClusterPage.accordion(2, 'K3S Options').should('be.visible'); // for K3S local cluster its K3S Options
       editLocalClusterPage.accordion(3, 'Member Roles').scrollIntoView().should('be.visible');
       editLocalClusterPage.accordion(4, 'Labels and Annotations').scrollIntoView().should('be.visible');
-      editLocalClusterPage.accordion(5, 'Networking').should('not.be.visible');
+      editLocalClusterPage.accordion(5, 'Networking').should('not.exist');
       editLocalClusterPage.accordion(6, 'Registries').scrollIntoView().should('be.visible');
       editLocalClusterPage.accordion(7, 'Advanced').scrollIntoView().should('be.visible');
 

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -600,8 +600,8 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
       editLocalClusterPage.accordion(3, 'Member Roles').scrollIntoView().should('be.visible');
       editLocalClusterPage.accordion(4, 'Labels and Annotations').scrollIntoView().should('be.visible');
       editLocalClusterPage.accordion(5, 'Networking').should('not.exist');
-      editLocalClusterPage.accordion(6, 'Registries').scrollIntoView().should('be.visible');
-      editLocalClusterPage.accordion(7, 'Advanced').scrollIntoView().should('be.visible');
+      editLocalClusterPage.accordion(5, 'Registries').scrollIntoView().should('be.visible');
+      editLocalClusterPage.accordion(6, 'Advanced').scrollIntoView().should('be.visible');
 
       // Issue #13614: Imported Cluster Version Mgmt: Conditionally show warning message
       editLocalClusterPage.versionManagementBanner().should('not.exist');

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -599,7 +599,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
       editLocalClusterPage.accordion(2, 'K3S Options').should('be.visible'); // for K3S local cluster its K3S Options
       editLocalClusterPage.accordion(3, 'Member Roles').scrollIntoView().should('be.visible');
       editLocalClusterPage.accordion(4, 'Labels and Annotations').scrollIntoView().should('be.visible');
-      editLocalClusterPage.accordion(5, 'Networking').scrollIntoView().should('be.visible');
+      editLocalClusterPage.accordion(5, 'Networking').scrollIntoView().should('not.be.visible');
       editLocalClusterPage.accordion(6, 'Registries').scrollIntoView().should('be.visible');
       editLocalClusterPage.accordion(7, 'Advanced').scrollIntoView().should('be.visible');
 

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -582,15 +582,16 @@ export default defineComponent({
             :label="t('cluster.rke2.enableNetworkPolicy.label')"
           />
         </div>
-        <h3>{{ t('cluster.tabs.ace') }}</h3>
-        <ACE
-          v-if="!isLocal"
-          v-model:value="normanCluster.localClusterAuthEndpoint"
-          :mode="mode"
-          @local-cluster-auth-endpoint-changed="enableLocalClusterAuthEndpoint"
-          @ca-certs-changed="(val)=>normanCluster.localClusterAuthEndpoint.caCerts = val"
-          @fqdn-changed="(val)=>normanCluster.localClusterAuthEndpoint.fqdn = val"
-        />
+        <div v-if="!isLocal">
+          <h3>{{ t('cluster.tabs.ace') }}</h3>
+          <ACE
+            v-model:value="normanCluster.localClusterAuthEndpoint"
+            :mode="mode"
+            @local-cluster-auth-endpoint-changed="enableLocalClusterAuthEndpoint"
+            @ca-certs-changed="(val)=>normanCluster.localClusterAuthEndpoint.caCerts = val"
+            @fqdn-changed="(val)=>normanCluster.localClusterAuthEndpoint.fqdn = val"
+          />
+        </div>
       </Accordion>
       <Accordion
         v-if="!isRKE1"

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -561,7 +561,7 @@ export default defineComponent({
         />
       </Accordion>
       <Accordion
-        v-if="!isCreate & !isRKE1"
+        v-if="!isCreate && !isRKE1 && (!isLocal || enableNetworkPolicySupported)"
         class="mb-20 accordion"
         title-key="imported.accordions.networking"
         data-testid="network-accordion"
@@ -582,8 +582,9 @@ export default defineComponent({
             :label="t('cluster.rke2.enableNetworkPolicy.label')"
           />
         </div>
-        <h3 v-t="'cluster.tabs.ace'" />
+        <h3>{{ t('cluster.tabs.ace') }}</h3>
         <ACE
+          v-if="!isLocal"
           v-model:value="normanCluster.localClusterAuthEndpoint"
           :mode="mode"
           @local-cluster-auth-endpoint-changed="enableLocalClusterAuthEndpoint"

--- a/pkg/imported/components/__tests__/CruImported.test.ts
+++ b/pkg/imported/components/__tests__/CruImported.test.ts
@@ -1,0 +1,124 @@
+import { shallowMount } from '@vue/test-utils';
+import CruImported from '@pkg/imported/components/CruImported.vue';
+import { _CREATE, _EDIT } from '@shell/config/query-params';
+import { IMPORTED_CLUSTER_VERSION_MANAGEMENT } from '@shell/config/labels-annotations';
+
+describe('cruImported component', () => {
+  const defaultSetup = {
+    global: {
+      mocks: {
+        $store: {
+          getters: {
+            'i18n/t':               (key: string) => key,
+            'features/get':         () => false,
+            'prefs/get':            () => [],
+            currentStore:           () => 'rancher',
+            'rancher/schemaFor':    jest.fn(),
+            'management/schemaFor': jest.fn(),
+          },
+          dispatch: jest.fn().mockResolvedValue({}),
+        },
+        $route:      { query: {} },
+        $fetchState: { pending: false }
+      },
+      stubs: {
+        CruResource:             { template: '<div><slot></slot></div>' },
+        Accordion:               { template: '<div class="accordion"><slot></slot></div>' },
+        Banner:                  true,
+        ClusterMembershipEditor: true,
+        Labels:                  true,
+        Basics:                  true,
+        ACE:                     true,
+        Checkbox:                true,
+        SchedulingCustomization: true,
+        KeyValue:                true,
+        NameNsDescription:       true,
+        Loading:                 true,
+        'router-link':           true
+      }
+    },
+    data: () => ({
+      normanCluster: {
+        name:                     '',
+        annotations:              { [IMPORTED_CLUSTER_VERSION_MANAGEMENT]: 'system-default' },
+        importedConfig:           {},
+        localClusterAuthEndpoint: {}
+      }
+    })
+  };
+
+  describe('networking tab visibility', () => {
+    it('should show the networking tab when not in create mode, not RKE1, and not local', () => {
+      const wrapper = shallowMount(CruImported, {
+        props: {
+          mode:  _EDIT,
+          value: {
+            id:                'cluster-id',
+            isRke1:            false,
+            isLocal:           false,
+            findNormanCluster: jest.fn().mockResolvedValue({})
+          }
+        },
+        ...defaultSetup
+      });
+
+      const networkAccordion = wrapper.find('[data-testid="network-accordion"]');
+
+      expect(networkAccordion.exists()).toBe(true);
+    });
+
+    it('should hide the networking tab in create mode', () => {
+      const wrapper = shallowMount(CruImported, {
+        props: {
+          mode:  _CREATE,
+          value: {
+            isRke1:  false,
+            isLocal: false,
+          }
+        },
+        ...defaultSetup
+      });
+
+      const networkAccordion = wrapper.find('[data-testid="network-accordion"]');
+
+      expect(networkAccordion.exists()).toBe(false);
+    });
+
+    it('should not display the ACE component if cluster is local', () => {
+      const wrapper = shallowMount(CruImported, {
+        props: {
+          mode:  _EDIT,
+          value: {
+            id:                'cluster-id',
+            isRke1:            false,
+            isLocal:           true,
+            findNormanCluster: jest.fn().mockResolvedValue({})
+          }
+        },
+        ...defaultSetup
+      });
+
+      const ace = wrapper.findComponent({ name: 'ACE' });
+
+      expect(ace.exists()).toBe(false);
+    });
+    it('should display the ACE component if cluster is not local', () => {
+      const wrapper = shallowMount(CruImported, {
+        props: {
+          mode:  _EDIT,
+          value: {
+            id:                'cluster-id',
+            isRke1:            false,
+            isLocal:           false,
+            findNormanCluster: jest.fn().mockResolvedValue({})
+          }
+        },
+        ...defaultSetup
+      });
+
+      const ace = wrapper.findComponent({ name: 'ACE' });
+
+      expect(ace.exists()).toBe(true);
+    });
+  });
+});

--- a/pkg/imported/components/__tests__/CruImported.test.ts
+++ b/pkg/imported/components/__tests__/CruImported.test.ts
@@ -50,7 +50,7 @@ describe('cruImported component', () => {
   describe('networking tab visibility', () => {
     it('should show the networking tab when not in create mode, not RKE1, and not local', () => {
       const wrapper = shallowMount(CruImported, {
-        props: {
+        propsData: {
           mode:  _EDIT,
           value: {
             id:                'cluster-id',
@@ -69,7 +69,7 @@ describe('cruImported component', () => {
 
     it('should hide the networking tab in create mode', () => {
       const wrapper = shallowMount(CruImported, {
-        props: {
+        propsData: {
           mode:  _CREATE,
           value: {
             isRke1:  false,
@@ -84,9 +84,51 @@ describe('cruImported component', () => {
       expect(networkAccordion.exists()).toBe(false);
     });
 
+    it('should show the networking tab when not in create mode, not RKE1, is local, and enableNetworkPolicySupported is true', () => {
+      const wrapper = shallowMount(CruImported, {
+        propsData: {
+          mode:  _EDIT,
+          value: {
+            id:                'cluster-id',
+            isRke1:            false,
+            isLocal:           true,
+            isK3s:             false,
+            isRke2:            false,
+            findNormanCluster: jest.fn().mockResolvedValue({})
+          }
+        },
+        ...defaultSetup
+      });
+
+      const networkAccordion = wrapper.find('[data-testid="network-accordion"]');
+
+      expect(networkAccordion.exists()).toBe(true);
+    });
+
+    it('should hide the networking tab when not in create mode, not RKE1, is local, and enableNetworkPolicySupported is false', () => {
+      const wrapper = shallowMount(CruImported, {
+        propsData: {
+          mode:  _EDIT,
+          value: {
+            id:                'cluster-id',
+            isRke1:            false,
+            isLocal:           true,
+            isK3s:             true,
+            isRke2:            false,
+            findNormanCluster: jest.fn().mockResolvedValue({})
+          }
+        },
+        ...defaultSetup
+      });
+
+      const networkAccordion = wrapper.find('[data-testid="network-accordion"]');
+
+      expect(networkAccordion.exists()).toBe(false);
+    });
+
     it('should not display the ACE component if cluster is local', () => {
       const wrapper = shallowMount(CruImported, {
-        props: {
+        propsData: {
           mode:  _EDIT,
           value: {
             id:                'cluster-id',
@@ -104,7 +146,7 @@ describe('cruImported component', () => {
     });
     it('should display the ACE component if cluster is not local', () => {
       const wrapper = shallowMount(CruImported, {
-        props: {
+        propsData: {
           mode:  _EDIT,
           value: {
             id:                'cluster-id',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16887 
<!-- Define findings related to the feature or bug issue. -->
Removed ACE for local cluster.
Added tests.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Hid ACE component for a local cluster.
Hid Networking accordion for a local cluster but still showing Networking if enabling network policy is supported. 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Check that ACE is hidden for local cluster.
Check that Networking tab is hidden for local cluster if it is rke2 or k3s (I am not sure if it is possible, but decided to keep the check in case it is)
Check that Networking tab is not hidden for non-local cluster or imported clusters that are not rke2 or k3s

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Imported clusters could be affected

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
