### PR TITLE
Fix switch cluster icon behaviour

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -101,6 +101,7 @@ export default {
     hasMultipleReadyClusters() {
       const readyCount = [...this.appBar.pinFiltered, ...this.appBar.clustersFiltered].filter((c) => c.ready).length;
 
+      // We check allClustersCount as a fallback for environments with many clusters where only a subset (e.g. 10) is currently loaded and visible.
       return readyCount > 1 || this.allClustersCount > this.maxClustersToShow;
     },
 

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -103,9 +103,10 @@ export default {
         return false;
       }
 
-      const readyCount = [...this.appBar.pinFiltered, ...this.appBar.clustersFiltered].filter((c) => c.ready).length;
+      const ready = [...this.appBar.pinFiltered, ...this.appBar.clustersFiltered].filter((c) => c.ready);
+      const readyCount = ready.length;
 
-      return readyCount > 1;
+      return readyCount > 1 || (readyCount === 1 && this.clusterId !== ready[0].id);
     },
 
     // New

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -98,15 +98,14 @@ export default {
       return count?.summary.count;
     },
 
-    hasMultipleReadyClusters() {
+    routeComboActive() {
+      if (!this.routeCombo) {
+        return false;
+      }
+
       const readyCount = [...this.appBar.pinFiltered, ...this.appBar.clustersFiltered].filter((c) => c.ready).length;
 
-      // We check allClustersCount as a fallback for environments with many clusters where only a subset (e.g. 10) is currently loaded and visible.
-      return readyCount > 1 || this.allClustersCount > this.maxClustersToShow;
-    },
-
-    routeComboActive() {
-      return this.routeCombo && this.hasMultipleReadyClusters;
+      return readyCount > 1;
     },
 
     // New

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -98,6 +98,16 @@ export default {
       return count?.summary.count;
     },
 
+    hasMultipleReadyClusters() {
+      const readyCount = [...this.appBar.pinFiltered, ...this.appBar.clustersFiltered].filter((c) => c.ready).length;
+
+      return readyCount > 1 || this.allClustersCount > this.maxClustersToShow;
+    },
+
+    routeComboActive() {
+      return this.routeCombo && this.hasMultipleReadyClusters;
+    },
+
     // New
     search() {
       return (this.clusterFilter || '').toLowerCase();
@@ -386,7 +396,7 @@ export default {
     },
 
     clusterMenuClick(ev, cluster) {
-      if (this.routeCombo) {
+      if (this.routeComboActive) {
         ev.preventDefault();
 
         if (this.isCurrRouteClusterExplorer && this.productFromRoute === this.currentProduct?.name) {
@@ -446,7 +456,7 @@ export default {
         content = this.shown ? null : contentText;
 
       // if key combo is pressed, then we update the tooltip as well
-      } else if (this.routeCombo &&
+      } else if (this.routeComboActive &&
         typeof item === 'object' &&
         !Array.isArray(item) &&
         item !== null &&
@@ -706,7 +716,7 @@ export default {
                     <ClusterIconMenu
                       v-clean-tooltip="getTooltipConfig(c, true)"
                       :cluster="c"
-                      :route-combo="routeCombo"
+                      :route-combo="routeComboActive"
                       class="rancher-provider-icon"
                     />
                     <div
@@ -785,7 +795,7 @@ export default {
                     <ClusterIconMenu
                       v-clean-tooltip="getTooltipConfig(c, true)"
                       :cluster="c"
-                      :route-combo="routeCombo"
+                      :route-combo="routeComboActive"
                       class="rancher-provider-icon"
                     />
                     <div

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -780,21 +780,22 @@ describe('topLevelMenu', () => {
         expect(wrapper.vm.routeComboActive).toBe(false);
       });
 
-      it('should be false when there is only one ready cluster', async() => {
+      it('should be false when there is only one ready cluster and it is the current cluster', async() => {
+        const store = generateStore([
+          {
+            nameDisplay: 'cluster1',
+            id:          'an-id1',
+            mgmt:        { id: 'an-id1' },
+            isReady:     true
+          }
+        ]);
+        store.getters.clusterId = 'an-id1';
+
         const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
           global: {
             mocks: {
               $route: {},
-              $store: {
-                ...generateStore([
-                  {
-                    nameDisplay: 'cluster1',
-                    id:          'an-id1',
-                    mgmt:        { id: 'an-id1' },
-                    isReady:     true
-                  }
-                ])
-              }
+              $store: store
             },
             stubs: ['BrandImage', 'router-link'],
           }
@@ -804,6 +805,33 @@ describe('topLevelMenu', () => {
         await wrapper.setData({ routeCombo: true });
 
         expect(wrapper.vm.routeComboActive).toBe(false);
+      });
+
+      it('should be true when there is only one ready cluster but it is not the current cluster', async() => {
+        const store = generateStore([
+          {
+            nameDisplay: 'cluster1',
+            id:          'an-id1',
+            mgmt:        { id: 'an-id1' },
+            isReady:     true
+          }
+        ]);
+        store.getters.clusterId = 'some-other-cluster-id';
+
+        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+          global: {
+            mocks: {
+              $route: {},
+              $store: store
+            },
+            stubs: ['BrandImage', 'router-link'],
+          }
+        });
+
+        await waitForIt();
+        await wrapper.setData({ routeCombo: true });
+
+        expect(wrapper.vm.routeComboActive).toBe(true);
       });
     });
   });

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -715,86 +715,8 @@ describe('topLevelMenu', () => {
   });
 
   describe('computed properties', () => {
-    describe('hasMultipleReadyClusters', () => {
-      it('should be false when there is only one ready cluster', async() => {
-        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
-          global: {
-            mocks: {
-              $route: {},
-              $store: {
-                ...generateStore([
-                  {
-                    nameDisplay: 'cluster1',
-                    id:          'an-id1',
-                    mgmt:        { id: 'an-id1' },
-                    isReady:     true
-                  }
-                ])
-              }
-            },
-            stubs: ['BrandImage', 'router-link'],
-          }
-        });
-
-        await waitForIt();
-        expect(wrapper.vm.hasMultipleReadyClusters).toBe(false);
-      });
-
-      it('should be true when there are multiple ready clusters', async() => {
-        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
-          global: {
-            mocks: {
-              $route: {},
-              $store: {
-                ...generateStore([
-                  {
-                    nameDisplay: 'cluster1',
-                    id:          'an-id1',
-                    mgmt:        { id: 'an-id1' },
-                    isReady:     true
-                  },
-                  {
-                    nameDisplay: 'cluster2',
-                    id:          'an-id2',
-                    mgmt:        { id: 'an-id2' },
-                    isReady:     true
-                  }
-                ])
-              }
-            },
-            stubs: ['BrandImage', 'router-link'],
-          }
-        });
-
-        await waitForIt();
-        expect(wrapper.vm.hasMultipleReadyClusters).toBe(true);
-      });
-
-      it('should be true when there are more clusters than maxClustersToShow', async() => {
-        const clusters = Array.from({ length: 15 }).map((_, i) => ({
-          nameDisplay: `cluster${ i }`,
-          id:          `an-id${ i }`,
-          mgmt:        { id: `an-id${ i }` },
-          isReady:     false
-        }));
-
-        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
-          global: {
-            mocks: {
-              $route: {},
-              $store: { ...generateStore(clusters) }
-            },
-            stubs: ['BrandImage', 'router-link'],
-          }
-        });
-
-        await waitForIt();
-        expect(wrapper.vm.hasMultipleReadyClusters).toBe(true);
-      });
-    });
-
     describe('routeComboActive', () => {
-      it('should be true when routeCombo is true and hasMultipleReadyClusters is true', async() => {
+      it('should be true when routeCombo is true and there are multiple ready clusters', async() => {
         const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
           global: {
             mocks: {
@@ -858,7 +780,7 @@ describe('topLevelMenu', () => {
         expect(wrapper.vm.routeComboActive).toBe(false);
       });
 
-      it('should be false when hasMultipleReadyClusters is false', async() => {
+      it('should be false when there is only one ready cluster', async() => {
         const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
           global: {
             mocks: {

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -713,4 +713,176 @@ describe('topLevelMenu', () => {
       expect(wrapper.vm.mgmtClusters).toStrictEqual([]);
     });
   });
+
+  describe('computed properties', () => {
+    describe('hasMultipleReadyClusters', () => {
+      it('should be false when there is only one ready cluster', async() => {
+        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+          global: {
+            mocks: {
+              $route: {},
+              $store: {
+                ...generateStore([
+                  {
+                    nameDisplay: 'cluster1',
+                    id:          'an-id1',
+                    mgmt:        { id: 'an-id1' },
+                    isReady:     true
+                  }
+                ])
+              }
+            },
+            stubs: ['BrandImage', 'router-link'],
+          }
+        });
+
+        await waitForIt();
+        expect(wrapper.vm.hasMultipleReadyClusters).toBe(false);
+      });
+
+      it('should be true when there are multiple ready clusters', async() => {
+        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+          global: {
+            mocks: {
+              $route: {},
+              $store: {
+                ...generateStore([
+                  {
+                    nameDisplay: 'cluster1',
+                    id:          'an-id1',
+                    mgmt:        { id: 'an-id1' },
+                    isReady:     true
+                  },
+                  {
+                    nameDisplay: 'cluster2',
+                    id:          'an-id2',
+                    mgmt:        { id: 'an-id2' },
+                    isReady:     true
+                  }
+                ])
+              }
+            },
+            stubs: ['BrandImage', 'router-link'],
+          }
+        });
+
+        await waitForIt();
+        expect(wrapper.vm.hasMultipleReadyClusters).toBe(true);
+      });
+
+      it('should be true when there are more clusters than maxClustersToShow', async() => {
+        const clusters = Array.from({ length: 15 }).map((_, i) => ({
+          nameDisplay: `cluster${ i }`,
+          id:          `an-id${ i }`,
+          mgmt:        { id: `an-id${ i }` },
+          isReady:     false
+        }));
+
+        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+          global: {
+            mocks: {
+              $route: {},
+              $store: { ...generateStore(clusters) }
+            },
+            stubs: ['BrandImage', 'router-link'],
+          }
+        });
+
+        await waitForIt();
+        expect(wrapper.vm.hasMultipleReadyClusters).toBe(true);
+      });
+    });
+
+    describe('routeComboActive', () => {
+      it('should be true when routeCombo is true and hasMultipleReadyClusters is true', async() => {
+        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+          global: {
+            mocks: {
+              $route: {},
+              $store: {
+                ...generateStore([
+                  {
+                    nameDisplay: 'cluster1',
+                    id:          'an-id1',
+                    mgmt:        { id: 'an-id1' },
+                    isReady:     true
+                  },
+                  {
+                    nameDisplay: 'cluster2',
+                    id:          'an-id2',
+                    mgmt:        { id: 'an-id2' },
+                    isReady:     true
+                  }
+                ])
+              }
+            },
+            stubs: ['BrandImage', 'router-link'],
+          }
+        });
+
+        await waitForIt();
+        await wrapper.setData({ routeCombo: true });
+
+        expect(wrapper.vm.routeComboActive).toBe(true);
+      });
+
+      it('should be false when routeCombo is false', async() => {
+        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+          global: {
+            mocks: {
+              $route: {},
+              $store: {
+                ...generateStore([
+                  {
+                    nameDisplay: 'cluster1',
+                    id:          'an-id1',
+                    mgmt:        { id: 'an-id1' },
+                    isReady:     true
+                  },
+                  {
+                    nameDisplay: 'cluster2',
+                    id:          'an-id2',
+                    mgmt:        { id: 'an-id2' },
+                    isReady:     true
+                  }
+                ])
+              }
+            },
+            stubs: ['BrandImage', 'router-link'],
+          }
+        });
+
+        await waitForIt();
+        await wrapper.setData({ routeCombo: false });
+
+        expect(wrapper.vm.routeComboActive).toBe(false);
+      });
+
+      it('should be false when hasMultipleReadyClusters is false', async() => {
+        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+          global: {
+            mocks: {
+              $route: {},
+              $store: {
+                ...generateStore([
+                  {
+                    nameDisplay: 'cluster1',
+                    id:          'an-id1',
+                    mgmt:        { id: 'an-id1' },
+                    isReady:     true
+                  }
+                ])
+              }
+            },
+            stubs: ['BrandImage', 'router-link'],
+          }
+        });
+
+        await waitForIt();
+        await wrapper.setData({ routeCombo: true });
+
+        expect(wrapper.vm.routeComboActive).toBe(false);
+      });
+    });
+  });
 });

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -789,7 +789,8 @@ describe('topLevelMenu', () => {
             isReady:     true
           }
         ]);
