### PR TITLE
[17563] Fixed and added unit test to capture this bug next time

### DIFF
--- a/shell/components/formatter/FleetSummaryGraph.vue
+++ b/shell/components/formatter/FleetSummaryGraph.vue
@@ -26,9 +26,6 @@ export default {
       if (this.clusterId) {
         return this.row.statusResourceCountsForCluster(this.clusterId);
       }
-      if (this.row.statusResourceCountsForCluster) {
-        return this.row.statusResourceCountsForCluster;
-      }
 
       return this.row.status?.resourceCounts || {};
     },

--- a/shell/components/formatter/__tests__/FleetSummaryGraph.test.ts
+++ b/shell/components/formatter/__tests__/FleetSummaryGraph.test.ts
@@ -1,0 +1,216 @@
+import { shallowMount } from '@vue/test-utils';
+import FleetSummaryGraph from '@shell/components/formatter/FleetSummaryGraph.vue';
+import { FLEET } from '@shell/config/types';
+import { ExtendedVue, Vue } from 'vue/types/vue';
+import { DefaultProps } from 'vue/types/options';
+
+const FleetSummaryGraphComponent = FleetSummaryGraph as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>;
+
+function makeRow({
+  type = FLEET.GIT_REPO,
+  resourceCounts = {},
+  targetClusters = [],
+  statusResourceCountsForCluster = undefined,
+}: {
+  type?: string;
+  resourceCounts?: Record<string, number>;
+  targetClusters?: any[];
+  statusResourceCountsForCluster?: any;
+} = {}) {
+  const row: Record<string, any> = {
+    id:     'test-ns/test-row',
+    type,
+    status: { resourceCounts },
+    targetClusters,
+  };
+
+  if (statusResourceCountsForCluster !== undefined) {
+    row.statusResourceCountsForCluster = statusResourceCountsForCluster;
+  }
+
+  return row;
+}
+
+describe('component: FleetSummaryGraph', () => {
+  describe('summary', () => {
+    it('returns status.resourceCounts for GitRepo rows', () => {
+      const resourceCounts = {
+        desiredReady: 7,
+        ready:        7,
+      };
+      const wrapper = shallowMount(FleetSummaryGraphComponent, {
+        propsData: {
+          row: makeRow({
+            resourceCounts,
+            targetClusters: [{ id: 'cluster-1' }],
+          }),
+        },
+      });
+
+      expect((wrapper.vm as any).summary).toStrictEqual(resourceCounts);
+    });
+
+    it('returns status.resourceCounts for HelmOp rows', () => {
+      const resourceCounts = {
+        desiredReady: 3,
+        ready:        2,
+        modified:     1,
+      };
+      const wrapper = shallowMount(FleetSummaryGraphComponent, {
+        propsData: {
+          row: makeRow({
+            type:           FLEET.HELM_OP,
+            resourceCounts,
+            targetClusters: [{ id: 'cluster-1' }],
+          }),
+        },
+      });
+
+      expect((wrapper.vm as any).summary).toStrictEqual(resourceCounts);
+    });
+
+    it('does not return function when row has statusResourceCountsForCluster as a method', () => {
+      const resourceCounts = {
+        desiredReady: 5,
+        ready:        5,
+      };
+      const wrapper = shallowMount(FleetSummaryGraphComponent, {
+        propsData: {
+          row: makeRow({
+            resourceCounts,
+            targetClusters:                 [{ id: 'cluster-1' }],
+            // Simulate a class method — the bug was that a truthy function
+            // caused summary to return the function itself instead of resourceCounts
+            statusResourceCountsForCluster: (clusterId: string) => ({ desiredReady: 0 }),
+          }),
+        },
+      });
+
+      const summary = (wrapper.vm as any).summary;
+
+      expect(typeof summary).not.toBe('function');
+      expect(summary).toStrictEqual(resourceCounts);
+    });
+
+    it('calls statusResourceCountsForCluster with clusterId when clusterId prop is set', () => {
+      const perClusterData = {
+        desiredReady: 2,
+        ready:        1,
+      };
+      const mockFn = jest.fn().mockReturnValue(perClusterData);
+
+      const wrapper = shallowMount(FleetSummaryGraphComponent, {
+        propsData: {
+          row:       makeRow({ statusResourceCountsForCluster: mockFn }),
+          clusterId: 'cluster-1',
+        },
+      });
+
+      expect((wrapper.vm as any).summary).toStrictEqual(perClusterData);
+      expect(mockFn).toHaveBeenCalledWith('cluster-1');
+    });
+
+    it('returns empty object when status.resourceCounts is undefined', () => {
+      const wrapper = shallowMount(FleetSummaryGraphComponent, { propsData: { row: makeRow() } });
+
+      expect((wrapper.vm as any).summary).toStrictEqual({});
+    });
+  });
+
+  describe('show', () => {
+    it('returns true when stateParts exist and row has targetClusters', () => {
+      const wrapper = shallowMount(FleetSummaryGraphComponent, {
+        propsData: {
+          row: makeRow({
+            resourceCounts: {
+              desiredReady: 5,
+              ready:        5,
+            },
+            targetClusters: [{ id: 'cluster-1' }],
+          }),
+        },
+      });
+
+      expect((wrapper.vm as any).show).toBeTruthy();
+    });
+
+    it('returns false when stateParts exist but targetClusters is empty', () => {
+      const wrapper = shallowMount(FleetSummaryGraphComponent, {
+        propsData: {
+          row: makeRow({
+            resourceCounts: {
+              desiredReady: 5,
+              ready:        5,
+            },
+            targetClusters: [],
+          }),
+        },
+      });
+
+      expect((wrapper.vm as any).show).toBeFalsy();
+    });
+
+    it('returns true for FLEET.CLUSTER type even without targetClusters', () => {
+      const wrapper = shallowMount(FleetSummaryGraphComponent, {
+        propsData: {
+          row: makeRow({
+            type:           FLEET.CLUSTER,
+            resourceCounts: {
+              desiredReady: 3,
+              ready:        3,
+            },
+          }),
+        },
+      });
+
+      expect((wrapper.vm as any).show).toBeTruthy();
+    });
+
+    it('returns false when resourceCounts is empty', () => {
+      const wrapper = shallowMount(FleetSummaryGraphComponent, { propsData: { row: makeRow({ targetClusters: [{ id: 'cluster-1' }] }) } });
+
+      expect((wrapper.vm as any).show).toBeFalsy();
+    });
+  });
+
+  describe('stateParts', () => {
+    it('filters out keys starting with "desired"', () => {
+      const wrapper = shallowMount(FleetSummaryGraphComponent, {
+        propsData: {
+          row: makeRow({
+            resourceCounts: {
+              desiredReady: 5,
+              ready:        5,
+            },
+            targetClusters: [{ id: 'cluster-1' }],
+          }),
+        },
+      });
+
+      const parts = (wrapper.vm as any).stateParts;
+
+      expect(parts.every((p: any) => !p.label.startsWith('Desired'))).toBe(true);
+    });
+
+    it('filters out entries with value 0', () => {
+      const wrapper = shallowMount(FleetSummaryGraphComponent, {
+        propsData: {
+          row: makeRow({
+            resourceCounts: {
+              desiredReady: 5,
+              ready:        5,
+              notReady:     0,
+            },
+            targetClusters: [{ id: 'cluster-1' }],
+          }),
+        },
+      });
+
+      const parts = (wrapper.vm as any).stateParts;
+      const labels = parts.map((p: any) => p.label);
+
+      expect(labels).toContain('Ready');
+      expect(labels).not.toContain('NotReady');
+    });
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17563
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- The fix is to remove one missing condition from an old implementation that would count the resources based on the cluster. Part of the code was removed but this was still missing. Since the name of the variable is the same for the one used as a function, it caused the flow that should be false to always be true.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- List of App Bundles should show the proper resource counts

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- List of Cluster 
- List of Cluster Group

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1748" height="1149" alt="image" src="https://github.com/user-attachments/assets/d7bc3826-80e3-44ca-9ca7-932f297b2264" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
