### PR TITLE
Automation: Update harvester tests for prime

### DIFF
--- a/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
+++ b/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
@@ -3,6 +3,7 @@ import { HarvesterClusterDetailsPo, HarvesterClusterPagePo } from '@/cypress/e2e
 import RepositoriesPagePo from '@/cypress/e2e/po/pages/chart-repositories.po';
 import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 import { CLUSTER_REPOS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
+import { qase } from '~/cypress/support/qase';
 
 const extensionsPo = new ExtensionsPagePo();
 const harvesterPo = new HarvesterClusterPagePo();
@@ -30,6 +31,27 @@ function harvesterExtensionCatalog(version: Cypress.RancherVersion) {
 }
 
 describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
+  before(() => {
+    cy.login();
+
+    // Clean up stale Harvester extension app and extension source repos to prevent test collisions
+    cy.createRancherResource('v1', 'catalog.cattle.io.apps/cattle-ui-plugin-system/harvester?action=uninstall', {}, false);
+
+    cy.getRancherResource('v1', 'catalog.cattle.io.clusterrepos').then((resp: Cypress.Response<any>) => {
+      const extensionRepoUrls = ['rancher/ui-plugin-charts', 'harvester/harvester-ui-extension'];
+      const matchingRepoIds = (resp.body?.data || [])
+        .filter((repo: any) => extensionRepoUrls.some((url) => repo?.spec?.gitRepo?.includes(url)))
+        .map((repo: any) => repo?.id)
+        .filter((id: string | undefined) => !!id);
+
+      cy.wrap(matchingRepoIds, { log: false }).each((repoId: string) => {
+        cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', repoId);
+        cy.waitForRancherResource('v1', 'catalog.cattle.io.clusterrepos', repoId, (resourceResp) => resourceResp.status === 404, 10, { failOnStatusCode: false })
+          .should('eq', true);
+      });
+    });
+  });
+
   beforeEach(() => {
     cy.login();
     cy.getRancherVersion().then((version) => {
@@ -40,14 +62,7 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
     });
   });
 
-  /**
-   * Assumes that Harvester Extension is NOT installed
-   *
-   * Harvester Extension will also be removed after all tests run
-   *
-   * (pattern needs fixing)
-   */
-  it('can auto install harvester and begin process of importing a harvester cluster', () => {
+  qase(7020, it('can auto install harvester and begin process of importing a harvester cluster', () => {
     cy.get<Cypress.RancherVersion>('@rancherVersion').then((version) => {
       const catalog = harvesterExtensionCatalog(version);
       const chartRepo = catalog.repo;
@@ -117,9 +132,9 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
         cy.deleteRancherResource('v1', 'provisioning.cattle.io.clusters', `fleet-default/${ harvesterClusterId }`);
       });
     });
-  });
+  }));
 
-  it('missing repo message should display when repo does NOT exist', () => {
+  qase(7021, it('missing repo message should display when repo does NOT exist', () => {
     cy.get<Cypress.RancherVersion>('@rancherVersion').then((version) => {
       const catalog = harvesterExtensionCatalog(version);
       const chartRepo = catalog.repo;
@@ -193,9 +208,9 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
       harvesterPo.updateOrInstallButton().checkVisible();
       harvesterPo.extensionWarning().should('have.text', 'The Harvester UI Extension is not installed');
     });
-  });
+  }));
 
-  it('able to update harvester extension version', () => {
+  qase(7022, it('able to update harvester extension version', () => {
     cy.get<Cypress.RancherVersion>('@rancherVersion').then((version) => {
       const catalog = harvesterExtensionCatalog(version);
       const chartRepo = catalog.repo;
@@ -280,12 +295,16 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
         extensionsPo.extensionCardHeaderStatusTooltip(harvesterTitle, 0).waitForTooltipWithText(`Installed (${ versions[0] })`);
       });
     });
-  });
+  }));
 
   afterEach(() => {
+    // Ensure Harvester extension is uninstalled and repo is deleted
     cy.createRancherResource('v1', 'catalog.cattle.io.apps/cattle-ui-plugin-system/harvester?action=uninstall', {}, false);
     cy.get<Cypress.RancherVersion>('@rancherVersion').then((version) => {
       cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', harvesterExtensionCatalog(version).repo, false);
+      // Verify deletion completed before proceeding (with retries)
+      cy.waitForRancherResource('v1', 'catalog.cattle.io.clusterrepos', harvesterExtensionCatalog(version).repo, (resp) => resp.status === 404, 10, { failOnStatusCode: false })
+        .should('eq', true);
     });
   });
 });

