### PR TITLE
Fix percent rollout inputs

### DIFF
--- a/shell/edit/workload/Upgrading.vue
+++ b/shell/edit/workload/Upgrading.vue
@@ -133,10 +133,10 @@ export default {
       } = this;
       let { maxSurge, maxUnavailable } = this;
 
-      if (this.surgeUnits === '%' && !maxSurge.includes('%')) {
+      if (this.surgeUnits === '%' && !`${ maxSurge }`.includes('%')) {
         maxSurge = `${ maxSurge }%`;
       }
-      if (this.unavailableUnits === '%' && !maxUnavailable.includes('%')) {
+      if (this.unavailableUnits === '%' && !`${ maxUnavailable }`.includes('%')) {
         maxUnavailable = `${ maxUnavailable }%`;
       }
 
@@ -204,7 +204,7 @@ export default {
       if (units === 'Pods') {
         this[target] = parseInt(value);
       } else {
-        this[target] = `${ value }%`;
+        this[target] = value;
       }
       if (target === 'maxSurge') {
         this.surgeUnits = units;

--- a/shell/edit/workload/__tests__/Upgrading.test.ts
+++ b/shell/edit/workload/__tests__/Upgrading.test.ts
@@ -26,9 +26,9 @@ describe('component: Upgrading', () => {
   });
 
   it.each([
-    ['surge', 'maxSurge', '%'],
-    ['unavailable', 'maxUnavailable', '%'],
-  ])('should set typed value in %p into %p and unit', (_field, key, unit) => {
+    ['maxSurge', '%'],
+    ['maxUnavailable', '%'],
+  ])('should set typed value in %p with %p unit', (key, unit) => {
     const wrapper = mount(Upgrading);
     const newValue = 123;
     const expectation = `${ newValue }${ unit }`;

--- a/shell/edit/workload/__tests__/Upgrading.test.ts
+++ b/shell/edit/workload/__tests__/Upgrading.test.ts
@@ -25,20 +25,17 @@ describe('component: Upgrading', () => {
     expect(wrapper.props('value')?.[key]).toBe(newValue);
   });
 
-  // TODO: #6179: Integrate test with component fix, as the scope is not to check the value of the input
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip.each([
+  it.each([
     ['surge', 'maxSurge', '%'],
     ['unavailable', 'maxUnavailable', '%'],
-  ])('should set typed value in %p into %p and unit', (field, key, unit) => {
+  ])('should set typed value in %p into %p and unit', (_field, key, unit) => {
     const wrapper = mount(Upgrading);
-    const input = wrapper.find(`[data-testid="input-policy-${ field }"]`).find('input');
     const newValue = 123;
     const expectation = `${ newValue }${ unit }`;
 
-    input.setValue(newValue);
-    input.trigger('blur');
+    wrapper.vm.updateWithUnits({ selected: unit, text: newValue }, key);
 
+    expect(wrapper.vm[key]).toBe(newValue);
     expect(wrapper.props('value')?.strategy.rollingUpdate[key]).toBe(expectation);
   });
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #6179

Fixes percentage-based rollout inputs in the Workload Deployment form so users can type values when the unit is `%`.

### Occurred changes and/or fixed issues
- Keeps `maxSurge` and `maxUnavailable` form state as numeric input values while users edit percentage-based rollout settings.
- Appends `%` only when writing the rolling update values back to the workload spec.
- Enables regression coverage for percentage max surge and max unavailable values.

### Technical notes summary
- `InputWithSelect` is rendered with `type=\"number\"`, so storing values like `123%` in the input-bound state causes the browser to reject the value and clear the input.
- The fix preserves the numeric display value for the input while still persisting Kubernetes rollout values as strings with `%` when the selected unit is `%`.
- The `%` check now stringifies the value before calling `includes`, which also handles numeric values when switching units.

### Areas or cases that should be tested
- Workload Deployment create/edit form > Scaling and Upgrade Policy > Max Surge with `%` selected.
- Workload Deployment create/edit form > Scaling and Upgrade Policy > Max Unavailable with `%` selected.
- Switch Max Surge and Max Unavailable between `Pods` and `%`, then type values and save.
- Confirm saved workload spec stores percentage values with `%` and pod-count values without `%`.
- Local automated test run:
  - `source \"$HOME/.nvm/nvm.sh\" && nvm use 24 && yarn test:ci shell/edit/workload/__tests__/Upgrading.test.ts`

### Areas which could experience regressions
- Workload Deployment rolling update fields: Max Surge and Max Unavailable.
- Workload DaemonSet rolling update Max Unavailable field.
- Unit switching behavior between `Pods` and `%` in workload upgrade policy inputs.

### Screenshot/Video
N/A. This is a form input behavior fix covered by unit tests.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`