### PR TITLE
Add tooltip and validation to CA bundle field in registry configs

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -8784,6 +8784,7 @@ registryMirrorRewrite:
 registryConfig:
   header: Registry Authentication
   toolTip: 'When an image needs to be pulled from the given registry hostname, this information will be used to verify the identity of the registry and authenticate to it.'
+  caBundleTooltip: 'A base64 encoded copy of the CA PEM is expected.'
   addLabel: Add Registry
   description: "Define the TLS and credential configuration for each registry hostname and mirror."
 

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/registries/RegistryConfigs.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/registries/RegistryConfigs.vue
@@ -8,7 +8,7 @@ import CreateEditView from '@shell/mixins/create-edit-view';
 import SecretSelector from '@shell/components/form/SecretSelector';
 import { SECRET_TYPES as TYPES } from '@shell/config/secret';
 import { isBase64 } from '@shell/utils/string';
-import { base64Decode, base64Encode } from '@shell/utils/crypto';
+import { base64Decode, base64Encode, PEM_HEADER } from '@shell/utils/crypto';
 
 export default {
   emits: ['updateConfigs'],
@@ -103,7 +103,7 @@ export default {
 
         configs[h] = {
           ...entry,
-          caBundle: entry.caBundle ? base64Encode(entry.caBundle) : null
+          caBundle: entry.caBundle ? (isBase64(entry.caBundle) ? entry.caBundle : base64Encode(entry.caBundle)) : null
         };
 
         delete configs[h].hostname;
@@ -111,6 +111,14 @@ export default {
 
       this.value.spec.rkeConfig.registries.configs = configs;
       this.$emit('updateConfigs', configs);
+    },
+
+    isValidFormat(val) {
+      if (!val) {
+        return true;
+      }
+
+      return isBase64(val) || val.includes(PEM_HEADER);
     },
 
     wrapRegisterBeforeHook(fn, ...args) {
@@ -192,6 +200,8 @@ export default {
               type="multiline"
               label="CA Cert Bundle"
               :mode="mode"
+              :status="row.value.caBundle && !isValidFormat(row.value.caBundle) ? 'error' : undefined"
+              :tooltip="t('registryConfig.caBundleTooltip')"
             />
 
             <div>

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/registries/__tests__/RegistryConfigs.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/registries/__tests__/RegistryConfigs.test.ts
@@ -3,6 +3,7 @@ import { clone } from '@shell/utils/object';
 import { _EDIT } from '@shell/config/query-params';
 import { PROV_CLUSTER } from '@shell/edit/provisioning.cattle.io.cluster/__tests__/utils/cluster';
 import RegistryConfigs from '@shell/edit/provisioning.cattle.io.cluster/tabs/registries/RegistryConfigs.vue';
+import { PEM_HEADER } from '@shell/utils/crypto';
 
 describe('component: RegistryConfigs', () => {
   let wrapper: Wrapper<InstanceType<typeof RegistryConfigs> & { [key: string]: any }>;
@@ -61,6 +62,22 @@ describe('component: RegistryConfigs', () => {
       wrapper.vm.update();
 
       expect(wrapper.emitted('updateConfigs')[0][0]['foo']['caBundle']).toBe('c3NoIGtleQ==');
+    });
+  });
+
+  describe('isValidFormat', () => {
+    it.each([
+      ['empty string', '', true],
+      ['base64', 'Zm9vYmFy', true],
+      ['PEM', `${ PEM_HEADER }\nfoo\n-----END CERTIFICATE-----`, true],
+      ['invalid', 'some random text', false],
+    ])('given %s format (%p), it should return %p', (_, val, expected) => {
+      wrapper = mount(
+        RegistryConfigs,
+        mountOptions
+      );
+
+      expect(wrapper.vm.isValidFormat(val)).toBe(expected);
     });
   });
 });

--- a/shell/utils/crypto/index.js
+++ b/shell/utils/crypto/index.js
@@ -8,6 +8,8 @@ import Sha1 from './browserSha1';
 const NORMAL = 'normal';
 const URL = 'url';
 
+export const PEM_HEADER = '-----BEGIN CERTIFICATE-----';
+
 export function base64Encode(string, alphabet = NORMAL) {
   let buf;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16003 
The UI lacked a hint and visual validation for "CA Cert Bundle" field. Additionally, there was a bug where pasting a valid Base64 string into the field would result in it being double-encoded upon save.

### Occurred changes and/or fixed issues
- Added an info tooltip to the "CA Cert Bundle" field explaining that a Base64 encoded copy of the CA PEM is expected.
- Added visual validation (error styling) to the field if the input is not a valid Base64 string or a plain text PEM string. This validation is non-blocking.
- Fixed a bug where a valid Base64 string entered into the field would be double-encoded on save.
- Added unit tests for the new `isValidFormat` validation method.

### Technical notes summary
The `caBundle` field supports both plain text PEM strings and Base64 strings. When editing an existing cluster, the component decodes the Base64 string to plain text for readability. The new `isValidFormat` method checks against both `isBase64` and the `PEM_HEADER` to gracefully support both input types without showing false positive validation errors on load. The `update` method was modified to check if the string is already Base64 before attempting to encode it, preventing the double-encoding bug.

### Areas or cases that should be tested
- Create a new RKE2/K3s cluster with a private registry.
- In the "Registry Authentication" section, interact with the "CA Cert Bundle" field:
  - Enter a valid plain text PEM certificate; verify no error styling is shown.
  - Enter a valid Base64 string(e.g. `Zm9vYmFy`); verify no error styling is shown.
  - Enter random text; verify the field turns red indicating an error.
- Save the cluster with a valid plain text PEM certificate and verify the API request payload contains the correct Base64 encoded version.
- Save the cluster with a valid Base64 string and verify the API request payload contains the exact same Base64 string (no double encoding).
- Edit an existing cluster with a CA Cert Bundle; verify the field loads the decoded plain text PEM without showing an error state.

### Areas which could experience regressions
- Provisioning RKE2/K3s clusters with private registries using CA Cert bundles.
- Editing existing RKE2/K3s clusters that have private registry configurations.


### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
