### PR TITLE
refactor: rename communityRepoRegexes to harvesterRepoRegexes and update related logic

### DIFF
--- a/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
@@ -15,11 +15,10 @@ import { NAME as APP_PRODUCT } from '@shell/config/product/apps';
 import { BLANK_CLUSTER } from '@shell/store/store-types.js';
 import { UI_PLUGIN_NAMESPACE } from '@shell/config/uiplugins';
 import {
-  HARVESTER_CHART, HARVESTER_COMMUNITY_REPO, HARVESTER_RANCHER_REPO, communityRepoRegexes, HARVESTER_CATALOG_IMAGES
+  HARVESTER_CHART, HARVESTER_COMMUNITY_REPO, HARVESTER_RANCHER_REPO, harvesterRepoRegexes, HARVESTER_CATALOG_IMAGES
 } from '../types';
 import {
   getLatestExtensionVersion,
-  getHelmRepositoryExact,
   getHelmRepositoryMatch,
   createHelmRepository,
   refreshHelmRepository,
@@ -67,7 +66,6 @@ export default {
     this.mgmtClusters = hash.mgmtClusters;
 
     this.harvesterRepository = await this.getHarvesterRepository();
-
     this.kubeVersion = this.$store.getters['management/byId'](MANAGEMENT.CLUSTER, 'local')?.kubernetesVersionBase || '';
   },
 
@@ -107,6 +105,7 @@ export default {
   },
 
   watch: {
+    // watch harvester repository, if it changes to a valid one, then we will check if there is an update for harvester extension, which will trigger the extension update message in the UI
     async harvesterRepository(neu) {
       if (neu) {
         await refreshHelmRepository(this.$store, neu.spec.gitRepo || neu.spec.url);
@@ -243,11 +242,7 @@ export default {
   methods: {
     async getHarvesterRepository() {
       try {
-        if (isRancherPrime()) {
-          return await getHelmRepositoryExact(this.$store, HARVESTER_REPO.gitRepo);
-        } else {
-          return await getHelmRepositoryMatch(this.$store, communityRepoRegexes, HARVESTER_CATALOG_IMAGES);
-        }
+        return await getHelmRepositoryMatch(this.$store, harvesterRepoRegexes, HARVESTER_CATALOG_IMAGES);
       } catch (error) {
         this.harvesterRepositoryError = true;
       }

--- a/pkg/harvester-manager/types.js
+++ b/pkg/harvester-manager/types.js
@@ -2,9 +2,10 @@ import { UI_PLUGINS_REPOS } from '@shell/config/uiplugins';
 
 export const HARVESTER_CATALOG_IMAGES = ['ui-plugin-catalog', 'ui-extension-harvester-ui-extension'];
 
-export const communityRepoRegexes = [
-  /^https:\/\/github\.com\/.*\/harvester-ui-extension+/g,
-  /^https:\/\/.*\.github\.io\/harvester-ui-extension+/g,
+export const harvesterRepoRegexes = [
+  /^https:\/\/github\.com\/.*\/harvester-ui-extension+/g, // e.g. https://github.com/harvester/harvester-ui-extension
+  /^https:\/\/.*\.github\.io\/harvester-ui-extension+/g, // e.g. https://github.io/harvester/harvester-ui-extension
+  UI_PLUGINS_REPOS.OFFICIAL.URL, // rancher/ui-plugin-charts
 ];
 
 export const HARVESTER_CHART = {

--- a/shell/utils/uiplugins.ts
+++ b/shell/utils/uiplugins.ts
@@ -180,18 +180,19 @@ export async function getHelmRepositoryExact(store: any, url: string): Promise<H
 /**
  *
  * @param store Vue store
- * @param urlRegexes Regex to match a community repository
+ * @param urlRegexes Regex to match against the repository's urls
  * @param catalogImages Catalog images to match against the repository's labels
  * @returns HelmRepository
  */
 export async function getHelmRepositoryMatch(store: any, urlRegexes: string[], catalogImages: string[]): Promise<HelmRepository> {
   return await getHelmRepository(store, (repository: any) => {
-    // if installed from rancher/ui-plugin-catalog or rancher/ui-extension-harvester-ui-extension
     const catalog = repository?.metadata?.labels?.[UI_PLUGIN_LABELS.CATALOG_IMAGE] || '';
 
-    if (catalogImages.includes(catalog)) {
+    // if installed from rancher/ui-plugin-catalog or rancher/ui-extension-harvester-ui-extension
+    if (catalog && catalogImages.includes(catalog)) {
       return true;
     }
+
     const target = repository.spec?.gitBranch ? repository.spec?.gitRepo : repository.spec?.url;
 
     return matchesSomeRegex(target, urlRegexes);


### PR DESCRIPTION
### Summary
Fixes #17601

### Occurred changes and/or fixed issues
The [missing](https://github.com/rancher/dashboard/blob/8d82e5bdac67eaa0c80f748f8bf85aff441311d7/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue#L127) message pops up because [this.harvesterRepository](https://github.com/rancher/dashboard/blob/8d82e5bdac67eaa0c80f748f8bf85aff441311d7/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue#L69) is undefined when Rancher Prime user installing harvester ui extension via [rancher/ui-plugin-catalog](https://hub.docker.com/r/rancher/ui-plugin-catalog/tags).




### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
Run locally as Rancher Prime : `PRIME=true API=[rancher IP] yarn dev`
**Before**
<img width="733" height="372" alt="image" src="https://github.com/user-attachments/assets/af15bdf4-5f85-4054-a259-2e2219693a1b" />

**After**
<img width="1496" height="753" alt="Screenshot 2026-05-19 at 4 28 28 PM" src="https://github.com/user-attachments/assets/587e80b7-7a27-40c5-9a51-b280b0e4d287" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

