### PR TITLE
[backport 2.13] fixed release notes test and flakiness caused by test isolation

### DIFF
--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -4,8 +4,8 @@ import DiagnosticsPagePo from '@/cypress/e2e/po/pages/diagnostics.po';
 
 const aboutPage = new AboutPagePo();
 
-describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
-  before(() => {
+describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
+  beforeEach(() => {
     cy.login();
   });
 
@@ -16,15 +16,13 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
   });
 
   it('no Prime info when community', { tags: '@noPrime' }, () => {
-    HomePagePo.goToAndWaitForGet();
-    AboutPagePo.navTo();
+    aboutPage.goTo();
     aboutPage.waitForPage();
-
     aboutPage.rancherPrimeInfo().should('not.exist');
   });
 
   it('can navigate to Diagnostics page', () => {
-    AboutPagePo.navTo();
+    aboutPage.goTo();
     aboutPage.waitForPage();
     aboutPage.diagnosticsBtn().click();
 
@@ -33,19 +31,23 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
     diagnosticsPo.waitForPage();
   });
 
+  // For v2.13.x, the prime links to release notes are not going to be implemented according to https://github.com/rancher/dashboard/issues/16323#issuecomment-4207507404
   it('can View release notes', () => {
-    AboutPagePo.navTo();
+    aboutPage.goTo();
     aboutPage.waitForPage();
+    const expectedOrigin = 'https://github.com';
+    const expectedUrlPattern = '/rancher/rancher/releases/tag/';
 
     aboutPage.clickVersionLink('View release notes');
-    cy.origin('https://github.com/rancher/rancher', () => {
-      cy.url().should('include', 'https://github.com/rancher/rancher/releases/tag/');
+    cy.origin(expectedOrigin, { args: { expectedUrlPattern } }, ({ expectedUrlPattern }) => {
+      cy.url().should('match', new RegExp(expectedUrlPattern));
     });
   });
 
   describe('Versions', () => {
     beforeEach(() => {
       aboutPage.goTo();
+      aboutPage.waitForPage();
     });
 
     it('can see rancher version', () => {
@@ -59,28 +61,28 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
 
     it('can navigate to /rancher/rancher', () => {
       aboutPage.clickVersionLink('Rancher');
-      cy.origin('https://github.com/rancher/rancher', () => {
+      cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/rancher');
       });
     });
 
     it('can navigate to /rancher/dashboard', () => {
       aboutPage.clickVersionLink('Dashboard');
-      cy.origin('https://github.com/rancher/dashboard', () => {
+      cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/dashboard');
       });
     });
 
     it('can navigate to /rancher/helm', () => {
       aboutPage.clickVersionLink('Helm');
-      cy.origin('https://github.com/rancher/helm', () => {
+      cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/helm');
       });
     });
 
     it('can navigate to /rancher/machine', () => {
       aboutPage.clickVersionLink('Machine');
-      cy.origin('https://github.com/rancher/machine', () => {
+      cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/machine');
       });
     });
@@ -93,6 +95,7 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
     // workaround to make the following CLI tests work https://github.com/cypress-io/cypress/issues/8089#issuecomment-1585159023
     beforeEach(() => {
       aboutPage.goTo();
+      aboutPage.waitForPage();
       cy.intercept('GET', 'https://releases.rancher.com/cli2/**').as('download');
     });
 
@@ -152,7 +155,6 @@ describe('About Page', { testIsolation: 'off', tags: ['@generic', '@adminUser', 
     }
 
     beforeEach(() => {
-      cy.login();
       interceptVersionAndSetToPrime().as('rancherVersion');
     });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
https://github.com/rancher/qa-tasks/issues/2269

### Occurred changes and/or fixed issues
Enabled Test Isolation to remove flakiness in the Versions test suite and updated the 'can View release notes' test to reflect the prime release notes url

### Areas or cases that should be tested
The `about.spec.ts` tests

All tests passing locally with node version v20.17.0 - 
Prime is failing because of this known bug, but not an issue with the test itself. https://github.com/rancher/dashboard/issues/17495

<img width="1511" height="1000" alt="Screenshot 2026-05-05 at 3 19 16 PM" src="https://github.com/user-attachments/assets/9079ff2f-1ebb-468a-b0fd-3562a0a817b9" />

Community:

<img width="1511" height="1000" alt="Screenshot 2026-05-05 at 6 09 48 PM" src="https://github.com/user-attachments/assets/0636aafa-02e4-42d8-a8d7-373c34be6cc1" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
