### PR TITLE
Add `clientAuthenticatedSearch` to Keycloak auth provider

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -806,6 +806,9 @@ authConfig:
     groupSearch:
       label: Enable group search
       tooltip: Allows users with appropriate permissions to search and view all groups within the OIDC provider's realm. This can be useful for administrators who need to assign global roles to groups that they are not currently a member of.
+    clientAuthenticatedSearch:
+      label: Enable client authenticated search
+      tooltip: Use the OIDC Client Credentials to authenticate to Keycloak when searching for users or groups. This will bypass user-based RBAC within the realm
   stateBanner:
     disabled: 'The {provider} authentication provider is currently disabled.'
     enabled: 'The {provider} authentication provider is currently enabled.'

--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -297,5 +297,59 @@ describe('oidc.vue', () => {
       expect(groupsClaim.exists()).toBe(false);
       expect(emailClaim.exists()).toBe(false);
     });
+
+    describe('clientAuthenticatedSearch checkbox', () => {
+      it('is not rendered for genericoidc', async() => {
+        const checkbox = wrapper.find('[data-testid="input-client-authenticated-group-search"]');
+
+        expect(checkbox.exists()).toBe(false);
+      });
+
+      it('is not rendered for cognito', async() => {
+        await wrapper.setData({ model: { ...mockModel, id: 'cognito' } });
+
+        const checkbox = wrapper.find('[data-testid="input-client-authenticated-group-search"]');
+
+        expect(checkbox.exists()).toBe(false);
+      });
+
+      it('is rendered for keycloakoidc', async() => {
+        await wrapper.setData({ model: { ...mockModel, id: 'keycloakoidc' } });
+
+        const checkbox = wrapper.find('[data-testid="input-client-authenticated-group-search"]');
+
+        expect(checkbox.exists()).toBe(true);
+      });
+
+      it('defaults to falsy when not set on keycloakoidc', async() => {
+        await wrapper.setData({ model: { ...mockModel, id: 'keycloakoidc' } });
+
+        expect(wrapper.vm.model.clientAuthenticatedSearch).toBeFalsy();
+      });
+
+      it('updates model when checkbox is clicked', async() => {
+        await wrapper.setData({
+          model: {
+            ...mockModel, id: 'keycloakoidc', clientAuthenticatedSearch: false
+          }
+        });
+
+        const checkbox = wrapper.getComponent('[data-testid="input-client-authenticated-group-search"]');
+
+        await checkbox.find('[role="checkbox"]').trigger('click');
+
+        expect(wrapper.vm.model.clientAuthenticatedSearch).toBe(true);
+      });
+
+      it('reflects a pre-existing true value from the model', async() => {
+        await wrapper.setData({
+          model: {
+            ...mockModel, id: 'keycloakoidc', clientAuthenticatedSearch: true
+          }
+        });
+
+        expect(wrapper.vm.model.clientAuthenticatedSearch).toBe(true);
+      });
+    });
   });
 });

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -453,6 +453,14 @@ export default {
               :mode="mode"
             />
             <Checkbox
+              v-if="isKeycloak"
+              v-model:value="model.clientAuthenticatedSearch"
+              data-testid="input-client-authenticated-group-search"
+              :label="t('authConfig.oidc.clientAuthenticatedSearch.label')"
+              :tooltip="t('authConfig.oidc.clientAuthenticatedSearch.tooltip')"
+              :mode="mode"
+            />
+            <Checkbox
               v-if="supportsCustomClaims"
               v-model:value="addCustomClaims"
               data-testid="input-add-custom-claims"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds an option to the Keycloak OIDC auth provider that allows for toggling client-based authentication for searches.

Fixes #17284 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add `clientAuthenticatedSearch` to Keycloak auth provider

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The primary motivation for this change is to support a backend change that resolves an issue for scenarios where http 403 errors can fill the Rancher/Keycloak logs when the auth provider is configured. This can happen when a user doesn't have view-users permission, then the REST api fails with an authorization error when searching for users.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Configure Keycloak OIDC and ensure that the new field persists on save/edit.

The new field should only be rendered on the Keycloak OIDC provider form.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

I think this change is quite limited in scope - we might see errors when saving the auth provider if something goes wrong.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="1371" height="900" alt="image" src="https://github.com/user-attachments/assets/4dc5fa4f-2280-4710-959d-70e8daeb82b3" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
