### PR TITLE
fix: harvester e2e test unable to click the version exceed the screen

### DIFF
--- a/cypress/e2e/po/components/labeled-select.po.ts
+++ b/cypress/e2e/po/components/labeled-select.po.ts
@@ -13,7 +13,7 @@ export default class LabeledSelectPo extends ComponentPo {
   }
 
   clickOption(optionIndex: number) {
-    return this.self().get(`.vs__dropdown-menu .vs__dropdown-option:nth-child(${ optionIndex })`).click();
+    return this.self().get(`.vs__dropdown-menu .vs__dropdown-option:nth-child(${ optionIndex })`).click({ force: true });
   }
 
   clickOptionWithLabel(label: string) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
failed e2e test case `missing repo message should display when repo does NOT exist`
https://github.com/rancher/dashboard/actions/runs/24915605535/job/72972695023?pr=17355

### Occurred changes and/or fixed issues
Harvester team release v1.8.0 last Friday which causes the version dropdown memu is too long to view in the screen.

http://nginx:asd@139.59.134.103/instance/a534a13e-6884-445f-8b7d-44c1d7404127/others/RECORDED_VIDEO

<img width="1036" height="787" alt="Screenshot 2026-04-26 at 2 54 55 AM" src="https://github.com/user-attachments/assets/ebf3a03b-642e-4567-8035-c3d4aef2736e" />

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
