### PR TITLE
Bump read-vault-secrets action, fix flaky edit-fake-cluster e2e test

### DIFF
--- a/.github/workflows/automation-candidate.yaml
+++ b/.github/workflows/automation-candidate.yaml
@@ -19,7 +19,7 @@ jobs:
     if: github.event_name == 'issues' && github.event.label.name == 'candidate-automation'
     steps:
       - name: Read QA secrets
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+        uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # v3
         with:
           secrets: |
             github/token/rancher--qa-tasks--issues--write token | QA_GH_TOKEN

--- a/.github/workflows/build-and-upload.yaml
+++ b/.github/workflows/build-and-upload.yaml
@@ -43,7 +43,7 @@ jobs:
         run: ./scripts/build-upload-gate
 
       - name: Get gcs auth
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+        uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # v3
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/google-auth/rancher/credentials token | GOOGLE_AUTH
@@ -86,7 +86,7 @@ jobs:
         run: ./scripts/build-embedded
 
       - name: Get gcs auth
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+        uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # v3
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/google-auth/rancher/credentials token | GOOGLE_AUTH

--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -31,7 +31,7 @@ jobs:
     # The FOSSA token is shared between all repos in Rancher's GH org. It can
     # be used directly and there is no need to request specific access to EIO.
     - name: Read FOSSA token
-      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+      uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # v3
       with:
         secrets: |
           secret/data/github/org/rancher/fossa/push token | FOSSA_API_KEY_PUSH_ONLY

--- a/.github/workflows/port-issue.yaml
+++ b/.github/workflows/port-issue.yaml
@@ -17,7 +17,7 @@ jobs:
     if: contains(github.event.comment.body, '/backport') || contains(github.event.comment.body, '/forwardport')
     steps:
       - name: Read secrets
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+        uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # v3
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APPID ;

--- a/.github/workflows/port-pr.yaml
+++ b/.github/workflows/port-pr.yaml
@@ -16,7 +16,7 @@ jobs:
     if: (startsWith(github.event.comment.body, '/backport') || startsWith(github.event.comment.body, '/forwardport')) && github.event.issue.pull_request
     steps:
       - name: Read secrets
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+        uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # v3
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APPID;

--- a/.github/workflows/pr-gh-project-processor.yaml
+++ b/.github/workflows/pr-gh-project-processor.yaml
@@ -23,7 +23,7 @@ jobs:
       with:
         node-version-file: '.nvmrc'
     - name: Read secrets
-      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+      uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # v3
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APP_ID ;