--- a/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
+++ b/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
@@ -9,30 +9,24 @@ const harvesterPo = new HarvesterClusterPagePo();
 const appRepoList = new RepositoriesPagePo(undefined, 'manager');
 
 let harvesterClusterName = '';
-const harvesterGitRepoName = 'harvester';
 const harvesterTitle = 'Harvester';
-const branchName = 'gh-pages';
-const harvesterGitRepoUrl = 'https://github.com/harvester/harvester-ui-extension.git';
 
-/**
- * Conditional retry for Harvester extension installation based on UI warning message
- * Checks for the "Warning, Harvester UI extension automatic installation failed" message
- * and reloads the page to retry if detected
- * Need conditional retry until this is resolved https://github.com/rancher/dashboard/issues/13093
- */
-function conditionalRetryHarvesterInstallation() {
-  // Check if the installation failed warning is displayed
-  harvesterPo.extensionWarning().then(($warning) => {
-    if ($warning.text().includes('Warning, Harvester UI extension automatic installation failed')) {
-      cy.log('Detected Harvester installation failed warning, reloading page and retrying...');
-      cy.reload();
-      harvesterPo.waitForPage();
-      // Second attempt at installation after reload...
-      harvesterPo.updateOrInstallButton().click();
-    } else {
-      cy.log('No installation failed warning detected, proceeding normally');
-    }
-  });
+// Cluster chart repository that supplies the Harvester UI extension (repo id, Git URL, branch)—differs for Community vs Prime.
+const HARVESTER_EXTENSION_CATALOG = {
+  community: {
+    repo:      'harvester',
+    gitRepo:   'https://github.com/harvester/harvester-ui-extension.git',
+    gitBranch: 'gh-pages',
+  },
+  prime: {
+    repo:      'rancher',
+    gitRepo:   'https://github.com/rancher/ui-plugin-charts',
+    gitBranch: 'main',
+  },
+};
+
+function harvesterExtensionCatalog(version: { RancherPrime?: string }) {
+  return version.RancherPrime === 'true' ? HARVESTER_EXTENSION_CATALOG.prime : HARVESTER_EXTENSION_CATALOG.community;
 }
 
 describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
@@ -51,237 +45,244 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
    * (pattern needs fixing)
    */
   it('can auto install harvester and begin process of importing a harvester cluster', () => {
-    cy.intercept('POST', CLUSTER_REPOS_BASE_URL).as('createHarvesterChart');
-    cy.intercept('PUT', `${ CLUSTER_REPOS_BASE_URL }/${ harvesterGitRepoName }`).as('updateHarvesterChart');
-    cy.intercept('POST', `${ CLUSTER_REPOS_BASE_URL }/${ harvesterGitRepoName }?action=install`).as('installHarvesterExtension');
-    cy.intercept('POST', '/v3/clusters').as('createHarvesterCluster');
+    cy.getRancherVersion().then((version) => {
+      const catalog = harvesterExtensionCatalog(version);
+      const chartRepo = catalog.repo;
 
-    // verify install button and message displays
-    harvesterPo.goTo();
-    harvesterPo.waitForPage();
-    harvesterPo.updateOrInstallButton().checkVisible();
-    harvesterPo.extensionWarning().should('have.text', 'The Harvester UI Extension is not installed');
+      cy.intercept('POST', CLUSTER_REPOS_BASE_URL).as('createChart');
+      cy.intercept('PUT', `${ CLUSTER_REPOS_BASE_URL }/${ chartRepo }`).as('updateChart');
+      cy.intercept('POST', `${ CLUSTER_REPOS_BASE_URL }/${ chartRepo }?action=install`).as('installHarvesterExtension');
+      cy.intercept('POST', '/v3/clusters').as('createHarvesterCluster');
 
-    // install harvester extension
-    harvesterPo.updateOrInstallButton().click();
-    cy.wait('@createHarvesterChart', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 201);
-    cy.wait('@updateHarvesterChart', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
-    // Wait for the installation request and handle 500 errors
-    cy.wait('@installHarvesterExtension', MEDIUM_TIMEOUT_OPT).then((interception) => {
-      const statusCode = interception.response?.statusCode;
-
-      if (statusCode === 201) {
-        cy.log('Harvester extension installation succeeded on first attempt');
-      } else if (statusCode === 500) {
-        cy.log('Harvester extension installation failed with 500 error, lets retry...');
-        conditionalRetryHarvesterInstallation();
-      } else {
-        throw new Error(`Unexpected status code: ${ statusCode }`);
-      }
-    });
-    harvesterPo.waitForPage();
-    cy.wait('@updateHarvesterChart', LONG_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
-    harvesterPo.extensionWarning(MEDIUM_TIMEOUT_OPT).should('not.exist');
-
-    // verify harvester extension added to extensions page
-    extensionsPo.goTo();
-    extensionsPo.waitForPage(null, 'installed');
-    extensionsPo.loading().should('not.exist');
-    extensionsPo.extensionCard(harvesterTitle).checkVisible();
-
-    // verify harvester repo is added to repos list page
-    appRepoList.goTo(undefined, 'manager');
-    appRepoList.waitForPage();
-    appRepoList.sortableTable().rowElementWithName(harvesterGitRepoName).should('be.visible');
-    appRepoList.list().state(harvesterGitRepoName).contains('Active', LONG_TIMEOUT_OPT);
-
-    // begin process of importing harvester cluster
-    harvesterPo.goTo();
-    harvesterPo.waitForPage();
-    cy.wait('@updateHarvesterChart', LONG_TIMEOUT_OPT);
-    harvesterPo.importHarvesterClusterButton().click();
-    harvesterPo.createHarvesterClusterForm().waitForPage(null, 'memberRoles');
-    harvesterPo.createHarvesterClusterForm().title().should('contain', 'Harvester Cluster:');
-    harvesterPo.createHarvesterClusterForm().nameNsDescription().name().set(harvesterClusterName);
-    harvesterPo.createHarvesterClusterForm().nameNsDescription().description().set(`${ harvesterClusterName }-desc`);
-    harvesterPo.createHarvesterClusterForm().resourceDetail().createEditView().create();
-    cy.wait('@createHarvesterCluster').then(({ response }) => {
-      expect(response?.statusCode).to.eq(201);
-
-      const harvesterClusterId = response.body.id;
-      const harvesterDetails = new HarvesterClusterDetailsPo(undefined, undefined, harvesterClusterId);
-
-      harvesterDetails.waitForPage(null, 'registration');
-      harvesterDetails.title().should('contain', harvesterClusterName);
-
-      // navigate to harvester list page and verify the logo and tagline do not display after cluster created
-      HarvesterClusterPagePo.navTo();
+      // verify install button and message displays
+      harvesterPo.goTo();
       harvesterPo.waitForPage();
-      harvesterPo.list().resourceTable().sortableTable().rowWithName(harvesterClusterName)
-        .checkVisible();
-      harvesterPo.harvesterLogo().should('not.exist');
-      harvesterPo.harvesterTagline().should('not.exist');
+      harvesterPo.updateOrInstallButton().checkVisible();
+      harvesterPo.extensionWarning().should('have.text', 'The Harvester UI Extension is not installed');
 
-      // #14285: Should be able to edit cluster here
-      harvesterPo.list().actionMenu(harvesterClusterName).getMenuItem('Edit Config').should('exist');
-      // delete cluster
-      cy.deleteRancherResource('v1', 'provisioning.cattle.io.clusters', `fleet-default/${ harvesterClusterId }`);
+      // install harvester extension
+      harvesterPo.updateOrInstallButton().click();
+      cy.wait('@createChart', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 201);
+      cy.wait('@updateChart', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
+      cy.wait('@installHarvesterExtension', MEDIUM_TIMEOUT_OPT);
+      harvesterPo.waitForPage();
+      cy.wait('@updateChart', LONG_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
+      harvesterPo.extensionWarning(MEDIUM_TIMEOUT_OPT).should('not.exist');
+
+      // verify harvester extension added to extensions page
+      extensionsPo.goTo();
+      extensionsPo.waitForTabs();
+      extensionsPo.waitForPage(null, 'installed');
+      extensionsPo.extensionCard(harvesterTitle).checkVisible();
+
+      // verify harvester repo is added to repos list page
+      appRepoList.goTo(undefined, 'manager');
+      appRepoList.waitForPage();
+      appRepoList.sortableTable().rowElementWithName(chartRepo).should('be.visible');
+      appRepoList.list().state(chartRepo).contains('Active', LONG_TIMEOUT_OPT);
+
+      // begin process of importing harvester cluster
+      harvesterPo.goTo();
+      harvesterPo.waitForPage();
+      cy.wait('@updateChart', LONG_TIMEOUT_OPT);
+      harvesterPo.importHarvesterClusterButton().click();
+      harvesterPo.createHarvesterClusterForm().waitForPage(null, 'memberRoles');
+      harvesterPo.createHarvesterClusterForm().title().should('contain', 'Harvester Cluster:');
+      harvesterPo.createHarvesterClusterForm().nameNsDescription().name().set(harvesterClusterName);
+      harvesterPo.createHarvesterClusterForm().nameNsDescription().description().set(`${ harvesterClusterName }-desc`);
+      harvesterPo.createHarvesterClusterForm().resourceDetail().createEditView().create();
+      cy.wait('@createHarvesterCluster').then(({ response }) => {
+        expect(response?.statusCode).to.eq(201);
+
+        const harvesterClusterId = response.body.id;
+        const harvesterDetails = new HarvesterClusterDetailsPo(undefined, undefined, harvesterClusterId);
+
+        harvesterDetails.waitForPage(null, 'registration');
+        harvesterDetails.title().should('contain', harvesterClusterName);
+
+        // navigate to harvester list page and verify the logo and tagline do not display after cluster created
+        HarvesterClusterPagePo.navTo();
+        harvesterPo.waitForPage();
+        harvesterPo.list().resourceTable().sortableTable().rowWithName(harvesterClusterName)
+          .checkVisible();
+        harvesterPo.harvesterLogo().should('not.exist');
+        harvesterPo.harvesterTagline().should('not.exist');
+
+        // #14285: Should be able to edit cluster here
+        harvesterPo.list().actionMenu(harvesterClusterName).getMenuItem('Edit Config').should('exist');
+        // delete cluster
+        cy.deleteRancherResource('v1', 'provisioning.cattle.io.clusters', `fleet-default/${ harvesterClusterId }`);
+      });
     });
   });
 
   it('missing repo message should display when repo does NOT exist', () => {
-    cy.intercept('POST', `${ CLUSTER_REPOS_BASE_URL }/${ harvesterGitRepoName }?action=install`).as('installHarvesterExtension');
-    cy.intercept('PUT', `${ CLUSTER_REPOS_BASE_URL }/${ harvesterGitRepoName }`).as('updateHarvesterChart');
+    cy.getRancherVersion().then((version) => {
+      const catalog = harvesterExtensionCatalog(version);
+      const chartRepo = catalog.repo;
 
-    // add harvester repo
-    cy.createRancherResource('v1', 'catalog.cattle.io.clusterrepos', {
-      type:     'catalog.cattle.io.clusterrepo',
-      metadata: { name: harvesterGitRepoName },
-      spec:     {
-        clientSecret: null, gitRepo: harvesterGitRepoUrl, gitBranch: branchName
-      }
-    });
+      cy.intercept('POST', `${ CLUSTER_REPOS_BASE_URL }/${ chartRepo }?action=install`).as('installHarvesterExtension');
+      cy.intercept('PUT', `${ CLUSTER_REPOS_BASE_URL }/${ chartRepo }`).as('updateHarvesterChart');
 
-    // Wait for repository to be downloaded and ready
-    cy.waitForRepositoryDownload('v1', 'catalog.cattle.io.clusterrepos', harvesterGitRepoName);
+      cy.createRancherResource('v1', 'catalog.cattle.io.clusterrepos', {
+        type:     'catalog.cattle.io.clusterrepo',
+        metadata: { name: catalog.repo },
+        spec:     {
+          clientSecret: null, gitRepo: catalog.gitRepo, gitBranch: catalog.gitBranch
+        }
+      });
 
-    appRepoList.goTo(undefined, 'manager');
-    appRepoList.waitForPage();
-    appRepoList.sortableTable().rowElementWithName(harvesterGitRepoName).should('be.visible');
-    appRepoList.list().state(harvesterGitRepoName).contains('Active', LONG_TIMEOUT_OPT);
+      cy.waitForRepositoryDownload('v1', 'catalog.cattle.io.clusterrepos', chartRepo);
 
-    extensionsPo.goTo();
-    extensionsPo.waitForPage(null, 'available', MEDIUM_TIMEOUT_OPT);
-    extensionsPo.loading().should('not.exist');
+      appRepoList.goTo(undefined, 'manager');
+      appRepoList.waitForPage();
+      appRepoList.sortableTable().rowElementWithName(chartRepo).should('be.visible');
+      appRepoList.list().state(chartRepo).contains('Active', LONG_TIMEOUT_OPT);
 
-    // click on install button on card
-    extensionsPo.extensionCardInstallClick(harvesterTitle);
-    extensionsPo.installModal().checkVisible();
+      extensionsPo.goTo();
+      extensionsPo.waitForTabs();
+      extensionsPo.waitForPage(null, 'available', MEDIUM_TIMEOUT_OPT);
+      extensionsPo.loading().should('not.exist');
 
-    // select latest version and click install
-    extensionsPo.installModal().selectVersionClick(1);
-    extensionsPo.installModal().installButton().click();
-    cy.wait('@installHarvesterExtension').its('response.statusCode').should('eq', 201);
-    extensionsPo.waitForPage(null, 'installed');
+      // click on install button on card
+      extensionsPo.extensionCardInstallClick(harvesterTitle);
+      extensionsPo.installModal().checkVisible();
 
-    extensionsPo.extensionReloadBanner().should('be.visible');
-    extensionsPo.extensionReloadClick();
-    extensionsPo.loading().should('not.exist');
-
-    harvesterPo.goTo();
-    harvesterPo.waitForPage();
-    cy.wait('@updateHarvesterChart', LONG_TIMEOUT_OPT);
-    harvesterPo.extensionWarning().should('not.exist');
-
-    // delete harvester repo
-    cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', harvesterGitRepoName);
-
-    harvesterPo.goTo();
-    harvesterPo.waitForPage();
-    // verify missing repo message displays
-    harvesterPo.extensionWarning().should('have.text', 'The Harvester UI Extension repository is missing');
-
-    // uninstall harvester
-    cy.createRancherResource('v1', 'catalog.cattle.io.apps/cattle-ui-plugin-system/harvester?action=uninstall', {});
-
-    // reload extensions
-    extensionsPo.goTo();
-    extensionsPo.waitForPage();
-    extensionsPo.loading().should('not.exist');
-    extensionsPo.extensionReloadBanner().should('be.visible');
-    extensionsPo.extensionReloadClick();
-    extensionsPo.loading().should('not.exist');
-
-    // verify install button and message displays
-    HarvesterClusterPagePo.navTo();
-    harvesterPo.waitForPage();
-    harvesterPo.updateOrInstallButton().checkVisible();
-    harvesterPo.extensionWarning().should('have.text', 'The Harvester UI Extension is not installed');
-  });
-
-  it('able to update harvester extension version', () => {
-    cy.intercept('POST', `${ CLUSTER_REPOS_BASE_URL }/${ harvesterGitRepoName }?action=install`).as('installHarvesterExtension');
-    cy.intercept('POST', `${ CLUSTER_REPOS_BASE_URL }/${ harvesterGitRepoName }?action=upgrade`).as('upgradeHarvesterExtension');
-    cy.intercept('PUT', `${ CLUSTER_REPOS_BASE_URL }/${ harvesterGitRepoName }`).as('updateHarvesterChart');
-
-    // add harvester repo
-    cy.createRancherResource('v1', 'catalog.cattle.io.clusterrepos', {
-      type:     'catalog.cattle.io.clusterrepo',
-      metadata: { name: harvesterGitRepoName },
-      spec:     {
-        clientSecret: null, gitRepo: harvesterGitRepoUrl, gitBranch: branchName
-      }
-    });
-
-    // Wait for repository to be downloaded and ready
-    cy.waitForRepositoryDownload('v1', 'catalog.cattle.io.clusterrepos', harvesterGitRepoName);
-
-    appRepoList.goTo(undefined, 'manager');
-    appRepoList.waitForPage();
-    appRepoList.sortableTable().rowElementWithName(harvesterGitRepoName).should('be.visible');
-    appRepoList.list().state(harvesterGitRepoName).contains('Active', LONG_TIMEOUT_OPT);
-
-    extensionsPo.goTo();
-    extensionsPo.waitForPage(null, 'available', MEDIUM_TIMEOUT_OPT);
-    extensionsPo.loading().should('not.exist');
-
-    // click on install button on card
-    extensionsPo.extensionCardInstallClick(harvesterTitle);
-    extensionsPo.installModal().checkVisible();
-
-    // Note - We can't fetch version from `catalog.cattle.io.clusterrepos/harvester?link=index` given it won't filter out invalid extensions
-    // for example in rancher 2.12 the harvester 1.7.0 extension is invalid... however still returned... resulting in expected versions that don't exist as valid options
-
-    extensionsPo.installModal().versionLabelSelect().toggle();
-    extensionsPo.installModal().versionLabelSelect().getOptionsAsStrings().then((versions) => {
-      // select older version and click install
-      extensionsPo.installModal().selectVersionClick(2, false);
+      // select latest version and click install
+      extensionsPo.installModal().selectVersionClick(1);
       extensionsPo.installModal().installButton().click();
       cy.wait('@installHarvesterExtension').its('response.statusCode').should('eq', 201);
       extensionsPo.waitForPage(null, 'installed');
 
       extensionsPo.extensionReloadBanner().should('be.visible');
       extensionsPo.extensionReloadClick();
+      extensionsPo.waitForTabs();
       extensionsPo.loading().should('not.exist');
-
-      // check harvester version on card - should be the latest available version
-      extensionsPo.extensionCardVersion(harvesterTitle).should('contain', versions[0]);
-
-      // hover checkmark - tooltip should have older version
-      extensionsPo.extensionCardHeaderStatusTooltip(harvesterTitle, 1).waitForTooltipWithText(`Installed (${ versions[1] })`);
 
       harvesterPo.goTo();
       harvesterPo.waitForPage();
       cy.wait('@updateHarvesterChart', LONG_TIMEOUT_OPT);
-
-      // check for update harvester message
-      harvesterPo.extensionWarning().invoke('text').should('match', /^Your current Harvester UI Extension \((v[\d.]+)\) is not the latest\.$/);
-      harvesterPo.updateOrInstallButton().click();
-
-      // wait for update version update
-      cy.wait('@upgradeHarvesterExtension', LONG_TIMEOUT_OPT).then(({ request, response }) => {
-        expect(response?.statusCode).to.eq(201);
-        expect(request?.body?.charts[0].version).to.eq(versions[0]);
-      });
-      cy.wait('@updateHarvesterChart', LONG_TIMEOUT_OPT);
-
-      // verify update button and message not displayed
       harvesterPo.extensionWarning().should('not.exist');
-      harvesterPo.updateOrInstallButton().checkNotExists();
+
+      cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', chartRepo);
+
+      harvesterPo.goTo();
+      harvesterPo.waitForPage();
+      // verify missing repo message displays
+      harvesterPo.extensionWarning().should('have.text', 'The Harvester UI Extension repository is missing');
+
+      // uninstall harvester
+      cy.createRancherResource('v1', 'catalog.cattle.io.apps/cattle-ui-plugin-system/harvester?action=uninstall', {});
+
+      // reload extensions
+      extensionsPo.goTo();
+      extensionsPo.waitForTabs();
+      extensionsPo.waitForPage();
+      extensionsPo.loading().should('not.exist');
+      extensionsPo.extensionReloadBanner().should('be.visible');
+      extensionsPo.extensionReloadClick();
+      extensionsPo.waitForTabs();
+      extensionsPo.loading().should('not.exist');
+
+      // verify install button and message displays
+      HarvesterClusterPagePo.navTo();
+      harvesterPo.waitForPage();
+      harvesterPo.updateOrInstallButton().checkVisible();
+      harvesterPo.extensionWarning().should('have.text', 'The Harvester UI Extension is not installed');
+    });
+  });
+
+  it('able to update harvester extension version', () => {
+    cy.getRancherVersion().then((version) => {
+      const catalog = harvesterExtensionCatalog(version);
+      const chartRepo = catalog.repo;
+
+      cy.intercept('POST', `${ CLUSTER_REPOS_BASE_URL }/${ chartRepo }?action=install`).as('installHarvesterExtension');
+      cy.intercept('POST', `${ CLUSTER_REPOS_BASE_URL }/${ chartRepo }?action=upgrade`).as('upgradeHarvesterExtension');
+      cy.intercept('PUT', `${ CLUSTER_REPOS_BASE_URL }/${ chartRepo }`).as('updateHarvesterChart');
+
+      cy.createRancherResource('v1', 'catalog.cattle.io.clusterrepos', {
+        type:     'catalog.cattle.io.clusterrepo',
+        metadata: { name: catalog.repo },
+        spec:     {
+          clientSecret: null, gitRepo: catalog.gitRepo, gitBranch: catalog.gitBranch
+        }
+      });
+
+      cy.waitForRepositoryDownload('v1', 'catalog.cattle.io.clusterrepos', chartRepo);
+
+      appRepoList.goTo(undefined, 'manager');
+      appRepoList.waitForPage();
+      appRepoList.sortableTable().rowElementWithName(chartRepo).should('be.visible');
+      appRepoList.list().state(chartRepo).contains('Active', LONG_TIMEOUT_OPT);
 
       extensionsPo.goTo();
-      extensionsPo.waitForPage(null, 'installed');
+      extensionsPo.waitForTabs();
+      extensionsPo.waitForPage(null, 'available', MEDIUM_TIMEOUT_OPT);
       extensionsPo.loading().should('not.exist');
-      // check harvester version on card after update - should be latest
-      extensionsPo.extensionCardVersion(harvesterTitle).should('contain', versions[0]);
 
-      // hover checkmark - tooltip should have latest version
-      extensionsPo.extensionCardHeaderStatusTooltip(harvesterTitle, 0).waitForTooltipWithText(`Installed (${ versions[0] })`);
+      // click on install button on card
+      extensionsPo.extensionCardInstallClick(harvesterTitle);
+      extensionsPo.installModal().checkVisible();
+
+      // Note - We can't fetch version from `catalog.cattle.io.clusterrepos/harvester?link=index` given it won't filter out invalid extensions
+      // for example in rancher 2.12 the harvester 1.7.0 extension is invalid... however still returned... resulting in expected versions that don't exist as valid options
+
+      extensionsPo.installModal().versionLabelSelect().toggle();
+      extensionsPo.installModal().versionLabelSelect().getOptionsAsStrings().then((versions) => {
+        // select older version and click install
+        extensionsPo.installModal().selectVersionClick(2, false);
+        extensionsPo.installModal().installButton().click();
+        cy.wait('@installHarvesterExtension').its('response.statusCode').should('eq', 201);
+        extensionsPo.waitForPage(null, 'installed');
+
+        extensionsPo.extensionReloadBanner().should('be.visible');
+        extensionsPo.extensionReloadClick();
+        extensionsPo.waitForTabs();
+        extensionsPo.loading().should('not.exist');
+
+        // check harvester version on card - should be the latest available version
+        extensionsPo.extensionCardVersion(harvesterTitle).should('contain', versions[0]);
+
+        // hover checkmark - tooltip should have older version
+        extensionsPo.extensionCardHeaderStatusTooltip(harvesterTitle, 1).waitForTooltipWithText(`Installed (${ versions[1] })`);
+
+        harvesterPo.goTo();
+        harvesterPo.waitForPage();
+        cy.wait('@updateHarvesterChart', LONG_TIMEOUT_OPT);
+
+        // check for update harvester message
+        harvesterPo.extensionWarning().invoke('text').should('match', /^Your current Harvester UI Extension \((v[\d.]+)\) is not the latest\.$/);
+        harvesterPo.updateOrInstallButton().click();
+
+        // wait for update version update
+        cy.wait('@upgradeHarvesterExtension', LONG_TIMEOUT_OPT).then(({ request, response }) => {
+          expect(response?.statusCode).to.eq(201);
+          expect(request?.body?.charts[0].version).to.eq(versions[0]);
+        });
+        cy.wait('@updateHarvesterChart', LONG_TIMEOUT_OPT);
+
+        // verify update button and message not displayed
+        harvesterPo.extensionWarning().should('not.exist');
+        harvesterPo.updateOrInstallButton().checkNotExists();
+
+        extensionsPo.goTo();
+        extensionsPo.waitForTabs();
+        extensionsPo.waitForPage(null, 'installed');
+        extensionsPo.loading().should('not.exist');
+        // check harvester version on card after update - should be latest
+        extensionsPo.extensionCardVersion(harvesterTitle).should('contain', versions[0]);
+
+        // hover checkmark - tooltip should have latest version
+        extensionsPo.extensionCardHeaderStatusTooltip(harvesterTitle, 0).waitForTooltipWithText(`Installed (${ versions[0] })`);
+      });
     });
   });
 
   afterEach(() => {
     cy.createRancherResource('v1', 'catalog.cattle.io.apps/cattle-ui-plugin-system/harvester?action=uninstall', {}, false);
-    cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', harvesterGitRepoName, false);
+    cy.getRancherVersion().then((version) => {
+      cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', harvesterExtensionCatalog(version).repo, false);
+    });
   });
 });

--- a/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
+++ b/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
@@ -25,13 +25,16 @@ const HARVESTER_EXTENSION_CATALOG = {
   },
 };
 
-function harvesterExtensionCatalog(version: { RancherPrime?: string }) {
+function harvesterExtensionCatalog(version: Cypress.RancherVersion) {
   return version.RancherPrime === 'true' ? HARVESTER_EXTENSION_CATALOG.prime : HARVESTER_EXTENSION_CATALOG.community;
 }
 
 describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
+    cy.getRancherVersion().then((version) => {
+      cy.wrap(version, { log: false }).as('rancherVersion');
+    });
     cy.createE2EResourceName('harvesterclustername').then((name) => {
       harvesterClusterName = name;
     });
@@ -45,7 +48,7 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
    * (pattern needs fixing)
    */
   it('can auto install harvester and begin process of importing a harvester cluster', () => {
-    cy.getRancherVersion().then((version) => {
+    cy.get<Cypress.RancherVersion>('@rancherVersion').then((version) => {
       const catalog = harvesterExtensionCatalog(version);
       const chartRepo = catalog.repo;
 
@@ -117,7 +120,7 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
   });
 
   it('missing repo message should display when repo does NOT exist', () => {
-    cy.getRancherVersion().then((version) => {
+    cy.get<Cypress.RancherVersion>('@rancherVersion').then((version) => {
       const catalog = harvesterExtensionCatalog(version);
       const chartRepo = catalog.repo;
 
@@ -193,7 +196,7 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
   });
 
   it('able to update harvester extension version', () => {
-    cy.getRancherVersion().then((version) => {
+    cy.get<Cypress.RancherVersion>('@rancherVersion').then((version) => {
       const catalog = harvesterExtensionCatalog(version);
       const chartRepo = catalog.repo;
 
@@ -281,7 +284,7 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
 
   afterEach(() => {
     cy.createRancherResource('v1', 'catalog.cattle.io.apps/cattle-ui-plugin-system/harvester?action=uninstall', {}, false);
-    cy.getRancherVersion().then((version) => {
+    cy.get<Cypress.RancherVersion>('@rancherVersion').then((version) => {
       cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', harvesterExtensionCatalog(version).repo, false);
     });
   });

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -73,6 +73,10 @@ export interface CreateResourceNameOptions {
 
 declare global {
   namespace Cypress {
+    interface RancherVersion {
+      RancherPrime?: string;
+    }
+
     interface Chainable {
       setupWebSocket: any;
       hideElementBySelector(...selectors: string[]): Chainable<void>;
@@ -124,7 +128,7 @@ declare global {
       }): Chainable;
       applyDefaultTestTheme(): Chainable<any>;
       restoreProductDefaultTestTheme(): Chainable<any>;
-      getRancherVersion(): Chainable<any>;
+      getRancherVersion(): Chainable<RancherVersion>;
       getRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId?: string, expectedStatusCode?: number): Chainable;
       setRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, body: any): Chainable;
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any, failOnStatusCode?: boolean): Chainable;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2282

1. Drive catalog setup, intercepts, waits, and cleanup from cy.getRancherVersion() so the spec works on both Community and Rancher Prime builds (Prime uses the rancher / ui-plugin-charts catalog instead of harvester / harvester-ui-extension).
2. Removed the install retry now that [rancher/dashboard#17159](https://github.com/rancher/dashboard/issues/17159) fixed the underlying flakiness; the spec now just asserts the install flow without the 500-retry path.

<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="704" height="146" alt="image" src="https://github.com/user-attachments/assets/4718d80b-763f-45de-b65e-adf088a3340f" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
