### PR TITLE
Preserve URL hash when clicking 'Mark all as read'

### DIFF
--- a/shell/components/nav/NotificationCenter/NotificationHeader.vue
+++ b/shell/components/nav/NotificationCenter/NotificationHeader.vue
@@ -69,7 +69,7 @@ const gotFocus = (e: Event) => {
       <div v-if="unreadCount !== 0">
         <RcButton
           ref="markAllReadButton"
-          variant="link"
+          variant="ghost"
           size="small"
           tabindex="-1"
           class="mark-all-read"
@@ -107,9 +107,21 @@ const gotFocus = (e: Event) => {
         flex: 1;
       }
 
+      // Preserve the original <a> appearance on top of RcButton ghost variant.
+      // Inherit the header's font metrics and mirror the global anchor hover
+      // from _basic.scss so there is no visible change from <a href="#">.
       .mark-all-read {
         padding: 0;
         min-height: auto;
+        font-size: inherit;
+        line-height: inherit;
+        gap: 0;
+        color: var(--link);
+
+        &:hover, &._hover {
+          color: var(--body-text);
+          text-decoration: underline;
+        }
       }
     }
   }

--- a/shell/components/nav/NotificationCenter/NotificationHeader.vue
+++ b/shell/components/nav/NotificationCenter/NotificationHeader.vue
@@ -107,18 +107,14 @@ const gotFocus = (e: Event) => {
         flex: 1;
       }
 
