### PR TITLE
tweak kontainer tests to reduce flake

### DIFF
--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -5,7 +5,7 @@ import DeactivateDriverDialogPo from '@/cypress/e2e/po/prompts/deactivateDriverD
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po';
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
-import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 
 describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@adminUser'] }, () => {
   const driversPage = new KontainerDriversPagePo();
@@ -85,7 +85,7 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     });
 
     driversPage.list().details(exampleDriver, 1).should('contain', 'Activating');
-    driversPage.list().details(exampleDriver, 1).contains('Active', { timeout: 60000 });
+    driversPage.list().details(exampleDriver, 1).should('contain', 'Active', { timeout: LONG_TIMEOUT_OPT });
 
     // Verify the driver tile appears on the cluster create page.
     // Legacy ember-based kontainer drivers are shown disabled with an informational tooltip
@@ -144,12 +144,9 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     driversPage.list().activate().click();
     cy.wait('@activateOpenTelekomDriver').its('response.statusCode').should('eq', 200);
     cy.wait('@activateOracleDriver').its('response.statusCode').should('eq', 200);
-    // wait for drivers to be activating
-    driversPage.list().details(openTelekomDriver, 1).should('contain', 'Activating');
-    driversPage.list().details(oracleDriver, 1).should('contain', 'Activating');
     // wait for drivers to be active
-    driversPage.list().details(openTelekomDriver, 1).should('contain', 'Active');
-    driversPage.list().details(oracleDriver, 1).should('contain', 'Active');
+    driversPage.list().details(openTelekomDriver, 1).should('contain', 'Active', MEDIUM_TIMEOUT_OPT);
+    driversPage.list().details(oracleDriver, 1).should('contain', 'Active', MEDIUM_TIMEOUT_OPT);
 
     // check options on cluster create page
     ClusterManagerListPagePo.navTo();
@@ -230,6 +227,10 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
       expect(response?.statusCode).to.eq(200);
       expect(isMatch(request.body, requestData)).to.equal(true);
     });
+
+    // wait for driver to be activating then active
+    driversPage.list().details(exampleDriver, 1).should('contain', 'Activating');
+    driversPage.list().details(exampleDriver, 1).should('contain', 'Active');
 
     // check options on cluster create page
     ClusterManagerListPagePo.navTo();

--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -245,8 +245,7 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
       expect(isMatch(request.body, requestData)).to.equal(true);
     });
 
-    // wait for driver to be activating then active
-    driversPage.list().details(exampleDriver, 1).should('contain', 'Activating');
+    // wait for driver to be active
     driversPage.list().details(exampleDriver, 1).should('contain', 'Active');
 
     // check options on cluster create page

--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -5,7 +5,7 @@ import DeactivateDriverDialogPo from '@/cypress/e2e/po/prompts/deactivateDriverD
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po';
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
-import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT, VERY_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 
 describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@adminUser'] }, () => {
   const driversPage = new KontainerDriversPagePo();
@@ -145,8 +145,8 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     cy.wait('@activateOpenTelekomDriver').its('response.statusCode').should('eq', 200);
     cy.wait('@activateOracleDriver').its('response.statusCode').should('eq', 200);
     // wait for drivers to be active
-    driversPage.list().details(openTelekomDriver, 1).contains('Active', VERY_LONG_TIMEOUT_OPT);
-    driversPage.list().details(oracleDriver, 1).contains('Active', VERY_LONG_TIMEOUT_OPT);
+    driversPage.list().details(openTelekomDriver, 1).contains('Active', LONG_TIMEOUT_OPT);
+    driversPage.list().details(oracleDriver, 1).contains('Active', LONG_TIMEOUT_OPT);
 
     // check options on cluster create page
     ClusterManagerListPagePo.navTo();

--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -221,6 +221,21 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     driversPage.list().resourceTable().sortableTable().checkVisible();
     driversPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
 
+    // Ensure driver is inactive before attempting to activate
+    driversPage.list().details(exampleDriver, 1).then(($el) => {
+      if ($el.text().includes('Active')) {
+        cy.intercept('POST', `/v3/kontainerDrivers/*?action=deactivate`).as('deactivateForSetup');
+        driversPage.list().actionMenu(downloadUrl).getMenuItem('Deactivate').click();
+        const deactivateDialog = new DeactivateDriverDialogPo();
+
+        deactivateDialog.deactivate();
+        cy.wait('@deactivateForSetup');
+        driversPage.list().details(exampleDriver, 1).should('contain', 'Inactive');
+      }
+    });
+
+    driversPage.list().details(exampleDriver, 1).should('contain', 'Inactive');
+
     cy.intercept('POST', `/v3/kontainerDrivers/*?action=activate`).as('activateDriver');
 
     driversPage.list().actionMenu(downloadUrl).getMenuItem('Activate').click();

--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -85,7 +85,7 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     });
 
     driversPage.list().details(exampleDriver, 1).should('contain', 'Activating');
-    driversPage.list().details(exampleDriver, 1).should('contain', 'Active', LONG_TIMEOUT_OPT );
+    driversPage.list().details(exampleDriver, 1).contains('Active', LONG_TIMEOUT_OPT);
 
     // Verify the driver tile appears on the cluster create page.
     // Legacy ember-based kontainer drivers are shown disabled with an informational tooltip
