### PR TITLE
xccdf report for compliance operator

### DIFF
--- a/creators/extension/app/app.package.json
+++ b/creators/extension/app/app.package.json
@@ -5,7 +5,9 @@
   "engines": {
     "node": ">=24"
   },
-  "dependencies": {},
+  "dependencies": {
+    "xmlbuilder2": "4.0.3"
+  },
   "resolutions": {
     "@types/node": "~25.3.0",
     "@types/lodash": "4.17.5"

--- a/creators/extension/app/app.package.json
+++ b/creators/extension/app/app.package.json
@@ -5,9 +5,7 @@
   "engines": {
     "node": ">=24"
   },
-  "dependencies": {
-    "xmlbuilder2": "4.0.3"
-  },
+  "dependencies": {},
   "resolutions": {
     "@types/node": "~25.3.0",
     "@types/lodash": "4.17.5"

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "vue3-virtual-scroll-list": "0.2.1",
     "vuedraggable": "4.1.0",
     "vuex": "4.1.0",
+    "xmlbuilder2": "4.0.1",
     "xterm": "5.2.1",
     "xterm-addon-canvas": "0.5.0",
     "xterm-addon-fit": "0.8.0",

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1514,9 +1514,12 @@ compliance:
       =1 { Any scheduled scans using this profile will no longer work. }
       other { Any scheduled scans using either of these profiles will no longer work. }
     }
-  downloadAllReports: Download All Saved Reports
-  downloadLatestReport: Download Latest Report
-  downloadReport: Download Report
+  downloadAllReports: Download All Saved Reports (CSV)
+  downloadAllReportsXCCDF: Download All Saved Reports (XCCDF)
+  downloadLatestReport: Download Latest Report (CSV)
+  downloadLatestReportXCCDF: Download Latest Report (XCCDF)
+  downloadReport: Download Report (CSV)
+  downloadReportXCCDF: Download Report (XCCDF)
   maxKubernetesVersion: Maximum allowed Kubernetes version
   minKubernetesVersion: Minimum required Kubernetes version
   noProfiles: There are no valid ClusterScanProfiles for this cluster type to select.

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1528,6 +1528,8 @@ compliance:
   reports: Reports
   retention: Retention Count
   scan:
+    errorNoParsedNodes: No nodes were parsed from the scan results, so no report can be generated.
+    errorDownload: Error downloading file
     description: Description
     fail: Fail
     lastScanTime: Last Scan Time

--- a/shell/models/compliance.cattle.io.clusterscan.js
+++ b/shell/models/compliance.cattle.io.clusterscan.js
@@ -196,17 +196,33 @@ export default class ClusterScan extends SteveModel {
 
     try {
       const benchmark = await this._resolveBenchmark();
-      const { generateXCCDF } = await import(/* webpackChunkName: "xccdf" */'@shell/utils/xccdf');
+      const { generateXCCDFPerNode } = await import(/* webpackChunkName: "xccdf" */'@shell/utils/xccdf');
 
-      const xml = generateXCCDF({
-        report:           report.parsedReport || {},
-        benchmarkVersion: report.parsedReport?.version || benchmark?.spec?.benchmarkVersion || '',
+      const parsed = report.parsedReport || {};
+      const common = {
+        report:           parsed,
+        benchmarkVersion: parsed.version || benchmark?.spec?.benchmarkVersion || '',
         metadata:         benchmark?.spec?.benchmarkMetadata || {},
         stigChecks:       benchmark?.spec?.stigChecks || {},
-        clusterName:      this.spec?.clusterName,
+      };
+
+      const toZip = {};
+
+      Object.entries(parsed.nodes || {}).forEach(([role, hosts]) => {
+        (hosts || []).forEach((hostname) => {
+          const xml = generateXCCDFPerNode({
+            ...common, hostname, role,
+          });
+
+          toZip[`${ labelFor(report) }--${ hostname }.xml`] = xml;
+        });
       });
 
-      downloadFile(`${ labelFor(report) }.xml`, xml, 'application/xml');
+      if (!isEmpty(toZip)) {
+        const zip = await generateZip(toZip);
+
+        downloadFile(`${ labelFor(report) }-per-node.zip`, zip, 'application/zip');
+      }
     } catch (err) {
       this.$dispatch('growl/fromError', { title: 'Error downloading file', err }, { root: true });
     }
@@ -218,19 +234,28 @@ export default class ClusterScan extends SteveModel {
 
     try {
       const benchmark = await this._resolveBenchmark();
-      const { generateXCCDF } = await import(/* webpackChunkName: "xccdf" */'@shell/utils/xccdf');
+      const { generateXCCDFPerNode } = await import(/* webpackChunkName: "xccdf" */'@shell/utils/xccdf');
 
       reports.forEach((report) => {
         try {
-          const xml = generateXCCDF({
-            report:           report.parsedReport || {},
-            benchmarkVersion: report.parsedReport?.version || benchmark?.spec?.benchmarkVersion || '',
+          const parsed = report.parsedReport || {};
+          const common = {
+            report:           parsed,
+            benchmarkVersion: parsed.version || benchmark?.spec?.benchmarkVersion || '',
             metadata:         benchmark?.spec?.benchmarkMetadata || {},
             stigChecks:       benchmark?.spec?.stigChecks || {},
-            clusterName:      this.spec?.clusterName,
-          });
+          };
+          const folder = labelFor(report);
 
-          toZip[`${ labelFor(report) }.xml`] = xml;
+          Object.entries(parsed.nodes || {}).forEach(([role, hosts]) => {
+            (hosts || []).forEach((hostname) => {
+              const xml = generateXCCDFPerNode({
+                ...common, hostname, role,
+              });
+
+              toZip[`${ folder }/${ hostname }.xml`] = xml;
+            });
+          });
         } catch (err) {
           this.$dispatch('growl/fromError', { title: 'Error downloading file', err }, { root: true });
         }
@@ -238,7 +263,7 @@ export default class ClusterScan extends SteveModel {
 
       if (!isEmpty(toZip)) {
         generateZip(toZip).then((zip) => {
-          downloadFile(`${ this.id }-reports-xccdf`, zip, 'application/zip');
+          downloadFile(`${ this.id }-reports-xccdf-per-node.zip`, zip, 'application/zip');
         });
       }
     } catch (err) {

--- a/shell/models/compliance.cattle.io.clusterscan.js
+++ b/shell/models/compliance.cattle.io.clusterscan.js
@@ -65,8 +65,29 @@ export default class ClusterScan extends SteveModel {
       total:   1,
     };
 
+    const downloadReportXCCDF = {
+      action:  'downloadLatestReportXCCDF',
+      enabled: this.hasReport,
+      icon:    'icon icon-download',
+      label:   t('compliance.downloadReportXCCDF'),
+      total:   1,
+    };
+
+    const downloadAllReportsXCCDF = {
+      action:  'downloadAllReportsXCCDF',
+      enabled: this.hasReport,
+      icon:    'icon icon-download',
+      label:   t('compliance.downloadAllReportsXCCDF'),
+      total:   1,
+    };
+
     if (this.hasReports) {
       out.unshift({ divider: true });
+      if (this.spec?.scheduledScanConfig?.cronSchedule) {
+        out.unshift(downloadAllReportsXCCDF);
+        downloadReportXCCDF.label = t('compliance.downloadLatestReportXCCDF');
+      }
+      out.unshift(downloadReportXCCDF);
       if (this.spec?.scheduledScanConfig?.cronSchedule) {
         out.unshift(downloadAllReports);
         downloadReport.label = t('compliance.downloadLatestReport');
@@ -150,6 +171,78 @@ export default class ClusterScan extends SteveModel {
       generateZip(toZip).then((zip) => {
         downloadFile(`${ this.id }-reports`, zip, 'application/zip');
       });
+    }
+  }
+
+  async _resolveBenchmark() {
+    const profileName = this.status?.lastRunScanProfileName;
+
+    if (!profileName) {
+      return null;
+    }
+    const profile = await this.$dispatch('find', { type: COMPLIANCE.CLUSTER_SCAN_PROFILE, id: profileName });
+    const benchmarkId = profile?.spec?.benchmarkVersion;
+
+    if (!benchmarkId) {
+      return null;
+    }
+
+    return this.$dispatch('find', { type: COMPLIANCE.BENCHMARK, id: benchmarkId });
+  }
+
+  async downloadLatestReportXCCDF() {
+    const reports = await this.getReports() || [];
+    const report = sortBy(reports, 'metadata.creationTimestamp', true)[0];
+
+    try {
+      const benchmark = await this._resolveBenchmark();
+      const { generateXCCDF } = await import(/* webpackChunkName: "xccdf" */'@shell/utils/xccdf');
+
+      const xml = generateXCCDF({
+        report:           report.parsedReport || {},
+        benchmarkVersion: report.parsedReport?.version || benchmark?.spec?.benchmarkVersion || '',
+        metadata:         benchmark?.spec?.benchmarkMetadata || {},
+        stigChecks:       benchmark?.spec?.stigChecks || {},
+        clusterName:      this.spec?.clusterName,
+      });
+
+      downloadFile(`${ labelFor(report) }.xml`, xml, 'application/xml');
+    } catch (err) {
+      this.$dispatch('growl/fromError', { title: 'Error downloading file', err }, { root: true });
+    }
+  }
+
+  async downloadAllReportsXCCDF() {
+    const toZip = {};
+    const reports = await this.getReports() || [];
+
+    try {
+      const benchmark = await this._resolveBenchmark();
+      const { generateXCCDF } = await import(/* webpackChunkName: "xccdf" */'@shell/utils/xccdf');
+
+      reports.forEach((report) => {
+        try {
+          const xml = generateXCCDF({
+            report:           report.parsedReport || {},
+            benchmarkVersion: report.parsedReport?.version || benchmark?.spec?.benchmarkVersion || '',
+            metadata:         benchmark?.spec?.benchmarkMetadata || {},
+            stigChecks:       benchmark?.spec?.stigChecks || {},
+            clusterName:      this.spec?.clusterName,
+          });
+
+          toZip[`${ labelFor(report) }.xml`] = xml;
+        } catch (err) {
+          this.$dispatch('growl/fromError', { title: 'Error downloading file', err }, { root: true });
+        }
+      });
+
+      if (!isEmpty(toZip)) {
+        generateZip(toZip).then((zip) => {
+          downloadFile(`${ this.id }-reports-xccdf`, zip, 'application/zip');
+        });
+      }
+    } catch (err) {
+      this.$dispatch('growl/fromError', { title: 'Error downloading file', err }, { root: true });
     }
   }
 

--- a/shell/models/compliance.cattle.io.clusterscan.js
+++ b/shell/models/compliance.cattle.io.clusterscan.js
@@ -142,7 +142,7 @@ export default class ClusterScan extends SteveModel {
 
       downloadFile(`${ labelFor(report) }.csv`, csv, 'application/csv');
     } catch (err) {
-      this.$dispatch('growl/fromError', { title: 'Error downloading file', err }, { root: true });
+      this.$dispatch('growl/fromError', { title: this.t('compliance.scan.errorDownload'), err }, { root: true });
     }
   }
 
@@ -164,7 +164,7 @@ export default class ClusterScan extends SteveModel {
 
         toZip[`${ labelFor(report) }.csv`] = csv;
       } catch (err) {
-        this.$dispatch('growl/fromError', { title: 'Error downloading file', err }, { root: true });
+        this.$dispatch('growl/fromError', { title: this.t('compliance.scan.errorDownload'), err }, { root: true });
       }
     });
     if (!isEmpty(toZip)) {
@@ -208,23 +208,27 @@ export default class ClusterScan extends SteveModel {
 
       const toZip = {};
 
-      Object.entries(parsed.nodes || {}).forEach(([role, hosts]) => {
-        (hosts || []).forEach((hostname) => {
-          const xml = generateXCCDFPerNode({
-            ...common, hostname, role,
+      if (!Object.entries(parsed.nodes || {}).length) {
+        this.$dispatch('growl/fromError', { title: this.t('compliance.scan.errorNoParsedNodes') }, { root: true });
+      } else {
+        Object.entries(parsed.nodes || {}).forEach(([role, hosts]) => {
+          (hosts || []).forEach((hostname) => {
+            const xml = generateXCCDFPerNode({
+              ...common, hostname, role,
+            });
+
+            toZip[`${ labelFor(report) }--${ hostname }.xml`] = xml;
           });
-
-          toZip[`${ labelFor(report) }--${ hostname }.xml`] = xml;
         });
-      });
 
-      if (!isEmpty(toZip)) {
-        const zip = await generateZip(toZip);
+        if (!isEmpty(toZip)) {
+          const zip = await generateZip(toZip);
 
-        downloadFile(`${ labelFor(report) }-per-node.zip`, zip, 'application/zip');
+          downloadFile(`${ labelFor(report) }-per-node.zip`, zip, 'application/zip');
+        }
       }
     } catch (err) {
-      this.$dispatch('growl/fromError', { title: 'Error downloading file', err }, { root: true });
+      this.$dispatch('growl/fromError', { title: this.t('compliance.scan.errorDownload'), err }, { root: true });
     }
   }
 
@@ -257,7 +261,7 @@ export default class ClusterScan extends SteveModel {
             });
           });
         } catch (err) {
-          this.$dispatch('growl/fromError', { title: 'Error downloading file', err }, { root: true });
+          this.$dispatch('growl/fromError', { title: this.t('compliance.scan.errorDownload'), err }, { root: true });
         }
       });
 
@@ -267,7 +271,7 @@ export default class ClusterScan extends SteveModel {
         });
       }
     } catch (err) {
-      this.$dispatch('growl/fromError', { title: 'Error downloading file', err }, { root: true });
+      this.$dispatch('growl/fromError', { title: this.t('compliance.scan.errorDownload'), err }, { root: true });
     }
   }
 

--- a/shell/models/compliance.cattle.io.clusterscan.js
+++ b/shell/models/compliance.cattle.io.clusterscan.js
@@ -240,35 +240,41 @@ export default class ClusterScan extends SteveModel {
       const benchmark = await this._resolveBenchmark();
       const { generateXCCDFPerNode } = await import(/* webpackChunkName: "xccdf" */'@shell/utils/xccdf');
 
-      reports.forEach((report) => {
-        try {
-          const parsed = report.parsedReport || {};
-          const common = {
-            report:           parsed,
-            benchmarkVersion: parsed.version || benchmark?.spec?.benchmarkVersion || '',
-            metadata:         benchmark?.spec?.benchmarkMetadata || {},
-            stigChecks:       benchmark?.spec?.stigChecks || {},
-          };
-          const folder = labelFor(report);
+      const hasParsedNodes = reports.some((report) => Object.entries(report.parsedReport?.nodes || {}).length);
 
-          Object.entries(parsed.nodes || {}).forEach(([role, hosts]) => {
-            (hosts || []).forEach((hostname) => {
-              const xml = generateXCCDFPerNode({
-                ...common, hostname, role,
+      if (!hasParsedNodes) {
+        this.$dispatch('growl/fromError', { title: this.t('compliance.scan.errorNoParsedNodes') }, { root: true });
+      } else {
+        reports.forEach((report) => {
+          try {
+            const parsed = report.parsedReport || {};
+            const common = {
+              report:           parsed,
+              benchmarkVersion: parsed.version || benchmark?.spec?.benchmarkVersion || '',
+              metadata:         benchmark?.spec?.benchmarkMetadata || {},
+              stigChecks:       benchmark?.spec?.stigChecks || {},
+            };
+            const folder = labelFor(report);
+
+            Object.entries(parsed.nodes || {}).forEach(([role, hosts]) => {
+              (hosts || []).forEach((hostname) => {
+                const xml = generateXCCDFPerNode({
+                  ...common, hostname, role,
+                });
+
+                toZip[`${ folder }/${ hostname }.xml`] = xml;
               });
-
-              toZip[`${ folder }/${ hostname }.xml`] = xml;
             });
-          });
-        } catch (err) {
-          this.$dispatch('growl/fromError', { title: this.t('compliance.scan.errorDownload'), err }, { root: true });
-        }
-      });
-
-      if (!isEmpty(toZip)) {
-        generateZip(toZip).then((zip) => {
-          downloadFile(`${ this.id }-reports-xccdf-per-node.zip`, zip, 'application/zip');
+          } catch (err) {
+            this.$dispatch('growl/fromError', { title: this.t('compliance.scan.errorDownload'), err }, { root: true });
+          }
         });
+
+        if (!isEmpty(toZip)) {
+          generateZip(toZip).then((zip) => {
+            downloadFile(`${ this.id }-reports-xccdf-per-node.zip`, zip, 'application/zip');
+          });
+        }
       }
     } catch (err) {
       this.$dispatch('growl/fromError', { title: this.t('compliance.scan.errorDownload'), err }, { root: true });

--- a/shell/package.json
+++ b/shell/package.json
@@ -142,6 +142,7 @@
     "webpack-bundle-analyzer": "4.10.2",
     "webpack-virtual-modules": "0.6.2",
     "worker-loader": "3.0.8",
+    "xmlbuilder2": "4.0.1",
     "xterm": "5.2.1",
     "xterm-addon-canvas": "0.5.0",
     "xterm-addon-fit": "0.8.0",

--- a/shell/utils/__tests__/xccdf.test.ts
+++ b/shell/utils/__tests__/xccdf.test.ts
@@ -1,0 +1,195 @@
+import { generateXCCDF } from '@shell/utils/xccdf';
+
+describe('xccdf util: generateXCCDF', () => {
+  const baseReport = {
+    version: '1.0',
+    total:   2,
+    pass:    1,
+    nodes:   { master: ['node-a'], node: ['node-b'] },
+    results: [{
+      id:          '5.1',
+      description: 'RBAC and Service Accounts',
+      checks:      [{
+        id:          '5.1.1',
+        description: 'Ensure that the cluster-admin role is only used where required',
+        audit:       'kubectl get clusterrolebindings',
+        remediation: 'Identify all clusterrolebindings to the cluster-admin role',
+        scored:      true,
+        state:       'pass',
+      }, {
+        id:          '5.1.2',
+        description: 'Minimize access to secrets',
+        audit:       'kubectl get roles',
+        remediation: 'Where possible, remove get, list and watch access to Secret objects',
+        scored:      false,
+        state:       'fail',
+      }],
+    }],
+  };
+
+  it('produces an XML document with an XML header and a Benchmark root', () => {
+    const xml = generateXCCDF({ report: baseReport, benchmarkVersion: 'cis-1.7' });
+
+    expect(xml).toMatch(/^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+    expect(xml).toContain('<Benchmark');
+    expect(xml).toContain('xmlns="http://checklists.nist.gov/xccdf/1.2"');
+    expect(xml).toContain('id="xccdf_compliance-operator_benchmark_kubernetes"');
+  });
+
+  it('uses the metadata title when provided, otherwise falls back to a CIS title from benchmarkVersion', () => {
+    const fallback = generateXCCDF({ report: baseReport, benchmarkVersion: 'cis-1.7' });
+
+    expect(fallback).toContain('<title>Kubernetes CIS Benchmark cis-1.7</title>');
+
+    const withTitle = generateXCCDF({
+      report:           baseReport,
+      benchmarkVersion: 'cis-1.7',
+      metadata:         { title: 'Custom Benchmark Title' },
+    });
+
+    expect(withTitle).toContain('<title>Custom Benchmark Title</title>');
+  });
+
+  it('emits one Group per result and one Rule per check', () => {
+    const xml = generateXCCDF({ report: baseReport, benchmarkVersion: 'cis-1.7' });
+
+    expect(xml).toContain('<Group id="5.1">');
+    expect(xml).toContain('id="xccdf_compliance-operator_rule_5.1.1"');
+    expect(xml).toContain('id="xccdf_compliance-operator_rule_5.1.2"');
+  });
+
+  it('maps state values to XCCDF result strings', () => {
+    const report = {
+      ...baseReport,
+      results: [{
+        id:          '1',
+        description: 'g',
+        checks:      [
+          {
+            id: 'a', description: 'a', state: 'pass' as const
+          },
+          {
+            id: 'b', description: 'b', state: 'fail' as const
+          },
+          {
+            id: 'c', description: 'c', state: 'skip' as const
+          },
+          {
+            id: 'd', description: 'd', state: 'warn' as const
+          },
+          {
+            id: 'e', description: 'e', state: 'notApplicable' as const
+          },
+        ],
+      }],
+    };
+
+    const xml = generateXCCDF({ report, benchmarkVersion: 'cis-1.7' });
+
+    expect(xml).toContain('<result>pass</result>');
+    expect(xml).toContain('<result>fail</result>');
+    expect(xml).toContain('<result>notselected</result>');
+    expect(xml).toContain('<result>informational</result>');
+    expect(xml).toContain('<result>notapplicable</result>');
+  });
+
+  it('marks scored checks with severity=medium and weight=10; unscored as low and 0', () => {
+    const xml = generateXCCDF({ report: baseReport, benchmarkVersion: 'cis-1.7' });
+
+    expect(xml).toMatch(/id="xccdf_compliance-operator_rule_5\.1\.1"[^>]*severity="medium"/);
+    expect(xml).toMatch(/id="xccdf_compliance-operator_rule_5\.1\.1"[^>]*weight="10"/);
+    expect(xml).toMatch(/id="xccdf_compliance-operator_rule_5\.1\.2"[^>]*severity="low"/);
+    expect(xml).toMatch(/id="xccdf_compliance-operator_rule_5\.1\.2"[^>]*weight="0"/);
+  });
+
+  it('computes score as pass/total*100, formatted to one decimal', () => {
+    const xml = generateXCCDF({ report: baseReport, benchmarkVersion: 'cis-1.7' });
+
+    expect(xml).toMatch(/<score[^>]*maximum="100\.0"[^>]*>50\.0<\/score>/);
+  });
+
+  it('returns score 0.0 when total is 0', () => {
+    const xml = generateXCCDF({
+      report: {
+        ...baseReport, total: 0, pass: 0, results: [],
+      },
+      benchmarkVersion: 'cis-1.7',
+    });
+
+    expect(xml).toMatch(/<score[^>]*>0\.0<\/score>/);
+  });
+
+  it('uses report.nodes for <target> elements when no clusterName is set', () => {
+    const xml = generateXCCDF({ report: baseReport, benchmarkVersion: 'cis-1.7' });
+
+    expect(xml).toContain('<target>node-a</target>');
+    expect(xml).toContain('<target>node-b</target>');
+  });
+
+  it('clusterName argument overrides metadata.clusterName and node-derived targets', () => {
+    const xml = generateXCCDF({
+      report:           baseReport,
+      benchmarkVersion: 'cis-1.7',
+      metadata:         { clusterName: 'from-metadata' },
+      clusterName:      'from-arg',
+    });
+
+    expect(xml).toContain('<target>from-arg</target>');
+    expect(xml).not.toContain('<target>from-metadata</target>');
+    expect(xml).not.toContain('<target>node-a</target>');
+  });
+
+  it('falls back to "not-applicable" for missing target addresses and target facts', () => {
+    const xml = generateXCCDF({ report: baseReport, benchmarkVersion: 'cis-1.7' });
+
+    expect(xml).toContain('<target-address>not-applicable</target-address>');
+    expect(xml).toContain('<fact name="not-applicable" type="string">not-applicable</fact>');
+  });
+
+  it('emits a single placeholder Group when results is empty', () => {
+    const xml = generateXCCDF({
+      report: {
+        version: '1.0', total: 0, pass: 0, results: [],
+      },
+      benchmarkVersion: 'cis-1.7',
+    });
+
+    expect(xml).toContain('<Group id="not-applicable">');
+  });
+
+  it('uses STIG metadata to override rule id, version, severity, fix, check system, and CCI idents', () => {
+    const xml = generateXCCDF({
+      report: {
+        ...baseReport,
+        results: [{
+          id:          'g1',
+          description: 'g',
+          checks:      [{
+            id: 'V-254553-TLS-apiserver', description: 'STIG check', scored: true, state: 'pass',
+          }],
+        }],
+      },
+      benchmarkVersion: 'rke2-stig-1.31',
+      stigChecks:       {
+        'V-254553': {
+          ruleId: 'SV-254553r1016525_rule', version: 'SV-254553r1016525_rule', severity: 'high', fixId: 'F-254553', checkId: 'C-254553', cci: ['CCI-000366'],
+        },
+      },
+    });
+
+    expect(xml).toContain('idref="SV-254553r1016525_rule_TLS-apiserver"');
+    expect(xml).toContain('severity="high"');
+    expect(xml).toContain('<ident system="http://cyber.mil/cci">CCI-000366</ident>');
+    expect(xml).toContain('fixref="F-254553"');
+    expect(xml).toContain('<check system="C-254553">');
+  });
+
+  it('preserves the operator-style rule id when there is no STIG metadata', () => {
+    const xml = generateXCCDF({
+      report:           baseReport,
+      benchmarkVersion: 'cis-1.7',
+    });
+
+    expect(xml).toContain('id="xccdf_compliance-operator_rule_5.1.1"');
+  });
+});

--- a/shell/utils/__tests__/xccdf.test.ts
+++ b/shell/utils/__tests__/xccdf.test.ts
@@ -1,4 +1,4 @@
-import { generateXCCDF } from '@shell/utils/xccdf';
+import { generateXCCDF, generateXCCDFPerNode } from '@shell/utils/xccdf';
 
 describe('xccdf util: generateXCCDF', () => {
   const baseReport = {
@@ -191,5 +191,201 @@ describe('xccdf util: generateXCCDF', () => {
     });
 
     expect(xml).toContain('id="xccdf_compliance-operator_rule_5.1.1"');
+  });
+});
+
+describe('xccdf util: generateXCCDFPerNode', () => {
+  const multiNodeReport = {
+    version: '1.0',
+    total:   3,
+    pass:    1,
+    nodes:   { master: ['m-1'], node: ['w-1', 'w-2'] },
+    results: [{
+      id:          '1.1',
+      description: 'Master Node Configuration',
+      checks:      [{
+        id:          '1.1.1',
+        description: 'master check',
+        scored:      true,
+        state:       'pass' as const,
+      }],
+    }, {
+      id:          '4.1',
+      description: 'Worker Node Configuration',
+      checks:      [{
+        id:          '4.1.1',
+        description: 'mixed check',
+        scored:      true,
+        state:       'mixed' as const,
+        nodes:       ['w-2'],
+      }, {
+        id:          '4.1.2',
+        description: 'failing check',
+        scored:      false,
+        state:       'fail' as const,
+      }],
+    }],
+  };
+
+  it('emits a single <target> equal to the hostname', () => {
+    const xml = generateXCCDFPerNode({
+      report: multiNodeReport, benchmarkVersion: 'cis-1.7', hostname: 'w-1', role: 'node',
+    });
+
+    expect(xml).toContain('<target>w-1</target>');
+    expect(xml).not.toContain('<target>w-2</target>');
+    expect(xml).not.toContain('<target>m-1</target>');
+  });
+
+  it('assigns each per-node document a TestResult id suffixed with the hostname so co-loaded files do not collide', () => {
+    const a = generateXCCDFPerNode({
+      report: multiNodeReport, benchmarkVersion: 'cis-1.7', hostname: 'w-1', role: 'node',
+    });
+    const b = generateXCCDFPerNode({
+      report: multiNodeReport, benchmarkVersion: 'cis-1.7', hostname: 'w-2', role: 'node',
+    });
+
+    expect(a).toContain('<TestResult id="xccdf_compliance-operator_testresult_1_w-1"');
+    expect(b).toContain('<TestResult id="xccdf_compliance-operator_testresult_1_w-2"');
+    expect(a).not.toContain('id="xccdf_compliance-operator_testresult_1_w-2"');
+  });
+
+  it('emits every rule from the cluster report regardless of role', () => {
+    const workerXml = generateXCCDFPerNode({
+      report: multiNodeReport, benchmarkVersion: 'cis-1.7', hostname: 'w-1', role: 'node',
+    });
+    const masterXml = generateXCCDFPerNode({
+      report: multiNodeReport, benchmarkVersion: 'cis-1.7', hostname: 'm-1', role: 'master',
+    });
+
+    [workerXml, masterXml].forEach((xml) => {
+      expect(xml).toContain('xccdf_compliance-operator_rule_1.1.1');
+      expect(xml).toContain('xccdf_compliance-operator_rule_4.1.1');
+      expect(xml).toContain('xccdf_compliance-operator_rule_4.1.2');
+    });
+  });
+
+  it('maps mixed-state checks to fail for dissenting hosts and pass for the rest', () => {
+    const dissenter = generateXCCDFPerNode({
+      report: multiNodeReport, benchmarkVersion: 'cis-1.7', hostname: 'w-2', role: 'node',
+    });
+    const compliant = generateXCCDFPerNode({
+      report: multiNodeReport, benchmarkVersion: 'cis-1.7', hostname: 'w-1', role: 'node',
+    });
+
+    expect(dissenter).toMatch(/idref="xccdf_compliance-operator_rule_4\.1\.1"[\s\S]*?<result>fail<\/result>/);
+    expect(compliant).toMatch(/idref="xccdf_compliance-operator_rule_4\.1\.1"[\s\S]*?<result>pass<\/result>/);
+  });
+
+  it('treats mixed-state checks with no dissent list as pass for all nodes', () => {
+    const report = {
+      ...multiNodeReport,
+      results: [{
+        id:          '4.1',
+        description: 'g',
+        checks:      [{
+          id: '4.1.9', description: 'm', state: 'mixed' as const,
+        }],
+      }],
+    };
+    const xml = generateXCCDFPerNode({
+      report, benchmarkVersion: 'cis-1.7', hostname: 'w-1', role: 'node',
+    });
+
+    expect(xml).toMatch(/idref="xccdf_compliance-operator_rule_4\.1\.9"[\s\S]*?<result>pass<\/result>/);
+  });
+
+  it('recomputes pass count per node while preserving cluster total as the scoring denominator', () => {
+    const report = {
+      version: '1.0',
+      total:   2,
+      pass:    1,
+      nodes:   { node: ['w-1', 'w-2'] },
+      results: [{
+        id:          '1',
+        description: 'g',
+        checks:      [
+          {
+            id: 'a', description: 'a', state: 'pass' as const
+          },
+          {
+            id: 'b', description: 'b', state: 'mixed' as const, nodes: ['w-2'],
+          },
+        ],
+      }],
+    };
+    const compliant = generateXCCDFPerNode({
+      report, benchmarkVersion: 'cis-1.7', hostname: 'w-1', role: 'node',
+    });
+    const dissenter = generateXCCDFPerNode({
+      report, benchmarkVersion: 'cis-1.7', hostname: 'w-2', role: 'node',
+    });
+
+    expect(compliant).toMatch(/<score[^>]*>100\.0<\/score>/);
+    expect(dissenter).toMatch(/<score[^>]*>50\.0<\/score>/);
+  });
+
+  it('preserves full rule metadata (title, fixtext, idents, check) from the cluster report', () => {
+    const report = {
+      version: '1.0',
+      total:   1,
+      pass:    1,
+      nodes:   { node: ['w-1'] },
+      results: [{
+        id:          'V-254554',
+        description: 'controller manager group',
+        checks:      [{
+          id:          'V-254554',
+          description: 'use-service-account-credentials',
+          audit:       '/bin/ps -fC kube-controller-manager',
+          remediation: 'set use-service-account-credentials=true',
+          scored:      true,
+          state:       'pass' as const,
+        }],
+      }],
+    };
+    const xml = generateXCCDFPerNode({
+      report, benchmarkVersion: 'rke2-stig-1.31-rgs', hostname: 'w-1', role: 'node',
+    });
+
+    expect(xml).toContain('<Group id="V-254554">');
+    expect(xml).toContain('<check-content>/bin/ps -fC kube-controller-manager</check-content>');
+    expect(xml).toContain('set use-service-account-credentials=true');
+  });
+
+  it('passes through non-mixed states unchanged', () => {
+    const report = {
+      ...multiNodeReport,
+      results: [{
+        id:          '4.1',
+        description: 'g',
+        checks:      [
+          {
+            id: 'a', description: 'a', state: 'pass' as const
+          },
+          {
+            id: 'b', description: 'b', state: 'fail' as const
+          },
+          {
+            id: 'c', description: 'c', state: 'skip' as const
+          },
+          {
+            id: 'd', description: 'd', state: 'warn' as const
+          },
+          {
+            id: 'e', description: 'e', state: 'notApplicable' as const
+          },
+        ],
+      }],
+    };
+    const xml = generateXCCDFPerNode({
+      report, benchmarkVersion: 'cis-1.7', hostname: 'w-1', role: 'node',
+    });
+
+    expect(xml).toContain('<result>pass</result>');
+    expect(xml).toContain('<result>fail</result>');
+    expect(xml).toContain('<result>notselected</result>');
+    expect(xml).toContain('<result>informational</result>');
+    expect(xml).toContain('<result>notapplicable</result>');
   });
 });

--- a/shell/utils/xccdf.ts
+++ b/shell/utils/xccdf.ts
@@ -15,6 +15,11 @@ export interface XccdfReportCheck {
   audit?: string;
   scored?: boolean;
   state?: string;
+  nodes?: string[];
+  // eslint-disable-next-line camelcase
+  node_type?: string[];
+  // eslint-disable-next-line camelcase
+  actual_value_per_node?: Record<string, string>;
 }
 
 export interface XccdfReportGroup {
@@ -82,6 +87,8 @@ export interface GenerateXccdfArgs {
   targetFacts?: XccdfTargetFact[];
   /** Override the cluster name used for the <target> element. Falls back to metadata.clusterName, then derived node names. */
   clusterName?: string;
+  /** Override the TestResult @id. Required when multiple documents from the same benchmark will be co-loaded into a validator. */
+  testResultId?: string;
 }
 
 const na = (s?: string): string => (s && s.length > 0 ? s : NA);
@@ -184,6 +191,7 @@ export function generateXCCDF({
   targetAddresses,
   targetFacts,
   clusterName,
+  testResultId,
 }: GenerateXccdfArgs): string {
   const now = new Date();
   const timeStr = now.toISOString().replace(/\.\d{3}Z$/, 'Z');
@@ -301,7 +309,7 @@ export function generateXCCDF({
   const targets = clusterName ? [clusterName] : metadata.clusterName ? [metadata.clusterName] : collectTargets(report);
 
   const testResult = benchmark.ele('TestResult', {
-    id:            `${ ID_PREFIX }_${ TEST_RESULT_ID_SUFFIX }`,
+    id:            testResultId || `${ ID_PREFIX }_${ TEST_RESULT_ID_SUFFIX }`,
     'start-time':  timeStr,
     'end-time':    timeStr,
     version:       benchmarkVersion,
@@ -368,4 +376,43 @@ export function generateXCCDF({
   testResult.ele('score', { system: SCORING_SYSTEM, maximum: '100.0' }).txt(scoreStr);
 
   return doc.end({ prettyPrint: true });
+}
+
+export interface GenerateXccdfPerNodeArgs extends Omit<GenerateXccdfArgs, 'clusterName' | 'targetAddresses' | 'targetFacts'> {
+  hostname: string;
+  role: string;
+}
+
+const remapCheckForNode = (check: XccdfReportCheck, hostname: string): XccdfReportCheck => {
+  const isMixed = (check.state || '').toLowerCase() === 'mixed';
+  const state = isMixed ? ((check.nodes || []).includes(hostname) ? 'fail' : 'pass') : check.state;
+
+  return { ...check, state };
+};
+
+export function generateXCCDFPerNode(args: GenerateXccdfPerNodeArgs): string {
+  const {
+    report, hostname, role, ...rest
+  } = args;
+
+  const perNodeResults: XccdfReportGroup[] = (report.results || []).map((group) => ({
+    ...group,
+    checks: (group.checks || []).map((c) => remapCheckForNode(c, hostname)),
+  }));
+
+  const passForNode = perNodeResults
+    .flatMap((g) => g.checks || [])
+    .filter((c) => (c.state || '').toLowerCase() === 'pass').length;
+
+  return generateXCCDF({
+    ...rest,
+    report: {
+      ...report,
+      results: perNodeResults,
+      pass:    passForNode,
+      nodes:   { [role]: [hostname] },
+    },
+    clusterName:  hostname,
+    testResultId: `${ ID_PREFIX }_${ TEST_RESULT_ID_SUFFIX }_${ safeId(hostname) }`,
+  });
 }

--- a/shell/utils/xccdf.ts
+++ b/shell/utils/xccdf.ts
@@ -1,0 +1,371 @@
+import { create } from 'xmlbuilder2';
+
+const XCCDF_NS = 'http://checklists.nist.gov/xccdf/1.2';
+const ID_PREFIX = 'xccdf_compliance-operator';
+const BENCHMARK_ID_SUFFIX = 'benchmark_kubernetes';
+const TEST_RESULT_ID_SUFFIX = 'testresult_1';
+const SCORING_SYSTEM = 'urn:xccdf:scoring:default';
+const CHECK_SYSTEM = 'urn:xccdf:check:manual';
+const NA = 'not-applicable';
+
+export interface XccdfReportCheck {
+  id?: string;
+  description?: string;
+  remediation?: string;
+  audit?: string;
+  scored?: boolean;
+  state?: string;
+}
+
+export interface XccdfReportGroup {
+  id?: string;
+  description?: string;
+  checks?: XccdfReportCheck[];
+}
+
+export interface XccdfReport {
+  version?: string;
+  total?: number;
+  pass?: number;
+  nodes?: Record<string, string[]>;
+  results?: XccdfReportGroup[];
+}
+
+export interface BenchmarkMetadata {
+  benchmarkId?: string;
+  title?: string;
+  clusterName?: string;
+  contributor?: string;
+  creator?: string;
+  description?: string;
+  frontMatter?: string;
+  notice?: string;
+  noticeId?: string;
+  plainText?: string;
+  plainTextId?: string;
+  platform?: string;
+  publisher?: string;
+  rearMatter?: string;
+  referenceHref?: string;
+  referenceTitle?: string;
+  referenceType?: string;
+  referenceSubject?: string;
+  referenceIdentifier?: string;
+  checkHref?: string;
+  checkName?: string;
+  source?: string;
+}
+
+export interface StigCheckMetadata {
+  ruleId?: string;
+  version?: string;
+  severity?: string;
+  fixId?: string;
+  checkId?: string;
+  cci?: string[];
+}
+
+export type StigChecks = Record<string, StigCheckMetadata>;
+
+export interface XccdfTargetFact {
+  name: string;
+  type: string;
+  value: string;
+}
+
+export interface GenerateXccdfArgs {
+  report: XccdfReport;
+  benchmarkVersion: string;
+  metadata?: BenchmarkMetadata;
+  stigChecks?: StigChecks;
+  targetAddresses?: string[];
+  targetFacts?: XccdfTargetFact[];
+  /** Override the cluster name used for the <target> element. Falls back to metadata.clusterName, then derived node names. */
+  clusterName?: string;
+}
+
+const na = (s?: string): string => (s && s.length > 0 ? s : NA);
+
+const safeId = (s: string): string => s.replace(/ /g, '_');
+
+const ruleIdFor = (checkId: string): string => `${ ID_PREFIX }_rule_${ safeId(checkId) }`;
+
+const fixIdFor = (checkId: string): string => `${ ruleIdFor(checkId) }_fix`;
+
+const profileIdFor = (benchmarkVersion: string): string => `${ ID_PREFIX }_profile_${ safeId(benchmarkVersion) }`;
+
+const stigGroupId = (checkId: string): string => {
+  const parts = checkId.split('-');
+
+  if (parts.length >= 2) {
+    return `${ parts[0] }-${ parts[1] }`;
+  }
+
+  return checkId;
+};
+
+const effectiveRuleId = (stig: StigCheckMetadata, checkId: string): string => {
+  if (!stig.ruleId) {
+    return ruleIdFor(checkId);
+  }
+  const gid = stigGroupId(checkId);
+
+  if (checkId === gid) {
+    return stig.ruleId;
+  }
+  const suffix = checkId.startsWith(`${ gid }-`) ? checkId.slice(gid.length + 1) : checkId;
+
+  return `${ stig.ruleId }_${ suffix }`;
+};
+
+const lookupStig = (stigChecks: StigChecks, checkId: string): StigCheckMetadata => {
+  return stigChecks[stigGroupId(checkId)] || {};
+};
+
+const mapResult = (state?: string): string => {
+  switch ((state || '').toLowerCase()) {
+  case 'pass': return 'pass';
+  case 'fail': return 'fail';
+  case 'skip': return 'notselected';
+  case 'notapplicable': return 'notapplicable';
+  case 'warn': return 'informational';
+  default: return 'informational';
+  }
+};
+
+const severityFor = (scored?: boolean): string => (scored ? 'medium' : 'low');
+
+const stigSeverity = (stigSev: string | undefined, scored?: boolean): string => stigSev || severityFor(scored);
+
+const ruleWeight = (scored?: boolean): string => (scored ? '10' : '0');
+
+const ruleRole = (scored?: boolean): string => (scored ? 'full' : 'unscored');
+
+const stigIdents = (ccis?: string[]): { system: string; value: string }[] => {
+  if (!ccis || ccis.length === 0) {
+    return [{ system: NA, value: NA }];
+  }
+
+  return ccis.map((cci) => ({ system: 'http://cyber.mil/cci', value: cci }));
+};
+
+const collectTargets = (report: XccdfReport): string[] => {
+  const seen = new Set<string>();
+  const targets: string[] = [];
+  const nodes = report.nodes || {};
+
+  Object.values(nodes).forEach((list) => {
+    (list || []).forEach((n) => {
+      if (!seen.has(n)) {
+        seen.add(n);
+        targets.push(n);
+      }
+    });
+  });
+
+  return targets.length > 0 ? targets : [NA];
+};
+
+const collectTargetAddresses = (addresses?: string[]): string[] => {
+  return addresses && addresses.length > 0 ? addresses : [NA];
+};
+
+const collectTargetFacts = (facts?: XccdfTargetFact[]): XccdfTargetFact[] => {
+  return facts && facts.length > 0 ? facts : [{
+    name: NA, type: 'string', value: NA
+  }];
+};
+
+export function generateXCCDF({
+  report,
+  benchmarkVersion,
+  metadata = {},
+  stigChecks = {},
+  targetAddresses,
+  targetFacts,
+  clusterName,
+}: GenerateXccdfArgs): string {
+  const now = new Date();
+  const timeStr = now.toISOString().replace(/\.\d{3}Z$/, 'Z');
+  const dateStr = timeStr.slice(0, 10);
+
+  const benchmarkId = metadata.benchmarkId || `${ ID_PREFIX }_${ BENCHMARK_ID_SUFFIX }`;
+  const benchmarkTitle = metadata.title || `Kubernetes CIS Benchmark ${ benchmarkVersion }`;
+
+  const doc = create({ version: '1.0', encoding: 'UTF-8' });
+  const benchmark = doc.ele('Benchmark', {
+    xmlns:      XCCDF_NS,
+    id:         benchmarkId,
+    resolved:   '1',
+    'xml:lang': 'en',
+    style:      '',
+  });
+
+  benchmark.ele('status', { date: dateStr }).txt('complete');
+  benchmark.ele('title').txt(benchmarkTitle);
+  benchmark.ele('description').txt(na(metadata.description));
+  benchmark.ele('notice', { id: na(metadata.noticeId) }).txt(na(metadata.notice));
+  benchmark.ele('front-matter').txt(na(metadata.frontMatter));
+  benchmark.ele('rear-matter').txt(na(metadata.rearMatter));
+
+  const ref = benchmark.ele('reference', { href: na(metadata.referenceHref) });
+
+  ref.ele('publisher').txt(na(metadata.publisher));
+  ref.ele('source').txt(na(metadata.source));
+
+  benchmark.ele('plain-text', { id: na(metadata.plainTextId) }).txt(na(metadata.plainText));
+  benchmark.ele('platform', { idref: na(metadata.platform) });
+  benchmark.ele('version').txt(na(report.version));
+
+  const meta = benchmark.ele('metadata');
+
+  meta.ele('creator').txt(na(metadata.creator));
+  meta.ele('publisher').txt(na(metadata.publisher));
+  meta.ele('contributor').txt(na(metadata.contributor));
+  meta.ele('source').txt(na(metadata.source));
+
+  benchmark.ele('model', { system: SCORING_SYSTEM });
+
+  const profile = benchmark.ele('Profile', { id: profileIdFor(benchmarkVersion) });
+
+  profile.ele('title').txt(benchmarkTitle);
+  profile.ele('description').txt(na(metadata.description));
+
+  const ruleResults: { check: XccdfReportCheck; effectiveId: string; stig: StigCheckMetadata }[] = [];
+  const groups = report.results || [];
+
+  groups.forEach((group) => {
+    const g = benchmark.ele('Group', { id: na(group.id) });
+
+    g.ele('title').txt(na(group.description));
+    g.ele('description').txt(na(group.description));
+
+    (group.checks || []).forEach((check) => {
+      const checkId = check.id || '';
+      const stig = lookupStig(stigChecks, checkId);
+      const effectiveId = effectiveRuleId(stig, checkId);
+      const ruleFixId = stig.fixId || fixIdFor(checkId);
+      const ruleCheckSystem = stig.checkId || CHECK_SYSTEM;
+      const checkHref = na(metadata.checkHref);
+      const checkName = na(metadata.checkName);
+
+      const rule = g.ele('Rule', {
+        id:       effectiveId,
+        selected: 'true',
+        weight:   ruleWeight(check.scored),
+        role:     ruleRole(check.scored),
+        severity: stigSeverity(stig.severity, check.scored),
+      });
+
+      rule.ele('version').txt(na(stig.version));
+      rule.ele('title').txt(na(`${ checkId } ${ check.description || '' }`));
+      rule.ele('description').txt(na(check.description));
+
+      const ruleRef = rule.ele('reference');
+
+      ruleRef.ele('title').txt(na(metadata.referenceTitle));
+      ruleRef.ele('subject').txt(na(metadata.referenceSubject));
+      ruleRef.ele('publisher').txt(na(metadata.publisher));
+      ruleRef.ele('type').txt(na(metadata.referenceType));
+      ruleRef.ele('identifier').txt(na(metadata.referenceIdentifier));
+
+      stigIdents(stig.cci).forEach((ident) => {
+        rule.ele('ident', { system: ident.system }).txt(ident.value);
+      });
+
+      rule.ele('fixtext', { fixref: ruleFixId }).txt(na(check.remediation));
+      rule.ele('fix', { id: ruleFixId });
+
+      const ruleCheck = rule.ele('check', { system: ruleCheckSystem });
+
+      ruleCheck.ele('check-content-ref', { name: checkName, href: checkHref });
+      ruleCheck.ele('check-content').txt(na(check.audit));
+
+      ruleResults.push({
+        check, effectiveId, stig
+      });
+    });
+  });
+
+  if (groups.length === 0) {
+    const g = benchmark.ele('Group', { id: NA });
+
+    g.ele('title').txt(NA);
+    g.ele('description').txt(NA);
+  }
+
+  const total = report.total || 0;
+  const pass = report.pass || 0;
+  const scoreStr = total > 0 ? ((pass / total) * 100).toFixed(1) : '0.0';
+
+  const targets = clusterName ? [clusterName] : metadata.clusterName ? [metadata.clusterName] : collectTargets(report);
+
+  const testResult = benchmark.ele('TestResult', {
+    id:            `${ ID_PREFIX }_${ TEST_RESULT_ID_SUFFIX }`,
+    'start-time':  timeStr,
+    'end-time':    timeStr,
+    version:       benchmarkVersion,
+    'test-system': ID_PREFIX,
+  });
+
+  testResult.ele('benchmark', { href: `#${ benchmarkId }`, id: benchmarkId });
+  testResult.ele('title').txt(benchmarkTitle);
+  testResult.ele('identity', { authenticated: 'true', privileged: 'true' }).txt('compliance-scan-serviceaccount');
+
+  targets.forEach((t) => testResult.ele('target').txt(t));
+  collectTargetAddresses(targetAddresses).forEach((a) => testResult.ele('target-address').txt(a));
+
+  const facts = testResult.ele('target-facts');
+
+  collectTargetFacts(targetFacts).forEach((f) => {
+    facts.ele('fact', { name: f.name, type: f.type }).txt(f.value);
+  });
+
+  testResult.ele('platform', { idref: na(metadata.platform) });
+
+  if (ruleResults.length === 0) {
+    const rr = testResult.ele('rule-result', {
+      idref:    NA,
+      role:     NA,
+      time:     timeStr,
+      severity: NA,
+      version:  NA,
+      weight:   NA,
+    });
+
+    rr.ele('ident', { system: NA }).txt(NA);
+    rr.ele('result').txt(NA);
+    const rrCheck = rr.ele('check', { system: NA });
+
+    rrCheck.ele('check-content-ref', { name: NA, href: NA });
+    rrCheck.ele('check-content').txt(NA);
+  } else {
+    ruleResults.forEach(({ check, effectiveId, stig }) => {
+      const ruleCheckSystem = stig.checkId || CHECK_SYSTEM;
+      const checkHref = na(metadata.checkHref);
+      const checkName = na(metadata.checkName);
+
+      const rr = testResult.ele('rule-result', {
+        idref:    effectiveId,
+        role:     ruleRole(check.scored),
+        time:     timeStr,
+        severity: stigSeverity(stig.severity, check.scored),
+        version:  na(stig.version),
+        weight:   ruleWeight(check.scored),
+      });
+
+      stigIdents(stig.cci).forEach((ident) => {
+        rr.ele('ident', { system: ident.system }).txt(ident.value);
+      });
+      rr.ele('result').txt(mapResult(check.state));
+      const rrCheck = rr.ele('check', { system: ruleCheckSystem });
+
+      rrCheck.ele('check-content-ref', { name: checkName, href: checkHref });
+      rrCheck.ele('check-content').txt(na(check.audit));
+    });
+  }
+
+  testResult.ele('score', { system: SCORING_SYSTEM, maximum: '100.0' }).txt(scoreStr);
+
+  return doc.end({ prettyPrint: true });
+}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes # https://github.com/rancher/compliance-operator/issues/319
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

This PR adds data processing to the compliance operator so results can be output in xccdf format, one report per node downloaded as a zip, which can then be imported into compliance tools such as stig-manager. 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Closely follows existing architecture used for csv output of compliance scans. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->

Changes should be isolated to compliance operator data processing. Should work in airgap scenarios. 

<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->

Safari

<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Some compliance operator changes were also required to gather more complete STIG data, see https://github.com/rancher/compliance-operator/pull/312.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Investigated implementing in compliance operator only, however limitations to etcd storage would have made this faulty for larger clusters. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Testing/Repro Steps

1. Build updated compliance operator image (https://github.com/rancher/compliance-operator/pull/312).

```bash
docker build --platform linux/amd64 -f package/Dockerfile -t <private-registry>/rancher/compliance-operator:dev
```
```bash
docker push <private-registry>/rancher/compliance-operator:dev
```

2. Ensure compliance operator chart is installed (via Rancher Charts).

3. Edit the deployment to use dev image with pull policy always.

```bash
kubectl edit deployment compliance-operator -n compliance-operator-system
```

```yaml
spec:
  template:
    spec:
      containers:
      - name: compliance-operator
      - image: <private-registry>/rancher/compliance-operator:dev
      - imagePullPolicy: Always
 ```

4. Apply updated compliance operator CRDs.

```bash
kubectl apply -f crds/clusterscan.yaml
kubectl apply -f crds/clusterscanbenchmark.yaml
kubectl apply -f crds/clusterscanreport.yaml
```

5. Build the dashboard locally, setting the API to the cluster you just configured.

```bash
API=https://rancher.local npx run dev
```

6. In the UI, run a compliance scan. Once complete, click download report (xccdf) and observe a zip file with .xml reports for each node in the cluster. 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
