### PR TITLE
Automation: Add Last Login sort test for Users page

### DIFF
--- a/cypress/e2e/tests/pages/users-and-auth/last-login-sort.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/last-login-sort.spec.ts
@@ -1,0 +1,98 @@
+import UsersPo from '@/cypress/e2e/po/pages/users-and-auth/users.po';
+import { USERS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
+
+const LAST_LOGIN_COLUMN = 6;
+const NAME_COLUMN = 3;
+
+describe('Users: Last Login sorting', { testIsolation: 'off', tags: ['@usersAndAuths', '@adminUser'] }, () => {
+  const runTimestamp = +new Date();
+  const usersPo = new UsersPo();
+  const userIdsList: string[] = [];
+  let userNullName: string;
+  let userActiveName: string;
+
+  before(() => {
+    cy.login();
+
+    cy.createUser({
+      username:   `llsort-null-${ runTimestamp }`,
+      globalRole: { role: 'user' },
+    }).then((resp: Cypress.Response<any>) => {
+      userNullName = resp.body.username;
+      userIdsList.push(resp.body.id);
+    });
+
+    cy.createUser({
+      username:   `llsort-active-${ runTimestamp }`,
+      globalRole: { role: 'user' },
+    }).then((resp: Cypress.Response<any>) => {
+      userActiveName = resp.body.username;
+      userIdsList.push(resp.body.id);
+    });
+  });
+
+  beforeEach(() => {
+    cy.intercept('GET', `${ USERS_BASE_URL }?*`).as('getUsers');
+  });
+
+  it('populate Last Login for the active test user', () => {
+    // Log in once as the active user so its `cattle.io/last-login` label is populated.
+    cy.clearAllSessions();
+    cy.login(userActiveName, Cypress.env('password'), false);
+  });
+
+  it('should place users with a null Last Login at the bottom in descending order and at the top in ascending order', () => {
+    cy.clearAllSessions();
+    cy.login();
+
+    usersPo.goTo();
+    usersPo.waitForPage();
+    cy.wait('@getUsers');
+
+    usersPo.list().resourceTable().sortableTable().checkVisible();
+    usersPo.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+
+    // Narrow the table to the two test users created in this run so ordering is deterministic
+    // even if previous failed runs left orphan users behind.
+    usersPo.list().resourceTable().sortableTable().filter(`-${ runTimestamp }`);
+    usersPo.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+    usersPo.list().resourceTable().sortableTable().checkRowCount(false, 2);
+
+    // First click selects the column for sorting in ASC order (icon points down).
+    // Null Last Login should bubble to the top, populated value to the bottom.
+    usersPo.list().resourceTable().sortableTable().sort(LAST_LOGIN_COLUMN)
+      .click();
+    usersPo.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+    usersPo.list().resourceTable().sortableTable().tableHeaderRow()
+      .checkSortOrder(LAST_LOGIN_COLUMN, 'down');
+
+    usersPo.list().resourceTable().sortableTable().row(0)
+      .column(NAME_COLUMN)
+      .should('contain', userNullName);
+    usersPo.list().resourceTable().sortableTable().row(1)
+      .column(NAME_COLUMN)
+      .should('contain', userActiveName);
+
+    // Second click flips to DESC order (icon points up).
+    // Populated Last Login should be on top, null user at the bottom.
+    usersPo.list().resourceTable().sortableTable().sort(LAST_LOGIN_COLUMN)
+      .click();
+    usersPo.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+    usersPo.list().resourceTable().sortableTable().tableHeaderRow()
+      .checkSortOrder(LAST_LOGIN_COLUMN, 'up');
+
+    usersPo.list().resourceTable().sortableTable().row(0)
+      .column(NAME_COLUMN)
+      .should('contain', userActiveName);
+    usersPo.list().resourceTable().sortableTable().row(1)
+      .column(NAME_COLUMN)
+      .should('contain', userNullName);
+  });
+
+  after(() => {
+    cy.deleteManyResources({
+      toDelete: userIdsList,
+      deleteFn: (r) => cy.deleteRancherResource('v1', 'management.cattle.io.users', r, false)
+    });
+  });
+});


### PR DESCRIPTION
### Summary
Fixes rancher/qa-tasks#1592

Adds an end-to-end test that covers ascending and descending sort by the Last Login column on the Users & Authentication page. 

### Technical notes summary
The test creates two users via the API, logs in once as one of them so its `cattle.io/last-login` label is populated, and then verifies that null values bubble to the top in ascending order and to the bottom in descending order.


### Areas or cases that should be tested
CI

### Areas which could experience regressions
CI

### Screenshot/Video
Playbook run:
<img width="1050" height="527" alt="Screenshot_2026-04-30_19-48-39" src="https://github.com/user-attachments/assets/420f8f00-3c52-4f2c-b316-20fac6e21bc2" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