-        store.getters.clusterId = 'an-id1';
+
+        store.getters.clusterId = 'an-id1' as any;
 
         const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
           global: {
@@ -816,7 +817,8 @@ describe('topLevelMenu', () => {
             isReady:     true
           }
         ]);
-        store.getters.clusterId = 'some-other-cluster-id';
+
+        store.getters.clusterId = 'some-other-cluster-id' as any;
 
         const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
           global: {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11328 
Holding `alt/option` incorrectly showed the "Switch clusters and keep location" prompt even with only one ready cluster.

### Occurred changes and/or fixed issues
- Added a `hasMultipleReadyClusters` check.
- The `alt/option` cluster switching UI and behavior only activates if there is >1 ready cluster (or total clusters > display limit).
- Added unit tests for the new computed properties.

### Technical notes summary
Introduced `routeComboActive` to gate the feature, ensuring `routeCombo` (the key press state) is true AND `hasMultipleReadyClusters` is true.

### Areas or cases that should be tested
- **Single Cluster:** Holding `alt/option` should NOT change the cluster icon or show the tooltip. Clicking works normally.
- **Multiple Clusters:** Holding `alt/option` changes the icon and shows the tooltip. Clicking switches the cluster context while keeping the current route.

### Areas which could experience regressions
- Top-level menu cluster navigation.
- The "Switch clusters" feature in multi-cluster setups.


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
