### PR TITLE
Create form validation parser

### DIFF
--- a/cypress/e2e/po/pages/explorer/project-secrets.po.ts
+++ b/cypress/e2e/po/pages/explorer/project-secrets.po.ts
@@ -62,6 +62,10 @@ export class ProjectSecretsCreateEditPo extends BaseDetailPagePo {
     return new LabeledInputPo('[data-testid="secret-basic-username"]');
   }
 
+  basicAuthPasswordInput() {
+    return new LabeledInputPo('[data-testid="secret-basic-password"]');
+  }
+
   saveOrCreate(): AsyncButtonPo {
     return new AsyncButtonPo('[data-testid="form-save"]', this.self());
   }

--- a/cypress/e2e/tests/pages/explorer2/storage/project-secrets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/project-secrets.spec.ts
@@ -8,6 +8,7 @@ const targetProject = {
 };
 const projectScopedSecretName = 'e2e-project-scoped-secret-name';
 const username = 'test';
+const password = 'test-password';
 
 describe('Project Secrets', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
   beforeEach(() => {
@@ -45,6 +46,7 @@ describe('Project Secrets', { testIsolation: 'off', tags: ['@explorer2', '@admin
     secretCreatePage.projectSelect().clickOptionWithLabel(targetProject.label);
     secretCreatePage.nameNsDescription().name().set(projectScopedSecretName);
     secretCreatePage.basicAuthUsernameInput().set(username);
+    secretCreatePage.basicAuthPasswordInput().set(password, true);
     secretCreatePage.saveOrCreate().click();
 
     cy.wait('@createProjectScopedSecret', { requestTimeout: 10000 }).then((req) => {

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
@@ -1,4 +1,4 @@
-import { defineComponent, nextTick } from 'vue';
+import { defineComponent, nextTick, provide, ref } from 'vue';
 import { mount, flushPromises } from '@vue/test-utils';
 import { useForm } from 'vee-validate';
 import { LabeledInput } from './index';
@@ -195,21 +195,27 @@ describe('component: LabeledInput', () => {
 
     it('with name prop: form-level validation schema error is shown when the form validates', async() => {
       const errorMessage = 'Username is required';
+      const showAllErrors = ref(false);
       let triggerFormValidation!: () => Promise<unknown>;
 
       const TestWrapper = defineComponent({
         components: { LabeledInput },
         setup() {
+          provide('vee-show-all-errors', showAllErrors);
+
           const { validate } = useForm({
             validationSchema: { username: (v: string) => (!v ? errorMessage : true) },
-            initialValues:    { username: '' }
+            initialValues:    { username: '' },
           });
 
-          triggerFormValidation = validate;
+          triggerFormValidation = async() => {
+            await validate();
+            showAllErrors.value = true;
+          };
 
           return {};
         },
-        template: '<LabeledInput name="username" value="" />'
+        template: '<LabeledInput name="username" value="" />',
       });
 
       const wrapper = mount(TestWrapper, { global: { mocks: { $store: { getters: { 'i18n/t': jest.fn() } } } } });

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -1,8 +1,5 @@
 <script lang="ts">
-import {
-  defineComponent, inject, computed, watch, ref, type Ref
-} from 'vue';
-import { useField } from 'vee-validate';
+import { defineComponent, inject, computed, toRef } from 'vue';
 import TextAreaAutoGrow from '@components/Form/TextArea/TextAreaAutoGrow.vue';
 import LabeledTooltip from '@components/LabeledTooltip/LabeledTooltip.vue';
 import { escapeHtml, generateRandomAlphaString } from '@shell/utils/string';
@@ -11,6 +8,7 @@ import { isValidCron } from 'cron-validator';
 import { debounce } from 'lodash';
 import { useLabeledFormElement, labeledFormElementProps } from '@shell/composables/useLabeledFormElement';
 import { useCompactInput } from '@shell/composables/useCompactInput';
+import { useVeeValidateField } from '@shell/composables/useVeeValidateField';
 
 interface NonReactiveProps {
   onInput: (event: Event) => void | ((event: Event) => void);
@@ -143,60 +141,12 @@ export default defineComponent({
     const { isCompact } = useCompactInput(props);
 
     const onInput = inject('onInput', provideProps.onInput);
-    const showAllErrors = inject<Ref<boolean>>('vee-show-all-errors', ref(false));
 
-    // Stable fallback name so useField is always called unconditionally.
-    // When no name prop is given the field won't match any form-schema path.
-    const standaloneFieldId = `__field__${ generateRandomAlphaString(12) }`;
-    const veeFieldName = computed(() => props.name || standaloneFieldId);
-
-    // Pass existing rules to vee-validate so field-level validation still runs
-    const veeValidator = (value: unknown): boolean | string => {
-      // Return true when name is absent to avoid duplicating
-      // useLabeledFormElement validation
-      if (!props.name) {
-        return true;
-      }
-      for (const rule of props.rules as Array<(v: unknown) => string | undefined>) {
-        const msg = rule(value);
-
-        if (msg) {
-          return msg;
-        }
-      }
-
-      return true;
-    };
-
-    const {
-      errorMessage: veeError,
-      handleBlur:   veeHandleBlur,
-      validate:     veeValidate,
-      value:        veeValue,
-      meta:         veeMeta,
-    } = useField<string | number | Record<string, unknown>>(
-      veeFieldName,
-      veeValidator,
-      {
-        initialValue:          props.value as string | number,
-        validateOnValueUpdate: true,
-        validateOnMount:       true,
-      }
-    );
-
-    // Keep vee-validate's internal value in sync with the controlled prop value.
-    watch(() => props.value, (v) => {
-      if (veeValue.value !== v) {
-        veeValue.value = v as string | number;
-      }
-    });
-
-    const effectiveValidationMessage = computed(() => {
-      if (props.name && veeError.value && (veeMeta.touched || showAllErrors.value)) {
-        return veeError.value;
-      }
-
-      return validationMessage.value;
+    const { effectiveValidationMessage, veeHandleBlur, veeValidate } = useVeeValidateField({
+      name:  toRef(props, 'name'),
+      rules: toRef(props, 'rules'),
+      value: toRef(props, 'value'),
+      validationMessage,
     });
 
     const effectiveStatus = computed(() => props.status);

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -170,12 +170,14 @@ export default defineComponent({
       handleBlur:   veeHandleBlur,
       validate:     veeValidate,
       value:        veeValue,
+      meta:         veeMeta,
     } = useField<string | number | Record<string, unknown>>(
       veeFieldName,
       veeValidator,
       {
         initialValue:          props.value as string | number,
         validateOnValueUpdate: true,
+        validateOnMount:       true,
       }
     );
 

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -1,5 +1,7 @@
 <script lang="ts">
-import { defineComponent, inject, computed, watch } from 'vue';
+import {
+  defineComponent, inject, computed, watch, ref, type Ref
+} from 'vue';
 import { useField } from 'vee-validate';
 import TextAreaAutoGrow from '@components/Form/TextArea/TextAreaAutoGrow.vue';
 import LabeledTooltip from '@components/LabeledTooltip/LabeledTooltip.vue';
@@ -141,6 +143,7 @@ export default defineComponent({
     const { isCompact } = useCompactInput(props);
 
     const onInput = inject('onInput', provideProps.onInput);
+    const showAllErrors = inject<Ref<boolean>>('vee-show-all-errors', ref(false));
 
     // Stable fallback name so useField is always called unconditionally.
     // When no name prop is given the field won't match any form-schema path.
@@ -189,7 +192,7 @@ export default defineComponent({
     });
 
     const effectiveValidationMessage = computed(() => {
-      if (props.name && veeError.value) {
+      if (props.name && veeError.value && (veeMeta.touched || showAllErrors.value)) {
         return veeError.value;
       }
 

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -12,7 +12,8 @@ import { _VIEW } from '@shell/config/query-params';
 import { useClickOutside } from '@shell/composables/useClickOutside';
 import { useLabeledFormElement, labeledFormElementProps } from '@shell/composables/useLabeledFormElement';
 import { useLabeledSelect } from '@shell/composables/useLabeledSelect';
-import { ref } from 'vue';
+import { computed, ref, watch } from 'vue';
+import { useField } from 'vee-validate';
 
 export default {
   name: 'LabeledSelect',
@@ -115,6 +116,11 @@ export default {
     noOptionsLabelKey: {
       type:    String,
       default: 'labelSelect.noOptions.empty'
+    },
+
+    name: {
+      type:    String,
+      default: null
     }
   },
 
@@ -161,6 +167,38 @@ export default {
       resizeHandlerFn(select);
     };
 
+    const standaloneFieldId = `__field__${ generateRandomAlphaString(12) }`;
+    const veeFieldName = computed(() => props.name || standaloneFieldId);
+
+    const veeValidator = (value) => {
+      if (!props.name) return true;
+      for (const rule of props.rules) {
+        const msg = rule(value);
+
+        if (msg) return msg;
+      }
+
+      return true;
+    };
+
+    const {
+      errorMessage: veeError,
+      handleBlur:   veeHandleBlur,
+      validate:     veeValidate,
+      value:        veeValue,
+      meta:         veeMeta,
+    } = useField(veeFieldName, veeValidator, {
+      initialValue:          props.value,
+      validateOnValueUpdate: true,
+      validateOnMount:       true,
+    });
+
+    watch(() => props.value, (v) => {
+      if (veeValue.value !== v) {
+        veeValue.value = v;
+      }
+    });
+
     return {
       isOpen,
       select,
@@ -186,6 +224,10 @@ export default {
       paginating,
       loadMore,
       setPaginationFilter,
+      veeError,
+      veeHandleBlur,
+      veeValidate,
+      veeMeta,
     };
   },
 
@@ -221,7 +263,13 @@ export default {
     // update placeholder text to inform user they can add their own opts when none are found
     showTagPrompts() {
       return !this.options.length && this.$attrs.taggable && this.isSearchable;
-    }
+    },
+
+    effectiveValidationMessage() {
+      if (this.name && this.veeError && this.veeMeta.touched && !this.focused) return this.veeError;
+
+      return this.validationMessage;
+    },
   },
 
   methods: {
@@ -272,6 +320,8 @@ export default {
       this.$emit('on-blur');
       this.selectedVisibility = 'visible';
       this.onBlurLabeled();
+      this.veeHandleBlur(undefined, false);
+      this.veeValidate();
     },
 
     onOpen() {
@@ -562,9 +612,9 @@ export default {
       :status="status"
     />
     <LabeledTooltip
-      v-if="!!validationMessage"
+      v-if="!!effectiveValidationMessage"
       :hover="hoverTooltip"
-      :value="validationMessage"
+      :value="effectiveValidationMessage"
     />
   </div>
 </template>

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -12,7 +12,7 @@ import { _VIEW } from '@shell/config/query-params';
 import { useClickOutside } from '@shell/composables/useClickOutside';
 import { useLabeledFormElement, labeledFormElementProps } from '@shell/composables/useLabeledFormElement';
 import { useLabeledSelect } from '@shell/composables/useLabeledSelect';
-import { computed, ref, watch } from 'vue';
+import { computed, inject, ref, watch } from 'vue';
 import { useField } from 'vee-validate';
 
 export default {
@@ -199,6 +199,16 @@ export default {
       }
     });
 
+    const effectiveValidationMessage = computed(() => {
+      if (props.name && veeError.value && (veeMeta.touched || showAllErrors.value)) {
+        return veeError.value;
+      }
+
+      return validationMessage.value;
+    });
+
+    const showAllErrors = inject('vee-show-all-errors', ref(false));
+
     return {
       isOpen,
       select,
@@ -210,7 +220,7 @@ export default {
       onFocusLabeled,
       onBlurLabeled,
       isDisabled,
-      validationMessage,
+      validationMessage: effectiveValidationMessage,
       requiredField,
       isSearchable,
       isFilterable,
@@ -228,6 +238,7 @@ export default {
       veeHandleBlur,
       veeValidate,
       veeMeta,
+      showAllErrors,
     };
   },
 
@@ -263,12 +274,6 @@ export default {
     // update placeholder text to inform user they can add their own opts when none are found
     showTagPrompts() {
       return !this.options.length && this.$attrs.taggable && this.isSearchable;
-    },
-
-    effectiveValidationMessage() {
-      if (this.name && this.veeError && this.veeMeta.touched && !this.focused) return this.veeError;
-
-      return this.validationMessage;
     },
   },
 

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -12,8 +12,8 @@ import { _VIEW } from '@shell/config/query-params';
 import { useClickOutside } from '@shell/composables/useClickOutside';
 import { useLabeledFormElement, labeledFormElementProps } from '@shell/composables/useLabeledFormElement';
 import { useLabeledSelect } from '@shell/composables/useLabeledSelect';
-import { computed, inject, ref, watch } from 'vue';
-import { useField } from 'vee-validate';
+import { ref, toRef } from 'vue';
+import { useVeeValidateField } from '@shell/composables/useVeeValidateField';
 
 export default {
   name: 'LabeledSelect',
@@ -167,47 +167,12 @@ export default {
       resizeHandlerFn(select);
     };
 
-    const standaloneFieldId = `__field__${ generateRandomAlphaString(12) }`;
-    const veeFieldName = computed(() => props.name || standaloneFieldId);
-
-    const veeValidator = (value) => {
-      if (!props.name) return true;
-      for (const rule of props.rules) {
-        const msg = rule(value);
-
-        if (msg) return msg;
-      }
-
-      return true;
-    };
-
-    const {
-      errorMessage: veeError,
-      handleBlur:   veeHandleBlur,
-      validate:     veeValidate,
-      value:        veeValue,
-      meta:         veeMeta,
-    } = useField(veeFieldName, veeValidator, {
-      initialValue:          props.value,
-      validateOnValueUpdate: true,
-      validateOnMount:       true,
+    const { effectiveValidationMessage, veeHandleBlur, veeValidate } = useVeeValidateField({
+      name:  toRef(props, 'name'),
+      rules: toRef(props, 'rules'),
+      value: toRef(props, 'value'),
+      validationMessage,
     });
-
-    watch(() => props.value, (v) => {
-      if (veeValue.value !== v) {
-        veeValue.value = v;
-      }
-    });
-
-    const effectiveValidationMessage = computed(() => {
-      if (props.name && veeError.value && (veeMeta.touched || showAllErrors.value)) {
-        return veeError.value;
-      }
-
-      return validationMessage.value;
-    });
-
-    const showAllErrors = inject('vee-show-all-errors', ref(false));
 
     return {
       isOpen,
@@ -234,11 +199,8 @@ export default {
       paginating,
       loadMore,
       setPaginationFilter,
-      veeError,
       veeHandleBlur,
       veeValidate,
-      veeMeta,
-      showAllErrors,
     };
   },
 
@@ -617,9 +579,9 @@ export default {
       :status="status"
     />
     <LabeledTooltip
-      v-if="!!effectiveValidationMessage"
+      v-if="!!validationMessage"
       :hover="hoverTooltip"
-      :value="effectiveValidationMessage"
+      :value="validationMessage"
     />
   </div>
 </template>

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -164,6 +164,14 @@ export default {
       }),
       type: Object,
     },
+    nameFieldName: {
+      type:    String,
+      default: null,
+    },
+    namespaceFieldName: {
+      type:    String,
+      default: null,
+    },
 
     /**
      * Inherited global identifier prefix for tests
@@ -438,6 +446,7 @@ export default {
       <LabeledInput
         ref="namespaceInput"
         v-model:value="namespace"
+        :name="namespaceFieldName"
         :label="t('namespace.label')"
         :placeholder="t('namespace.createNamespace')"
         :disabled="namespaceReallyDisabled"
@@ -464,6 +473,7 @@ export default {
       <LabeledSelect
         v-show="!createNamespace"
         v-model:value="namespace"
+        :name="namespaceFieldName"
         :clearable="true"
         :options="options"
         :disabled="namespaceReallyDisabled"
@@ -487,6 +497,7 @@ export default {
         ref="nameInput"
         key="name"
         v-model:value="name"
+        :name="nameFieldName"
         data-testid="NameNsDescriptionNameInput"
         :label="t(nameLabel)"
         :placeholder="t(namePlaceholder)"

--- a/shell/composables/useFormValidation.ts
+++ b/shell/composables/useFormValidation.ts
@@ -1,0 +1,81 @@
+import { computed, provide, ref } from 'vue';
+import { useForm } from 'vee-validate';
+import formRulesGenerator from '@shell/utils/validators/formRules/index';
+import type { Validator } from '@shell/utils/validators/formRules/index';
+import type { Translation } from '@shell/types/t';
+
+export interface RuleSet {
+  path: string;
+  rules: string[];
+  translationKey?: string;
+}
+
+const nullValidator: Validator = () => undefined;
+
+function createRuleResolver(
+  t: Translation,
+  ruleSets: RuleSet[],
+  extraRules: Record<string, Validator>
+) {
+  return (path: string): Validator[] => {
+    const set = ruleSets.find((s) => s.path === path);
+
+    if (!set) return [];
+
+    const key = set.translationKey ? t(set.translationKey) : 'Value';
+    const allRules = {
+      ...formRulesGenerator(t, { key }),
+      ...extraRules,
+    };
+
+    return set.rules.map((r) => (allRules[r] as Validator) || nullValidator);
+  };
+}
+
+/**
+ * For root/parent form components. Creates a vee-validate form context and
+ * resolves fvFormRuleSets-style rule string arrays into validator functions.
+ * Child components rendered within this form should use useFormRules instead.
+ */
+export function useFormValidation(
+  t: Translation,
+  ruleSets: RuleSet[],
+  extraRules: Record<string, Validator> = {}
+) {
+  const { errors, validate } = useForm();
+  const showAllErrors = ref(false);
+
+  provide('vee-show-all-errors', showAllErrors);
+
+  const getRules = createRuleResolver(t, ruleSets, extraRules);
+  const isFormValid = computed(() => Object.keys(errors.value).length === 0);
+
+  const validateForm: typeof validate = async(...args) => {
+    const result = await validate(...args);
+
+    showAllErrors.value = true;
+
+    return result;
+  };
+
+  return {
+    getRules,
+    isFormValid,
+    validateForm,
+    veeErrors: errors,
+    showAllErrors,
+  };
+}
+
+/**
+ * For child components that render inside a parent useFormValidation() form.
+ * Resolves rule strings into validator functions without creating a new form
+ * context — fields register with the nearest ancestor's useFormValidation() context.
+ */
+export function useFormRules(
+  t: Translation,
+  ruleSets: RuleSet[],
+  extraRules: Record<string, Validator> = {}
+) {
+  return { getRules: createRuleResolver(t, ruleSets, extraRules) };
+}

--- a/shell/composables/useFormValidation.ts
+++ b/shell/composables/useFormValidation.ts
@@ -28,7 +28,19 @@ function createRuleResolver(
       ...extraRules,
     };
 
-    return set.rules.map((r) => (allRules[r] as Validator) || nullValidator);
+    return set.rules.map((r) => {
+      const rule = allRules[r] as Validator | undefined;
+
+      if (rule) {
+        return rule;
+      }
+
+      if (process.env.NODE_ENV !== 'production') {
+        throw new Error(`[useFormValidation] Unknown validation rule: "${ r }". Check for a typo in your ruleSets.`);
+      }
+
+      return nullValidator;
+    });
   };
 }
 

--- a/shell/composables/useVeeValidateField.test.ts
+++ b/shell/composables/useVeeValidateField.test.ts
@@ -1,0 +1,159 @@
+import {
+  computed, defineComponent, nextTick, provide, ref
+} from 'vue';
+import { mount, flushPromises } from '@vue/test-utils';
+import { useVeeValidateField } from './useVeeValidateField';
+
+function createHarness(opts: {
+  name?: string | null;
+  rules?: Array<(v: unknown) => string | undefined>;
+  value?: unknown;
+  validationMessage?: string;
+  showAllErrors?: boolean;
+}) {
+  return defineComponent({
+    setup() {
+      const nameRef = ref(opts.name ?? null);
+      const rulesRef = ref(opts.rules ?? []);
+      const valueRef = ref(opts.value ?? '');
+      const validationMessageRef = computed(() => opts.validationMessage);
+
+      if (opts.showAllErrors) {
+        provide('vee-show-all-errors', ref(true));
+      }
+
+      const result = useVeeValidateField({
+        name:              nameRef,
+        rules:             rulesRef,
+        value:             valueRef,
+        validationMessage: validationMessageRef,
+      });
+
+      return {
+        ...result,
+        nameRef,
+        valueRef,
+      };
+    },
+    template: '<div />',
+  });
+}
+
+describe('useVeeValidateField', () => {
+  describe('without a name prop', () => {
+    it('falls back to the passed validationMessage', async() => {
+      const errorMessage = 'This field is required';
+      const wrapper = mount(createHarness({
+        name:              null,
+        validationMessage: errorMessage,
+      }));
+
+      await flushPromises();
+
+      expect(wrapper.vm.effectiveValidationMessage).toBe(errorMessage);
+    });
+
+    it('does not run rules through vee-validate', async() => {
+      const rule = jest.fn(() => 'error');
+      const wrapper = mount(createHarness({
+        name:  null,
+        rules: [rule],
+        value: '',
+      }));
+
+      await flushPromises();
+
+      expect(wrapper.vm.effectiveValidationMessage).toBeUndefined();
+    });
+  });
+
+  describe('with a name prop', () => {
+    it('does not show error before the field is touched', async() => {
+      const errorMessage = 'Cannot be empty';
+      const wrapper = mount(createHarness({
+        name:  'testField',
+        rules: [(v) => (!v ? errorMessage : undefined)],
+        value: '',
+      }));
+
+      await flushPromises();
+
+      expect(wrapper.vm.effectiveValidationMessage).toBeUndefined();
+    });
+
+    it('shows vee-validate error after veeHandleBlur + veeValidate', async() => {
+      const errorMessage = 'Cannot be empty';
+      const wrapper = mount(createHarness({
+        name:  'testField',
+        rules: [(v) => (!v ? errorMessage : undefined)],
+        value: '',
+      }));
+
+      wrapper.vm.veeHandleBlur(undefined, false);
+      await wrapper.vm.veeValidate();
+      await flushPromises();
+
+      expect(wrapper.vm.effectiveValidationMessage).toBe(errorMessage);
+    });
+
+    it('shows error without touch when showAllErrors is injected as true', async() => {
+      const errorMessage = 'Cannot be empty';
+      const showAllErrors = ref(false);
+
+      const inner = defineComponent({
+        setup() {
+          const nameRef = ref('testField');
+          const rulesRef = ref([(v: unknown) => (!v ? errorMessage : undefined)]);
+          const valueRef = ref('');
+          const validationMessageRef = computed(() => undefined as string | undefined);
+
+          return useVeeValidateField({
+            name:              nameRef,
+            rules:             rulesRef,
+            value:             valueRef,
+            validationMessage: validationMessageRef,
+          });
+        },
+        template: '<div />',
+      });
+
+      const outer = defineComponent({
+        components: { inner },
+        setup() {
+          provide('vee-show-all-errors', showAllErrors);
+        },
+        template: '<inner ref="innerRef" />',
+      });
+
+      const wrapper = mount(outer);
+      const innerVm = wrapper.getComponent(inner);
+
+      await flushPromises();
+      expect(innerVm.vm.effectiveValidationMessage).toBeUndefined();
+
+      showAllErrors.value = true;
+      await nextTick();
+
+      expect(innerVm.vm.effectiveValidationMessage).toBe(errorMessage);
+    });
+
+    it('clears vee-validate error when value becomes valid', async() => {
+      const errorMessage = 'Cannot be empty';
+      const wrapper = mount(createHarness({
+        name:  'testField',
+        rules: [(v) => (!v ? errorMessage : undefined)],
+        value: '',
+      }));
+
+      wrapper.vm.veeHandleBlur(undefined, false);
+      await wrapper.vm.veeValidate();
+      await flushPromises();
+      expect(wrapper.vm.effectiveValidationMessage).toBe(errorMessage);
+
+      wrapper.vm.valueRef = 'some value';
+      await flushPromises();
+
+      expect(wrapper.vm.effectiveValidationMessage).toBeUndefined();
+    });
+  });
+});

--- a/shell/composables/useVeeValidateField.ts
+++ b/shell/composables/useVeeValidateField.ts
@@ -1,0 +1,67 @@
+import { computed, inject, ref, watch } from 'vue';
+import type { Ref } from 'vue';
+import { useField } from 'vee-validate';
+import { generateRandomAlphaString } from '@shell/utils/string';
+
+interface UseVeeValidateFieldOptions {
+  name: Ref<string | null | undefined>;
+  rules: Ref<Array<any>>;
+  value: Ref<unknown>;
+  validationMessage: Ref<unknown>;
+}
+
+export function useVeeValidateField({
+  name,
+  rules,
+  value,
+  validationMessage,
+}: UseVeeValidateFieldOptions) {
+  const showAllErrors = inject<Ref<boolean>>('vee-show-all-errors', ref(false));
+  const standaloneFieldId = `__field__${ generateRandomAlphaString(12) }`;
+  const veeFieldName = computed(() => name.value || standaloneFieldId);
+
+  const veeValidator = (v: unknown): boolean | string => {
+    if (!name.value) return true;
+    for (const rule of rules.value as Array<(v: unknown) => string | undefined>) {
+      const msg = rule(v);
+
+      if (msg) return msg;
+    }
+
+    return true;
+  };
+
+  const {
+    errorMessage: veeError,
+    handleBlur:   veeHandleBlur,
+    validate:     veeValidate,
+    value:        veeValue,
+    meta:         veeMeta,
+  } = useField<unknown>(veeFieldName, veeValidator, {
+    initialValue:          value.value,
+    validateOnValueUpdate: true,
+    validateOnMount:       true,
+  });
+
+  // Keep vee-validate's internal value in sync with the controlled prop value.
+  watch(value, (v) => {
+    if (veeValue.value !== v) {
+      veeValue.value = v;
+    }
+  });
+
+  const effectiveValidationMessage = computed(() => {
+    if (name.value && veeError.value && (veeMeta.touched || showAllErrors.value)) {
+      return veeError.value;
+    }
+
+    return validationMessage.value;
+  });
+
+  return {
+    effectiveValidationMessage,
+    veeHandleBlur,
+    veeValidate,
+    showAllErrors,
+  };
+}

--- a/shell/edit/secret/__tests__/ssh.test.ts
+++ b/shell/edit/secret/__tests__/ssh.test.ts
@@ -1,18 +1,17 @@
 import { mount } from '@vue/test-utils';
+import { createStore } from 'vuex';
 import { _VIEW, _EDIT, _CREATE } from '@shell/config/query-params';
 import Ssh from '@shell/edit/secret/ssh.vue';
-
-const mockedStore = () => {
-  return { getters: { 'i18n/t': jest.fn() } };
-};
 
 const mockedRoute = { query: {} };
 
 const requiredSetup = () => {
+  const store = createStore({ getters: { 'i18n/t': () => jest.fn() } });
+
   return {
     global: {
-      mocks: {
-        $store:      mockedStore(),
+      plugins: [store],
+      mocks:   {
         $route:      mockedRoute,
         $fetchState: {},
       }

--- a/shell/edit/secret/basic.vue
+++ b/shell/edit/secret/basic.vue
@@ -1,5 +1,8 @@
 <script>
+import { useStore } from 'vuex';
 import { LabeledInput } from '@components/Form/LabeledInput';
+import { useFormRules } from '@shell/composables/useFormValidation';
+import { useI18n } from '@shell/composables/useI18n';
 
 export default {
   components: { LabeledInput },
@@ -14,6 +17,28 @@ export default {
       type:     String,
       required: true,
     }
+  },
+
+  setup() {
+    const store = useStore();
+    const { t } = useI18n(store);
+    const { getRules } = useFormRules(
+      t,
+      [
+        {
+          path:           'username',
+          rules:          ['required'],
+          translationKey: 'secret.basic.username',
+        },
+        {
+          path:           'password',
+          rules:          ['required'],
+          translationKey: 'secret.basic.password',
+        },
+      ]
+    );
+
+    return { getRules };
   },
 
   data() {
@@ -46,18 +71,23 @@ export default {
       <div class="col span-6">
         <LabeledInput
           v-model:value="username"
+          name="username"
           required
           :label="t('secret.basic.username')"
           :mode="mode"
+          :rules="getRules('username')"
           data-testid="secret-basic-username"
         />
       </div>
       <div class="col span-6">
         <LabeledInput
           v-model:value="password"
+          name="password"
+          required
           :label="t('secret.basic.password')"
           :mode="mode"
           type="password"
+          :rules="getRules('password')"
         />
       </div>
     </div>

--- a/shell/edit/secret/basic.vue
+++ b/shell/edit/secret/basic.vue
@@ -88,6 +88,7 @@ export default {
           :mode="mode"
           type="password"
           :rules="getRules('password')"
+          data-testid="secret-basic-password"
         />
       </div>
     </div>

--- a/shell/edit/secret/index.vue
+++ b/shell/edit/secret/index.vue
@@ -7,7 +7,9 @@ import {
 } from '@shell/config/query-params';
 import { MANAGEMENT, NAMESPACE, DEFAULT_WORKSPACE, VIRTUAL_TYPES } from '@shell/config/types';
 import { CAPI, UI_PROJECT_SECRET } from '@shell/config/labels-annotations';
-import FormValidation from '@shell/mixins/form-validation';
+import { useStore } from 'vuex';
+import { useFormValidation } from '@shell/composables/useFormValidation';
+import { useI18n } from '@shell/composables/useI18n';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
 import { LabeledInput } from '@components/Form/LabeledInput';
@@ -48,7 +50,36 @@ export default {
     SelectIconGrid
   },
 
-  mixins: [CreateEditView, FormValidation],
+  mixins: [CreateEditView],
+
+  setup() {
+    const store = useStore();
+    const { t } = useI18n(store);
+    const {
+      getRules, isFormValid, validateForm, veeErrors
+    } = useFormValidation(
+      t,
+      [
+        {
+          path:           'metadata.name',
+          rules:          ['required'],
+          translationKey: 'nameNsDescription.name.label',
+        },
+        {
+          path:           'metadata.namespace',
+          rules:          ['required'],
+          translationKey: 'nameNsDescription.namespace.label',
+        },
+      ]
+    );
+
+    return {
+      getRules,
+      isFormValid,
+      veeValidateForm: validateForm,
+      veeErrors,
+    };
+  },
 
   async fetch() {
     if ( this.isCloud ) {
@@ -119,16 +150,6 @@ export default {
       secretType:        this.value._type,
       initialSecretType: this.value._type,
       projectName:       null,
-      fvFormRuleSets:    [
-        {
-          path:  'metadata.name',
-          rules: ['required'],
-        },
-        {
-          path:  'metadata.namespace',
-          rules: ['required'],
-        },
-      ],
     };
   },
 
@@ -288,6 +309,14 @@ export default {
 
   methods: {
     async saveSecret(btnCb) {
+      const { valid } = await this.veeValidateForm();
+
+      if (!valid) {
+        btnCb(false);
+
+        return;
+      }
+
       if ( this.errors ) {
         clear(this.errors);
       }
@@ -399,7 +428,7 @@ export default {
     <CruResource
       v-else
       :mode="mode"
-      :validation-passed="fvFormIsValid"
+      :validation-passed="isFormValid"
       :selected-subtype="value._type"
       :resource="value"
       :errors="errors"
@@ -416,6 +445,9 @@ export default {
         :value="value"
         :mode="mode"
         :namespaced="!isCloud"
+        :name-field-name="'metadata.name'"
+        :namespace-field-name="'metadata.namespace'"
+        :rules="{ name: getRules('metadata.name'), namespace: getRules('metadata.namespace'), description: [] }"
         @update:value="$emit('input', $event)"
       />
       <NameNsDescription
@@ -423,10 +455,8 @@ export default {
         :value="value"
         :namespaced="false"
         :mode="mode"
-        :rules="{
-          name: fvGetAndReportPathRules('metadata.name'),
-          namespace: fvGetAndReportPathRules('metadata.namespace'),
-        }"
+        :name-field-name="'metadata.name'"
+        :rules="{ name: getRules('metadata.name'), namespace: [], description: [] }"
       >
         <template #project-selector>
           <LabeledSelect

--- a/shell/edit/secret/index.vue
+++ b/shell/edit/secret/index.vue
@@ -70,6 +70,16 @@ export default {
           rules:          ['required'],
           translationKey: 'nameNsDescription.namespace.label',
         },
+        {
+          path:           'secretType',
+          rules:          ['required'],
+          translationKey: 'secret.type',
+        },
+        {
+          path:           'secret._type',
+          rules:          ['required'],
+          translationKey: 'secret.customType',
+        },
       ]
     );
 
@@ -283,7 +293,7 @@ export default {
     },
 
     dataTabHasError() {
-      const topLevelFields = new Set(['metadata.name', 'metadata.namespace']);
+      const topLevelFields = new Set(['metadata.name', 'metadata.namespace', 'secretType', 'secret._type']);
 
       return Object.keys(this.veeErrors).some((key) => !topLevelFields.has(key));
     },
@@ -484,11 +494,13 @@ export default {
         <div class="col span-3">
           <LabeledSelect
             v-model:value="secretType"
+            name="secretType"
             :options="secretTypes"
             :searchable="false"
             :mode="mode"
             :multiple="false"
             :reduce="(e) => e.value"
+            :rules="getRules('secretType')"
             label-key="secret.type"
             required
             @update:value="selectCustomType"
@@ -501,8 +513,10 @@ export default {
             ref="customType"
             v-model:value="value._type"
             v-focus
+            name="secret._type"
             label-key="secret.customType"
             :mode="mode"
+            :rules="getRules('secret._type')"
             required
           />
         </div>

--- a/shell/edit/secret/index.vue
+++ b/shell/edit/secret/index.vue
@@ -282,6 +282,12 @@ export default {
       return this.$store.getters['prefs/get'](HIDE_SENSITIVE);
     },
 
+    dataTabHasError() {
+      const topLevelFields = new Set(['metadata.name', 'metadata.namespace']);
+
+      return Object.keys(this.veeErrors).some((key) => !topLevelFields.has(key));
+    },
+
     dataLabel() {
       switch (this.value._type) {
       case TYPES.TLS:
@@ -522,6 +528,7 @@ export default {
           name="data"
           :label="dataLabel"
           :weight="99"
+          :error="dataTabHasError"
         >
           <component
             :is="dataComponent"

--- a/shell/edit/secret/registry.vue
+++ b/shell/edit/secret/registry.vue
@@ -1,6 +1,9 @@
 <script>
+import { useStore } from 'vuex';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import { RadioGroup } from '@components/Form/Radio';
+import { useFormRules } from '@shell/composables/useFormValidation';
+import { useI18n } from '@shell/composables/useI18n';
 
 export default {
   components: { LabeledInput, RadioGroup },
@@ -15,6 +18,33 @@ export default {
       type:     String,
       required: true,
     }
+  },
+
+  setup() {
+    const store = useStore();
+    const { t } = useI18n(store);
+    const { getRules } = useFormRules(
+      t,
+      [
+        {
+          path:           'registryUrl',
+          rules:          ['required'],
+          translationKey: 'secret.registry.domainName',
+        },
+        {
+          path:           'username',
+          rules:          ['required'],
+          translationKey: 'secret.registry.username',
+        },
+        {
+          path:           'password',
+          rules:          ['required'],
+          translationKey: 'secret.registry.password',
+        },
+      ]
+    );
+
+    return { getRules };
   },
 
   data() {
@@ -118,26 +148,34 @@ export default {
     >
       <LabeledInput
         v-model:value="registryUrl"
+        name="registryUrl"
         required
         :label="t('secret.registry.domainName')"
         placeholder="e.g. index.docker.io"
         :mode="mode"
+        :rules="getRules('registryUrl')"
       />
     </div>
     <div class="row mb-20">
       <div class="col span-6">
         <LabeledInput
           v-model:value="username"
+          name="username"
+          required
           :label="t('secret.registry.username')"
           :mode="mode"
+          :rules="getRules('username')"
         />
       </div>
       <div class="col span-6">
         <LabeledInput
           v-model:value="password"
+          name="password"
+          required
           :label="t('secret.registry.password')"
           :mode="mode"
           type="password"
+          :rules="getRules('password')"
         />
       </div>
     </div>

--- a/shell/edit/secret/ssh.vue
+++ b/shell/edit/secret/ssh.vue
@@ -1,6 +1,9 @@
 <script>
+import { useStore } from 'vuex';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import FileSelector, { createOnSelected } from '@shell/components/form/FileSelector';
+import { useFormRules } from '@shell/composables/useFormValidation';
+import { useI18n } from '@shell/composables/useI18n';
 
 export default {
   components: { LabeledInput, FileSelector },
@@ -15,6 +18,28 @@ export default {
       type:     String,
       required: true,
     }
+  },
+
+  setup() {
+    const store = useStore();
+    const { t } = useI18n(store);
+    const { getRules } = useFormRules(
+      t,
+      [
+        {
+          path:           'ssh-publickey',
+          rules:          ['required'],
+          translationKey: 'secret.ssh.public',
+        },
+        {
+          path:           'ssh-privatekey',
+          rules:          ['required'],
+          translationKey: 'secret.ssh.private',
+        },
+      ]
+    );
+
+    return { getRules };
   },
 
   data() {
@@ -60,10 +85,12 @@ export default {
         <LabeledInput
           v-model:value="username"
           type="multiline"
+          name="ssh-publickey"
           data-testid="ssh-public-key"
           :label="t('secret.ssh.public')"
           :mode="mode"
           required
+          :rules="getRules('ssh-publickey')"
           :placeholder="t('secret.ssh.publicPlaceholder')"
         />
         <FileSelector
@@ -76,10 +103,12 @@ export default {
         <LabeledInput
           v-model:value="password"
           type="multiline"
+          name="ssh-privatekey"
           data-testid="ssh-private-key"
           :label="t('secret.ssh.private')"
           :mode="mode"
           required
+          :rules="getRules('ssh-privatekey')"
           :placeholder="t('secret.ssh.privatePlaceholder')"
         />
         <FileSelector

--- a/shell/edit/secret/tls.vue
+++ b/shell/edit/secret/tls.vue
@@ -1,7 +1,10 @@
 <script>
 import { _EDIT } from '@shell/config/query-params';
+import { useStore } from 'vuex';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import FileSelector, { createOnSelected } from '@shell/components/form/FileSelector';
+import { useFormRules } from '@shell/composables/useFormValidation';
+import { useI18n } from '@shell/composables/useI18n';
 
 export default {
   components: { LabeledInput, FileSelector },
@@ -16,6 +19,28 @@ export default {
       type:     String,
       required: true,
     }
+  },
+
+  setup() {
+    const store = useStore();
+    const { t } = useI18n(store);
+    const { getRules } = useFormRules(
+      t,
+      [
+        {
+          path:           'tls.key',
+          rules:          ['required'],
+          translationKey: 'secret.certificate.privateKey',
+        },
+        {
+          path:           'tls.crt',
+          rules:          ['required'],
+          translationKey: 'secret.certificate.certificate',
+        },
+      ]
+    );
+
+    return { getRules };
   },
 
   data() {
@@ -63,9 +88,12 @@ export default {
       <div class="col span-6">
         <LabeledInput
           v-model:value="key"
+          name="tls.key"
+          required
           type="multiline"
           :label="t('secret.certificate.privateKey')"
           :mode="mode"
+          :rules="getRules('tls.key')"
           :placeholder="t('secret.certificate.privateKeyPlaceholder')"
         />
         <FileSelector
@@ -77,10 +105,12 @@ export default {
       <div class="col span-6">
         <LabeledInput
           v-model:value="crt"
+          name="tls.crt"
           required
           type="multiline"
           :label="t('secret.certificate.certificate')"
           :mode="mode"
+          :rules="getRules('tls.crt')"
           :placeholder="t('secret.certificate.certificatePlaceholder')"
         />
         <FileSelector


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This creates a `useFormValidation()` composable that acts as a bridge between existing validation rules defined in the form validation mixin and vee-validate. This also updates the secret forms to demonstrate replacing existing form validation logic with the `useFormValidation()` composable.

Fixes #17354
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Update LabeledSelect and NameNsDescription for vee-validate
- Create form validation parser
- Migrate Secret form to vee-validate
- Add new validation rules for SSH secrets
- Add validation for custom secrets
- Add validation for remaining secret forms
- Create `useVeeValidateField()` composable
- Fix failing test by updating auth requirements

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This change intends to introduce a "bridge" that will help us to transition away from the form validation mixin over to vee-validate with a minimal amount of refactoring. By introducing a parser that translates form validation rules into a format usable by vee-validate, most of our future effort will involve identifying existing components with validators already defined and introducing a setup option that invokes `useFormValidation()` with the same rules applied. Most of this work could be automated if this approach works reliably enough. 

This PR also demonstrates how we could use the composable to easily expand validation rules to existing components via `useFromRules()`. `useFromRules()` relies on some root vee-validate form implementation, typically applied by `useFormValidation()` in these examples.  

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Cluster Explorer => Storage => Secrets. Ensure that all secrets properly pass/fail validation and can be created/updated when validation passes.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Users & Authentication => User retention settings. Validation should behave as it did before with the minor changes to the vee-validate implementation. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Validation fails when missing required inputs

<img width="1375" height="789" alt="image" src="https://github.com/user-attachments/assets/9b63c939-f43c-4300-9d40-6bffb7793964" />

#### Validation passes

<img width="1375" height="789" alt="image" src="https://github.com/user-attachments/assets/9e7b58f8-6bdd-44c4-943f-69fe960398fa" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
