### PR TITLE
Fix chart `targetNamespace` references to use version annotations

### DIFF
--- a/shell/chart/monitoring/index.vue
+++ b/shell/chart/monitoring/index.vue
@@ -17,6 +17,7 @@ import Tabbed from '@shell/components/Tabbed';
 import { allHash } from '@shell/utils/promise';
 import { STORAGE_CLASS, PVC, SECRET, WORKLOAD_TYPES } from '@shell/config/types';
 import { CATTLE_MONITORING_NAMESPACE } from '@shell/utils/monitoring';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
 
 export default {
   emits: ['register-before-hook', 'input'],
@@ -49,6 +50,12 @@ export default {
       default: () => {
         return {};
       },
+    },
+
+    // The selected chart version object, passed from install.vue
+    version: {
+      type:    Object,
+      default: null,
     },
   },
 
@@ -92,7 +99,9 @@ export default {
 
     const hash = await allHash(hashPromises);
 
-    this.targetNamespace = hash.namespaces[this.chart.targetNamespace] || false;
+    const ns = this.version?.annotations?.[CATALOG_ANNOTATIONS.NAMESPACE] || this.chart.targetNamespace;
+
+    this.targetNamespace = hash.namespaces[ns] || false;
 
     if (!isEmpty(hash.storageClasses)) {
       this.storageClasses = hash.storageClasses;

--- a/shell/components/InstallHelmCharts.vue
+++ b/shell/components/InstallHelmCharts.vue
@@ -248,7 +248,7 @@ export default {
 
       };
 
-      this.installCmd.namespace = this.targetNamespace || this.chart?.targetNamespace || 'default';
+      this.installCmd.namespace = this.targetNamespace || this.versionInfo?.chart?.annotations?.[CATALOG_ANNOTATIONS.NAMESPACE] || this.chart?.targetNamespace || 'default';
     }
   },
 
