### PR TITLE
Migrate the OIDC auth provider form to use vee-validate

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -797,6 +797,7 @@ authConfig:
       label: Scopes
       placeholder: openid
       protip: The <code>openid</code>, <code>profile</code>, and <code>email</code> scopes are required and cannot be removed.
+      missingRequired: "The required {count, plural, =1 {scope is} other {scopes are}} missing: {scopes}"
     pkce:
       label: Enable PKCE (S256)
       tooltip: Enable Proof Key for Code Exchange (PKCE) using the S256 code challenge method. When enabled, this client must use PKCE with S256 for authorization requests.

--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -151,6 +151,15 @@ export default {
       validationMessage: ref(null),
     });
 
+    // Only structural changes (add, delete, paste) mark trigger validation
+    // when invoking update()
+    const isStructuralChange = ref(false);
+
+    const validate = () => {
+      veeHandleBlur(undefined, false);
+      veeValidate();
+    };
+
     /**
      * Cleanup rows and emit input
      */
@@ -169,8 +178,10 @@ export default {
         }
       }
       emit('update:value', out);
-      veeHandleBlur(undefined, false);
-      veeValidate();
+      if (isStructuralChange.value) {
+        validate();
+        isStructuralChange.value = false;
+      }
     };
 
     const lastUpdateWasFromValue = ref(false);
@@ -205,6 +216,8 @@ export default {
       isView,
       update,
       effectiveValidationMessage,
+      isStructuralChange,
+      validate,
     };
   },
 
