### PR TITLE
Remove stgregistry for release-2.14

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -25,7 +25,6 @@
       },
       "e2e": {
         "rancher-image": {
-          "registry": "stgregistry.suse.com",
           "namespace": "rancher",
           "name": "rancher",
           "tag": "v2.14-head"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

The CI is failing for 2.14 backport PRs due to missing Rancher 2.14 image in the staging registry:

https://github.com/rancher/dashboard/actions/runs/25312212106/job/74236577143?pr=17475

```
Using Rancher Container Image: stgregistry.suse.com/rancher/rancher:v2.14-head
Unable to find image 'stgregistry.suse.com/rancher/rancher:v2.14-head' locally
docker: Error response from daemon: manifest for stgregistry.suse.com/rancher/rancher:v2.14-head not found: manifest unknown: manifest unknown
```

This is a temporary solution - we should revert it once the image is pushed.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
