### PR TITLE
Fix about.spec.ts - made release notes test adapted to released prime versions

### DIFF
--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -37,11 +37,11 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
     cy.getRancherVersion().then((version) => {
       const isPrime = version.RancherPrime === 'true';
       const expectedOrigin = isPrime ? 'https://documentation.suse.com' : 'https://github.com';
-      const expectedPath = isPrime ? '/cloudnative/rancher-manager/latest/en/release-notes' : '/rancher/rancher/releases/tag/';
+      const expectedUrlPattern = isPrime ? '/cloudnative/rancher-manager/.+/en/release-notes' : '/rancher/rancher/releases/tag/';
 
       aboutPage.clickVersionLink('View release notes');
-      cy.origin(expectedOrigin, { args: { expectedPath } }, ({ expectedPath }) => {
-        cy.url().should('include', expectedPath);
+      cy.origin(expectedOrigin, { args: { expectedUrlPattern } }, ({ expectedUrlPattern }) => {
+        cy.url().should('match', new RegExp(expectedUrlPattern));
       });
     });
   });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
https://github.com/rancher/qa-tasks/issues/2339

### Occurred changes and/or fixed issues
Made the expected release notes url more flexible in test 'can View release notes' as the url changes for released prime versions. (has the version number instead of 'latest')

### Areas or cases that should be tested
the 'about.spec.ts' in both prime and community, but most importantly prime, 
with dev build and released builds.

### Areas which could experience regressions
Low risk change for regressions, but worth checking how the test behaves across rancher dev versions and released versions

### Screenshot/Video
<img width="1511" height="1000" alt="Screenshot 2026-05-04 at 2 41 20 PM" src="https://github.com/user-attachments/assets/e54bb309-513b-4f4d-b28c-353a2ff455e0" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
