### PR TITLE
[backport 2.14.2] fixed release notes test and flakiness caused by test isolation

### DIFF
--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -4,8 +4,8 @@ import DiagnosticsPagePo from '@/cypress/e2e/po/pages/diagnostics.po';
 
 const aboutPage = new AboutPagePo();
 
-describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
-  before(() => {
+describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+  beforeEach(() => {
     cy.login();
   });
 
@@ -16,15 +16,13 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
   });
 
   it('no Prime info when community', { tags: '@noPrime' }, () => {
-    HomePagePo.goToAndWaitForGet();
-    AboutPagePo.navTo();
+    aboutPage.goTo();
     aboutPage.waitForPage();
-
     aboutPage.rancherPrimeInfo().should('not.exist');
   });
 
   it('can navigate to Diagnostics page', () => {
-    AboutPagePo.navTo();
+    aboutPage.goTo();
     aboutPage.waitForPage();
     aboutPage.diagnosticsBtn().click();
 
@@ -34,18 +32,24 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
   });
 
   it('can View release notes', () => {
-    AboutPagePo.navTo();
+    aboutPage.goTo();
     aboutPage.waitForPage();
+    cy.getRancherVersion().then((version) => {
+      const isPrime = version.RancherPrime === 'true';
+      const expectedOrigin = isPrime ? 'https://documentation.suse.com' : 'https://github.com';
+      const expectedUrlPattern = isPrime ? '/cloudnative/rancher-manager/.+/en/release-notes' : '/rancher/rancher/releases/tag/';
 
-    aboutPage.clickVersionLink('View release notes');
-    cy.origin('https://github.com/rancher/rancher', () => {
-      cy.url().should('include', 'https://github.com/rancher/rancher/releases/tag/');
+      aboutPage.clickVersionLink('View release notes');
+      cy.origin(expectedOrigin, { args: { expectedUrlPattern } }, ({ expectedUrlPattern }) => {
+        cy.url().should('match', new RegExp(expectedUrlPattern));
+      });
     });
   });
 
   describe('Versions', () => {
     beforeEach(() => {
       aboutPage.goTo();
+      aboutPage.waitForPage();
     });
 
     it('can see rancher version', () => {
@@ -59,28 +63,28 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
 
     it('can navigate to /rancher/rancher', () => {
       aboutPage.clickVersionLink('Rancher');
-      cy.origin('https://github.com/rancher/rancher', () => {
+      cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/rancher');
       });
     });
 
     it('can navigate to /rancher/dashboard', () => {
       aboutPage.clickVersionLink('Dashboard');
-      cy.origin('https://github.com/rancher/dashboard', () => {
+      cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/dashboard');
       });
     });
 
     it('can navigate to /rancher/helm', () => {
       aboutPage.clickVersionLink('Helm');
-      cy.origin('https://github.com/rancher/helm', () => {
+      cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/helm');
       });
     });
 
     it('can navigate to /rancher/machine', () => {
       aboutPage.clickVersionLink('Machine');
-      cy.origin('https://github.com/rancher/machine', () => {
+      cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/machine');
       });
     });
@@ -93,6 +97,7 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
     // workaround to make the following CLI tests work https://github.com/cypress-io/cypress/issues/8089#issuecomment-1585159023
     beforeEach(() => {
       aboutPage.goTo();
+      aboutPage.waitForPage();
       cy.intercept('GET', 'https://releases.rancher.com/cli2/**').as('download');
     });
 
@@ -152,7 +157,6 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
     }
 
     beforeEach(() => {
-      cy.login();
       interceptVersionAndSetToPrime().as('rancherVersion');
     });
 


### PR DESCRIPTION
Fixes #
https://github.com/rancher/qa-tasks/issues/2269

Occurred changes and/or fixed issues
Enabled Test Isolation to remove flakiness in the Versions test suite and updated the 'can View release notes' test to reflect the prime release notes url

Areas or cases that should be tested
The about.spec.ts tests

### Screenshot/Video

Community:
<img width="1511" height="948" alt="Screenshot 2026-05-01 at 11 19 57 AM" src="https://github.com/user-attachments/assets/44e9cfd4-2274-4c7d-9f34-d0e757e0d358" />

Prime:
<img width="1511" height="1000" alt="Screenshot 2026-05-04 at 3 53 07 PM" src="https://github.com/user-attachments/assets/102066b8-658a-432f-aca3-48c66b0ced6f" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