@@ -145,8 +145,8 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     cy.wait('@activateOpenTelekomDriver').its('response.statusCode').should('eq', 200);
     cy.wait('@activateOracleDriver').its('response.statusCode').should('eq', 200);
     // wait for drivers to be active
-    driversPage.list().details(openTelekomDriver, 1).should('contain', 'Active', VERY_LONG_TIMEOUT_OPT);
-    driversPage.list().details(oracleDriver, 1).should('contain', 'Active', VERY_LONG_TIMEOUT_OPT);
+    driversPage.list().details(openTelekomDriver, 1).contains('Active', VERY_LONG_TIMEOUT_OPT);
+    driversPage.list().details(oracleDriver, 1).contains('Active', VERY_LONG_TIMEOUT_OPT);
 
     // check options on cluster create page
     ClusterManagerListPagePo.navTo();

--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -5,7 +5,7 @@ import DeactivateDriverDialogPo from '@/cypress/e2e/po/prompts/deactivateDriverD
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po';
 import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
-import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT, VERY_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 
 describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@adminUser'] }, () => {
   const driversPage = new KontainerDriversPagePo();
@@ -85,7 +85,7 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     });
 
     driversPage.list().details(exampleDriver, 1).should('contain', 'Activating');
-    driversPage.list().details(exampleDriver, 1).should('contain', 'Active', { timeout: LONG_TIMEOUT_OPT });
+    driversPage.list().details(exampleDriver, 1).should('contain', 'Active', LONG_TIMEOUT_OPT );
 
     // Verify the driver tile appears on the cluster create page.
     // Legacy ember-based kontainer drivers are shown disabled with an informational tooltip
@@ -145,8 +145,8 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
     cy.wait('@activateOpenTelekomDriver').its('response.statusCode').should('eq', 200);
     cy.wait('@activateOracleDriver').its('response.statusCode').should('eq', 200);
     // wait for drivers to be active
-    driversPage.list().details(openTelekomDriver, 1).should('contain', 'Active', MEDIUM_TIMEOUT_OPT);
-    driversPage.list().details(oracleDriver, 1).should('contain', 'Active', MEDIUM_TIMEOUT_OPT);
+    driversPage.list().details(openTelekomDriver, 1).should('contain', 'Active', VERY_LONG_TIMEOUT_OPT);
+    driversPage.list().details(oracleDriver, 1).should('contain', 'Active', VERY_LONG_TIMEOUT_OPT);
 
     // check options on cluster create page
     ClusterManagerListPagePo.navTo();
@@ -201,6 +201,8 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
       expect(response?.statusCode).to.eq(200);
       expect(isMatch(request.body, requestData)).to.equal(true);
     });
+
+    driversPage.list().details(exampleDriver, 1).should('contain', 'Inactive');
 
     // check options on cluster create page
     ClusterManagerListPagePo.navTo();
@@ -330,31 +332,22 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
       body:       { }
     }).as('deleteDriver');
 
-    // Scroll element into view and select with force
-    driversPage.list().resourceTable().sortableTable().rowElementWithName(exampleDriver)
-      .scrollIntoView();
-    driversPage.list().resourceTable().sortableTable().rowSelectCtlWithName(exampleDriver)
-      .set();
-    driversPage.list().resourceTable().sortableTable().bulkActionDropDownOpen();
-    driversPage.list().resourceTable().sortableTable().bulkActionDropDownButton('Delete')
-      .click({ force: true });
+    driversPage.list().actionMenu(exampleDriver).getMenuItem('Delete').click();
 
-    driversPage.list().resourceTable().sortableTable().rowNames()
-      .then((rows: any) => {
-        const promptRemove = new PromptRemove();
+    const promptRemove = new PromptRemove();
 
-        promptRemove.remove();
+    promptRemove.remove();
 
-        cy.wait('@deleteDriver').then(({ response }) => {
-          expect(response?.statusCode).to.eq(200);
-          if (response?.statusCode === 200) {
-            removeDriver = false;
-          }
-          driversPage.waitForPage();
-          driversPage.list().resourceTable().sortableTable().rowNames()
-            .should('not.contain', exampleDriver);
-        });
-      });
+    cy.wait('@deleteDriver').then(({ response }) => {
+      expect(response?.statusCode).to.eq(200);
+    });
+
+    driversPage.waitForPage();
+    driversPage.list().resourceTable().sortableTable().rowElementWithName(exampleDriver, MEDIUM_TIMEOUT_OPT)
+      .should('not.exist');
+
+    // only mark removeDriver false once tests assert the driver is actually gone
+    removeDriver = false;
   });
 
   after(() => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17735
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates kontainer driver tests to remove a race condition. Instead of waiting for an Activating state in one driver before asserting an Activating state in another, which may have already progressed to Active, only the Active state is asserted in the bulk activation step.

The Activating -> Active status updates are still validated in the 'can create new driver' test

also in this pr:
- fixed invalid timeout in 'create new driver' test
- updated the delete driver test to use the action menu 'delete' option instead of re-testing the bulk action delete that is covered by another test
- updated the assertion in the delete driver test to fail when the driver is still present
- update activate driver test to ensure the example driver is actually inactive before the rest of the test runs
- update the deactivate driver test to assert that the driver is actually reported as deactivated


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
