### PR TITLE
Fix Cluster/Node Drivers list link from driver edit page

### DIFF
--- a/shell/models/kontainerdriver.js
+++ b/shell/models/kontainerdriver.js
@@ -5,6 +5,13 @@ export default class KontainerDriver extends Driver {
     return 'c-cluster-manager-driver-kontainerdriver';
   }
 
+  get parentLocationOverride() {
+    return {
+      name:   'c-cluster-manager-driver-kontainerdriver',
+      params: { cluster: this.$rootGetters['clusterId'] }
+    };
+  }
+
   get _availableActions() {
     const out = [
       {

--- a/shell/models/nodedriver.js
+++ b/shell/models/nodedriver.js
@@ -13,6 +13,13 @@ export default class NodeDriver extends Driver {
     return 'c-cluster-manager-driver-nodedriver';
   }
 
+  get parentLocationOverride() {
+    return {
+      name:   'c-cluster-manager-driver-nodedriver',
+      params: { cluster: this.$rootGetters['clusterId'] }
+    };
+  }
+
   get _availableActions() {
     const out = [
       {


### PR DESCRIPTION
### Summary
Fixes #13297

### Occurred changes and/or fixed issues
The breadcrumb on the driver edit page now returns to the populated Drivers list instead of an empty generic resource list.

### Technical notes summary
Added `parentLocationOverride` to `shell/models/kontainerdriver.js` and `shell/models/nodedriver.js so` the back-link matches the existing `listLocation` (Norman-backed Drivers page) instead of the default Steve resource list.

### Areas or cases that should be tested
Edit a cluster driver and a node driver, then use the breadcrumb / save / cancel to return to the Drivers list — it should be populated and on the correct tab.

### Areas which could experience regressions
Back-navigation from kontainer/node driver edit pages.

### Screenshot/Video

<!-- TODO(manual upload): drag-drop each file into this section to replace the matching line. Files live in the project workspace. -->
- Before fix: 

[before-fix (1).webm](https://github.com/user-attachments/assets/d6ccff0b-4e42-41fb-8932-5e8812669fce)

- After fix: 

[after-fix.webm](https://github.com/user-attachments/assets/11c531a6-1cad-4943-badf-154b35e94354)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`