### PR TITLE
[backport v2.14.2] Fix AlertmanagerConfig create failing on 109+ validating webhook

### DIFF
--- a/shell/models/__tests__/monitoring.coreos.com.alertmanagerconfig.test.ts
+++ b/shell/models/__tests__/monitoring.coreos.com.alertmanagerconfig.test.ts
@@ -1,0 +1,98 @@
+import AlertmanagerConfig from '@shell/models/monitoring.coreos.com.alertmanagerconfig';
+
+const base = {
+  apiVersion: 'monitoring.coreos.com/v1alpha1',
+  kind:       'AlertmanagerConfig',
+  metadata:   { name: 'test', namespace: 'default' },
+};
+
+const build = (data: Record<string, any>) => new AlertmanagerConfig(data) as any;
+
+describe('class AlertmanagerConfig', () => {
+  describe('applyDefaults', () => {
+    it('on a fresh resource, seeds the route with defaults and no match/matchRe', () => {
+      const amc = build({ ...base });
+
+      amc.applyDefaults();
+
+      expect(amc.spec.receivers).toStrictEqual([]);
+      expect(amc.spec.route).toStrictEqual({
+        groupBy:        [],
+        groupWait:      '30s',
+        groupInterval:  '5m',
+        repeatInterval: '4h',
+        matchers:       [],
+      });
+    });
+
+    it('backfills route defaults on a resource loaded without a route', () => {
+      const amc = build({
+        ...base,
+        spec: { receivers: [{ name: 'existing' }] },
+      });
+
+      amc.applyDefaults();
+
+      expect(amc.spec.route).toBeDefined();
+      expect(amc.spec.route.receiver).toBeUndefined();
+      expect(amc.spec.route.matchers).toStrictEqual([]);
+    });
+
+    it('preserves existing matchers on load', () => {
+      const matchers = [{
+        name: 'severity', value: 'warning', matchType: '='
+      }];
+      const amc = build({
+        ...base,
+        spec: {
+          receivers: [{ name: 'existing' }],
+          route:     { receiver: 'existing', matchers },
+        },
+      });
+
+      amc.applyDefaults();
+
+      expect(amc.spec.route.matchers).toStrictEqual(matchers);
+    });
+  });
+
+  describe('cleanForSave', () => {
+    it('drops spec.route when no receiver is set — this is what fixes #17347 on 109+ charts', () => {
+      const amc = build({ ...base });
+
+      const out = amc.cleanForSave({
+        ...base,
+        spec: {
+          receivers: [],
+          route:     {
+            groupBy:        [],
+            groupWait:      '30s',
+            groupInterval:  '5m',
+            repeatInterval: '4h',
+            matchers:       [],
+          },
+        },
+      }, true);
+
+      expect(out.spec.route).toBeUndefined();
+      expect(out.spec.receivers).toStrictEqual([]);
+    });
+
+    it('keeps spec.route when a receiver is set', () => {
+      const amc = build({ ...base });
+
+      const out = amc.cleanForSave({
+        ...base,
+        spec: {
+          receivers: [{ name: 'existing' }],
+          route:     {
+            receiver: 'existing', groupBy: [], matchers: []
+          },
+        },
+      }, false);
+
+      expect(out.spec.route).toBeDefined();
+      expect(out.spec.route.receiver).toBe('existing');
+    });
+  });
+});

--- a/shell/models/monitoring.coreos.com.alertmanagerconfig.js
+++ b/shell/models/monitoring.coreos.com.alertmanagerconfig.js
@@ -5,25 +5,39 @@ import { set } from '@shell/utils/object';
 
 export default class AlertmanagerConfig extends SteveModel {
   applyDefaults() {
-    if (this.spec) {
-      return this.spec;
-    }
-    const existingReceivers = this.spec?.route?.receivers || [];
+    const spec = this.spec || {};
 
-    const defaultSpec = {
-      receivers: [...existingReceivers],
-      route:     {
-        receivers:      this.spec?.route?.receivers || [],
-        groupBy:        this.spec?.route?.groupBy || [],
-        groupWait:      this.spec?.route?.groupWait || '30s',
-        groupInterval:  this.spec?.route?.groupInterval || '5m',
-        repeatInterval: this.spec?.route?.repeatInterval || '4h',
-        match:          this.spec?.route?.match || {},
-        matchRe:        this.spec?.route?.matchRe || {}
+    spec.receivers = spec.receivers || [];
+
+    // Always provide a route object so the Route tab has something to bind to,
+    // even when loading a resource that was saved without `spec.route`.
+    const route = { ...(spec.route || {}) };
+
+    route.groupBy = route.groupBy || [];
+    route.groupWait = route.groupWait || '30s';
+    route.groupInterval = route.groupInterval || '5m';
+    route.repeatInterval = route.repeatInterval || '4h';
+    route.matchers = route.matchers || [];
+
+    spec.route = route;
+
+    set(this, 'spec', spec);
+  }
+
+  cleanForSave(data, forNew) {
+    const val = super.cleanForSave(data, forNew);
+    const route = val?.spec?.route;
+
+    if (route) {
+      // When a route is present its `receiver` is required and must match an
+      // entry in `spec.receivers`. Until the user has defined a receiver the
+      // root route can't direct alerts anywhere, so drop it entirely
+      if (!route.receiver) {
+        delete val.spec.route;
       }
-    };
+    }
 
-    set(this, 'spec', defaultSpec);
+    return val;
   }
 
   get _availableActions() {


### PR DESCRIPTION
### Summary
Fixes #17356

Manual backport of #17351 to `release-2.14`. The automatic `/backport v2.14.2` failed with an `add/add` conflict on the new test file (see [bot comment](https://github.com/rancher/dashboard/pull/17351#issuecomment-4407724126)); a normal cherry-pick of the squashed merge commit applies cleanly, so no manual conflict resolution was required.

### Occurred changes and/or fixed issues
`applyDefaults` seeded `spec.route.match: {}`, `matchRe: {}`, and `receivers: []` — none exist on the CRD. `<=108` silently pruned them; the `109+` validating webhook rejects the payload. Stop seeding the bad fields and drop `spec.route` on save when no `receiver` is set (optional on the CRD).

### Technical notes summary
Identical to the master PR — no version-specific adjustments needed. Cherry-pick of `c6ccc7d` from master.

### Areas or cases that should be tested
- Create an AMC with just a name on Monitoring 109.0.0+ — should succeed.
- Same on `<=108` — regression check.

### Areas which could experience regressions
No other consumers of `spec.route.match` / `matchRe` / `receivers` in the code path.

### Screenshot/Video
See #17351 for before/after recordings.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`