--- a/cypress/e2e/blueprints/nav/fake-cluster.ts
+++ b/cypress/e2e/blueprints/nav/fake-cluster.ts
@@ -2528,7 +2528,7 @@ export function generateFakeClusterDataAndIntercepts({
   cy.intercept({
     method:   'GET',
     pathname: '/v1/provisioning.cattle.io.clusters',
-    query:    { pagesize: '*' }
+    query:    { pagesize: '100000' }
   }, (req) => {
     req.continue((res) => {
       const localIndex = res.body.data.findIndex((item: any) => item.id.includes('/local'));
@@ -2552,25 +2552,40 @@ export function generateFakeClusterDataAndIntercepts({
     });
   }).as('provCluster');
 
+  const update = (clusters: any[]) => {
+    const localIndex = clusters.findIndex((item: any) => item.id.includes('local'));
+
+    if (localIndex >= 0) {
+      const localCluster = clusters[localIndex];
+
+      localCluster.spec.description = longClusterDescription;
+    }
+
+    clusters.push(fakeNavClusterData.mgmtClusterObj);
+  };
+
   // add extra cluster to the nav list to test https://github.com/rancher/dashboard/issues/10452
   cy.intercept({
     method:   'GET',
     pathname: '/v1/management.cattle.io.clusters',
-    query:    { pagesize: '*' }
+    query:    { pagesize: '10' }
   }, (req) => {
     req.continue((res) => {
-      const localIndex = res.body.data.findIndex((item: any) => item.id.includes('local'));
-
-      if (localIndex >= 0) {
-        const localCluster = res.body.data[localIndex];
-
-        localCluster.spec.description = longClusterDescription;
-      }
-
-      res.body.data.push(fakeNavClusterData.mgmtClusterObj);
+      update(res.body.data);
       res.send(res.body);
     });
-  }).as('mgmtClusters');
+  }).as('mgmtClustersSideNav');
+
+  cy.intercept({
+    method:   'GET',
+    pathname: '/v1/management.cattle.io.clusters',
+    query:    { pagesize: '100' }
+  }, (req) => {
+    req.continue((res) => {
+      update(res.body.data);
+      res.send(res.body);
+    });
+  }).as('mgmtClustersLists');
 
   cy.intercept('GET', `/v1/management.cattle.io.clusters/${ fakeNavClusterData.mgmtClusterObj.id }?*`, (req) => {
     req.reply({

--- a/cypress/e2e/po/components/action-menu-shell.po.ts
+++ b/cypress/e2e/po/components/action-menu-shell.po.ts
@@ -9,8 +9,24 @@ export default class ActionMenuPo extends ComponentPo {
     return this.self().find('[dropdown-menu-item]').eq(index).click();
   }
 
+  checkNoActionsAvailable(present = true) {
+    if (present) {
+      return this.self().should('contain', 'No actions available');
+    } else {
+      return this.self().should('not.contain', 'No actions available');
+    }
+  }
+
+  atLeastOneActiveMenuItem() {
+    return this.self().find('[dropdown-menu-item]:not([disabled])').should('exist');
+  }
+
   getMenuItem(name: string) {
-    return this.self().get('[dropdown-menu-item]').contains(name);
+    return this.self().contains('[dropdown-menu-item]', name);
+  }
+
+  waitForMenuItem(name: string) {
+    return this.getMenuItem(name).should('be.visible');
   }
 
   menuItemNames() {

--- a/cypress/e2e/po/components/loading.po.ts
+++ b/cypress/e2e/po/components/loading.po.ts
@@ -1,5 +1,7 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 
 export default class LoadingPo extends ComponentPo {
-
+  constructor(selector = '.loading-indicator') {
+    super(selector);
+  }
 }

--- a/cypress/e2e/po/components/sortable-table.po.ts
+++ b/cypress/e2e/po/components/sortable-table.po.ts
@@ -191,7 +191,7 @@ export default class SortableTablePo extends ComponentPo {
 
   rowActionMenu() {
     // Get the visible dropdown menu - this ensures we only interact with a menu that's actually open
-    return new ActionMenuPo(cy.get('[dropdown-menu-collection]:visible'));
+    return new ActionMenuPo('[dropdown-menu-collection]:visible');
   }
 
   noRowsShouldNotExist() {
@@ -244,9 +244,9 @@ export default class SortableTablePo extends ComponentPo {
 
     // Wait for the dropdown to finish loading (not show "No actions available")
     if (!skipNoActionAvailableCheck) {
-      actionMenu.self().should('not.contain', 'No actions available');
+      actionMenu.checkNoActionsAvailable(false);
       // Ensure at least one non-disabled menu item is present
-      actionMenu.self().find('[dropdown-menu-item]:not([disabled])').should('exist');
+      actionMenu.atLeastOneActiveMenuItem();
     }
 
     return actionMenu;

--- a/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po.ts
+++ b/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po.ts
@@ -112,7 +112,9 @@ export default class ClusterManagerListPagePo extends BaseListPagePo {
   }
 
   editCluster(name: string) {
-    this.sortableTable().rowActionMenuOpen(name).getMenuItem('Edit Config').click();
+    const rowMenu = this.sortableTable().rowActionMenuOpen(name);
+
+    return rowMenu.waitForMenuItem('Edit Config').click();
   }
 
   /**

--- a/cypress/e2e/tests/pages/manager/edit-fake-cluster.spec.ts
+++ b/cypress/e2e/tests/pages/manager/edit-fake-cluster.spec.ts
@@ -1,14 +1,17 @@
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterManagerEditGenericPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-generic.po';
-import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import { RANCHER_PAGE_EXCEPTIONS, catchTargetPageException } from '@/cypress/support/utils/exception-utils';
 import { CURRENT_RANCHER_VERSION } from '@shell/config/version.js';
-import PagePo from '@/cypress/e2e/po/pages/page.po';
-
 import { generateFakeClusterDataAndIntercepts } from '@/cypress/e2e/blueprints/nav/fake-cluster';
+import LoadingPo from '@/cypress/e2e/po/components/loading.po';
+
 const fakeProvClusterId = 'some-fake-cluster-id';
 const fakeMgmtClusterId = 'some-fake-mgmt-id';
+
+const clusterList = new ClusterManagerListPagePo('_');
+const loadingPo = new LoadingPo();
+const editCluster = new ClusterManagerEditGenericPagePo('_', fakeProvClusterId);
 
 describe('Cluster Edit', { tags: ['@manager', '@adminUser'] }, () => {
   describe('Cluster Edit (Fake DO cluster)', () => {
@@ -18,31 +21,25 @@ describe('Cluster Edit', { tags: ['@manager', '@adminUser'] }, () => {
       });
 
       cy.login();
+
+      HomePagePo.goTo();
+
+      cy.wait('@mgmtClustersSideNav');
+      cy.wait('@mgmtClustersLists');
+      cy.wait('@provClusters');
+
+      clusterList.navToMenuEntry('Cluster Management');
+      clusterList.waitForPage();
+
+      cy.wait('@mgmtClustersLists');
+      cy.wait('@provClusters');
+
+      clusterList.editCluster(fakeProvClusterId);
+
+      editCluster.waitForPage();
     });
 
     it('Clearing a registry auth item on the UI (Cluster Edit Config) should retain its authentication ID', () => {
-      HomePagePo.goTo();
-      const burgerMenu = new BurgerMenuPo();
-
-      BurgerMenuPo.toggle();
-      const clusterManagementNavItem = burgerMenu.links().contains(`Cluster Management`);
-
-      clusterManagementNavItem.should('exist');
-      clusterManagementNavItem.click();
-      const clusterList = new ClusterManagerListPagePo('_');
-
-      clusterList.waitForPage();
-      cy.intercept({
-        method:   'GET',
-        pathname: '/v1/provisioning.cattle.io.clusters',
-        query:    { pagesize: '100000' }
-      }).as('waitForDropDownInfo'); // Wait for request which will populate the drop down
-
-      cy.wait('@waitForDropDownInfo');
-      clusterList.editCluster(fakeProvClusterId);
-
-      const editCluster = new ClusterManagerEditGenericPagePo('_', fakeProvClusterId);
-
       editCluster.clickTab('#registry');
       editCluster.registryAuthenticationItems().closeArrayListItem(0);
 
@@ -53,17 +50,10 @@ describe('Cluster Edit', { tags: ['@manager', '@adminUser'] }, () => {
 
     // testing https://github.com/rancher/dashboard/issues/10192
     it('"documentation" link in editing a cluster should open in a new tab', () => {
-      HomePagePo.goTo();
-
       catchTargetPageException(RANCHER_PAGE_EXCEPTIONS);
 
-      const page = new PagePo('');
-      const clusterList = new ClusterManagerListPagePo('_');
-
-      page.navToMenuEntry('Cluster Management');
-      clusterList.waitForPage();
-
-      clusterList.list().actionMenu(fakeProvClusterId).getMenuItem('Edit Config').click();
+      // Don't click until the loading indicator isn't there....
+      loadingPo.checkNotExists();
 
       // since in Cypress we cannot assert directly a link on a new tab
       // next best thing is to assert that the link has _blank

--- a/cypress/e2e/tests/pages/manager/edit-fake-cluster.spec.ts
+++ b/cypress/e2e/tests/pages/manager/edit-fake-cluster.spec.ts
@@ -32,7 +32,13 @@ describe('Cluster Edit', { tags: ['@manager', '@adminUser'] }, () => {
       const clusterList = new ClusterManagerListPagePo('_');
 
       clusterList.waitForPage();
-      cy.wait('@provClusters'); // Wait for request which will populate the drop down
+      cy.intercept({
+        method:   'GET',
+        pathname: '/v1/provisioning.cattle.io.clusters',
+        query:    { pagesize: '100000' }
+      }).as('waitForDropDownInfo'); // Wait for request which will populate the drop down
+
+      cy.wait('@waitForDropDownInfo');
       clusterList.editCluster(fakeProvClusterId);
 
       const editCluster = new ClusterManagerEditGenericPagePo('_', fakeProvClusterId);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Bump read-vault-secrets action
- This was pinned to a version that did not pin it's own actions

Additionally fix a really flakey edit-fake-cluster test (given changes to listing clusters)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
