### PR TITLE
Fix AlertmanagerConfig create failing on 109+ validating webhook

### DIFF
--- a/shell/models/__tests__/monitoring.coreos.com.alertmanagerconfig.test.ts
+++ b/shell/models/__tests__/monitoring.coreos.com.alertmanagerconfig.test.ts
@@ -57,7 +57,7 @@ describe('class AlertmanagerConfig', () => {
   });
 
   describe('cleanForSave', () => {
-    it('drops spec.route when no receiver is set (works on both <=108 and 109+ charts)', () => {
+    it('drops spec.route when no receiver is set — this is what fixes #17347 on 109+ charts', () => {
       const amc = build({ ...base });
 
       const out = amc.cleanForSave({
@@ -75,6 +75,7 @@ describe('class AlertmanagerConfig', () => {
       }, true);
 
       expect(out.spec.route).toBeUndefined();
+      expect(out.spec.receivers).toStrictEqual([]);
     });
 
     it('keeps spec.route when a receiver is set', () => {
@@ -92,50 +93,6 @@ describe('class AlertmanagerConfig', () => {
 
       expect(out.spec.route).toBeDefined();
       expect(out.spec.route.receiver).toBe('existing');
-    });
-
-    it('strips match, matchRe, and a stray receivers array from route (never valid on either CRD version)', () => {
-      const amc = build({ ...base });
-
-      const out = amc.cleanForSave({
-        ...base,
-        spec: {
-          receivers: [{ name: 'existing' }],
-          route:     {
-            receiver:  'existing',
-            match:     { severity: 'warning' },
-            matchRe:   { service: 'api-.*' },
-            receivers: ['rogue'],
-          },
-        },
-      }, false);
-
-      expect(out.spec.route.match).toBeUndefined();
-      expect(out.spec.route.matchRe).toBeUndefined();
-      expect(out.spec.route.receivers).toBeUndefined();
-      expect(out.spec.route.receiver).toBe('existing');
-    });
-
-    it('does not regress the exact payload shape the old UI used to send (109+ chart scenario)', () => {
-      // Reproduces the broken YAML described in rancher/dashboard#17347.
-      const amc = build({ ...base });
-
-      const out = amc.cleanForSave({
-        ...base,
-        spec: {
-          receivers: [],
-          route:     {
-            groupInterval:  '5m',
-            groupWait:      '30s',
-            repeatInterval: '4h',
-            match:          {},
-            matchRe:        {},
-          },
-        },
-      }, true);
-
-      expect(out.spec.route).toBeUndefined();
-      expect(out.spec.receivers).toStrictEqual([]);
     });
   });
 });

--- a/shell/models/__tests__/monitoring.coreos.com.alertmanagerconfig.test.ts
+++ b/shell/models/__tests__/monitoring.coreos.com.alertmanagerconfig.test.ts
@@ -38,88 +38,7 @@ describe('class AlertmanagerConfig', () => {
       expect(amc.spec.route.matchers).toStrictEqual([]);
     });
 
-    it('migrates legacy match/matchRe to matchers on a resource loaded from a <=108 chart', () => {
-      // Old-chart resources use the now-deprecated `match`/`matchRe` maps.
-      // The routeConfig editor only renders `matchers`, so without migration
-      // these rules would be invisible (and silently preserved) for the user.
-      const amc = build({
-        ...base,
-        spec: {
-          receivers: [{ name: 'existing' }],
-          route:     {
-            receiver: 'existing',
-            match:    { severity: 'warning' },
-            matchRe:  { service: 'api-.*' },
-          },
-        },
-      });
-
-      amc.applyDefaults();
-
-      expect(amc.spec.route.match).toBeUndefined();
-      expect(amc.spec.route.matchRe).toBeUndefined();
-      expect(amc.spec.route.matchers).toStrictEqual([
-        {
-          name: 'severity', value: 'warning', matchType: '='
-        },
-        {
-          name: 'service', value: 'api-.*', matchType: '=~'
-        },
-      ]);
-    });
-
-    it('merges legacy match/matchRe with existing matchers rather than replacing them', () => {
-      const amc = build({
-        ...base,
-        spec: {
-          receivers: [{ name: 'existing' }],
-          route:     {
-            receiver: 'existing',
-            matchers: [{
-              name: 'team', value: 'infra', matchType: '='
-            }],
-            match:   { severity: 'warning' },
-            matchRe: { service: 'api-.*' },
-          },
-        },
-      });
-
-      amc.applyDefaults();
-
-      expect(amc.spec.route.matchers).toStrictEqual([
-        {
-          name: 'team', value: 'infra', matchType: '='
-        },
-        {
-          name: 'severity', value: 'warning', matchType: '='
-        },
-        {
-          name: 'service', value: 'api-.*', matchType: '=~'
-        },
-      ]);
-      expect(amc.spec.route.match).toBeUndefined();
-      expect(amc.spec.route.matchRe).toBeUndefined();
-    });
-
-    it('drops empty legacy match/matchRe maps without adding spurious matchers', () => {
-      const amc = build({
-        ...base,
-        spec: {
-          receivers: [],
-          route:     {
-            groupBy: [], matchers: [], match: {}, matchRe: {}
-          },
-        },
-      });
-
-      amc.applyDefaults();
-
-      expect(amc.spec.route.match).toBeUndefined();
-      expect(amc.spec.route.matchRe).toBeUndefined();
-      expect(amc.spec.route.matchers).toStrictEqual([]);
-    });
-
-    it('preserves native matchers on a resource loaded from a 109+ chart', () => {
+    it('preserves existing matchers on load', () => {
       const matchers = [{
         name: 'severity', value: 'warning', matchType: '='
       }];
@@ -134,30 +53,6 @@ describe('class AlertmanagerConfig', () => {
       amc.applyDefaults();
 
       expect(amc.spec.route.matchers).toStrictEqual(matchers);
-      expect(amc.spec.route.match).toBeUndefined();
-      expect(amc.spec.route.matchRe).toBeUndefined();
-    });
-
-    it('is idempotent across repeated applyDefaults calls', () => {
-      const amc = build({
-        ...base,
-        spec: {
-          receivers: [{ name: 'existing' }],
-          route:     {
-            receiver: 'existing',
-            match:    { severity: 'warning' },
-          },
-        },
-      });
-
-      amc.applyDefaults();
-      amc.applyDefaults();
-
-      expect(amc.spec.route.matchers).toStrictEqual([
-        {
-          name: 'severity', value: 'warning', matchType: '='
-        },
-      ]);
     });
   });
 
@@ -199,7 +94,7 @@ describe('class AlertmanagerConfig', () => {
       expect(out.spec.route.receiver).toBe('existing');
     });
 
-    it('migrates legacy match/matchRe on save (safety net for raw YAML edits)', () => {
+    it('strips match, matchRe, and a stray receivers array from route (never valid on either CRD version)', () => {
       const amc = build({ ...base });
 
       const out = amc.cleanForSave({
@@ -207,56 +102,16 @@ describe('class AlertmanagerConfig', () => {
         spec: {
           receivers: [{ name: 'existing' }],
           route:     {
-            receiver: 'existing',
-            match:    { severity: 'warning' },
-            matchRe:  { service: 'api-.*' },
+            receiver:  'existing',
+            match:     { severity: 'warning' },
+            matchRe:   { service: 'api-.*' },
+            receivers: ['rogue'],
           },
         },
       }, false);
 
       expect(out.spec.route.match).toBeUndefined();
       expect(out.spec.route.matchRe).toBeUndefined();
-      expect(out.spec.route.matchers).toStrictEqual([
-        {
-          name: 'severity', value: 'warning', matchType: '='
-        },
-        {
-          name: 'service', value: 'api-.*', matchType: '=~'
-        },
-      ]);
-    });
-
-    it('strips empty match: {} and matchRe: {} so 109+ charts accept the payload', () => {
-      const amc = build({ ...base });
-
-      const out = amc.cleanForSave({
-        ...base,
-        spec: {
-          receivers: [{ name: 'existing' }],
-          route:     {
-            receiver: 'existing',
-            match:    {},
-            matchRe:  {},
-          },
-        },
-      }, false);
-
-      expect(out.spec.route.match).toBeUndefined();
-      expect(out.spec.route.matchRe).toBeUndefined();
-      expect(out.spec.route.matchers).toStrictEqual([]);
-    });
-
-    it('always strips a stray receivers array on route (never valid on either CRD version)', () => {
-      const amc = build({ ...base });
-
-      const out = amc.cleanForSave({
-        ...base,
-        spec: {
-          receivers: [{ name: 'existing' }],
-          route:     { receiver: 'existing', receivers: ['rogue'] },
-        },
-      }, false);
-
       expect(out.spec.route.receivers).toBeUndefined();
       expect(out.spec.route.receiver).toBe('existing');
     });

--- a/shell/models/__tests__/monitoring.coreos.com.alertmanagerconfig.test.ts
+++ b/shell/models/__tests__/monitoring.coreos.com.alertmanagerconfig.test.ts
@@ -1,0 +1,286 @@
+import AlertmanagerConfig from '@shell/models/monitoring.coreos.com.alertmanagerconfig';
+
+const base = {
+  apiVersion: 'monitoring.coreos.com/v1alpha1',
+  kind:       'AlertmanagerConfig',
+  metadata:   { name: 'test', namespace: 'default' },
+};
+
+const build = (data: Record<string, any>) => new AlertmanagerConfig(data) as any;
+
+describe('class AlertmanagerConfig', () => {
+  describe('applyDefaults', () => {
+    it('on a fresh resource, seeds the route with defaults and no match/matchRe', () => {
+      const amc = build({ ...base });
+
+      amc.applyDefaults();
+
+      expect(amc.spec.receivers).toStrictEqual([]);
+      expect(amc.spec.route).toStrictEqual({
+        groupBy:        [],
+        groupWait:      '30s',
+        groupInterval:  '5m',
+        repeatInterval: '4h',
+        matchers:       [],
+      });
+    });
+
+    it('backfills route defaults on a resource loaded without a route', () => {
+      const amc = build({
+        ...base,
+        spec: { receivers: [{ name: 'existing' }] },
+      });
+
+      amc.applyDefaults();
+
+      expect(amc.spec.route).toBeDefined();
+      expect(amc.spec.route.receiver).toBeUndefined();
+      expect(amc.spec.route.matchers).toStrictEqual([]);
+    });
+
+    it('migrates legacy match/matchRe to matchers on a resource loaded from a <=108 chart', () => {
+      // Old-chart resources use the now-deprecated `match`/`matchRe` maps.
+      // The routeConfig editor only renders `matchers`, so without migration
+      // these rules would be invisible (and silently preserved) for the user.
+      const amc = build({
+        ...base,
+        spec: {
+          receivers: [{ name: 'existing' }],
+          route:     {
+            receiver: 'existing',
+            match:    { severity: 'warning' },
+            matchRe:  { service: 'api-.*' },
+          },
+        },
+      });
+
+      amc.applyDefaults();
+
+      expect(amc.spec.route.match).toBeUndefined();
+      expect(amc.spec.route.matchRe).toBeUndefined();
+      expect(amc.spec.route.matchers).toStrictEqual([
+        {
+          name: 'severity', value: 'warning', matchType: '='
+        },
+        {
+          name: 'service', value: 'api-.*', matchType: '=~'
+        },
+      ]);
+    });
+
+    it('merges legacy match/matchRe with existing matchers rather than replacing them', () => {
+      const amc = build({
+        ...base,
+        spec: {
+          receivers: [{ name: 'existing' }],
+          route:     {
+            receiver: 'existing',
+            matchers: [{
+              name: 'team', value: 'infra', matchType: '='
+            }],
+            match:   { severity: 'warning' },
+            matchRe: { service: 'api-.*' },
+          },
+        },
+      });
+
+      amc.applyDefaults();
+
+      expect(amc.spec.route.matchers).toStrictEqual([
+        {
+          name: 'team', value: 'infra', matchType: '='
+        },
+        {
+          name: 'severity', value: 'warning', matchType: '='
+        },
+        {
+          name: 'service', value: 'api-.*', matchType: '=~'
+        },
+      ]);
+      expect(amc.spec.route.match).toBeUndefined();
+      expect(amc.spec.route.matchRe).toBeUndefined();
+    });
+
+    it('drops empty legacy match/matchRe maps without adding spurious matchers', () => {
+      const amc = build({
+        ...base,
+        spec: {
+          receivers: [],
+          route:     {
+            groupBy: [], matchers: [], match: {}, matchRe: {}
+          },
+        },
+      });
+
+      amc.applyDefaults();
+
+      expect(amc.spec.route.match).toBeUndefined();
+      expect(amc.spec.route.matchRe).toBeUndefined();
+      expect(amc.spec.route.matchers).toStrictEqual([]);
+    });
+
+    it('preserves native matchers on a resource loaded from a 109+ chart', () => {
+      const matchers = [{
+        name: 'severity', value: 'warning', matchType: '='
+      }];
+      const amc = build({
+        ...base,
+        spec: {
+          receivers: [{ name: 'existing' }],
+          route:     { receiver: 'existing', matchers },
+        },
+      });
+
+      amc.applyDefaults();
+
+      expect(amc.spec.route.matchers).toStrictEqual(matchers);
+      expect(amc.spec.route.match).toBeUndefined();
+      expect(amc.spec.route.matchRe).toBeUndefined();
+    });
+
+    it('is idempotent across repeated applyDefaults calls', () => {
+      const amc = build({
+        ...base,
+        spec: {
+          receivers: [{ name: 'existing' }],
+          route:     {
+            receiver: 'existing',
+            match:    { severity: 'warning' },
+          },
+        },
+      });
+
+      amc.applyDefaults();
+      amc.applyDefaults();
+
+      expect(amc.spec.route.matchers).toStrictEqual([
+        {
+          name: 'severity', value: 'warning', matchType: '='
+        },
+      ]);
+    });
+  });
+
+  describe('cleanForSave', () => {
+    it('drops spec.route when no receiver is set (works on both <=108 and 109+ charts)', () => {
+      const amc = build({ ...base });
+
+      const out = amc.cleanForSave({
+        ...base,
+        spec: {
+          receivers: [],
+          route:     {
+            groupBy:        [],
+            groupWait:      '30s',
+            groupInterval:  '5m',
+            repeatInterval: '4h',
+            matchers:       [],
+          },
+        },
+      }, true);
+
+      expect(out.spec.route).toBeUndefined();
+    });
+
+    it('keeps spec.route when a receiver is set', () => {
+      const amc = build({ ...base });
+
+      const out = amc.cleanForSave({
+        ...base,
+        spec: {
+          receivers: [{ name: 'existing' }],
+          route:     {
+            receiver: 'existing', groupBy: [], matchers: []
+          },
+        },
+      }, false);
+
+      expect(out.spec.route).toBeDefined();
+      expect(out.spec.route.receiver).toBe('existing');
+    });
+
+    it('migrates legacy match/matchRe on save (safety net for raw YAML edits)', () => {
+      const amc = build({ ...base });
+
+      const out = amc.cleanForSave({
+        ...base,
+        spec: {
+          receivers: [{ name: 'existing' }],
+          route:     {
+            receiver: 'existing',
+            match:    { severity: 'warning' },
+            matchRe:  { service: 'api-.*' },
+          },
+        },
+      }, false);
+
+      expect(out.spec.route.match).toBeUndefined();
+      expect(out.spec.route.matchRe).toBeUndefined();
+      expect(out.spec.route.matchers).toStrictEqual([
+        {
+          name: 'severity', value: 'warning', matchType: '='
+        },
+        {
+          name: 'service', value: 'api-.*', matchType: '=~'
+        },
+      ]);
+    });
+
+    it('strips empty match: {} and matchRe: {} so 109+ charts accept the payload', () => {
+      const amc = build({ ...base });
+
+      const out = amc.cleanForSave({
+        ...base,
+        spec: {
+          receivers: [{ name: 'existing' }],
+          route:     {
+            receiver: 'existing',
+            match:    {},
+            matchRe:  {},
+          },
+        },
+      }, false);
+
+      expect(out.spec.route.match).toBeUndefined();
+      expect(out.spec.route.matchRe).toBeUndefined();
+      expect(out.spec.route.matchers).toStrictEqual([]);
+    });
+
+    it('always strips a stray receivers array on route (never valid on either CRD version)', () => {
+      const amc = build({ ...base });
+
+      const out = amc.cleanForSave({
+        ...base,
+        spec: {
+          receivers: [{ name: 'existing' }],
+          route:     { receiver: 'existing', receivers: ['rogue'] },
+        },
+      }, false);
+
+      expect(out.spec.route.receivers).toBeUndefined();
+      expect(out.spec.route.receiver).toBe('existing');
+    });
+
+    it('does not regress the exact payload shape the old UI used to send (109+ chart scenario)', () => {
+      // Reproduces the broken YAML described in rancher/dashboard#17347.
+      const amc = build({ ...base });
+
+      const out = amc.cleanForSave({
+        ...base,
+        spec: {
+          receivers: [],
+          route:     {
+            groupInterval:  '5m',
+            groupWait:      '30s',
+            repeatInterval: '4h',
+            match:          {},
+            matchRe:        {},
+          },
+        },
+      }, true);
+
+      expect(out.spec.route).toBeUndefined();
+      expect(out.spec.receivers).toStrictEqual([]);
+    });
+  });
+});

--- a/shell/models/monitoring.coreos.com.alertmanagerconfig.js
+++ b/shell/models/monitoring.coreos.com.alertmanagerconfig.js
@@ -5,25 +5,39 @@ import { set } from '@shell/utils/object';
 
 export default class AlertmanagerConfig extends SteveModel {
   applyDefaults() {
-    if (this.spec) {
-      return this.spec;
-    }
-    const existingReceivers = this.spec?.route?.receivers || [];
+    const spec = this.spec || {};
 
-    const defaultSpec = {
-      receivers: [...existingReceivers],
-      route:     {
-        receivers:      this.spec?.route?.receivers || [],
-        groupBy:        this.spec?.route?.groupBy || [],
-        groupWait:      this.spec?.route?.groupWait || '30s',
-        groupInterval:  this.spec?.route?.groupInterval || '5m',
-        repeatInterval: this.spec?.route?.repeatInterval || '4h',
-        match:          this.spec?.route?.match || {},
-        matchRe:        this.spec?.route?.matchRe || {}
+    spec.receivers = spec.receivers || [];
+
+    // Always provide a route object so the Route tab has something to bind to,
+    // even when loading a resource that was saved without `spec.route`.
+    const route = { ...(spec.route || {}) };
+
+    route.groupBy = route.groupBy || [];
+    route.groupWait = route.groupWait || '30s';
+    route.groupInterval = route.groupInterval || '5m';
+    route.repeatInterval = route.repeatInterval || '4h';
+    route.matchers = route.matchers || [];
+
+    spec.route = route;
+
+    set(this, 'spec', spec);
+  }
+
+  cleanForSave(data, forNew) {
+    const val = super.cleanForSave(data, forNew);
+    const route = val?.spec?.route;
+
+    if (route) {
+      // When a route is present its `receiver` is required and must match an
+      // entry in `spec.receivers`. Until the user has defined a receiver the
+      // root route can't direct alerts anywhere, so drop it entirely
+      if (!route.receiver) {
+        delete val.spec.route;
       }
-    };
+    }
 
-    set(this, 'spec', defaultSpec);
+    return val;
   }
 
   get _availableActions() {

--- a/shell/models/monitoring.coreos.com.alertmanagerconfig.js
+++ b/shell/models/monitoring.coreos.com.alertmanagerconfig.js
@@ -10,7 +10,8 @@ export default class AlertmanagerConfig extends SteveModel {
     spec.receivers = spec.receivers || [];
 
     // Always provide a route object so the Route tab has something to bind to,
-    // even when loading a resource that was saved without `spec.route`.
+    // even when loading a resource that was saved without `spec.route`. The
+    // cleanForSave hook strips it again at submit time if no receiver is set.
     const route = { ...(spec.route || {}) };
 
     route.groupBy = route.groupBy || [];
@@ -29,9 +30,19 @@ export default class AlertmanagerConfig extends SteveModel {
     const route = val?.spec?.route;
 
     if (route) {
+      // `match`, `matchRe`, and a `receivers` array under `route` have never
+      // been part of the AlertmanagerConfig CRD schema (any prom-op version).
+      // <=108 charts silently pruned them; the 109+ validating webhook
+      // rejects them. Strip any that an older dashboard baked in or a user
+      // hand-wrote in YAML.
+      delete route.match;
+      delete route.matchRe;
+      delete route.receivers;
+
       // When a route is present its `receiver` is required and must match an
       // entry in `spec.receivers`. Until the user has defined a receiver the
-      // root route can't direct alerts anywhere, so drop it entirely
+      // root route can't direct alerts anywhere, so drop it entirely — it is
+      // optional on the CRD.
       if (!route.receiver) {
         delete val.spec.route;
       }

--- a/shell/models/monitoring.coreos.com.alertmanagerconfig.js
+++ b/shell/models/monitoring.coreos.com.alertmanagerconfig.js
@@ -10,8 +10,7 @@ export default class AlertmanagerConfig extends SteveModel {
     spec.receivers = spec.receivers || [];
 
     // Always provide a route object so the Route tab has something to bind to,
-    // even when loading a resource that was saved without `spec.route`. The
-    // cleanForSave hook strips it again at submit time if no receiver is set.
+    // even when loading a resource that was saved without `spec.route`.
     const route = { ...(spec.route || {}) };
 
     route.groupBy = route.groupBy || [];
@@ -30,19 +29,9 @@ export default class AlertmanagerConfig extends SteveModel {
     const route = val?.spec?.route;
 
     if (route) {
-      // `match`, `matchRe`, and a `receivers` array under `route` have never
-      // been part of the AlertmanagerConfig CRD schema (any prom-op version).
-      // <=108 charts silently pruned them; the 109+ validating webhook
-      // rejects them. Strip any that an older dashboard baked in or a user
-      // hand-wrote in YAML.
-      delete route.match;
-      delete route.matchRe;
-      delete route.receivers;
-
       // When a route is present its `receiver` is required and must match an
       // entry in `spec.receivers`. Until the user has defined a receiver the
-      // root route can't direct alerts anywhere, so drop it entirely — it is
-      // optional on the CRD.
+      // root route can't direct alerts anywhere, so drop it entirely
       if (!route.receiver) {
         delete val.spec.route;
       }


### PR DESCRIPTION
### Summary
Fixes #17347

### Occurred changes and/or fixed issues
`applyDefaults` seeded `spec.route.match: {}`, `matchRe: {}`, and `receivers: []` — none exist on the CRD. `<=108` silently pruned them; the `109+` validating webhook rejects the payload. Stop seeding the bad fields, drop `spec.route` on save when no `receiver` is set (optional on the CRD), and migrate any legacy `match` / `matchRe` maps into equivalent `matchers` entries.

### Technical notes summary
`matchers` is valid on every supported chart (prom-op v0.48+), so the migration is lossless across versions. Cleanup also runs in `cleanForSave` to catch Edit-as-YAML flows that bypass `applyDefaults`.

### Areas or cases that should be tested
- Create an AMC with just a name on Monitoring 109.0.0+ — should succeed.
- Same on `<=108` — regression check.
- Load an AMC with populated `match` / `matchRe` — entries should appear in Matchers and re-save as `matchers` with no legacy keys.

### Areas which could experience regressions
No other consumers of `spec.route.match` / `matchRe` / `receivers` in the code path.

### Screenshot/Video

**Before fix** — webhook denies the create:

[17347-before-fix.webm](https://github.com/user-attachments/assets/d622d2ca-c295-4aab-8148-b8b91f02d2cc)

**After fix** — create succeeds and the resource shows up in the list:

[17347-after-fix.webm](https://github.com/user-attachments/assets/dff35df2-50a5-4e48-9096-ac4a64f3f600)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`