### PR TITLE
[ Apps & Marketplace ] - Remove date when no date info available

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1140,7 +1140,6 @@ catalog:
         label: Chart Versions
         showMore: Show More
         showLess: Show Less
-        missingVersionDate: No date available for this chart version
       home: Homepage
       repository: Repository Page
       maintainers: Maintainers
@@ -1195,8 +1194,6 @@ catalog:
       label: Add new
       ariaLabel: Add a new repository
     appChartCard:
-      subHeaderItem:
-        missingVersionDate: Last updated date is not available for this chart
       footerItem:
         ariaLabel: 'Apply {filter} filter'
     statusFilterCautions:

--- a/shell/models/__tests__/chart.test.ts
+++ b/shell/models/__tests__/chart.test.ts
@@ -17,7 +17,7 @@ type MockChartContext = {
 };
 
 interface CardContent {
-  subHeaderItems: { label: string, labelTooltip?: string}[];
+  subHeaderItems: { label: string, labelTooltip?: string, icon?: string, iconTooltip?: string }[];
   footerItems: { labels: string[]; icon?: string }[];
   statuses: { tooltip: { key?: string; text?: string }; color: string }[];
 }
@@ -403,10 +403,32 @@ describe('class Chart', () => {
       });
 
       const result = chart.cardContent as CardContent;
-      const lastUpdatedItem = result.subHeaderItems[1];
 
-      expect(lastUpdatedItem.label).toBe('generic.na');
-      expect(lastUpdatedItem.labelTooltip).toBe('catalog.charts.appChartCard.subHeaderItem.missingVersionDate');
+      expect(result.subHeaderItems).toHaveLength(1);
+      expect(result.subHeaderItems[0].icon).toBe('icon-version-alt');
+    });
+
+    it('handles falsy time for last updated date', () => {
+      const chartWithFalsyTime = {
+        ...base,
+        versions: [{
+          ...base.versions[0],
+          created: '',
+        }]
+      };
+      const chart = new Chart(chartWithFalsyTime, {
+        rootGetters: {
+          'cluster/all':  () => [],
+          'i18n/t':       (key: string) => key,
+          currentCluster: { workerOSs: [] },
+          'prefs/get':    () => false,
+        },
+      });
+
+      const result = chart.cardContent as CardContent;
+
+      expect(result.subHeaderItems).toHaveLength(1);
+      expect(result.subHeaderItems[0].icon).toBe('icon-version-alt');
     });
   });
 });

