### PR TITLE
Chart readme standalone page

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1156,6 +1156,9 @@ catalog:
     deprecatedWarning: '{chartName} has been marked as deprecated. Use caution when installing this helm chart as it might be removed in the future.'
     experimentalWarning: '{chartName} has been marked as experimental. Use caution when installing this helm chart as it might not function as expected.'
     deprecatedAndExperimentalWarning: '{chartName} has been marked as deprecated and experimental. Use caution when installing this helm chart as it might be removed in the future and might not function as expected.'
+    viewReadmeSeparately:
+      label: View separately
+      tooltip: Open the readme in a new tab
     installedAppsSelector:
       ariaLabel: Select installed app instance
     chartButton:

--- a/shell/components/templates/standalone.vue
+++ b/shell/components/templates/standalone.vue
@@ -1,3 +1,9 @@
+<script>
+import Brand from '@shell/mixins/brand';
+
+export default { mixins: [Brand] };
+</script>
+
 <template>
   <router-view :key="$route.path" />
 </template>
@@ -5,5 +11,16 @@
 <style lang="scss">
 body, #__root, #__layout {
   height: 100%;
+  background: var(--body-bg);
+  color: var(--body-text);
+}
+
+// Standalone pages should not reserve dashboard layout areas (e.g. side nav and header).
+#__layout {
+  --header-height: 0px;
+  --nav-width: 0px;
+  --wm-vl-width: 0px;
+  --wm-vr-width: 0px;
+  --wm-height: 0px;
 }
 </style>

--- a/shell/config/router/routes.js
+++ b/shell/config/router/routes.js
@@ -138,6 +138,12 @@ export default [
     component: () => interopDefault(import('@shell/components/templates/standalone.vue')),
     name:      'standalone',
     children:  [
+      {
+        path:      '/c/:cluster/readme',
+        component: () => interopDefault(import('@shell/pages/readme.vue')),
+        name:      'readme',
+        meta:      { requiresAuthentication: true }
+      },
     ]
   },
   {

--- a/shell/config/router/routes.js
+++ b/shell/config/router/routes.js
@@ -142,7 +142,7 @@ export default [
         path:      '/c/:cluster/readme',
         component: () => interopDefault(import('@shell/pages/readme.vue')),
         name:      'readme',
-        meta:      { requiresAuthentication: true }
+        meta:      { requiresAuthentication: true, standalone: true }
       },
     ]
   },