@@ -239,6 +252,7 @@ export default {
   },
   methods: {
     add() {
+      this.isStructuralChange = true;
       this.rows.push({ value: clone(this.defaultAddValue) });
       if (this.defaultAddValue) {
         this.queueUpdate();
@@ -257,6 +271,7 @@ export default {
      */
     remove(row, index) {
       this.$emit('remove', { row, index });
+      this.isStructuralChange = true;
       removeAt(this.rows, index);
       this.queueUpdate();
     },
@@ -268,6 +283,7 @@ export default {
       event.preventDefault();
       const text = event.clipboardData.getData('text/plain');
 
+      this.isStructuralChange = true;
       if (this.valueMultiline) {
         // Allow to paste multiple lines
         this.rows[index].value = text;
@@ -363,6 +379,7 @@ export default {
                   :aria-label="a11yLabel ? `${a11yLabel} ${t('generic.ariaLabel.genericRow', {index: idx+1})}` : undefined"
                   @paste="onPaste(idx, $event)"
                   @update:value="queueUpdate"
+                  @blur="validate"
                 />
                 <LabeledInput
                   v-else-if="rules.length > 0"
@@ -376,6 +393,7 @@ export default {
                   :aria-label="a11yLabel ? `${a11yLabel} ${t('generic.ariaLabel.genericRow', {index: idx+1})}` : undefined"
                   @paste="onPaste(idx, $event)"
                   @update:value="queueUpdate"
+                  @blur="validate"
                 />
                 <input
                   v-else
@@ -386,6 +404,7 @@ export default {
                   :disabled="isView || disabled"
                   :aria-label="a11yLabel ? `${a11yLabel} ${t('generic.ariaLabel.genericRow', {index: idx+1})}` : undefined"
                   @paste="onPaste(idx, $event)"
+                  @blur="validate"
                 >
               </slot>
             </div>

--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -6,7 +6,7 @@ import { removeAt } from '@shell/utils/array';
 import { TextAreaAutoGrow } from '@components/Form/TextArea';
 import { clone } from '@shell/utils/object';
 import { LabeledInput } from '@components/Form/LabeledInput';
-import LabeledTooltip from '@components/LabeledTooltip/LabeledTooltip.vue';
+import Banner from '@components/Banner/Banner.vue';
 import { useVeeValidateField } from '@shell/composables/useVeeValidateField';
 const DEFAULT_PROTIP = 'Tip: Paste lines into any list field for easy bulk entry';
 
@@ -14,7 +14,7 @@ export default {
   emits: ['add', 'remove', 'update:value'],
 
   components: {
-    TextAreaAutoGrow, LabeledInput, LabeledTooltip
+    TextAreaAutoGrow, LabeledInput, Banner
   },
   props: {
     value: {
@@ -329,6 +329,12 @@ export default {
         </h3>
       </slot>
     </div>
+    <Banner
+      v-if="effectiveValidationMessage"
+      class="validation-banner"
+      color="error"
+      :label="effectiveValidationMessage"
+    />
 
     <div>
       <template v-if="rows.length">
@@ -478,24 +484,20 @@ export default {
         </slot>
       </div>
     </div>
-    <LabeledTooltip
-      v-if="effectiveValidationMessage"
-      :value="effectiveValidationMessage"
-    />
   </div>
 </template>
 
 <style lang="scss" scoped>
-  .array-list-main-container {
-    position: relative;
-  }
-
   .title {
     margin-bottom: 10px;
   }
 
   .required {
     color: var(--error);
+  }
+
+  .validation-banner {
+    margin-top: 0;
   }
 
   .box {

--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -1,18 +1,22 @@
 <script>
-import { ref, watch, computed } from 'vue';
+import { ref, watch, computed, toRef } from 'vue';
 import debounce from 'lodash/debounce';
 import { _EDIT, _VIEW } from '@shell/config/query-params';
 import { removeAt } from '@shell/utils/array';
 import { TextAreaAutoGrow } from '@components/Form/TextArea';
 import { clone } from '@shell/utils/object';
 import { LabeledInput } from '@components/Form/LabeledInput';
+import LabeledTooltip from '@components/LabeledTooltip/LabeledTooltip.vue';
+import { useVeeValidateField } from '@shell/composables/useVeeValidateField';
 const DEFAULT_PROTIP = 'Tip: Paste lines into any list field for easy bulk entry';
 
 export default {
   emits: ['add', 'remove', 'update:value'],
 
-  components: { TextAreaAutoGrow, LabeledInput },
-  props:      {
+  components: {
+    TextAreaAutoGrow, LabeledInput, LabeledTooltip
+  },
+  props: {
     value: {
       type:    Array,
       default: null,
@@ -106,7 +110,17 @@ export default {
     componentTestid: {
       type:    String,
       default: 'array-list',
-    }
+    },
+
+    /**
+     * Field name for vee-validate integration. When provided, the component
+     * registers with a parent form context for schema-level validation.
+     */
+    name: {
+      type:    String,
+      default: null,
+    },
+
   },
 
   setup(props, { emit }) {
@@ -124,6 +138,17 @@ export default {
 
     const isView = computed(() => {
       return props.mode === _VIEW;
+    });
+
+    // vee-validate integration: array-level validation via a parent form schema.
+    // Per-item validation continues to use the existing `rules` prop on
+    // LabeledInput.
+    const arrayValue = computed(() => props.value || []);
+    const { effectiveValidationMessage, veeHandleBlur, veeValidate } = useVeeValidateField({
+      name:              toRef(props, 'name'),
+      rules:             ref([]),
+      value:             arrayValue,
+      validationMessage: ref(null),
     });
 
     /**
@@ -144,6 +169,8 @@ export default {
         }
       }
       emit('update:value', out);
+      veeHandleBlur(undefined, false);
+      veeValidate();
     };
 
     const lastUpdateWasFromValue = ref(false);
@@ -177,6 +204,7 @@ export default {
       queueUpdate,
       isView,
       update,
+      effectiveValidationMessage,
     };
   },
 
@@ -431,10 +459,18 @@ export default {
         </slot>
       </div>
     </div>
+    <LabeledTooltip
+      v-if="effectiveValidationMessage"
+      :value="effectiveValidationMessage"
+    />
   </div>
 </template>
 
 <style lang="scss" scoped>
+  .array-list-main-container {
+    position: relative;
+  }
+
   .title {
     margin-bottom: 10px;
   }

--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -1,6 +1,6 @@
 import { nextTick } from 'vue';
 /* eslint-disable jest/no-hooks */
-import { mount, type VueWrapper } from '@vue/test-utils';
+import { mount, type VueWrapper, flushPromises } from '@vue/test-utils';
 import { _EDIT } from '@shell/config/query-params';
 
 import oidc from '@shell/edit/auth/oidc.vue';
@@ -8,6 +8,18 @@ import oidc from '@shell/edit/auth/oidc.vue';
 jest.mock('@shell/utils/clipboard', () => {
   return { copyTextToClipboard: jest.fn(() => Promise.resolve({})) };
 });
+
+const mockStore = {
+  getters: {
+    'i18n/t':      (key: string) => key,
+    'i18n/exists': () => false,
+  },
+};
+
+jest.mock('vuex', () => ({
+  ...jest.requireActual('vuex'),
+  useStore: () => mockStore,
+}));
 
 const validClientId = 'rancheroidc';
 const validClientSecret = 'TOkUxg0P67m1UXWNkJLHDPkUZFIKOWSq';
@@ -79,20 +91,26 @@ describe('oidc.vue', () => {
     });
 
     describe('have "Create" button disabled', () => {
-      it('given missing Auth endpoint URL', () => {
+      // validateAllFields() replicates what happens on blur in a real browser: it runs
+      // the toTypedSchema validators for every registered field and flushes async errors.
+      it('given missing Auth endpoint URL', async() => {
         wrapper.vm.model.authEndpoint = '';
         wrapper.vm.model.scopes = 'openid profile email'; // set scope to be sure
         wrapper.vm.oidcScope = ['openid', 'profile', 'email']; // TODO #13457: this is duplicated due wrong format of scopes
+        await wrapper.vm.validateAllFields();
+        await flushPromises();
 
         const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
 
         expect(saveButton.disabled).toBe(true);
       });
 
-      it('given missing required basic scopes', () => {
-        wrapper.vm.model.authEndpoint = 'whatever'; // set auth endpoint to be sure
+      it('given missing required basic scopes', async() => {
+        wrapper.vm.model.authEndpoint = validAuthEndpoint; // set auth endpoint to be sure
         wrapper.vm.model.scopes = 'something else'; // set wrong scope
         wrapper.vm.oidcScope = ['something', 'else']; // TODO #13457: this is duplicated due wrong format of scopes
+        await wrapper.vm.validateAllFields();
+        await flushPromises();
 
         const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
 
@@ -101,7 +119,8 @@ describe('oidc.vue', () => {
 
       it('when provider is disabled and editing config before fields are filled in', async() => {
         wrapper.setData({ model: {}, editConfig: true });
-        await nextTick();
+        await wrapper.vm.validateAllFields();
+        await flushPromises();
 
         const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
 
@@ -110,7 +129,8 @@ describe('oidc.vue', () => {
 
       it('when provider is disabled and editing config after required fields and scope is missing openid', async() => {
         wrapper.setData({ oidcUrls: { url: validUrl, realm: validRealm } });
-        await nextTick();
+        await wrapper.vm.validateAllFields();
+        await flushPromises();
 
         const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
 

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -1,5 +1,9 @@
 <script>
-import { ref, computed } from 'vue';
+import { ref, computed, provide } from 'vue';
+import { useStore } from 'vuex';
+import { useForm } from 'vee-validate';
+import { toTypedSchema } from '@vee-validate/zod';
+import * as z from 'zod';
 import Loading from '@shell/components/Loading';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import AuthConfig, { SLO_OPTION_VALUES } from '@shell/mixins/auth-config';
@@ -16,7 +20,7 @@ import { RadioGroup } from '@components/Form/Radio';
 import { Checkbox } from '@components/Form/Checkbox';
 import { BASE_SCOPES } from '@shell/store/auth';
 import CopyToClipboardText from '@shell/components/CopyToClipboardText.vue';
-import { isValidUrl } from '@shell/utils/validators/setting';
+import { useI18n } from '@shell/composables/useI18n';
 
 const PKCE_S256 = 'S256';
 
@@ -42,9 +46,13 @@ export default {
   mixins: [CreateEditView, AuthConfig],
 
   setup() {
+    const store = useStore();
+    const { t } = useI18n(store);
+
     // These refs sync mixin-state for the composition api
     const modelId = ref(null);
     const sloTypeRef = ref(null);
+    const customEndpointEnabled = ref(false);
 
     const isAmazonCognito = computed(() => modelId.value === 'cognito');
     const isKeycloak = computed(() => modelId.value === 'keycloakoidc');
@@ -55,10 +63,52 @@ export default {
     const requiresAuthEndpoint = computed(() => ['genericoidc', 'keycloakoidc'].includes(modelId.value));
     const sloEndSessionEndpointUiEnabled = computed(() => [SLO_OPTION_VALUES.all, SLO_OPTION_VALUES.both].includes(sloTypeRef.value));
 
+    // z.preprocess coerces null/undefined to '' before validation. This
+    // prevents the raw "Expected string, received null" zod message.
+    const coerce = (schema) => z.preprocess((v) => v ?? '', schema);
+    const requiredField = (key) => coerce(z.string().min(1, t('validation.required', { key: t(key) })));
+    const requiredUrlField = (key) => coerce(z.string().min(1, t('validation.required', { key: t(key) })).url(t('validation.genericUrl')));
+    const optionalField = coerce(z.string());
+
+    // Reactive schema uses computed to reshape when provider or endpoint mode
+    // changes.
+    const validationSchema = computed(() => toTypedSchema(
+      z.object({
+        clientId:     requiredField('authConfig.oidc.clientId'),
+        clientSecret: requiredField('authConfig.oidc.clientSecret'),
+
+        url:   !customEndpointEnabled.value && !isAmazonCognito.value ? requiredUrlField('authConfig.oidc.url') : optionalField,
+        realm: !customEndpointEnabled.value && !isAmazonCognito.value ? requiredField('authConfig.oidc.realm') : optionalField,
+
+        rancherUrl: customEndpointEnabled.value && !isAmazonCognito.value ? requiredField('authConfig.oidc.rancherUrl') : optionalField,
+        issuer:     customEndpointEnabled.value || isAmazonCognito.value ? requiredField('authConfig.oidc.issuer') : optionalField,
+
+        authEndpoint: requiresAuthEndpoint.value ? requiredUrlField('authConfig.oidc.authEndpoint') : optionalField,
+
+        endSessionEndpoint: sloEndSessionEndpointUiEnabled.value ? requiredUrlField('authConfig.oidc.endSessionEndpoint.title') : optionalField,
+
+      })
+    ));
+
+    const showAllErrors = ref(false);
+
+    provide('vee-show-all-errors', showAllErrors);
+
+    const { errors, validate } = useForm({ validationSchema });
+    const isFormValid = computed(() => Object.keys(errors.value).length === 0);
+
+    const validateAllFields = async() => {
+      await validate();
+      showAllErrors.value = true;
+    };
+
     return {
       PKCE_S256,
+      isFormValid,
+      validateAllFields,
       modelId,
       sloTypeRef,
+      customEndpointEnabled,
       isAmazonCognito,
       isKeycloak,
       isGenericOidc,
@@ -122,32 +172,7 @@ export default {
         return true;
       }
 
-      const { clientId, clientSecret } = this.model;
-      const isMissingAuthEndpoint = (this.requiresAuthEndpoint && !this.model.authEndpoint);
-      const isMissingScopes = !this.requiredScopes.every((scope) => this.oidcScope.includes(scope));
-
-      if (isMissingAuthEndpoint || isMissingScopes) {
-        return false;
-      }
-
-      // make sure that if SLO options are enabled on radio group, field "endSessionEndpoint" is required
-      if (this.isLogoutAllSupported && this.sloEndSessionEndpointUiEnabled && (!this.model.endSessionEndpoint || !isValidUrl(this.model.endSessionEndpoint))) {
-        return false;
-      }
-
-      if (this.isAmazonCognito) {
-        const { issuer } = this.model;
-
-        return !!(clientId && clientSecret && issuer);
-      } else if ( !this.customEndpoint.value ) {
-        const { url, realm } = this.oidcUrls;
-
-        return !!(clientId && clientSecret && url && realm);
-      } else {
-        const { rancherUrl, issuer } = this.model;
-
-        return !!(clientId && clientSecret && rancherUrl && issuer);
-      }
+      return this.isFormValid;
     },
 
     /**
@@ -179,7 +204,7 @@ export default {
   },
 
   watch: {
-    fvFormIsValid(newValue) {
+    validationPassed(newValue) {
       this.$emit('validationChanged', !!newValue);
     },
 
@@ -188,6 +213,10 @@ export default {
         this.modelId = newVal;
       },
       immediate: true,
+    },
+
+    'customEndpoint.value'(v) {
+      this.customEndpointEnabled = v;
     },
 
     'oidcUrls.url'() {
@@ -379,6 +408,7 @@ export default {
           <div class="col span-6">
             <LabeledInput
               v-model:value="model.clientId"
+              name="clientId"
               :label="t(`authConfig.oidc.clientId`)"
               :mode="mode"
               required
@@ -388,6 +418,7 @@ export default {
           <div class="col span-6">
             <LabeledInput
               v-model:value="model.clientSecret"
+              name="clientSecret"
               :label="t(`authConfig.oidc.clientSecret`)"
               :mode="mode"
               required
@@ -528,6 +559,7 @@ export default {
             <div class="col span-6">
               <LabeledInput
                 v-model:value="oidcUrls.url"
+                name="url"
                 :label="t(`authConfig.oidc.url`)"
                 :mode="mode"
                 :required="!customEndpoint.value"
@@ -538,6 +570,7 @@ export default {
             <div class="col span-6">
               <LabeledInput
                 v-model:value="oidcUrls.realm"
+                name="realm"
                 :label="t(`authConfig.oidc.realm`)"
                 :mode="mode"
                 :required="!customEndpoint.value"
@@ -552,6 +585,7 @@ export default {
             <div class="col span-6">
               <LabeledInput
                 v-model:value="model.rancherUrl"
+                name="rancherUrl"
                 :label="t(`authConfig.oidc.rancherUrl`)"
                 :mode="mode"
                 required
@@ -565,6 +599,7 @@ export default {
             <div class="col span-6">
               <LabeledInput
                 v-model:value="model.issuer"
+                name="issuer"
                 :label="t(`authConfig.oidc.issuer`)"
                 :mode="mode"
                 required
@@ -575,6 +610,7 @@ export default {
             <div class="col span-6">
               <LabeledInput
                 v-model:value="model.authEndpoint"
+                name="authEndpoint"
                 :label="t(`authConfig.oidc.authEndpoint`)"
                 :mode="mode"
                 :disabled="!customEndpoint.value"
@@ -635,6 +671,7 @@ export default {
             <div class="col span-6">
               <LabeledInput
                 v-model:value="model.issuer"
+                name="issuer"
                 :label="t(`authConfig.oidc.issuer`)"
                 :mode="mode"
                 required
@@ -686,6 +723,7 @@ export default {
             <div class="col span-6">
               <LabeledInput
                 v-model:value="model.endSessionEndpoint"
+                name="endSessionEndpoint"
                 :tooltip="t('authConfig.oidc.endSessionEndpoint.tooltip')"
                 :label="t('authConfig.oidc.endSessionEndpoint.title')"
                 :mode="mode"

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -53,8 +53,12 @@ export default {
     const modelId = ref(null);
     const sloTypeRef = ref(null);
     const customEndpointEnabled = ref(false);
-    const requiredScopesRef = ref([]);
 
+    const requiredScopes = computed(() => {
+      const scopes = BASE_SCOPES[modelId.value]?.[0];
+
+      return scopes ? scopes.split(' ') : [];
+    });
     const isAmazonCognito = computed(() => modelId.value === 'cognito');
     const isKeycloak = computed(() => modelId.value === 'keycloakoidc');
     const isGenericOidc = computed(() => modelId.value === 'genericoidc');
@@ -91,9 +95,9 @@ export default {
         scope: z.preprocess(
           (v) => (Array.isArray(v) ? v : []),
           z.array(z.string()).refine(
-            (arr) => requiredScopesRef.value?.every((s) => arr.includes(s)),
+            (arr) => requiredScopes.value?.every((s) => arr.includes(s)),
             (arr) => {
-              const missing = requiredScopesRef.value?.filter((s) => !arr.includes(s));
+              const missing = requiredScopes.value?.filter((s) => !arr.includes(s));
 
               return { message: t('authConfig.oidc.scope.missingRequired', { scopes: missing?.join(', '), count: missing?.length }) };
             }
@@ -121,7 +125,6 @@ export default {
       modelId,
       sloTypeRef,
       customEndpointEnabled,
-      requiredScopesRef,
       isAmazonCognito,
       isKeycloak,
       isGenericOidc,
@@ -188,15 +191,6 @@ export default {
       return this.isFormValid;
     },
 
-    /**
-     * TODO #13457: Refactor scopes to be an array of terms
-     * Return valid scopes
-     * The scopes for given auth provider (model.id) have format of ['scope1 scope2 scope3']
-     */
-    requiredScopes() {
-      return this.model?.id ? (BASE_SCOPES[this.model.id] || []) ? (BASE_SCOPES[this.model.id] || [])[0].split(' ') : [] : [];
-    },
-
     isLogoutAllSupported() {
       return this.model?.logoutAllSupported;
     },
@@ -230,13 +224,6 @@ export default {
 
     'customEndpoint.value'(v) {
       this.customEndpointEnabled = v;
-    },
-
-    requiredScopes: {
-      handler(v) {
-        this.requiredScopesRef = v;
-      },
-      immediate: true,
     },
 
     'oidcUrls.url'() {

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -53,6 +53,7 @@ export default {
     const modelId = ref(null);
     const sloTypeRef = ref(null);
     const customEndpointEnabled = ref(false);
+    const requiredScopesRef = ref([]);
 
     const isAmazonCognito = computed(() => modelId.value === 'cognito');
     const isKeycloak = computed(() => modelId.value === 'keycloakoidc');
@@ -87,6 +88,17 @@ export default {
 
         endSessionEndpoint: sloEndSessionEndpointUiEnabled.value ? requiredUrlField('authConfig.oidc.endSessionEndpoint.title') : optionalField,
 
+        scope: z.preprocess(
+          (v) => (Array.isArray(v) ? v : []),
+          z.array(z.string()).refine(
+            (arr) => requiredScopesRef.value?.every((s) => arr.includes(s)),
+            (arr) => {
+              const missing = requiredScopesRef.value?.filter((s) => !arr.includes(s));
+
+              return { message: t('authConfig.oidc.scope.missingRequired', { scopes: missing?.join(', '), count: missing?.length }) };
+            }
+          )
+        ),
       })
     ));
 
@@ -109,6 +121,7 @@ export default {
       modelId,
       sloTypeRef,
       customEndpointEnabled,
+      requiredScopesRef,
       isAmazonCognito,
       isKeycloak,
       isGenericOidc,
@@ -168,7 +181,7 @@ export default {
     },
 
     validationPassed() {
-      if ( this.model.enabled && !this.editConfig ) {
+      if ( this.model?.enabled && !this.editConfig ) {
         return true;
       }
 
@@ -181,7 +194,7 @@ export default {
      * The scopes for given auth provider (model.id) have format of ['scope1 scope2 scope3']
      */
     requiredScopes() {
-      return this.model.id ? (BASE_SCOPES[this.model.id] || []) ? (BASE_SCOPES[this.model.id] || [])[0].split(' ') : [] : [];
+      return this.model?.id ? (BASE_SCOPES[this.model.id] || []) ? (BASE_SCOPES[this.model.id] || [])[0].split(' ') : [] : [];
     },
 
     isLogoutAllSupported() {
@@ -217,6 +230,13 @@ export default {
 
     'customEndpoint.value'(v) {
       this.customEndpointEnabled = v;
+    },
+
+    requiredScopes: {
+      handler(v) {
+        this.requiredScopesRef = v;
+      },
+      immediate: true,
     },
 
     'oidcUrls.url'() {
@@ -686,6 +706,7 @@ export default {
           <div class="col span-6">
             <ArrayList
               v-model:value="oidcScope"
+              name="scope"
               :mode="mode"
               :title="t('authConfig.oidc.scope.label')"
               :value-placeholder="t('authConfig.oidc.scope.placeholder')"

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -1,4 +1,5 @@
 <script>
+import { ref, computed } from 'vue';
 import Loading from '@shell/components/Loading';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import AuthConfig, { SLO_OPTION_VALUES } from '@shell/mixins/auth-config';
@@ -41,7 +42,32 @@ export default {
   mixins: [CreateEditView, AuthConfig],
 
   setup() {
-    return { PKCE_S256 };
+    // These refs sync mixin-state for the composition api
+    const modelId = ref(null);
+    const sloTypeRef = ref(null);
+
+    const isAmazonCognito = computed(() => modelId.value === 'cognito');
+    const isKeycloak = computed(() => modelId.value === 'keycloakoidc');
+    const isGenericOidc = computed(() => modelId.value === 'genericoidc');
+    const supportsCustomClaims = computed(() => isKeycloak.value || isGenericOidc.value);
+    const supportsGroupSearch = computed(() => modelId.value !== 'cognito');
+    const requiresCert = computed(() => modelId.value !== 'cognito');
+    const requiresAuthEndpoint = computed(() => ['genericoidc', 'keycloakoidc'].includes(modelId.value));
+    const sloEndSessionEndpointUiEnabled = computed(() => [SLO_OPTION_VALUES.all, SLO_OPTION_VALUES.both].includes(sloTypeRef.value));
+
+    return {
+      PKCE_S256,
+      modelId,
+      sloTypeRef,
+      isAmazonCognito,
+      isKeycloak,
+      isGenericOidc,
+      supportsCustomClaims,
+      supportsGroupSearch,
+      requiresCert,
+      requiresAuthEndpoint,
+      sloEndSessionEndpointUiEnabled,
+    };
   },
 
   data() {
@@ -124,10 +150,6 @@ export default {
       }
     },
 
-    requiresAuthEndpoint() {
-      return ['genericoidc', 'keycloakoidc'].includes(this.model.id);
-    },
-
     /**
      * TODO #13457: Refactor scopes to be an array of terms
      * Return valid scopes
@@ -135,32 +157,6 @@ export default {
      */
     requiredScopes() {
       return this.model.id ? (BASE_SCOPES[this.model.id] || []) ? (BASE_SCOPES[this.model.id] || [])[0].split(' ') : [] : [];
-    },
-
-    requiresCert() {
-      // We assume all do, apart from the ones here, which do not
-      return !(['cognito'].includes(this.model.id));
-    },
-
-    supportsGroupSearch() {
-      // We assume all do, apart from the ones here, which do not
-      return !(['cognito'].includes(this.model.id));
-    },
-
-    isAmazonCognito() {
-      return this.model?.id === 'cognito';
-    },
-
-    isGenericOidc() {
-      return this.model?.id === 'genericoidc';
-    },
-
-    isKeycloak() {
-      return this.model?.id === 'keycloakoidc';
-    },
-
-    supportsCustomClaims() {
-      return this.isGenericOidc || this.isKeycloak;
     },
 
     isLogoutAllSupported() {
@@ -180,15 +176,18 @@ export default {
 
       return sloOptionSelected?.label || '';
     },
-
-    sloEndSessionEndpointUiEnabled() {
-      return this.sloType === SLO_OPTION_VALUES.all || this.sloType === SLO_OPTION_VALUES.both;
-    },
   },
 
   watch: {
     fvFormIsValid(newValue) {
       this.$emit('validationChanged', !!newValue);
+    },
+
+    'model.id': {
+      handler(newVal) {
+        this.modelId = newVal;
+      },
+      immediate: true,
     },
 
     'oidcUrls.url'() {
@@ -228,6 +227,7 @@ export default {
 
     // sloType is defined on shell/mixins/auth-config.js
     sloType(neu) {
+      this.sloTypeRef = neu;
       switch (neu) {
       case SLO_OPTION_VALUES.rancher:
         this.model.logoutAllEnabled = false;

--- a/shell/package.json
+++ b/shell/package.json
@@ -40,6 +40,7 @@
     "@types/semver": "^7.5.8",
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",
+    "@vee-validate/zod": "4.15.0",
     "@vue/cli-plugin-babel": "~5.0.0",
     "@vue/cli-plugin-typescript": "~5.0.0",
     "@vue/cli-service": "5.0.8",
@@ -130,7 +131,8 @@
     "xterm-addon-search": "0.13.0",
     "xterm-addon-web-links": "0.9.0",
     "xterm-addon-webgl": "0.16.0",
-    "yarn": "1.22.22"
+    "yarn": "1.22.22",
+    "zod": "3.24.3"
   },
   "resolutions": {
     "d3-color": "3.1.0",

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -3024,6 +3024,14 @@
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
+"@vee-validate/zod@4.15.0":
+  version "4.15.0"
+  resolved "https://registry.npmjs.org/@vee-validate/zod/-/zod-4.15.0.tgz#2de193da114eda9f873b5a677f13c23bcecb58aa"
+  integrity sha512-MpvIKiyg9X5yD8bJW0no2AU7wtR2T5mrvD9tuPRiie951sU2n6QKgMV38qKKOiqFBCxsMSjIuLLLV3V5kVE4nQ==
+  dependencies:
+    type-fest "^4.8.3"
+    vee-validate "4.15.0"
+
 "@vue/babel-helper-vue-jsx-merge-props@^1.4.0":
   version "1.4.0"
   resolved "https://registry.npmjs.org/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.4.0.tgz#8d53a1e21347db8edbe54d339902583176de09f2"
@@ -11722,6 +11730,14 @@ vary@~1.1.2:
   resolved "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
+vee-validate@4.15.0:
+  version "4.15.0"
+  resolved "https://registry.npmjs.org/vee-validate/-/vee-validate-4.15.0.tgz#eb77a9c867669d34abbc33ca5e16f2a991eb7ad5"
+  integrity sha512-PGJh1QCFwCBjbHu5aN6vB8macYVWrajbDvgo1Y/8fz9n/RVIkLmZCJDpUgu7+mUmCOPMxeyq7vXUOhbwAqdXcA==
+  dependencies:
+    "@vue/devtools-api" "^7.5.2"
+    type-fest "^4.8.3"
+
 vee-validate@^4.15.1:
   version "4.15.1"
   resolved "https://registry.npmjs.org/vee-validate/-/vee-validate-4.15.1.tgz#66e787e88916baa05f42e53bc0848e0878d50f91"
@@ -12349,3 +12365,8 @@ yarn@1.22.22:
   version "1.22.22"
   resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz#ac34549e6aa8e7ead463a7407e1c7390f61a6610"
   integrity sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==
+
+zod@3.24.3:
+  version "3.24.3"
+  resolved "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz#1f40f750a05e477396da64438e0e1c0995dafd87"
+  integrity sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This migrates the custom validation implementation for the OIDC auth provider to a pure vee-validate/zod implementation. 

Fixes #17754
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Migrate computed props to composition api for oidc
- Validate oidc auth provider form with vee-validate/zod
- Add vee-validate to ArrayList
- Fix unit tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

In order to get this to work with `useForm` from vee-validate, we need to find a way to sync values from the form's mixins with the composition API. This is currently accomplished via watchers that exist to sync values with the refs (99078ad9f823b10aeb1b9ac17686355044903a44). I think that the proper, long-term solution will be to migrate away from mixins to the composition API. Take care in reviewing this pattern, there's a higher risk of errors with the current approach.

The validation approach using vee-validate/zod is used to demonstrate validation without the form-validation mixin or bridge in use. More information about the patterns represented in this PR can be found in the vee-validation documentation: https://vee-validate.logaretm.com/v4/guide/composition-api/typed-schema/#zod

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Test configuring the Keycloak auth provider. Instructions for getting started can be found in: https://github.com/rancher/ui-internal-tools/tree/main/keycloak

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

There are risks that the authentication logic has been unintentionally altered with this change. Edge-cases could need additional consideration. For example, what happens if the form passes validation in the UI, but the server rejects the form? 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Inline validation errors
<img width="1362" height="796" alt="image" src="https://github.com/user-attachments/assets/f04c46e7-c239-4a78-a6c2-c1594b9ec547" />

#### URL validation
<img width="1362" height="796" alt="image" src="https://github.com/user-attachments/assets/86cb8d46-9edf-4b5e-9e66-bd43eb6d6e19" />

#### ArrayList validation
<img width="1362" height="796" alt="image" src="https://github.com/user-attachments/assets/f68a90ff-ac32-4cc0-885a-d8bc30f2ea17" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
