### PR TITLE
Fix SortableTable sort cache returning stale rows after filter change

### DIFF
--- a/shell/components/SortableTable/__tests__/sorting.test.ts
+++ b/shell/components/SortableTable/__tests__/sorting.test.ts
@@ -1,0 +1,126 @@
+import sorting from '@shell/components/SortableTable/sorting';
+
+const { arrangedRows } = sorting.computed;
+
+describe('sorting mixin', () => {
+  describe('arrangedRows', () => {
+    function createContext({
+      rows = [] as any[],
+      sortFields = ['id'],
+      descending = false,
+      sortGeneration = undefined as string | undefined,
+      sortGenerationFn = (() => 'gen1') as (() => string) | undefined,
+      externalPaginationEnabled = false,
+      cacheKey = null as string | null,
+      cachedRows = null as any[] | null,
+      cachedRowsRef = null as any[] | null,
+    } = {}) {
+      return {
+        rows,
+        sortFields,
+        descending,
+        sortGeneration,
+        sortGenerationFn,
+        externalPaginationEnabled,
+        cacheKey,
+        cachedRows,
+        cachedRowsRef,
+      };
+    }
+
+    it('should return undefined when externalPaginationEnabled is true', () => {
+      const ctx = createContext({ externalPaginationEnabled: true });
+
+      expect(arrangedRows.call(ctx)).toBeUndefined();
+    });
+
+    it('should sort rows by the given sort fields', () => {
+      const rows = [{ id: 'b' }, { id: 'a' }, { id: 'c' }];
+      const ctx = createContext({ rows, sortGenerationFn: undefined });
+
+      const result = arrangedRows.call(ctx);
+
+      expect(result.map((r: any) => r.id)).toStrictEqual(['a', 'b', 'c']);
+    });
+
+    it('should cache results when sortGenerationFn is provided', () => {
+      const rows = [{ id: 'b' }, { id: 'a' }];
+      const ctx = createContext({ rows });
+
+      const result1 = arrangedRows.call(ctx);
+
+      expect(ctx.cacheKey).not.toBeNull();
+      expect(ctx.cachedRows).toStrictEqual(result1);
+
+      const result2 = arrangedRows.call(ctx);
+
+      expect(result2).toBe(ctx.cachedRows);
+    });
+
+    it('should invalidate cache when rows change to different items with the same count', () => {
+      const rowsA = [{ id: 'alpha' }];
+      const rowsB = [{ id: 'beta' }];
+      const ctx = createContext({ rows: rowsA });
+
+      const resultA = arrangedRows.call(ctx);
+
+      expect(resultA.map((r: any) => r.id)).toStrictEqual(['alpha']);
+
+      ctx.rows = rowsB;
+      const resultB = arrangedRows.call(ctx);
+
+      expect(resultB.map((r: any) => r.id)).toStrictEqual(['beta']);
+    });
+
+    it('should return cached rows when same rows are passed again', () => {
+      const rows = [{ id: 'x' }, { id: 'y' }];
+      const ctx = createContext({ rows });
+
+      arrangedRows.call(ctx);
+      const cached = ctx.cachedRows;
+
+      const result = arrangedRows.call(ctx);
+
+      expect(result).toBe(cached);
+    });
+
+    it('should invalidate cache when descending changes', () => {
+      const rows = [{ id: 'a' }, { id: 'b' }];
+      const ctx = createContext({ rows });
+
+      arrangedRows.call(ctx);
+
+      ctx.descending = true;
+      const result = arrangedRows.call(ctx);
+
+      expect(result.map((r: any) => r.id)).toStrictEqual(['b', 'a']);
+    });
+
+    it('should not cache when there is no sortGenerationFn or sortGeneration', () => {
+      const rows = [{ id: 'a' }];
+      const ctx = createContext({ rows });
+
+      ctx.sortGenerationFn = undefined;
+      ctx.sortGeneration = undefined;
+
+      arrangedRows.call(ctx);
+
+      expect(ctx.cacheKey).toBeNull();
+      expect(ctx.cachedRows).toBeNull();
+    });
+
+    it('should use sortGeneration over sortGenerationFn when provided', () => {
+      const rows = [{ id: 'a' }];
+      const ctx = createContext({
+        rows,
+        sortGeneration:   'custom-gen',
+        sortGenerationFn: () => 'fn-gen',
+      });
+
+      arrangedRows.call(ctx);
+
+      expect(ctx.cacheKey).toContain('custom-gen');
+      expect(ctx.cacheKey).not.toContain('fn-gen');
+    });
+  });
+});

--- a/shell/components/SortableTable/sorting.js
+++ b/shell/components/SortableTable/sorting.js
@@ -50,7 +50,8 @@ export default {
 
       if ( sortGenerationKey) {
         key = `${ sortGenerationKey }/${ this.rows.length }/${ this.descending }/${ this.sortFields.join(',') }`;
-        if ( this.cacheKey === key ) {
+
+        if ( this.cacheKey === key && this.cachedRowsRef === this.rows ) {
           return this.cachedRows;
         }
       }
@@ -60,6 +61,7 @@ export default {
       if ( key ) {
         this.cacheKey = key;
         this.cachedRows = out;
+        this.cachedRowsRef = this.rows;
       }
 
       return out;
@@ -104,8 +106,9 @@ export default {
     return {
       sortBy,
       descending,
-      cachedRows: null,
-      cacheKey:   null,
+      cachedRows:    null,
+      cachedRowsRef: null,
+      cacheKey:      null,
     };
   },
 


### PR DESCRIPTION
### Summary
Fixes #15576

### Occurred changes and/or fixed issues

I'm never very confident when working in the table area so if you have any other insights that could provide a better root cause we can always try something different.

The `arrangedRows` computed property in SortableTable's sorting mixin used `rows.length` in its cache key and I'm assuming that was to detect when the array changed. When a filter changed the displayed rows to a different set with the same count, the cache key matched and stale cached rows were returned.

Adding a reference check (`cachedRowsRef`) that compares the current `rows` array reference against the one stored at cache time will ensure we invalidate the cache if the backing rows change.

### Technical notes summary

- [`sorting.js`](https://github.com/codyrancher/dashboard/blob/8ab98b702ba55a187573aa2729edab0ce064af60/shell/components/SortableTable/sorting.js#L51-L58): cache hit now requires both the string key match AND `this.cachedRowsRef === this.rows`

### Areas or cases that should be tested

- Any SortableTable with a local filter that changes the displayed rows (e.g. status filter on vulnerability-scanner registries)
- Filter between two states that produce different rows of equal count, verify the table updates
- Verify sort cache still works (sorting the same rows twice should not re-sort)

### Areas which could experience regressions

- Any component relying on the sort cache behavior in SortableTable

### Screenshot/Video

**Before fix (2 registries, equal count per filter)** - filtering by "Failed" incorrectly shows the "Completed" row because the cache key's `rows.length` is the same (1 vs 1):

https://github.com/user-attachments/assets/610fd09d-abb6-44e7-b954-60a3254d64db

**Before fix (3 registries, unequal count per filter)** - filtering works correctly because the cache key's `rows.length` differs (1 vs 2), showing that the length check was the only thing differentiating cached results:

https://github.com/user-attachments/assets/56c4c8f8-38e4-41e7-963e-2646b7193034

**After fix** - filtering works correctly regardless of row count, because the `cachedRowsRef` reference check catches that the source array changed:

https://github.com/user-attachments/assets/5f4b0546-e562-4531-af90-578287607564

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`