### PR TITLE
fix: scope configureType by product to prevent global route overrides

### DIFF
--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -73,6 +73,7 @@ export function init(store) {
   ]);
 
   configureType(SNAPSHOT, { depaginate: true });
+  configureType(CATALOG.CLUSTER_REPO, { listCreateButtonLabelKey: 'catalog.repo.add' });
 
   configureType(CAPI.RANCHER_CLUSTER, {
     showListMasthead: false, namespaced: false, alias: [HCI.CLUSTER]

--- a/shell/core/productDebugger.js
+++ b/shell/core/productDebugger.js
@@ -21,8 +21,13 @@ export function DSLRegistrationsPerProduct(store, prodName) {
     }
 
     // prod configureType
-    if (dataType === 'typeOptions' && typeMapData[dataType].filter((item) => item.customRoute && item.customRoute.name.includes(prodName))) {
-      parsedData['configureType'] = typeMapData[dataType].filter((item) => item.customRoute && item.customRoute.name.includes(prodName));
+    if (dataType === 'typeOptions') {
+      const allTypeOptions = Object.values(typeMapData[dataType]).flat();
+      const filtered = allTypeOptions.filter((item) => item.customRoute && item.customRoute.name.includes(prodName));
+
+      if (filtered.length > 0) {
+        parsedData['configureType'] = filtered;
+      }
     }
 
     // other types which map with prodName

--- a/shell/store/__tests__/type-map.test.ts
+++ b/shell/store/__tests__/type-map.test.ts
@@ -1406,19 +1406,26 @@ describe('type-map', () => {
         });
       });
 
-      it('should log error when product parameter is missing', () => {
-        const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      it('should throw error when product parameter is missing in new format (2.15+)', () => {
         const state = { typeOptions: {} } as any;
 
-        mutations.configureType(state, {
-          match:       'pod',
-          customRoute: { name: 'route' }
-        });
+        expect(() => {
+          mutations.configureType(state, {
+            match:       'pod',
+            customRoute: { name: 'route' }
+          });
+        }).toThrow(/product parameter is required/);
+      });
 
-        expect(consoleSpy).toHaveBeenCalledWith('configureType called without product parameter');
-        expect(state.typeOptions).toStrictEqual({});
+      it('should throw error with type info when product parameter is missing', () => {
+        const state = { typeOptions: {} } as any;
 
-        consoleSpy.mockRestore();
+        expect(() => {
+          mutations.configureType(state, {
+            match:       'pod',
+            customRoute: { name: 'route' }
+          });
+        }).toThrow(/for type/);
       });
 
       it('should allow different types in same product', () => {
@@ -1566,6 +1573,237 @@ describe('type-map', () => {
 
         expect(product2Opts.customRoute).toBeUndefined();
         expect(product2Opts.isCreatable).toBe(true);
+      });
+
+      describe('backward compatibility - legacy array format (Rancher 2.14)', () => {
+        it('should handle legacy array format with product field', () => {
+          const state = {
+            typeOptions: [
+              {
+                match: 'pod', product: 'explorer', customRoute: { name: 'explorer-route' }
+              },
+              {
+                match: 'pod', product: 'product-1', customRoute: { name: 'product-1-route' }
+              }
+            ]
+          } as any;
+
+          const explorerOptions = getters.optionsFor(state, {}, {}, { productId: 'explorer' });
+          const product1Options = getters.optionsFor(state, {}, {}, { productId: 'product-1' });
+
+          expect(explorerOptions('pod', false).customRoute.name).toBe('explorer-route');
+          expect(product1Options('pod', false).customRoute.name).toBe('product-1-route');
+        });
+
+        it('should handle legacy array format with entries without product field', () => {
+          const state = {
+            typeOptions: [
+              {
+                match: 'pod', product: 'explorer', customRoute: { name: 'explorer-route' }
+              },
+              { match: 'pod', customRoute: { name: 'shared-route' } }
+            ]
+          } as any;
+
+          const explorerOptions = getters.optionsFor(state, {}, {}, { productId: 'explorer' });
+          const otherProductOptions = getters.optionsFor(state, {}, {}, { productId: 'other' });
+
+          // explorer gets its product-specific entry (matches first)
+          expect(explorerOptions('pod', false).customRoute.name).toBe('explorer-route');
+
+          // other product gets only unscoped entries
+          expect(otherProductOptions('pod', false).customRoute.name).toBe('shared-route');
+        });
+      });
+
+      describe('backward compatibility - missing product parameter (old extensions in 2.15)', () => {
+        it('should reject unscoped config (requires product parameter in 2.15+)', () => {
+          const state = { typeOptions: {} } as any;
+
+          expect(() => {
+            mutations.configureType(state, {
+              match:       'pod',
+              customRoute: { name: 'legacy-route' }
+            });
+          }).toThrow(/product parameter is required/);
+        });
+
+        it('should retrieve legacyCompatibilityProdRegistration entries for products without specific config', () => {
+          const state = {
+            typeOptions: {
+              'product-1':                         [{ match: 'pod', customRoute: { name: 'product-1-route' } }],
+              legacyCompatibilityProdRegistration: [{ match: 'pod', customRoute: { name: 'legacy-route' } }]
+            }
+          } as any;
+
+          const product1Options = getters.optionsFor(state, {}, {}, { productId: 'product-1' });
+          const product2Options = getters.optionsFor(state, {}, {}, { productId: 'product-2' });
+
+          // product-1 gets its own config (takes precedence)
+          expect(product1Options('pod', false).customRoute.name).toBe('product-1-route');
+
+          // product-2 gets legacy entries
+          expect(product2Options('pod', false).customRoute.name).toBe('legacy-route');
+        });
+
+        it('should merge product-specific and legacyCompatibilityProdRegistration buckets in getter', () => {
+          const state = {
+            typeOptions: {
+              'product-1':                         [{ match: 'deployment', customRoute: { name: 'product-1-deployment-route' } }],
+              legacyCompatibilityProdRegistration: [{ match: 'pod', customRoute: { name: 'legacy-pod-route' } }]
+            }
+          } as any;
+
+          const product1Options = getters.optionsFor(state, {}, {}, { productId: 'product-1' });
+
+          // pod from legacy bucket (product-1 doesn't have pod config)
+          expect(product1Options('pod', false).customRoute.name).toBe('legacy-pod-route');
+
+          // deployment from product-specific bucket
+          expect(product1Options('deployment', false).customRoute.name).toBe('product-1-deployment-route');
+        });
+      });
+
+      describe('mixed extensions scenario (2.15 with old + new extensions)', () => {
+        it('should handle old extension (2.14 shell) + new extension (2.15 shell) in same product', () => {
+          const state = {
+            typeOptions: {
+              explorer:                            [{ match: 'pod', customRoute: { name: 'explorer-pod-route' } }],
+              legacyCompatibilityProdRegistration: [
+                { match: 'secret', customRoute: { name: 'legacy-secret-route' } },
+                { match: 'configmap', customRoute: { name: 'legacy-configmap-route' } }
+              ]
+            }
+          } as any;
+
+          const explorerOptions = getters.optionsFor(state, {}, {}, { productId: 'explorer' });
+
+          // New extension config (product-specific)
+          expect(explorerOptions('pod', false).customRoute.name).toBe('explorer-pod-route');
+
+          // Old extension configs (from legacy bucket)
+          expect(explorerOptions('secret', false).customRoute.name).toBe('legacy-secret-route');
+          expect(explorerOptions('configmap', false).customRoute.name).toBe('legacy-configmap-route');
+        });
+
+        it('should prioritize product-specific config over legacy bucket when same type in both', () => {
+          const state = {
+            typeOptions: {
+              'product-1':                         [{ match: 'pod', customRoute: { name: 'product-1-route' } }],
+              legacyCompatibilityProdRegistration: [{ match: 'pod', customRoute: { name: 'legacy-route' } }]
+            }
+          } as any;
+
+          const product1Options = getters.optionsFor(state, {}, {}, { productId: 'product-1' });
+
+          // product-specific should come first in the array and match first
+          expect(product1Options('pod', false).customRoute.name).toBe('product-1-route');
+        });
+
+        it('should work with multiple products having both specific and legacy configs', () => {
+          const state = {
+            typeOptions: {
+              'product-1':                         [{ match: 'pod', customRoute: { name: 'p1-pod' } }],
+              'product-2':                         [{ match: 'pod', customRoute: { name: 'p2-pod' } }],
+              legacyCompatibilityProdRegistration: [
+                { match: 'secret', customRoute: { name: 'legacy-secret' } },
+                { match: 'pod', customRoute: { name: 'legacy-pod' } }
+              ]
+            }
+          } as any;
+
+          const p1Options = getters.optionsFor(state, {}, {}, { productId: 'product-1' });
+          const p2Options = getters.optionsFor(state, {}, {}, { productId: 'product-2' });
+          const p3Options = getters.optionsFor(state, {}, {}, { productId: 'product-3' });
+
+          // product-1: gets its own pod config, ignores legacy pod, gets legacy secret
+          expect(p1Options('pod', false).customRoute.name).toBe('p1-pod');
+          expect(p1Options('secret', false).customRoute.name).toBe('legacy-secret');
+
+          // product-2: gets its own pod config, ignores legacy pod, gets legacy secret
+          expect(p2Options('pod', false).customRoute.name).toBe('p2-pod');
+          expect(p2Options('secret', false).customRoute.name).toBe('legacy-secret');
+
+          // product-3: gets only legacy configs
+          expect(p3Options('pod', false).customRoute.name).toBe('legacy-pod');
+          expect(p3Options('secret', false).customRoute.name).toBe('legacy-secret');
+        });
+      });
+
+      describe('product name validation', () => {
+        it('should throw error when product name equals reserved legacyCompatibilityProdRegistration', () => {
+          const state = { typeOptions: {} } as any;
+
+          expect(() => {
+            mutations.configureType(state, {
+              product:     'legacyCompatibilityProdRegistration',
+              match:       'pod',
+              customRoute: { name: 'route' }
+            });
+          }).toThrow(/cannot be "legacyCompatibilityProdRegistration"/);
+        });
+
+        it('should allow empty string in getter (falsy, bypasses validation)', () => {
+          const state = { typeOptions: { 'product-1': [{ match: 'pod', customRoute: { name: 'p1-route' } }] } } as any;
+          const optionsFn = getters.optionsFor(state, {}, {}, { productId: 'product-1' });
+
+          // Empty string is falsy so it skips validation and uses current product context
+          expect(() => {
+            optionsFn('pod', false, '');
+          }).not.toThrow();
+        });
+
+        it('should throw error in getter when product override is the reserved name', () => {
+          const state = { typeOptions: { 'product-1': [] } } as any;
+          const optionsFn = getters.optionsFor(state, {}, {}, { productId: 'product-1' });
+
+          expect(() => {
+            optionsFn('pod', false, 'legacyCompatibilityProdRegistration');
+          }).toThrow(/cannot be "legacyCompatibilityProdRegistration"/);
+        });
+
+        it('should allow undefined product (triggers default context in getter)', () => {
+          const state = { typeOptions: { 'product-1': [{ match: 'pod', customRoute: { name: 'p1-route' } }] } } as any;
+          const optionsFn = getters.optionsFor(state, {}, {}, { productId: 'product-1' });
+
+          // undefined product should use current product context
+          expect(() => {
+            optionsFn('pod', false, undefined);
+          }).not.toThrow();
+        });
+
+        it('should allow valid product names', () => {
+          const state = { typeOptions: {} } as any;
+
+          expect(() => {
+            mutations.configureType(state, {
+              product:     'my-product',
+              match:       'pod',
+              customRoute: { name: 'route' }
+            });
+          }).not.toThrow();
+
+          expect(state.typeOptions['my-product']).toHaveLength(1);
+        });
+      });
+
+      describe('edge cases and potential issues', () => {
+        it('should handle explicit product override with product parameter in getter', () => {
+          const state = {
+            typeOptions: {
+              'product-1': [{ match: 'pod', customRoute: { name: 'p1-route' } }],
+              'product-2': [{ match: 'pod', customRoute: { name: 'p2-route' } }]
+            }
+          } as any;
+
+          const product1Options = getters.optionsFor(state, {}, {}, { productId: 'product-1' });
+
+          // Without override, should use product-1
+          expect(product1Options('pod', false).customRoute.name).toBe('p1-route');
+
+          // With explicit override to product-2, should use product-2
+          expect(product1Options('pod', false, 'product-2').customRoute.name).toBe('p2-route');
+        });
       });
     });
   });

--- a/shell/store/__tests__/type-map.test.ts
+++ b/shell/store/__tests__/type-map.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable jest/max-nested-describe */
 
-import { TYPE_MODES, getters } from '../type-map';
+import { TYPE_MODES, getters, mutations } from '../type-map';
 import { NAME as EXPLORER } from '@shell/config/product/explorer';
 import {
   COUNT,
@@ -1339,6 +1339,172 @@ describe('type-map', () => {
       expect(getters.groupLabel(state)(undefined)).toBeUndefined();
       // Non-existent group returns undefined
       expect(getters.groupLabel(state)('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('configureType - product scoping', () => {
+    describe('mutations.configureType', () => {
+      it('should scope typeOptions by product', () => {
+        const state = { typeOptions: {} } as any;
+
+        mutations.configureType(state, {
+          product:     'product-1',
+          match:       'pod',
+          customRoute: { name: 'product-1-route' }
+        });
+
+        mutations.configureType(state, {
+          product:     'explorer',
+          match:       'pod',
+          customRoute: { name: 'explorer-route' }
+        });
+
+        expect(state.typeOptions['product-1']).toHaveLength(1);
+        expect(state.typeOptions['product-1'][0].customRoute.name).toBe('product-1-route');
+        expect(state.typeOptions['explorer']).toHaveLength(1);
+        expect(state.typeOptions['explorer'][0].customRoute.name).toBe('explorer-route');
+      });
+
+      it('should merge multiple configures for same type in same product', () => {
+        const state = { typeOptions: {} } as any;
+
+        mutations.configureType(state, {
+          product:     'product-1',
+          match:       'pod',
+          isCreatable: false
+        });
+
+        mutations.configureType(state, {
+          product:     'product-1',
+          match:       'pod',
+          customRoute: { name: 'custom' }
+        });
+
+        expect(state.typeOptions['product-1']).toHaveLength(1);
+        expect(state.typeOptions['product-1'][0].isCreatable).toBe(false);
+        expect(state.typeOptions['product-1'][0].customRoute.name).toBe('custom');
+      });
+
+      it('should merge custom data objects when configuring same type multiple times', () => {
+        const state = { typeOptions: {} } as any;
+
+        mutations.configureType(state, {
+          product: 'product-1',
+          match:   'pod',
+          custom:  { setting1: 'value1' }
+        });
+
+        mutations.configureType(state, {
+          product: 'product-1',
+          match:   'pod',
+          custom:  { setting2: 'value2' }
+        });
+
+        expect(state.typeOptions['product-1'][0].custom).toStrictEqual({
+          setting1: 'value1',
+          setting2: 'value2'
+        });
+      });
+
+      it('should log error when product parameter is missing', () => {
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+        const state = { typeOptions: {} } as any;
+
+        mutations.configureType(state, {
+          match:       'pod',
+          customRoute: { name: 'route' }
+        });
+
+        expect(consoleSpy).toHaveBeenCalledWith('configureType called without product parameter');
+        expect(state.typeOptions).toStrictEqual({});
+
+        consoleSpy.mockRestore();
+      });
+
+      it('should allow different types in same product', () => {
+        const state = { typeOptions: {} } as any;
+
+        mutations.configureType(state, {
+          product:     'product-1',
+          match:       'pod',
+          customRoute: { name: 'pod-route' }
+        });
+
+        mutations.configureType(state, {
+          product:     'product-1',
+          match:       'deployment',
+          customRoute: { name: 'deployment-route' }
+        });
+
+        expect(state.typeOptions['product-1']).toHaveLength(2);
+        expect(state.typeOptions['product-1'][0].customRoute.name).toBe('pod-route');
+        expect(state.typeOptions['product-1'][1].customRoute.name).toBe('deployment-route');
+      });
+    });
+
+    describe('getters.optionsFor - product filtering', () => {
+      it('should return product-scoped options', () => {
+        const state = {
+          typeOptions: {
+            'product-1': [{ match: 'pod', customRoute: { name: 'product-1-route' } }],
+            explorer:    [{ match: 'pod', customRoute: { name: 'explorer-route' } }]
+          }
+        } as any;
+
+        const rootGetters = { productId: 'product-1' };
+
+        const optionsFn = getters.optionsFor(state, {}, {}, rootGetters);
+        const opts = optionsFn('pod', false);
+
+        expect(opts.customRoute.name).toBe('product-1-route');
+      });
+
+      it('should return defaults when type not configured in current product', () => {
+        const state = { typeOptions: { explorer: [{ match: 'pod', customRoute: { name: 'explorer-route' } }] } } as any;
+
+        const rootGetters = { productId: 'product-1' };
+
+        const optionsFn = getters.optionsFor(state, {}, {}, rootGetters);
+        const opts = optionsFn('pod', false);
+
+        expect(opts.customRoute).toBeUndefined();
+        expect(opts.isCreatable).toBe(true); // default value
+      });
+
+      it('should handle missing product gracefully', () => {
+        const state = { typeOptions: {} } as any;
+        const rootGetters = { productId: 'nonexistent' };
+
+        const optionsFn = getters.optionsFor(state, {}, {}, rootGetters);
+        const opts = optionsFn('pod', false);
+
+        expect(opts.isCreatable).toBe(true); // defaults
+        expect(opts.customRoute).toBeUndefined();
+      });
+
+      it('should not apply explorer product config to other products', () => {
+        const state = {
+          typeOptions: {
+            explorer:    [{ match: 'pod', customRoute: { name: 'explorer-pod-route' } }],
+            'product-1': [{ match: 'pod', customRoute: { name: 'product-1-pod-route' } }]
+          }
+        } as any;
+
+        // Check explorer product
+        const explorerOptions = getters.optionsFor(state, {}, {}, { productId: 'explorer' });
+
+        expect(explorerOptions('pod', false).customRoute.name).toBe('explorer-pod-route');
+
+        // Check other product
+        const product1Options = getters.optionsFor(state, {}, {}, { productId: 'product-1' });
+
+        expect(product1Options('pod', false).customRoute.name).toBe('product-1-pod-route');
+
+        // Check unconfigured product
+        const product2Options = getters.optionsFor(state, {}, {}, { productId: 'product-2' });
+
+        expect(product2Options('pod', false).customRoute).toBeUndefined();
+      });
     });
   });
 });

--- a/shell/store/__tests__/type-map.test.ts
+++ b/shell/store/__tests__/type-map.test.ts
@@ -1505,6 +1505,68 @@ describe('type-map', () => {
 
         expect(product2Options('pod', false).customRoute).toBeUndefined();
       });
+
+      it('should use explicit product parameter when provided', () => {
+        const state = {
+          typeOptions: {
+            explorer: [
+              {
+                match:       'pod',
+                customRoute: { name: 'explorer-route' },
+                localOnly:   true
+              }
+            ],
+            'product-1': [
+              {
+                match:       'pod',
+                customRoute: { name: 'product-1-route' },
+                localOnly:   false
+              }
+            ]
+          }
+        } as any;
+
+        const optionsFn = getters.optionsFor(state, {}, {}, { productId: 'product-1' });
+
+        // Without product override, should use current product (product-1)
+        const defaultOpts = optionsFn('pod', false);
+
+        expect(defaultOpts.customRoute.name).toBe('product-1-route');
+        expect(defaultOpts.localOnly).toBe(false);
+
+        // With product override to explorer, should use explorer's config
+        const explorerOpts = optionsFn('pod', false, 'explorer');
+
+        expect(explorerOpts.customRoute.name).toBe('explorer-route');
+        expect(explorerOpts.localOnly).toBe(true);
+      });
+
+      it('should handle product override for unconfigured types', () => {
+        const state = {
+          typeOptions: {
+            explorer: [
+              {
+                match:       'pod',
+                customRoute: { name: 'explorer-route' }
+              }
+            ]
+          }
+        } as any;
+
+        const optionsFn = getters.optionsFor(state, {}, {}, { productId: 'product-1' });
+
+        // Override to explorer which has config
+        const explorerOpts = optionsFn('secret', false, 'explorer');
+
+        expect(explorerOpts.customRoute).toBeUndefined(); // secret not configured in explorer
+        expect(explorerOpts.isCreatable).toBe(true); // uses default
+
+        // Override to product-2 which has no config
+        const product2Opts = optionsFn('pod', false, 'product-2');
+
+        expect(product2Opts.customRoute).toBeUndefined();
+        expect(product2Opts.isCreatable).toBe(true);
+      });
     });
   });
 });

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -551,7 +551,7 @@ export const getters = {
       subTypes:                 [],
     };
 
