### PR TITLE
feat: support separate administration hostname for keycloak provider

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -776,6 +776,7 @@ authConfig:
     jwksUrl: JWKS URL
     tokenEndpoint: Token Endpoint
     userInfoEndpoint: User Info Endpoint
+    adminEndpoint: Administration API Endpoint
     acrValue: Authorization Context Reference
     customClaims:
       label: Custom Claims

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -556,6 +556,7 @@ authConfig:
       realm: Keycloak Realm
     issuer: 发行者
     authEndpoint: Auth 端点
+    adminEndpoint: Administration API 端点
     cert:
       label: 证书
       placeholder: 粘贴证书，以-----BEGIN CERTIFICATE----- 开始。

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -626,6 +626,20 @@ export default {
                 />
               </div>
             </div>
+
+            <div
+              v-if="isKeycloak"
+              class="row mb-20"
+            >
+              <div class="col span-6">
+                <LabeledInput
+                  v-model:value="model.adminEndpoint"
+                  :label="t(`authConfig.oidc.adminEndpoint`)"
+                  :mode="mode"
+                  :disabled="!customEndpoint.value"
+                />
+              </div>
+            </div>
           </AdvancedSection>
         </template>
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/rancher/issues/53967
Related: https://github.com/rancher/rancher/pull/54958
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Add a new advanced option `Administration API Endpoint` to the Keycloak OIDC provider configuration.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
The primary motivation for this change is to support scenarios where Keycloak Administration endpoints are exposed on a separate hostname according to [best practices](https://www.keycloak.org/server/configuration-production#_exposing_the_keycloak_administration_apis_and_ui_on_a_different_hostname).

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Configure Keycloak OIDC and ensure that the new field persists on save/edit.
The new field should only be rendered on the Keycloak OIDC provider form.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Unsure.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
