### PR TITLE
Fix pnap machine config authentication

### DIFF
--- a/shell/store/pnap.js
+++ b/shell/store/pnap.js
@@ -88,7 +88,7 @@ export const actions = {
     const headers = { Accept: 'application/json' };
 
     if ( credentialId ) {
-      headers['X-API-CattleAuth-Header'] = `Bearer credID=${ credentialId } passwordField=token`;
+      headers['X-API-CattleAuth-Header'] = `Basic credID=${ credentialId } passwordField=clientSecret usernameField=clientId`;
     } else if ( clientId ) {
       const credentials = `${ clientId }:${ clientSecret }`;
       const encoded = base64Encode(credentials);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17404
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the pnap store to use the Basic auth signer instead of Bearer. I determined that Basic was the correct signer by examining the sample network requests that can be made in the pnap api documentation - https://developers.phoenixnap.com/apis


### Areas or cases that should be tested
I can provide some sample creds for Rancher eng/QA.

The pnap machine config component shouldn't show an error banner on initial load; check #17404 for repro steps.

### Areas which could experience regressions
Creating new pnap credentials

### Screenshot/Video
<img width="2009" height="794" alt="Screenshot 2026-04-29 at 10 42 08 AM" src="https://github.com/user-attachments/assets/53e08b37-1c07-490b-ac19-670e880de66a" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
