### PR TITLE
Hide namespace picker on project secrets list page

### DIFF
--- a/cypress/e2e/tests/pages/explorer2/storage/project-secrets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/project-secrets.spec.ts
@@ -28,9 +28,6 @@ describe('Project Secrets', { testIsolation: 'off', tags: ['@explorer2', '@admin
   });
 
   it('creates a project-scoped secret and displays it in the list', () => {
-    namespaceFilter.toggle();
-    namespaceFilter.clickOptionByLabel('All Namespaces');
-    namespaceFilter.closeDropdown();
     const secretCreatePage = new ProjectSecretsCreateEditPo('local');
 
     projectSecretsListPage.goTo();

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -183,6 +183,13 @@ export default {
     },
 
     showFilter() {
+      // Hide the namespace picker on the project scope secrets list page
+      const isProjectSecretList = this.$route.params?.resource === 'projectsecret' && !this.$route.params?.id && !this.$route.name?.endsWith('-create');
+
+      if (isProjectSecretList) {
+        return false;
+      }
+
       // Some products won't have a current cluster
       const validClusterOrProduct = this.currentCluster ||
                  (this.currentProduct && this.currentProduct.customNamespaceFilter) ||

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -1,7 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import debounce from 'lodash/debounce';
-import { MANAGEMENT, NORMAN, STEVE } from '@shell/config/types';
+import { MANAGEMENT, NORMAN, STEVE, VIRTUAL_TYPES } from '@shell/config/types';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import { ucFirst } from '@shell/utils/string';
 import { isAlternate, isMac } from '@shell/utils/platform';
@@ -183,8 +183,8 @@ export default {
     },
 
     showFilter() {
-      // Hide the namespace picker on the project scope secrets list page
-      const isProjectSecretList = this.$route.params?.resource === 'projectsecret' && !this.$route.params?.id && !this.$route.name?.endsWith('-create');
+      // Hide the namespace picker on the project-scoped secrets list page
+      const isProjectSecretList = this.$route.params?.resource === VIRTUAL_TYPES.PROJECT_SECRETS && !this.$route.params?.id && !this.$route.name?.endsWith('-create');
 
       if (isProjectSecretList) {
         return false;

--- a/shell/components/nav/__tests__/Header.test.ts
+++ b/shell/components/nav/__tests__/Header.test.ts
@@ -217,6 +217,19 @@ describe('component: Header', () => {
       expect((wrapper.vm as any).showFilter).toBe(false);
     });
 
+    it('should return false when on the project scope secrets list page', () => {
+      const wrapper = createWrapper(
+        {
+          name:   'c-cluster-explorer-projectsecret',
+          path:   '/c/local/explorer/projectsecret',
+          params: { resource: 'projectsecret' },
+        },
+        { currentCluster: { id: 'local' }, currentProduct: { showNamespaceFilter: true } },
+      );
+
+      expect((wrapper.vm as any).showFilter).toBe(false);
+    });
+
     it('should return true when showNamespaceFilter is enabled regardless of route', () => {
       const wrapper = createWrapper(
         {

--- a/shell/components/nav/__tests__/Header.test.ts
+++ b/shell/components/nav/__tests__/Header.test.ts
@@ -217,10 +217,10 @@ describe('component: Header', () => {
       expect((wrapper.vm as any).showFilter).toBe(false);
     });
 
-    it('should return false when on the project scope secrets list page', () => {
+    it('should return false when on the project-scoped secrets list page', () => {
       const wrapper = createWrapper(
         {
-          name:   'c-cluster-explorer-projectsecret',
+          name:   'c-cluster-product-resource',
           path:   '/c/local/explorer/projectsecret',
           params: { resource: 'projectsecret' },
         },
@@ -228,6 +228,32 @@ describe('component: Header', () => {
       );
 
       expect((wrapper.vm as any).showFilter).toBe(false);
+    });
+
+    it('should return true when on the project-scoped secrets detail page (has params.id)', () => {
+      const wrapper = createWrapper(
+        {
+          name:   'c-cluster-product-resource-id',
+          path:   '/c/local/explorer/projectsecret/my-secret',
+          params: { resource: 'projectsecret', id: 'my-secret' },
+        },
+        { currentCluster: { id: 'local' }, currentProduct: { showNamespaceFilter: true } },
+      );
+
+      expect((wrapper.vm as any).showFilter).toBe(true);
+    });
+
+    it('should return true when on the project-scoped secrets create page', () => {
+      const wrapper = createWrapper(
+        {
+          name:   'c-cluster-product-resource-create',
+          path:   '/c/local/explorer/projectsecret/create',
+          params: { resource: 'projectsecret' },
+        },
+        { currentCluster: { id: 'local' }, currentProduct: { showNamespaceFilter: true } },
+      );
+
+      expect((wrapper.vm as any).showFilter).toBe(true);
     });
 
     it('should return true when showNamespaceFilter is enabled regardless of route', () => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14893 

### Occurred changes and/or fixed issues
- Hid the namespace filter in the top navigation bar when viewing the Project Scoped Secrets list page.

### Technical notes summary
- Updated the `showFilter` computed property in `shell/components/nav/Header.vue` to evaluate to `false` when the route is the list view for the `projectsecret` resource. 
- The condition specifically checks that `this.$route.params.resource === 'projectsecret'` and that the user is not on a detail or create page (`!this.$route.params?.id` and `!this.$route.name?.endsWith('-create')`).
- Added unit tests in `shell/components/nav/__tests__/Header.test.ts` to verify the namespace picker is hidden for the `projectsecret` list route but behaves normally for others.

### Areas or cases that should be tested
- Navigate to the **Project Scoped Secrets** list page and verify that the namespace picker in the top header is hidden.
- Navigate to creating a new Project Scoped Secret or editing an existing one, and ensure no unexpected behavior occurs with the header.
- Navigate to other standard resource list pages (like ConfigMaps or Deployments) and verify that the namespace/workspace picker remains visible and functional.

### Areas which could experience regressions
- Visibility of the namespace picker on list pages of other resource types.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1281" height="496" alt="image" src="https://github.com/user-attachments/assets/d071e81a-600c-4794-bba0-842c27a6022a" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
