### PR TITLE
Deprecated annotation for extensions

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1188,9 +1188,7 @@ catalog:
       all: All Operating Systems
       linux: Linux
       windows: Windows
-    search: Search the catalogue...
-    deprecatedChartsFilter:
-      label: Show deprecated apps
+    search: Search the catalog...
     addNewRepo:
       label: Add new
       ariaLabel: Add a new repository
@@ -5453,6 +5451,7 @@ inactivity:
 # Rancher Extensions
 plugins:
   altIcon: Icon for {extension} extension card
+  deprecatedExtension: This extension is deprecated and will soon be removed from the catalog.
   incompatiblePrimeOnly: "The latest version of this extension ({ version }) needs Rancher Prime in order to be installed."
   incompatibleRancherVersion: "The latest version of this extension ({ version }) is not compatible with the current Rancher version ({ required })."
   incompatibleKubeVersion: "The latest version of this extension ({ version }) is not compatible with the current Kube version ({ required })."

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5451,7 +5451,7 @@ inactivity:
 # Rancher Extensions
 plugins:
   altIcon: Icon for {extension} extension card
-  deprecatedExtension: This extension is deprecated and will soon be removed from the catalog.
+  deprecatedExtension: This extension is deprecated and may soon be removed from the catalog.
   incompatiblePrimeOnly: "The latest version of this extension ({ version }) needs Rancher Prime in order to be installed."
   incompatibleRancherVersion: "The latest version of this extension ({ version }) is not compatible with the current Rancher version ({ required })."
   incompatibleKubeVersion: "The latest version of this extension ({ version }) is not compatible with the current Kube version ({ required })."

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -87,6 +87,7 @@ export const CATALOG = {
 
   PRIME_ONLY:   'catalog.cattle.io/prime-only',
   EXPERIMENTAL: 'catalog.cattle.io/experimental',
+  DEPRECATED:   'catalog.cattle.io/deprecated',
   NAMESPACE:    'catalog.cattle.io/namespace',
   RELEASE_NAME: 'catalog.cattle.io/release-name',
   FEATURED:     'catalog.cattle.io/featured',

--- a/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
+++ b/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
@@ -487,7 +487,8 @@ export default {
         flex-direction: column;
         overflow: hidden;
 
-        .banner.warning {
+        .banner.warning,
+        .banner.error {
           margin-top: 0;
           margin-bottom: 32px;
         }

--- a/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
+++ b/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
@@ -51,8 +51,22 @@ export default {
   computed: {
     ...mapGetters({ theme: 'prefs/theme' }),
 
-    isDeprecated() {
-      return uiPluginHasAnnotation(this.info?.chart, CATALOG_ANNOTATIONS.DEPRECATED, 'true');
+    errorMessage() {
+      return this.info?.installedError || (this.info?.helmError ? this.t('plugins.helmError') : null);
+    },
+
+    warningMessages() {
+      const warnings = [];
+
+      if (uiPluginHasAnnotation(this.info?.chart, CATALOG_ANNOTATIONS.DEPRECATED, 'true')) {
+        warnings.push(this.t('plugins.deprecatedExtension'));
+      }
+
+      if (this.info?.incompatibilityMessage) {
+        warnings.push(this.info.incompatibilityMessage);
+      }
+
+      return warnings;
     },
 
     applyDarkModeBg() {
@@ -315,11 +329,18 @@ export default {
             class="plugin-tags-container"
           />
           <Banner
-            v-if="isDeprecated"
+            v-for="(msg, i) in warningMessages"
+            :key="i"
             color="warning"
-            class="mb-20 mt-0"
           >
-            {{ t('plugins.deprecatedExtension') }}
+            {{ msg }}
+          </Banner>
+
+          <Banner
+            v-if="errorMessage"
+            color="error"
+          >
+            {{ errorMessage }}
           </Banner>
 
           <div class="plugin-versions-container">
@@ -468,6 +489,7 @@ export default {
 
         .banner.warning {
           margin-top: 0;
+          margin-bottom: 32px;
         }
 
         .plugin-info-detail {

--- a/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
+++ b/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
@@ -7,7 +7,9 @@ import genericPluginSvg from '~shell/assets/images/generic-plugin.svg';
 import { SETTING } from '@shell/config/settings';
 import { useWatcherBasedSetupFocusTrapWithDestroyIncluded } from '@shell/composables/focusTrap';
 import { getPluginChartVersionLabel, getPluginChartVersion } from '@shell/utils/uiplugins';
-import { isChartVersionHigher } from '@shell/config/uiplugins';
+import { isChartVersionHigher, uiPluginHasAnnotation } from '@shell/config/uiplugins';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
+import Banner from '@components/Banner/Banner.vue';
 import RcButton from '@components/RcButton/RcButton.vue';
 import AppChartCardFooter from '@shell/pages/c/_cluster/apps/charts/AppChartCardFooter.vue';
 
@@ -25,6 +27,7 @@ export default {
     }
   },
   components: {
+    Banner,
     ChartReadme,
     LazyImage,
     RcButton,
@@ -47,6 +50,10 @@ export default {
   },
   computed: {
     ...mapGetters({ theme: 'prefs/theme' }),
+
+    isDeprecated() {
+      return uiPluginHasAnnotation(this.info?.chart, CATALOG_ANNOTATIONS.DEPRECATED, 'true');
+    },
 
     applyDarkModeBg() {
       if (this.theme === 'dark') {
@@ -307,6 +314,13 @@ export default {
             :items="info.tags"
             class="plugin-tags-container"
           />
+          <Banner
+            v-if="isDeprecated"
+            color="warning"
+            class="mb-20 mt-0"
+          >
+            {{ t('plugins.deprecatedExtension') }}
+          </Banner>
 
           <div class="plugin-versions-container">
             <h3>

--- a/shell/pages/c/_cluster/uiplugins/__tests__/PluginInfoPanel.test.ts
+++ b/shell/pages/c/_cluster/uiplugins/__tests__/PluginInfoPanel.test.ts
@@ -101,21 +101,63 @@ describe('component: PluginInfoPanel', () => {
     });
   });
 
-  describe('isDeprecated', () => {
+  describe('errorMessage', () => {
     beforeEach(() => {
       wrapper = mountComponent();
     });
 
-    it('should return true if the extension chart has the deprecated annotation', () => {
-      wrapper.vm.info = { chart: { versions: [{ annotations: { [CATALOG_ANNOTATIONS.DEPRECATED]: 'true' } }] } };
+    it('should return installedError if present', () => {
+      wrapper.vm.info = { installedError: 'install error' };
 
-      expect(wrapper.vm.isDeprecated).toBe(true);
+      expect(wrapper.vm.errorMessage).toBe('install error');
     });
 
-    it('should return false if the extension chart does not have the deprecated annotation', () => {
+    it('should return translated helmError if present', () => {
+      wrapper.vm.info = { helmError: true };
+
+      expect(wrapper.vm.errorMessage).toBe('plugins.helmError');
+    });
+
+    it('should return null if no error', () => {
+      wrapper.vm.info = {};
+
+      expect(wrapper.vm.errorMessage).toBeNull();
+    });
+  });
+
+  describe('warningMessages', () => {
+    beforeEach(() => {
+      wrapper = mountComponent();
+    });
+
+    it('should include deprecated message if the extension chart has the deprecated annotation', () => {
+      wrapper.vm.info = { chart: { versions: [{ annotations: { [CATALOG_ANNOTATIONS.DEPRECATED]: 'true' } }] } };
+
+      expect(wrapper.vm.warningMessages).toContain('plugins.deprecatedExtension');
+    });
+
+    it('should include incompatibilityMessage if present', () => {
+      wrapper.vm.info = { incompatibilityMessage: 'incompatibility error' };
+
+      expect(wrapper.vm.warningMessages).toContain('incompatibility error');
+    });
+
+    it('should include both deprecated and incompatibility messages if both are present', () => {
+      wrapper.vm.info = {
+        chart:                  { versions: [{ annotations: { [CATALOG_ANNOTATIONS.DEPRECATED]: 'true' } }] },
+        incompatibilityMessage: 'incompatibility error'
+      };
+
+      expect(wrapper.vm.warningMessages).toStrictEqual([
+        'plugins.deprecatedExtension',
+        'incompatibility error'
+      ]);
+    });
+
+    it('should return an empty array if neither is present', () => {
       wrapper.vm.info = { chart: { versions: [{ annotations: { [CATALOG_ANNOTATIONS.CERTIFIED]: 'rancher' } }] } };
 
-      expect(wrapper.vm.isDeprecated).toBe(false);
+      expect(wrapper.vm.warningMessages).toStrictEqual([]);
     });
   });
 });

--- a/shell/pages/c/_cluster/uiplugins/__tests__/PluginInfoPanel.test.ts
+++ b/shell/pages/c/_cluster/uiplugins/__tests__/PluginInfoPanel.test.ts
@@ -1,5 +1,6 @@
 import { shallowMount, VueWrapper } from '@vue/test-utils';
 import PluginInfoPanel from '@shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
 
 jest.mock('@shell/config/uiplugins', () => ({
   ...jest.requireActual('@shell/config/uiplugins'),
@@ -97,6 +98,24 @@ describe('component: PluginInfoPanel', () => {
       const label = wrapper.vm.getVersionLabel(version);
 
       expect(label).toBe('1.0.0 (plugins.labels.current)');
+    });
+  });
+
+  describe('isDeprecated', () => {
+    beforeEach(() => {
+      wrapper = mountComponent();
+    });
+
+    it('should return true if the extension chart has the deprecated annotation', () => {
+      wrapper.vm.info = { chart: { versions: [{ annotations: { [CATALOG_ANNOTATIONS.DEPRECATED]: 'true' } }] } };
+
+      expect(wrapper.vm.isDeprecated).toBe(true);
+    });
+
+    it('should return false if the extension chart does not have the deprecated annotation', () => {
+      wrapper.vm.info = { chart: { versions: [{ annotations: { [CATALOG_ANNOTATIONS.CERTIFIED]: 'rancher' } }] } };
+
+      expect(wrapper.vm.isDeprecated).toBe(false);
     });
   });
 });

--- a/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { shallowMount, VueWrapper } from '@vue/test-utils';
 import UiPluginsPage from '@shell/pages/c/_cluster/uiplugins/index.vue';
 import { UI_PLUGIN_NAMESPACE } from '@shell/config/uiplugins';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
 
 const t = (key: string, args: Object) => {
   if (args) {
@@ -292,7 +293,7 @@ describe('page: UI plugins/Extensions', () => {
     });
 
     it('should return "deprecated" status for deprecated plugins', () => {
-      const plugin = { chart: { deprecated: true } };
+      const plugin = { chart: { versions: [{ annotations: { [CATALOG_ANNOTATIONS.DEPRECATED]: 'true' } }] } };
       const statuses = wrapper.vm.getStatuses(plugin);
 
       expect(statuses[0].tooltip.key).toBe('generic.deprecated');
@@ -323,7 +324,7 @@ describe('page: UI plugins/Extensions', () => {
     });
 
     it('should combine deprecated and other errors in tooltip', () => {
-      const plugin = { chart: { deprecated: true }, helmError: true };
+      const plugin = { chart: { versions: [{ annotations: { [CATALOG_ANNOTATIONS.DEPRECATED]: 'true' } }] }, helmError: true };
       const statuses = wrapper.vm.getStatuses(plugin);
       const warningStatus = statuses.find((status: any) => status.icon === 'icon-alert-alt');
 

--- a/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
@@ -296,7 +296,8 @@ describe('page: UI plugins/Extensions', () => {
       const plugin = { chart: { versions: [{ annotations: { [CATALOG_ANNOTATIONS.DEPRECATED]: 'true' } }] } };
       const statuses = wrapper.vm.getStatuses(plugin);
 
-      expect(statuses[0].tooltip.key).toBe('generic.deprecated');
+      expect(statuses[0].tooltip.text).toBe('generic.deprecated');
+      expect(statuses[0].color).toBe('error');
     });
 
     it('should return error status for installedError', () => {
@@ -304,15 +305,17 @@ describe('page: UI plugins/Extensions', () => {
       const statuses = wrapper.vm.getStatuses(plugin);
 
       expect(statuses[0].icon).toBe('icon-alert-alt');
-      expect(statuses[0].tooltip.text).toBe('generic.error: An error occurred');
+      expect(statuses[0].color).toBe('error');
+      expect(statuses[0].tooltip.text).toBe('An error occurred');
     });
 
-    it('should return error status for incompatibilityMessage', () => {
+    it('should return warning status for incompatibilityMessage', () => {
       const plugin = { incompatibilityMessage: 'Incompatible version' };
       const statuses = wrapper.vm.getStatuses(plugin);
 
       expect(statuses[0].icon).toBe('icon-alert-alt');
-      expect(statuses[0].tooltip.text).toBe('generic.error: Incompatible version');
+      expect(statuses[0].color).toBe('error');
+      expect(statuses[0].tooltip.text).toBe('Incompatible version');
     });
 
     it('should return error status for helmError', () => {
@@ -320,15 +323,16 @@ describe('page: UI plugins/Extensions', () => {
       const statuses = wrapper.vm.getStatuses(plugin);
 
       expect(statuses[0].icon).toBe('icon-alert-alt');
-      expect(statuses[0].tooltip.text).toBe('generic.error: plugins.helmError');
+      expect(statuses[0].color).toBe('error');
+      expect(statuses[0].tooltip.text).toBe('plugins.helmError');
     });
 
-    it('should combine deprecated and other errors in tooltip', () => {
+    it('should combine deprecated and warning in tooltip, and keep error separate', () => {
       const plugin = { chart: { versions: [{ annotations: { [CATALOG_ANNOTATIONS.DEPRECATED]: 'true' } }] }, helmError: true };
       const statuses = wrapper.vm.getStatuses(plugin);
-      const warningStatus = statuses.find((status: any) => status.icon === 'icon-alert-alt');
+      const errorStatus = statuses.find((status: any) => status.color === 'error');
 
-      expect(warningStatus.tooltip.text).toBe('generic.deprecated. generic.error: plugins.helmError');
+      expect(errorStatus.tooltip.text).toBe('generic.deprecated<br/>plugins.helmError');
     });
   });
 

--- a/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
@@ -327,7 +327,7 @@ describe('page: UI plugins/Extensions', () => {
       expect(statuses[0].tooltip.text).toBe('plugins.helmError');
     });
 
-    it('should combine deprecated and warning in tooltip, and keep error separate', () => {
+    it('should combine deprecated and error messages in a single tooltip', () => {
       const plugin = { chart: { versions: [{ annotations: { [CATALOG_ANNOTATIONS.DEPRECATED]: 'true' } }] }, helmError: true };
       const statuses = wrapper.vm.getStatuses(plugin);
       const errorStatus = statuses.find((status: any) => status.color === 'error');

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -989,24 +989,27 @@ export default {
     getStatuses(plugin) {
       const statuses = [];
 
-      const errorTooltip = plugin.installedError || plugin.incompatibilityMessage || (plugin.helmError ? this.t('plugins.helmError') : null);
+      const errorMsg = plugin.installedError || (plugin.helmError ? this.t('plugins.helmError') : null);
+      const incompatibilityMsg = plugin.incompatibilityMessage;
       const isDeprecated = uiPluginHasAnnotation(plugin?.chart, CATALOG_ANNOTATIONS.DEPRECATED, 'true');
 
-      if (isDeprecated || errorTooltip) {
-        let tooltip;
+      const tooltipMsgs = [];
 
-        if (isDeprecated && errorTooltip) {
-          tooltip = { text: `${ this.t('generic.deprecated') }. ${ this.t('generic.error') }: ${ errorTooltip }` };
-        } else if (isDeprecated) {
-          tooltip = { key: 'generic.deprecated' };
-        } else { // errorTooltip is present
-          tooltip = { text: `${ this.t('generic.error') }: ${ errorTooltip }` };
-        }
+      if (isDeprecated) {
+        tooltipMsgs.push(this.t('generic.deprecated'));
+      }
 
+      if (errorMsg) {
+        tooltipMsgs.push(errorMsg);
+      } else if (incompatibilityMsg) {
+        tooltipMsgs.push(incompatibilityMsg);
+      }
+
+      if (tooltipMsgs.length) {
         statuses.push({
-          icon:  'icon-alert-alt',
-          color: 'error',
-          tooltip
+          icon:    'icon-alert-alt',
+          color:   'error',
+          tooltip: { text: tooltipMsgs.join('<br/>') }
         });
       }
 

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -990,7 +990,7 @@ export default {
       const statuses = [];
 
       const errorTooltip = plugin.installedError || plugin.incompatibilityMessage || (plugin.helmError ? this.t('plugins.helmError') : null);
-      const isDeprecated = plugin?.chart?.deprecated;
+      const isDeprecated = uiPluginHasAnnotation(plugin?.chart, CATALOG_ANNOTATIONS.DEPRECATED, 'true');
 
       if (isDeprecated || errorTooltip) {
         let tooltip;

--- a/shell/store/__tests__/catalog.test.ts
+++ b/shell/store/__tests__/catalog.test.ts
@@ -1,30 +1,54 @@
 import { CATALOG } from '@shell/config/types';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
 import {
   state, getters, actions, mutations, filterAndArrangeCharts
 } from '../catalog';
 import { createStore } from 'vuex';
 
 const clusterRepo = { _key: 'testClusterRepo' };
-const repoChartName = 'abc';
+const repoChartName = 'regular-chart';
 const repoChart = {
   name:     repoChartName,
   type:     'namespaced',
   version:  1,
   metadata: { name: repoChartName }
 };
-const repoCharts = [repoChart];
+const deprecatedByFieldChartName = 'deprecated-by-field-chart';
+const deprecatedByFieldChart = {
+  name:       deprecatedByFieldChartName,
+  type:       'namespaced',
+  version:    1,
+  deprecated: true,
+  metadata:   { name: deprecatedByFieldChartName }
+};
+const deprecatedByAnnotationChartName = 'deprecated-by-annotation-chart';
+const deprecatedByAnnotationChart = {
+  name:        deprecatedByAnnotationChartName,
+  type:        'namespaced',
+  version:     1,
+  annotations: { [CATALOG_ANNOTATIONS.DEPRECATED]: 'true' },
+  metadata:    { name: deprecatedByAnnotationChartName }
+};
 const repo = {
   metadata:   { name: 'testRepo' },
   _key:       'testRepo',
   links:      { index: 'fetchindex' },
   canLoad:    true,
-  followLink: () => ({ entries: { [repoChartName]: repoCharts } })
+  followLink: () => ({
+    entries: {
+      [repoChartName]:                   [repoChart],
+      [deprecatedByFieldChartName]:      [deprecatedByFieldChart],
+      [deprecatedByAnnotationChartName]: [deprecatedByAnnotationChart]
+    }
+  })
 };
 
 const catalogStoreName = 'catalog';
 const clusterStore = 'cluster';
 
 const expectedChartKey = `namespace/${ repo._key }/${ repoChartName }`;
+const expectedDeprecatedByFieldChartKey = `namespace/${ repo._key }/${ deprecatedByFieldChartName }`;
+const expectedDeprecatedByAnnotationChartKey = `namespace/${ repo._key }/${ deprecatedByAnnotationChartName }`;
 const initialVersionInfo = { junk: true };
 const initialRawChartName = 'cde';
 const initialRawChart = {
@@ -160,10 +184,20 @@ describe('catalog', () => {
       expect(rawCharts[expectedChartKey]).toBeDefined();
       expect(rawCharts[expectedChartKey].id).toBe(expectedChartKey);
       expect(rawCharts[expectedChartKey].versions[0].version).toBe(repoChart.version);
-      expect(charts[0]).toBeDefined();
-      expect(charts[0].id).toBe(initialRawChart.id);
-      expect(charts[1]).toBeDefined();
-      expect(charts[1].id).toBe(expectedChartKey);
+
+      expect(rawCharts[expectedDeprecatedByFieldChartKey]).toBeDefined();
+      expect(rawCharts[expectedDeprecatedByFieldChartKey].id).toBe(expectedDeprecatedByFieldChartKey);
+      expect(rawCharts[expectedDeprecatedByFieldChartKey].deprecated).toBe(true);
+
+      expect(rawCharts[expectedDeprecatedByAnnotationChartKey]).toBeDefined();
+      expect(rawCharts[expectedDeprecatedByAnnotationChartKey].id).toBe(expectedDeprecatedByAnnotationChartKey);
+      expect(rawCharts[expectedDeprecatedByAnnotationChartKey].deprecated).toBe(true);
+
+      expect(charts).toHaveLength(4);
+      expect(charts.find((c: any) => c.id === initialRawChart.id)).toBeDefined();
+      expect(charts.find((c: any) => c.id === expectedChartKey)).toBeDefined();
+      expect(charts.find((c: any) => c.id === expectedDeprecatedByFieldChartKey)).toBeDefined();
+      expect(charts.find((c: any) => c.id === expectedDeprecatedByAnnotationChartKey)).toBeDefined();
 
       // Version info should be unchanged
       expect(store.state[catalogStoreName].versionInfos).toStrictEqual(initialVersionInfo);
@@ -197,10 +231,18 @@ describe('catalog', () => {
       expect(rawCharts[expectedChartKey].id).toBe(expectedChartKey);
       expect(rawCharts[expectedChartKey].versions[0].version).toBe(repoChart.version);
 
-      expect(charts).toHaveLength(1);
-      expect(charts[0]).toBeDefined();
-      expect(charts[0].id).toBe(expectedChartKey);
-      expect(charts[0].versions[0].version).toBe(repoChart.version);
+      expect(rawCharts[expectedDeprecatedByFieldChartKey]).toBeDefined();
+      expect(rawCharts[expectedDeprecatedByFieldChartKey].id).toBe(expectedDeprecatedByFieldChartKey);
+      expect(rawCharts[expectedDeprecatedByFieldChartKey].deprecated).toBe(true);
+
+      expect(rawCharts[expectedDeprecatedByAnnotationChartKey]).toBeDefined();
+      expect(rawCharts[expectedDeprecatedByAnnotationChartKey].id).toBe(expectedDeprecatedByAnnotationChartKey);
+      expect(rawCharts[expectedDeprecatedByAnnotationChartKey].deprecated).toBe(true);
+
+      expect(charts).toHaveLength(3);
+      expect(charts.find((c: any) => c.id === expectedChartKey)).toBeDefined();
+      expect(charts.find((c: any) => c.id === expectedDeprecatedByFieldChartKey)).toBeDefined();
+      expect(charts.find((c: any) => c.id === expectedDeprecatedByAnnotationChartKey)).toBeDefined();
 
       // Version info should be changed (it's now empty given reset)
       expect(store.state[catalogStoreName].versionInfos).toStrictEqual({ });
@@ -229,9 +271,18 @@ describe('catalog', () => {
       expect(rawCharts[expectedChartKey].id).toBe(expectedChartKey);
       expect(rawCharts[expectedChartKey].versions[0].version).toBe(repoChart.version);
 
-      expect(charts).toHaveLength(1);
-      expect(charts[0]).toBeDefined();
-      expect(charts[0].id).toBe(expectedChartKey);
+      expect(rawCharts[expectedDeprecatedByFieldChartKey]).toBeDefined();
+      expect(rawCharts[expectedDeprecatedByFieldChartKey].id).toBe(expectedDeprecatedByFieldChartKey);
+      expect(rawCharts[expectedDeprecatedByFieldChartKey].deprecated).toBe(true);
+
+      expect(rawCharts[expectedDeprecatedByAnnotationChartKey]).toBeDefined();
+      expect(rawCharts[expectedDeprecatedByAnnotationChartKey].id).toBe(expectedDeprecatedByAnnotationChartKey);
+      expect(rawCharts[expectedDeprecatedByAnnotationChartKey].deprecated).toBe(true);
+
+      expect(charts).toHaveLength(3);
+      expect(charts.find((c: any) => c.id === expectedChartKey)).toBeDefined();
+      expect(charts.find((c: any) => c.id === expectedDeprecatedByFieldChartKey)).toBeDefined();
+      expect(charts.find((c: any) => c.id === expectedDeprecatedByAnnotationChartKey)).toBeDefined();
     });
 
     it('repoKeys provided, ignoring unrelated charts and versions', async() => {
@@ -275,6 +326,9 @@ describe('catalog', () => {
       // The old initialRawChart (with repoKey: repo._key) SHOULD be wiped and replaced
       expect(rawCharts[initialRawChart.id]).not.toBeDefined();
       expect(rawCharts[expectedChartKey]).toBeDefined();
+
+      expect(rawCharts[expectedDeprecatedByFieldChartKey]).toBeDefined();
+      expect(rawCharts[expectedDeprecatedByAnnotationChartKey]).toBeDefined();
 
       // The targeted version info SHOULD be wiped
       expect(versionInfos[targetedVersionKey]).not.toBeDefined();

--- a/shell/store/catalog.js
+++ b/shell/store/catalog.js
@@ -538,7 +538,9 @@ function addChart(ctx, map, chart, repo) {
     certified = CATALOG_ANNOTATIONS._OTHER;
   }
 
-  if ( chart.deprecated ) {
+  const isDeprecated = !!chart.deprecated || chart.annotations?.[CATALOG_ANNOTATIONS.DEPRECATED] === 'true';
+
+  if ( isDeprecated ) {
     sideLabel = DEPRECATED;
   } else if ( chart.annotations?.[CATALOG_ANNOTATIONS.EXPERIMENTAL] ) {
     sideLabel = EXPERIMENTAL;
@@ -596,7 +598,7 @@ function addChart(ctx, map, chart, repo) {
       versions:         [],
       keywords:         chart.keywords || [],
       categories:       filterCategories(chart.keywords),
-      deprecated:       !!chart.deprecated,
+      deprecated:       isDeprecated,
       primeOnly,
       experimental,
       hidden:           !!chart.annotations?.[CATALOG_ANNOTATIONS.HIDDEN],


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17027 

### Occurred changes and/or fixed issues
Refactored the way deprecated UI extensions and Helm charts are identified and displayed in the UI to support the new `catalog.cattle.io/deprecated` annotation.

### Technical notes summary
* `@shell/store/catalog.js`: Set the internal `deprecated` flag on parsed chart objects if either the existing `deprecated` property is `true` or the new `catalog.cattle.io/deprecated` annotation is `'true'`.
* Added a new warning banner below tags for deprecated extensions.
* Added a new error banner below tags for error message.
* Changed `incompatibilityMessage` to be considered as a warning and displayed as a warning banner on the slide-in panel.
* `index.vue`: Updated UI plugins to strictly rely on the new `catalog.cattle.io/deprecated` annotation to determine deprecation status.
* `index.vue`: Simplified `getStatuses` to use `<br/>` for combining tooltip messages for better i18n support.
* Updated related unit tests in `catalog.test.ts`, `index.test.ts`, and `PluginInfoPanel.test.ts`.

### Areas or cases that should be tested
* Ensure UI extensions with the `catalog.cattle.io/deprecated: "true"` annotation show the yellow banner in the details panel and warning icon on the card.
* Ensure extensions with an `incompatibilityMessage` show a yellow warning banner and card tooltip.
* Ensure general catalog charts correctly show as deprecated if they have either the `deprecated` property or the new annotation.
* Ensure errors display as red error banners.

### Areas which could experience regressions
* Extension card tooltips and slide-in details panel.
* General catalog chart processing.


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
deprecation warning:
<img width="616" height="444" alt="Screenshot 2026-04-28 at 6 52 45 PM" src="https://github.com/user-attachments/assets/72f2d703-e6a1-46f5-a995-3ec2b07bb14d" />
incompatibility warning:
<img width="616" height="471" alt="Screenshot 2026-04-28 at 6 53 08 PM" src="https://github.com/user-attachments/assets/0dde7106-9ea2-48e3-8eab-06f837673a81" />
mocked error:
<img width="612" height="431" alt="Screenshot 2026-04-28 at 7 01 06 PM" src="https://github.com/user-attachments/assets/b322b59c-7883-4720-a73d-e4b06a5fd759" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
