### PR TITLE
[backport v2.13.6] Automation: Make custom node SSH user configurable via CUSTOM_NODE_USER

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -103,6 +103,7 @@ export default defineConfig({
     azureClientSecret:        process.env.AZURE_CLIENT_SECRET,
     customNodeIp:             process.env.CUSTOM_NODE_IP,
     customNodeKey:            process.env.CUSTOM_NODE_KEY,
+    customNodeUser:           process.env.CUSTOM_NODE_USER || 'ec2-user',
     accessibility:            !!process.env.TEST_A11Y, // Are we running accessibility tests?
     a11yFolder:               path.join('.', 'cypress', 'accessibility'),
     gkeServiceAccount:        process.env.GKE_SERVICE_ACCOUNT,

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
@@ -54,7 +54,9 @@ export default class ClusterManagerCreatePagePo extends ClusterManagerCreateImpo
   }
 
   customClusterRegistrationCmd(cmd: string) {
-    return `ssh -i custom_node.key -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" root@${ Cypress.env('customNodeIp') } \"nohup ${ cmd }\"`;
+    const sshUser = Cypress.env('customNodeUser');
+
+    return `ssh -i custom_node.key -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" ${ sshUser }@${ Cypress.env('customNodeIp') } \"nohup ${ cmd }\"`;
   }
 
   credentialsBanner() {

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -171,7 +171,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
           // The test validate the warning when selecting none, but now this get back to calico.
           // A CNI is mandatory to get the cluster active otherwise manual intervention is needed or
           // the use of a cloud provider but that's not in scope.
-          spec: { rkeConfig: { machineGlobalConfig: { cni: 'calico', 'ingress-controller': 'ingress-nginx' }, machinePoolDefaults: { hostnameLengthLimit: 15 } } }
+          spec: { rkeConfig: { machineGlobalConfig: { cni: 'calico' }, machinePoolDefaults: { hostnameLengthLimit: 15 } } }
         };
 
         cy.userPreferences();
@@ -216,6 +216,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         cy.wait('@createRequest').then((intercept) => {
           // Issue with linter https://github.com/cypress-io/eslint-plugin-cypress/issues/3
           expect(isMatch(intercept.request.body, request)).to.equal(true);
+          expect(['ingress-nginx', 'traefik']).to.include(intercept.request.body.spec?.rkeConfig?.machineGlobalConfig?.['ingress-controller']);
         });
 
         detailRKE2ClusterPage().waitForPage(undefined, 'registration');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes rancher/qa-tasks#2319
Additionally fixes an small regression introduced by this change: https://github.com/rancher/dashboard/pull/17152
Backport of: https://github.com/rancher/dashboard/pull/17465

### Technical notes summary
This change is identical to the master fix, but it deals with a regression due to the ingress-controller migration.

### Areas or cases that should be tested
CI

### Areas which could experience regressions
CI

### Screenshot/Video
<img width="924" height="703" alt="image" src="https://github.com/user-attachments/assets/06fbbfd5-9fb0-4c1c-9464-2dc28bb76e2f" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