--- a/shell/mixins/brand.js
+++ b/shell/mixins/brand.js
@@ -183,7 +183,8 @@ export default {
     },
     setBodyClass() {
       const body = document.getElementsByTagName('body')[0];
-      const cssClass = `overflow-hidden dashboard-body`;
+      const isStandalone = this.$route?.meta?.standalone;
+      const cssClass = isStandalone ? 'dashboard-body' : 'overflow-hidden dashboard-body';
       let bodyClass = `theme-${ this.theme } ${ cssClass }`;
 
       if ( this.brand ) {

--- a/shell/pages/__tests__/readme.test.ts
+++ b/shell/pages/__tests__/readme.test.ts
@@ -1,0 +1,49 @@
+import Readme from '@shell/pages/readme.vue';
+
+describe('page: Readme', () => {
+  describe('computed', () => {
+    it('showAppReadme defaults to false', () => {
+      const thisContext = { $route: { query: {} } };
+
+      const result = (Readme.computed!.showAppReadme as () => boolean).call(thisContext);
+
+      expect(result).toBe(false);
+    });
+
+    it('hideReadmeFirstTitle defaults to false', () => {
+      const thisContext = { $route: { query: {} } };
+
+      const result = (Readme.computed!.hideReadmeFirstTitle as () => boolean).call(thisContext);
+
+      expect(result).toBe(false);
+    });
+
+    it('parses showAppReadme and hideReadmeFirstTitle from query', () => {
+      const thisContext = {
+        $route: {
+          query: {
+            showAppReadme:        'true',
+            hideReadmeFirstTitle: 'true',
+          }
+        }
+      };
+
+      const showAppReadme = (Readme.computed!.showAppReadme as () => boolean).call(thisContext);
+      const hideReadmeFirstTitle = (Readme.computed!.hideReadmeFirstTitle as () => boolean).call(thisContext);
+
+      expect(showAppReadme).toBe(true);
+      expect(hideReadmeFirstTitle).toBe(true);
+    });
+  });
+
+  describe('fetch', () => {
+    it('calls fetchChart', async() => {
+      const fetchChart = jest.fn();
+      const thisContext = { fetchChart };
+
+      await (Readme.fetch as () => Promise<void>).call(thisContext);
+
+      expect(fetchChart).toHaveBeenCalledWith();
+    });
+  });
+});

--- a/shell/pages/c/_cluster/apps/charts/__tests__/chart.test.ts
+++ b/shell/pages/c/_cluster/apps/charts/__tests__/chart.test.ts
@@ -1,5 +1,8 @@
 import Chart from '@shell/pages/c/_cluster/apps/charts/chart.vue';
 import { APP_UPGRADE_STATUS } from '@shell/store/catalog';
+import {
+  CHART, REPO, REPO_TYPE, VERSION, DEPRECATED
+} from '@shell/config/query-params';
 
 jest.mock('clipboard-polyfill', () => ({ writeText: () => {} }));
 
@@ -319,6 +322,43 @@ describe('page: Chart Detail', () => {
       expect(result[0].label).toBe('default/app-one');
       expect(result[1].label).toBe('kube-system/app-two (generic.upgradeable)');
       expect(result[2].label).toBe('monitoring/app-three');
+    });
+  });
+
+  describe('methods: openReadme', () => {
+    it('opens standalone readme URL with chart context and without theme query', () => {
+      const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+      const resolve = jest.fn(() => ({ href: '/c/local/readme?x=y' }));
+      const thisContext = {
+        $router: { resolve },
+        $route:  { params: { cluster: 'local' } },
+        query:   {
+          repoType:    'cluster',
+          repoName:    'rancher-charts',
+          chartName:   'test-chart',
+          versionName: '',
+          deprecated:  'false',
+        },
+        targetVersion: '1.2.3'
+      };
+
+      (Chart.methods!.openReadme as () => void).call(thisContext);
+
+      expect(resolve).toHaveBeenCalledWith({
+        name:   'readme',
+        params: { cluster: 'local' },
+        query:  {
+          [REPO_TYPE]:          'cluster',
+          [REPO]:               'rancher-charts',
+          [CHART]:              'test-chart',
+          [VERSION]:            '1.2.3',
+          [DEPRECATED]:         'false',
+          showAppReadme:        'false',
+          hideReadmeFirstTitle: 'false',
+        }
+      });
+      expect(openSpy).toHaveBeenCalledWith('/c/local/readme?x=y', '_blank');
+      openSpy.mockRestore();
     });
   });
 });

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -14,7 +14,7 @@ import { isMissingDate } from '@shell/utils/time';
 import { escapeHtml } from '@shell/utils/string';
 import { mapGetters } from 'vuex';
 import { APP_UPGRADE_STATUS, compatibleVersionsFor } from '@shell/store/catalog';
-import { compareChartVersions } from '@shell/utils/chart';
+import { compareChartVersions, getStandaloneReadmeUrl } from '@shell/utils/chart';
 import AppChartCardSubHeader from '@shell/pages/c/_cluster/apps/charts/AppChartCardSubHeader';
 import AppChartCardFooter from '@shell/pages/c/_cluster/apps/charts/AppChartCardFooter';
 import day from 'dayjs';
@@ -364,6 +364,20 @@ export default {
           [VERSION]: version,
         }
       };
+    },
+    openReadme() {
+      const url = getStandaloneReadmeUrl(this.$router, {
+        cluster:              this.$route.params.cluster,
+        repoType:             this.query.repoType,
+        repoName:             this.query.repoName,
+        chartName:            this.query.chartName,
+        versionName:          this.query.versionName || this.targetVersion,
+        deprecated:           this.query.deprecated,
+        showAppReadme:        false,
+        hideReadmeFirstTitle: false,
+      });
+
+      window.open(url, '_blank');
     }
   },
 };
