### PR TITLE
Fix Kiali and Jaeger links on Istio's overview page

### DIFF
--- a/shell/pages/c/_cluster/istio/__tests__/istio.index.test.ts
+++ b/shell/pages/c/_cluster/istio/__tests__/istio.index.test.ts
@@ -1,0 +1,194 @@
+import { nextTick } from 'vue';
+import { shallowMount } from '@vue/test-utils';
+import IstioOverview from '@shell/pages/c/_cluster/istio/index.vue';
+import { SERVICE } from '@shell/config/types';
+import Loading from '@shell/components/Loading';
+
+const createMockService = (name: string, namespace: string, label: string, proxyUrlReturn: string) => ({
+  id:       `${ namespace }/${ name }`,
+  type:     'service',
+  metadata: {
+    name,
+    namespace,
+    labels: { app: label },
+  },
+  proxyUrl: jest.fn(() => proxyUrlReturn),
+});
+
+describe('page: IstioOverview', () => {
+  const createWrapper = (overrides: Record<string, any> = {}) => {
+    const mockDispatch = jest.fn();
+    const mockSchemaFor = jest.fn();
+    const mockResolve = jest.fn(() => ({ href: '/c/_/monitoring' }));
+
+    const defaultMocks = {
+      $fetchState: { pending: false },
+      $store:      {
+        dispatch: mockDispatch,
+        getters:  {
+          'prefs/theme':       'dark',
+          'i18n/t':            (key: string) => key,
+          'cluster/schemaFor': mockSchemaFor,
+        },
+      },
+      $route:  { params: { cluster: '_' } },
+      $router: { resolve: mockResolve },
+    };
+
+    const wrapper = shallowMount(IstioOverview, {
+      global: {
+        mocks:      { ...defaultMocks, ...(overrides.mocks || {}) },
+        directives: { 'clean-html': () => {} },
+        stubs:      { t: true, ...(overrides.stubs || {}) },
+      },
+    });
+
+    return {
+      wrapper, mockDispatch, mockSchemaFor, mockResolve
+    };
+  };
+
+  describe('fetch', () => {
+    it('dispatches findLabelSelector for kiali with correct label selector', async() => {
+      const { wrapper, mockDispatch, mockSchemaFor } = createWrapper();
+
+      mockSchemaFor.mockReturnValue({});
+      mockDispatch.mockResolvedValue({ data: [] });
+
+      await (IstioOverview as any).fetch.call(wrapper.vm);
+
+      expect(mockDispatch).toHaveBeenCalledWith('cluster/findLabelSelector', {
+        type:     SERVICE,
+        matching: { labelSelector: { matchLabels: { app: 'kiali' } } },
+        opt:      { transient: true },
+      });
+    });
+
+    it('dispatches findLabelSelector for jaeger with correct label selector', async() => {
+      const { wrapper, mockDispatch, mockSchemaFor } = createWrapper();
+
+      mockSchemaFor.mockReturnValue({});
+      mockDispatch.mockResolvedValue({ data: [] });
+
+      await (IstioOverview as any).fetch.call(wrapper.vm);
+
+      expect(mockDispatch).toHaveBeenCalledWith('cluster/findLabelSelector', {
+        type:     SERVICE,
+        matching: { labelSelector: { matchLabels: { app: 'jaeger' } } },
+        opt:      { transient: true },
+      });
+    });
+
+    it('sets kialiService and jaegerService from response data', async() => {
+      const mockKiali = createMockService('kiali', 'istio-system', 'kiali', '/proxy/kiali');
+      const mockJaeger = createMockService('jaeger-query', 'istio-system', 'jaeger', '/proxy/jaeger');
+      const { wrapper, mockDispatch, mockSchemaFor } = createWrapper();
+
+      mockSchemaFor.mockReturnValue({});
+      mockDispatch
+        .mockResolvedValueOnce({ data: [mockKiali] })
+        .mockResolvedValueOnce({ data: [mockJaeger] });
+
+      await (IstioOverview as any).fetch.call(wrapper.vm);
+
+      expect(wrapper.vm.kialiService).toStrictEqual(mockKiali);
+      expect(wrapper.vm.jaegerService).toStrictEqual(mockJaeger);
+    });
+
+    it('skips dispatches when schemaFor returns falsy', async() => {
+      const { wrapper, mockDispatch, mockSchemaFor } = createWrapper();
+
+      mockSchemaFor.mockReturnValue(null);
+
+      await (IstioOverview as any).fetch.call(wrapper.vm);
+
+      expect(mockDispatch).not.toHaveBeenCalledWith('cluster/findLabelSelector', expect.anything());
+      expect(wrapper.vm.kialiService).toBeNull();
+      expect(wrapper.vm.jaegerService).toBeNull();
+    });
+
+    it('sets services to null when response data is empty', async() => {
+      const { wrapper, mockDispatch, mockSchemaFor } = createWrapper();
+
+      mockSchemaFor.mockReturnValue({});
+      mockDispatch.mockResolvedValue({ data: [] });
+
+      await (IstioOverview as any).fetch.call(wrapper.vm);
+
+      expect(wrapper.vm.kialiService).toBeNull();
+      expect(wrapper.vm.jaegerService).toBeNull();
+    });
+  });
+
+  describe('computed properties', () => {
+    it('kialiUrl returns null when kialiService is null', () => {
+      const { wrapper } = createWrapper();
+
+      expect(wrapper.vm.kialiUrl).toBeNull();
+    });
+
+    it('kialiUrl calls proxyUrl with correct arguments when service exists', async() => {
+      const mockKiali = createMockService('kiali', 'istio-system', 'kiali', '/proxy/kiali');
+      const { wrapper } = createWrapper();
+
+      wrapper.setData({ kialiService: mockKiali });
+      await nextTick();
+
+      expect(wrapper.vm.kialiUrl).toStrictEqual('/proxy/kiali');
+      expect(mockKiali.proxyUrl).toHaveBeenCalledWith('http', '20001');
+    });
+
+    it('jaegerUrl returns null when jaegerService is null', () => {
+      const { wrapper } = createWrapper();
+
+      expect(wrapper.vm.jaegerUrl).toBeNull();
+    });
+
+    it('jaegerUrl calls proxyUrl with correct arguments and appends /jaeger/search', async() => {
+      const mockJaeger = createMockService('jaeger-query', 'istio-system', 'jaeger', '/proxy/jaeger');
+      const { wrapper } = createWrapper();
+
+      wrapper.setData({ jaegerService: mockJaeger });
+      await nextTick();
+
+      expect(wrapper.vm.jaegerUrl).toStrictEqual('/proxy/jaeger/jaeger/search');
+      expect(mockJaeger.proxyUrl).toHaveBeenCalledWith('http', '16686');
+    });
+  });
+
+  describe('template rendering', () => {
+    it('shows Loading component when fetchState is pending', () => {
+      const { wrapper } = createWrapper({ mocks: { $fetchState: { pending: true } } });
+
+      expect(wrapper.findComponent(Loading).exists()).toBe(true);
+      expect(wrapper.find('.links').exists()).toBe(false);
+    });
+
+    it('shows disabled state when service URLs are null', () => {
+      const { wrapper } = createWrapper();
+      const containers = wrapper.findAll('.link-container');
+
+      expect(containers).toHaveLength(2);
+      containers.forEach((container) => {
+        expect(container.classes()).toContain('disabled');
+      });
+      expect(wrapper.findAll('.disabled-msg')).toHaveLength(2);
+    });
+
+    it('hides disabled state when services are set', async() => {
+      const mockKiali = createMockService('kiali', 'istio-system', 'kiali', '/proxy/kiali');
+      const mockJaeger = createMockService('jaeger-query', 'istio-system', 'jaeger', '/proxy/jaeger');
+      const { wrapper } = createWrapper();
+
+      wrapper.setData({ kialiService: mockKiali, jaegerService: mockJaeger });
+      await nextTick();
+
+      const containers = wrapper.findAll('.link-container');
+
+      containers.forEach((container) => {
+        expect(container.classes()).not.toContain('disabled');
+      });
+      expect(wrapper.findAll('.disabled-msg')).toHaveLength(0);
+    });
+  });
+});

