### PR TITLE
Automation: Update assertion to checkCountAtLeast

### DIFF
--- a/cypress/e2e/po/components/notification-center.po.ts
+++ b/cypress/e2e/po/components/notification-center.po.ts
@@ -84,4 +84,9 @@ export default class NotificationsCenterPo extends ComponentPo {
   checkCount(count: number) {
     return this.self().find('[data-testid="notifications-center-item"]').should('have.length', count);
   }
+
+  /** Assert at least `min` notifications (exact count may vary). */
+  checkCountAtLeast(min: number) {
+    return this.self().find('[data-testid="notifications-center-item"]').should('have.length.at.least', min);
+  }
 }

--- a/cypress/e2e/tests/pages/generic/home.spec.ts
+++ b/cypress/e2e/tests/pages/generic/home.spec.ts
@@ -36,11 +36,12 @@ function goToHomePageAndSettle() {
 }
 
 // Prime shows an extra notification vs Community
+// Min items: Community 1, Prime 2. Count can be higher (dynamic new-release applies to Community and Prime).
 function assertHomeNotificationCount(nc: NotificationsCenterPo) {
   cy.getRancherVersion().then((version) => {
-    const expectedCount = version.RancherPrime === 'true' ? 2 : 1;
+    const minCount = version.RancherPrime === 'true' ? 2 : 1;
 
-    nc.checkCount(expectedCount);
+    nc.checkCountAtLeast(minCount);
   });
 }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2271

Home page Cypress was asserting an exact notification count, which breaks when extra items (for example new-release notices) appear. This adds checkCountAtLeast on the notification center PO and switches the home spec to require at least 1 (Community) or 2 (Prime) items instead of an exact length.

Changes made in 2.13 and 2.14 already.
Forward port of commit https://github.com/rancher/dashboard/pull/17146/commits/7c37af7fbb4829f3f78ef7b00f0f5dba8f784b24

<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
