### PR TITLE
Fix delay when navigating to a cluster

### DIFF
--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -727,13 +727,13 @@ describe('topLevelMenu', () => {
                     nameDisplay: 'cluster1',
                     id:          'an-id1',
                     mgmt:        { id: 'an-id1' },
-                    isReady:     true
+                    canExplore:  true
                   },
                   {
                     nameDisplay: 'cluster2',
                     id:          'an-id2',
                     mgmt:        { id: 'an-id2' },
-                    isReady:     true
+                    canExplore:  true
                   }
                 ])
               }
@@ -786,7 +786,7 @@ describe('topLevelMenu', () => {
             nameDisplay: 'cluster1',
             id:          'an-id1',
             mgmt:        { id: 'an-id1' },
-            isReady:     true
+            canExplore:  true
           }
         ]);
 
@@ -814,7 +814,7 @@ describe('topLevelMenu', () => {
             nameDisplay: 'cluster1',
             id:          'an-id1',
             mgmt:        { id: 'an-id1' },
-            isReady:     true
+            canExplore:  true
           }
         ]);
 

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -469,8 +469,10 @@ const sharedActions = {
     const worker = (this.$workers || {})[getters.storeName];
 
     if (worker) {
+      const storeName = getters.storeName;
+
       worker.postMessage({ destroyWorker: true }); // we're only passing the boolean here because the key needs to be something truthy to ensure it's passed on the object.
-      cleanupTasks.push(waitFor(() => !this.$workers[getters.storeName], 'Worker is destroyed'));
+      cleanupTasks.push(waitFor(() => !this.$workers?.[storeName], 'Worker to be destroyed', 30000, 10, true));
     }
 
     if ( socket ) {

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -1041,6 +1041,8 @@ export const actions = {
     // This is a workaround for a timing issue where the mgmt cluster schema may not be available
     // Try and wait until the schema exists before proceeding
     await dispatch('management/waitForSchema', { type: MANAGEMENT.CLUSTER });
+    // Similarly to above, we somehow get here without everything in management land being ready. FF needed to determine pagination state
+    await dispatch('management/waitForHaveAll', { type: MANAGEMENT.FEATURE });
 
     // If SSP is on we won't have requested all clusters
     if (!paginateClusters({ rootGetters, state })) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17634
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- issue 1
  - `loadCluster` --> `await dispatch('cluster/unsubscribe');` --> `cleanupTasks.push(waitFor(() => !this.$workers[getters.storeName], 'Worker is destroyed'));`
  - the waitFor was not immediately resolved, so waited the default 500ms before checking again
  - for some reason we're now not in the immediate world so wait the 500ms
  - resolution is to reduce the delay in waitFor to 50ms
  - i haven't managed to work out why this is now an issue, so this is almost a work around (but a logical one)
- issue 2
  - race condition for `loadCluster` and feature flag
  - we check if vai enabled (via FF), and if not wait for all mgmt clusters. with vai disabled this is fetched later on
  - however if FF aren't fetched by the time we decided to wait for mgmt clusters.. we wait... and if FF are later fetched and vai is enabled we won't fetch all clusters.... so the UI blocks on blue spinner until the wait fails

### Technical notes summary
- Superseded
  - https://github.com/rancher/dashboard/pull/17641
  - https://github.com/rancher/dashboard/pull/17703

### Areas or cases that should be tested
- home page --> cluster list --> cluster (quicker than before, at least 450ms)
- nav to any cluster --> Workloads --> Deployment page --> refresh ~5 times (should always load quicker than 10 seconds...)

### Areas which could experience regressions
- cluster --> home page --> cluster list (this is as quick as before)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
