### PR TITLE
Fix malformed feature flag support

### DIFF
--- a/shell/list/__tests__/management.cattle.io.feature.test.ts
+++ b/shell/list/__tests__/management.cattle.io.feature.test.ts
@@ -1,0 +1,105 @@
+import { shallowMount } from '@vue/test-utils';
+
+jest.mock('@shell/mixins/resource-fetch', () => ({
+  __esModule: true,
+  default:    {
+    data() {
+      return {
+        forceUpdateLiveAndDelayed: 0, loading: false, rows: []
+      };
+    },
+    async $fetchType() {}
+  }
+}));
+
+// eslint-disable-next-line import/first
+import ManagementFeature from '@shell/list/management.cattle.io.feature.vue';
+
+const createMockStore = () => ({
+  getters: {
+    'i18n/t':               (key: string) => key,
+    'management/schemaFor': () => ({ resourceMethods: ['PUT'] }),
+  },
+  dispatch: jest.fn(),
+});
+
+const createWrapper = (rows: any[]) => {
+  return shallowMount(ManagementFeature, {
+    props: {
+      resource: 'management.cattle.io.feature',
+      schema:   { id: 'management.cattle.io.feature' } as any,
+    },
+    data:   () => ({ rows }),
+    global: {
+      mocks: {
+        $store:      createMockStore(),
+        $fetchState: { pending: false },
+        $fetchType:  jest.fn(),
+      },
+      stubs: {
+        // Render the cell:name slot directly so we can assert on the lock icon
+        ResourceTable: {
+          props:    ['rows'],
+          template: '<div><slot name="cell:name" :row="rows[0]" /></div>',
+        },
+      },
+    }
+  });
+};
+
+describe('list/management.cattle.io.feature', () => {
+  describe('locked icon rendering in cell:name slot', () => {
+    it('should render the lock icon when status.lockedValue is not null', () => {
+      const row = {
+        metadata:    { name: 'feature-a' },
+        nameDisplay: 'feature-a',
+        status:      { lockedValue: true },
+      };
+
+      const wrapper = createWrapper([row]);
+
+      expect(wrapper.find('i.icon-lock').exists()).toBe(true);
+    });
+
+    it('should not render the lock icon when status.lockedValue is null', () => {
+      const row = {
+        metadata:    { name: 'feature-a' },
+        nameDisplay: 'feature-a',
+        status:      { lockedValue: null },
+      };
+
+      const wrapper = createWrapper([row]);
+
+      expect(wrapper.find('i.icon-lock').exists()).toBe(false);
+    });
+
+    it('should not throw and should not render the lock icon when status is missing (malformed feature flag)', () => {
+      const row = {
+        metadata:    { name: 'feature-a' },
+        nameDisplay: 'feature-a',
+      };
+
+      expect(() => createWrapper([row])).not.toThrow();
+
+      const wrapper = createWrapper([row]);
+
+      expect(wrapper.find('i.icon-lock').exists()).toBe(false);
+    });
+  });
+
+  describe('filteredRows', () => {
+    it('should filter out hidden feature flags', () => {
+      const rows = [
+        { metadata: { name: 'fleet' } },
+        { metadata: { name: 'some-feature' } },
+      ];
+
+      const wrapper = createWrapper(rows);
+
+      const filtered = (wrapper.vm as any).filteredRows;
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].metadata.name).toBe('some-feature');
+    });
+  });
+});

