### PR TITLE
Prevent state badge from drifting away from short resource names

### DIFF
--- a/shell/assets/styles/base/_variables.scss
+++ b/shell/assets/styles/base/_variables.scss
@@ -10,6 +10,8 @@ $unlabeled-input-height: 40px;
 $unlabaled-select-padding: 3px 0;
 $footer-height: 60px;
 
+$resource-detail-min-width: 740px;
+
 $input-padding-lg: 18px;
 $input-padding-sm: 10px;
 $input-line-height: 18px;

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
@@ -105,6 +105,7 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
     .row {
       gap: 8px;
 
+      // Hide clearfix pseudo-elements inherited from the global .row class
       &::before, &::after {
         display: none;
       }
@@ -117,6 +118,8 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
         flex: 1;
         min-width: 0;
 
+        // Override inline-block on .popover-card-target so it respects the
+        // parent's width constraint instead of sizing to its content
         :deep(.popover-card-target) {
           width: 100%;
         }

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
@@ -109,6 +109,8 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
 
       .full-custom-value {
         flex: 1;
+        min-width: 0;
+        @include clip;
       }
 
       .value {

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
@@ -103,6 +103,8 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
     flex-direction: column;
 
     .row {
+      gap: 8px;
+
       &:not(:last-of-type) {
         margin-bottom: 8px;
       }
@@ -130,7 +132,7 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
 
       .label {
         width: 30%;
-        min-width: 120px;
+        min-width: min-content;
       }
 
       .status {

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
@@ -105,6 +105,10 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
     .row {
       gap: 8px;
 
+      &::before, &::after {
+        display: none;
+      }
+
       &:not(:last-of-type) {
         margin-bottom: 8px;
       }
@@ -112,8 +116,10 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
       .full-custom-value {
         flex: 1;
         min-width: 0;
-        overflow: hidden;
-        max-height: 1lh;
+
+        :deep(.popover-card-target) {
+          width: 100%;
+        }
       }
 
       .value {

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
@@ -112,7 +112,8 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
       .full-custom-value {
         flex: 1;
         min-width: 0;
-        @include clip;
+        overflow: hidden;
+        max-height: 1lh;
       }
 
       .value {

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -82,6 +82,10 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
 
 <style lang="scss" scoped>
 .metadata {
+    .identifying-info {
+      overflow: hidden;
+    }
+
     .labels-and-annotations-empty {
       grid-column: span 2;
     }

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -83,6 +83,8 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
 <style lang="scss" scoped>
 .metadata {
     .identifying-info {
+      // Allow the grid cell to shrink below its content size without
+      // using overflow:hidden, which would clip the namespace popover
       min-width: 0;
     }
 

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -83,7 +83,7 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
 <style lang="scss" scoped>
 .metadata {
     .identifying-info {
-      overflow: hidden;
+      min-width: 0;
     }
 
     .labels-and-annotations-empty {

--- a/shell/components/Resource/Detail/ResourcePopover/index.vue
+++ b/shell/components/Resource/Detail/ResourcePopover/index.vue
@@ -118,6 +118,7 @@ const actionInvoked = () => {
     align-items: center;
     max-width: 100%;
 
+    // Truncate the link text instead of wrapping to a second line
     a {
       overflow: hidden;
       text-overflow: ellipsis;
@@ -127,6 +128,7 @@ const actionInvoked = () => {
   }
 
   .rc-status-indicator {
+      // Keep the status dot from collapsing when the link text is long
       flex-shrink: 0;
       margin-right: 12px;
       height: initial;

--- a/shell/components/Resource/Detail/ResourcePopover/index.vue
+++ b/shell/components/Resource/Detail/ResourcePopover/index.vue
@@ -115,11 +115,20 @@ const actionInvoked = () => {
 
   .display {
     display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+
+    a {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
+    }
   }
 
   .rc-status-indicator {
+      flex-shrink: 0;
       margin-right: 12px;
-      margin-top: 4px;
       height: initial;
       line-height: initial;
   }

--- a/shell/components/Resource/Detail/SpacedRow.vue
+++ b/shell/components/Resource/Detail/SpacedRow.vue
@@ -7,9 +7,10 @@
 <style lang="scss" scoped>
 .spaced-row {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   grid-auto-flow: dense;
   grid-gap: 24px;
   justify-content: space-evenly;
+  min-width: 630px;
 }
 </style>

--- a/shell/components/Resource/Detail/SpacedRow.vue
+++ b/shell/components/Resource/Detail/SpacedRow.vue
@@ -11,6 +11,7 @@
   grid-auto-flow: dense;
   grid-gap: 24px;
   justify-content: space-evenly;
-  min-width: 630px;
+  // Match the title bar floor so sections scroll together
+  min-width: $resource-detail-min-width;
 }
 </style>

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -159,12 +159,11 @@ const showAdditionalActionButtons = computed(() => isArray(additionalActions));
 
 <style lang="scss" scoped>
 .title-bar {
-  min-width: 740px;
-
   .badge-state {
     font-size: 16px;
     margin-left: 12px;
     position: relative;
+    flex: 0 0 auto;
   }
 
   .icon-document {
@@ -176,6 +175,8 @@ const showAdditionalActionButtons = computed(() => isArray(additionalActions));
   .actions {
     display: flex;
     align-items: center;
+    flex: 0 0 auto;
+    margin-left: 16px;
   }
 
   .show-configuration, &:deep() .actions > button {
@@ -198,15 +199,17 @@ const showAdditionalActionButtons = computed(() => isArray(additionalActions));
     max-width: 60%;
   }
 
-  // This prevents the title from overlapping with the actions
+  // Title takes the remaining row space; min-width: 0 lets its children
+  // (resource-name) shrink so the action buttons stay visible on narrow viewports.
   .title {
-    max-width: calc(100% - 260px);
+    flex: 1 1 auto;
+    min-width: 0;
   }
 
-  // We want the resource name to be what collaspes wh
   .resource-name {
     display: inline-block;
-    flex: 1;
+    flex: 1 1 auto;
+    min-width: 0;
     white-space: nowrap;
     overflow-x: hidden;
     overflow-y: clip;

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -210,7 +210,7 @@ const showAdditionalActionButtons = computed(() => isArray(additionalActions));
 
   .resource-name {
     display: inline-block;
-    flex: 1 1 auto;
+    flex: 0 1 auto;
     min-width: 0;
     white-space: nowrap;
     overflow-x: hidden;

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -159,6 +159,8 @@ const showAdditionalActionButtons = computed(() => isArray(additionalActions));
 
 <style lang="scss" scoped>
 .title-bar {
+  min-width: 630px;
+
   .badge-state {
     font-size: 16px;
     margin-left: 12px;

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -159,7 +159,7 @@ const showAdditionalActionButtons = computed(() => isArray(additionalActions));
 
 <style lang="scss" scoped>
 .title-bar {
-  min-width: 630px;
+  min-width: $resource-detail-min-width;
 
   .badge-state {
     font-size: 16px;


### PR DESCRIPTION
### Summary
Fixes #17479

### Occurred changes and/or fixed issues
When a resource has a short name (e.g. "ab"), the state badge ("Active") was pushed far to the right of the title bar, separated from the name by a large gap. This happened because `.resource-name` used `flex: 1 1 auto`, causing it to grow and fill all available space in the flex row regardless of content width.

Changed `.resource-name` from `flex: 1 1 auto` to `flex: 0 1 auto` in [`TitleBar/index.vue`](https://github.com/codyrancher/dashboard/blob/2d534e2de9028f18fdf781da7f8733cd32799e01/shell/components/Resource/Detail/TitleBar/index.vue#L213) so the name only takes the space its content needs. It still shrinks (`flex-shrink: 1`) and truncates with ellipsis when the name is long.

### Technical notes summary
One-line CSS change: `flex-grow` from `1` to `0` on `.resource-name`. The element retains `flex-shrink: 1`, `min-width: 0`, `overflow-x: hidden`, and `text-overflow: ellipsis`, so long names still truncate correctly.

### Areas or cases that should be tested
- Resource detail pages with very short names (1-3 characters)
- Resource detail pages with long names that exceed the title bar width
- Various viewport widths (1280px, 900px, 750px) to confirm the badge stays adjacent and names truncate properly
- Resources with and without state badges

### Areas which could experience regressions
- Title bar layout on resource detail pages at narrow viewports
- Badge positioning when the resource name is long enough to need truncation

### Screenshot/Video

**Before (bug):** badge drifts far right of short resource names, tested at multiple viewport widths

https://github.com/user-attachments/assets/09a56733-621c-4e31-aac7-c193a75b5b9c

**After (fix):** badge stays adjacent to the resource name at all widths

https://github.com/user-attachments/assets/82648b71-eb00-4920-8e4f-101a7d9fb507

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`