### PR TITLE
Fix auth provider warning text to reflect actual permissions granted

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -500,7 +500,7 @@ authConfig:
     unrestricted: Allow any valid user
   allowedPrincipalIds:
     title: Authorized Users & Groups
-  associatedWarning: 'The {provider} account that is used to enable the external provider will be granted admin permissions. If you use a test account or non-admin account, that account will still be granted admin-level permissions. See <a href="{docsBase}/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config#external-authentication-configuration-and-principal-users" target="_blank" rel="noopener noreferrer nofollow">External Authentication Configuration and Principal Users</a> to understand why.'
+  associatedWarning: 'The {provider} account that is used to enable the external provider will be granted permissions equal to the currently logged in Rancher user. See <a href="{docsBase}/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config#external-authentication-configuration-and-principal-users" target="_blank" rel="noopener noreferrer nofollow">External Authentication Configuration and Principal Users</a> to understand why.'
   githubapp:
     clientId:
       label: Client ID


### PR DESCRIPTION
### Summary
Fixes #12492

### Occurred changes and/or fixed issues
The auth provider warning incorrectly states the external account will always receive admin permissions. In reality it receives permissions equal to the currently logged-in user. Updated the `associatedWarning` translation string accordingly.

### Technical notes summary
Single string change in `shell/assets/translations/en-us.yaml`.

### Areas or cases that should be tested
- Navigate to Users & Authentication > Auth Provider > any provider (e.g. GitHub)
- Verify the warning banner text and documentation link

### Areas which could experience regressions
None. Copy-only change.

### Screenshot/Video

**Before:**

https://github.com/user-attachments/assets/e4e282d1-c697-45a3-b0f5-72af8f1e0b06

**After:**

https://github.com/user-attachments/assets/12c21517-462c-4d4d-aa4b-292921300a99

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles Admin, Standard User and User Base