-    return (schemaOrType, pagination) => {
+    return (schemaOrType, pagination, product) => {
       // Note - This can run a LOT so needs to be performant
 
       if (!schemaOrType) {
@@ -559,8 +559,8 @@ export const getters = {
       }
 
       const type = (typeof schemaOrType === 'object' ? schemaOrType.id : schemaOrType);
-      const currentProduct = rootGetters['productId'];
-      const productTypeOptions = state.typeOptions[currentProduct] || [];
+      const productToUse = product || rootGetters['productId'];
+      const productTypeOptions = state.typeOptions[productToUse] || [];
       const found = productTypeOptions.find((entry) => {
         const re = stringToRegex(entry.match);
 
@@ -948,7 +948,7 @@ export const getters = {
         });
 
         const attrs = schema.attributes || {};
-        const typeOptions = getters['optionsFor'](schema);
+        const typeOptions = getters['optionsFor'](schema, undefined, product);
 
         schemaModes[TYPE_MODES.BASIC] = schemaModes[TYPE_MODES.BASIC] && getters.groupForBasicType(product, schema.id);
 
@@ -1859,8 +1859,10 @@ export const actions = {
     dispatch('prefs/set', { key: EXPANDED_GROUPS, value: groups }, { root: true });
   },
 
-  configureType({ commit }, options) {
-    commit('configureType', options);
+  configureType({ commit, rootGetters }, options) {
+    const product = options.product || rootGetters['productId'];
+
+    commit('configureType', { ...options, product });
   }
 };
 

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -20,7 +20,7 @@
 // importList(type)                 Returns a promise that resolves to the list component for type
 // importDetail(type[,subType])     Returns a promise that resolves to the detail component for type
 // importEdit(type[,subType])       Returns a promise that resolves to the edit component for type
-// optionsFor(schemaOrType)         Return the configured options for a type (from configureType)
+// optionsFor(schemaOrType, pagination(bool), product(string)) Return the configured options for a type (from configureType) - additional product param can be passed if "optionsFor" needed isn't the current product
 //
 // 3) Changing specialization info about a type
 // For all:
@@ -107,6 +107,7 @@
 //                               notFilterNamespace:  undefined -- Define namespaces that do not need to be filtered
 //                               localOnly: False -- Hide this type from the nav/search bar on downstream clusters
 //                               custom: any - Custom options for a given type
+//                               product: string - If set, this type's options will only apply when that product is active
 //                           }
 // )
 // ignoreGroup(group):        Never show group or any types in it
@@ -373,6 +374,18 @@ export function DSL(store, product, module = 'type-map') {
   };
 }
 
+const LEGACY_COMPATIBILITY_BUCKET = 'legacyCompatibilityProdRegistration';
+
+function validateProductName(product) {
+  if (!product || typeof product !== 'string' || product.trim() === '') {
+    throw new Error(`Product name must be a non-empty string, got: ${ JSON.stringify(product) }`);
+  }
+
+  if (product === LEGACY_COMPATIBILITY_BUCKET) {
+    throw new Error(`Product name cannot be "${ LEGACY_COMPATIBILITY_BUCKET }" as it is reserved for backward compatibility`);
+  }
+}
+
 let called = false;
 
 export async function applyProducts(store, $extension) {
@@ -558,9 +571,29 @@ export const getters = {
         return {};
       }
 
+      if (product) {
+        validateProductName(product);
+      }
+
       const type = (typeof schemaOrType === 'object' ? schemaOrType.id : schemaOrType);
       const productToUse = product || rootGetters['productId'];
-      const productTypeOptions = state.typeOptions[productToUse] || [];
+
+      // Handle both array (pre-2.15) and object (2.15+) state.typeOptions formats for backwards compatibility
+      let productTypeOptions = [];
+
+      if (Array.isArray(state.typeOptions)) {
+        // Legacy format: filter the flat array for entries matching the product or entries without a product field
+        productTypeOptions = state.typeOptions.filter((entry) => entry.product === productToUse || !entry.product
+        );
+      } else {
+        // New format: direct object lookup by product, with fallback to legacy compatibility bucket for unscoped entries
+        // (e.g., extensions compiled with pre-2.15 shell that don't send product parameter)
+        productTypeOptions = [
+          ...(state.typeOptions[productToUse] || []),
+          ...(state.typeOptions[LEGACY_COMPATIBILITY_BUCKET] || [])
+        ];
+      }
+
       const found = productTypeOptions.find((entry) => {
         const re = stringToRegex(entry.match);
 
@@ -1793,34 +1826,53 @@ export const mutations = {
 
   configureType(state, options) {
     const { product, ...typeOptions } = options;
-
-    if (!product) {
-      // eslint-disable-next-line no-console
-      console.error('configureType called without product parameter');
-
-      return;
-    }
-
     const match = regexToString(ensureRegex(typeOptions.match));
 
-    // Initialize product's typeOptions array if needed
-    if (!state.typeOptions[product]) {
-      state.typeOptions[product] = [];
-    }
+    // Handle both old (array) and new (object) state.typeOptions formats for backwards compatibility
+    // Old format (pre-2.15): state.typeOptions = []
+    // New format (2.15+): state.typeOptions = { productName: [...] }
+    if (Array.isArray(state.typeOptions)) {
+      // Legacy path: old format for extensions compiled with pre-2.15 shell
+      // In 2.14, product parameter is not validated/enforced
+      const idx = state.typeOptions.findIndex((obj) => obj.match === match);
+      let obj = { ...options, match };
 
-    const productTypeOptions = state.typeOptions[product];
-    const idx = productTypeOptions.findIndex((obj) => obj.match === match);
-    let obj = { ...typeOptions, match };
-
-    if ( idx >= 0 ) {
-      // Merge the custom data object - multiple configures will update existing rather than overwrite
-      obj.custom = Object.assign(productTypeOptions[idx].custom || {}, obj.custom || {});
-      obj = Object.assign(productTypeOptions[idx], obj);
-      productTypeOptions.splice(idx, 1, obj);
+      if ( idx >= 0 ) {
+        // Merge the custom data object - multiple configures will update existing rather than overwrite
+        obj.custom = Object.assign(state.typeOptions[idx].custom || {}, obj.custom || {});
+        obj = Object.assign(state.typeOptions[idx], obj);
+        state.typeOptions.splice(idx, 1, obj);
+      } else {
+        state.typeOptions.push(obj);
+      }
     } else {
-      const obj = Object.assign({}, typeOptions, { match });
+      // New path: object format with product scoping (2.15+)
+      // Product is required in new format
+      if (!product) {
+        throw new Error(`configureType: product parameter is required in Rancher 2.15+, not provided for type "${ match }"`);
+      }
 
-      productTypeOptions.push(obj);
+      validateProductName(product);
+
+      // Initialize product's typeOptions array if needed
+      if (!state.typeOptions[product]) {
+        state.typeOptions[product] = [];
+      }
+
+      const productTypeOptions = state.typeOptions[product];
+      const idx = productTypeOptions.findIndex((obj) => obj.match === match);
+      let obj = { ...typeOptions, match };
+
+      if ( idx >= 0 ) {
+        // Merge the custom data object - multiple configures will update existing rather than overwrite
+        obj.custom = Object.assign(productTypeOptions[idx].custom || {}, obj.custom || {});
+        obj = Object.assign(productTypeOptions[idx], obj);
+        productTypeOptions.splice(idx, 1, obj);
+      } else {
+        const obj = Object.assign({}, typeOptions, { match });
+
+        productTypeOptions.push(obj);
+      }
     }
   },
 

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -290,7 +290,9 @@ export function DSL(store, product, module = 'type-map') {
     },
 
     configureType(match, options) {
-      store.commit(`${ module }/configureType`, { ...options, match });
+      store.commit(`${ module }/configureType`, {
+        ...options, match, product
+      });
     },
 
     componentForType(match, replace) {
@@ -412,7 +414,7 @@ export const state = function() {
     typeMappings:            [],
     typeMoveMappings:        [],
     typeToComponentMappings: [],
-    typeOptions:             [],
+    typeOptions:             {},
     groupBy:                 {},
     headers:                 {},
     paginationHeaders:       {},
@@ -557,7 +559,9 @@ export const getters = {
       }
 
       const type = (typeof schemaOrType === 'object' ? schemaOrType.id : schemaOrType);
-      const found = state.typeOptions.find((entry) => {
+      const currentProduct = rootGetters['productId'];
+      const productTypeOptions = state.typeOptions[currentProduct] || [];
+      const found = productTypeOptions.find((entry) => {
         const re = stringToRegex(entry.match);
 
         return re.test(type);
@@ -1522,6 +1526,10 @@ export const mutations = {
       delete state.virtualTypes[product];
     }
 
+    if (state.typeOptions[product]) {
+      delete state.typeOptions[product];
+    }
+
     if (state.basicTypes[product]) {
       // Remove table header configuration
       Object.keys(state.basicTypes[product]).forEach((type) => {
@@ -1784,20 +1792,35 @@ export const mutations = {
   },
 
   configureType(state, options) {
-    const match = regexToString(ensureRegex(options.match));
+    const { product, ...typeOptions } = options;
 
-    const idx = state.typeOptions.findIndex((obj) => obj.match === match);
-    let obj = { ...options, match };
+    if (!product) {
+      // eslint-disable-next-line no-console
+      console.error('configureType called without product parameter');
+
+      return;
+    }
+
+    const match = regexToString(ensureRegex(typeOptions.match));
+
+    // Initialize product's typeOptions array if needed
+    if (!state.typeOptions[product]) {
+      state.typeOptions[product] = [];
+    }
+
+    const productTypeOptions = state.typeOptions[product];
+    const idx = productTypeOptions.findIndex((obj) => obj.match === match);
+    let obj = { ...typeOptions, match };
 
     if ( idx >= 0 ) {
       // Merge the custom data object - multiple configures will update existing rather than overwrite
-      obj.custom = Object.assign(state.typeOptions[idx].custom || {}, obj.custom || {});
-      obj = Object.assign(state.typeOptions[idx], obj);
-      state.typeOptions.splice(idx, 1, obj);
+      obj.custom = Object.assign(productTypeOptions[idx].custom || {}, obj.custom || {});
+      obj = Object.assign(productTypeOptions[idx], obj);
+      productTypeOptions.splice(idx, 1, obj);
     } else {
-      const obj = Object.assign({}, options, { match });
+      const obj = Object.assign({}, typeOptions, { match });
 
-      state.typeOptions.push(obj);
+      productTypeOptions.push(obj);
     }
   },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17400 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

**Root Cause**

The `state.typeOptions` array was flat and global, with no product scoping. When `configureType` was called with `customRoute`, it stored the route globally. The `optionsFor` getter returned the first match without filtering by product, causing routes from one product to leak into others.

**Solution**

Scope `typeOptions` by product, following the existing architectural pattern used by `virtualTypes`, `spoofedTypes`, and `basicTypes`. This ensures each product's type configuration is isolated and only applies within that product's context.

**Changes**

`shell/store/type-map.js`

1. **State initialization (line 420)**
   - Changed `typeOptions: []` to `typeOptions: {}`
   - Now stores options as `{ [product]: [options] }` instead of flat array

2. **DSL method (line 298)**
   - Updated `configureType` to pass `product` parameter from closure to mutation
   - No changes needed to extension code - automatically works correctly

3. **optionsFor getter (lines 567-568)**
   - Added `const currentProduct = rootGetters['productId']`
   - Filter `typeOptions` by current product: `state.typeOptions[currentProduct] || []`
   - Fallback to empty array if product not configured

4. **Remove mutation (lines 1534-1536)**
   - Added cleanup of `state.typeOptions[product]` when product is removed
   - Prevents memory leaks when extensions are uninstalled

5. **configureType mutation (lines 1800-1828)**
   - Extract and validate `product` parameter
   - Initialize product-scoped array if needed: `state.typeOptions[product] = []`
   - Store options in product-scoped array instead of flat array
   - Maintain existing merge logic for multiple configures of same type

`shell/store/__tests__/type-map.test.ts`

Added 9 new unit tests covering:
- Product scoping isolation
- Merging multiple configures in same product
- Custom data object merging
- Error handling for missing product parameter
- Multiple types in same product
- optionsFor filtering by product
- Default behavior when type not configured
- Missing product graceful handling
- Product isolation verification

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Edit `pkg/kubectl-explain/index.ts` and add the following code:
```
// Add a product with a child resource page (new product registration)
  plugin.addProduct({
    name:  'product-1',
    label: 'Product One',
  }, [{ type: 'pod' }]);
```
- a new top-level extension should appear on the sidebar
- Navigate to any cluster --> Workloads --> Pods
- Pods list view page should retain the context of the cluster
- test links for `create`, `edit`, `detail` and make sure links are consistent with the cluster explorer page
- Navigate to the new top-level-product
- Pods list view page on the new product registered should follow `<!--PRODUCT-->/c/_/pod`
- test links for `create`, `edit`, `detail` and make sure links are consistent with the url structure from the previous point


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
