### PR TITLE
Automation: Update extension card status icon PO and use stg registry for e2e tests

### DIFF
--- a/cypress/e2e/po/pages/extensions.po.ts
+++ b/cypress/e2e/po/pages/extensions.po.ts
@@ -210,12 +210,12 @@ export default class ExtensionsPagePo extends PagePo {
     return this.clickAction(extensionTitle, 'Uninstall');
   }
 
-  extensionCardHeaderStatusIcons(extensionTitle: string, index: number): Cypress.Chainable {
-    return this.extensionCard(extensionTitle).self().find(`[data-testid="item-card-header-status-${ index }"]`);
+  extensionCardHeaderStatusIcons(extensionTitle: string, selector: 'upgrade' | 'confirmation' | 'alert'): Cypress.Chainable {
+    return this.extensionCard(extensionTitle).self().find(`[data-testid="item-card-header-statuses-status"] .icon-${ selector }-alt`);
   }
 
-  extensionCardHeaderStatusTooltip(extensionTitle: string, index: number): TooltipPo {
-    return new TooltipPo(this.extensionCardHeaderStatusIcons(extensionTitle, index));
+  extensionCardHeaderStatusTooltip(extensionTitle: string, selector: 'upgrade' | 'confirmation' | 'alert'): TooltipPo {
+    return new TooltipPo(this.extensionCardHeaderStatusIcons(extensionTitle, selector));
   }
 
   // ------------------ extension install modal ------------------

--- a/cypress/e2e/tests/pages/charts/question-tabs.spec.ts
+++ b/cypress/e2e/tests/pages/charts/question-tabs.spec.ts
@@ -15,7 +15,7 @@ describe('Charts Install', { tags: ['@charts', '@adminUser'] }, () => {
     describe('Vsphere Cpi chart install - Tabs visibility', () => {
       it('Should not show any tabs on "Edit Options" screen if there is only 1 group', () => {
         ChartPage.navTo(null, 'vSphere CPI');
-        chartPage.waitForPage('repo-type=cluster&repo=rancher-rke2-charts&chart=rancher-vsphere-cpi&version=1.13.000');
+        chartPage.waitForPage('repo-type=cluster&repo=rancher-rke2-charts&chart=rancher-vsphere-cpi&version=1.14.000');
         chartPage.goToInstall();
         installChart.nextPage();
 

--- a/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
+++ b/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
@@ -248,7 +248,7 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
       extensionsPo.extensionCardVersion(harvesterTitle).should('contain', versions[0]);
 
       // hover checkmark - tooltip should have older version
-      extensionsPo.extensionCardHeaderStatusTooltip(harvesterTitle, 1).waitForTooltipWithText(`Installed (${ versions[1] })`);
+      extensionsPo.extensionCardHeaderStatusTooltip(harvesterTitle, 'confirmation').waitForTooltipWithText(`Installed (${ versions[1] })`);
 
       harvesterPo.goTo();
       harvesterPo.waitForPage();
@@ -276,7 +276,7 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
       extensionsPo.extensionCardVersion(harvesterTitle).should('contain', versions[0]);
 
       // hover checkmark - tooltip should have latest version
-      extensionsPo.extensionCardHeaderStatusTooltip(harvesterTitle, 0).waitForTooltipWithText(`Installed (${ versions[0] })`);
+      extensionsPo.extensionCardHeaderStatusTooltip(harvesterTitle, 'confirmation').waitForTooltipWithText(`Installed (${ versions[0] })`);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "install:ci": "yarn install --frozen-lockfile",
     "dev": "bash -c 'source ./scripts/version && NODE_ENV=dev ./node_modules/.bin/vue-cli-service serve'",
     "mem-dev": "bash -c 'source ./scripts/version && NODE_ENV=dev node --max-old-space-size=8192 ./node_modules/.bin/vue-cli-service serve'",
-    "docker:local:start": "docker run -d --restart=unless-stopped -p 80:80 -p 443:443 -e CATTLE_BOOTSTRAP_PASSWORD=password -e CATTLE_PASSWORD_MIN_LENGTH=3 --name cypress --privileged rancher/rancher:v2.13-head",
+    "docker:local:start": "docker run -d --restart=unless-stopped -p 80:80 -p 443:443 -e CATTLE_BOOTSTRAP_PASSWORD=password -e CATTLE_PASSWORD_MIN_LENGTH=3 --name cypress --privileged stgregistry.suse.com/rancher/rancher:v2.13-head",
     "docker:local:stop": "docker kill cypress || true && docker rm cypress || true",
     "docker:local:logs": "docker logs cypress > $E2E_RANCHER_LOG 2>&1",
     "k3s:local:start": "./scripts/e2e-k3s-start $RANCHER_VERSION_E2E",

--- a/scripts/e2e-docker-start
+++ b/scripts/e2e-docker-start
@@ -37,7 +37,7 @@ docker run -d --restart=unless-stopped -p 80:80 -p 443:443 ${VOLUME_ARGS} \
   -e CATTLE_TRACE=true \
   --name cypress \
   --privileged \
-  rancher/rancher:${RANCHER_IMG_VERSION} \
+  stgregistry.suse.com/rancher/rancher:${RANCHER_IMG_VERSION} \
   --features=oidc-provider=true
 
 docker ps


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2347

3 Fixes:

1) Make extension card status icon selector resilient by using class selector instead of index.
The harvester extension test selected the card's status icon by positional index, which shifted whenever a Rancher compatibility-error icon was rendered, causing flaky failures.

2) Target the staging registry for running e2e tests in the release-2.13 branch (release maintenance)

3) Chart version bump
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
