### PR TITLE
Automation: Cluster Tools - Add resource polling for reliability and refactor

### DIFF
--- a/cypress/e2e/tests/pages/explorer2/cluster-tools.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/cluster-tools.spec.ts
@@ -1,21 +1,45 @@
 import ClusterToolsPagePo from '@/cypress/e2e/po/pages/explorer/cluster-tools.po';
 import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dashboard.po';
 import { InstallChartPage } from '@/cypress/e2e/po/pages/explorer/charts/install-charts.po';
-import { CLUSTER_APPS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
+import { CLUSTER_APPS_BASE_URL, CLUSTER_REPOS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
 import { runTestWhenChartAvailable } from '@/cypress/support/commands/rancher-api-commands';
 import Kubectl from '@/cypress/e2e/po/components/kubectl.po';
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import LoadingPo from '@/cypress/e2e/po/components/loading.po';
+import { qase } from '@/cypress/support/qase';
 
 const clusterTools = new ClusterToolsPagePo('local');
 const kubectl = new Kubectl();
+const loadingPo = new LoadingPo('.loading-indicator');
 
 describe('Cluster Tools', { tags: ['@explorer2', '@adminUser'] }, () => {
+  const CHART = {
+    name: 'Alerting Drivers',
+    id:   'rancher-alerting-drivers',
+    repo: 'rancher-charts'
+  };
+  const NAMESPACE = 'default';
+
+  const cleanup = () => {
+    cy.createRancherResource('v1', `catalog.cattle.io.apps/${ NAMESPACE }/${ CHART.id }?action=uninstall`, '{}', false);
+    cy.waitForRancherResource('v1', 'catalog.cattle.io.apps', `${ NAMESPACE }/${ CHART.id }`, (resp: any) => resp.status === 404, 20, { failOnStatusCode: false });
+  };
+
+  const waitForToolsPage = () => {
+    clusterTools.goTo();
+    clusterTools.waitForPage();
+    cy.wait('@fetchChartData', MEDIUM_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
+    cy.get('@fetchChartData.all').should('have.length.at.least', 3);
+    loadingPo.checkNotExists(MEDIUM_TIMEOUT_OPT);
+  };
+
   beforeEach(() => {
     cy.login();
+    cy.intercept('GET', `${ CLUSTER_REPOS_BASE_URL }/**`).as('fetchChartData');
   });
 
-  it('can navigate to cluster tools and see all feature charts', () => {
+  qase(2061, it('can navigate to cluster tools and see all feature charts', () => {
     const clusterDashboard = new ClusterDashboardPagePo('local');
 
     clusterDashboard.goTo();
@@ -26,72 +50,89 @@ describe('Cluster Tools', { tags: ['@explorer2', '@adminUser'] }, () => {
     cy.getClusterToolsChartCount().then((expectedCount) => {
       clusterTools.featureChartCards().should('have.length', expectedCount);
     });
-  });
+  }));
 
-  it('can deploy chart successfully', function() {
-    runTestWhenChartAvailable('rancher-charts', 'rancher-alerting-drivers', this, () => {
-      // Clean up any previously installed chart before each attempt, so retries start with a clean state
-      cy.createRancherResource('v1', 'catalog.cattle.io.apps/default/rancher-alerting-drivers?action=uninstall', '{}', false);
-      cy.waitForRancherResource('v1', 'catalog.cattle.io.apps', 'default/rancher-alerting-drivers', (resp: any) => resp.status === 404, 20, { failOnStatusCode: false });
+  describe('Install', () => {
+    beforeEach(function() {
+      runTestWhenChartAvailable(CHART.repo, CHART.id, this, cleanup);
+    });
 
-      clusterTools.goTo();
-      clusterTools.waitForPage();
-      clusterTools.getChartVersion('Alerting Drivers').invoke('text').then((el) => {
-        const chartVersion = el.trim();
+    qase(2062, it('can deploy chart successfully', function() {
+      runTestWhenChartAvailable(CHART.repo, CHART.id, this, () => {
+        waitForToolsPage();
 
-        const chartType = 'rancher-alerting-drivers';
-        const installAlertingDriversPage = `repo-type=cluster&repo=rancher-charts&chart=${ chartType }&version=${ chartVersion }&tools`;
-        const installCharts = new InstallChartPage();
+        clusterTools.getChartVersion(CHART.name).invoke('text').then((el) => {
+          const chartVersion = el.trim();
 
-        clusterTools.goToInstall('Alerting Drivers');
-        installCharts.waitForPage(installAlertingDriversPage);
-        installCharts.nextPage();
+          const installAlertingDriversPage = `repo-type=cluster&repo=${ CHART.repo }&chart=${ CHART.id }&version=${ chartVersion }&tools`;
+          const installCharts = new InstallChartPage();
 
-        cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=install').as('chartInstall');
-        installCharts.installChart();
+          clusterTools.goToInstall(CHART.name);
+          installCharts.waitForPage(installAlertingDriversPage);
+          installCharts.nextPage();
+
+          cy.intercept('POST', `/v1/catalog.cattle.io.clusterrepos/${ CHART.repo }?action=install`).as('chartInstall');
+          installCharts.installChart();
+        });
         cy.wait('@chartInstall').its('response.statusCode').should('eq', 201);
         clusterTools.waitForPage();
         kubectl.waitForTerminalStatus('Connected');
+        cy.waitForResourceState('v1', 'catalog.cattle.io.apps', `${ NAMESPACE }/${ CHART.id }`, 'deployed', 40);
         kubectl.waitForTerminalStatus('Disconnected', MEDIUM_TIMEOUT_OPT);
       });
-    });
+    }));
   });
 
-  it('can edit chart successfully', function() {
-    runTestWhenChartAvailable('rancher-charts', 'rancher-alerting-drivers', this, () => {
-      clusterTools.goTo();
-      clusterTools.waitForPage();
-      clusterTools.editChart('Alerting Drivers');
-
-      const installChart = new InstallChartPage();
-
-      installChart.nextPage();
-
-      cy.intercept('POST', 'v1/catalog.cattle.io.clusterrepos/rancher-charts?action=upgrade').as('chartUpdate');
-      installChart.installChart();
-      cy.wait('@chartUpdate').its('response.statusCode').should('eq', 201);
-      clusterTools.waitForPage();
-      kubectl.waitForTerminalStatus('Connected');
-      kubectl.waitForTerminalStatus('Disconnected', MEDIUM_TIMEOUT_OPT);
+  describe('Manage Installed Chart', () => {
+    beforeEach(function() {
+      runTestWhenChartAvailable(CHART.repo, CHART.id, this, () => {
+        cleanup();
+        cy.getChartVersions(CHART.repo, CHART.id).then((versions) => {
+          cy.installChart(CHART.repo, CHART.id, CHART.name, versions[0], NAMESPACE);
+        });
+        cy.waitForResourceState('v1', 'catalog.cattle.io.apps', `${ NAMESPACE }/${ CHART.id }`, 'deployed', 40);
+      });
     });
+
+    qase(2063, it('can edit chart successfully', function() {
+      runTestWhenChartAvailable(CHART.repo, CHART.id, this, () => {
+        waitForToolsPage();
+        clusterTools.editChart(CHART.name);
+
+        const installChartPage = new InstallChartPage();
+
+        installChartPage.nextPage();
+
+        cy.intercept('POST', `v1/catalog.cattle.io.clusterrepos/${ CHART.repo }?action=upgrade`).as('chartUpdate');
+        installChartPage.installChart();
+        cy.wait('@chartUpdate').its('response.statusCode').should('eq', 201);
+        clusterTools.waitForPage();
+        kubectl.waitForTerminalStatus('Connected');
+        cy.waitForResourceState('v1', 'catalog.cattle.io.apps', `${ NAMESPACE }/${ CHART.id }`, 'deployed', 40);
+        kubectl.waitForTerminalStatus('Disconnected', MEDIUM_TIMEOUT_OPT);
+      });
+    }));
+
+    qase(2060, it('can uninstall chart successfully', function() {
+      runTestWhenChartAvailable(CHART.repo, CHART.id, this, () => {
+        waitForToolsPage();
+        clusterTools.deleteChart(CHART.name);
+
+        const promptRemove = new PromptRemove();
+
+        promptRemove.checkbox().checkNotExists();
+
+        cy.intercept('POST', `${ CLUSTER_APPS_BASE_URL }/${ NAMESPACE }/${ CHART.id }?action=uninstall`).as('chartUninstall');
+        promptRemove.remove();
+        cy.wait('@chartUninstall').its('response.statusCode').should('eq', 201);
+        // we can't check that the initial state is connected... as the supporting socket can connect and disconnect quicker than we can show the window
+        // kubectl.waitForTerminalStatus('Connected');
+        kubectl.waitForTerminalStatus('Disconnected', MEDIUM_TIMEOUT_OPT);
+      });
+    }));
   });
 
-  it('can uninstall chart successfully', function() {
-    runTestWhenChartAvailable('rancher-charts', 'rancher-alerting-drivers', this, () => {
-      clusterTools.goTo();
-      clusterTools.waitForPage();
-      clusterTools.deleteChart('Alerting Drivers');
-
-      const promptRemove = new PromptRemove();
-
-      promptRemove.checkbox().checkNotExists();
-
-      cy.intercept('POST', `${ CLUSTER_APPS_BASE_URL }/default/rancher-alerting-drivers?action=uninstall`).as('chartUninstall');
-      promptRemove.remove();
-      cy.wait('@chartUninstall').its('response.statusCode').should('eq', 201);
-      // we can't check that the initial state is connected... as the supporting socket can connect and disconnect quicker than we can show the window
-      // kubectl.waitForTerminalStatus('Connected');
-      kubectl.waitForTerminalStatus('Disconnected');
-    });
+  after(() => {
+    cleanup();
   });
 });

--- a/cypress/globals.d.ts
+++ b/cypress/globals.d.ts
@@ -136,11 +136,13 @@ declare global {
       waitForRancherResources(prefix: 'v3' | 'v1', resourceType: string, expectedResourcesTotal: number, greaterThan?: boolean): Chainable;
       waitForInterceptWithConflictRetry(alias: string, successStatusCode?: number, retryStatusCodes?: number[], options?: { timeout?: number }): Chainable;
       waitForRepositoryDownload(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, retries?: number): Chainable;
-      waitForResourceState(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, resourceState?: string, retries?: number): Chainable;
+      waitForResourceState(prefix: 'v3' | 'v1', resourceType: string, resourceId: string, resourceState?: string, retries?: number, failOnStatusCode?: boolean): Chainable;
       deleteRancherResource(prefix: 'v3' | 'v1' | 'k8s', resourceType: string, resourceId: string, failOnStatusCode?: boolean): Chainable;
       getClusterIdByName(clusterName: string): Chainable<string>;
       checkChartPresence(repoName: string, chartKey: string): Chainable<{ inFiltered: boolean, inUnfiltered: boolean }>;
       getClusterToolsChartCount(repoName?: string): Chainable<number>;
+      installChart(repo: string, chartId: string, chartName: string, chartVersion: string, namespace: string): Chainable;
+      getChartVersions(repo: string, chartId: string): Chainable<string[]>;
       deleteNodeTemplate(nodeTemplateId: string, timeout?: number, failOnStatusCode?: boolean)
       /**
        * Delete a namespace and wait for it to 404. Helpful when the ns contains many resources

--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -691,12 +691,17 @@ Cypress.Commands.add('waitForRepositoryDownload', (prefix, resourceType, resourc
 /**
  * Wait for repository to be state
  */
-Cypress.Commands.add('waitForResourceState', (prefix, resourceType, resourceId, resourceState = 'active', retries = 20) => {
+Cypress.Commands.add('waitForResourceState', (prefix, resourceType, resourceId, resourceState = 'active', retries = 20, failOnStatusCode = false) => {
   return cy.waitForRancherResource(prefix, resourceType, resourceId, (resp) => {
+    // The resource may not exist yet (404) right after creation or update, so we should return false to retry instead of failing immediately
+    if (resp.status === 404) {
+      return false;
+    }
+
     const state = resp.body.metadata?.state;
 
     return state && state.transitioning === false && state.name === resourceState;
-  }, retries);
+  }, retries, { failOnStatusCode });
 });
 
 /**
@@ -1592,6 +1597,59 @@ Cypress.Commands.add('checkChartPresence', (repoName: string, chartKey: string) 
 
       return { inFiltered, inUnfiltered };
     });
+  });
+});
+
+/**
+ * Get the list of available versions for a chart from the filtered catalog index for a given repo.
+ * Versions are returned in the order Rancher reports them (newest first).
+ * Callers can pick whichever version they need (e.g. `versions[0]` for latest).
+ */
+Cypress.Commands.add('getChartVersions', (repo: string, chartId: string) => {
+  const baseUrl = `${ Cypress.env('api') }/v1/catalog.cattle.io.clusterrepos/${ repo }`;
+
+  const headers = {
+    'x-api-csrf': token.value,
+    Accept:       'application/json',
+  };
+
+  return cy.request({
+    method: 'GET',
+    url:    `${ baseUrl }?link=index`,
+    headers,
+  }).then((resp) => {
+    const versions = resp.body?.entries?.[chartId];
+
+    return versions.map((v: any) => v.version as string);
+  });
+});
+
+/**
+ * Install a Helm chart via the Rancher API (bypassing the install wizard UI).
+ * Useful for test setup where the install flow itself is not under test.
+ */
+Cypress.Commands.add('installChart', (repo: string, chartId: string, chartName: string, chartVersion: string, namespace: string) => {
+  return cy.createRancherResource('v1', `catalog.cattle.io.clusterrepos/${ repo }?action=install`, {
+    charts: [
+      {
+        chartName:   chartId,
+        version:     chartVersion,
+        releaseName: chartId,
+        description: chartName,
+        annotations: {
+          'catalog.cattle.io/ui-source-repo-type': 'cluster',
+          'catalog.cattle.io/ui-source-repo':      repo
+        },
+        values: {}
+      }
+    ],
+    noHooks:                  false,
+    timeout:                  '1000s',
+    wait:                     true,
+    namespace,
+    projectId:                '',
+    disableOpenAPIValidation: false,
+    skipCRDs:                 false,
   });
 });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2316

**Fix:** Adds explicit resource polling (cy.waitForResourceState(...)) after install/upgrade to ensure the chart is fully deployed before proceeding, fixing timing issues and flakiness.

**Refactor:** Introduces a CHART metadata object and NAMESPACE variable to eliminate hardcoded values and repetition. and replace all chart and namespace references with these variables throughout the test suite.
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="673" height="200" alt="image" src="https://github.com/user-attachments/assets/f5db2bca-6b8b-40fe-beaf-7f4cc617d750" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
