### PR TITLE
Improve styling of helm apps upgrade badge used in the apps list

### DIFF
--- a/shell/list/catalog.cattle.io.app.vue
+++ b/shell/list/catalog.cattle.io.app.vue
@@ -40,14 +40,15 @@ export default {
     data-testid="installed-app-catalog-list"
   >
     <template #cell:upgrade="{row}">
-      <span
+      <div
         v-if="row.upgradeAvailable === APP_UPGRADE_STATUS.SINGLE_UPGRADE"
-        class="badge-state bg-warning hand"
+        v-clean-tooltip="row.upgradeAvailableVersion"
+        class="badge-state bg-warning hand app-upgrade-badge"
         @click="row.goToUpgrade(row.upgradeAvailableVersion)"
       >
-        {{ row.upgradeAvailableVersion }}
+        <div>{{ row.upgradeAvailableVersion }}</div>
         <i class="icon icon-upload" />
-      </span>
+      </div>
       <span
         v-else-if="row.upgradeAvailable === APP_UPGRADE_STATUS.NOT_APPLICABLE"
         v-t="'catalog.app.managed'"
@@ -69,8 +70,27 @@ export default {
   </PaginatedResourceTable>
 </template>
 
-<style scoped>
+<style scoped lang="scss">
 .apps :deep() .state-description{
   color: var(--error)
 }
+
+.badge-state.app-upgrade-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--border-radius);
+  padding: 2px 5px;
+
+  > div {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  > .icon {
+    flex-shrink: 0;
+  }
+}
+
 </style>

--- a/shell/list/catalog.cattle.io.app.vue
+++ b/shell/list/catalog.cattle.io.app.vue
@@ -79,7 +79,7 @@ export default {
   display: inline-flex;
   align-items: center;
   border-radius: var(--border-radius);
-  padding: 2px 5px;
+  padding: 2px 4px;
 
   > div {
     overflow: hidden;


### PR DESCRIPTION
### Summary
Fixes #17328

Improves the styling of the upgrade-available badge shown in the Helm apps list so that long version strings are handled gracefully and the badge renders consistently with other badges in the UI.

### Occurred changes and/or fixed issues

- Updated the upgrade badge in [shell/list/catalog.cattle.io.app.vue](shell/list/catalog.cattle.io.app.vue) used for the `catalog.cattle.io.app` list.
- Switched the badge element from a `<span>` to a `<div>` wrapping the version label and the upload icon, so flex layout and text truncation work correctly.
- Added a tooltip (`v-clean-tooltip`) that displays the full `upgradeAvailableVersion` on hover, so the full version is accessible even when the visible text is truncated.
- Added a new `app-upgrade-badge` class with scoped SCSS rules:
  - `display: inline-flex` with `align-items: center` to vertically align the version text and icon.
  - `border-radius: var(--border-radius)` and `padding: 2px 5px` for consistent badge styling.
  - Inner `<div>` uses `overflow: hidden`, `text-overflow: ellipsis`, `white-space: nowrap`, and `min-width: 0` so long version strings truncate with an ellipsis instead of breaking the row layout.
  - Icon uses `flex-shrink: 0` to ensure it is never squashed when the container narrows.
- Converted the `<style>` block from plain CSS to `lang="scss"` to allow the nested selectors.

### Screenshot/Video

With this change, now renders like this:

<img width="845" height="411" alt="image" src="https://github.com/user-attachments/assets/598f7d23-5da1-402f-997e-c36d32d49c7b" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
