### PR TITLE
feat: hide create namespace button based on project schema permissions

### DIFF
--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -295,7 +295,8 @@ export default {
       return this.$store.getters['i18n/t']('resourceTable.groupLabel.notInAProject');
     },
     showCreateNsButton() {
-      return this.groupPreference !== 'namespace';
+      const canCreateNamespace = this.schema?.collectionMethods?.includes('POST');
+      return this.groupPreference !== 'namespace' && canCreateNamespace;
     },
     projectGroupBy() {
       return this.groupPreference === 'none' ? null : 'groupById';

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -295,9 +295,7 @@ export default {
       return this.$store.getters['i18n/t']('resourceTable.groupLabel.notInAProject');
     },
     showCreateNsButton() {
-      const canCreateNamespace = this.schema?.collectionMethods?.includes('POST');
-
-      return this.groupPreference !== 'namespace' && canCreateNamespace;
+      return this.groupPreference !== 'namespace' && this.isNamespaceCreatable;
     },
     projectGroupBy() {
       return this.groupPreference === 'none' ? null : 'groupById';

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -296,6 +296,7 @@ export default {
     },
     showCreateNsButton() {
       const canCreateNamespace = this.schema?.collectionMethods?.includes('POST');
+
       return this.groupPreference !== 'namespace' && canCreateNamespace;
     },
     projectGroupBy() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes # https://github.com/harvester/harvester/issues/10241

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
feat: hide create namespace button based on project schema permissions. If no POST methods in schema (read-only) user, hide the create namespace button on project/namespace page.

<img width="1376" height="513" alt="Screenshot 2026-05-05 at 3 03 24 PM" src="https://github.com/user-attachments/assets/57b6bf3d-9f2c-4d81-8bc1-76c7c1cd8c31" />

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

<img width="1489" height="820" alt="Screenshot 2026-05-05 at 3 19 39 PM" src="https://github.com/user-attachments/assets/83ada53a-5f60-45c1-b969-80deb4de2aec" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
