### PR TITLE
[release-2.14.1] Set codeFreeze to true for several release versions

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -21,7 +21,7 @@
     "release-2.14": {
       "milestone": {
         "version": "v2.14.1",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -39,7 +39,7 @@
     "release-2.13": {
       "milestone": {
         "version": "v2.13.5",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -58,7 +58,7 @@
     "release-2.12": {
       "milestone": {
         "version": "v2.12.9",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -77,7 +77,7 @@
     "release-2.11": {
       "milestone": {
         "version": "v2.11.13",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {


### PR DESCRIPTION
Updated codeFreeze status to true for multiple releases.

- 2.14.1
- 2.13.5
- 2.12.9
- 2.11.12

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
