### PR TITLE
[Jenkins] Adding method to CAPI e2e tests

### DIFF
--- a/cypress/e2e/po/components/action-menu.po.ts
+++ b/cypress/e2e/po/components/action-menu.po.ts
@@ -12,4 +12,8 @@ export default class ActionMenuPo extends ComponentPo {
   getMenuItem(name: string) {
     return this.self().find('[dropdown-menu-item]').contains(name);
   }
+
+  static checkNoActionMenuIsVisible() {
+    return cy.get('[dropdown-menu-collection]:visible').should('have.length', 0);
+  }
 }

--- a/cypress/e2e/po/lists/base-resource-list.po.ts
+++ b/cypress/e2e/po/lists/base-resource-list.po.ts
@@ -22,13 +22,6 @@ export default class BaseResourceList extends ComponentPo {
     return this.resourceTable().sortableTable().rowActionMenuClose(rowLabel);
   }
 
-  /**
-   * Asserts that no action menu dropdowns are currently visible
-   */
-  checkActionMenuNotVisible() {
-    return cy.get('body').find('[dropdown-menu-collection]:visible').should('have.length', 0);
-  }
-
   rowWithName(rowLabel: string) {
     return this.resourceTable().sortableTable().rowWithName(rowLabel);
   }

--- a/cypress/e2e/po/lists/base-resource-list.po.ts
+++ b/cypress/e2e/po/lists/base-resource-list.po.ts
@@ -22,6 +22,13 @@ export default class BaseResourceList extends ComponentPo {
     return this.resourceTable().sortableTable().rowActionMenuClose(rowLabel);
   }
 
+  /**
+   * Asserts that no action menu dropdowns are currently visible
+   */
+  checkActionMenuNotVisible() {
+    return cy.get('body').find('[dropdown-menu-collection]:visible').should('have.length', 0);
+  }
+
   rowWithName(rowLabel: string) {
     return this.resourceTable().sortableTable().rowWithName(rowLabel);
   }

--- a/cypress/e2e/tests/pages/manager/v2prov-capi.spec.ts
+++ b/cypress/e2e/tests/pages/manager/v2prov-capi.spec.ts
@@ -1,5 +1,6 @@
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import ActionMenuPo from '@/cypress/e2e/po/components/action-menu.po';
 import { qase } from '@/cypress/support/qase';
 
 import { mockCapiMgmtCluster, mockCapiProvCluster } from '@/cypress/e2e/blueprints/manager/v2prov-capi-cluster-mocks';
@@ -38,7 +39,7 @@ describe('Cluster List - v2 Provisioning CAPI Clusters', { tags: ['@manager', '@
 
     // Close the first row action menu so its overlay does not block subsequent row actions.
     clusterList.list().actionMenuClose(clusterName);
-    clusterList.list().checkActionMenuNotVisible();
+    ActionMenuPo.checkNoActionMenuIsVisible();
 
     clusterList.list().actionMenu('local').getMenuItem('Edit Config').should('exist');
   }));

--- a/cypress/e2e/tests/pages/manager/v2prov-capi.spec.ts
+++ b/cypress/e2e/tests/pages/manager/v2prov-capi.spec.ts
@@ -38,7 +38,7 @@ describe('Cluster List - v2 Provisioning CAPI Clusters', { tags: ['@manager', '@
 
     // Close the first row action menu so its overlay does not block subsequent row actions.
     clusterList.list().actionMenuClose(clusterName);
-    cy.get('body').find('[dropdown-menu-collection]:visible').should('have.length', 0);
+    clusterList.list().checkActionMenuNotVisible();
 
     clusterList.list().actionMenu('local').getMenuItem('Edit Config').should('exist');
   }));


### PR DESCRIPTION
Created method `checkActionMenuNotVisible();` in `cypress/e2e/po/lists/base-resource-list.po.ts` that asserts that a given action menu dropdown is not visible in the page, as a way to ensure the dropdown is properly closed before proceeding with the tests. The method can be applied to all the page objects that extend the `base-resource-list.po`. But this PR addresses its implementation for the `/cypress/e2e/tests/pages/manager/v2prov-capi.spec.ts`.

### Summary
Fixes #
Addresses the PR feedback from backport 2.14 (https://github.com/rancher/dashboard/pull/17203#discussion_r3081709228) to make it consistent across all versions

### Areas or cases that should be tested
Run `v2prov-capi.spec.ts` 

### Areas which could experience regressions
double check that there's no regression with the use of ActionMenuClose();

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