--- a/shell/list/management.cattle.io.feature.vue
+++ b/shell/list/management.cattle.io.feature.vue
@@ -69,7 +69,7 @@ export default {
         <div class="feature-name">
           <div>{{ scope.row.nameDisplay }}</div>
           <i
-            v-if="scope.row.status.lockedValue !== null"
+            v-if="scope.row.status && scope.row.status.lockedValue !== null"
             class="icon icon-lock"
           />
         </div>

--- a/shell/models/__tests__/management.cattle.io.feature.test.ts
+++ b/shell/models/__tests__/management.cattle.io.feature.test.ts
@@ -1,0 +1,132 @@
+import Feature from '@shell/models/management.cattle.io.feature.js';
+import Resource from '@shell/plugins/dashboard-store/resource-class';
+
+describe('class Feature', () => {
+  const ctx = {
+    dispatch:    jest.fn(),
+    rootGetters: { 'i18n/t': (key: string) => key },
+    getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
+  };
+
+  // The parent Resource._availableActions getter depends on runtime config we don't have
+  // in tests — stub it out so we can assert on Feature's own additions.
+  beforeEach(() => {
+    jest.spyOn(Resource.prototype, '_availableActions', 'get').mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('enabled getter', () => {
+    it.each([
+      [true, true],
+      [false, false],
+    ])('should return lockedValue (%s) when status.lockedValue is not null', (lockedValue, expected) => {
+      const feature = new Feature({
+        spec:   { value: false },
+        status: { lockedValue, default: false }
+      }, ctx);
+
+      expect(feature.enabled).toBe(expected);
+    });
+
+    it('should return spec.value when lockedValue is null and spec.value is set', () => {
+      const feature = new Feature({
+        spec:   { value: true },
+        status: { lockedValue: null, default: false }
+      }, ctx);
+
+      expect(feature.enabled).toBe(true);
+    });
+
+    it('should fall back to status.default when lockedValue is null and spec.value is null', () => {
+      const feature = new Feature({
+        spec:   { value: null },
+        status: { lockedValue: null, default: true }
+      }, ctx);
+
+      expect(feature.enabled).toBe(true);
+    });
+
+    it('should not throw when status is missing (malformed feature flag)', () => {
+      const feature = new Feature({ spec: { value: true } }, ctx);
+
+      expect(() => feature.enabled).not.toThrow();
+      expect(feature.enabled).toBe(true);
+    });
+  });
+
+  describe('restartRequired getter', () => {
+    it('should return false when status.dynamic is true', () => {
+      const feature = new Feature({ spec: {}, status: { dynamic: true, lockedValue: null } }, ctx);
+
+      expect(feature.restartRequired).toBe(false);
+    });
+
+    it('should return true when status.dynamic is false', () => {
+      const feature = new Feature({ spec: {}, status: { dynamic: false, lockedValue: null } }, ctx);
+
+      expect(feature.restartRequired).toBe(true);
+    });
+
+    it('should return true when status is missing (malformed feature flag)', () => {
+      const feature = new Feature({ spec: {} }, ctx);
+
+      expect(() => feature.restartRequired).not.toThrow();
+      expect(feature.restartRequired).toBe(true);
+    });
+  });
+
+  describe('_availableActions getter', () => {
+    it('should disable the toggle action when lockedValue is not null', () => {
+      const feature = new Feature({
+        spec:   { value: false },
+        status: {
+          lockedValue: true, default: false, dynamic: true
+        },
+      }, ctx);
+
+      jest.spyOn(feature, 'canUpdate', 'get').mockReturnValue(true);
+
+      const actions = feature._availableActions;
+
+      expect(actions[0].action).toBe('toggleFeatureFlag');
+      expect(actions[0].enabled).toBe(false);
+    });
+
+    it('should enable the toggle action when lockedValue is null and user canUpdate', () => {
+      const feature = new Feature({
+        spec:   { value: false },
+        status: {
+          lockedValue: null, default: false, dynamic: true
+        },
+        id: 'some-feature',
+      }, ctx);
+
+      jest.spyOn(feature, 'canUpdate', 'get').mockReturnValue(true);
+
+      const actions = feature._availableActions;
+
+      expect(actions[0].action).toBe('toggleFeatureFlag');
+      expect(actions[0].enabled).toBe(true);
+    });
+
+    it('should not throw and should disable the toggle action when status is missing (malformed feature flag)', () => {
+      const feature = new Feature({
+        spec: { value: false },
+        id:   'some-feature',
+      }, ctx);
+
+      jest.spyOn(feature, 'canUpdate', 'get').mockReturnValue(true);
+      jest.spyOn(feature, 'enabled', 'get').mockReturnValue(false);
+
+      expect(() => feature._availableActions).not.toThrow();
+
+      const actions = feature._availableActions;
+
+      expect(actions[0].action).toBe('toggleFeatureFlag');
+      expect(actions[0].enabled).toBeFalsy();
+    });
+  });
+});

--- a/shell/models/__tests__/management.cattle.io.feature.test.ts
+++ b/shell/models/__tests__/management.cattle.io.feature.test.ts
@@ -119,7 +119,6 @@ describe('class Feature', () => {
       }, ctx);
 
       jest.spyOn(feature, 'canUpdate', 'get').mockReturnValue(true);
-      jest.spyOn(feature, 'enabled', 'get').mockReturnValue(false);
 
       expect(() => feature._availableActions).not.toThrow();
 

--- a/shell/models/management.cattle.io.feature.js
+++ b/shell/models/management.cattle.io.feature.js
@@ -8,7 +8,7 @@ export default class Feature extends HybridModel {
 
   get enabled() {
     // If lockedValue is not null, then this is the value that the flag is locked to, so that should be used
-    if (this.status.lockedValue !== null) {
+    if (this.status && this.status.lockedValue !== null) {
       return this.status.lockedValue;
     }
 
@@ -17,7 +17,7 @@ export default class Feature extends HybridModel {
   }
 
   get restartRequired() {
-    return !this.status.dynamic;
+    return !this.status?.dynamic;
   }
 
   get canYaml() {
@@ -43,7 +43,7 @@ export default class Feature extends HybridModel {
     // User can not disable or enable if the feature flag is locked
     // Note: lockedValue is the value that the feature flag is locked to, so it can be true or false
     // It can also be null, which indicates that the feature flag is not locked
-    enableAction.enabled = enableAction.enabled && (this.status.lockedValue === null);
+    enableAction.enabled = enableAction.enabled && (this.status && this.status.lockedValue === null);
 
     out.unshift(enableAction);
 


### PR DESCRIPTION
### Summary
Fixes #17226

Fix an issue where a malformed feature flag (one missing the `status` field) would break the Feature Flags list UI.

### Occurred changes and/or fixed issues

- `shell/models/management.cattle.io.feature.js`: guard `status` reads in the `enabled`, `restartRequired`, and `_availableActions` getters so a missing `status` no longer throws.
- `shell/list/management.cattle.io.feature.vue`: guard `scope.row.status` before reading `lockedValue` when deciding whether to render the lock icon.
- Added unit tests for both files covering the malformed (missing `status`) case alongside the existing happy/unhappy paths.

### Technical notes summary

- `status` is a field on the Feature CRD and is normally always present. Observed in the field that under certain conditions the object can be returned without it, so the UI now treats `status` as optional.
- `restartRequired` uses optional chaining (`!this.status?.dynamic`), so when `status` is missing it returns `true` (conservatively assumes a restart is needed) rather than throwing.
- When `status` is missing, `_availableActions` now disables the enable/disable toggle action, since we can't determine `lockedValue`.

### Areas or cases that should be tested

- Feature Flags list page loads with a mix of healthy and malformed feature flags — the list should render all rows without errors in the console.
- Locked feature flag shows the lock icon next to its name.
- Unlocked feature flag does not show the lock icon.
- Malformed feature flag (missing `status`) renders as a row with no lock icon and no thrown exception.
- The enable/disable action is disabled on a malformed feature flag and on any locked feature flag.

### Areas which could experience regressions

- Feature Flags list page (`management.cattle.io.feature`) — rendering, row actions, lock indicator.
- Any other area that consumes the `Feature` model's `enabled`, `restartRequired`, or `_availableActions` getters.

### Screenshot/Video

<img width="845" height="411" alt="image" src="https://github.com/user-attachments/assets/1571668d-3ff1-433c-98e7-918ed27acb78" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