--- a/shell/models/chart.js
+++ b/shell/models/chart.js
@@ -151,7 +151,7 @@ export default class Chart extends SteveModel {
     const subHeaderItems = [];
 
     if (latestVersion) {
-      const hasZeroTime = latestVersion.created === ZERO_TIME;
+      const isMissingDate = !latestVersion.created || latestVersion.created === ZERO_TIME;
 
       subHeaderItems.push({
         icon:        'icon-version-alt',
@@ -159,17 +159,13 @@ export default class Chart extends SteveModel {
         label:       latestVersion.version
       });
 
-      const lastUpdatedItem = {
-        icon:        'icon-refresh-alt',
-        iconTooltip: { key: 'tableHeaders.lastUpdated' },
-        label:       hasZeroTime ? this.t('generic.na') : day(latestVersion.created).format('MMM D, YYYY')
-      };
-
-      if (hasZeroTime) {
-        lastUpdatedItem.labelTooltip = this.t('catalog.charts.appChartCard.subHeaderItem.missingVersionDate');
+      if (!isMissingDate) {
+        subHeaderItems.push({
+          icon:        'icon-refresh-alt',
+          iconTooltip: { key: 'tableHeaders.lastUpdated' },
+          label:       day(latestVersion.created).format('MMM D, YYYY')
+        });
       }
-
-      subHeaderItems.push(lastUpdatedItem);
     }
 
     const footerItems = [

--- a/shell/models/chart.js
+++ b/shell/models/chart.js
@@ -5,8 +5,9 @@ import {
 import { BLANK_CLUSTER } from '@shell/store/store-types.js';
 import { SHOW_PRE_RELEASE } from '@shell/store/prefs';
 import { getLatestCompatibleVersion } from '@shell/utils/chart';
+import { isMissingDate } from '@shell/utils/time';
 import SteveModel from '@shell/plugins/steve/steve-class';
-import { CATALOG, ZERO_TIME } from '@shell/config/types';
+import { CATALOG } from '@shell/config/types';
 import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
 import day from 'dayjs';
 
@@ -151,15 +152,13 @@ export default class Chart extends SteveModel {
     const subHeaderItems = [];
 
     if (latestVersion) {
-      const isMissingDate = !latestVersion.created || latestVersion.created === ZERO_TIME;
-
       subHeaderItems.push({
         icon:        'icon-version-alt',
         iconTooltip: { key: 'tableHeaders.version' },
         label:       latestVersion.version
       });
 
-      if (!isMissingDate) {
+      if (!isMissingDate(latestVersion.created)) {
         subHeaderItems.push({
           icon:        'icon-refresh-alt',
           iconTooltip: { key: 'tableHeaders.lastUpdated' },

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -345,18 +345,13 @@ export default {
         });
       }
     },
+    isMissingDate(date) {
+      return !date || date === ZERO_TIME;
+    },
     formatVersionDate(date) {
-      if (date === ZERO_TIME) {
-        return this.t('generic.na');
-      }
-
       return day(date).format('MMM D, YYYY');
     },
     getVersionDateTooltip(date) {
-      if (date === ZERO_TIME) {
-        return this.t('catalog.chart.info.chartVersions.missingVersionDate');
-      }
-
       const dateFormat = escapeHtml(this.$store.getters['prefs/get'](DATE_FORMAT));
 
       return day(date).format(dateFormat);
@@ -602,6 +597,7 @@ export default {
               />
             </div>
             <p
+              v-if="!isMissingDate(vers.created)"
               v-clean-tooltip="{ content: getVersionDateTooltip(vers.created), placement: 'left'}"
               class="version-date"
             >

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -10,7 +10,7 @@ import {
   CHART, REPO, REPO_TYPE, VERSION, SEARCH_QUERY, CATEGORY, TAG, DEPRECATED, NAMESPACE, NAME, NEW_APP_INSTANCE, _FLAGGED
 } from '@shell/config/query-params';
 import { DATE_FORMAT } from '@shell/store/prefs';
-import { ZERO_TIME } from '@shell/config/types';
+import { isMissingDate } from '@shell/utils/time';
 import { escapeHtml } from '@shell/utils/string';
 import { mapGetters } from 'vuex';
 import { APP_UPGRADE_STATUS, compatibleVersionsFor } from '@shell/store/catalog';
@@ -47,7 +47,6 @@ export default {
   data() {
     return {
       SEARCH_QUERY,
-      ZERO_TIME,
       showLastVersions:       7,
       showMoreVersions:       false,
       selectedInstalledAppId: null,
@@ -218,6 +217,7 @@ export default {
   },
 
   methods: {
+    isMissingDate,
     /**
      * Computes statuses for the chart detail page based on the selected installed app.
      * When an app is selected, shows instance-specific installed/upgradeable status.
@@ -344,9 +344,6 @@ export default {
           query: { [type]: queryValue },
         });
       }
-    },
-    isMissingDate(date) {
-      return !date || date === ZERO_TIME;
     },
     formatVersionDate(date) {
       return day(date).format('MMM D, YYYY');

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -5,7 +5,8 @@ import { mapPref, PLUGIN_DEVELOPER } from '@shell/store/prefs';
 import { sortBy } from '@shell/utils/sort';
 import genericPluginSvg from '~shell/assets/images/generic-plugin.svg';
 import { allHash } from '@shell/utils/promise';
-import { CATALOG, UI_PLUGIN, MANAGEMENT, ZERO_TIME } from '@shell/config/types';
+import { CATALOG, UI_PLUGIN, MANAGEMENT } from '@shell/config/types';
+import { isMissingDate } from '@shell/utils/time';
 import { SETTING } from '@shell/config/settings';
 import { fetchOrCreateSetting } from '@shell/utils/settings';
 import { getVersionData, isRancherPrime } from '@shell/config/version';
@@ -896,9 +897,7 @@ export default {
         label:       plugin.displayVersionLabel,
       }];
 
-      const isMissingDate = !plugin.created || plugin.created === ZERO_TIME;
-
-      if (!isMissingDate) {
+      if (!isMissingDate(plugin.created)) {
         items.push({
           icon:        'icon-refresh-alt',
           iconTooltip: { key: 'tableHeaders.lastUpdated' },

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -896,18 +896,14 @@ export default {
         label:       plugin.displayVersionLabel,
       }];
 
-      if (plugin.created) {
-        const hasZeroTime = plugin.created === ZERO_TIME;
-        const lastUpdatedItem = {
+      const isMissingDate = !plugin.created || plugin.created === ZERO_TIME;
+
+      if (!isMissingDate) {
+        items.push({
           icon:        'icon-refresh-alt',
           iconTooltip: { key: 'tableHeaders.lastUpdated' },
-          label:       hasZeroTime ? this.t('generic.na') : day(plugin.created).format('MMM D, YYYY')
-        };
-
-        if (hasZeroTime) {
-          lastUpdatedItem.labelTooltip = this.t('catalog.charts.appChartCard.subHeaderItem.missingVersionDate');
-        }
-        items.push(lastUpdatedItem);
+          label:       day(plugin.created).format('MMM D, YYYY')
+        });
       }
 
       if (plugin.installing) {

--- a/shell/utils/__tests__/time.test.ts
+++ b/shell/utils/__tests__/time.test.ts
@@ -1,6 +1,19 @@
 import { DATE_FORMAT, TIME_FORMAT } from '@shell/store/prefs';
-import { dateTimeFormat } from '@shell/utils/time';
+import { dateTimeFormat, isMissingDate } from '@shell/utils/time';
 import { type Store } from 'vuex';
+import { ZERO_TIME } from '@shell/config/types';
+
+describe('function: isMissingDate', () => {
+  it.each([
+    [undefined, true],
+    [null, true],
+    ['', true],
+    [ZERO_TIME, true],
+    ['2010-10-21T04:29:00Z', false],
+  ])('given %p, returns %p', (date, expected) => {
+    expect(isMissingDate(date)).toBe(expected);
+  });
+});
 
 describe('function: dateTimeFormat', () => {
   jest.useFakeTimers()

--- a/shell/utils/time.ts
+++ b/shell/utils/time.ts
@@ -2,6 +2,11 @@ import day from 'dayjs';
 import { escapeHtml } from '@shell/utils/string';
 import { DATE_FORMAT, TIME_FORMAT } from '@shell/store/prefs';
 import { type Store } from 'vuex';
+import { ZERO_TIME } from '@shell/config/types';
+
+export function isMissingDate(date: string | undefined | null): boolean {
+  return !date || date === ZERO_TIME;
+}
 
 const FACTORS = [60, 60, 24];
 const LABELS = ['sec', 'min', 'hour', 'day'];


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16832 

### Occurred changes and/or fixed issues
Hides the "last updated" item and version date completely when a chart or UI plugin version is missing a created date (falsy or `ZERO_TIME`), instead of displaying "n/a" with a refresh icon.

### Technical notes summary
- Replaced `hasZeroTime` with `isMissingDate` (`!date || date === ZERO_TIME`). 
- Avoided rendering empty elements by omitting them from DOM and data structures directly.
- `shell/models/chart.js` & `shell/pages/c/_cluster/uiplugins/index.vue`: Only adds the "last updated" subheader item if the date exists and isn't `ZERO_TIME`.
- Removed unused translation keys `catalog.charts.appChartCard.subHeaderItem.missingVersionDate` and `catalog.chart.info.chartVersions.missingVersionDate`.
- Added/updated unit tests in `chart.test.ts` for zero and falsy date cases.

### Areas or cases that should be tested
- Apps -> Charts: Verify charts with missing dates do not show an empty "last updated" subheader item or refresh icon on their cards.
- Chart Details page: Verify the version history right sidebar omits dates/tooltips for versions with missing dates.
- Extensions: Verify UI plugin cards with missing dates omit the "last updated" info.

### Areas which could experience regressions
- Chart cards on the Apps/Charts page.
- UI Plugin cards on the Extensions page.
- The version list in the right sidebar of the Chart Details page.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="589" height="365" alt="image" src="https://github.com/user-attachments/assets/262083a0-5f41-4276-94e5-af68d0e3378b" />
<img width="1495" height="565" alt="Screenshot 2026-04-29 at 2 58 21 PM" src="https://github.com/user-attachments/assets/52ac0132-35e1-4437-83c2-58462bdc5a1f" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
