### PR TITLE
[backport v2.14.2] Automation: Make custom node SSH user configurable via CUSTOM_NODE_USER

### DIFF
--- a/cypress/base-config.ts
+++ b/cypress/base-config.ts
@@ -124,6 +124,7 @@ const baseConfig = defineConfig({
     azureClientSecret:        process.env.AZURE_CLIENT_SECRET,
     customNodeIp:             process.env.CUSTOM_NODE_IP,
     customNodeKey:            process.env.CUSTOM_NODE_KEY,
+    customNodeUser:           process.env.CUSTOM_NODE_USER || 'ec2-user',
     accessibility:            !!process.env.TEST_A11Y, // Are we running accessibility tests?
     a11yFolder:               path.join('.', 'cypress', 'accessibility'),
     gkeServiceAccount:        process.env.GKE_SERVICE_ACCOUNT,

--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po.ts
@@ -54,7 +54,9 @@ export default class ClusterManagerCreatePagePo extends ClusterManagerCreateImpo
   }
 
   customClusterRegistrationCmd(cmd: string) {
-    return `ssh -i custom_node.key -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" root@${ Cypress.env('customNodeIp') } \"nohup ${ cmd }\"`;
+    const sshUser = Cypress.env('customNodeUser');
+
+    return `ssh -i custom_node.key -o "StrictHostKeyChecking=no" -o "UserKnownHostsFile=/dev/null" ${ sshUser }@${ Cypress.env('customNodeIp') } \"nohup ${ cmd }\"`;
   }
 
   credentialsBanner() {


### PR DESCRIPTION
### Summary
Fixes rancher/qa-tasks#2319
Backport of: https://github.com/rancher/dashboard/pull/17465


### Occurred changes and/or fixed issues
This change is identical to the master fix,  clean cherry pick.

### Technical notes summary


### Areas or cases that should be tested
CI

### Areas which could experience regressions
CI

### Screenshot/Video

<img width="912" height="679" alt="image" src="https://github.com/user-attachments/assets/33f91868-1afc-4748-bed3-371783569f66" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