@@ -535,13 +549,27 @@ export default {
     </div>
 
     <div class="chart-body">
-      <ChartReadme
+      <div
         v-if="hasReadme"
-        :version-info="versionInfo"
-        :show-app-readme="false"
-        :hide-readme-first-title="false"
-        class="chart-body__readme"
-      />
+        class="readme-wrapper"
+      >
+        <RcButton
+          v-clean-tooltip="t('catalog.chart.viewReadmeSeparately.tooltip')"
+          class="open-readme-button"
+          secondary
+          rightIcon="external-link"
+          @click="openReadme()"
+        >
+          {{ t('catalog.chart.viewReadmeSeparately.label') }}
+          <span class="sr-only">{{ t('generic.opensInNewTab') }}</span>
+        </RcButton>
+        <ChartReadme
+          :version-info="versionInfo"
+          :show-app-readme="false"
+          :hide-readme-first-title="false"
+          class="chart-body__readme"
+        />
+      </div>
       <div
         v-else
         class="chart-body__readme"
@@ -827,9 +855,31 @@ export default {
 
   .chart-body {
     display: flex;
-    &__readme {
+    .readme-wrapper {
+      position: relative;
       flex: 1;
       min-width: 400px;
+
+      .open-readme-button {
+        display: flex;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 100ms ease-in;
+        position: absolute;
+        top: 12px;
+        right: 24px;
+      }
+
+      &:hover,
+      &:focus-within {
+        .open-readme-button {
+          opacity: 1;
+          pointer-events: auto;
+        }
+      }
+    }
+
+    &__readme {
       padding: 12px 24px;
     }
     &__info {

--- a/shell/pages/readme.vue
+++ b/shell/pages/readme.vue
@@ -1,0 +1,88 @@
+<script>
+import Loading from '@shell/components/Loading';
+import ChartReadme from '@shell/components/ChartReadme';
+import ChartMixin from '@shell/mixins/chart';
+import isEqual from 'lodash/isEqual';
+
+const readQueryBool = (value, defaultValue) => {
+  if (value === undefined) {
+    return defaultValue;
+  }
+
+  return `${ value }` === 'true';
+};
+
+export default {
+  components: {
+    ChartReadme,
+    Loading,
+  },
+
+  mixins: [ChartMixin],
+
+  async fetch() {
+    await this.fetchChart();
+  },
+
+  computed: {
+    showAppReadme() {
+      return readQueryBool(this.$route.query.showAppReadme, false);
+    },
+
+    hideReadmeFirstTitle() {
+      return readQueryBool(this.$route.query.hideReadmeFirstTitle, false);
+    }
+  },
+
+  watch: {
+    '$route.query'(neu, old) {
+      if (!isEqual(neu, old) && Object.keys(neu).length > 0) {
+        this.$fetch();
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" />
+  <main
+    v-else
+    class="readme-page"
+  >
+    <div
+      v-if="versionInfoError"
+      class="readme-page__content"
+    >
+      {{ versionInfoError }}
+    </div>
+    <ChartReadme
+      v-else-if="hasReadme"
+      :version-info="versionInfo"
+      :show-app-readme="showAppReadme"
+      :hide-readme-first-title="hideReadmeFirstTitle"
+      class="readme-page__content"
+    />
+    <div
+      v-else
+      class="readme-page__content"
+    >
+      {{ t('catalog.install.appReadmeMissing', {}, true) }}
+    </div>
+  </main>
+</template>
+
+<style lang="scss" scoped>
+.readme-page {
+  box-sizing: border-box;
+  min-height: 100%;
+  padding: 24px;
+  background-color: var(--body-bg);
+  color: var(--body-text);
+
+  &__content {
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+}
+</style>

--- a/shell/utils/__tests__/chart.test.ts
+++ b/shell/utils/__tests__/chart.test.ts
@@ -1,4 +1,7 @@
-import { compareChartVersions } from '@shell/utils/chart';
+import { compareChartVersions, getStandaloneReadmeUrl } from '@shell/utils/chart';
+import {
+  CHART, REPO, REPO_TYPE, VERSION, DEPRECATED
+} from '@shell/config/query-params';
 
 describe('compareChartVersions', () => {
   describe('standard SemVer Comparison', () => {
@@ -91,6 +94,66 @@ describe('compareChartVersions', () => {
       expect(compareChartVersions('invalid', '1.0.0')).not.toBe(0);
       expect(compareChartVersions('a', 'b')).toBe(-1);
       expect(compareChartVersions('b', 'a')).toBe(1);
+    });
+  });
+});
+
+describe('getStandaloneReadmeUrl', () => {
+  it('builds readme route with defaults', () => {
+    const router = { resolve: jest.fn(() => ({ href: '/c/local/readme' })) };
+
+    const href = getStandaloneReadmeUrl(router as any, {
+      cluster:     'local',
+      repoType:    'cluster',
+      repoName:    'rancher-charts',
+      chartName:   'my-chart',
+      versionName: '1.2.3',
+      deprecated:  'false',
+    });
+
+    expect(href).toBe('/c/local/readme');
+    expect(router.resolve).toHaveBeenCalledWith({
+      name:   'readme',
+      params: { cluster: 'local' },
+      query:  {
+        [REPO_TYPE]:          'cluster',
+        [REPO]:               'rancher-charts',
+        [CHART]:              'my-chart',
+        [VERSION]:            '1.2.3',
+        [DEPRECATED]:         'false',
+        showAppReadme:        'true',
+        hideReadmeFirstTitle: 'true'
+      }
+    });
+  });
+
+  it('builds readme route with explicit options', () => {
+    const router = { resolve: jest.fn(() => ({ href: '/c/c-abc/readme' })) };
+
+    const href = getStandaloneReadmeUrl(router as any, {
+      cluster:              'c-abc',
+      repoType:             'cluster',
+      repoName:             'partner-charts',
+      chartName:            'other-chart',
+      versionName:          '9.9.9',
+      deprecated:           'true',
+      showAppReadme:        false,
+      hideReadmeFirstTitle: false,
+    });
+
+    expect(href).toBe('/c/c-abc/readme');
+    expect(router.resolve).toHaveBeenCalledWith({
+      name:   'readme',
+      params: { cluster: 'c-abc' },
+      query:  {
+        [REPO_TYPE]:          'cluster',
+        [REPO]:               'partner-charts',
+        [CHART]:              'other-chart',
+        [VERSION]:            '9.9.9',
+        [DEPRECATED]:         'true',
+        showAppReadme:        'false',
+        hideReadmeFirstTitle: 'false'
+      }
     });
   });
 });

--- a/shell/utils/chart.js
+++ b/shell/utils/chart.js
@@ -1,6 +1,9 @@
 import semver from 'semver';
 import { compare } from '@shell/utils/version';
 import { compatibleVersionsFor } from '@shell/store/catalog';
+import {
+  CHART, REPO, REPO_TYPE, VERSION, DEPRECATED
+} from '@shell/config/query-params';
 
 /**
  * Compares two chart versions using SemVer logic, with special handling for Rancher's "up" build metadata.
@@ -79,4 +82,37 @@ export function getLatestCompatibleVersion(chart, workerOSs, showPrerelease) {
   const compatible = compatibleVersionsFor(chart, workerOSs, showPrerelease);
 
   return (compatible.length ? compatible[0] : chart.versions[0]) || {};
+}
+
+/**
+ * Builds the route URL for the standalone chart readme page.
+ *
+ * The helper maps chart context into query params so the readme page can fetch
+ * version info directly (instead of relying on local/session storage transfer).
+ */
+export function getStandaloneReadmeUrl(router, {
+  cluster,
+  repoType,
+  repoName,
+  chartName,
+  versionName,
+  deprecated,
+  showAppReadme = true,
+  hideReadmeFirstTitle = true,
+} = {}) {
+  const { href } = router.resolve({
+    name:   'readme',
+    params: { cluster },
+    query:  {
+      [REPO_TYPE]:          repoType,
+      [REPO]:               repoName,
+      [CHART]:              chartName,
+      [VERSION]:            versionName,
+      [DEPRECATED]:         deprecated,
+      showAppReadme:        String(showAppReadme),
+      hideReadmeFirstTitle: String(hideReadmeFirstTitle),
+    }
+  });
+
+  return href;
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14919

Added a "View separately" action on chart detail readme that opens a standalone, auth-protected readme page in a new tab.

### Occurred changes and/or fixed issues
- Added `readme` route: `/c/:cluster/readme` with `requiresAuthentication: true`.
- Added standalone readme page to render chart readme content only.
- Added chart detail readme action button (hover/focus visible) to open standalone readme.
- Added readme URL helper for route/query generation.
- Added i18n entries for readme action label/tooltip.
- Updated interaction styling for button visibility and pointer behavior.

### Technical notes summary
- Route uses existing auth guard behavior via `requiresAuthentication`.
- Added helper + unit coverage for URL generation and readme open behavior.
- Added readme page tests for query parsing and fetch flow.

### Areas or cases that should be tested
- Chart detail: button visibility on hover/focus and click behavior.
- New-tab readme: content-only layout, no side nav/header.
- Auth: unauthenticated access to `/c/:cluster/readme`.
- Theme: light/dark rendering in standalone readme.
- Keyboard navigations.

### Areas which could experience regressions
- Chart detail readme action area (hover/focus/click behavior).
- Query-based chart context propagation to readme page.
- Standalone layout/theming behavior.
- Keyboard navigations.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/b78f0a8d-2c09-464c-800e-2ff4a387c4c6


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
