### PR TITLE
[backport v2.13.6] Refine matching charts for apps

### DIFF
--- a/shell/models/__tests__/catalog.cattle.io.app.test.ts
+++ b/shell/models/__tests__/catalog.cattle.io.app.test.ts
@@ -87,6 +87,19 @@ const certManagerOfficialMatchingChart2 = {
   }]
 };
 
+// Simulates the chart data fetched from the repository where the home URL has changed in newer versions
+// AND the older installed version has been dropped/replaced from the repository index.
+const certManagerOfficialMatchingChartNewHomeOnly = {
+  name:     chartName,
+  repoName: certManagerOfficial.repoName,
+  versions: [{
+    version:     latestVersion,
+    home:        certManagerOfficial.home,
+    repoName:    certManagerOfficial.repoName,
+    annotations: {},
+  }]
+};
+
 const installedCertManagerAppCoFromRancherUI = {
   metadata: {
     annotations: { [CATALOG_ANNOTATIONS.SOURCE_REPO_NAME]: appCo.repoName },
@@ -130,7 +143,8 @@ describe('class CatalogApp', () => {
       [installedCertManagerOfficialFromRancherUI, [], APP_UPGRADE_STATUS.NO_UPGRADE],
       [installedCertManagerOfficialFromRancherUI, [certManagerOfficialMatchingChart1], APP_UPGRADE_STATUS.SINGLE_UPGRADE],
       [installedCertManagerOfficialFromRancherUI, [certManagerOfficialMatchingChart1, appCoMatchingChart1], APP_UPGRADE_STATUS.SINGLE_UPGRADE],
-      [installedCertManagerOfficialFromRancherUI, [certManagerOfficialMatchingChart1, certManagerOfficialMatchingChart2], APP_UPGRADE_STATUS.MULTIPLE_UPGRADES]
+      [installedCertManagerOfficialFromRancherUI, [certManagerOfficialMatchingChart1, certManagerOfficialMatchingChart2], APP_UPGRADE_STATUS.MULTIPLE_UPGRADES],
+      [installedCertManagerOfficialFromRancherUI, [certManagerOfficialMatchingChartNewHomeOnly], APP_UPGRADE_STATUS.SINGLE_UPGRADE]
     ];
 
     it.each(testCases)('should return the correct upgrade status', (installedChart: Object, matchingCharts: any, expected: any) => {

--- a/shell/models/catalog.cattle.io.app.js
+++ b/shell/models/catalog.cattle.io.app.js
@@ -78,28 +78,32 @@ export default class CatalogApp extends SteveModel {
       return [];
     }
 
-    // Filtering matches by verifying if the current version is in the matched chart's available versions, and that the home value matches as well
-    const thisHome = chart?.metadata?.home;
-    const bestMatches = matchingCharts.filter(({ versions }) => {
-      // First checking if the latest version has the same home value
-      if (thisHome === versions[0]?.home) {
-        return true;
-      }
-
-      for (let i = 1; i < versions.length; i++) {
-        const { version, home } = versions[i];
-
-        // Finding the exact version, if the version is not there, then most likely it's not a match
-        // if the exact version is found, then we can compare the home value
-        if (version === this.currentVersion && (home === thisHome)) {
+    if (!repoName || matchingCharts.length > 1) {
+      // Filtering matches by verifying if the current version is in the matched chart's available versions, and that the home value matches as well
+      const thisHome = chart?.metadata?.home;
+      const bestMatches = matchingCharts.filter(({ versions }) => {
+        // First checking if the latest version has the same home value
+        if (thisHome === versions[0]?.home) {
           return true;
         }
-      }
 
-      return false;
-    });
+        for (let i = 1; i < versions.length; i++) {
+          const { version, home } = versions[i];
 
-    return bestMatches;
+          // Finding the exact version, if the version is not there, then most likely it's not a match
+          // if the exact version is found, then we can compare the home value
+          if (version === this.currentVersion && (home === thisHome)) {
+            return true;
+          }
+        }
+
+        return false;
+      });
+
+      return bestMatches;
+    }
+
+    return matchingCharts;
   }
 
   get currentVersion() {


### PR DESCRIPTION
Backports PR #16568 to release-2.13.

Refines the logic for identifying matching charts for installed applications to improve the accuracy of upgrade status detection.

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17377 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Skipped `home` URL validation when a chart has a repository and exactly one match. This allows upgrades to proceed when the upstream chart's `home` URL changes in a newer version.

### Technical notes summary
I've wrapped the existing `home` URL filtering logic inside an `if (!repoName || matchingCharts.length > 1)` condition. This ensures we still correctly prevent suggesting updates from a UI-added repo for charts installed via CLI. At the same time, it avoids unnecessary home URL checks when only a single match is found among the existing repositories. Also added a unit test.

### Areas or cases that should be tested
Testing the real scenario explained in SURE-11006 is tricky. If you can't test it by yourself you might need to do this: 

1. Apps > Repositories > Create a repo using my testing helm repo URL `https://momesgin.github.io/mo-charts/`
2. Install version **0.2.0**
3. Make sure on **Installed Apps** page the **Upgradable** column displays **0.3.0** in front of the chart
4. Ping me to update the repo by replacing the old home URL
5. Refresh the repo and check the Installed Apps page again
6. Without my fix the **Upgradable** column should NOT display **0.3.0** in front of the chart, but with my fix it **should**

### Areas which could experience regressions
- Make sure `cert-manager` installed via CLI doesn't get an upgrade suggestion from a repository added to the UI that also has `cert-manager` chart(e.g. AppCo). For more info you can check [the original issue](https://github.com/rancher/dashboard/issues/11465).

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
