### PR TITLE
Fix runAsUser and fsGroup validation error when clearing fields

### DIFF
--- a/shell/components/form/Security.vue
+++ b/shell/components/form/Security.vue
@@ -140,11 +140,12 @@ export default {
         this.afterPrivilegedTickedMessage = this.t('workload.container.security.privileged.afterTick.false');
       }
 
-      if (securityContext.fsGroup === '') {
+      // Drop empty values so we don't send a string for int64 fields.
+      if (securityContext.fsGroup === '' || securityContext.fsGroup === null) {
         delete securityContext.fsGroup;
       }
 
-      if (securityContext.runAsUser === '') {
+      if (securityContext.runAsUser === '' || securityContext.runAsUser === null) {
         delete securityContext.runAsUser;
       }
 
@@ -175,6 +176,7 @@ export default {
             ref="firstFocusable"
             v-model:value.number="securityContext.fsGroup"
             type="number"
+            min="0"
             :mode="mode"
             :label="t('workload.container.security.fsGroup')"
             @update:value="update"
@@ -283,6 +285,8 @@ export default {
           </legend>
           <LabeledInput
             v-model:value.number="securityContext.runAsUser"
+            type="number"
+            min="0"
             :label="t('workload.container.security.runAsUser.label')"
             :mode="mode"
             @update:value="update"

--- a/shell/components/form/Security.vue
+++ b/shell/components/form/Security.vue
@@ -141,11 +141,11 @@ export default {
       }
 
       // Drop empty values so we don't send a string for int64 fields.
-      if (securityContext.fsGroup === '' || securityContext.fsGroup === null) {
+      if (securityContext.fsGroup === '' || securityContext.fsGroup === null || securityContext.fsGroup === undefined) {
         delete securityContext.fsGroup;
       }
 
-      if (securityContext.runAsUser === '' || securityContext.runAsUser === null) {
+      if (securityContext.runAsUser === '' || securityContext.runAsUser === null || securityContext.runAsUser === undefined) {
         delete securityContext.runAsUser;
       }
 

--- a/shell/components/form/__tests__/Security.test.ts
+++ b/shell/components/form/__tests__/Security.test.ts
@@ -79,6 +79,25 @@ describe('component: Security', () => {
       expect(wrapper.emitted('update:value')).toHaveLength(1);
     });
 
+    // Regression: clearing runAsUser must drop the key from the emitted object.
+    // Otherwise the spec is sent with `runAsUser: ""` and the API rejects with
+    // "cannot unmarshal string ... of type int64". See issue #9601.
+    it('should omit runAsUser from the emitted value when the input is cleared', async() => {
+      const wrapper = mount(Security, {
+        props: {
+          mode: _EDIT, formType: FORM_TYPES.CONTAINER, value: { runAsUser: 33 }
+        }
+      });
+      const input = wrapper.find('[data-testid="input-security-runAsUser"]').find('input');
+
+      await input.setValue('');
+
+      const events = wrapper.emitted('update:value') ?? [];
+      const last = events[events.length - 1][0] as Record<string, unknown>;
+
+      expect(Object.prototype.hasOwnProperty.call(last, 'runAsUser')).toBe(false);
+    });
+
     it.each([
       'privileged',
       'allowPrivilegeEscalation',
@@ -138,6 +157,26 @@ describe('component: Security', () => {
       input.setValue(newValue);
 
       expect(wrapper.emitted('update:value')).toHaveLength(1);
+    });
+
+    // Regression for #9601 — see equivalent container-level test above.
+    it.each([
+      ['runAsUser', { runAsUser: 33 }],
+      ['fsGroup', { fsGroup: 100 }],
+    ])('should omit %p from the emitted value when the input is cleared', async(field, initial) => {
+      const wrapper = mount(Security, {
+        props: {
+          mode: _EDIT, formType: FORM_TYPES.POD, value: initial
+        }
+      });
+      const input = wrapper.find(`[data-testid="input-security-${ field }"]`).find('input');
+
+      await input.setValue('');
+
+      const events = wrapper.emitted('update:value') ?? [];
+      const last = events[events.length - 1][0] as Record<string, unknown>;
+
+      expect(Object.prototype.hasOwnProperty.call(last, field)).toBe(false);
     });
   });
 });

--- a/shell/components/form/__tests__/Security.test.ts
+++ b/shell/components/form/__tests__/Security.test.ts
@@ -98,6 +98,23 @@ describe('component: Security', () => {
       expect(Object.prototype.hasOwnProperty.call(last, 'runAsUser')).toBe(false);
     });
 
+    it('should omit runAsUser from the emitted value when it is undefined', async() => {
+      const wrapper = mount(Security, {
+        props: {
+          mode: _EDIT, formType: FORM_TYPES.CONTAINER, value: {}
+        }
+      });
+
+      const checkbox = wrapper.find('[data-testid="input-security-runasNonRoot"]').find('label');
+
+      await checkbox.trigger('click');
+
+      const events = wrapper.emitted('update:value') ?? [];
+      const last = events[events.length - 1][0] as Record<string, unknown>;
+
+      expect(Object.prototype.hasOwnProperty.call(last, 'runAsUser')).toBe(false);
+    });
+
     it.each([
       'privileged',
       'allowPrivilegeEscalation',
@@ -157,6 +174,26 @@ describe('component: Security', () => {
       input.setValue(newValue);
 
       expect(wrapper.emitted('update:value')).toHaveLength(1);
+    });
+
+    it.each([
+      'runAsUser',
+      'fsGroup',
+    ])('should omit %p from the emitted value when it is undefined', async(field) => {
+      const wrapper = mount(Security, {
+        props: {
+          mode: _EDIT, formType: FORM_TYPES.POD, value: {}
+        }
+      });
+
+      const checkbox = wrapper.find('[data-testid="input-security-runasNonRoot"]').find('label');
+
+      await checkbox.trigger('click');
+
+      const events = wrapper.emitted('update:value') ?? [];
+      const last = events[events.length - 1][0] as Record<string, unknown>;
+
+      expect(Object.prototype.hasOwnProperty.call(last, field)).toBe(false);
     });
 
     // Regression for #9601 — see equivalent container-level test above.


### PR DESCRIPTION
### Summary
Fixes #9601

### Occurred changes and/or fixed issues
Clearing `runAsUser` or `fsGroup` inputs sent `""` or `null` instead of omitting the key.

### Technical notes summary
- Strip `null`, `""` and `undefined` values for `fsGroup`/`runAsUser` in `Security.vue`'s `update()` before emit
- Add `type="number" min="0"` to `runAsUser` input (was missing); add `min="0"` to `fsGroup` input

### Areas or cases that should be tested
- Edit a Deployment with `runAsUser` set, clear the field, save - should succeed
- Same for `fsGroup` on the pod security context tab

### Areas which could experience regressions
- Workload forms using the `Security` component

### Screenshot/Video

**Before fix** - clearing Run as User ID and saving produces `cannot unmarshal string into Go struct field of type int64`:

https://github.com/user-attachments/assets/5ac47a58-7ea3-47c1-801e-cc2f25c1a7ae

**After fix** - clearing Run as User ID and saving succeeds, redirects to deployment list:

https://github.com/user-attachments/assets/0324970f-fec0-4815-8601-24159f387229

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`