### PR TITLE
Adjust tooltip if links.shell is disabled

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -219,6 +219,7 @@ nav:
   import: Import YAML
   home: Home
   shell: Kubectl Shell
+  shellDisabledTooltip: Shell access has been disabled by your cluster administrator
   shellShortcut: Kubectl Shell {key}
   support: |-
     {hasSupport, select,

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -155,6 +155,7 @@ export default {
       if (!this.shellEnabled) {
         return this.t('nav.shellDisabledTooltip');
       }
+
       return this.t('nav.shellShortcut', { key: this.shellShortcut });
     },
 

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -151,6 +151,13 @@ export default {
       return !!this.currentCluster?.links?.shell;
     },
 
+    shellTooltip() {
+      if (!this.shellEnabled) {
+        return this.t('nav.shellDisabledTooltip');
+      }
+      return this.t('nav.shellShortcut', { key: this.shellShortcut });
+    },
+
     showKubeShell() {
       return !this.rootProduct?.hideKubeShell;
     },
@@ -627,7 +634,7 @@ export default {
           <button
             v-if="showKubeShell"
             id="btn-kubectl"
-            v-clean-tooltip="t('nav.shellShortcut', {key: shellShortcut})"
+            v-clean-tooltip="shellTooltip"
             v-shortkey="{windows: ['ctrl', '`'], mac: ['meta', '`']}"
             :disabled="!shellEnabled"
             type="button"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/17516

Partial fix for SURE-8604
<!-- Define findings related to the feature or bug issue. -->

Overall dashboard does well to gracefully handle with `links.shell` is not defined by backend.
This PR enhances the primary header level Shell button with a clear tooltip explaining feature access restriction.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

When new feature flag is disabled the Shell button will provide more helpful tooltip.
Potentially our professional word-smiths have a better suggestion for the text there.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Very minimal logic change involved to pick between default tooltip and new disabled text.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

The new Shell feature flag should be toggled off and then the new tooltip can be confirmed.
When the feature is enable the Kubectl Shell should still work.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- Any tests that rely on Shell will break if the Feature flag (backend) is set to `false` to disable shell.
- Any test cases that specifically read the tooltip of the Shell button in the header.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
