### PR TITLE
[ Apps > Installed Apps ] Fix broken cancel button

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/__tests__/install.test.ts
+++ b/shell/pages/c/_cluster/apps/charts/__tests__/install.test.ts
@@ -91,4 +91,57 @@ describe('page: Install', () => {
     expect(wrapper.vm.forceNamespace).toBe('custom-ns');
     expect(wrapper.vm.value.metadata.name).toBe('custom-name');
   });
+
+  describe('cancel()', () => {
+    it('should route to appLocation if chart is not defined and specific query flags are absent', () => {
+      const mockReplace = jest.fn();
+      const expectedLocation = { name: 'app-location' };
+
+      const wrapper = mount(Install, {
+        global: {
+          mocks: {
+            $store: {
+              getters: {
+                'i18n/t':     (key: string) => key,
+                'cluster/id': 'cluster-id',
+              }
+            },
+            $route:      { query: {} },
+            $router:     { replace: mockReplace },
+            $fetchState: { pending: false },
+          },
+          stubs: {
+            Loading:             true,
+            Wizard:              true,
+            Banner:              true,
+            Checkbox:            true,
+            LabeledInput:        true,
+            LabeledSelect:       true,
+            NameNsDescription:   true,
+            Tabbed:              true,
+            Questions:           true,
+            YamlEditor:          true,
+            ResourceCancelModal: true,
+            UnitInput:           true,
+            TypeDescription:     true,
+            LazyImage:           true,
+            ChartReadme:         true,
+            ButtonGroup:         true,
+          }
+        },
+        data() {
+          return {
+            existing: false,
+            chart:    null,
+          };
+        }
+      });
+
+      jest.spyOn((wrapper.vm as any), 'appLocation').mockReturnValue(expectedLocation);
+
+      (wrapper.vm as any).cancel();
+
+      expect(mockReplace).toHaveBeenCalledWith(expectedLocation);
+    });
+  });
 });

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -1110,6 +1110,8 @@ export default {
         this.$router.replace(this.clusterToolsLocation());
       } else if (this.$route.query[FROM_CLUSTER] === _FLAGGED) {
         this.$router.replace(this.clustersLocation());
+      } else if (!this.chart) {
+        this.$router.replace(this.appLocation());
       } else {
         this.$router.replace(this.chartLocation(false));
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17292 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Updated the `cancel()` method in `shell/pages/c/_cluster/apps/charts/install.vue` to check if `this.chart` is undefined/falsy.
- If no chart is present, it now correctly redirects to the generic apps list (`this.appLocation()`) instead of attempting to navigate to the specific chart's location (`this.chartLocation()`).
- Added a corresponding unit test in `shell/pages/c/_cluster/apps/charts/__tests__/install.test.ts` to verify this new routing behavior.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
When `this.chart` was not available, the `cancel()` method was falling back to the `else` block which routes to `chartLocation(false)`. This could cause issues because `chartLocation()` relies on a valid chart. An explicit `else if (!this.chart)` condition was added to safely handle this missing state.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Navigate to the Explorer > Apps > Installed Apps
2. Find a "Managed" app like `fleet` and click on the action menu and select "Edit / Change Version"
3. Click on the "Cancel" button
4. Verify that the user is correctly redirected to the Installed Apps page and there are no console error anymore

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Cancelling charts installation and upgrade flows

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
