### PR TITLE
Prevent state badge from drifting away from short resource names

### DIFF
--- a/cypress/e2e/tests/pages/explorer2/storage/configmap-detail-title-bar.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/configmap-detail-title-bar.spec.ts
@@ -1,0 +1,53 @@
+import { ConfigMapCreateEditPagePo } from '@/cypress/e2e/po/pages/explorer/config-map.po';
+
+const localCluster = 'local';
+const namespace = 'default';
+const shortName = `a`;
+const longName = `e2e-test-long-configmap-name-that-should-truncate-with-ellipsis`;
+
+describe('ConfigMap Detail Title Bar', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
+  before(() => {
+    cy.login();
+    cy.createConfigMap(namespace, shortName);
+    cy.createConfigMap(namespace, longName);
+  });
+
+  it('should keep the state badge adjacent to a short resource name', () => {
+    const detailPage = new ConfigMapCreateEditPagePo(localCluster, namespace, shortName);
+
+    detailPage.goTo();
+    detailPage.waitForPage();
+
+    cy.get('.title-bar h1.title .resource-name').then(($name) => {
+      cy.get('.title-bar h1.title .badge-state').then(($badge) => {
+        const nameRect = $name[0].getBoundingClientRect();
+        const badgeRect = $badge[0].getBoundingClientRect();
+        const gap = badgeRect.left - nameRect.right;
+
+        expect(gap).to.be.lessThan(20);
+      });
+    });
+  });
+
+  it('should keep the state badge adjacent to a long resource name', () => {
+    const detailPage = new ConfigMapCreateEditPagePo(localCluster, namespace, longName);
+
+    detailPage.goTo();
+    detailPage.waitForPage();
+
+    cy.get('.title-bar h1.title .resource-name').then(($name) => {
+      cy.get('.title-bar h1.title .badge-state').then(($badge) => {
+        const nameRect = $name[0].getBoundingClientRect();
+        const badgeRect = $badge[0].getBoundingClientRect();
+        const gap = badgeRect.left - nameRect.right;
+
+        expect(gap).to.be.lessThan(20);
+      });
+    });
+  });
+
+  after('clean up', () => {
+    cy.deleteRancherResource('v1', 'configmaps', `${ namespace }/${ shortName }`);
+    cy.deleteRancherResource('v1', 'configmaps', `${ namespace }/${ longName }`);
+  });
+});

--- a/shell/components/Resource/Detail/TitleBar/index.vue
+++ b/shell/components/Resource/Detail/TitleBar/index.vue
@@ -204,7 +204,7 @@ const showAdditionalActionButtons = computed(() => isArray(additionalActions));
 
   .resource-name {
     display: inline-block;
-    flex: 1 1 auto;
+    flex: 0 1 auto;
     min-width: 0;
     white-space: nowrap;
     overflow-x: hidden;


### PR DESCRIPTION
### Summary
Fixes #17479

### Occurred changes and/or fixed issues
Short resource names (e.g. "ab") caused the state badge ("Active") to drift far right of the title text. The `.resource-name` element used `flex: 1 1 auto`, growing to fill all available space. Changed to `flex: 0 1 auto` in [`TitleBar/index.vue`](https://github.com/codyrancher/dashboard/blob//shell/components/Resource/Detail/TitleBar/index.vue#L213) so it sizes to content while still shrinking and truncating for long names.

### Technical notes summary
One-line CSS change: `flex-grow` from `1` to `0` on `.resource-name`.

### Areas or cases that should be tested
- Resource detail pages with short and long names at various viewport widths

### Areas which could experience regressions
- Title bar layout and badge positioning on resource detail pages

### Screenshot/Video

**Before:** badge displaced from short name

https://github.com/user-attachments/assets/09a56733-621c-4e31-aac7-c193a75b5b9c

**After:** badge adjacent to name at all widths

https://github.com/user-attachments/assets/82648b71-eb00-4920-8e4f-101a7d9fb507

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`