### PR TITLE
Fixed add on values being reset on cluster edit

### DIFF
--- a/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-rke2-custom.po.ts
+++ b/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-rke2-custom.po.ts
@@ -1,4 +1,6 @@
 import ClusterManagerCreateImportPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/cluster-create-import.po';
+import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
+import AddonConfigPo from '@/cypress/e2e/po/components/addon-config.po';
 
 /**
  * Edit page for an RKE2 custom cluster
@@ -14,5 +16,13 @@ export default class ClusterManagerEditRke2CustomPagePo extends ClusterManagerCr
 
   constructor(clusterId = '_', clusterName: string) {
     super(ClusterManagerEditRke2CustomPagePo.createPath(clusterId, clusterName));
+  }
+
+  clusterConfigurationTabs(): TabbedPo {
+    return new TabbedPo();
+  }
+
+  calicoAddonConfig(): AddonConfigPo {
+    return new AddonConfigPo();
   }
 }

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -326,6 +326,35 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
           expect(obj.kind).to.equal('Cluster');
         });
       });
+      it('preserves custom addon config values after saving cluster config', () => {
+        const customAddonConfig = `goodvalue: yay\nnested:\n  enabled: true`;
+        const updatedDescription = `${ rke2CustomName }-addon-persist-check`;
+
+        clusterList.goTo();
+        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
+
+        editCreatedClusterPage().waitForPage('mode=edit', 'basic');
+        editCreatedClusterPage().clusterConfigurationTabs().clickTabWithSelector('#rke2-calico');
+        editCreatedClusterPage().calicoAddonConfig().yamlEditor().input()
+          .set(customAddonConfig);
+        editCreatedClusterPage().save();
+
+        clusterList.waitForPage();
+        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
+
+        editCreatedClusterPage().waitForPage('mode=edit', 'basic');
+        editCreatedClusterPage().nameNsDescription().description().set(updatedDescription);
+        editCreatedClusterPage().save();
+
+        clusterList.waitForPage();
+        clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
+
+        editCreatedClusterPage().waitForPage('mode=edit', 'basic');
+        editCreatedClusterPage().clusterConfigurationTabs().clickTabWithSelector('#rke2-calico');
+        editCreatedClusterPage().calicoAddonConfig().yamlEditor().input()
+          .value()
+          .should('equal', customAddonConfig);
+      });
 
       it('can delete cluster', () => {
         clusterList.goTo();

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -174,7 +174,7 @@ export default {
     Object.entries(this.chartValues).forEach(([name, value]) => {
       const key = this.chartVersionKey(name);
 
-      this.set(this.userChartValues, key, value);
+      this.userChartValues[key] = value;
     });
     this.setAgentConfiguration();
   },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17498 
<!-- Define findings related to the feature or bug issue. -->
Fixed Add On config values being reset on cluster edit.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This is a regression introduced as part of the Traefik change.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Create a cluster with non-default config of cilium add on
2. Go to edit that cluster. Make sure add-on's config is displayed correctly.
3. Edit some unrelated field. Save
4.  Go to edit that cluster. Make sure add-on's config matches original configuration.
5. Repeat for other add on providers

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
