### PR TITLE
[backport v2.14.3] Fix incorrect button sizes introduced by RcButton changes

### DIFF
--- a/cypress/e2e/po/components/create-edit-view.po.ts
+++ b/cypress/e2e/po/components/create-edit-view.po.ts
@@ -24,7 +24,7 @@ export default class CreateEditViewPo extends ComponentPo {
   }
 
   cancel() {
-    return new AsyncButtonPo(this.self().find('.cru-resource-footer .role-secondary')).click();
+    return new AsyncButtonPo(this.self().find('.cru-resource-footer .variant-secondary')).click();
   }
 
   saveAndWait() {

--- a/cypress/e2e/po/pages/explorer/charts/install-charts.po.ts
+++ b/cypress/e2e/po/pages/explorer/charts/install-charts.po.ts
@@ -23,7 +23,7 @@ export class InstallChartPage extends PagePo {
   }
 
   nextPage() {
-    const btn = new AsyncButtonPo('.controls-steps .btn.role-primary');
+    const btn = new AsyncButtonPo('.controls-steps .btn.variant-primary');
 
     btn.click(true);
 

--- a/cypress/e2e/po/pages/explorer/secrets.po.ts
+++ b/cypress/e2e/po/pages/explorer/secrets.po.ts
@@ -44,7 +44,7 @@ export class SecretsListPagePo extends BaseListPagePo {
   }
 
   createButtonTitle() {
-    return this.createButton().invoke('text');
+    return this.createButton().invoke('text').invoke('trim');
   }
 
   list() {

--- a/pkg/rancher-components/src/components/RcButton/RcButton.test.ts
+++ b/pkg/rancher-components/src/components/RcButton/RcButton.test.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount, RouterLinkStub } from '@vue/test-utils';
 import RcButton from './RcButton.vue';
 
 describe('rcButton.vue', () => {
@@ -136,6 +136,42 @@ describe('rcButton.vue', () => {
       const button = wrapper.find('button');
 
       expect(button.classes()).toContain('variant-ghost');
+    });
+  });
+
+  describe('to prop', () => {
+    it('renders as a <button> when no "to" prop is provided', () => {
+      const wrapper = mount(RcButton);
+
+      expect(wrapper.find('button').exists()).toBe(true);
+      expect(wrapper.findComponent(RouterLinkStub).exists()).toBe(false);
+    });
+
+    it('renders as a RouterLink when "to" prop is provided', () => {
+      const to = { name: 'some-route' };
+      const wrapper = mount(RcButton, {
+        props:  { to },
+        global: { stubs: { RouterLink: RouterLinkStub } },
+      });
+
+      const link = wrapper.findComponent(RouterLinkStub);
+
+      expect(link.exists()).toBe(true);
+      expect(wrapper.find('button').exists()).toBe(false);
+      expect(link.props('to')).toStrictEqual(to);
+    });
+
+    it('applies button classes when rendered as a RouterLink', () => {
+      const wrapper = mount(RcButton, {
+        props:  { to: '/foo', variant: 'secondary' },
+        global: { stubs: { RouterLink: RouterLinkStub } },
+      });
+
+      const link = wrapper.findComponent(RouterLinkStub);
+
+      expect(link.classes()).toContain('rc-button');
+      expect(link.classes()).toContain('btn');
+      expect(link.classes()).toContain('variant-secondary');
     });
   });
 });

--- a/pkg/rancher-components/src/components/RcButton/RcButton.vue
+++ b/pkg/rancher-components/src/components/RcButton/RcButton.vue
@@ -7,10 +7,15 @@
  *
  * <rc-button variant="primary" @click="doAction">Perform an Action</rc-button>
  */
-import { computed, ref } from 'vue';
+import { computed, ref, resolveComponent } from 'vue';
+import type { RouteLocationRaw } from 'vue-router';
 import {
-  ButtonVariantProps, ButtonSizeProps, ButtonVariantNewProps, ButtonSizeNewProps, ButtonSize,
-  IconProps
+  ButtonVariantProps,
+  ButtonSizeProps,
+  ButtonVariantNewProps,
+  ButtonSizeNewProps,
+  ButtonSize,
+  IconProps,
 } from './types';
 import RcIcon from '@components/RcIcon/RcIcon.vue';
 