@@ -360,7 +360,7 @@ export default {
           this.canInstallChart = false;
         } else {
           try {
-            const app = await this.$store.dispatch(`${ this.store }/find`, { type: CATALOG.APP, id: `${ this.targetNamespace || this.chart?.targetNamespace || 'default' }/${ this.chartName }` });
+            const app = await this.$store.dispatch(`${ this.store }/find`, { type: CATALOG.APP, id: `${ this.targetNamespace || this.versionInfo?.chart?.annotations?.[CATALOG_ANNOTATIONS.NAMESPACE] || this.chart?.targetNamespace || 'default' }/${ this.chartName }` });
 
             if (app) {
               this.installedVersion = app?.spec?.chart?.metadata?.appVersion;

--- a/shell/mixins/__tests__/chart.test.ts
+++ b/shell/mixins/__tests__/chart.test.ts
@@ -366,6 +366,52 @@ describe('chartMixin', () => {
     });
   });
 
+  describe('isChartTargeted', () => {
+    const DummyComponent = {
+      mixins:   [ChartMixin],
+      template: '<div></div>',
+    };
+
+    const mockStore = {
+      dispatch: jest.fn(() => Promise.resolve()),
+      getters:  { 'i18n/t': (key: string) => key }
+    };
+
+    it('should return truthy when version annotations have both namespace and release-name', () => {
+      const wrapper = mount(DummyComponent, {
+        data: () => ({
+          version: {
+            annotations: {
+              [CATALOG_ANNOTATIONS.NAMESPACE]:    'custom-ns',
+              [CATALOG_ANNOTATIONS.RELEASE_NAME]: 'custom-name',
+            }
+          }
+        }),
+        global: { mocks: { $store: mockStore } }
+      });
+
+      expect(wrapper.vm.isChartTargeted).toBeTruthy();
+    });
+
+    it('should return falsy when version annotations are missing', () => {
+      const wrapper = mount(DummyComponent, {
+        data:   () => ({ version: { annotations: {} } }),
+        global: { mocks: { $store: mockStore } }
+      });
+
+      expect(wrapper.vm.isChartTargeted).toBeFalsy();
+    });
+
+    it('should return falsy when version is null', () => {
+      const wrapper = mount(DummyComponent, {
+        data:   () => ({ version: null }),
+        global: { mocks: { $store: mockStore } }
+      });
+
+      expect(wrapper.vm.isChartTargeted).toBeFalsy();
+    });
+  });
+
   describe('mappedVersions', () => {
     it('should return versions sorted by semver (descending)', () => {
       const versions = [

--- a/shell/mixins/__tests__/chart.test.ts
+++ b/shell/mixins/__tests__/chart.test.ts
@@ -214,6 +214,72 @@ describe('chartMixin', () => {
         id:   'custom-ns/custom-name'
       });
     });
+
+    it('should fall back to matchingInstalledApps when version namespace lookup fails', async() => {
+      const installedApp = {
+        id:   'other-ns/custom-name',
+        spec: { chart: { metadata: { version: '0.9.0' } } }
+      };
+
+      const mockStore = {
+        dispatch: jest.fn((action, payload) => {
+          if (action === 'cluster/find') {
+            return Promise.reject(new Error('not found'));
+          }
+
+          return Promise.resolve();
+        }),
+        getters: {
+          currentCluster: () => {},
+          isRancher:      () => true,
+          'catalog/repo': () => {
+            return () => 'repo';
+          },
+          'catalog/chart': () => {
+            return {
+              id:                    'chart-id',
+              versions:              [{ version: '1.0.0' }],
+              matchingInstalledApps: [installedApp]
+            };
+          },
+          'catalog/version': () => ({
+            version:     '1.0.0',
+            annotations: {
+              [CATALOG_ANNOTATIONS.NAMESPACE]:    'custom-ns',
+              [CATALOG_ANNOTATIONS.RELEASE_NAME]: 'custom-name',
+            }
+          }),
+          'prefs/get': () => {},
+          'i18n/t':    () => jest.fn()
+        }
+      };
+
+      const DummyComponent = {
+        mixins:   [ChartMixin],
+        template: '<div></div>',
+      };
+
+      const wrapper = mount(
+        DummyComponent,
+        {
+          global: {
+            mocks: {
+              $store: mockStore,
+              $route: {
+                query: {
+                  chart:       'chart_name',
+                  versionName: '1.0.0'
+                }
+              }
+            }
+          }
+        });
+
+      await wrapper.vm.fetchChart();
+
+      expect(wrapper.vm.existing).toStrictEqual(installedApp);
+      expect(wrapper.vm.mode).toStrictEqual('edit');
+    });
   });
 
   describe('action', () => {

--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -271,7 +271,7 @@ export default {
     },
 
     isChartTargeted() {
-      return this.chart?.targetNamespace && this.chart?.targetName;
+      return this.version?.annotations?.[CATALOG_ANNOTATIONS.NAMESPACE] && this.version?.annotations?.[CATALOG_ANNOTATIONS.RELEASE_NAME];
     },
 
     hasQuestions() {

--- a/shell/mixins/chart.js
+++ b/shell/mixins/chart.js
@@ -423,8 +423,12 @@ export default {
             });
             this.mode = _EDIT;
           } catch (e) {
-            this.mode = _CREATE;
-            this.existing = null;
+            // Version targets a different namespace than where the app is installed.
+            // Fall back to matching installed apps (e.g. chart detail page).
+            const matching = this.chart?.matchingInstalledApps || [];
+
+            this.existing = matching[0] || null;
+            this.mode = this.existing ? _EDIT : _CREATE;
           }
         } else {
           // Regular chart (not targeted) - check if there are installed instances.

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -859,7 +859,6 @@ export default {
     .readme-wrapper {
       position: relative;
       flex: 1;
-      min-width: 400px;
 
       .open-readme-button {
         display: flex;
@@ -881,6 +880,8 @@ export default {
     }
 
     &__readme {
+      flex: 1;
+      min-width: 400px;
       padding: 12px 24px;
     }
     &__info {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16521

PR #16372 fixed the chart install flow to use version-specific annotations instead of chart-level properties for target namespace and release name. This PR applies the same fix to the remaining locations in the codebase that still used the old chart-level properties.

### Occurred changes and/or fixed issues

- `shell/mixins/chart.js` — `isChartTargeted` computed property now checks `version.annotations` instead of `chart.targetNamespace` / `chart.targetName`
- `shell/chart/monitoring/index.vue` — Namespace lookup now uses version annotations with chart-level fallback. Added `version` as a declared prop instead of relying on `$attrs`
- `shell/components/InstallHelmCharts.vue` — Install namespace (line 251) and "is already installed" check (line 363) now prefer `versionInfo.chart.annotations` over `chart.targetNamespace`
- `shell/mixins/__tests__/chart.test.ts` — Added unit tests for `isChartTargeted`

### Technical notes summary

`chart.targetNamespace` and `chart.targetName` are set in `shell/store/catalog.js` from chart-level annotations in the Helm index, which reflect the **latest** version. When a user selects a specific version that targets a different namespace, these properties are incorrect. The fix is to prefer version-specific annotations (`catalog.cattle.io/namespace` and `catalog.cattle.io/release-name`) and fall back to chart-level properties only when version annotations are not available.

### Areas or cases that should be tested

- Install a chart that has different target namespaces across versions (in 2.12 Rancher Turtles could be used to test but I couldn't find one for 2.15, you can use my dummy chart by adding this repo: `https://momesgin.github.io/mo-charts`). Select an older version and verify the correct namespace is used
- On the chart detail page, verify the "already installed" warning (isChartTargeted) shows correctly for targeted charts across different versions
- Verify monitoring chart installation still targets the correct namespace (`cattle-monitoring-system`)
- Test the `InstallHelmCharts` component flow used by UI extensions (e.g. CAPI Turtles) to ensure namespace resolution works correctly(@mantis-toboggan-md I didn't test this myself, hoping you could confirm this 🙏)

### Areas which could experience regressions

- Chart install flow — namespace assignment when installing/upgrading charts with fixed target namespaces
- Chart detail page — the "already installed" warning display for targeted charts
- Monitoring chart — namespace resolution during the monitoring chart configuration UI
- UI extensions using `InstallHelmCharts` component — namespace resolution and "already installed" detection

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/bb92389b-54c0-419f-91cb-45db6af82ee5


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
