### PR TITLE
add missing repo owner gate to a job for extension workflows

### DIFF
--- a/.github/workflows/test-extension-workflows-master.yml
+++ b/.github/workflows/test-extension-workflows-master.yml
@@ -108,7 +108,7 @@ jobs:
       tag: ${{ needs.retrieve-tags-master.outputs.CREATORS_TAG }}
 
   slack-message:
-    if: ${{ always() }}
+    if: ${{ always() && github.repository_owner == 'rancher' }}
     runs-on: ubuntu-latest
     needs: [creators-shipped-worflows-checks, test-extensions-creators-and-update-paths, retrieve-tags-master, test-build-extension-charts-master, test-build-extension-catalog-master, test-release-shell-pkg-master, test-release-creators-pkg-master]
     steps: 

--- a/.github/workflows/test-extension-workflows-release-2.8.yml
+++ b/.github/workflows/test-extension-workflows-release-2.8.yml
@@ -76,7 +76,7 @@ jobs:
       tag: ${{ needs.retrieve-tags-release-2-dot-8.outputs.CREATORS_TAG }}
 
   slack-message:
-    if: ${{ always() }}
+    if: ${{ always() && github.repository_owner == 'rancher' }}
     runs-on: ubuntu-latest
     needs: [retrieve-tags-release-2-dot-8, test-build-extension-charts-release-2-dot-8, test-build-extension-catalog-release-2-dot-8, test-release-shell-pkg-release-2-dot-8, test-release-creators-pkg-release-2-dot-8]
     steps: 

--- a/.github/workflows/test-extension-workflows-release-2.9.yml
+++ b/.github/workflows/test-extension-workflows-release-2.9.yml
@@ -76,7 +76,7 @@ jobs:
       tag: ${{ needs.retrieve-tags-release-2-dot-9.outputs.CREATORS_TAG }}
 
   slack-message:
-    if: ${{ always() }}
+    if: ${{ always() && github.repository_owner == 'rancher' }}
     runs-on: ubuntu-latest
     needs: [retrieve-tags-release-2-dot-9, test-build-extension-charts-release-2-dot-9, test-build-extension-catalog-release-2-dot-9, test-release-shell-pkg-release-2-dot-9, test-release-creators-pkg-release-2-dot-9]
     steps: 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17489 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Should prevent having any failures on `test-extension-workflows-*` workflows since the only job that's missing a gate in terms of ownership was the slack post job

**IMPORTANT NOTICE: Every user needs to update their forks after this code get's merged**

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
