### PR TITLE
[backport 2.14] - Automation: Fix fleeet clusters handle error missing sub row element

### DIFF
--- a/cypress/e2e/po/lists/fleet-clusters-list.po.ts
+++ b/cypress/e2e/po/lists/fleet-clusters-list.po.ts
@@ -1,0 +1,8 @@
+import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
+
+export default class FleetClustersListPo extends BaseResourceList {
+  // Specific method: filters the sub-rows that correspond to fleet cluster
+  fleetClusterRows() {
+    return this.self().find('tbody tr.labels-row');
+  }
+}

--- a/cypress/e2e/po/pages/fleet/fleet.cattle.io.cluster.po.ts
+++ b/cypress/e2e/po/pages/fleet/fleet.cattle.io.cluster.po.ts
@@ -65,6 +65,12 @@ export class FleetClusterDetailsPo extends BaseDetailPagePo {
   addAppButton() {
     return this.self().get('.btn').contains('Create App Bundle');
   }
+
+  hasClusterLabel(key: string, value: string) {
+    return this.self()
+      .find('.tag-data')
+      .contains(`${ key }: ${ value }`);
+  }
 }
 
 export class FleetClusterEditPo extends BaseDetailPagePo {

--- a/cypress/e2e/po/pages/fleet/fleet.cattle.io.cluster.po.ts
+++ b/cypress/e2e/po/pages/fleet/fleet.cattle.io.cluster.po.ts
@@ -5,6 +5,7 @@ import { BaseDetailPagePo } from '@/cypress/e2e/po/pages/base/base-detail-page.p
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import { BaseListPagePo } from '@/cypress/e2e/po/pages/base/base-list-page.po';
 import ResourceTablePo from '@/cypress/e2e/po/components/resource-table.po';
+import FleetClustersListPo from '@/cypress/e2e/po/lists/fleet-clusters-list.po';
 
 export class FleetClusterListPagePo extends BaseListPagePo {
     static url = `/c/_/fleet/fleet.cattle.io.cluster`
@@ -30,6 +31,10 @@ export class FleetClusterListPagePo extends BaseListPagePo {
 
     selectWorkspace(workspaceName = 'fleet-local') {
       return this.header().selectWorkspace(workspaceName);
+    }
+
+    fleetClusterTable(): FleetClustersListPo {
+      return new FleetClustersListPo('[data-testid="sortable-table-list-container"]');
     }
 
     editFleetCluster(workspace: string, clusterName: string): FleetClusterEditPo {

--- a/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
@@ -2,14 +2,15 @@ import { FleetClusterListPagePo, FleetClusterDetailsPo } from '@/cypress/e2e/po/
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import { MenuActions } from '@/cypress/support/types/menu-actions';
 import { gitRepoTargetAllClustersRequest } from '@/cypress/e2e/blueprints/fleet/gitrepos';
-import { FleetApplicationListPagePo, FleetGitRepoCreateEditPo, FleetApplicationCreatePo } from '~/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
+import { FleetApplicationListPagePo, FleetGitRepoCreateEditPo, FleetApplicationCreatePo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
 import { WorkloadsDeploymentsListPagePo } from '@/cypress/e2e/po/pages/explorer/workloads/workloads-deployments.po';
 import * as path from 'path';
 import * as jsyaml from 'js-yaml';
 import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
-import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT, VERY_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import { EXTRA_LONG_TIMEOUT_OPT, LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT, VERY_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 import { FeatureFlagsPagePo } from '@/cypress/e2e/po/pages/global-settings/feature-flags.po';
 import LoadingPo from '@/cypress/e2e/po/components/loading.po';
+import { qase } from '@/cypress/support/qase';
 
 const fleetClusterListPage = new FleetClusterListPagePo();
 const fleetAppBundlesListPage = new FleetApplicationListPagePo();
@@ -81,7 +82,7 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
     cy.updateNamespaceFilter('local', 'none', '{"local":["all://user"]}');
   });
 
-  it('data is populated in fleet cluster list and detail view', () => {
+  qase(9691, it('data is populated in fleet cluster list and detail view', () => {
     ClusterManagerListPagePo.navTo();
     clusterList.waitForPage();
     clusterList.list().state(clusterName).contains('Active', VERY_LONG_TIMEOUT_OPT);
@@ -108,7 +109,7 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
     fleetClusterListPage.resourceTableDetails(clusterName, 2).should('be.visible');
     // check cluster state in fleet
     fleetClusterListPage.resourceTableDetails(clusterName, 1).contains('Not Ready', MEDIUM_TIMEOUT_OPT);
-    fleetClusterListPage.resourceTableDetails(clusterName, 1).contains('Active', LONG_TIMEOUT_OPT);
+    fleetClusterListPage.resourceTableDetails(clusterName, 1).contains('Active', EXTRA_LONG_TIMEOUT_OPT);
     // check Git Repos ready
     fleetClusterListPage.resourceTableDetails(clusterName, 3).should('have.text', '1');
     // check Helm Ops ready
@@ -117,10 +118,6 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
     fleetClusterListPage.resourceTableDetails(clusterName, 5).should('have.text', '2');
     // check resources: testing https://github.com/rancher/dashboard/issues/11154
     fleetClusterListPage.resourceTableDetails(clusterName, 6).contains( ' 7 ', MEDIUM_TIMEOUT_OPT);
-    // check cluster labels
-    fleetClusterListPage.list().resourceTable().sortableTable()
-      .subRows()
-      .should('contain.text', 'foo=bar');
 
     const fleetClusterDetailsPage = new FleetClusterDetailsPo(namespace, clusterName);
 
@@ -128,6 +125,9 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
     fleetClusterListPage.goToDetailsPage(clusterName);
     fleetClusterDetailsPage.waitForPage(null, 'applications');
     fleetClusterDetailsPage.clusterTabs().clickTabWithSelector('[data-testid="btn-applications"]');
+
+    // check cluster labels
+    fleetClusterDetailsPage.hasClusterLabel('foo', 'bar').should('be.visible');
 
     // check state
     fleetClusterDetailsPage.appBundlesList().resourceTableDetails(gitRepo, 1).contains('Active');
@@ -140,8 +140,8 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
     // check target
     fleetClusterDetailsPage.appBundlesList().resourceTableDetails(gitRepo, 5).contains('All');
     // check cluster resources
-    fleetClusterDetailsPage.appBundlesList().resourceTableDetails(gitRepo, 7).should('have.text', ' 1 ');
-  });
+    fleetClusterDetailsPage.appBundlesList().resourceTableDetails(gitRepo, 7).should('contain.text', '—');
+  }));
 
   it('check all tabs are available in the details view', () => {
     // testing https://github.com/rancher/dashboard/issues/11155
@@ -421,6 +421,10 @@ describe('Fleet CLuster List - resources', { tags: ['@fleet', '@adminUser'] }, (
   });
 
   it('should only display action menu with allowed actions only', () => {
+    // Ensure table is fully loaded before interacting with action menu
+    fleetClusterListPage.list().resourceTable().sortableTable().checkVisible();
+    fleetClusterListPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+
     const constActionMenu = fleetClusterListPage.list().resourceTable().sortableTable()
       .rowActionMenuOpen('local');
 

--- a/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-clusters.spec.ts
@@ -2,7 +2,7 @@ import { FleetClusterListPagePo, FleetClusterDetailsPo } from '@/cypress/e2e/po/
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import { MenuActions } from '@/cypress/support/types/menu-actions';
 import { gitRepoTargetAllClustersRequest } from '@/cypress/e2e/blueprints/fleet/gitrepos';
-import { FleetApplicationListPagePo, FleetGitRepoCreateEditPo, FleetApplicationCreatePo } from '~/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
+import { FleetApplicationListPagePo, FleetGitRepoCreateEditPo, FleetApplicationCreatePo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
 import { WorkloadsDeploymentsListPagePo } from '@/cypress/e2e/po/pages/explorer/workloads/workloads-deployments.po';
 import * as path from 'path';
 import * as jsyaml from 'js-yaml';
@@ -10,6 +10,7 @@ import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
 import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT, VERY_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 import { FeatureFlagsPagePo } from '@/cypress/e2e/po/pages/global-settings/feature-flags.po';
 import LoadingPo from '@/cypress/e2e/po/components/loading.po';
+import { qase } from '@/cypress/support/qase';
 
 const fleetClusterListPage = new FleetClusterListPagePo();
 const fleetAppBundlesListPage = new FleetApplicationListPagePo();
@@ -81,7 +82,7 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
     cy.updateNamespaceFilter('local', 'none', '{"local":["all://user"]}');
   });
 
-  it('data is populated in fleet cluster list and detail view', () => {
+  qase(3813, it('data is populated in fleet cluster list and detail view', () => {
     ClusterManagerListPagePo.navTo();
     clusterList.waitForPage();
     clusterList.list().state(clusterName).contains('Active', VERY_LONG_TIMEOUT_OPT);
@@ -118,9 +119,7 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
     // check resources: testing https://github.com/rancher/dashboard/issues/11154
     fleetClusterListPage.resourceTableDetails(clusterName, 6).contains( ' 7 ', MEDIUM_TIMEOUT_OPT);
     // check cluster labels
-    fleetClusterListPage.list().resourceTable().sortableTable()
-      .subRows()
-      .should('contain.text', 'foo=bar');
+    fleetClusterListPage.fleetClusterTable().fleetClusterRows().should('contain.text', 'foo=bar');
 
     const fleetClusterDetailsPage = new FleetClusterDetailsPo(namespace, clusterName);
 
@@ -141,7 +140,7 @@ describe('Fleet Clusters - bundle manifests are deployed from the BundleDeployme
     fleetClusterDetailsPage.appBundlesList().resourceTableDetails(gitRepo, 5).contains('All');
     // check cluster resources
     fleetClusterDetailsPage.appBundlesList().resourceTableDetails(gitRepo, 7).should('have.text', ' 1 ');
-  });
+  }));
 
   it('check all tabs are available in the details view', () => {
     // testing https://github.com/rancher/dashboard/issues/11155
@@ -421,6 +420,9 @@ describe('Fleet CLuster List - resources', { tags: ['@fleet', '@adminUser'] }, (
   });
 
   it('should only display action menu with allowed actions only', () => {
+    // Ensure table is fully loaded before interacting with action menu
+    fleetClusterListPage.list().resourceTable().sortableTable().checkVisible();
+    fleetClusterListPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
     const constActionMenu = fleetClusterListPage.list().resourceTable().sortableTable()
       .rowActionMenuOpen('local');
 

--- a/cypress/jenkins/cypress.sh
+++ b/cypress/jenkins/cypress.sh
@@ -21,6 +21,8 @@ yarn add -W mocha cypress-mochawesome-reporter cypress-multi-reporters cypress-c
 
 yarn add -W https://github.com/elaichenkov/cypress-delete-downloads-folder
 
+yarn add -D @percy/cli
+
 export NO_COLOR=1
 export PERCY_CLIENT_ERROR_LOGS=false
 CYPRESS_grepTags="CYPRESSTAGS" npx percy exec -- cypress run --browser chrome --config-file cypress/jenkins/cypress.config.jenkins.ts


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/qa-tasks#2268

Backport of https://github.com/rancher/dashboard/pull/17035

Fixed a validation error where a sub-row element was not found.
Additionally, the code layout was corrected and a test option was added to ensure proper visibility.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="959" height="486" alt="Screenshot 2026-04-27 at 1 17 14 p m" src="https://github.com/user-attachments/assets/448ea158-1c24-4d8a-923b-8f24c6ee68a6" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`