### PR TITLE
Dev docs: document skip chart tests env variable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,7 @@ Please see [Rancher UI Internal Documentation - Testing - Unit Tests](https://ex
 - `TEST_SKIP` - Comma-separated test directories to skip (e.g., setup,extensions)
 - `TEST_ONLY` - Comma-separated test directories to run exclusively
 - `GREP_TAGS` - Filter tests by tags
+- `CYPRESS_ALLOW_FILTERED_CATALOG_SKIP` - When `true`, chart tests may skip if a chart is hidden in the UI filtered catalog but present in the unfiltered index. When unset or not `true`, those tests fail.
 
 ## Agentic Workflows
 

--- a/docs/agents.md/contributors/3_e2e-tests.md
+++ b/docs/agents.md/contributors/3_e2e-tests.md
@@ -22,3 +22,4 @@
 - `TEST_SKIP` - Comma-separated test directories to skip (e.g., setup,extensions)
 - `TEST_ONLY` - Comma-separated test directories to run exclusively
 - `GREP_TAGS` - Filter tests by tags
+- `CYPRESS_ALLOW_FILTERED_CATALOG_SKIP` - When `true`, chart tests may skip if a chart is hidden in the UI filtered catalog but present in the unfiltered index. When unset or not `true`, those tests fail.

--- a/docusaurus/docs/internal/testing/e2e-test.md
+++ b/docusaurus/docs/internal/testing/e2e-test.md
@@ -74,6 +74,15 @@ It is now possible to skip features by using the `TEST_SKIP` env var, e.g. `TEST
 Alternatively is possible to solely run a specific feature by using the `TEST_ONLY` env var, e.g. `TEST_ONLY=setup`.
 The features are folder name based and can be found in `cypress/e2e/tests/pages`.
 
+### Skip chart tests behavior
+
+Some chart E2E tests check charts that are hidden in the UI catalog. If a chart is intentionally hidden, the E2E test is skipped.
+
+- `CYPRESS_ALLOW_FILTERED_CATALOG_SKIP=true`: skip those tests.
+- `CYPRESS_ALLOW_FILTERED_CATALOG_SKIP` unset (or not `true`): fail those tests.
+
+This only applies when the chart exists in the unfiltered catalog index but is hidden in the UI filtered catalog.
+
 ## Skipping e2e tests
 
 CI gates can be disabled in the following way:


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2311

Update dev docs to include newly added `CYPRESS_ALLOW_FILTERED_CATALOG_SKIP` env variable. 
<!-- Define findings related to the feature or bug issue. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
