### PR TITLE
Replace anchor tags styled as buttons with button component

### DIFF
--- a/cypress/e2e/po/pages/explorer/cluster-project-members.po.ts
+++ b/cypress/e2e/po/pages/explorer/cluster-project-members.po.ts
@@ -20,7 +20,7 @@ export default class ClusterProjectMembersPo extends PagePo {
   }
 
   triggerAddClusterOrProjectMemberAction() {
-    return cy.get('.btn.role-primary.pull-right').click();
+    return cy.get(`[data-testid="button-cluster-member-add"]`).click();
   }
 
   triggerAddProjectMemberAction(projectLabel: string) {

--- a/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
@@ -27,6 +27,7 @@ import {
   waitForUIPackage,
 } from '@shell/utils/uiplugins';
 import { isRancherPrime, getVersionData } from '@shell/config/version';
+import { RcButton } from '@components/RcButton';
 
 const HARVESTER_REPO = isRancherPrime() ? HARVESTER_RANCHER_REPO : HARVESTER_COMMUNITY_REPO;
 
@@ -37,7 +38,8 @@ export default {
     ResourceTable,
     Masthead,
     TypeDescription,
-    Loading
+    Loading,
+    RcButton,
   },
 
   props: {
@@ -394,12 +396,12 @@ export default {
           v-if="isAdmin"
           #extraActions
         >
-          <router-link
+          <rc-button
+            size="large"
             :to="importLocation"
-            class="btn role-primary"
           >
             {{ t('cluster.importAction') }}
-          </router-link>
+          </rc-button>
         </template>
       </Masthead>
       <ResourceTable

--- a/pkg/rancher-components/src/components/RcButton/RcButton.test.ts
+++ b/pkg/rancher-components/src/components/RcButton/RcButton.test.ts
@@ -139,6 +139,33 @@ describe('rcButton.vue', () => {
     });
   });
 
+  describe('space key navigation', () => {
+    it('triggers click when Space is pressed on a link button', async() => {
+      const to = { name: 'some-route' };
+      const wrapper = mount(RcButton, {
+        props:  { to },
+        global: { stubs: { RouterLink: RouterLinkStub } },
+      });
+
+      const link = wrapper.findComponent(RouterLinkStub);
+      const clickSpy = jest.spyOn(link.element, 'click');
+
+      await link.trigger('keydown', { key: ' ' });
+
+      expect(clickSpy).toHaveBeenCalledWith();
+    });
+
+    it('triggers click when Space is pressed on a regular button', async() => {
+      const wrapper = mount(RcButton);
+      const button = wrapper.find('button');
+      const clickSpy = jest.spyOn(button.element, 'click');
+
+      await button.trigger('keydown', { key: ' ' });
+
+      expect(clickSpy).toHaveBeenCalledWith();
+    });
+  });
+
   describe('to prop', () => {
     it('renders as a <button> when no "to" prop is provided', () => {
       const wrapper = mount(RcButton);

--- a/pkg/rancher-components/src/components/RcButton/RcButton.test.ts
+++ b/pkg/rancher-components/src/components/RcButton/RcButton.test.ts
@@ -166,6 +166,82 @@ describe('rcButton.vue', () => {
     });
   });
 
+  describe('to and href mutual exclusion', () => {
+    it('warns when both "to" and "href" props are provided', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      mount(RcButton, {
+        props:  { to: '/foo', href: 'https://example.com' },
+        global: { stubs: { RouterLink: RouterLinkStub } },
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith('[RcButton] "to" and "href" are mutually exclusive. Provide only one.');
+      warnSpy.mockRestore();
+    });
+
+    it('does not warn when only "to" is provided', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      mount(RcButton, {
+        props:  { to: '/foo' },
+        global: { stubs: { RouterLink: RouterLinkStub } },
+      });
+
+      expect(warnSpy).not.toHaveBeenCalledWith('[RcButton] "to" and "href" are mutually exclusive. Provide only one.');
+      warnSpy.mockRestore();
+    });
+
+    it('does not warn when only "href" is provided', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      mount(RcButton, { props: { href: 'https://example.com' } });
+
+      expect(warnSpy).not.toHaveBeenCalledWith('[RcButton] "to" and "href" are mutually exclusive. Provide only one.');
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('href prop', () => {
+    it('renders as an <a> element when "href" prop is provided', () => {
+      const wrapper = mount(RcButton, { props: { href: 'https://example.com' } });
+
+      expect(wrapper.find('a').exists()).toBe(true);
+      expect(wrapper.find('button').exists()).toBe(false);
+    });
+
+    it('sets the href attribute on the rendered anchor', () => {
+      const href = 'https://example.com';
+      const wrapper = mount(RcButton, { props: { href } });
+
+      expect(wrapper.find('a').attributes('href')).toStrictEqual(href);
+    });
+
+    it('sets role="link" when rendered as an anchor', () => {
+      const wrapper = mount(RcButton, { props: { href: 'https://example.com' } });
+
+      expect(wrapper.find('a').attributes('role')).toStrictEqual('link');
+    });
+
+    it('applies button classes when rendered as an anchor', () => {
+      const wrapper = mount(RcButton, { props: { href: 'https://example.com', variant: 'secondary' } });
+      const anchor = wrapper.find('a');
+
+      expect(anchor.classes()).toContain('rc-button');
+      expect(anchor.classes()).toContain('btn');
+      expect(anchor.classes()).toContain('variant-secondary');
+    });
+
+    it('triggers click when Space is pressed on an anchor', async() => {
+      const wrapper = mount(RcButton, { props: { href: 'https://example.com' } });
+      const anchor = wrapper.find('a');
+      const clickSpy = jest.spyOn(anchor.element, 'click');
+
+      await anchor.trigger('keydown', { key: ' ' });
+
+      expect(clickSpy).toHaveBeenCalledWith();
+    });
+  });
+
   describe('to prop', () => {
     it('renders as a <button> when no "to" prop is provided', () => {
       const wrapper = mount(RcButton);

--- a/pkg/rancher-components/src/components/RcButton/RcButton.test.ts
+++ b/pkg/rancher-components/src/components/RcButton/RcButton.test.ts
@@ -150,19 +150,19 @@ describe('rcButton.vue', () => {
       const link = wrapper.findComponent(RouterLinkStub);
       const clickSpy = jest.spyOn(link.element, 'click');
 
-      await link.trigger('keydown', { key: ' ' });
+      await link.trigger('keyup', { key: ' ' });
 
       expect(clickSpy).toHaveBeenCalledWith();
     });
 
-    it('triggers click when Space is pressed on a regular button', async() => {
+    it('does not manually trigger click when Space is pressed on a regular button', async() => {
       const wrapper = mount(RcButton);
       const button = wrapper.find('button');
       const clickSpy = jest.spyOn(button.element, 'click');
 
-      await button.trigger('keydown', { key: ' ' });
+      await button.trigger('keyup', { key: ' ' });
 
-      expect(clickSpy).toHaveBeenCalledWith();
+      expect(clickSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -236,7 +236,7 @@ describe('rcButton.vue', () => {
       const anchor = wrapper.find('a');
       const clickSpy = jest.spyOn(anchor.element, 'click');
 
-      await anchor.trigger('keydown', { key: ' ' });
+      await anchor.trigger('keyup', { key: ' ' });
 
       expect(clickSpy).toHaveBeenCalledWith();
     });

--- a/pkg/rancher-components/src/components/RcButton/RcButton.vue
+++ b/pkg/rancher-components/src/components/RcButton/RcButton.vue
@@ -110,6 +110,10 @@ const focus = () => {
   RcFocusTarget?.value?.focus();
 };
 
+const handleSpace = (event: KeyboardEvent) => {
+  (event.target as HTMLElement).click();
+};
+
 defineExpose({ focus });
 </script>
 
@@ -120,6 +124,7 @@ defineExpose({ focus });
     :role="role"
     :to="to"
     :class="{ ...buttonClass }"
+    @keydown.space.prevent="handleSpace"
   >
     <slot
       v-if="$slots.before || props.leftIcon"

--- a/pkg/rancher-components/src/components/RcButton/RcButton.vue
+++ b/pkg/rancher-components/src/components/RcButton/RcButton.vue
@@ -7,8 +7,7 @@
  *
  * <rc-button variant="primary" @click="doAction">Perform an Action</rc-button>
  */
-import { computed, ref, resolveComponent } from 'vue';
-import type { RouteLocationRaw } from 'vue-router';
+import { computed, ref, resolveComponent, watchEffect } from 'vue';
 import {
   ButtonVariantProps,
   ButtonSizeProps,
@@ -16,6 +15,7 @@ import {
   ButtonSizeNewProps,
   ButtonSize,
   IconProps,
+  NavigationProps,
 } from './types';
 import RcIcon from '@components/RcIcon/RcIcon.vue';
 
@@ -44,16 +44,48 @@ const props = withDefaults(
         ButtonSizeProps &
         ButtonVariantNewProps &
         ButtonSizeNewProps &
-        IconProps & { to?: RouteLocationRaw }
+        IconProps &
+        NavigationProps
     >(),
   {
     size: 'medium',
     to:   undefined,
+    href: undefined,
   }
 );
 
-const tag = computed(() => (props.to ? resolveComponent('RouterLink') : 'button'));
-const role = computed(() => (props.to ? 'link' : 'button'));
+if (process.env.NODE_ENV !== 'production') {
+  watchEffect(() => {
+    if (props.to && props.href) {
+      console.warn('[RcButton] "to" and "href" are mutually exclusive. Provide only one.'); // eslint-disable-line no-console
+    }
+  });
+}
+
+const tag = computed(() => {
+  if (props.to) {
+    return resolveComponent('RouterLink');
+  }
+  if (props.href) {
+    return 'a';
+  }
+
+  return 'button';
+});
+
+const role = computed(() => (props.to || props.href ? 'link' : 'button'));
+
+const linkProps = computed(() => {
+  if (props.to) {
+    return { to: props.to };
+  }
+
+  if (props.href) {
+    return { href: props.href };
+  }
+
+  return {};
+});
 
 const activeVariantClassName = computed(() => {
   if (props.variant === 'multiAction' || props.multiAction) {
@@ -122,7 +154,7 @@ defineExpose({ focus });
     :is="tag"
     ref="RcFocusTarget"
     :role="role"
-    :to="to"
+    v-bind="linkProps"
     :class="{ ...buttonClass }"
     @keydown.space.prevent="handleSpace"
   >
@@ -292,7 +324,7 @@ defineExpose({ focus });
       font-size: 12px;
       min-height: 24px;
 
-      padding: 0 8px;
+      padding: var(--rc-button-padding, 0 8px);
       gap: 8px;
     }
   }
@@ -304,7 +336,7 @@ defineExpose({ focus });
       font-size: 14px;
       min-height: 32px;
 
-      padding: 0 12px;
+      padding: var(--rc-button-padding, 0 12px);
       gap: 8px;
     }
   }
@@ -316,7 +348,7 @@ defineExpose({ focus });
       font-size: 16px;
       min-height: 40px;
 
-      padding: 0 16px;
+      padding: var(--rc-button-padding, 0 16px);
       gap: 12px;
     }
   }

--- a/pkg/rancher-components/src/components/RcButton/RcButton.vue
+++ b/pkg/rancher-components/src/components/RcButton/RcButton.vue
@@ -142,7 +142,19 @@ const focus = () => {
   RcFocusTarget?.value?.focus();
 };
 
+const preventScroll = (event: KeyboardEvent) => {
+  if (tag.value === 'button') {
+    return;
+  }
+
+  event.preventDefault();
+};
+
 const handleSpace = (event: KeyboardEvent) => {
+  if (tag.value === 'button') {
+    return;
+  }
+
   (event.target as HTMLElement).click();
 };
 
@@ -156,7 +168,8 @@ defineExpose({ focus });
     :role="role"
     v-bind="linkProps"
     :class="{ ...buttonClass }"
-    @keydown.space.prevent="handleSpace"
+    @keydown.space="preventScroll"
+    @keyup.space="handleSpace"
   >
     <slot
       v-if="$slots.before || props.leftIcon"

--- a/pkg/rancher-components/src/components/RcButton/types.ts
+++ b/pkg/rancher-components/src/components/RcButton/types.ts
@@ -1,4 +1,7 @@
+import type { RouteLocationRaw } from 'vue-router';
 import { RcIconType } from '@components/RcIcon/types';
+
+export type NavigationProps = { to?: RouteLocationRaw; href?: string }
 
 // TODO: 13211 Investigate why `InstanceType<typeof RcButton>` fails prod builds
 // export type RcButtonType = InstanceType<typeof RcButton>

--- a/shell/chart/monitoring/prometheus/index.vue
+++ b/shell/chart/monitoring/prometheus/index.vue
@@ -12,6 +12,7 @@ import { RadioGroup } from '@components/Form/Radio';
 import { set } from '@shell/utils/object';
 import { simplify, convert } from '@shell/utils/selector';
 import { POD } from '@shell/config/types';
+import { RcButton } from '@components/RcButton';
 
 export default {
   components: {
@@ -22,6 +23,7 @@ export default {
     MatchExpressions,
     RadioGroup,
     StorageClassSelector,
+    RcButton,
   },
 
   props: {
@@ -190,12 +192,13 @@ export default {
           :key="i"
           class="mt-10"
         >
-          <router-link
+          <rc-button
+            size="large"
+            variant="tertiary"
             :to="wl.link"
-            class="btn role-tertiary"
           >
             {{ wl.label }}
-          </router-link>
+          </rc-button>
         </div>
       </template>
     </Banner>

--- a/shell/components/ExplorerMembers.vue
+++ b/shell/components/ExplorerMembers.vue
@@ -313,6 +313,7 @@ export default {
           <rc-button
             size="large"
             class="pull-right"
+            data-testid="button-cluster-member-add"
             :to="createLocation"
           >
             {{ t('members.createActionLabel') }}

--- a/shell/components/ExplorerMembers.vue
+++ b/shell/components/ExplorerMembers.vue
@@ -12,6 +12,7 @@ import { mapGetters } from 'vuex';
 import { canViewProjectMembershipEditor } from '@shell/components/form/Members/ProjectMembershipEditor.vue';
 import { allHash } from '@shell/utils/promise';
 import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
+import { RcButton } from '@components/RcButton';
 
 /**
  * Explorer members page.
@@ -26,7 +27,8 @@ export default {
     ResourceTable,
     Tabbed,
     Tab,
-    SortableTable
+    SortableTable,
+    RcButton,
   },
 
   props: {
@@ -308,12 +310,13 @@ export default {
           v-if="canEditClusterMembers"
           class="row mb-10 cluster-add"
         >
-          <router-link
+          <rc-button
+            size="large"
+            class="pull-right"
             :to="createLocation"
-            class="btn role-primary pull-right"
           >
             {{ t('members.createActionLabel') }}
-          </router-link>
+          </rc-button>
         </div>
         <ResourceTable
           :schema="schema"

--- a/shell/components/ExplorerProjectsNamespaces.vue
+++ b/shell/components/ExplorerProjectsNamespaces.vue
@@ -20,6 +20,7 @@ import { HARVESTER_NAME as HARVESTER } from '@shell/config/features';
 import perfSettingsUtils from '@shell/utils/perf-setting.utils';
 import ActionMenu from '@shell/components/ActionMenuShell.vue';
 import { useRuntimeFlag } from '@shell/composables/useRuntimeFlag';
+import { RcButton } from '@components/RcButton';
 
 export default {
   name:       'ListProjectNamespace',
@@ -29,6 +30,7 @@ export default {
     ResourceTable,
     ButtonMultiAction,
     ActionMenu,
+    RcButton
   },
   mixins: [ResourceFetch],
 
@@ -445,13 +447,14 @@ export default {
         v-if="showCreateNsButton"
         #extraActions
       >
-        <router-link
+        <rc-button
+          size="large"
+          class="mr-10"
           :to="createNamespaceLocationFlatList()"
-          class="btn role-primary mr-10"
           data-testid="create_project_namespaces"
         >
           {{ t('projectNamespaces.createNamespace') }}
-        </router-link>
+        </rc-button>
       </template>
     </Masthead>
     <!-- Extensions area -->
@@ -495,13 +498,14 @@ export default {
             </div>
           </div>
           <div class="right mr-10">
-            <router-link
+            <rc-button
               v-if="isNamespaceCreatable && (canSeeProjectlessNamespaces || group.group.key !== notInProjectKey)"
-              class="create-namespace btn btn-sm role-secondary mr-5"
+              variant="secondary"
+              class="mr-5"
               :to="createNamespaceLocation(group.group)"
             >
               {{ t('projectNamespaces.createNamespace') }}
-            </router-link>
+            </rc-button>
             <template v-if="featureDropdownMenu">
               <ActionMenu
                 v-if="showProjectActionButton(group.group)"

--- a/shell/components/fleet/FleetIntro.vue
+++ b/shell/components/fleet/FleetIntro.vue
@@ -1,9 +1,12 @@
 <script>
+import { RcButton } from '@components/RcButton';
 import { NAME } from '@shell/config/product/fleet';
 
 export default {
 
   name: 'FleetIntro',
+
+  components: { RcButton },
 
   props: {
     schema: {
@@ -63,12 +66,13 @@ export default {
       v-if="canCreate"
       class="actions"
     >
-      <router-link
+      <rc-button
+        size="large"
+        variant="secondary"
         :to="to"
-        class="btn role-secondary"
       >
         {{ t(`fleet.${ labelKey }.intro.add`) }}
-      </router-link>
+      </rc-button>
     </div>
   </div>
 </template>

--- a/shell/components/fleet/FleetNoWorkspaces.vue
+++ b/shell/components/fleet/FleetNoWorkspaces.vue
@@ -2,8 +2,11 @@
 <script>
 import { FLEET } from '@shell/config/types';
 import { NAME } from '@shell/config/product/fleet';
+import { RcButton } from '@components/RcButton';
 export default {
   name: 'NoWorkspaces',
+
+  components: { RcButton },
 
   props: {
     canView: {
@@ -34,12 +37,13 @@ export default {
       v-if="canView"
       class="actions"
     >
-      <router-link
+      <rc-button
+        size="large"
+        variant="secondary"
         :to="formRoute"
-        class="btn role-secondary"
       >
         {{ t('fleet.gitRepo.workspace.addWorkspace') }}
-      </router-link>
+      </rc-button>
     </div>
   </div>
 </template>

--- a/shell/components/fleet/dashboard/Empty.vue
+++ b/shell/components/fleet/dashboard/Empty.vue
@@ -1,7 +1,10 @@
-
 <script>
+import { RcButton } from '@components/RcButton';
+
 export default {
   name: 'FleetDashboardEmpty',
+
+  components: { RcButton },
 
   props: {
     permissions: {
@@ -38,12 +41,13 @@ export default {
       <h3 class="mb-30">
         {{ t('fleet.dashboard.noApplications', null, true) }}
       </h3>
-      <router-link
+      <rc-button
+        size="large"
+        variant="secondary"
         :to="getStartedLink"
-        class="btn role-secondary"
       >
         {{ t('fleet.dashboard.getStarted') }}
-      </router-link>
+      </rc-button>
     </template>
   </div>
 </template>

--- a/shell/components/templates/default.vue
+++ b/shell/components/templates/default.vue
@@ -140,10 +140,6 @@ export default {
       debugger;
     },
 
-    skipToMainContent() {
-      document.getElementById('main-content')?.focus();
-    },
-
     async toggleShell() {
       const clusterId = this.$route.params.cluster;
 
@@ -171,7 +167,7 @@ export default {
     <rc-button
       size="large"
       class="skip-to-content"
-      @click="skipToMainContent"
+      :to="{ hash: '#main-content' }"
     >
       {{ t('nav.skipToContent') }}
     </rc-button>

--- a/shell/components/templates/default.vue
+++ b/shell/components/templates/default.vue
@@ -24,6 +24,7 @@ import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
 import { getClusterFromRoute, getProductFromRoute } from '@shell/utils/router';
 import SideNav from '@shell/components/SideNav';
 import { Layout } from '@shell/types/window-manager';
+import { RcButton } from '@components/RcButton';
 
 const SET_LOGIN_ACTION = 'set-as-login';
 
@@ -42,6 +43,7 @@ export default {
     AwsComplianceBanner,
     Inactivity,
     SideNav,
+    RcButton,
   },
 
   mixins: [PageHeaderActions, Brand, BrowserTabVisibility],
@@ -138,6 +140,10 @@ export default {
       debugger;
     },
 
+    skipToMainContent() {
+      document.getElementById('main-content')?.focus();
+    },
+
     async toggleShell() {
       const clusterId = this.$route.params.cluster;
 
@@ -162,10 +168,13 @@ export default {
 
 <template>
   <div class="dashboard-root">
-    <a
-      href="#main-content"
-      class="skip-to-content btn role-primary"
-    >{{ t('nav.skipToContent') }}</a>
+    <rc-button
+      size="large"
+      class="skip-to-content"
+      @click="skipToMainContent"
+    >
+      {{ t('nav.skipToContent') }}
+    </rc-button>
     <FixedBanner :header="true" />
     <AwsComplianceBanner v-if="managementReady" />
     <div

--- a/shell/components/templates/home.vue
+++ b/shell/components/templates/home.vue
@@ -12,6 +12,7 @@ import Inactivity from '@shell/components/Inactivity';
 import { mapState, mapGetters } from 'vuex';
 import PromptModal from '@shell/components/PromptModal';
 import { Layout } from '@shell/types/window-manager';
+import { RcButton } from '@components/RcButton';
 
 export default {
 
@@ -24,6 +25,7 @@ export default {
     AwsComplianceBanner,
     Inactivity,
     PromptModal,
+    RcButton
   },
 
   mixins: [Brand, BrowserTabVisibility],
@@ -62,10 +64,13 @@ export default {
 
 <template>
   <div class="dashboard-root">
-    <a
-      href="#main-content"
-      class="skip-to-content btn role-primary"
-    >{{ t('nav.skipToContent') }}</a>
+    <rc-button
+      size="large"
+      class="skip-to-content"
+      :to="{ hash: '#main-content' }"
+    >
+      {{ t('nav.skipToContent') }}
+    </rc-button>
     <FixedBanner :header="true" />
     <Inactivity />
     <AwsComplianceBanner />

--- a/shell/components/templates/plain.vue
+++ b/shell/components/templates/plain.vue
@@ -15,6 +15,7 @@ import Inactivity from '@shell/components/Inactivity';
 import { mapGetters } from 'vuex';
 import PromptModal from '@shell/components/PromptModal';
 import { Layout } from '@shell/types/window-manager';
+import { RcButton } from '@components/RcButton';
 
 export default {
 
@@ -30,6 +31,7 @@ export default {
     SlideInPanelManager,
     AwsComplianceBanner,
     Inactivity,
+    RcButton
   },
 
   mixins: [Brand, BrowserTabVisibility],
@@ -66,10 +68,13 @@ export default {
 
 <template>
   <div class="dashboard-root">
-    <a
-      href="#main-content"
-      class="skip-to-content btn role-primary"
-    >{{ t('nav.skipToContent') }}</a>
+    <rc-button
+      size="large"
+      class="skip-to-content"
+      :to="{ hash: '#main-content' }"
+    >
+      {{ t('nav.skipToContent') }}
+    </rc-button>
     <FixedBanner :header="true" />
     <AwsComplianceBanner />
 

--- a/shell/config/router/index.js
+++ b/shell/config/router/index.js
@@ -9,6 +9,23 @@ export const routerOptions = {
   base:     process.env.routerBase || '/',
   routes:   Routes,
   fallback: false,
+  scrollBehavior(to, from, savedPosition) {
+    // Returning the savedPosition will result in a native-like behavior when
+    // navigating with back/forward buttons
+    if (savedPosition) {
+      return savedPosition;
+    }
+
+    // Simulate the "scroll to anchor" behavior when the hash changes.
+    // For example, the skip to content link
+    if (to.hash) {
+      const el = document.getElementById(to.hash.slice(1));
+
+      el?.focus();
+
+      return { el: to.hash };
+    }
+  },
 };
 
 export function extendRouter(config, context) {

--- a/shell/config/router/index.js
+++ b/shell/config/router/index.js
@@ -16,10 +16,9 @@ export const routerOptions = {
       return savedPosition;
     }
 
-    // Simulate the "scroll to anchor" behavior when the hash changes.
-    // For example, the skip to content link
-    if (to.hash) {
-      const el = document.getElementById(to.hash.slice(1));
+    // Handle the "skip to main content" link
+    if (to.hash === '#main-content') {
+      const el = document.getElementById('main-content');
 
       el?.focus();
 

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -12,6 +12,7 @@ import AuthBanner from '@shell/components/auth/AuthBanner';
 import config, { OKTA, SHIBBOLETH } from '@shell/edit/auth/ldap/config';
 import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBanners';
 import RadioGroup from '@components/Form/Radio/RadioGroup.vue';
+import { RcButton } from '@components/RcButton';
 
 // Standard LDAP defaults
 const LDAP_DEFAULTS = {
@@ -47,7 +48,8 @@ export default {
     FileSelector,
     config,
     AuthBanner,
-    AuthProviderWarningBanners
+    AuthProviderWarningBanners,
+    RcButton,
   },
 
   mixins: [CreateEditView, AuthConfig],
@@ -193,13 +195,17 @@ export default {
               >
                 <div>{{ t('authConfig.saml.search.on') }}</div>
                 <div>
-                  <a
-                    class="toggle-btn"
+                  <rc-button
+                    variant="link"
                     @click="showLdapDetails = !showLdapDetails"
                   >
-                    <template v-if="showLdapDetails">{{ t('authConfig.saml.search.hide') }}</template>
-                    <template v-else>{{ t('authConfig.saml.search.show') }}</template>
-                  </a>
+                    <template v-if="showLdapDetails">
+                      {{ t('authConfig.saml.search.hide') }}
+                    </template>
+                    <template v-else>
+                      {{ t('authConfig.saml.search.show') }}
+                    </template>
+                  </rc-button>
                 </div>
               </div>
             </Banner>
@@ -422,11 +428,6 @@ export default {
 
     > :first-child {
       flex: 1;
-    }
-
-    .toggle-btn {
-      cursor: pointer;
-      user-select: none;
     }
   }
 </style>

--- a/shell/list/group.principal.vue
+++ b/shell/list/group.principal.vue
@@ -9,10 +9,11 @@ import { NAME } from '@shell/config/product/auth';
 import { MODE, _EDIT } from '@shell/config/query-params';
 import { mapState } from 'vuex';
 import { BLANK_CLUSTER } from '@shell/store/store-types.js';
+import { RcButton } from '@components/RcButton';
 
 export default {
   components: {
-    AsyncButton, ResourceTable, Masthead, Loading
+    AsyncButton, ResourceTable, Masthead, Loading, RcButton
   },
   props: {
     resource: {
@@ -130,13 +131,13 @@ export default {
           :class="{'mr-5': canCreateGlobalRoleBinding}"
           @click="refreshGroupMemberships"
         />
-        <router-link
+        <rc-button
           v-if="canCreateGlobalRoleBinding"
+          size="large"
           :to="assignLocation"
-          class="btn role-primary"
         >
           {{ t("authGroups.actions.assignRoles") }}
-        </router-link>
+        </rc-button>
       </template>
     </Masthead>
 

--- a/shell/list/harvesterhci.io.management.cluster.vue
+++ b/shell/list/harvesterhci.io.management.cluster.vue
@@ -8,6 +8,7 @@ import { HARVESTER_NAME as VIRTUAL } from '@shell/config/features';
 import { CAPI, HCI, MANAGEMENT } from '@shell/config/types';
 import { isHarvesterCluster } from '@shell/utils/cluster';
 import { allHash } from '@shell/utils/promise';
+import { RcButton } from '@components/RcButton';
 
 export default {
   components: {
@@ -15,7 +16,8 @@ export default {
     ResourceTable,
     Masthead,
     TypeDescription,
-    Loading
+    Loading,
+    RcButton,
   },
 
   props: {
@@ -128,12 +130,12 @@ export default {
         v-if="canCreateCluster"
         slot="extraActions"
       >
-        <n-link
+        <rc-button
           :to="importLocation"
-          class="btn role-primary"
+          size="large"
         >
           {{ t('cluster.importAction') }}
-        </n-link>
+        </rc-button>
       </template>
     </Masthead>
 
@@ -166,12 +168,9 @@ export default {
       </template>
 
       <template #cell:harvester="{row}">
-        <n-link
-          class="btn btn-sm role-primary"
-          :to="row.detailLocation"
-        >
+        <rc-button :to="row.detailLocation">
           {{ t('harvesterManager.manage') }}
-        </n-link>
+        </rc-button>
       </template>
     </ResourceTable>
     <div v-else>

--- a/shell/list/management.cattle.io.user.vue
+++ b/shell/list/management.cattle.io.user.vue
@@ -7,6 +7,7 @@ import Masthead from '@shell/components/ResourceList/Masthead';
 import ResourceFetch from '@shell/mixins/resource-fetch';
 import { isAdminUser } from '@shell/store/type-map';
 import TableDataUserIcon from '@shell/components/TableDataUserIcon';
+import { RcButton } from '@components/RcButton';
 
 export default {
   components: {
@@ -14,6 +15,7 @@ export default {
     ResourceTable,
     Masthead,
     TableDataUserIcon,
+    RcButton
   },
   mixins: [ResourceFetch],
   props:  {
@@ -128,14 +130,17 @@ export default {
         v-if="isAdmin"
         #subHeader
       >
-        <router-link
+        <rc-button
+          variant="link"
+          class="btn-user-retention"
           :to="{ name: 'c-cluster-auth-user.retention'}"
-          class="btn role-link btn-sm btn-user-retention"
           data-testid="router-link-user-retention"
         >
-          <i class="icon icon-gear" />
+          <template #before>
+            <i class="icon icon-gear" />
+          </template>
           {{ t('user.retention.button.label') }}
-        </router-link>
+        </rc-button>
       </template>
     </Masthead>
 
@@ -159,10 +164,8 @@ export default {
   </div>
 </template>
 
-<style lang="scss">
-  .btn-user-retention {
-    display: flex;
-    gap: 0.25rem;
-    padding: 0;
+<style lang="scss" scoped>
+  .btn.rc-button.btn-medium.btn-user-retention:not(.btn-sm) {
+    padding: 0; //retain the padding override for left-alignment with the header
   }
 </style>

--- a/shell/list/management.cattle.io.user.vue
+++ b/shell/list/management.cattle.io.user.vue
@@ -165,7 +165,7 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  .btn.rc-button.btn-medium.btn-user-retention:not(.btn-sm) {
+  a.rc-button.variant-link.btn-user-retention {
     padding: 0; //retain the padding override for left-alignment with the header
   }
 </style>

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -296,7 +296,7 @@ export default {
         >
           <rc-button
             size="large"
-            class="mr10"
+            class="mr-10"
             :to="importLocation"
             data-testid="cluster-manager-list-import"
           >

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -17,10 +17,15 @@ import ProvCluster from '@shell/models/provisioning.cattle.io.cluster';
 import ManagementClusterUtils from '@shell/list/utils/management.cattle.io.cluster.utils';
 import { STEVE_AUTOSCALER_ENABLED } from '@shell/config/pagination-table-headers';
 import { filterHiddenLocalCluster, filterOnlyKubernetesClusters } from '@shell/utils/cluster';
+import { RcButton } from '@components/RcButton';
 
 export default {
   components: {
-    Banner, PaginatedResourceTable, Masthead, MachineSummaryGraph
+    Banner,
+    PaginatedResourceTable,
+    Masthead,
+    MachineSummaryGraph,
+    RcButton,
   },
 
   data() {
@@ -289,13 +294,14 @@ export default {
           v-if="canImport"
           #extraActions
         >
-          <router-link
+          <rc-button
+            size="large"
+            class="mr10"
             :to="importLocation"
-            class="btn role-primary mr-10"
             data-testid="cluster-manager-list-import"
           >
             {{ t('cluster.importAction') }}
-          </router-link>
+          </rc-button>
         </template>
       </Masthead>
 
@@ -329,14 +335,14 @@ export default {
         </template>
         <template #cell:explorer="{row}">
           <!-- Align side nav cluster, home page name link and cluster management cluster explor buttons on canExplore -->
-          <router-link
+          <rc-button
             v-if="row.canExplore"
+            variant="secondary"
             data-testid="cluster-manager-list-explore-management"
-            class="btn btn-sm role-secondary"
             :to="{name: 'c-cluster', params: {cluster: row.id}}"
           >
             {{ t('cluster.explore') }}
-          </router-link>
+          </rc-button>
           <button
             v-else
             data-testid="cluster-manager-list-explore"

--- a/shell/pages/about.vue
+++ b/shell/pages/about.vue
@@ -10,10 +10,11 @@ import TabTitle from '@shell/components/TabTitle';
 import { PanelLocation, ExtensionPoint } from '@shell/core/types';
 import ExtensionPanel from '@shell/components/ExtensionPanel';
 import { getVersionInfo } from '@shell/utils/version';
+import { RcButton } from '@components/RcButton';
 
 export default {
   components: {
-    BackLink, ExtensionPanel, Loading, TabTitle
+    BackLink, ExtensionPanel, Loading, TabTitle, RcButton
   },
   mixins: [BackRoute],
   async fetch() {
@@ -85,16 +86,14 @@ export default {
           {{ t('about.title') }}
         </TabTitle>
       </h1>
-      <router-link
+      <rc-button
+        size="large"
         :to="{ name: 'diagnostic' }"
-        class="btn role-primary"
         data-testid="about__diagnostics_button"
-        role="button"
         :aria-label="t('about.diagnostic.title')"
-        @keyup.space="$router.push({ name: 'diagnostic' })"
       >
         {{ t('about.diagnostic.title') }}
-      </router-link>
+      </rc-button>
     </div>
     <!-- Extensions area -->
     <ExtensionPanel

--- a/shell/pages/c/_cluster/apps/charts/AppChartCardFooter.vue
+++ b/shell/pages/c/_cluster/apps/charts/AppChartCardFooter.vue
@@ -195,7 +195,7 @@ function getTooltip(key: string, fallback?: string): string | undefined {
   }
 }
 
-button.variant-ghost.app-chart-card-footer-button {
+button.rc-button.variant-ghost.app-chart-card-footer-button {
   padding: 0;
   gap: 0;
   min-height: 20px;

--- a/shell/pages/c/_cluster/auth/roles/index.vue
+++ b/shell/pages/c/_cluster/auth/roles/index.vue
@@ -7,6 +7,7 @@ import Loading from '@shell/components/Loading';
 import { SUBTYPE_MAPPING, CREATE_VERBS } from '@shell/models/management.cattle.io.roletemplate';
 import { NAME } from '@shell/config/product/auth';
 import { BLANK_CLUSTER } from '@shell/store/store-types.js';
+import { RcButton } from '@components/RcButton';
 
 const GLOBAL = SUBTYPE_MAPPING.GLOBAL.key;
 const CLUSTER = SUBTYPE_MAPPING.CLUSTER.key;
@@ -31,7 +32,7 @@ export default {
   name: 'Roles',
 
   components: {
-    Tab, Tabbed, ResourceTable, Loading
+    Tab, Tabbed, ResourceTable, Loading, RcButton
   },
 
   async fetch() {
@@ -162,13 +163,13 @@ export default {
       </div>
       <div class="actions-container">
         <div class="actions">
-          <router-link
+          <rc-button
             v-if="canCreate"
+            size="large"
             :to="createLocation"
-            class="btn role-primary"
           >
             {{ createLabel }}
-          </router-link>
+          </rc-button>
         </div>
       </div>
     </header>

--- a/shell/pages/c/_cluster/fleet/application/index.vue
+++ b/shell/pages/c/_cluster/fleet/application/index.vue
@@ -4,6 +4,7 @@ import { checkPermissions, checkSchemasForFindAllHash } from '@shell/utils/auth'
 import Masthead from '@shell/components/ResourceList/Masthead';
 import FleetNoWorkspaces from '@shell/components/fleet/FleetNoWorkspaces.vue';
 import FleetApplications from '@shell/components/fleet/FleetApplications';
+import { RcButton } from '@components/RcButton';
 
 const schema = {
   id:   FLEET.APPLICATION,
@@ -16,6 +17,7 @@ export default {
     Masthead,
     FleetNoWorkspaces,
     FleetApplications,
+    RcButton,
   },
 
   props: {
@@ -117,12 +119,12 @@ export default {
       :type-display="t('fleet.application.pageTitle')"
     >
       <template #createButton>
-        <router-link
+        <rc-button
+          size="large"
           :to="createLocation"
-          class="btn role-primary"
         >
           {{ t('fleet.application.actions.create') }}
-        </router-link>
+        </rc-button>
       </template>
     </Masthead>
     <FleetApplications

--- a/shell/pages/fail-whale.vue
+++ b/shell/pages/fail-whale.vue
@@ -8,11 +8,12 @@ import FixedBanner from '@shell/components/FixedBanner';
 import GrowlManager from '@shell/components/GrowlManager';
 import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
 import PromptModal from '@shell/components/PromptModal';
+import { RcButton } from '@components/RcButton';
 
 export default {
 
   components: {
-    BrandImage, FixedBanner, GrowlManager, Header, PromptModal
+    BrandImage, FixedBanner, GrowlManager, Header, PromptModal, RcButton
   },
   mixins: [Brand, BrowserTabVisibility],
 
@@ -106,12 +107,12 @@ export default {
                 {{ displayError }}
               </h2>
               <p class="mt-20">
-                <a
-                  :href="home"
-                  class="btn role-primary"
+                <rc-button
+                  size="large"
+                  :to="home"
                 >
                   {{ t('nav.home') }}
-                </a>
+                </rc-button>
               </p>
               <hr
                 class="custom-content"
@@ -119,12 +120,13 @@ export default {
                 role="none"
               >
               <p class="mt-20">
-                <a
-                  class="btn role-secondary"
+                <rc-button
+                  size="large"
+                  variant="secondary"
                   @click="$router.push(previousRoute.fullPath)"
                 >
                   {{ t('nav.failWhale.reload') }}
-                </a>
+                </rc-button>
               </p>
             </div>
           </div>

--- a/shell/pages/fail-whale.vue
+++ b/shell/pages/fail-whale.vue
@@ -109,7 +109,7 @@ export default {
               <p class="mt-20">
                 <rc-button
                   size="large"
-                  :to="home"
+                  :href="home"
                 >
                   {{ t('nav.home') }}
                 </rc-button>

--- a/shell/pages/fail-whale.vue
+++ b/shell/pages/fail-whale.vue
@@ -62,10 +62,13 @@ export default {
 
 <template>
   <div class="dashboard-root">
-    <a
-      href="#main-content"
-      class="skip-to-content btn role-primary"
-    >{{ t('nav.skipToContent') }}</a>
+    <rc-button
+      size="large"
+      class="skip-to-content"
+      :to="{ hash: '#main-content' }"
+    >
+      {{ t('nav.skipToContent') }}
+    </rc-button>
     <FixedBanner :header="true" />
     <PromptModal />
     <div

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -598,14 +598,6 @@ export default defineComponent({
                     &mdash;
                   </td>
                 </template>
-                <!-- <template #cell:explorer="{row}">
-                    <router-link v-if="row && row.isReady" class="btn btn-sm role-primary" :to="{name: 'c-cluster', params: {cluster: row.id}}">
-                      {{ t('landing.clusters.explore') }}
-                    </router-link>
-                    <button v-else :disabled="true" class="btn btn-sm role-primary">
-                      {{ t('landing.clusters.explore') }}
-                    </button>
-                  </template> -->
               </ResourceTable>
             </div>
             <div
@@ -734,14 +726,6 @@ export default defineComponent({
                     &mdash;
                   </td>
                 </template>
-                <!-- <template #cell:explorer="{row}">
-                  <router-link v-if="row && row.isReady" class="btn btn-sm role-primary" :to="{name: 'c-cluster', params: {cluster: row.id}}">
-                    {{ t('landing.clusters.explore') }}
-                  </router-link>
-                  <button v-else :disabled="true" class="btn btn-sm role-primary">
-                    {{ t('landing.clusters.explore') }}
-                  </button>
-                </template> -->
               </PaginatedResourceTable>
             </div>
             <div

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -35,6 +35,7 @@ import Preset from '@shell/mixins/preset';
 import { PaginationFeatureHomePageClusterConfig } from '@shell/types/resources/settings';
 import MgmtCluster from '@shell/models/management.cattle.io.cluster';
 import ManagementClusterUtils from '@shell/list/utils/management.cattle.io.cluster.utils';
+import { RcButton } from '@components/RcButton';
 
 export default defineComponent({
   name:       'Home',
@@ -50,6 +51,7 @@ export default defineComponent({
     ResourceTable,
     DynamicContentBanner,
     DynamicContentPanel,
+    RcButton
   },
 
   mixins: [PageHeaderActions, Preset],
@@ -504,39 +506,31 @@ export default defineComponent({
                   #header-middle
                 >
                   <div class="table-heading">
-                    <router-link
+                    <rc-button
                       v-if="!!provClusterSchema"
+                      variant="secondary"
                       :to="manageLocation"
-                      class="btn btn-sm role-secondary"
                       data-testid="cluster-management-manage-button"
-                      role="button"
                       :aria-label="t('cluster.manageAction')"
-                      @keyup.space="$router.push(manageLocation)"
                     >
                       {{ t('cluster.manageAction') }}
-                    </router-link>
-                    <router-link
+                    </rc-button>
+                    <rc-button
                       v-if="canCreateCluster"
                       :to="importLocation"
-                      class="btn btn-sm role-primary"
                       data-testid="cluster-create-import-button"
-                      role="button"
                       :aria-label="t('cluster.importAction')"
-                      @keyup.space="$router.push(importLocation)"
                     >
                       {{ t('cluster.importAction') }}
-                    </router-link>
-                    <router-link
+                    </rc-button>
+                    <rc-button
                       v-if="canCreateCluster"
                       :to="createLocation"
-                      class="btn btn-sm role-primary"
                       data-testid="cluster-create-button"
-                      role="button"
                       :aria-label="t('generic.create')"
-                      @keyup.space="$router.push(createLocation)"
                     >
                       {{ t('generic.create') }}
-                    </router-link>
+                    </rc-button>
                   </div>
                 </template>
                 <template #col:name="{row}">
@@ -665,39 +659,31 @@ export default defineComponent({
                   #header-middle
                 >
                   <div class="table-heading">
-                    <router-link
+                    <rc-button
                       v-if="!!provClusterSchema"
+                      variant="secondary"
                       :to="manageLocation"
-                      class="btn btn-sm role-secondary"
                       data-testid="cluster-management-manage-button"
-                      role="button"
                       :aria-label="t('cluster.manageAction')"
-                      @keyup.space="$router.push(manageLocation)"
                     >
                       {{ t('cluster.manageAction') }}
-                    </router-link>
-                    <router-link
+                    </rc-button>
+                    <rc-button
                       v-if="canCreateCluster"
                       :to="importLocation"
-                      class="btn btn-sm role-primary"
                       data-testid="cluster-create-import-button"
-                      role="button"
                       :aria-label="t('cluster.importAction')"
-                      @keyup.space="$router.push(importLocation)"
                     >
                       {{ t('cluster.importAction') }}
-                    </router-link>
-                    <router-link
+                    </rc-button>
+                    <rc-button
                       v-if="canCreateCluster"
                       :to="createLocation"
-                      class="btn btn-sm role-primary"
                       data-testid="cluster-create-button"
-                      role="button"
                       :aria-label="t('generic.create')"
-                      @keyup.space="$router.push(createLocation)"
                     >
                       {{ t('generic.create') }}
-                    </router-link>
+                    </rc-button>
                   </div>
                 </template>
                 <template #col:name="{row}">

--- a/shell/pages/support/index.vue
+++ b/shell/pages/support/index.vue
@@ -9,6 +9,7 @@ import { addParam } from '@shell/utils/url';
 import { isRancherPrime } from '@shell/config/version';
 import TabTitle from '@shell/components/TabTitle';
 import CspAdapterUtils from '@shell/utils/cspAdaptor';
+import { RcButton } from '@components/RcButton';
 
 export default {
 
@@ -16,7 +17,8 @@ export default {
     BannerGraphic,
     IndentedPanel,
     CommunityLinks,
-    TabTitle
+    TabTitle,
+    RcButton,
   },
 
   async fetch() {
@@ -112,6 +114,12 @@ export default {
     }
   },
 
+  methods: {
+    downloadSupportConfig() {
+      window.location.href = this.supportConfigLink;
+    },
+  },
+
 };
 </script>
 <template>
@@ -155,13 +163,14 @@ export default {
               <p class="pb-10">
                 {{ hasAWSSupport ? t("support.suse.access.aws.text") : t("support.suse.access.text") }}
               </p>
-              <a
+              <rc-button
                 v-if="hasAWSSupport"
-                class="mr-5 btn role-secondary btn-sm"
-                :href="supportConfigLink"
+                variant="secondary"
+                class="mr-5"
+                @click="downloadSupportConfig"
               >
                 {{ t('support.suse.access.aws.generateConfig') }}
-              </a>
+              </rc-button>
               <a
                 :href="sccLink"
                 target="_blank"

--- a/shell/pages/support/index.vue
+++ b/shell/pages/support/index.vue
@@ -114,12 +114,6 @@ export default {
     }
   },
 
-  methods: {
-    downloadSupportConfig() {
-      window.location.href = this.supportConfigLink;
-    },
-  },
-
 };
 </script>
 <template>
@@ -167,7 +161,7 @@ export default {
                 v-if="hasAWSSupport"
                 variant="secondary"
                 class="mr-5"
-                @click="downloadSupportConfig"
+                :href="supportConfigLink"
               >
                 {{ t('support.suse.access.aws.generateConfig') }}
               </rc-button>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This replaces all link button instances with the `RcButton` implementation. #17178 introduced a change to allow `RcButton` to render link buttons when the `to` prop is supplied. The benefit of this is that link buttons can now be handled in a controlled and consistent way. 

Fixes #13174 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Replace router-link tags with buttons
- Trigger click when space is pressed for link buttons
- Replace anchor tag buttons with button component
- Clean up template comments in home.vue
- Retain link semantics for skip to main content
- Replace `n-link` button instances
- Add `data-testid` to cluster member add button

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

For accessibility and consistency, link buttons should register a "click" on pressing both "space" and "enter" via the keyboard; this is an effort we addressed during the accessibility epic. While testing I noted that "space" was not registering the click properly when rendering a link button through RcButton, so this has been fixed via 4fa5db820f665574eef94819e202d787467a269a. All link buttons should now have a consistent mode of keyboard interaction throughout Dashboard with this change in place. 

46a87294fbc7dae2f54c4fbec4d5f40ad9649930 contains a change to preserve the "skip to main content" link semantics. It should be a minor change to `vue-router`, but has a global effect that can impact router behavior. More details about this change can be found in the vue-router docs[^1]. 

[^1]: https://router.vuejs.org/guide/advanced/scroll-behavior.html

Items to note:

- `btn-sm` closely maps to the "medium" size for RcButton. This is the default, so the `size` prop has been omitted in these areas.
- Link buttons without a size (`btn-`) class have been assumed to be the "large" size for RcButton. This is being done to maintain consistency with the existing button heights.
- `role-primary` maps to the "primary" variant for RcButton. This is the default, so the `variant` prop has been omitted in these areas. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- RcButton with `to` prop renders as router-link (<a>), space bar triggers navigation in addition to the enter key
- RcButton with `to` prop carries role="link" so screen readers announce it as a link, not a button
- `n-link` button replacements navigate to the correct routes in Harvester cluster list
- Replaced anchor tag buttons in SAML auth page still perform their actions
- Replaced elements in: 
   - fail-whale page still work (navigate home, reload, etc.)
   - Support index page still navigate or open the correct destinations
- Skip to main content retains `<a>` semantics via the router scroll behavior; clicking scrolls to `#content`

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- The new global `scrollBehavior` in `router/index.js` affects all hash-anchor navigation app-wide, not just skip-to-content
- SAML/support/fail-whale pages: if any of those replaced anchors had `target="_blank"`, that attribute needs to be forwarded through RcButton

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
