### PR TITLE
Fix resource detail title bar overflow on narrow viewports

### DIFF
--- a/shell/assets/styles/base/_variables.scss
+++ b/shell/assets/styles/base/_variables.scss
@@ -10,6 +10,8 @@ $unlabeled-input-height: 40px;
 $unlabaled-select-padding: 3px 0;
 $footer-height: 60px;
 
+$resource-detail-min-width: 740px;
+
 $input-padding-lg: 18px;
 $input-padding-sm: 10px;
 $input-line-height: 18px;

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
@@ -105,6 +105,7 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
     .row {
       gap: 8px;
 
+      // Hide clearfix pseudo-elements inherited from the global .row class
       &::before, &::after {
         display: none;
       }
@@ -117,6 +118,8 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
         flex: 1;
         min-width: 0;
 
+        // Override inline-block on .popover-card-target so it respects the
+        // parent's width constraint instead of sizing to its content
         :deep(.popover-card-target) {
           width: 100%;
         }

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
@@ -109,6 +109,8 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
 
       .full-custom-value {
         flex: 1;
+        min-width: 0;
+        @include clip;
       }
 
       .value {

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
@@ -103,6 +103,8 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
     flex-direction: column;
 
     .row {
+      gap: 8px;
+
       &:not(:last-of-type) {
         margin-bottom: 8px;
       }
@@ -130,7 +132,7 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
 
       .label {
         width: 30%;
-        min-width: 120px;
+        min-width: min-content;
       }
 
       .status {

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
@@ -105,6 +105,10 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
     .row {
       gap: 8px;
 
+      &::before, &::after {
+        display: none;
+      }
+
       &:not(:last-of-type) {
         margin-bottom: 8px;
       }
@@ -112,8 +116,10 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
       .full-custom-value {
         flex: 1;
         min-width: 0;
-        overflow: hidden;
-        max-height: 1lh;
+
+        :deep(.popover-card-target) {
+          width: 100%;
+        }
       }
 
       .value {

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
@@ -112,7 +112,8 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
       .full-custom-value {
         flex: 1;
         min-width: 0;
-        @include clip;
+        overflow: hidden;
+        max-height: 1lh;
       }
 
       .value {

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -82,6 +82,10 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
 
 <style lang="scss" scoped>
 .metadata {
+    .identifying-info {
+      overflow: hidden;
+    }
+
     .labels-and-annotations-empty {
       grid-column: span 2;
     }

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -83,6 +83,8 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
 <style lang="scss" scoped>
 .metadata {
     .identifying-info {
+      // Allow the grid cell to shrink below its content size without
+      // using overflow:hidden, which would clip the namespace popover
       min-width: 0;
     }
 

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -83,7 +83,7 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
 <style lang="scss" scoped>
 .metadata {
     .identifying-info {
-      overflow: hidden;
+      min-width: 0;
     }
 
     .labels-and-annotations-empty {

--- a/shell/components/Resource/Detail/ResourcePopover/index.vue
+++ b/shell/components/Resource/Detail/ResourcePopover/index.vue
@@ -118,6 +118,7 @@ const actionInvoked = () => {
     align-items: center;
     max-width: 100%;
 
+    // Truncate the link text instead of wrapping to a second line
     a {
       overflow: hidden;
       text-overflow: ellipsis;
@@ -127,6 +128,7 @@ const actionInvoked = () => {
   }
 
   .rc-status-indicator {
+      // Keep the status dot from collapsing when the link text is long
       flex-shrink: 0;
       margin-right: 12px;
       height: initial;

--- a/shell/components/Resource/Detail/ResourcePopover/index.vue
+++ b/shell/components/Resource/Detail/ResourcePopover/index.vue
@@ -115,11 +115,20 @@ const actionInvoked = () => {
 
   .display {
     display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+
+    a {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
+    }
   }
 
   .rc-status-indicator {
+      flex-shrink: 0;
       margin-right: 12px;
-      margin-top: 4px;
       height: initial;
       line-height: initial;
   }

--- a/shell/components/Resource/Detail/SpacedRow.vue
+++ b/shell/components/Resource/Detail/SpacedRow.vue
@@ -7,9 +7,10 @@
 <style lang="scss" scoped>
 .spaced-row {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   grid-auto-flow: dense;
   grid-gap: 24px;
   justify-content: space-evenly;
+  min-width: 630px;
 }
 </style>

--- a/shell/components/Resource/Detail/SpacedRow.vue
+++ b/shell/components/Resource/Detail/SpacedRow.vue
@@ -11,6 +11,7 @@
   grid-auto-flow: dense;
   grid-gap: 24px;
   justify-content: space-evenly;
-  min-width: 630px;
+  // Match the title bar floor so sections scroll together
+  min-width: $resource-detail-min-width;
 }
 </style>

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -159,12 +159,11 @@ const showAdditionalActionButtons = computed(() => isArray(additionalActions));
 
 <style lang="scss" scoped>
 .title-bar {
-  min-width: 740px;
-
   .badge-state {
     font-size: 16px;
     margin-left: 12px;
     position: relative;
+    flex: 0 0 auto;
   }
 
   .icon-document {
@@ -176,6 +175,8 @@ const showAdditionalActionButtons = computed(() => isArray(additionalActions));
   .actions {
     display: flex;
     align-items: center;
+    flex: 0 0 auto;
+    margin-left: 16px;
   }
 
   .show-configuration, &:deep() .actions > button {
@@ -198,15 +199,17 @@ const showAdditionalActionButtons = computed(() => isArray(additionalActions));
     max-width: 60%;
   }
 
-  // This prevents the title from overlapping with the actions
+  // Title takes the remaining row space; min-width: 0 lets its children
+  // (resource-name) shrink so the action buttons stay visible on narrow viewports.
   .title {
-    max-width: calc(100% - 260px);
+    flex: 1 1 auto;
+    min-width: 0;
   }
 
-  // We want the resource name to be what collaspes wh
   .resource-name {
     display: inline-block;
-    flex: 1;
+    flex: 1 1 auto;
+    min-width: 0;
     white-space: nowrap;
     overflow-x: hidden;
     overflow-y: clip;

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -159,6 +159,8 @@ const showAdditionalActionButtons = computed(() => isArray(additionalActions));
 
 <style lang="scss" scoped>
 .title-bar {
+  min-width: 630px;
+
   .badge-state {
     font-size: 16px;
     margin-left: 12px;

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -159,7 +159,7 @@ const showAdditionalActionButtons = computed(() => isArray(additionalActions));
 
 <style lang="scss" scoped>
 .title-bar {
-  min-width: 630px;
+  min-width: $resource-detail-min-width;
 
   .badge-state {
     font-size: 16px;


### PR DESCRIPTION
### Summary
Fixes #15206

### Occurred changes and/or fixed issues

The exact behavior from the original issue no longer reproduces on `master`, but the resource detail metadata section still had room for improvement at narrow viewports: namespace text could wrap instead of truncating, the global `.row` clearfix interfered with the flex layout, and the metadata/cards sections lacked a consistent `min-width` floor.

### Technical notes summary

- **ResourcePopover**: Truncate namespace link text with ellipsis; prevent status dot from shrinking
- **IdentifyingInformation**: Hide inherited clearfix pseudo-elements; constrain `.popover-card-target` width
- **Metadata**: Use `min-width: 0` instead of `overflow: hidden` so popovers aren't clipped
- **SpacedRow/TitleBar**: Extract shared `$resource-detail-min-width` variable (740px)

### Areas or cases that should be tested

- Resource detail pages at various viewport widths (1400px down to 800px)
- Namespace popover still appears on hover and is not clipped

### Areas which could experience regressions

- Resource detail pages using the Masthead/Metadata components
- PopoverCard in the identifying information section (namespace mouseover)

### Screenshot/Video

**Before:**

[before-fix (2).webm](https://github.com/user-attachments/assets/525b6821-52a6-4df7-ac3d-965973232b01)



**After:**

https://github.com/user-attachments/assets/cded9749-8e86-415f-a5ec-2c14342e3edc

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`