--- a/shell/pages/c/_cluster/istio/index.vue
+++ b/shell/pages/c/_cluster/istio/index.vue
@@ -8,12 +8,27 @@ export default {
   components: { Loading },
 
   async fetch() {
-    try {
-      this.kialiService = await this.$store.dispatch('cluster/find', { type: SERVICE, id: 'istio-system/kiali' });
-    } catch {}
-    try {
-      this.jaegerService = await this.$store.dispatch('cluster/find', { type: SERVICE, id: 'istio-system/tracing' });
-    } catch {}
+    if (this.$store.getters['cluster/schemaFor'](SERVICE)) {
+      try {
+        const kialiResponse = await this.$store.dispatch('cluster/findLabelSelector', {
+          type:     SERVICE,
+          matching: { labelSelector: { matchLabels: { app: 'kiali' } } },
+          opt:      { transient: true }
+        });
+
+        this.kialiService = kialiResponse.data?.[0] || null;
+      } catch {}
+
+      try {
+        const jaegerResponse = await this.$store.dispatch('cluster/findLabelSelector', {
+          type:     SERVICE,
+          matching: { labelSelector: { matchLabels: { app: 'jaeger' } } },
+          opt:      { transient: true }
+        });
+
+        this.jaegerService = jaegerResponse.data?.[0] || null;
+      } catch {}
+    }
   },
 
   data() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14237

Istio overview page used hardcoded namespace/service names (`istio-system/kiali`, `istio-system/tracing`) to discover Kiali and Jaeger services. Switched to label-based discovery using `findLabelSelector` with `matchLabels: { app: 'kiali' }` / `{ app: 'jaeger' }`, following the Longhorn overview page pattern.

### Occurred changes and/or fixed issues
- Replaced `cluster/find` with `cluster/findLabelSelector` for both services in `shell/pages/c/_cluster/istio/index.vue`

### Technical notes summary
- Added `cluster/schemaFor(SERVICE)` guard to skip lookups when user lacks permission
- Added unit tests covering fetch behavior, computed properties, and template rendering

### Areas or cases that should be tested
- First install Istio from AppCo repository
- Verify disabled state when Kiali/Jaeger services are not installed
- Install Kiali/Jaeger and verify the overview page discovers them
- Test with a user role lacking service list permissions

### Areas which could experience regressions
- Make sure the Istio's overview page still works properly when it's installed from a non-AppCo repo
- Istio overview page Kiali/Jaeger proxy links

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/0704dd5a-f6c6-4ebe-b668-5e88e122bfd8


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
