### PR TITLE
Fix Ingress form editor to handle backend.service.port.name

### DIFF
--- a/shell/edit/networking.k8s.io.ingress/DefaultBackend.vue
+++ b/shell/edit/networking.k8s.io.ingress/DefaultBackend.vue
@@ -77,6 +77,7 @@ export default {
   },
   methods: {
     update() {
+      // Fresh object so the old port path (name vs number) doesn't linger.
       const backend = {};
       const parsed = Number.parseInt(this.servicePort);
       const servicePort = Number.isNaN(parsed) ? this.servicePort : parsed;
@@ -124,6 +125,7 @@ export default {
         class="col span-3"
         :style="{'margin-right': '0px'}"
       >
+        <!-- :required drives the asterisk; portRequired doesn't have .name === 'required' -->
         <LabeledInput
           v-if="portOptions.length === 0 || isView"
           v-model:value="servicePort"

--- a/shell/edit/networking.k8s.io.ingress/DefaultBackend.vue
+++ b/shell/edit/networking.k8s.io.ingress/DefaultBackend.vue
@@ -78,7 +78,8 @@ export default {
   methods: {
     update() {
       const backend = {};
-      const servicePort = Number.parseInt(this.servicePort) || this.servicePort;
+      const parsed = Number.parseInt(this.servicePort);
+      const servicePort = Number.isNaN(parsed) ? this.servicePort : parsed;
       const portPath = typeof servicePort === 'number' ? this.value.servicePortPath : this.value.servicePortNamePath;
 
       set(backend, this.value.serviceNamePath, this.serviceName);
@@ -127,6 +128,7 @@ export default {
           v-if="portOptions.length === 0 || isView"
           v-model:value="servicePort"
           :mode="mode"
+          :required="true"
           :label="t('ingress.defaultBackend.port.label')"
           :placeholder="t('ingress.defaultBackend.port.placeholder')"
           :rules="rules.port"
@@ -136,6 +138,7 @@ export default {
           v-else
           v-model:value="servicePort"
           :mode="mode"
+          :required="true"
           :options="portOptions"
           :label="t('ingress.defaultBackend.port.label')"
           :placeholder="t('ingress.defaultBackend.port.placeholder')"

--- a/shell/edit/networking.k8s.io.ingress/DefaultBackend.vue
+++ b/shell/edit/networking.k8s.io.ingress/DefaultBackend.vue
@@ -43,7 +43,9 @@ export default {
     const backend = get(this.value.spec, this.value.defaultBackendPath);
 
     this.serviceName = get(backend, this.value.serviceNamePath) || '';
-    this.servicePort = get(backend, this.value.servicePortPath) || '';
+    this.servicePort = get(backend, this.value.servicePortPath) ||
+      get(backend, this.value.servicePortNamePath) ||
+      '';
   },
   computed: {
     isView() {
@@ -75,10 +77,12 @@ export default {
   },
   methods: {
     update() {
-      const backend = get(this.value.spec, this.value.defaultBackendPath) || {};
+      const backend = {};
+      const servicePort = Number.parseInt(this.servicePort) || this.servicePort;
+      const portPath = typeof servicePort === 'number' ? this.value.servicePortPath : this.value.servicePortNamePath;
 
       set(backend, this.value.serviceNamePath, this.serviceName);
-      set(backend, this.value.servicePortPath, this.servicePort);
+      set(backend, portPath, servicePort);
       set(this.value.spec, this.value.defaultBackendPath, backend);
 
       this.$emit('update:value', this.value);
@@ -121,7 +125,7 @@ export default {
       >
         <LabeledInput
           v-if="portOptions.length === 0 || isView"
-          v-model:value.number="servicePort"
+          v-model:value="servicePort"
           :mode="mode"
           :label="t('ingress.defaultBackend.port.label')"
           :placeholder="t('ingress.defaultBackend.port.placeholder')"

--- a/shell/edit/networking.k8s.io.ingress/RulePath.vue
+++ b/shell/edit/networking.k8s.io.ingress/RulePath.vue
@@ -87,7 +87,8 @@ export default {
   },
   methods: {
     update() {
-      const servicePort = Number.parseInt(this.servicePort) || this.servicePort;
+      const parsed = Number.parseInt(this.servicePort);
+      const servicePort = Number.isNaN(parsed) ? this.servicePort : parsed;
       const serviceName = this.serviceName.label || this.serviceName;
       const out = {
         id: this.value.id, backend: {}, path: this.path, pathType: this.pathType

--- a/shell/edit/networking.k8s.io.ingress/RulePath.vue
+++ b/shell/edit/networking.k8s.io.ingress/RulePath.vue
@@ -79,10 +79,11 @@ export default {
     set(this.value, 'path', this.value.path || '');
     set(this.value, 'pathType', this.value.pathType || this.pathTypes[0]);
     set(this.value.backend, this.ingress.serviceNamePath, get(this.value.backend, this.ingress.serviceNamePath) || '');
-    set(this.value.backend, this.ingress.servicePortPath, get(this.value.backend, this.ingress.servicePortPath) || '');
 
     this.serviceName = get(this.value.backend, this.ingress.serviceNamePath);
-    this.servicePort = get(this.value.backend, this.ingress.servicePortPath);
+    this.servicePort = get(this.value.backend, this.ingress.servicePortPath) ||
+      get(this.value.backend, this.ingress.servicePortNamePath) ||
+      '';
   },
   methods: {
     update() {
@@ -92,7 +93,9 @@ export default {
         id: this.value.id, backend: {}, path: this.path, pathType: this.pathType
       };
 
-      set(out.backend, this.ingress.servicePortPath, servicePort);
+      const portPath = typeof servicePort === 'number' ? this.ingress.servicePortPath : this.ingress.servicePortNamePath;
+
+      set(out.backend, portPath, servicePort);
       set(out.backend, this.ingress.serviceNamePath, serviceName);
 
       this.$emit('update:value', out);

--- a/shell/edit/networking.k8s.io.ingress/index.vue
+++ b/shell/edit/networking.k8s.io.ingress/index.vue
@@ -221,7 +221,8 @@ export default {
     willSave() {
       const backend = get(this.value.spec, this.value.defaultBackendPath);
       const serviceName = get(backend, this.value.serviceNamePath);
-      const servicePort = get(backend, this.value.servicePortPath);
+      const servicePort = get(backend, this.value.servicePortPath) ||
+        get(backend, this.value.servicePortNamePath);
 
       if (backend && (!serviceName || !servicePort)) {
         const path = this.value.defaultBackendPath;

--- a/shell/edit/networking.k8s.io.ingress/index.vue
+++ b/shell/edit/networking.k8s.io.ingress/index.vue
@@ -94,10 +94,10 @@ export default {
         },
         { path: 'spec', rules: ['backEndOrRules'] },
         {
-          path: 'spec.defaultBackend.service.name', rules: ['required'], translationKey: 'ingress.defaultBackend.targetService.label'
+          path: 'spec.defaultBackend.service.name', rules: ['defaultBackendNameRequired'], translationKey: 'ingress.defaultBackend.targetService.label'
         },
         {
-          path: 'spec.defaultBackend.service.port', rules: ['portRequired', 'portRange'], translationKey: 'ingress.defaultBackend.port.label'
+          path: 'spec.defaultBackend.service.port', rules: ['defaultBackendPortRequired', 'portRange'], translationKey: 'ingress.defaultBackend.port.label'
         },
         { path: 'spec.tls.hosts', rules: ['required', 'wildcardHostname'] }
       ],
@@ -156,8 +156,36 @@ export default {
         }
       };
 
+      const hasDefaultBackendService = () => {
+        const backend = get(this.value?.spec, this.value.defaultBackendPath);
+
+        return !!get(backend, this.value.serviceNamePath);
+      };
+
+      const nameLabel = this.t('ingress.defaultBackend.targetService.label');
+
+      // Only enforce required on the default backend when a service is selected.
+      // Selecting "None" means the user wants to remove the backend; willSave() handles cleanup.
+      const defaultBackendNameRequired = (name) => {
+        if (hasDefaultBackendService() && !name) {
+          return this.t('validation.required', { key: nameLabel });
+        }
+      };
+
+      const defaultBackendPortRequired = (port) => {
+        if (!hasDefaultBackendService()) {
+          return;
+        }
+
+        return portRequired(port);
+      };
+
       return {
-        backEndOrRules, portRequired, portRange
+        backEndOrRules,
+        portRequired,
+        portRange,
+        defaultBackendNameRequired,
+        defaultBackendPortRequired,
       };
     },
     tabErrors() {
@@ -176,17 +204,10 @@ export default {
       };
     },
     defaultBackendPathRules() {
-      const rulesExist = (this.value?.spec?.rules || []).length > 0;
-      const defaultBackendExist = !!this.value?.spec?.defaultBackend?.service;
-
-      if (!rulesExist || defaultBackendExist) {
-        return {
-          name: this.fvGetAndReportPathRules('spec.defaultBackend.service.name'),
-          port: this.fvGetAndReportPathRules('spec.defaultBackend.service.port'),
-        };
-      }
-
-      return { name: [], port: [] };
+      return {
+        name: this.fvGetAndReportPathRules('spec.defaultBackend.service.name'),
+        port: this.fvGetAndReportPathRules('spec.defaultBackend.service.port'),
+      };
     },
     serviceTargets() {
       return this.ingressHelper.findAndMapServiceTargets(this.services);

--- a/shell/edit/networking.k8s.io.ingress/index.vue
+++ b/shell/edit/networking.k8s.io.ingress/index.vue
@@ -87,7 +87,7 @@ export default {
           path: 'spec.rules.http.paths.path', rules: ['absolutePath'], translationKey: 'ingress.rules.path.label'
         },
         {
-          path: 'spec.rules.http.paths.backend.service.port', rules: ['portNumberOrName'], translationKey: 'ingress.rules.port.label'
+          path: 'spec.rules.http.paths.backend.service.port', rules: ['portRequired', 'portRange'], translationKey: 'ingress.rules.port.label'
         },
         {
           path: 'spec.rules.http.paths.backend.service.name', rules: ['required'], translationKey: 'ingress.rules.target.label'
@@ -97,7 +97,7 @@ export default {
           path: 'spec.defaultBackend.service.name', rules: ['required'], translationKey: 'ingress.defaultBackend.targetService.label'
         },
         {
-          path: 'spec.defaultBackend.service.port', rules: ['portNumberOrName'], translationKey: 'ingress.defaultBackend.port.label'
+          path: 'spec.defaultBackend.service.port', rules: ['portRequired', 'portRange'], translationKey: 'ingress.defaultBackend.port.label'
         },
         { path: 'spec.tls.hosts', rules: ['required', 'wildcardHostname'] }
       ],
@@ -125,13 +125,40 @@ export default {
         }
       };
 
-      const portNumberOrName = (port) => {
-        if (!port || (!port.number && !port.name)) {
-          return this.t('validation.required', { key: this.t('ingress.rules.port.label') });
+      const portLabel = this.t('ingress.rules.port.label');
+
+      // Built-in `required` won't work: it passes for empty objects like {} or { name: '' }.
+      const portRequired = (port) => {
+        if (typeof port === 'string' || typeof port === 'number') {
+          if (!port) {
+            return this.t('validation.required', { key: portLabel });
+          }
+        } else if (!port || (!port.number && !port.name)) {
+          return this.t('validation.required', { key: portLabel });
         }
       };
 
-      return { backEndOrRules, portNumberOrName };
+      const portRange = (port) => {
+        let num;
+
+        if (typeof port === 'number') {
+          num = port;
+        } else if (typeof port === 'string') {
+          num = Number.parseInt(port);
+        } else if (port?.number) {
+          num = port.number;
+        }
+
+        if (num !== undefined && !Number.isNaN(num) && (num < 1 || num > 65535)) {
+          return this.t('validation.number.between', {
+            key: portLabel, min: '1', max: '65535'
+          });
+        }
+      };
+
+      return {
+        backEndOrRules, portRequired, portRange
+      };
     },
     tabErrors() {
       return {

--- a/shell/edit/networking.k8s.io.ingress/index.vue
+++ b/shell/edit/networking.k8s.io.ingress/index.vue
@@ -87,7 +87,7 @@ export default {
           path: 'spec.rules.http.paths.path', rules: ['absolutePath'], translationKey: 'ingress.rules.path.label'
         },
         {
-          path: 'spec.rules.http.paths.backend.service.port.number', rules: ['required'], translationKey: 'ingress.rules.port.label'
+          path: 'spec.rules.http.paths.backend.service.port', rules: ['portNumberOrName'], translationKey: 'ingress.rules.port.label'
         },
         {
           path: 'spec.rules.http.paths.backend.service.name', rules: ['required'], translationKey: 'ingress.rules.target.label'
@@ -97,11 +97,11 @@ export default {
           path: 'spec.defaultBackend.service.name', rules: ['required'], translationKey: 'ingress.defaultBackend.targetService.label'
         },
         {
-          path: 'spec.defaultBackend.service.port.number', rules: ['required', 'requiredInt', 'portNumber'], translationKey: 'ingress.defaultBackend.port.label'
+          path: 'spec.defaultBackend.service.port', rules: ['portNumberOrName'], translationKey: 'ingress.defaultBackend.port.label'
         },
         { path: 'spec.tls.hosts', rules: ['required', 'wildcardHostname'] }
       ],
-      fvReportedValidationPaths: ['spec.rules.http.paths.backend.service.port.number', 'spec.rules.http.paths.path', 'spec.rules.http.paths.backend.service.name']
+      fvReportedValidationPaths: ['spec.rules.http.paths.backend.service.port', 'spec.rules.http.paths.path', 'spec.rules.http.paths.backend.service.name']
     };
   },
 
@@ -125,19 +125,25 @@ export default {
         }
       };
 
-      return { backEndOrRules };
+      const portNumberOrName = (port) => {
+        if (!port || (!port.number && !port.name)) {
+          return this.t('validation.required', { key: this.t('ingress.rules.port.label') });
+        }
+      };
+
+      return { backEndOrRules, portNumberOrName };
     },
     tabErrors() {
       return {
-        rules:          this.fvGetPathErrors(['spec.rules.host', 'spec.rules.http.paths.path', 'spec.rules.http.paths.backend.service.port.number', 'spec.rules.http.paths.backend.service.name'])?.length > 0,
-        defaultBackend: this.fvGetPathErrors(['spec.defaultBackend.service.name', 'spec.defaultBackend.service.port.number'])?.length > 0
+        rules:          this.fvGetPathErrors(['spec.rules.host', 'spec.rules.http.paths.path', 'spec.rules.http.paths.backend.service.port', 'spec.rules.http.paths.backend.service.name'])?.length > 0,
+        defaultBackend: this.fvGetPathErrors(['spec.defaultBackend.service.name', 'spec.defaultBackend.service.port'])?.length > 0
       };
     },
     rulesPathRules() {
       return {
         requestHost: this.fvGetAndReportPathRules('spec.rules.host'),
         path:        this.fvGetAndReportPathRules('spec.rules.http.paths.path'),
-        port:        this.fvGetAndReportPathRules('spec.rules.http.paths.backend.service.port.number'),
+        port:        this.fvGetAndReportPathRules('spec.rules.http.paths.backend.service.port'),
         target:      this.fvGetAndReportPathRules('spec.rules.http.paths.backend.service.name'),
 
       };
@@ -149,7 +155,7 @@ export default {
       if (!rulesExist || defaultBackendExist) {
         return {
           name: this.fvGetAndReportPathRules('spec.defaultBackend.service.name'),
-          port: this.fvGetAndReportPathRules('spec.defaultBackend.service.port.number'),
+          port: this.fvGetAndReportPathRules('spec.defaultBackend.service.port'),
         };
       }
 

--- a/shell/models/networking.k8s.io.ingress.js
+++ b/shell/models/networking.k8s.io.ingress.js
@@ -84,7 +84,7 @@ export default class Ingress extends SteveModel {
       serviceTargetTo: this.targetTo(workloads, serviceName),
       certs:           this.certLinks(rule, certificates),
       targetLink:      this.targetLink(workloads, serviceName),
-      port:            get(path?.backend, this.servicePortPath)
+      port:            get(path?.backend, this.servicePortPath) || get(path?.backend, this.servicePortNamePath)
     };
   }
 
@@ -179,6 +179,13 @@ export default class Ingress extends SteveModel {
 
   get servicePortPath() {
     const nestedPath = 'service.port.number';
+    const flatPath = 'servicePort';
+
+    return this.useNestedBackendField ? nestedPath : flatPath;
+  }
+
+  get servicePortNamePath() {
+    const nestedPath = 'service.port.name';
     const flatPath = 'servicePort';
 
     return this.useNestedBackendField ? nestedPath : flatPath;

--- a/shell/models/networking.k8s.io.ingress.js
+++ b/shell/models/networking.k8s.io.ingress.js
@@ -186,6 +186,7 @@ export default class Ingress extends SteveModel {
 
   get servicePortNamePath() {
     const nestedPath = 'service.port.name';
+    // Flat API has a single `servicePort` field for both name and number.
     const flatPath = 'servicePort';
 
     return this.useNestedBackendField ? nestedPath : flatPath;

--- a/shell/utils/__tests__/ingress.test.ts
+++ b/shell/utils/__tests__/ingress.test.ts
@@ -73,6 +73,18 @@ describe('ingress', () => {
         }],
       },
       {
+        desc:     'includes port names alongside port numbers when available',
+        services: [{
+          metadata: { name: 'named-ports-service' },
+          spec:     { ports: [{ port: 80, name: 'http' }, { port: 443, name: 'https' }] },
+        }],
+        expected: [{
+          label: 'named-ports-service',
+          value: 'named-ports-service',
+          ports: [80, 'http', 443, 'https'],
+        }],
+      },
+      {
         desc:     'returns undefined ports when service has no spec.ports',
         services: [{
           metadata: { name: 'headless-service' },
@@ -120,6 +132,18 @@ describe('ingress', () => {
             ports: [9090, 9091],
           },
         ],
+      },
+      {
+        desc:     'includes only port numbers when ports have no names',
+        services: [{
+          metadata: { name: 'unnamed-service' },
+          spec:     { ports: [{ port: 3000 }] },
+        }],
+        expected: [{
+          label: 'unnamed-service',
+          value: 'unnamed-service',
+          ports: [3000],
+        }],
       },
     ])('$desc', ({ services, expected }) => {
       const helper = makeHelper();

--- a/shell/utils/__tests__/ingress.test.ts
+++ b/shell/utils/__tests__/ingress.test.ts
@@ -1,21 +1,13 @@
 import IngressDetailEditHelper from '@shell/utils/ingress';
 import { SECRET_TYPES as TYPES } from '@shell/config/secret';
+import { get, set } from '@shell/utils/object';
 
-/**
- * Mirrors the port parsing logic used in RulePath.vue and DefaultBackend.vue
- * to decide whether to write port.number or port.name
- */
 function parseServicePort(rawPort: string | number): string | number {
   const parsed = Number.parseInt(String(rawPort));
 
   return Number.isNaN(parsed) ? rawPort : parsed;
 }
 
-/**
- * Mirrors the portRequired validation rule from index.vue.
- * Handles both scalar values (from component-level validation)
- * and port objects (from form-validation mixin).
- */
 function portRequired(port: any): string | undefined {
   if (typeof port === 'string' || typeof port === 'number') {
     if (!port) {
@@ -28,10 +20,6 @@ function portRequired(port: any): string | undefined {
   return undefined;
 }
 
-/**
- * Mirrors the portRange validation rule from index.vue.
- * Checks that a numeric port is within 1-65535 (handles both scalar and object inputs).
- */
 function portRange(port: any): string | undefined {
   let num;
 
@@ -48,6 +36,45 @@ function portRange(port: any): string | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * Mirrors willSave() from index.vue.
+ * Clears the default backend when the service name or port is missing.
+ */
+function willSave(spec: any, paths: { defaultBackendPath: string; serviceNamePath: string; servicePortPath: string; servicePortNamePath: string }): void {
+  const backend = get(spec, paths.defaultBackendPath);
+  const serviceName = get(backend, paths.serviceNamePath);
+  const servicePort = get(backend, paths.servicePortPath) ||
+    get(backend, paths.servicePortNamePath);
+
+  if (backend && (!serviceName || !servicePort)) {
+    set(spec, paths.defaultBackendPath, null);
+  }
+}
+
+/**
+ * Mirrors defaultBackendNameRequired from index.vue.
+ * Only enforces required when a service is actually selected.
+ */
+function defaultBackendNameRequired(name: any, hasService: boolean): string | undefined {
+  if (hasService && !name) {
+    return 'Target Service is required';
+  }
+
+  return undefined;
+}
+
+/**
+ * Mirrors defaultBackendPortRequired from index.vue.
+ * Delegates to portRequired only when a service is selected.
+ */
+function defaultBackendPortRequired(port: any, hasService: boolean): string | undefined {
+  if (!hasService) {
+    return undefined;
+  }
+
+  return portRequired(port);
 }
 
 const makeHelper = () => new IngressDetailEditHelper({
@@ -434,6 +461,93 @@ describe('ingress', () => {
       ])('invalid: $desc', ({ port }) => {
         expect(portRange(port)).toBeDefined();
       });
+    });
+  });
+
+  describe('willSave', () => {
+    const nestedPaths = {
+      defaultBackendPath:  'defaultBackend',
+      serviceNamePath:     'service.name',
+      servicePortPath:     'service.port.number',
+      servicePortNamePath: 'service.port.name',
+    };
+
+    it('preserves backend when port.number is set', () => {
+      const spec = { defaultBackend: { service: { name: 'my-svc', port: { number: 80 } } } };
+
+      willSave(spec, nestedPaths);
+      expect(spec.defaultBackend).toStrictEqual({ service: { name: 'my-svc', port: { number: 80 } } });
+    });
+
+    it('preserves backend when port.name is set', () => {
+      const spec = { defaultBackend: { service: { name: 'my-svc', port: { name: 'http' } } } };
+
+      willSave(spec, nestedPaths);
+      expect(spec.defaultBackend).toStrictEqual({ service: { name: 'my-svc', port: { name: 'http' } } });
+    });
+
+    it('clears backend when service name is empty', () => {
+      const spec = { defaultBackend: { service: { name: '', port: { number: 80 } } } };
+
+      willSave(spec, nestedPaths);
+      expect(spec.defaultBackend).toBeNull();
+    });
+
+    it('clears backend when both port paths are empty', () => {
+      const spec = { defaultBackend: { service: { name: 'my-svc', port: {} } } };
+
+      willSave(spec, nestedPaths);
+      expect(spec.defaultBackend).toBeNull();
+    });
+
+    it('clears backend when port is undefined', () => {
+      const spec = { defaultBackend: { service: { name: 'my-svc' } } };
+
+      willSave(spec, nestedPaths);
+      expect(spec.defaultBackend).toBeNull();
+    });
+
+    it('does nothing when there is no backend', () => {
+      const spec = { rules: [{}] } as any;
+
+      willSave(spec, nestedPaths);
+      expect(spec).toStrictEqual({ rules: [{}] });
+    });
+  });
+
+  describe('defaultBackendNameRequired', () => {
+    it('returns error when service is selected but name is empty', () => {
+      expect(defaultBackendNameRequired('', true)).toBeDefined();
+    });
+
+    it('passes when service is selected and name is set', () => {
+      expect(defaultBackendNameRequired('my-svc', true)).toBeUndefined();
+    });
+
+    it('passes when no service is selected and name is empty', () => {
+      expect(defaultBackendNameRequired('', false)).toBeUndefined();
+    });
+
+    it('passes when no service is selected and name is undefined', () => {
+      expect(defaultBackendNameRequired(undefined, false)).toBeUndefined();
+    });
+  });
+
+  describe('defaultBackendPortRequired', () => {
+    it('delegates to portRequired when service is selected', () => {
+      expect(defaultBackendPortRequired('', true)).toBeDefined();
+      expect(defaultBackendPortRequired(80, true)).toBeUndefined();
+      expect(defaultBackendPortRequired('http', true)).toBeUndefined();
+      expect(defaultBackendPortRequired({ number: 80 }, true)).toBeUndefined();
+      expect(defaultBackendPortRequired({ name: 'http' }, true)).toBeUndefined();
+      expect(defaultBackendPortRequired({}, true)).toBeDefined();
+    });
+
+    it('skips validation when no service is selected', () => {
+      expect(defaultBackendPortRequired('', false)).toBeUndefined();
+      expect(defaultBackendPortRequired(undefined, false)).toBeUndefined();
+      expect(defaultBackendPortRequired(null, false)).toBeUndefined();
+      expect(defaultBackendPortRequired({}, false)).toBeUndefined();
     });
   });
 });

--- a/shell/utils/__tests__/ingress.test.ts
+++ b/shell/utils/__tests__/ingress.test.ts
@@ -1,6 +1,55 @@
 import IngressDetailEditHelper from '@shell/utils/ingress';
 import { SECRET_TYPES as TYPES } from '@shell/config/secret';
 
+/**
+ * Mirrors the port parsing logic used in RulePath.vue and DefaultBackend.vue
+ * to decide whether to write port.number or port.name
+ */
+function parseServicePort(rawPort: string | number): string | number {
+  const parsed = Number.parseInt(String(rawPort));
+
+  return Number.isNaN(parsed) ? rawPort : parsed;
+}
+
+/**
+ * Mirrors the portRequired validation rule from index.vue.
+ * Handles both scalar values (from component-level validation)
+ * and port objects (from form-validation mixin).
+ */
+function portRequired(port: any): string | undefined {
+  if (typeof port === 'string' || typeof port === 'number') {
+    if (!port) {
+      return 'Port is required';
+    }
+  } else if (!port || (!port.number && !port.name)) {
+    return 'Port is required';
+  }
+
+  return undefined;
+}
+
+/**
+ * Mirrors the portRange validation rule from index.vue.
+ * Checks that a numeric port is within 1-65535 (handles both scalar and object inputs).
+ */
+function portRange(port: any): string | undefined {
+  let num;
+
+  if (typeof port === 'number') {
+    num = port;
+  } else if (typeof port === 'string') {
+    num = Number.parseInt(port);
+  } else if (port?.number) {
+    num = port.number;
+  }
+
+  if (num !== undefined && !Number.isNaN(num) && (num < 1 || num > 65535)) {
+    return 'Port number must be between 1 and 65535';
+  }
+
+  return undefined;
+}
+
 const makeHelper = () => new IngressDetailEditHelper({
   $store:    {} as any,
   namespace: 'default',
@@ -145,10 +194,246 @@ describe('ingress', () => {
           ports: [3000],
         }],
       },
+      {
+        desc:     'skips empty-string port names',
+        services: [{
+          metadata: { name: 'empty-name-svc' },
+          spec:     { ports: [{ port: 8080, name: '' }] },
+        }],
+        expected: [{
+          label: 'empty-name-svc',
+          value: 'empty-name-svc',
+          ports: [8080],
+        }],
+      },
+      {
+        desc:     'handles mix of named and unnamed ports on the same service',
+        services: [{
+          metadata: { name: 'mixed-svc' },
+          spec:     { ports: [{ port: 80, name: 'http' }, { port: 9090 }] },
+        }],
+        expected: [{
+          label: 'mixed-svc',
+          value: 'mixed-svc',
+          ports: [80, 'http', 9090],
+        }],
+      },
     ])('$desc', ({ services, expected }) => {
       const helper = makeHelper();
 
       expect(helper.findAndMapServiceTargets(services)).toStrictEqual(expected);
+    });
+  });
+
+  describe('parseServicePort', () => {
+    it.each([
+      {
+        desc:     'parses numeric string to number',
+        input:    '80',
+        expected: 80,
+      },
+      {
+        desc:     'parses large port number',
+        input:    '65535',
+        expected: 65535,
+      },
+      {
+        desc:     'keeps string port name as-is',
+        input:    'http',
+        expected: 'http',
+      },
+      {
+        desc:     'keeps string port name with hyphens',
+        input:    'my-port',
+        expected: 'my-port',
+      },
+      {
+        desc:     'handles zero as a number (not as falsy)',
+        input:    '0',
+        expected: 0,
+      },
+      {
+        desc:     'handles already-numeric input',
+        input:    443 as any,
+        expected: 443,
+      },
+      {
+        desc:     'keeps empty string as empty string',
+        input:    '',
+        expected: '',
+      },
+    ])('$desc', ({ input, expected }) => {
+      expect(parseServicePort(input)).toStrictEqual(expected);
+    });
+
+    it('routes numeric result to port.number path', () => {
+      const servicePort = parseServicePort('80');
+
+      expect(typeof servicePort).toBe('number');
+    });
+
+    it('routes string result to port.name path', () => {
+      const servicePort = parseServicePort('http');
+
+      expect(typeof servicePort).toBe('string');
+    });
+  });
+
+  describe('portRequired validation', () => {
+    describe('object input (form mixin)', () => {
+      it.each([
+        {
+          desc: 'passes when port.number is set',
+          port: { number: 80 },
+        },
+        {
+          desc: 'passes when port.name is set',
+          port: { name: 'http' },
+        },
+        {
+          desc: 'passes when both are set',
+          port: {
+            number: 80,
+            name:   'http',
+          },
+        },
+        {
+          desc: 'passes when port.number is 0 but name is set',
+          port: {
+            number: 0,
+            name:   'http',
+          },
+        },
+      ])('valid: $desc', ({ port }) => {
+        expect(portRequired(port)).toBeUndefined();
+      });
+
+      it.each([
+        {
+          desc: 'port is undefined',
+          port: undefined,
+        },
+        {
+          desc: 'port is null',
+          port: null,
+        },
+        {
+          desc: 'port is empty object',
+          port: {},
+        },
+        {
+          desc: 'port.number is 0 and no name',
+          port: { number: 0 },
+        },
+        {
+          desc: 'port.name is empty string and no number',
+          port: { name: '' },
+        },
+      ])('invalid: $desc', ({ port }) => {
+        expect(portRequired(port)).toBeDefined();
+      });
+    });
+
+    describe('scalar input (component)', () => {
+      it.each([
+        {
+          desc: 'passes for numeric port',
+          port: 80,
+        },
+        {
+          desc: 'passes for string port name',
+          port: 'http',
+        },
+      ])('valid: $desc', ({ port }) => {
+        expect(portRequired(port)).toBeUndefined();
+      });
+
+      it.each([
+        {
+          desc: 'empty string',
+          port: '',
+        },
+        {
+          desc: 'zero',
+          port: 0,
+        },
+      ])('invalid: $desc', ({ port }) => {
+        expect(portRequired(port)).toBeDefined();
+      });
+    });
+  });
+
+  describe('portRange validation', () => {
+    describe('object input (form mixin)', () => {
+      it.each([
+        {
+          desc: 'passes for port.number 1 (minimum)',
+          port: { number: 1 },
+        },
+        {
+          desc: 'passes for port.number 65535 (maximum)',
+          port: { number: 65535 },
+        },
+        {
+          desc: 'passes when only port.name is set',
+          port: { name: 'http' },
+        },
+      ])('valid: $desc', ({ port }) => {
+        expect(portRange(port)).toBeUndefined();
+      });
+
+      it.each([
+        {
+          desc: 'port.number exceeds 65535',
+          port: { number: 70000 },
+        },
+        {
+          desc: 'port.number is negative',
+          port: { number: -1 },
+        },
+      ])('invalid: $desc', ({ port }) => {
+        expect(portRange(port)).toBeDefined();
+      });
+    });
+
+    describe('scalar input (component)', () => {
+      it.each([
+        {
+          desc: 'passes for port 1 (minimum)',
+          port: 1,
+        },
+        {
+          desc: 'passes for port 65535 (maximum)',
+          port: 65535,
+        },
+        {
+          desc: 'passes for numeric string "443"',
+          port: '443',
+        },
+        {
+          desc: 'passes for string port name',
+          port: 'http',
+        },
+      ])('valid: $desc', ({ port }) => {
+        expect(portRange(port)).toBeUndefined();
+      });
+
+      it.each([
+        {
+          desc: 'number exceeds 65535',
+          port: 70000,
+        },
+        {
+          desc: 'negative number',
+          port: -1,
+        },
+        {
+          desc: 'string "70000" exceeds range',
+          port: '70000',
+        },
+      ])('invalid: $desc', ({ port }) => {
+        expect(portRange(port)).toBeDefined();
+      });
     });
   });
 });

--- a/shell/utils/ingress.ts
+++ b/shell/utils/ingress.ts
@@ -56,7 +56,15 @@ class IngressDetailEditHelper {
     return services.map((service) => ({
       label: service.metadata.name,
       value: service.metadata.name,
-      ports: service.spec.ports?.map((p: any) => p.port)
+      ports: service.spec.ports?.flatMap((p: any) => {
+        const options = [p.port];
+
+        if (p.name) {
+          options.push(p.name);
+        }
+
+        return options;
+      })
     }));
   }
 }


### PR DESCRIPTION
### Summary
Fixes #17105

### Occurred changes and/or fixed issues
The Ingress form editor only read/wrote `backend.service.port.number`, so Ingresses using `backend.service.port.name` showed a blank port field. This adds support for both across reading, writing, validation, and the port dropdown.

### Technical notes summary
- Added `servicePortNamePath` getter to the Ingress model
- `findAndMapServiceTargets` now includes port names in dropdown options
- `RulePath.vue` and `DefaultBackend.vue` read from both `port.number` and `port.name`, write to the correct path based on type
- Replaced single `portNumberOrName` validator with `portRequired` (presence check) and `portRange` (1-65535), both handling scalar and object inputs
- Fixed `Number.parseInt` fallthrough when port value is falsy (e.g. 0)
- Restored required asterisk on DefaultBackend port fields
- List/detail view falls back to port name when port number is not set

### Reproduction resources

Apply these to create a Service with named ports and two Ingresses (one using `port.name`, one using `port.number`):

```yaml
apiVersion: v1
kind: Service
metadata:
  name: test-web-service
  namespace: default
spec:
  ports:
    - name: http
      port: 80
      targetPort: 8080
    - name: https
      port: 443
      targetPort: 8443
  selector:
    app: test-web
```

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: ingress-port-name
  namespace: default
spec:
  rules:
    - host: name.example.com
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: test-web-service
                port:
                  name: http
```

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: ingress-port-number
  namespace: default
spec:
  rules:
    - host: number.example.com
      http:
        paths:
          - path: /
            pathType: Prefix
            backend:
              service:
                name: test-web-service
                port:
                  number: 80
```

The bug: editing `ingress-port-name` in the form editor shows a blank port field. Editing `ingress-port-number` works fine.

### Areas or cases that should be tested
- Edit `ingress-port-name` and verify the port field shows "http"
- Edit `ingress-port-number` and verify the port field shows "80"
- Create a new Ingress, select `test-web-service`, and verify both port numbers and names appear in the dropdown
- Save with a port name and verify the YAML uses `port.name`; same for `port.number`
- Verify the Default Backend tab works with both formats
- Verify the form blocks saving without a port specified
- Verify port range validation rejects values outside 1-65535

### Areas which could experience regressions
- Ingress form creation and editing (rules and default backend)
- Ingress list page port display
- Form validation for port fields

### Screenshot/Video

**Before (bug):** YAML shows `port.name: http` is defined, but the form editor's port field is empty (red highlight)

https://github.com/user-attachments/assets/12e5e558-c02c-4981-aa8a-4606a8c17cd6

**After (fix):** port name "http" is correctly displayed in the form (green highlight), save succeeds

https://github.com/user-attachments/assets/6a226fa9-4fde-40dd-a12a-87ac2f6a77ba

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`