### PR TITLE
Improve race conditions around detail/edit page --> list transitions

### DIFF
--- a/shell/plugins/dashboard-store/actions.js
+++ b/shell/plugins/dashboard-store/actions.js
@@ -697,10 +697,22 @@ export default {
       }
     }
 
+    const havePage = getters.havePage(type);
+
     opt = opt || {};
     opt.url = getters.urlFor(type, id, opt);
 
     const res = await dispatch('request', { opt, type });
+
+    if (!havePage && getters.havePage(type)) {
+      // There may be a super edge case where list --> detail (whilst loading) --> list navigation causes the list's rows to disappear
+      // Somehow the `findPage` from the list page returns before the `find`. The `find` then clears the page state in the cache.
+      // If this has happened silently return (we don't care about result)
+      // https://github.com/rancher/dashboard/issues/17524
+      console.warn(`Prevented \`find\` action from polluting cache for type "${ type }" (currently represents a page).`); // eslint-disable-line no-console
+
+      return;
+    }
 
     if (!opt.transient) {
       await dispatch('load', { data: res, invalidatePageCache: opt.invalidatePageCache });

--- a/shell/plugins/steve/__tests__/subscribe.spec.ts
+++ b/shell/plugins/steve/__tests__/subscribe.spec.ts
@@ -343,7 +343,7 @@ describe('steve: subscribe', () => {
 
         // call watch
         actions.watch({
-          state, dispatch, getters, rootGetters
+          state, dispatch, getters, rootGetters, commit
         }, {
           ...obj,
           revision,
@@ -488,6 +488,7 @@ describe('steve: subscribe', () => {
         const state = {
           started:         [],
           inError:         {},
+          queue:           [],
           listenerManager: new SteveWatchEventListenerManager()
         };
         const _getters = {

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -553,7 +553,7 @@ const sharedActions = {
    * @param {STEVE_WATCH_PARAMS} params
    */
   watch({
-    state, dispatch, getters, rootGetters
+    state, dispatch, getters, rootGetters, commit
   }, params) {
     state.debugSocket && console.info(`Watch Request [${ getters.storeName }]`, JSON.stringify(params)); // eslint-disable-line no-console
     let {
@@ -620,6 +620,9 @@ const sharedActions = {
         if (debounceMs) {
           msg.debounceMs = debounceMs;
         }
+
+        // Anything in the queue will pollute the result set, so clear (and print to console so we know it's working)
+        commit('clearFromQueue', { type, log: true });
       }
     }
 
@@ -1556,10 +1559,20 @@ const defaultMutations = {
     state.socketListenerManager = new SteveWatchEventListenerManager(state.config.namespace);
   },
 
-  clearFromQueue(state, type) {
+  clearFromQueue(state, args) {
+    const safeArgs = typeof args === 'object' ? args : { type: args };
+    const { type, log } = safeArgs;
+
     // Remove anything in the queue that is a resource update for the given type
     state.queue = state.queue.filter((item) => {
-      return item.body?.type !== type;
+      const keep = item.body?.type !== type;
+
+      if (!keep && log) {
+        // eslint-disable-next-line no-console
+        console.info(`Clearing queued item of type \`${ type }\` from queue`, item);
+      }
+
+      return keep;
     });
   },
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17524
Contributes to #16794
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- detail pages or edit pages work with a single resource cached in the store
- when navigating back from those pages to a list view we clear the cache and populate it with a pages worth of resources (if in vai world)
- there's a number of ways where the detail/edit pages can still be processing socket messages during the transition to the list page and afterwards
- in some places we stop them at source (the cache contains a page and we receive a change message for a single resource --> log messages `Prevented watch resource.change data from polluting the cache..`
- in other places we stop them when the messages have been added to a queue and processed after page change (log messages `Prevented loadMulti mutation from polluting the cache...`)
  - this PR improves this process by clearing the queue when we're loading a list, so in theory we shouldn't now even hit the `loadMulti` part
  - this contributes to #16794
- #17524 introduces another possible way
  - the response to the detail pages 'find' is processed after the list page calls and populates the cache
  - this PR now checks if the cache has transitioned from no page --> have page and if so abort the 'find' mechanism


### Areas or cases that should be tested
- As per issue

### Areas which could experience regressions
- unwatch might be affected given the change in signature of clearFromQueue. this is called often though (for instance when we leave a list page)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