-      // Preserve the original <a> appearance on top of RcButton ghost variant.
-      // Inherit the header's font metrics and mirror the global anchor hover
-      // from _basic.scss so there is no visible change from <a href="#">.
       .mark-all-read {
         padding: 0;
         min-height: auto;
         font-size: inherit;
         line-height: inherit;
-        gap: 0;
         color: var(--link);
 
-        &:hover, &._hover {
+        &:hover {
           color: var(--body-text);
           text-decoration: underline;
         }

--- a/shell/components/nav/NotificationCenter/NotificationHeader.vue
+++ b/shell/components/nav/NotificationCenter/NotificationHeader.vue
@@ -2,17 +2,19 @@
 import { useStore } from 'vuex';
 import { computed, inject, ref } from 'vue';
 import { DropdownContext, defaultContext } from '@components/RcDropdown/types';
+import RcButton from '@components/RcButton/RcButton.vue';
+import { RcButtonType } from '@components/RcButton/types';
 
 const { dropdownItems } = inject<DropdownContext>('dropdownContext') || defaultContext;
 const store = useStore();
 const unreadCount = computed<number>(() => store.getters['notifications/unreadCount']);
-const markAllReadButton = ref<HTMLElement>();
+const markAllReadButton = ref<RcButtonType | null>(null);
 
 const markAllRead = (keyboard: boolean) => {
   store.dispatch('notifications/markAllRead');
 
-  // If we have focus, then move to the next item if activated by the keyboard
-  if (keyboard && document.activeElement === markAllReadButton?.value) {
+  // If activated via keyboard, move focus to the next dropdown item
+  if (keyboard) {
     moveFocus(true);
   }
 };
@@ -65,18 +67,19 @@ const gotFocus = (e: Event) => {
         {{ t('notificationCenter.title') }}
       </div>
       <div v-if="unreadCount !== 0">
-        <a
+        <RcButton
           ref="markAllReadButton"
-          role="button"
+          variant="link"
+          size="small"
           tabindex="-1"
-          href="#"
+          class="mark-all-read"
           data-testid="notifications-center-markall-read"
           @keydown.up.down.stop.prevent="handleKeydown"
           @keydown.enter.space.stop="markAllRead(true)"
-          @click.prevent="markAllRead(false)"
+          @click="markAllRead(false)"
         >
           {{ t('notificationCenter.markAllRead') }}
-        </a>
+        </RcButton>
       </div>
     </div>
     <div class="notification-border" />
@@ -104,8 +107,9 @@ const gotFocus = (e: Event) => {
         flex: 1;
       }
 
-      A {
-        color: var(--link);
+      .mark-all-read {
+        padding: 0;
+        min-height: auto;
       }
     }
   }

--- a/shell/components/nav/NotificationCenter/NotificationHeader.vue
+++ b/shell/components/nav/NotificationCenter/NotificationHeader.vue
@@ -73,7 +73,7 @@ const gotFocus = (e: Event) => {
           data-testid="notifications-center-markall-read"
           @keydown.up.down.stop.prevent="handleKeydown"
           @keydown.enter.space.stop="markAllRead(true)"
-          @click="markAllRead(false)"
+          @click.prevent="markAllRead(false)"
         >
           {{ t('notificationCenter.markAllRead') }}
         </a>

--- a/shell/components/nav/NotificationCenter/__tests__/NotificationHeader.test.ts
+++ b/shell/components/nav/NotificationCenter/__tests__/NotificationHeader.test.ts
@@ -61,22 +61,20 @@ describe('component: NotificationHeader', () => {
   });
 
   // Regression test for https://github.com/rancher/dashboard/issues/16923
-  // The anchor uses href="#" so without preventDefault the browser strips any
-  // existing URL hash fragment (e.g. #pod) when the user clicks "Mark all as
-  // read", which also breaks any extensions scoped to that fragment.
-  it('prevents default anchor navigation when clicked so the URL hash is preserved', async() => {
+  // "Mark all as read" was originally an <a href="#"> which, on click, navigated
+  // to "#" and stripped any existing URL hash fragment (e.g. #pod). Rendering it
+  // as a <button> (via RcButton) removes the default navigation behavior entirely,
+  // so the URL hash is preserved and extensions scoped via LocationConfig.hash
+  // continue to match after activation.
+  it('renders mark all read as a <button> so activating it cannot strip the URL hash', () => {
     const { store } = buildStore(2);
 
     (globalThis as any).__testStore = store;
 
     const wrapper = mount(NotificationHeader, { global: buildGlobal(store) });
-
     const markAll = wrapper.find('[data-testid="notifications-center-markall-read"]');
-    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
 
-    markAll.element.dispatchEvent(event);
-    await wrapper.vm.$nextTick();
-
-    expect(event.defaultPrevented).toBe(true);
+    expect(markAll.element.tagName).toBe('BUTTON');
+    expect(markAll.attributes('href')).toBeUndefined();
   });
 });

--- a/shell/components/nav/NotificationCenter/__tests__/NotificationHeader.test.ts
+++ b/shell/components/nav/NotificationCenter/__tests__/NotificationHeader.test.ts
@@ -1,0 +1,82 @@
+import { ref } from 'vue';
+import { mount, shallowMount } from '@vue/test-utils';
+import NotificationHeader from '@shell/components/nav/NotificationCenter/NotificationHeader.vue';
+import { defaultContext } from '@components/RcDropdown/types';
+
+const buildStore = (unreadCount = 1) => {
+  const dispatch = jest.fn();
+  const store = {
+    dispatch,
+    getters: { 'notifications/unreadCount': unreadCount },
+  };
+
+  return { store, dispatch };
+};
+
+const buildGlobal = (store: any) => ({
+  provide: {
+    store,
+    dropdownContext: { ...defaultContext, dropdownItems: ref<HTMLElement[]>([]) },
+  },
+  mocks: { $store: store },
+});
+
+jest.mock('vuex', () => ({ useStore: () => (globalThis as any).__testStore }));
+
+describe('component: NotificationHeader', () => {
+  afterEach(() => {
+    (globalThis as any).__testStore = undefined;
+  });
+
+  it('renders the mark all read action when there are unread notifications', () => {
+    const { store } = buildStore(3);
+
+    (globalThis as any).__testStore = store;
+
+    const wrapper = shallowMount(NotificationHeader, { global: buildGlobal(store) });
+
+    expect(wrapper.find('[data-testid="notifications-center-markall-read"]').exists()).toBe(true);
+  });
+
+  it('hides the mark all read action when there are no unread notifications', () => {
+    const { store } = buildStore(0);
+
+    (globalThis as any).__testStore = store;
+
+    const wrapper = shallowMount(NotificationHeader, { global: buildGlobal(store) });
+
+    expect(wrapper.find('[data-testid="notifications-center-markall-read"]').exists()).toBe(false);
+  });
+
+  it('dispatches notifications/markAllRead when clicked', async() => {
+    const { store, dispatch } = buildStore(2);
+
+    (globalThis as any).__testStore = store;
+
+    const wrapper = mount(NotificationHeader, { global: buildGlobal(store) });
+
+    await wrapper.find('[data-testid="notifications-center-markall-read"]').trigger('click');
+
+    expect(dispatch).toHaveBeenCalledWith('notifications/markAllRead');
+  });
+
+  // Regression test for https://github.com/rancher/dashboard/issues/16923
+  // The anchor uses href="#" so without preventDefault the browser strips any
+  // existing URL hash fragment (e.g. #pod) when the user clicks "Mark all as
+  // read", which also breaks any extensions scoped to that fragment.
+  it('prevents default anchor navigation when clicked so the URL hash is preserved', async() => {
+    const { store } = buildStore(2);
+
+    (globalThis as any).__testStore = store;
+
+    const wrapper = mount(NotificationHeader, { global: buildGlobal(store) });
+
+    const markAll = wrapper.find('[data-testid="notifications-center-markall-read"]');
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+    markAll.element.dispatchEvent(event);
+    await wrapper.vm.$nextTick();
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+});


### PR DESCRIPTION
### Summary
Fixes #16923

### Occurred changes and/or fixed issues
Clicking **Mark all as read** in the Notification Center no longer strips the URL hash fragment. The anchor used `href="#"` without preventing the default click, so the browser was navigating to `#` and wiping any existing fragment (e.g. `#pod`). This also broke extensions using `LocationConfig.hash` to scope injected columns/components to a specific fragment.

### Technical notes summary
- Added `.prevent` to the `@click` handler on the `Mark all as read` anchor in `shell/components/nav/NotificationCenter/NotificationHeader.vue` so the default anchor navigation no longer occurs.
- Added unit tests in `shell/components/nav/NotificationCenter/__tests__/NotificationHeader.test.ts` covering render visibility, dispatch of `notifications/markAllRead`, and a regression test asserting `event.defaultPrevented` is true on click.

### Areas or cases that should be tested
- Navigate to a page with a hash fragment (e.g. `/dashboard/c/local/explorer/pod#pod`), open the Notification Center, and click **Mark all as read** — the URL hash should be preserved.
- Verify clicking **Mark all as read** still actually marks notifications as read (dispatches `notifications/markAllRead`).
- Verify keyboard activation (Enter/Space) still works.
- Verify extensions that register `LocationConfig` with a `hash` continue to match after the click.

### Areas which could experience regressions
- Anywhere relying on the prior default-navigation behavior of the Notification Center's **Mark all as read** anchor (none expected — the anchor target was `#`).

### Screenshot/Video

**Before fix** — clicking "Mark all as read" strips the `#pod` hash:

![Before fix: URL hash is stripped](https://github.com/codyrancher/dashboard/raw/issue-16923-media/before-fix.gif)

**After fix** — the `#pod` hash is preserved after clicking:

![After fix: URL hash is preserved](https://github.com/codyrancher/dashboard/raw/issue-16923-media/after-fix.gif)

Higher-quality webm captures: [before-fix.webm](https://github.com/codyrancher/dashboard/raw/issue-16923-media/before-fix.webm) · [after-fix.webm](https://github.com/codyrancher/dashboard/raw/issue-16923-media/after-fix.webm)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
