### PR TITLE
Add SLO functionality to the AzureAD auth provider

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -734,7 +734,7 @@ authConfig:
       label: Auth Endpoint
     endSessionEndpoint:
       title: End Session Endpoint
-      tooltip: Azure AD URL used for logging a user out of their session (e.g. https://login.microsoftonline.com/{tenant}/oauth2/v2.0/logout)
+      tooltip: Azure AD URL used for logging a user out of their session (e.g. https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/logout)
     groupMembershipFilter:
       label: Group Membership Filter
       enable: Limit users by group membership

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -732,6 +732,9 @@ authConfig:
       label: Token Endpoint
     authEndpoint:
       label: Auth Endpoint
+    endSessionEndpoint:
+      title: End Session Endpoint
+      tooltip: Azure AD URL used for logging a user out of their session (e.g. https://login.microsoftonline.com/{tenant}/oauth2/v2.0/logout)
     groupMembershipFilter:
       label: Group Membership Filter
       enable: Limit users by group membership

--- a/shell/edit/auth/__tests__/azuread.test.ts
+++ b/shell/edit/auth/__tests__/azuread.test.ts
@@ -310,30 +310,43 @@ describe('edit: azureAD SSO logout should', () => {
   });
 
   it.each([
-    { sloType: SLO_OPTION_VALUES.all, endSessionEndpoint: '', disabled: true },
-    { sloType: SLO_OPTION_VALUES.all, endSessionEndpoint: 'not-a-url', disabled: true },
-    { sloType: SLO_OPTION_VALUES.all, endSessionEndpoint: 'https://login.microsoftonline.com/tenant/oauth2/v2.0/logout', disabled: false },
-    { sloType: SLO_OPTION_VALUES.both, endSessionEndpoint: '', disabled: true },
-    { sloType: SLO_OPTION_VALUES.both, endSessionEndpoint: 'https://login.microsoftonline.com/tenant/oauth2/v2.0/logout', disabled: false },
+    {
+      sloType: SLO_OPTION_VALUES.all, endSessionEndpoint: '', disabled: true
+    },
+    {
+      sloType: SLO_OPTION_VALUES.all, endSessionEndpoint: 'not-a-url', disabled: true
+    },
+    {
+      sloType: SLO_OPTION_VALUES.all, endSessionEndpoint: 'https://login.microsoftonline.com/tenant/oauth2/v2.0/logout', disabled: false
+    },
+    {
+      sloType: SLO_OPTION_VALUES.both, endSessionEndpoint: '', disabled: true
+    },
+    {
+      sloType: SLO_OPTION_VALUES.both, endSessionEndpoint: 'https://login.microsoftonline.com/tenant/oauth2/v2.0/logout', disabled: false
+    },
   ])('has save button disabled=$disabled when sloType=$sloType and endSessionEndpoint=$endSessionEndpoint', async(testCase) => {
     wrapper = mount(AzureAD, {
       ...requiredSetup({
-        logoutAllSupported:    true,
-        tenantId:              validTenantId,
-        applicationId:         validApplicationId,
-        applicationSecret:     validAppSecret,
-        endSessionEndpoint:    testCase.endSessionEndpoint,
+        logoutAllSupported: true,
+        tenantId:           validTenantId,
+        applicationId:      validApplicationId,
+        applicationSecret:  validAppSecret,
+        endSessionEndpoint: testCase.endSessionEndpoint,
       }),
       data() {
         return {
-          isEnabling:     true,
-          editConfig:     false,
-          model:          {
+          isEnabling: true,
+          editConfig: false,
+          model:      {
             ...mockModel,
             logoutAllSupported: true,
             tenantId:           validTenantId,
             applicationId:      validApplicationId,
             applicationSecret:  validAppSecret,
+            graphEndpoint:      validGraphEndpoint,
+            tokenEndpoint:      validTokenEndpoint,
+            authEndpoint:       validAuthEndpoint,
             endSessionEndpoint: testCase.endSessionEndpoint,
           },
           sloType:        testCase.sloType,

--- a/shell/edit/auth/__tests__/azuread.test.ts
+++ b/shell/edit/auth/__tests__/azuread.test.ts
@@ -3,6 +3,7 @@ import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import AzureAD from '@shell/edit/auth/azuread.vue';
 import { _EDIT } from '@shell/config/query-params';
+import { SLO_OPTION_VALUES } from '@shell/mixins/auth-config';
 
 jest.mock('@shell/utils/clipboard', () => {
   return { copyTextToClipboard: jest.fn(() => Promise.resolve({})) };
@@ -28,43 +29,44 @@ const mockModel = {
   type:     'azureADConfig',
 };
 
+const requiredSetup = (modelOverrides = {}) => ({
+  data() {
+    return {
+      isEnabling:     true,
+      editConfig:     false,
+      model:          { ...mockModel, ...modelOverrides },
+      serverSetting:  null,
+      errors:         [],
+      originalModel:  null,
+      principals:     [],
+      authConfigName: 'azuread',
+    };
+  },
+  global: {
+    mocks: {
+      $fetchState: { pending: false },
+      $store:      {
+        getters: {
+          currentStore:              () => 'current_store',
+          'current_store/schemaFor': jest.fn(),
+          'current_store/all':       jest.fn(),
+          'i18n/t':                  (val: string) => val,
+          'i18n/exists':             jest.fn(),
+        },
+        dispatch: jest.fn()
+      },
+      $route:  { query: { AS: '' }, params: { id: 'azure' } },
+      $router: { applyQuery: jest.fn() },
+    },
+  },
+  propsData: {
+    value: { applicationSecret: '' },
+    mode:  _EDIT,
+  },
+});
+
 describe('edit: azureAD should', () => {
   let wrapper: any;
-  const requiredSetup = () => ({
-    data() {
-      return {
-        isEnabling:     true,
-        editConfig:     false,
-        model:          { ...mockModel },
-        serverSetting:  null,
-        errors:         [],
-        originalModel:  null,
-        principals:     [],
-        authConfigName: 'azuread',
-      };
-    },
-    global: {
-      mocks: {
-        $fetchState: { pending: false },
-        $store:      {
-          getters: {
-            currentStore:              () => 'current_store',
-            'current_store/schemaFor': jest.fn(),
-            'current_store/all':       jest.fn(),
-            'i18n/t':                  (val: string) => val,
-            'i18n/exists':             jest.fn(),
-          },
-          dispatch: jest.fn()
-        },
-        $route:  { query: { AS: '' }, params: { id: 'azure' } },
-        $router: { applyQuery: jest.fn() },
-      },
-    },
-    propsData: {
-      value: { applicationSecret: '' },
-      mode:  _EDIT,
-    },
-  });
 
   beforeEach(() => {
     wrapper = mount(AzureAD, { ...requiredSetup() });
@@ -234,5 +236,173 @@ describe('edit: azureAD should', () => {
     await nextTick();
 
     expect(saveButton.disabled).toBe(testCase.result);
+  });
+});
+
+describe('edit: azureAD SSO logout should', () => {
+  let wrapper: any;
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('not render SLO section when logoutAllSupported is false', () => {
+    wrapper = mount(AzureAD, { ...requiredSetup({ logoutAllSupported: false }) });
+    const sloSection = wrapper.find('[data-testid="azuread-sloType"]');
+
+    expect(sloSection.exists()).toBe(false);
+  });
+
+  it('render SLO section when logoutAllSupported is true', async() => {
+    wrapper = mount(AzureAD, { ...requiredSetup({ logoutAllSupported: true }) });
+    await nextTick();
+    const sloSection = wrapper.find('[data-testid="azuread-sloType"]');
+
+    expect(sloSection.exists()).toBe(true);
+  });
+
+  it('not render endSessionEndpoint field when sloType is rancher', async() => {
+    wrapper = mount(AzureAD, {
+      ...requiredSetup({ logoutAllSupported: true }),
+      data() {
+        return {
+          ...requiredSetup({ logoutAllSupported: true }).data(),
+          sloType: SLO_OPTION_VALUES.rancher,
+        };
+      },
+    });
+    await nextTick();
+    const endSessionEndpointField = wrapper.find('[data-testid="azuread-endSessionEndpoint"]');
+
+    expect(endSessionEndpointField.exists()).toBe(false);
+  });
+
+  it('render endSessionEndpoint field when sloType is all', async() => {
+    wrapper = mount(AzureAD, {
+      ...requiredSetup({ logoutAllSupported: true }),
+      data() {
+        return {
+          ...requiredSetup({ logoutAllSupported: true }).data(),
+          sloType: SLO_OPTION_VALUES.all,
+        };
+      },
+    });
+    await nextTick();
+    const endSessionEndpointField = wrapper.find('[data-testid="azuread-endSessionEndpoint"]');
+
+    expect(endSessionEndpointField.exists()).toBe(true);
+  });
+
+  it('render endSessionEndpoint field when sloType is both', async() => {
+    wrapper = mount(AzureAD, {
+      ...requiredSetup({ logoutAllSupported: true }),
+      data() {
+        return {
+          ...requiredSetup({ logoutAllSupported: true }).data(),
+          sloType: SLO_OPTION_VALUES.both,
+        };
+      },
+    });
+    await nextTick();
+    const endSessionEndpointField = wrapper.find('[data-testid="azuread-endSessionEndpoint"]');
+
+    expect(endSessionEndpointField.exists()).toBe(true);
+  });
+
+  it.each([
+    { sloType: SLO_OPTION_VALUES.all, endSessionEndpoint: '', disabled: true },
+    { sloType: SLO_OPTION_VALUES.all, endSessionEndpoint: 'not-a-url', disabled: true },
+    { sloType: SLO_OPTION_VALUES.all, endSessionEndpoint: 'https://login.microsoftonline.com/tenant/oauth2/v2.0/logout', disabled: false },
+    { sloType: SLO_OPTION_VALUES.both, endSessionEndpoint: '', disabled: true },
+    { sloType: SLO_OPTION_VALUES.both, endSessionEndpoint: 'https://login.microsoftonline.com/tenant/oauth2/v2.0/logout', disabled: false },
+  ])('has save button disabled=$disabled when sloType=$sloType and endSessionEndpoint=$endSessionEndpoint', async(testCase) => {
+    wrapper = mount(AzureAD, {
+      ...requiredSetup({
+        logoutAllSupported:    true,
+        tenantId:              validTenantId,
+        applicationId:         validApplicationId,
+        applicationSecret:     validAppSecret,
+        endSessionEndpoint:    testCase.endSessionEndpoint,
+      }),
+      data() {
+        return {
+          isEnabling:     true,
+          editConfig:     false,
+          model:          {
+            ...mockModel,
+            logoutAllSupported: true,
+            tenantId:           validTenantId,
+            applicationId:      validApplicationId,
+            applicationSecret:  validAppSecret,
+            endSessionEndpoint: testCase.endSessionEndpoint,
+          },
+          sloType:        testCase.sloType,
+          serverSetting:  null,
+          errors:         [],
+          originalModel:  null,
+          principals:     [],
+          authConfigName: 'azuread',
+        };
+      },
+    });
+    await nextTick();
+    const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+
+    expect(saveButton.disabled).toBe(testCase.disabled);
+  });
+
+  it('sets logoutAllEnabled=false and logoutAllForced=false when sloType changes to rancher', async() => {
+    wrapper = mount(AzureAD, {
+      ...requiredSetup({ logoutAllSupported: true }),
+      data() {
+        return {
+          ...requiredSetup({ logoutAllSupported: true }).data(),
+          sloType: SLO_OPTION_VALUES.all,
+        };
+      },
+    });
+    await nextTick();
+    wrapper.vm.sloType = SLO_OPTION_VALUES.rancher;
+    await nextTick();
+
+    expect(wrapper.vm.model.logoutAllEnabled).toBe(false);
+    expect(wrapper.vm.model.logoutAllForced).toBe(false);
+    expect(wrapper.vm.model.endSessionEndpoint).toBe('');
+  });
+
+  it('sets logoutAllEnabled=true and logoutAllForced=true when sloType changes to all', async() => {
+    wrapper = mount(AzureAD, {
+      ...requiredSetup({ logoutAllSupported: true }),
+      data() {
+        return {
+          ...requiredSetup({ logoutAllSupported: true }).data(),
+          sloType: SLO_OPTION_VALUES.rancher,
+        };
+      },
+    });
+    await nextTick();
+    wrapper.vm.sloType = SLO_OPTION_VALUES.all;
+    await nextTick();
+
+    expect(wrapper.vm.model.logoutAllEnabled).toBe(true);
+    expect(wrapper.vm.model.logoutAllForced).toBe(true);
+  });
+
+  it('sets logoutAllEnabled=true and logoutAllForced=false when sloType changes to both', async() => {
+    wrapper = mount(AzureAD, {
+      ...requiredSetup({ logoutAllSupported: true }),
+      data() {
+        return {
+          ...requiredSetup({ logoutAllSupported: true }).data(),
+          sloType: SLO_OPTION_VALUES.rancher,
+        };
+      },
+    });
+    await nextTick();
+    wrapper.vm.sloType = SLO_OPTION_VALUES.both;
+    await nextTick();
+
+    expect(wrapper.vm.model.logoutAllEnabled).toBe(true);
+    expect(wrapper.vm.model.logoutAllForced).toBe(false);
   });
 });

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -76,6 +76,8 @@ export default {
     if ( this.value?.graphEndpoint ) {
       this.setInitialEndpoint(this.value.graphEndpoint);
     }
+
+    await this.mixinFetch();
   },
 
   data() {

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -617,7 +617,7 @@ export default {
             <div class="col span-6">
               <LabeledInput
                 v-model:value="model.endSessionEndpoint"
-                :tooltip="t('authConfig.azuread.endSessionEndpoint.tooltip')"
+                :tooltip="t('authConfig.azuread.endSessionEndpoint.tooltip', { tenantId: `${ tenantId || 'tenant-id' }` }, true)"
                 :label="t('authConfig.azuread.endSessionEndpoint.title')"
                 :mode="mode"
                 :rules="fvGetAndReportPathRules('endSessionEndpoint')"

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -11,7 +11,7 @@ import { Checkbox } from '@components/Form/Checkbox';
 import AuthBanner from '@shell/components/auth/AuthBanner';
 import CopyToClipboardText from '@shell/components/CopyToClipboardText.vue';
 import AllowedPrincipals from '@shell/components/auth/AllowedPrincipals';
-import AuthConfig from '@shell/mixins/auth-config';
+import AuthConfig, { SLO_OPTION_VALUES } from '@shell/mixins/auth-config';
 import { AZURE_MIGRATED } from '@shell/config/labels-annotations';
 import { get } from '@shell/utils/object';
 import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBanners';
@@ -83,6 +83,7 @@ export default {
       isGroupMembershipFilterEnabled: !!this.value.groupMembershipFilter,
       endpoint:                       'standard',
       oldEndpoint:                    false,
+      SLO_OPTION_VALUES,
 
       // Storing the applicationSecret is necessary because norman doesn't support returning secrets and when we
       // override the steve authconfig with a norman config the applicationSecret is lost
@@ -95,6 +96,7 @@ export default {
         { path: 'graphEndpoint', rules: ['graphEndpointRequired', 'graphEndpointMustBeURL'] },
         { path: 'tokenEndpoint', rules: ['tokenEndpointRequired', 'tokenEndpointMustBeURL'] },
         { path: 'authEndpoint', rules: ['authEndpointRequired', 'authEndpointMustBeURL'] },
+        { path: 'endSessionEndpoint', rules: ['endSessionEndpointRequiredAndValid'] },
       ]
     };
   },
@@ -103,17 +105,18 @@ export default {
     // Cannot pass this.model as a rootObject because it is undefined at that point, so had to use a workaround
     fvExtraRules() {
       return {
-        tenantIdRequired:          this.modelFieldRequired('tenantId', 'authConfig.azuread.tenantId.label'),
-        applicationIdRequired:     this.modelFieldRequired('applicationId', 'authConfig.azuread.applicationId.label'),
-        applicationSecretRequired: this.applicationSecretRequired(),
-        endpointRequired:          this.modelFieldRequired('endpoint', 'authConfig.azuread.endpoint.label'),
-        endpointMustBeURL:         this.modelFieldURL('endpoint'),
-        graphEndpointRequired:     this.modelFieldRequired('graphEndpoint', 'authConfig.azuread.graphEndpoint.label'),
-        graphEndpointMustBeURL:    this.modelFieldURL('graphEndpoint'),
-        tokenEndpointRequired:     this.modelFieldRequired('tokenEndpoint', 'authConfig.azuread.tokenEndpoint.label'),
-        tokenEndpointMustBeURL:    this.modelFieldURL('tokenEndpoint'),
-        authEndpointRequired:      this.modelFieldRequired('authEndpoint', 'authConfig.azuread.authEndpoint.label'),
-        authEndpointMustBeURL:     this.modelFieldURL('authEndpoint')
+        tenantIdRequired:                   this.modelFieldRequired('tenantId', 'authConfig.azuread.tenantId.label'),
+        applicationIdRequired:              this.modelFieldRequired('applicationId', 'authConfig.azuread.applicationId.label'),
+        applicationSecretRequired:          this.applicationSecretRequired(),
+        endpointRequired:                   this.modelFieldRequired('endpoint', 'authConfig.azuread.endpoint.label'),
+        endpointMustBeURL:                  this.modelFieldURL('endpoint'),
+        graphEndpointRequired:              this.modelFieldRequired('graphEndpoint', 'authConfig.azuread.graphEndpoint.label'),
+        graphEndpointMustBeURL:             this.modelFieldURL('graphEndpoint'),
+        tokenEndpointRequired:              this.modelFieldRequired('tokenEndpoint', 'authConfig.azuread.tokenEndpoint.label'),
+        tokenEndpointMustBeURL:             this.modelFieldURL('tokenEndpoint'),
+        authEndpointRequired:               this.modelFieldRequired('authEndpoint', 'authConfig.azuread.authEndpoint.label'),
+        authEndpointMustBeURL:              this.modelFieldURL('authEndpoint'),
+        endSessionEndpointRequiredAndValid: this.endSessionEndpointRule(),
       };
     },
 
@@ -165,7 +168,29 @@ export default {
     },
     editMemberConfig() {
       return this.model.enabled && !this.isEnabling && !this.editConfig;
-    }
+    },
+
+    isLogoutAllSupported() {
+      return this.model?.logoutAllSupported;
+    },
+
+    sloOptions() {
+      return [
+        { value: SLO_OPTION_VALUES.rancher, label: this.t('authConfig.slo.sloOptions.onlyRancher', { name: this.model?.nameDisplay }) },
+        { value: SLO_OPTION_VALUES.all, label: this.t('authConfig.slo.sloOptions.logoutAll', { name: this.model?.nameDisplay }) },
+        { value: SLO_OPTION_VALUES.both, label: this.t('authConfig.slo.sloOptions.choose') },
+      ];
+    },
+
+    sloTypeText() {
+      const sloOptionSelected = this.sloOptions.find((item) => item.value === this.sloType);
+
+      return sloOptionSelected?.label || '';
+    },
+
+    sloEndSessionEndpointUiEnabled() {
+      return this.sloType === SLO_OPTION_VALUES.all || this.sloType === SLO_OPTION_VALUES.both;
+    },
   },
 
   watch: {
@@ -176,6 +201,25 @@ export default {
     tenantId() {
       if (this.endpoint !== 'custom') {
         this.setEndpoints(this.endpoint);
+      }
+    },
+
+    // sloType is defined on shell/mixins/auth-config.js
+    sloType(neu) {
+      switch (neu) {
+      case SLO_OPTION_VALUES.rancher:
+        this.model.logoutAllEnabled = false;
+        this.model.logoutAllForced = false;
+        this.model.endSessionEndpoint = '';
+        break;
+      case SLO_OPTION_VALUES.all:
+        this.model.logoutAllEnabled = true;
+        this.model.logoutAllForced = true;
+        break;
+      case SLO_OPTION_VALUES.both:
+        this.model.logoutAllEnabled = true;
+        this.model.logoutAllForced = false;
+        break;
       }
     },
 
@@ -294,7 +338,21 @@ export default {
 
         return rule(this.model[path]);
       };
-    }
+    },
+
+    endSessionEndpointRule() {
+      return () => {
+        if (!this.isLogoutAllSupported || !this.sloEndSessionEndpointUiEnabled) {
+          return undefined;
+        }
+        if (!this.model.endSessionEndpoint) {
+          return this.t('validation.required', { key: this.t('authConfig.azuread.endSessionEndpoint.title') });
+        }
+        const rule = formRulesGenerator(this.$store.getters['i18n/t'], {}).url;
+
+        return rule(this.model.endSessionEndpoint);
+      };
+    },
   }
 };
 </script>
@@ -347,6 +405,14 @@ export default {
             <tr>
               <td>{{ t(`authConfig.azuread.authEndpoint.label`) }}:</td>
               <td>{{ model.authEndpoint }}</td>
+            </tr>
+            <tr v-if="isLogoutAllSupported">
+              <td>{{ t('authConfig.slo.sloTitle') }}:</td>
+              <td>{{ sloTypeText }}</td>
+            </tr>
+            <tr v-if="isLogoutAllSupported && sloEndSessionEndpointUiEnabled">
+              <td>{{ t('authConfig.azuread.endSessionEndpoint.title') }}:</td>
+              <td>{{ model.endSessionEndpoint }}</td>
             </tr>
           </template>
           <template
@@ -517,6 +583,46 @@ export default {
                 :rules="fvGetAndReportPathRules('authEndpoint')"
                 :mode="mode"
                 data-testid="input-azureAD-authEndpoint"
+              />
+            </div>
+          </div>
+        </div>
+
+        <!-- SLO logout -->
+        <div
+          v-if="isLogoutAllSupported"
+          class="mb-20"
+        >
+          <div class="row">
+            <div class="col span-12">
+              <h3>{{ t('authConfig.slo.sloTitle') }}</h3>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col span-4">
+              <RadioGroup
+                v-model:value="sloType"
+                :mode="mode"
+                :options="sloOptions"
+                :disabled="!model.logoutAllSupported"
+                name="sloTypeRadio"
+                data-testid="azuread-sloType"
+              />
+            </div>
+          </div>
+          <div
+            v-if="sloEndSessionEndpointUiEnabled"
+            class="row mt-20"
+          >
+            <div class="col span-6">
+              <LabeledInput
+                v-model:value="model.endSessionEndpoint"
+                :tooltip="t('authConfig.azuread.endSessionEndpoint.tooltip')"
+                :label="t('authConfig.azuread.endSessionEndpoint.title')"
+                :mode="mode"
+                :rules="fvGetAndReportPathRules('endSessionEndpoint')"
+                :required="true"
+                data-testid="azuread-endSessionEndpoint"
               />
             </div>
           </div>

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -8,7 +8,7 @@ import { addParams, parse as parseUrl, removeParam } from '@shell/utils/url';
 
 // configuration for Single Logout/SLO
 // admissable auth providers compatible with SLO, based on shell/models/management.cattle.io.authconfig "configType"
-export const SLO_AUTH_PROVIDERS = ['oidc', 'saml'];
+export const SLO_AUTH_PROVIDERS = ['oidc', 'saml', 'oauth'];
 
 // this is connected to the redirect url, for which the logic can be found in "shell/store/auth"
 const SLO_TOKENS_ENDPOINT_LOGOUT_RES_BASETYPE = ['authConfigLogoutOutput'];


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds single log out functionality to the AzureAD auth provider.

Fixes #17283
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add SLO for the Azure AD auth provider
- Fix failing test
- Fix the AzureAD SLO tooltip
- Explicitly invoke `this.mixinFetch()`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This is adding the SLO functionality that already exists for OIDC and SAML and applying it to AzureAD. These changes are ported over from the existing implementations and adapted to AzureAD now that the backend supports this behavior.  

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

AzureAD - confirm that the auth provider can still be configured properly. When the auth provider is configured, ensure that the different SLO modes can be selected and configured. The logout behavior should function as described, depending on the SLO mode selected.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

The existing behavior should remain as-is - this change is mostly additive. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### New SLO Area for AzureAD

<img width="1377" height="792" alt="image" src="https://github.com/user-attachments/assets/fea117a5-eab5-4a11-8364-1a651ec7c7a9" />

#### SLO Modal is triggered when logging out of AzureAD

<img width="1377" height="792" alt="image" src="https://github.com/user-attachments/assets/135103f4-24f9-493c-ba6e-f3e7d477b0e0" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
