### PR TITLE
[ Apps > Charts ] - Fix tag options

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/apps/charts/__tests__/index.test.ts
@@ -1,0 +1,55 @@
+import Charts from '@shell/pages/c/_cluster/apps/charts/index.vue';
+import { UI_PLUGIN_ANNOTATION } from '@shell/config/uiplugins';
+
+describe('page: Charts Index', () => {
+  describe('computed: tagOptions', () => {
+    it('should gather tags exclusively from enabledCharts, omitting tags from hidden or extension charts present in allCharts (e.g., primeOnly)', () => {
+      const thisContext = {
+        // allCharts contains a UI plugin/extension chart with the 'primeOnly' tag.
+        allCharts: [
+          { tags: ['appTag1'] },
+          { tags: ['primeOnly'], annotations: { [UI_PLUGIN_ANNOTATION.NAME]: UI_PLUGIN_ANNOTATION.VALUE } },
+        ],
+        // enabledCharts has already filtered out the extension chart.
+        enabledCharts: [
+          { tags: ['appTag1'] },
+        ]
+      };
+
+      const result = (Charts.computed!.tagOptions as () => any[]).call(thisContext);
+
+      expect(result).toStrictEqual([
+        { value: 'apptag1', label: 'appTag1' },
+      ]);
+
+      const hasPrimeOnly = result.some((tag) => tag.value === 'primeonly');
+
+      expect(hasPrimeOnly).toBe(false);
+    });
+  });
+
+  describe('computed: categoryOptions', () => {
+    it('should gather categories exclusively from enabledCharts, omitting categories from hidden or extension charts present in allCharts', () => {
+      const thisContext = {
+        allCharts: [
+          { categories: ['category1'] },
+          { categories: ['categoryFromExtension1'], annotations: { [UI_PLUGIN_ANNOTATION.NAME]: UI_PLUGIN_ANNOTATION.VALUE } },
+        ],
+        enabledCharts: [
+          { categories: ['category1'] },
+        ],
+        $store: { getters: { 'i18n/withFallback': (key: string, fallback: any, c: string) => c } }
+      };
+
+      const result = (Charts.computed!.categoryOptions as () => any[]).call(thisContext);
+
+      expect(result).toStrictEqual([
+        { value: 'category1', label: 'category1' },
+      ]);
+
+      const hasExtensionCategory = result.some((cat) => cat.value === 'categoryFromExtension1');
+
+      expect(hasExtensionCategory).toBe(false);
+    });
+  });
+});

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -200,7 +200,7 @@ export default {
     tagOptions() {
       const outSet = new Set();
 
-      this.allCharts.forEach((chart) => {
+      this.enabledCharts.forEach((chart) => {
         if (Array.isArray(chart.tags)) {
           chart.tags.forEach((tag) => outSet.add(tag));
         }
@@ -270,7 +270,7 @@ export default {
     categoryOptions() {
       const map = {};
 
-      for ( const chart of this.allCharts ) {
+      for ( const chart of this.enabledCharts ) {
         for ( const c of chart.categories ) {
           if ( !map[c] ) {
             const labelKey = `catalog.charts.categories.${ lcFirst(c) }`;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17325 
<!-- Define findings related to the feature or bug issue. -->
<!-- This template is for Devs to give QA details before moving the issue To-Test -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Previously, the tag options on the filter panel were generated by iterating over `this.allCharts`, which includes UI plugins and hidden charts that are never actually rendered on the Charts page. By changing the iteration to `this.enabledCharts`, the filter options now accurately reflect only the visible charts.

Although we didn't have a wrong category option we were iterating over `this.allCharts` which also now changed to the correct iteration to `this.enabledCharts`.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- Updated the `tagOptions` and `categoryOptions` computed properties in the Charts page (`@shell/pages/c/_cluster/apps/charts/index.vue`) to build their option lists from `enabledCharts` instead of `allCharts`.
- Added unit tests to verify that extension and hidden chart tags/categories are correctly filtered out.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Testing this on Prime version will be the most reliable way by checking the absence of `Prime Only` tag on the charts page, but if your instance's backend points to 2.14 you could also test this by checking the absence of `Experimental` tag on the filter panel.

Note: For Prime you might need to add the extension repository to see the prime only options `https://github.com/rancher/ui-plugin-charts`(`main` branch)

1. Navigate to **Apps** > **Charts**.
2. Check the **Tag** filter options: verify that `Prime Only` tag do not appear.
3. Verify that selecting any available tag correctly filters the visible charts without resulting in an empty list (unless combined with other mutually exclusive filters).

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Tag and Category filtering on the Apps & Marketplace > Charts page.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="746" height="772" alt="image" src="https://github.com/user-attachments/assets/4e88ea7a-6a0e-4f1b-82e1-09af6afb2cc1" />

Prime version:
<img width="969" height="825" alt="image" src="https://github.com/user-attachments/assets/999e157c-9941-4291-b880-e1fd83b9960f" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
