### PR TITLE
Reorder paths so that `@components` takes priority for automatic imports

### DIFF
--- a/pkg/harvester-manager/tsconfig.json
+++ b/pkg/harvester-manager/tsconfig.json
@@ -29,6 +29,9 @@
       "scripthost"
     ],
     "paths": {
+      "@components/*": [
+        "../../pkg/rancher-components/src/components/*"
+      ],
       "@shell/core/*": [
         "../../shell/core/*"
       ],

--- a/shell/tsconfig.paths.json
+++ b/shell/tsconfig.paths.json
@@ -1,11 +1,9 @@
 {
   "compilerOptions": {
     "paths": {
-      "~/*": [
-        "../*"
-      ],
-      "@/*": [
-        "../*"
+      "@components/*": [
+        "./rancher-components/*",
+        "../pkg/rancher-components/src/components/*"
       ],
       "@shell/*": [
         "../shell/*"
@@ -13,9 +11,11 @@
       "@pkg/*": [
         "../shell/pkg/*"
       ],
-      "@components/*": [
-        "./rancher-components/*",
-        "../pkg/rancher-components/src/components/*"
+      "~/*": [
+        "../*"
+      ],
+      "@/*": [
+        "../*"
       ]
     },
   },

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,11 +1,8 @@
 {
   "compilerOptions": {
     "paths": {
-      "~/*": [
-        "*"
-      ],
-      "@/*": [
-        "*"
+      "@components/*": [
+        "pkg/rancher-components/src/components/*"
       ],
       "@shell/*": [
         "shell/*"
@@ -13,8 +10,11 @@
       "@pkg/*": [
         "shell/pkg/*"
       ],
-      "@components/*": [
-        "pkg/rancher-components/src/components/*"
+      "~/*": [
+        "*"
+      ],
+      "@/*": [
+        "*"
       ]
     },
   },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This reorders paths in several of the project's `tsconfig` files to give precedence to `@component` over `~/` when automatically importing in editors. 

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Reorder paths so that `@components` takes priority

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Paths are evaluated in their insertion order in the array. Reordering it so that `@components` is higher up, gives this alias higher precedence over aliases with less specificity (`@`/`~`).

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Choose an existing component in your editor, start typing `RcButton` in the `components` option. Autocomplete should trigger while you are typing, select an option and check the import that is used - the alias used should be `@components` rather than `~/`.

This is a common point of friction which I encountered again while working on #17574

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

All of the existing aliases still exist, so they should still remain valid.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