@@ -33,7 +38,22 @@ const buttonSizesNew: { size: ButtonSize, className: string }[] = [
   { size: 'large', className: 'btn-large' },
 ];
 
-const props = withDefaults(defineProps<ButtonVariantProps & ButtonSizeProps & ButtonVariantNewProps & ButtonSizeNewProps & IconProps>(), { size: 'medium' });
+const props = withDefaults(
+  defineProps<
+        ButtonVariantProps &
+        ButtonSizeProps &
+        ButtonVariantNewProps &
+        ButtonSizeNewProps &
+        IconProps & { to?: RouteLocationRaw }
+    >(),
+  {
+    size: 'medium',
+    to:   undefined,
+  }
+);
+
+const tag = computed(() => (props.to ? resolveComponent('RouterLink') : 'button'));
+const role = computed(() => (props.to ? 'link' : 'button'));
 
 const activeVariantClassName = computed(() => {
   if (props.variant === 'multiAction' || props.multiAction) {
@@ -94,9 +114,11 @@ defineExpose({ focus });
 </script>
 
 <template>
-  <button
+  <component
+    :is="tag"
     ref="RcFocusTarget"
-    role="button"
+    :role="role"
+    :to="to"
     :class="{ ...buttonClass }"
   >
     <slot
@@ -124,14 +146,22 @@ defineExpose({ focus });
         size="inherit"
       />
     </slot>
-  </button>
+  </component>
 </template>
 
 <style lang="scss" scoped>
-button {
+.rc-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+
+  // Override global .btn > .icon:not(:only-child) { margin-right: 6px } from _button.scss.
+  // RcButton uses flex gap for spacing instead. The :not(:only-child) clause matches the global
+  // selector so we win on specificity regardless of stylesheet load order; :deep() is needed to
+  // target slotted content.
+  & > :deep(.icon:not(:only-child)) {
+    margin-right: 0;
+  }
 
   // Much of the styling in here came from _button.scss. Because we're making changes from role to variant and we don't want to impact existing use cases we're pulling in some of these styles. We should in the long run deprecate that file.
   // Variant styles

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownTrigger.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownTrigger.vue
@@ -35,18 +35,20 @@ defineExpose({ focus });
     @keydown.enter.space="handleKeydown"
     @click="showMenu(true)"
   >
-    <template #before>
-      <slot name="before">
-        <!-- Empty Content -->
-      </slot>
+    <template
+      v-if="$slots.before"
+      #before
+    >
+      <slot name="before" />
     </template>
     <slot name="default">
       <!--Empty slot content-->
     </slot>
-    <template #after>
-      <slot name="after">
-        <!-- Empty Content -->
-      </slot>
+    <template
+      v-if="$slots.after"
+      #after
+    >
+      <slot name="after" />
     </template>
   </RcButton>
 </template>

--- a/shell/components/ActionDropdownShell.vue
+++ b/shell/components/ActionDropdownShell.vue
@@ -35,6 +35,7 @@ const setBulkActionOfInterest = (act: HiddenAction | null, event: 'mouseover' | 
   >
     <rc-dropdown-trigger
       class="bulk-actions-dropdown"
+      size="large"
       :disabled="disabled"
     >
       <template #before>
@@ -42,7 +43,7 @@ const setBulkActionOfInterest = (act: HiddenAction | null, event: 'mouseover' | 
       </template>
       <span>{{ t('sortableTable.bulkActions.collapsed.label') }}</span>
       <template #after>
-        <i class="ml-10 icon icon-chevron-down" />
+        <i class="icon icon-chevron-down" />
       </template>
     </rc-dropdown-trigger>
     <template #dropdownCollection>

--- a/shell/components/CruResourceFooter.vue
+++ b/shell/components/CruResourceFooter.vue
@@ -3,13 +3,16 @@ import { mapGetters } from 'vuex';
 
 import AsyncButton from '@shell/components/AsyncButton';
 import ResourceCancelModal from '@shell/components/ResourceCancelModal';
+import { RcButton } from '@components/RcButton';
 import { _VIEW } from '@shell/config/query-params';
 
 export default {
   emits: ['cancel-confirmed', 'finish'],
 
-  components: { AsyncButton, ResourceCancelModal },
-  props:      {
+  components: {
+    AsyncButton, RcButton, ResourceCancelModal
+  },
+  props: {
     mode: {
       type:    String,
       default: 'create',
@@ -84,16 +87,17 @@ export default {
   <div class="cru-resource-footer">
     <slot name="footer-prefix" />
     <slot name="cancel">
-      <button
+      <RcButton
         v-if="!isView && showCancel"
         id="cru-cancel"
         :data-testid="componentTestid + '-cancel'"
         type="button"
-        class="btn role-secondary"
+        variant="secondary"
+        size="large"
         @click="confirmCancelRequired ? checkCancel(true) : $emit('cancel-confirmed', true)"
       >
         <t k="generic.cancel" />
-      </button>
+      </RcButton>
     </slot>
     <slot :checkCancel="checkCancel">
       <AsyncButton

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -167,12 +167,6 @@ const showAdditionalActionButtons = computed(() => isArray(additionalActions));
     position: relative;
   }
 
-  .icon-document {
-    width: 15px;
-    font-size: 16px;
-    margin-right: 10px;
-  }
-
   .actions {
     display: flex;
     align-items: center;

--- a/shell/components/ResourceList/Masthead.vue
+++ b/shell/components/ResourceList/Masthead.vue
@@ -2,6 +2,7 @@
 import { mapGetters } from 'vuex';
 import Favorite from '@shell/components/nav/Favorite';
 import TypeDescription from '@shell/components/TypeDescription';
+import { RcButton } from '@components/RcButton';
 import { get } from '@shell/utils/object';
 import { AS, _YAML } from '@shell/config/query-params';
 import ResourceLoadingIndicator from './ResourceLoadingIndicator';
@@ -16,6 +17,7 @@ export default {
 
   components: {
     Favorite,
+    RcButton,
     TypeDescription,
     ResourceLoadingIndicator,
     TabTitle
@@ -198,22 +200,24 @@ export default {
           <slot name="extraActions" />
 
           <slot name="createButton">
-            <router-link
+            <RcButton
               v-if="hasEditComponent && _isCreatable"
-              :to="_createLocation"
-              class="btn role-primary"
+              variant="primary"
+              size="large"
               :data-testid="componentTestid+'-create'"
+              :to="_createLocation"
             >
               {{ _createButtonlabel }}
-            </router-link>
-            <router-link
+            </RcButton>
+            <RcButton
               v-else-if="_isYamlCreatable"
-              :to="_yamlCreateLocation"
-              class="btn role-primary"
+              variant="primary"
+              size="large"
               :data-testid="componentTestid+'-create-yaml'"
+              :to="_yamlCreateLocation"
             >
               {{ t("resourceList.head.createFromYaml") }}
-            </router-link>
+            </RcButton>
           </slot>
         </div>
       </slot>

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -26,6 +26,7 @@ import ButtonMultiAction from '@shell/components/ButtonMultiAction.vue';
 import ActionMenu from '@shell/components/ActionMenuShell.vue';
 import { useRuntimeFlag } from '@shell/composables/useRuntimeFlag';
 import ActionDropdownShell from '@shell/components/ActionDropdownShell.vue';
+import { RcButton } from '@components/RcButton';
 import { useTabCountUpdater } from '@shell/components/form/ResourceTabs/composable';
 
 // Uncomment for table performance debugging
@@ -65,6 +66,7 @@ export default {
     ButtonMultiAction,
     ActionMenu,
     ActionDropdownShell,
+    RcButton,
   },
 
   mixins: [
@@ -1116,17 +1118,17 @@ export default {
         >
           <slot name="header-left">
             <template v-if="tableActions">
-              <button
+              <RcButton
                 v-for="(act) in availableActions"
                 :id="act.action"
                 :key="act.action"
                 v-clean-tooltip="actionTooltip"
                 type="button"
-                class="btn role-primary"
+                variant="primary"
+                size="large"
                 :class="{[bulkActionClass]:true}"
                 :disabled="!act.enabled"
                 :data-testid="componentTestid + '-' + act.action"
-                role="button"
                 :aria-label="act.label"
                 @click="applyTableAction(act, null, $event)"
                 @keydown.enter.stop
@@ -1138,7 +1140,7 @@ export default {
                   :class="act.icon"
                 />
                 <span v-clean-html="act.label" />
-              </button>
+              </RcButton>
               <template v-if="featureDropdownMenu">
                 <ActionDropdownShell
                   :disabled="!selectedRows.length"
@@ -2154,11 +2156,6 @@ export default {
         }
       }
 
-      .bulk-action  {
-        .icon {
-          vertical-align: -10%;
-        }
-      }
     }
 
     .middle {

--- a/shell/components/Wizard.vue
+++ b/shell/components/Wizard.vue
@@ -2,6 +2,7 @@
 import { _CREATE, _VIEW } from '@shell/config/query-params';
 import AsyncButton from '@shell/components/AsyncButton';
 import { Banner } from '@components/Banner';
+import { RcButton } from '@components/RcButton';
 import Loading from '@shell/components/Loading';
 import { stringify } from '@shell/utils/error';
 import LazyImage from '@shell/components/LazyImage';
@@ -28,6 +29,7 @@ export default {
   components: {
     AsyncButton,
     Banner,
+    RcButton,
     Loading,
     LazyImage,
   },
@@ -44,7 +46,6 @@ export default {
     loading: Wizard will block until all steps are not loading
     nextButton?: {
       labelKey?: default to `wizard.next`
-      style?:  defaults to `btn role-primary`
     },
     previousButton: {
       disable: defaults to false
@@ -185,9 +186,6 @@ export default {
       return this.steps.filter((step) => !step.hidden);
     },
 
-    nextButtonStyle() {
-      return this.activeStep.nextButton?.style || `btn role-primary`;
-    },
     nextButtonLabel() {
       return this.activeStep.nextButton?.labelKey || `wizard.next`;
     }
@@ -444,13 +442,14 @@ export default {
             name="cancel"
             :cancel="cancel"
           >
-            <button
+            <RcButton
               type="button"
-              class="btn role-secondary"
+              variant="secondary"
+              size="large"
               @click="cancel"
             >
               <t k="generic.cancel" />
-            </button>
+            </RcButton>
           </slot>
           <div class="controls-steps">
             <slot
@@ -458,14 +457,15 @@ export default {
               name="back"
               :back="back"
             >
-              <button
+              <RcButton
                 :disabled="!canPrevious || (!editFirstStep && activeStepIndex===1)"
                 type="button"
-                class="btn role-secondary"
+                variant="secondary"
+                size="large"
                 @click="back()"
               >
                 <t k="wizard.previous" />
-              </button>
+              </RcButton>
             </slot>
             <slot
               v-if="activeStepIndex === visibleSteps.length-1"
@@ -484,14 +484,15 @@ export default {
               name="next"
               :next="next"
             >
-              <button
+              <RcButton
                 :disabled="!canNext"
                 type="button"
-                :class="nextButtonStyle"
+                variant="primary"
+                size="large"
                 @click="next()"
               >
                 <t :k="nextButtonLabel" />
-              </button>
+              </RcButton>
             </slot>
           </div>
         </div>

--- a/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
+++ b/shell/pages/c/_cluster/uiplugins/PluginInfoPanel.vue
@@ -349,6 +349,7 @@ export default {
                   v-for="btn in panelActions"
                   :key="btn.action"
                   class="mmr-3 mmb-3"
+                  size="large"
                   :variant="btn.role"
                   @click="onButtonClick(btn)"
                 >

--- a/storybook/.storybook/preview.ts
+++ b/storybook/.storybook/preview.ts
@@ -29,10 +29,12 @@ setup((vueApp) => {
 
   vueApp.component('v-select', vSelect);
   vueApp.use(ShortKey, { prevent: ['input', 'textarea', 'select'] });
-  vueApp.component('router-link', {
-    props:   ['to'],
-    template: '<a>link</a>',
-  })
+  const RouterLinkStub = {
+    props:    ['to'],
+    template: '<a :href="typeof to === \'string\' ? to : \'#\'"><slot /></a>',
+  };
+  vueApp.component('router-link', RouterLinkStub);
+  vueApp.component('RouterLink', RouterLinkStub);
   vueApp.config.globalProperties.$store = store
 })
 

--- a/storybook/src/stories/Components/RcButton.mdx
+++ b/storybook/src/stories/Components/RcButton.mdx
@@ -17,6 +17,19 @@ Different button variants for different purposes and visual hierarchy:
 
 <Canvas of={RcButtonStories.AllVariants} />
 
+## As Router Link
+
+When the `to` prop is provided, RcButton renders as an `<a>` tag (via Vue Router's `<RouterLink>`) instead of a `<button>`.
+This enables client-side navigation while preserving all button styling.
+
+The rendered HTML changes from:
+- **Without `to`:** `<button class="rc-button btn variant-primary ...">` 
+- **With `to`:** `<a class="rc-button btn variant-primary ..." href="/path">`
+
+This improves accessibility and enables standard link behaviors like ctrl+click to open in a new tab.
+
+<Canvas of={RcButtonStories.AsRouterLink} />
+
 ## Button Sizes
 
 Buttons are available in three sizes: small, medium (default), and large:

--- a/storybook/src/stories/Components/RcButton.stories.ts
+++ b/storybook/src/stories/Components/RcButton.stories.ts
@@ -26,6 +26,10 @@ const meta: Meta<typeof RcButton> = {
       control:     { type: 'select' },
       description: 'Icon to display on the right side of the button text.'
     },
+    to: {
+      control:     { type: 'text' },
+      description: 'When provided, renders the button as a RouterLink for client-side navigation instead of a plain button element.'
+    },
   }
 };
 
@@ -47,12 +51,12 @@ export const Default: Story = {
 };
 
 export const AllVariants: Story = {
-  render: (args: any) => ({
+  render: () => ({
     components: { RcButton },
     setup() {
       const variants: ButtonVariant[] = ['primary', 'secondary', 'tertiary', 'link', 'multiAction', 'ghost'];
 
-      return { args, variants };
+      return { variants };
     },
     template: `<div style="display: flex; flex-direction: column; gap: 20px; max-width: 800px;">
       <div v-for="variant in variants" :key="variant" style="display: flex; align-items: center; gap: 20px;">
@@ -63,17 +67,66 @@ export const AllVariants: Story = {
   }),
   parameters: {
     controls: { disabled: true },
-    docs:     { canvas: { sourceState: 'none' } }
+    docs:     {
+      source: {
+        code: `<RcButton variant="primary">Primary</RcButton>
+<RcButton variant="secondary">Secondary</RcButton>
+<RcButton variant="tertiary">Tertiary</RcButton>
+<RcButton variant="link">Link</RcButton>
+<RcButton variant="multiAction">MultiAction</RcButton>
+<RcButton variant="ghost">Ghost</RcButton>`,
+        language: 'html',
+      }
+    }
+  },
+};
+
+export const AsRouterLink: Story = {
+  render: () => ({
+    components: { RcButton },
+    setup() {
+      const variants: ButtonVariant[] = ['primary', 'secondary', 'tertiary', 'link'];
+
+      return { variants };
+    },
+    template: `<div style="display: flex; flex-direction: column; gap: 20px; max-width: 800px;">
+      <div v-for="variant in variants" :key="variant" style="display: flex; align-items: center; gap: 20px;">
+        <div style="min-width: 120px; font-weight: bold;">{{ variant }}</div>
+        <RcButton :variant="variant" size="medium" to="/">{{ variant }}</RcButton>
+      </div>
+    </div>`,
+  }),
+  parameters: {
+    controls: { disabled: true },
+    docs:     {
+      description: {
+        story: `When the \`to\` prop is provided, RcButton renders as a \`<a>\` tag (via Vue Router's \`<RouterLink>\`) instead of a \`<button>\`.
+This enables client-side navigation while preserving all button styling.
+The rendered HTML changes from \`<button class="rc-button btn ...">\` to \`<a class="rc-button btn ..." href="/path">\`,
+which improves accessibility and allows standard link behaviors like ctrl+click to open in a new tab.`
+      },
+      source: {
+        code: `<!-- String path: renders as <a href="/resources" class="rc-button btn variant-primary ..."> -->
+<RcButton variant="primary" to="/resources">Resources</RcButton>
+
+<!-- Route object: renders as <a href="/c/local/..." class="rc-button btn variant-secondary ..."> -->
+<RcButton variant="secondary" :to="{ name: 'c-cluster-resource', params: { cluster: 'local' } }">Cluster</RcButton>
+
+<!-- Without to: renders as <button class="rc-button btn variant-primary ..."> -->
+<RcButton variant="primary" @click="doAction">Action</RcButton>`,
+        language: 'html',
+      }
+    }
   },
 };
 
 export const AllSizes: Story = {
-  render: (args: any) => ({
+  render: () => ({
     components: { RcButton },
     setup() {
       const sizes: ButtonSize[] = ['small', 'medium', 'large'];
 
-      return { args, sizes };
+      return { sizes };
     },
     template: `<div style="display: flex; flex-direction: column; gap: 20px; max-width: 800px;">
       <div v-for="size in sizes" :key="size" style="display: flex; align-items: center; gap: 20px;">
@@ -84,17 +137,21 @@ export const AllSizes: Story = {
   }),
   parameters: {
     controls: { disabled: true },
-    docs:     { canvas: { sourceState: 'none' } }
+    docs:     {
+      source: {
+        code: `<RcButton variant="primary" size="small">Small</RcButton>
+<RcButton variant="primary" size="medium">Medium</RcButton>
+<RcButton variant="primary" size="large">Large</RcButton>`,
+        language: 'html',
+      }
+    }
   },
 };
 
 export const WithIcons: Story = {
-  render: (args: any) => ({
+  render: () => ({
     components: { RcButton },
-    setup() {
-      return { args };
-    },
-    template: `<div style="display: flex; flex-wrap: wrap; gap: 20px;">
+    template:   `<div style="display: flex; flex-wrap: wrap; gap: 20px;">
       <RcButton variant="primary" left-icon="plus">Add Item</RcButton>
       <RcButton variant="secondary" left-icon="search">Search</RcButton>
       <RcButton variant="tertiary" right-icon="chevronDown">Dropdown</RcButton>
@@ -104,6 +161,15 @@ export const WithIcons: Story = {
   }),
   parameters: {
     controls: { disabled: true },
-    docs:     { canvas: { sourceState: 'none' } }
+    docs:     {
+      source: {
+        code: `<RcButton variant="primary" left-icon="plus">Add Item</RcButton>
+<RcButton variant="secondary" left-icon="search">Search</RcButton>
+<RcButton variant="tertiary" right-icon="chevronDown">Dropdown</RcButton>
+<RcButton variant="primary" left-icon="download" right-icon="chevronRight">Download</RcButton>
+<RcButton variant="ghost" left-icon="edit">Edit</RcButton>`,
+        language: 'html',
+      }
+    }
   },
 };


### PR DESCRIPTION
### Notes
- Given the attention these changes get we may want to skip backporting this but I'll leave it to you if you'd like to also backport the router-link changes.
- We also omitted the `project-secrets.po.ts` change from this one.

### Summary
Backport of #17178 to `release-2.14`.

The automatic backport via `/backport v2.14.2` failed due to merge conflicts ([comment](https://github.com/rancher/dashboard/pull/17178#issuecomment-4407718404)). This PR cherry-picks the squash merge commit and resolves the conflicts manually.

### Occurred changes and/or fixed issues
- **RcButton**: Override global style to fix spacing.
- **RcDropdownTrigger**: Only render `#before`/`#after` when provided to resolve spacing issue.
- **SortableTable**: Converted buttons to RcButton on bulk's size.
- **Masthead**: Converted Create button to RcButton
- **CruResourceFooter**: Converted Cancel button to RcButton
- **TitleBar**: Removed `.icon-document` margin styles
- **ActionDropdownShell**: Removed `ml-10` class from chevron icon

### Areas or cases that should be tested
- Header icon buttons (bell, page actions, user menu) sizing and spacing
- Table action buttons
- Create button on list pages
- Show Configuration button and action menu on resource detail pages
- Label/annotation tags on resource detail pages
- Cancel button in create/edit forms

### Areas which could experience regressions
- Any component using RcButton
- Navigation via Create button (now uses `$router.push` instead of `router-link`)

### Screenshot/Video
See #17178 for before/after recordings.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`