### PR TITLE
Automation: Stabilize Amazon EC2 machine pool scale assertions

### DIFF
--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-rke2.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/tabs/machine-pools-tab-rke2.po.ts
@@ -25,6 +25,10 @@ export default class MachinePoolRke2 extends ComponentPo {
     return new LabeledSelectPo('[data-testid="amazonEc2__selectedNetwork"]');
   }
 
+  region(): LabeledSelectPo {
+    return new LabeledSelectPo('[data-testid="amazonEc2__region"]');
+  }
+
   enableDualStack(): CheckboxInputPo {
     return new CheckboxInputPo('[data-testid="amazonEc2__enableIpv6"]');
   }

--- a/cypress/e2e/po/lists/machine-pools-list.po.ts
+++ b/cypress/e2e/po/lists/machine-pools-list.po.ts
@@ -63,6 +63,10 @@ export default class MachinePoolsListPo extends BaseResourceList {
       .find('[data-testid="machine-progress-bar"]');
   }
 
+  progressBarElements(poolName: string, selector: string, options?: GetOptions) {
+    return this.machineProgressBar(poolName).find(selector, options);
+  }
+
   scaleDownButton(poolName: string) {
     return this.resourceTable().sortableTable().groupElementWithName(poolName)
       .find('[data-testid="scale-down-button"]');

--- a/cypress/e2e/tests/pages/fleet/helmop.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/helmop.spec.ts
@@ -2,7 +2,7 @@ import { FleetApplicationCreatePo, FleetApplicationListPagePo } from '~/cypress/
 import { FleetHelmOpCreateEditPo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.helmop.po';
 import { generateFakeClusterDataAndIntercepts } from '@/cypress/e2e/blueprints/nav/fake-cluster';
 import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
-import { EXTRA_LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import { EXTRA_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 
 const fakeProvClusterId = 'fake-cluster-id';
 const fakeMgmtClusterId = 'fake-mgmt-id';
@@ -262,20 +262,7 @@ describe('Fleet HelmOps', { testIsolation: 'off', tags: ['@fleet', '@adminUser']
       helmOpEditPage.resourceDetail().createEditView().save();
 
       // Wait for successful update request
-      // Dashboard automatically retries on 409 conflicts, so we wait for requests until we get a 200
-      cy.wait('@updateHelmOp').then((interception) => {
-        if (interception.response?.statusCode === 200) {
-          return cy.wrap(interception);
-        }
-
-        return cy.wait('@updateHelmOp', MEDIUM_TIMEOUT_OPT);
-      }).then((interception) => {
-        // Verify we got a successful response
-        // If Dashboard's automatic retry didn't work, this will fail
-        expect(interception.response?.statusCode).to.eq(200);
-
-        return interception;
-      }).then(({ request, response }: any) => {
+      cy.waitForInterceptWithConflictRetry('@updateHelmOp').then(({ request, response }: any) => {
         // Verify request payload contains downstreamResources in spec (not spec.helm)
         // testing: https://github.com/rancher/dashboard/pull/15921
         expect(request.body.spec.downstreamResources).to.be.an('array');

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -226,7 +226,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
     clusterDetails.poolsList('machine').machinePoolReadyofDesiredCount(`${ this.rke2Ec2ClusterName }-pool1`, /1$/, LONG_TIMEOUT_OPT);
 
     // progress bar should either be all green (first machine done by this stage) or all red (first machine still provisioning)
-    clusterDetails.poolsList('machine').machineProgressBar(`${ this.rke2Ec2ClusterName }-pool1`).find('.piece').should('have.length', 1);
+    clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.piece').should('have.length', 1);
 
     // Scale up the machine pool
     clusterDetails.poolsList('machine').scaleUpButton(`${ this.rke2Ec2ClusterName }-pool1`)
@@ -238,16 +238,16 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
     clusterDetails.poolsList('machine').machinePoolReadyofDesiredCount(`${ this.rke2Ec2ClusterName }-pool1`, /^[0-9] of 2$/);
 
     // progress bar should contain red - possibly green/red if first machine is done but definitely at least red
-    clusterDetails.poolsList('machine').machineProgressBar(`${ this.rke2Ec2ClusterName }-pool1`).find('.bg-error').should('exist');
+    clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.bg-error').should('exist');
 
     // Verify the machine pool is scaled up to 2
     clusterDetails.poolsList('machine').machinePoolReadyofDesiredCount(`${ this.rke2Ec2ClusterName }-pool1`, /^2$/, VERY_LONG_TIMEOUT_OPT);
     clusterDetails.poolsList('machine').resourceTable().sortableTable().checkRowCount(false, 2, LONG_TIMEOUT_OPT);
 
     // check that progress bar contains green and no red
-    clusterDetails.poolsList('machine').machineProgressBar(`${ this.rke2Ec2ClusterName }-pool1`).find('.bg-error').should('not.exist');
-    clusterDetails.poolsList('machine').machineProgressBar(`${ this.rke2Ec2ClusterName }-pool1`).find('.bg-success').should('exist');
-    clusterDetails.poolsList('machine').machineProgressBar(`${ this.rke2Ec2ClusterName }-pool1`).find('.piece').should('have.length', 1);
+    clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.bg-error', MEDIUM_TIMEOUT_OPT).should('not.exist');
+    clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.bg-success').should('exist');
+    clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.piece').should('have.length', 1);
 
     // Verify the scale down button is now enabled (since we have 2 nodes)
     clusterDetails.poolsList('machine').scaleDownButton(`${ this.rke2Ec2ClusterName }-pool1`)
@@ -278,9 +278,9 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
       .click();
 
     clusterDetails.poolsList('machine').machinePoolReadyofDesiredCount(`${ this.rke2Ec2ClusterName }-pool1`, /^2$/, MEDIUM_TIMEOUT_OPT);
-    clusterDetails.poolsList('machine').machineProgressBar(`${ this.rke2Ec2ClusterName }-pool1`).find('.bg-error').should('not.exist');
-    clusterDetails.poolsList('machine').machineProgressBar(`${ this.rke2Ec2ClusterName }-pool1`).find('.bg-success').should('exist');
-    clusterDetails.poolsList('machine').machineProgressBar(`${ this.rke2Ec2ClusterName }-pool1`).find('.piece').should('have.length', 1);
+    clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.bg-error').should('not.exist');
+    clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.bg-success').should('exist');
+    clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.piece').should('have.length', 1);
 
     // Verify the scale down button is enabled
     clusterDetails.poolsList('machine').scaleDownButton(`${ this.rke2Ec2ClusterName }-pool1`)
@@ -299,19 +299,21 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
     promptModal().clickActionButton('Confirm');
 
     cy.wait('@scaleDownMachineDeployment').its('response.statusCode').should('eq', 200);
-    clusterDetails.poolsList('machine').machineProgressBar(`${ this.rke2Ec2ClusterName }-pool1`).find('.bg-error').should('exist');
-    clusterDetails.poolsList('machine').machineProgressBar(`${ this.rke2Ec2ClusterName }-pool1`).find('.bg-success').should('exist');
-    clusterDetails.poolsList('machine').machineProgressBar(`${ this.rke2Ec2ClusterName }-pool1`).find('.piece').should('have.length', 2);
+    clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.bg-error', MEDIUM_TIMEOUT_OPT).should('exist');
+    clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.bg-success').should('exist');
+    clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.piece').should('have.length', 2);
+
+    // Verify the cluster is updating
+    clusterDetails.resourceDetail().masthead().resourceStatus().contains('Updating');
 
     // Verify the machine pool is scaled down to 1
     clusterDetails.poolsList('machine').machinePoolReadyofDesiredCount(`${ this.rke2Ec2ClusterName }-pool1`, /^1$/, MEDIUM_TIMEOUT_OPT);
     // progress bar should contain green and no other color
-    clusterDetails.poolsList('machine').machineProgressBar(`${ this.rke2Ec2ClusterName }-pool1`).find('.bg-error').should('not.exist');
-    clusterDetails.poolsList('machine').machineProgressBar(`${ this.rke2Ec2ClusterName }-pool1`).find('.bg-success').should('exist');
-    clusterDetails.poolsList('machine').machineProgressBar(`${ this.rke2Ec2ClusterName }-pool1`).find('.piece').should('have.length', 1);
+    clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.bg-error', VERY_LONG_TIMEOUT_OPT).should('not.exist');
+    clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.bg-success').should('exist');
+    clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.piece').should('have.length', 1);
 
-    // Verify the cluster is updating -> active
-    clusterDetails.resourceDetail().masthead().resourceStatus().contains('Updating');
+    // Verify the cluster is active
     clusterDetails.resourceDetail().masthead().resourceStatus().contains('Active', VERY_LONG_TIMEOUT_OPT);
     clusterDetails.poolsList('machine').resourceTable().sortableTable().checkRowCount(false, 1, VERY_LONG_TIMEOUT_OPT);
 
@@ -463,6 +465,11 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
     // set cluster name to enable save button
     createRKE2ClusterPage.nameNsDescription().name().set(this.rke2Ec2ClusterName);
 
+    // set region
+    createRKE2ClusterPage.machinePoolTab().region().toggle();
+    createRKE2ClusterPage.machinePoolTab().region().clickOptionWithLabel('us-west-2');
+    createRKE2ClusterPage.machinePoolTab().region().checkOptionSelected('us-west-2');
+
     createRKE2ClusterPage.machinePoolTab().enableDualStack().set();
 
     createRKE2ClusterPage.machinePoolTab().networks().toggle();
@@ -581,6 +588,11 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
 
     // set cluster name to enable save button
     createRKE2ClusterPage.nameNsDescription().name().set(this.rke2Ec2ClusterName);
+
+    // set region
+    createRKE2ClusterPage.machinePoolTab().region().toggle();
+    createRKE2ClusterPage.machinePoolTab().region().clickOptionWithLabel('us-west-2');
+    createRKE2ClusterPage.machinePoolTab().region().checkOptionSelected('us-west-2');
 
     createRKE2ClusterPage.machinePoolTab().enableDualStack().set();
 

--- a/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-provisioning-amazon-ec2-rke2.spec.ts
@@ -84,7 +84,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
     });
 
     cy.wait('@pageLoad').its('response.statusCode').should('eq', 200);
-    loadingPo.checkNotExists();
+    loadingPo.checkNotExists(MEDIUM_TIMEOUT_OPT);
     createRKE2ClusterPage.waitForPage('type=amazonec2&rkeType=rke2', 'basic');
     createRKE2ClusterPage.nameNsDescription().name().set(this.rke2Ec2ClusterName);
     createRKE2ClusterPage.nameNsDescription().description().set(`${ this.rke2Ec2ClusterName }-description`);
@@ -232,7 +232,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
     clusterDetails.poolsList('machine').scaleUpButton(`${ this.rke2Ec2ClusterName }-pool1`)
       .click();
 
-    cy.wait('@scaleUpMachineDeployment').its('response.statusCode').should('eq', 200);
+    cy.waitForInterceptWithConflictRetry('@scaleUpMachineDeployment');
 
     clusterDetails.poolsList('machine').machineUnavailableCount(`${ this.rke2Ec2ClusterName }-pool1`).then((c) => parseInt(c)).should('be.greaterThan', 0);
     clusterDetails.poolsList('machine').machinePoolReadyofDesiredCount(`${ this.rke2Ec2ClusterName }-pool1`, /^[0-9] of 2$/);
@@ -298,7 +298,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
     promptModal().getBody().should('contain', `${ this.rke2Ec2ClusterName }-pool1`);
     promptModal().clickActionButton('Confirm');
 
-    cy.wait('@scaleDownMachineDeployment').its('response.statusCode').should('eq', 200);
+    cy.waitForInterceptWithConflictRetry('@scaleDownMachineDeployment');
     clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.bg-error', MEDIUM_TIMEOUT_OPT).should('exist');
     clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.bg-success').should('exist');
     clusterDetails.poolsList('machine').progressBarElements(`${ this.rke2Ec2ClusterName }-pool1`, '.piece').should('have.length', 2);
@@ -345,16 +345,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
     editClusterPage.save().click();
 
     // Wait for the cluster update to complete
-    cy.wait('@clusterUpdate').then((interception) => {
-      // If 409 conflict, wait for retry
-      if (interception.response?.statusCode === 409) {
-        cy.log('Cluster update failed with 409 error, waiting for retry...');
-
-        return cy.wait('@clusterUpdate', MEDIUM_TIMEOUT_OPT);
-      }
-
-      return cy.wrap(interception);
-    }).then(({ response }: any) => {
+    cy.waitForInterceptWithConflictRetry('@clusterUpdate').then(({ response }: any) => {
       expect(response?.statusCode).to.equal(200);
       expect(response?.body).to.have.property('kind', 'Cluster');
       expect(response?.body.metadata).to.have.property('name', this.rke2Ec2ClusterName);
@@ -417,18 +408,20 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
   it('can delete an Amazon EC2 RKE2 cluster', function() {
     ClusterManagerListPagePo.navTo();
     clusterList.waitForPage();
+    cy.intercept('DELETE', `/v1/provisioning.cattle.io.clusters/fleet-default/${ this.rke2Ec2ClusterName }`).as('deleteRke2Cluster');
     clusterList.list().actionMenu(this.rke2Ec2ClusterName).getMenuItem('Delete').click();
 
-    clusterList.sortableTable().rowNames('.cluster-link').then((rows: any) => {
-      const promptRemove = new PromptRemove();
+    const promptRemove = new PromptRemove();
 
-      promptRemove.confirm(this.rke2Ec2ClusterName);
-      promptRemove.remove();
+    promptRemove.confirm(this.rke2Ec2ClusterName);
+    promptRemove.remove();
+    cy.wait('@deleteRke2Cluster').its('response.statusCode').should('eq', 200);
 
-      clusterList.waitForPage();
-      clusterList.list().state(this.rke2Ec2ClusterName).should('contain', 'Removing');
-      clusterList.sortableTable().checkRowCount(false, rows.length - 1, MEDIUM_TIMEOUT_OPT);
-      clusterList.sortableTable().rowNames('.cluster-link').should('not.contain', this.rke2Ec2ClusterName);
+    clusterList.waitForPage();
+    clusterList.sortableTable().rowElements(LONG_TIMEOUT_OPT).should(($rows) => {
+      const tableText = Cypress.$.makeArray<any>($rows).map((row) => row.innerText).join(' ');
+
+      expect(tableText).to.not.contain(this.rke2Ec2ClusterName);
     });
   });
 
@@ -458,7 +451,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
     clusterList.waitForPage();
     clusterList.createCluster();
     createRKE2ClusterPage.selectCreate(0);
-    loadingPo.checkNotExists();
+    loadingPo.checkNotExists(MEDIUM_TIMEOUT_OPT);
     createRKE2ClusterPage.rke2PageTitle().should('include', 'Create Amazon EC2');
     createRKE2ClusterPage.waitForPage('type=amazonec2&rkeType=rke2', 'basic');
 
@@ -467,8 +460,8 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
 
     // set region
     createRKE2ClusterPage.machinePoolTab().region().toggle();
-    createRKE2ClusterPage.machinePoolTab().region().clickOptionWithLabel('us-west-2');
-    createRKE2ClusterPage.machinePoolTab().region().checkOptionSelected('us-west-2');
+    createRKE2ClusterPage.machinePoolTab().region().clickOptionWithLabel('us-west-1');
+    createRKE2ClusterPage.machinePoolTab().region().checkOptionSelected('us-west-1');
 
     createRKE2ClusterPage.machinePoolTab().enableDualStack().set();
 
@@ -582,7 +575,7 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
     clusterList.waitForPage();
     clusterList.createCluster();
     createRKE2ClusterPage.selectCreate(0);
-    loadingPo.checkNotExists();
+    loadingPo.checkNotExists(MEDIUM_TIMEOUT_OPT);
     createRKE2ClusterPage.rke2PageTitle().should('include', 'Create Amazon EC2');
     createRKE2ClusterPage.waitForPage('type=amazonec2&rkeType=rke2', 'basic');
 
@@ -591,8 +584,8 @@ describe('Deploy RKE2 cluster using node driver on Amazon EC2', { tags: ['@manag
 
     // set region
     createRKE2ClusterPage.machinePoolTab().region().toggle();
-    createRKE2ClusterPage.machinePoolTab().region().clickOptionWithLabel('us-west-2');
-    createRKE2ClusterPage.machinePoolTab().region().checkOptionSelected('us-west-2');
+    createRKE2ClusterPage.machinePoolTab().region().clickOptionWithLabel('us-west-1');
+    createRKE2ClusterPage.machinePoolTab().region().checkOptionSelected('us-west-1');
 
     createRKE2ClusterPage.machinePoolTab().enableDualStack().set();
 

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -130,6 +130,7 @@ declare global {
       createRancherResource(prefix: 'v3' | 'v1', resourceType: string, body: any, failOnStatusCode?: boolean): Chainable;
       waitForRancherResource(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, testFn: (resp: any) => boolean, retries?: number, config?: {failOnStatusCode?: boolean, retryOnNetworkFailure?: boolean, timeout?: number}): Chainable;
       waitForRancherResources(prefix: 'v3' | 'v1', resourceType: string, expectedResourcesTotal: number, greaterThan?: boolean): Chainable;
+      waitForInterceptWithConflictRetry(alias: string, successStatusCode?: number, retryStatusCodes?: number[], options?: { timeout?: number }): Chainable;
       waitForRepositoryDownload(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, retries?: number): Chainable;
       waitForResourceState(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, resourceState?: string, retries?: number): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1' | 'k8s', resourceType: string, resourceId: string, failOnStatusCode?: boolean): Chainable;

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -3,6 +3,7 @@ import { CreateUserParams, CreateAmazonRke2ClusterParams, CreateAmazonRke2Cluste
 import { groupByPayload } from '@/cypress/e2e/blueprints/user_preferences/group_by';
 import { CypressChainable } from '~/cypress/e2e/po/po.types';
 import { MEDIUM_API_DELAY } from '@/cypress/support/utils/api-endpoints';
+import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 import { base64Encode } from '@shell/utils/crypto/index.js';
 
 // This file contains commands which makes API requests to the rancher API.
@@ -649,6 +650,30 @@ Cypress.Commands.add('waitForRancherResources', (prefix, resourceType, expectedR
   };
 
   return retry();
+});
+
+/**
+ * Wait for an intercepted request to complete with the expected status code.
+ * If the response is a 409 Conflict (or another retryable status), waits for one automatic retry before asserting success.
+ */
+Cypress.Commands.add('waitForInterceptWithConflictRetry', (alias: string, successStatusCode = 200, retryStatusCodes = [409], options = MEDIUM_TIMEOUT_OPT) => {
+  return cy.wait(alias).then((interception) => {
+    const statusCode = interception.response?.statusCode;
+
+    if (statusCode === successStatusCode) {
+      return cy.wrap(interception);
+    }
+
+    if (statusCode && retryStatusCodes.includes(statusCode)) {
+      return cy.wait(alias, options);
+    }
+
+    return cy.wrap(interception);
+  }).then((interception) => {
+    expect(interception.response?.statusCode).to.eq(successStatusCode);
+
+    return interception;
+  });
 });
 
 /**

--- a/shell/machine-config/amazonec2.vue
+++ b/shell/machine-config/amazonec2.vue
@@ -329,6 +329,7 @@ export default {
               :searchable="true"
               :disabled="disabled"
               :label="t('cluster.machineConfig.amazonEc2.region')"
+              data-testid="amazonEc2__region"
             />
           </div>
           <div class="col span-6">


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2275

- Adds progressBarElements helper to machine pool PO and migrate Amazon EC2 RKE2 scale up/down tests to use it for progress checks.
- Stabilize negative assertions for missing .bg-error states by using explicit timeouts where needed.
- Adds `waitForInterceptWithConflictRetry` custom command to handle the dashboard's built-in 409 conflict retry behavior on cluster operations.
- Updates the EC2 networking tests to explicitly select region us-west-2 so test behavior aligns with the mocked AWS data; the available VPC/network options in the UI are derived from the mocked DescribeVpcs payload in describe-vpcs-response.ts
<!-- Define findings related to the feature or bug issue. -->


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
