### PR TITLE
Fix ghost card on installed extensions tab

### DIFF
--- a/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
@@ -1,9 +1,13 @@
 import { shallowMount, VueWrapper } from '@vue/test-utils';
 import UiPluginsPage from '@shell/pages/c/_cluster/uiplugins/index.vue';
-import { UI_PLUGIN_NAMESPACE } from '@shell/config/uiplugins';
+import {
+  UI_PLUGIN_NAMESPACE,
+  UI_PLUGIN_CHART_ANNOTATIONS,
+  EXTENSIONS_INCOMPATIBILITY_TYPES
+} from '@shell/config/uiplugins';
 import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
 
-const t = (key: string, args: Object) => {
+const t = (key: string, args?: object, raw?: boolean) => {
   if (args) {
     return `${ key } with ${ JSON.stringify(args) }`;
   }
@@ -609,6 +613,717 @@ describe('page: UI plugins/Extensions', () => {
 
       // plugin4 has no op, so its status should be cleared
       expect(updatePluginInstallStatusMock).toHaveBeenCalledWith('repo/plugin4', false);
+    });
+  });
+
+  describe('extractCertificationFlags', () => {
+    it('should extract all flags as true when annotations match', () => {
+      const annotations = {
+        [CATALOG_ANNOTATIONS.PRIME_ONLY]:   'true',
+        [CATALOG_ANNOTATIONS.EXPERIMENTAL]: 'true',
+        [CATALOG_ANNOTATIONS.CERTIFIED]:    CATALOG_ANNOTATIONS._RANCHER,
+      };
+      const result = wrapper.vm.extractCertificationFlags(annotations);
+
+      expect(result).toStrictEqual({
+        primeOnly:    true,
+        experimental: true,
+        certified:    true,
+      });
+    });
+
+    it('should return all flags as false when annotations are empty', () => {
+      const result = wrapper.vm.extractCertificationFlags({});
+
+      expect(result).toStrictEqual({
+        primeOnly:    false,
+        experimental: false,
+        certified:    false,
+      });
+    });
+
+    it('should return all flags as false when annotations are undefined', () => {
+      const result = wrapper.vm.extractCertificationFlags(undefined);
+
+      expect(result).toStrictEqual({
+        primeOnly:    false,
+        experimental: false,
+        certified:    false,
+      });
+    });
+
+    it('should not treat non-"true" values as truthy for primeOnly and experimental', () => {
+      const annotations = {
+        [CATALOG_ANNOTATIONS.PRIME_ONLY]:   'false',
+        [CATALOG_ANNOTATIONS.EXPERIMENTAL]: '1',
+        [CATALOG_ANNOTATIONS.CERTIFIED]:    'community',
+      };
+      const result = wrapper.vm.extractCertificationFlags(annotations);
+
+      expect(result).toStrictEqual({
+        primeOnly:    false,
+        experimental: false,
+        certified:    false,
+      });
+    });
+
+    it('should handle partial annotations', () => {
+      const annotations = { [CATALOG_ANNOTATIONS.PRIME_ONLY]: 'true' };
+      const result = wrapper.vm.extractCertificationFlags(annotations);
+
+      expect(result).toStrictEqual({
+        primeOnly:    true,
+        experimental: false,
+        certified:    false,
+      });
+    });
+  });
+
+  describe('buildIncompatibilityMessage', () => {
+    it('should build a message for HOST incompatibility type', () => {
+      const versionData = {
+        version:                    '2.0.0',
+        versionIncompatibilityData: {
+          type:           EXTENSIONS_INCOMPATIBILITY_TYPES.HOST,
+          cardMessageKey: 'plugins.incompatible.host',
+          required:       'rancher-prime',
+          mainHost:       'rancher-manager',
+        }
+      };
+      const result = wrapper.vm.buildIncompatibilityMessage(versionData);
+
+      expect(result).toBe(`plugins.incompatible.host with ${ JSON.stringify({
+        version:  '2.0.0',
+        required: 'rancher-prime',
+        mainHost: 'rancher-manager',
+      }) }`);
+    });
+
+    it('should build a message for non-HOST incompatibility type without mainHost', () => {
+      const versionData = {
+        version:                    '2.0.0',
+        versionIncompatibilityData: {
+          type:           EXTENSIONS_INCOMPATIBILITY_TYPES.KUBE,
+          cardMessageKey: 'plugins.incompatible.kube',
+          required:       '1.25.0',
+        }
+      };
+      const result = wrapper.vm.buildIncompatibilityMessage(versionData);
+
+      expect(result).toBe(`plugins.incompatible.kube with ${ JSON.stringify({
+        version:  '2.0.0',
+        required: '1.25.0',
+      }) }`);
+    });
+
+    it('should handle missing required field', () => {
+      const versionData = {
+        version:                    '2.0.0',
+        versionIncompatibilityData: {
+          type:           EXTENSIONS_INCOMPATIBILITY_TYPES.UI,
+          cardMessageKey: 'plugins.incompatible.ui',
+        }
+      };
+      const result = wrapper.vm.buildIncompatibilityMessage(versionData);
+
+      expect(result).toBe(`plugins.incompatible.ui with ${ JSON.stringify({
+        version:  '2.0.0',
+        required: undefined,
+      }) }`);
+    });
+  });
+
+  describe('mapChartToPluginItem', () => {
+    const createChartWrapper = (overrides = {}) => {
+      const store = {
+        getters: {
+          'prefs/get':         jest.fn(),
+          'catalog/rawCharts': [],
+          'uiplugins/plugins': [],
+          'uiplugins/errors':  {},
+        },
+        dispatch: () => Promise.resolve(),
+      };
+
+      const w = shallowMount(UiPluginsPage, {
+        global: {
+          mocks: {
+            $store: store,
+            t,
+            ...overrides,
+          },
+          stubs: { ActionMenu: { template: '<div />' } }
+        }
+      });
+
+      w.vm.rancherVersion = '2.9.0';
+      w.vm.kubeVersion = '1.28.0';
+      w.vm.installing = {};
+
+      return w;
+    };
+
+    it('should map a chart with compatible versions correctly', () => {
+      const w = createChartWrapper();
+
+      const chart = {
+        chartName:        'my-extension',
+        chartNameDisplay: 'My Extension',
+        chartDescription: 'A test extension',
+        id:               'repo/my-extension',
+        icon:             'chart-icon.svg',
+        versions:         [{
+          version:      '1.0.0',
+          appVersion:   '1.0.0',
+          created:      '2024-01-01',
+          annotations:  {
+            [CATALOG_ANNOTATIONS.EXPERIMENTAL]: 'true',
+            [CATALOG_ANNOTATIONS.CERTIFIED]:    CATALOG_ANNOTATIONS._RANCHER,
+          }
+        }]
+      };
+
+      const result = w.vm.mapChartToPluginItem(chart);
+
+      expect(result.name).toBe('my-extension');
+      expect(result.label).toBe('My Extension');
+      expect(result.description).toBe('A test extension');
+      expect(result.id).toBe('repo/my-extension');
+      expect(result.installed).toBe(false);
+      expect(result.builtin).toBe(false);
+      expect(result.chart).toBe(chart);
+      expect(result.versions).toHaveLength(1);
+      expect(result.displayVersion).toBe('1.0.0');
+      expect(result.displayVersionLabel).toBe('1.0.0');
+    });
+
+    it('should use chart annotation DISPLAY_NAME as label when present', () => {
+      const w = createChartWrapper();
+
+      const chart = {
+        chartName:        'my-extension',
+        chartNameDisplay: 'My Extension',
+        chartDescription: 'desc',
+        id:               'repo/my-extension',
+        versions:         [{
+          version:     '1.0.0',
+          annotations: { [UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME]: 'Custom Display Name' }
+        }],
+      };
+
+      const result = w.vm.mapChartToPluginItem(chart);
+
+      expect(result.label).toBe('Custom Display Name');
+    });
+
+    it('should set installing status when plugin is being installed', () => {
+      const w = createChartWrapper();
+
+      w.vm.installing = { 'repo/my-extension': 'install' };
+
+      const chart = {
+        chartName:        'my-extension',
+        chartNameDisplay: 'My Extension',
+        chartDescription: 'desc',
+        id:               'repo/my-extension',
+        versions:         [{ version: '1.0.0', annotations: {} }]
+      };
+
+      const result = w.vm.mapChartToPluginItem(chart);
+
+      expect(result.installing).toBe('install');
+    });
+
+    it('should extract certification flags from compatible version', () => {
+      const w = createChartWrapper();
+
+      const chart = {
+        chartName:        'certified-extension',
+        chartNameDisplay: 'Certified Extension',
+        chartDescription: 'desc',
+        id:               'repo/certified',
+        versions:         [{
+          version:     '1.0.0',
+          annotations: {
+            [CATALOG_ANNOTATIONS.PRIME_ONLY]:   'true',
+            [CATALOG_ANNOTATIONS.EXPERIMENTAL]: 'false',
+            [CATALOG_ANNOTATIONS.CERTIFIED]:    CATALOG_ANNOTATIONS._RANCHER,
+          }
+        }]
+      };
+
+      const result = w.vm.mapChartToPluginItem(chart);
+
+      expect(result.primeOnly).toBe(true);
+      expect(result.experimental).toBe(false);
+      expect(result.certified).toBe(true);
+    });
+  });
+
+  describe('buildLoadedPluginItem', () => {
+    it('should build an item for a non-builtin loaded plugin', () => {
+      const plugin = {
+        name:     'my-plugin',
+        id:       'my-plugin-id',
+        builtin:  false,
+        metadata: {
+          version:     '1.2.3',
+          description: 'Plugin description',
+          icon:        'plugin-icon.svg',
+          rancher:     { annotations: {} },
+        }
+      };
+
+      const result = wrapper.vm.buildLoadedPluginItem(plugin);
+
+      expect(result).toStrictEqual({
+        name:                'my-plugin',
+        label:               'my-plugin',
+        description:         'Plugin description',
+        icon:                'plugin-icon.svg',
+        id:                  'my-plugin-id',
+        versions:            [],
+        displayVersion:      '1.2.3',
+        displayVersionLabel: '1.2.3',
+        installed:           true,
+        installedVersion:    '1.2.3',
+        builtin:             false,
+        primeOnly:           false,
+        experimental:        false,
+        certified:           false,
+      });
+    });
+
+    it('should use DISPLAY_NAME annotation as label when available', () => {
+      const plugin = {
+        name:     'my-plugin',
+        id:       'my-plugin-id',
+        builtin:  false,
+        metadata: {
+          version: '1.0.0',
+          rancher: { annotations: { [UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME]: 'Pretty Name' } }
+        }
+      };
+
+      const result = wrapper.vm.buildLoadedPluginItem(plugin);
+
+      expect(result?.label).toBe('Pretty Name');
+    });
+
+    it('should return null for hidden builtin plugins', () => {
+      const plugin = {
+        name:     'hidden-builtin',
+        id:       'hidden-id',
+        builtin:  true,
+        metadata: {
+          version: '1.0.0',
+          rancher: { [UI_PLUGIN_CHART_ANNOTATIONS.HIDDEN_BUILTIN]: true, annotations: {} }
+        }
+      };
+
+      const result = wrapper.vm.buildLoadedPluginItem(plugin);
+
+      expect(result).toBeNull();
+    });
+
+    it('should NOT return null for visible builtin plugins', () => {
+      const plugin = {
+        name:     'visible-builtin',
+        id:       'visible-id',
+        builtin:  true,
+        metadata: {
+          version: '1.0.0',
+          rancher: { annotations: {} }
+        }
+      };
+
+      const result = wrapper.vm.buildLoadedPluginItem(plugin);
+
+      expect(result).not.toBeNull();
+      expect(result?.builtin).toBe(true);
+    });
+
+    it('should default displayVersionLabel to "-" when version is missing', () => {
+      const plugin = {
+        name:     'no-version',
+        id:       'no-version-id',
+        builtin:  false,
+        metadata: { rancher: { annotations: {} } }
+      };
+
+      const result = wrapper.vm.buildLoadedPluginItem(plugin);
+
+      expect(result?.displayVersionLabel).toBe('-');
+    });
+
+    it('should extract certification flags from rancher annotations', () => {
+      const plugin = {
+        name:     'certified-plugin',
+        id:       'cert-id',
+        builtin:  false,
+        metadata: {
+          version: '1.0.0',
+          rancher: {
+            annotations: {
+              [CATALOG_ANNOTATIONS.PRIME_ONLY]:   'true',
+              [CATALOG_ANNOTATIONS.EXPERIMENTAL]: 'true',
+              [CATALOG_ANNOTATIONS.CERTIFIED]:    CATALOG_ANNOTATIONS._RANCHER,
+            }
+          }
+        }
+      };
+
+      const result = wrapper.vm.buildLoadedPluginItem(plugin);
+
+      expect(result?.primeOnly).toBe(true);
+      expect(result?.experimental).toBe(true);
+      expect(result?.certified).toBe(true);
+    });
+
+    it('should handle metadata.rancher being a non-object', () => {
+      const plugin = {
+        name:     'legacy-plugin',
+        id:       'legacy-id',
+        builtin:  false,
+        metadata: {
+          version: '1.0.0',
+          rancher: 'not-an-object'
+        }
+      };
+
+      const result = wrapper.vm.buildLoadedPluginItem(plugin);
+
+      expect(result?.label).toBe('legacy-plugin');
+      expect(result?.primeOnly).toBe(false);
+    });
+  });
+
+  describe('wirePluginCRToChart', () => {
+    let wireWrapper: VueWrapper<any>;
+
+    const createWireWrapper = (apps: any[] = []) => {
+      const store = {
+        getters: {
+          'prefs/get':         jest.fn(),
+          'catalog/rawCharts': {},
+          'uiplugins/plugins': [],
+          'uiplugins/errors':  {},
+          'management/all':    () => apps,
+          'i18n/withFallback': (_key: string, _fallback: null, repoName: string) => repoName,
+        },
+        dispatch: () => Promise.resolve(),
+      };
+
+      const w = shallowMount(UiPluginsPage, {
+        global: {
+          mocks: {
+            $store: store,
+            t,
+          },
+          stubs: { ActionMenu: { template: '<div />' } }
+        }
+      });
+
+      w.vm.installing = {};
+
+      return w;
+    };
+
+    beforeEach(() => {
+      wireWrapper = createWireWrapper();
+    });
+
+    it('should wire CR to matching chart when found by repo name', () => {
+      const apps = [{
+        metadata: {
+          name:      'my-plugin',
+          namespace: UI_PLUGIN_NAMESPACE,
+          labels:    { [CATALOG_ANNOTATIONS.CLUSTER_REPO_NAME]: 'rancher-charts' }
+        },
+        spec: { chart: { metadata: { annotations: {} } } }
+      }];
+
+      wireWrapper = createWireWrapper(apps);
+
+      const all: any[] = [{
+        name:                'my-plugin',
+        chart:               { repoName: 'rancher-charts' },
+        installableVersions: [],
+      }];
+
+      const pluginCR = { name: 'my-plugin', version: '1.0.0' };
+
+      wireWrapper.vm.wirePluginCRToChart(pluginCR, all);
+
+      expect(all).toHaveLength(1);
+      expect(all[0].installed).toBe(true);
+      expect(all[0].uiplugin).toBe(pluginCR);
+      expect(all[0].installedVersion).toBe('1.0.0');
+    });
+
+    it('should set upgrade when a newer installable version exists', () => {
+      const apps = [{
+        metadata: {
+          name:      'my-plugin',
+          namespace: UI_PLUGIN_NAMESPACE,
+          labels:    { [CATALOG_ANNOTATIONS.CLUSTER_REPO_NAME]: 'rancher-charts' }
+        },
+        spec: { chart: { metadata: { annotations: {} } } }
+      }];
+
+      wireWrapper = createWireWrapper(apps);
+
+      const all: any[] = [{
+        name:                'my-plugin',
+        chart:               { repoName: 'rancher-charts' },
+        installableVersions: [{ version: '2.0.0', appVersion: '2.0.0', annotations: {} }],
+      }];
+
+      const pluginCR = { name: 'my-plugin', version: '1.0.0' };
+
+      wireWrapper.vm.wirePluginCRToChart(pluginCR, all);
+
+      expect(all[0].upgrade).toBe('2.0.0');
+    });
+
+    it('should NOT set upgrade when installed version matches latest', () => {
+      const apps = [{
+        metadata: {
+          name:      'my-plugin',
+          namespace: UI_PLUGIN_NAMESPACE,
+          labels:    { [CATALOG_ANNOTATIONS.CLUSTER_REPO_NAME]: 'rancher-charts' }
+        },
+        spec: { chart: { metadata: { annotations: {} } } }
+      }];
+
+      wireWrapper = createWireWrapper(apps);
+
+      const all: any[] = [{
+        name:                'my-plugin',
+        chart:               { repoName: 'rancher-charts' },
+        installableVersions: [{ version: '1.0.0', annotations: {} }],
+      }];
+
+      const pluginCR = { name: 'my-plugin', version: '1.0.0' };
+
+      wireWrapper.vm.wirePluginCRToChart(pluginCR, all);
+
+      expect(all[0].upgrade).toBeUndefined();
+    });
+
+    it('should push new item when no matching chart is found', () => {
+      const apps = [{
+        metadata: {
+          name:      'orphan-plugin',
+          namespace: UI_PLUGIN_NAMESPACE,
+          labels:    { [CATALOG_ANNOTATIONS.CLUSTER_REPO_NAME]: 'removed-repo' }
+        },
+        spec: {
+          chart: {
+            metadata: {
+              name:        'Orphan Plugin',
+              description: 'Plugin from removed repo',
+              icon:        'orphan-icon.svg',
+              annotations: { [UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME]: 'Orphan Display Name' }
+            }
+          }
+        }
+      }];
+
+      wireWrapper = createWireWrapper(apps);
+
+      const all: any[] = [];
+      const pluginCR = {
+        name:        'orphan-plugin',
+        version:     '1.0.0',
+        description: 'fallback desc',
+        isDeveloper: false,
+      };
+
+      wireWrapper.vm.wirePluginCRToChart(pluginCR, all);
+
+      expect(all).toHaveLength(1);
+      expect(all[0].name).toBe('orphan-plugin');
+      expect(all[0].label).toBe('Orphan Display Name');
+      expect(all[0].description).toBe('Plugin from removed repo');
+      expect(all[0].icon).toBe('orphan-icon.svg');
+      expect(all[0].installed).toBe(true);
+      expect(all[0].uiplugin).toBe(pluginCR);
+      expect(all[0].originalRepoNameDisplay).toBe('removed-repo');
+    });
+
+    it('should push new item with fallback values when app has no chart metadata', () => {
+      wireWrapper = createWireWrapper([]);
+
+      const all: any[] = [];
+      const pluginCR = {
+        name:        'no-app-plugin',
+        version:     '1.0.0',
+        description: 'CR description',
+        isDeveloper: true,
+      };
+
+      wireWrapper.vm.wirePluginCRToChart(pluginCR, all);
+
+      expect(all).toHaveLength(1);
+      expect(all[0].label).toBe('no-app-plugin');
+      expect(all[0].description).toBe('CR description');
+      expect(all[0].isDeveloper).toBe(true);
+      expect(all[0].originalRepoNameDisplay).toBeNull();
+    });
+
+    it('should not match chart from a different repo', () => {
+      const apps = [{
+        metadata: {
+          name:      'my-plugin',
+          namespace: UI_PLUGIN_NAMESPACE,
+          labels:    { [CATALOG_ANNOTATIONS.CLUSTER_REPO_NAME]: 'repo-a' }
+        },
+        spec: { chart: { metadata: { annotations: {} } } }
+      }];
+
+      wireWrapper = createWireWrapper(apps);
+
+      const all: any[] = [{
+        name:                'my-plugin',
+        chart:               { repoName: 'repo-b' },
+        installableVersions: [],
+      }];
+
+      const pluginCR = { name: 'my-plugin', version: '1.0.0' };
+
+      wireWrapper.vm.wirePluginCRToChart(pluginCR, all);
+
+      expect(all).toHaveLength(2);
+      expect(all[0].installed).toBeUndefined();
+      expect(all[1].installed).toBe(true);
+      expect(all[1].uiplugin).toBe(pluginCR);
+    });
+  });
+
+  describe('mergePluginErrors', () => {
+    it('should set installedError for string UI errors', () => {
+      const store = {
+        getters: {
+          'prefs/get':         jest.fn(),
+          'catalog/rawCharts': [],
+          'uiplugins/plugins': [],
+          'uiplugins/errors':  { 'my-plugin': 'plugins.error.load' },
+        },
+        dispatch: () => Promise.resolve(),
+      };
+
+      const w = shallowMount(UiPluginsPage, {
+        global: {
+          mocks: { $store: store, t },
+          stubs: { ActionMenu: { template: '<div />' } }
+        }
+      });
+
+      w.vm.errors = {};
+
+      const all = [{ name: 'my-plugin', id: 'repo/my-plugin' }];
+
+      w.vm.mergePluginErrors(all);
+
+      expect(all[0]).toHaveProperty('installedError', 'plugins.error.load');
+    });
+
+    it('should set empty installedError for non-string UI errors', () => {
+      const store = {
+        getters: {
+          'prefs/get':         jest.fn(),
+          'catalog/rawCharts': [],
+          'uiplugins/plugins': [],
+          'uiplugins/errors':  { 'my-plugin': true },
+        },
+        dispatch: () => Promise.resolve(),
+      };
+
+      const w = shallowMount(UiPluginsPage, {
+        global: {
+          mocks: { $store: store, t },
+          stubs: { ActionMenu: { template: '<div />' } }
+        }
+      });
+
+      w.vm.errors = {};
+
+      const all = [{ name: 'my-plugin', id: 'repo/my-plugin' }];
+
+      w.vm.mergePluginErrors(all);
+
+      expect(all[0]).toHaveProperty('installedError', '');
+    });
+
+    it('should set helmError from component errors', () => {
+      const all = [{ name: 'my-plugin', id: 'repo/my-plugin' }];
+
+      wrapper.vm.errors = { 'repo/my-plugin': 'helm failed' };
+      wrapper.vm.mergePluginErrors(all);
+
+      expect(all[0]).toHaveProperty('helmError', true);
+    });
+
+    it('should not modify plugins that have no matching errors', () => {
+      const store = {
+        getters: {
+          'prefs/get':         jest.fn(),
+          'catalog/rawCharts': [],
+          'uiplugins/plugins': [],
+          'uiplugins/errors':  { 'other-plugin': 'some error' },
+        },
+        dispatch: () => Promise.resolve(),
+      };
+
+      const w = shallowMount(UiPluginsPage, {
+        global: {
+          mocks: { $store: store, t },
+          stubs: { ActionMenu: { template: '<div />' } }
+        }
+      });
+
+      w.vm.errors = { 'other-id': 'error' };
+
+      const all = [{ name: 'my-plugin', id: 'repo/my-plugin' }];
+
+      w.vm.mergePluginErrors(all);
+
+      expect(all[0]).not.toHaveProperty('installedError');
+      expect(all[0]).not.toHaveProperty('helmError');
+    });
+
+    it('should handle both UI errors and helm errors for different plugins', () => {
+      const store = {
+        getters: {
+          'prefs/get':         jest.fn(),
+          'catalog/rawCharts': [],
+          'uiplugins/plugins': [],
+          'uiplugins/errors':  { 'plugin-a': 'plugins.error.load' },
+        },
+        dispatch: () => Promise.resolve(),
+      };
+
+      const w = shallowMount(UiPluginsPage, {
+        global: {
+          mocks: { $store: store, t },
+          stubs: { ActionMenu: { template: '<div />' } }
+        }
+      });
+
+      w.vm.errors = { 'repo/plugin-b': 'helm failure' };
+
+      const all = [
+        { name: 'plugin-a', id: 'repo/plugin-a' },
+        { name: 'plugin-b', id: 'repo/plugin-b' },
+      ];
+
+      w.vm.mergePluginErrors(all);
+
+      expect(all[0]).toHaveProperty('installedError', 'plugins.error.load');
+      expect(all[0]).not.toHaveProperty('helmError');
+      expect(all[1]).not.toHaveProperty('installedError');
+      expect(all[1]).toHaveProperty('helmError', true);
     });
   });
 });

--- a/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
@@ -773,10 +773,10 @@ describe('page: UI plugins/Extensions', () => {
         id:               'repo/my-extension',
         icon:             'chart-icon.svg',
         versions:         [{
-          version:      '1.0.0',
-          appVersion:   '1.0.0',
-          created:      '2024-01-01',
-          annotations:  {
+          version:     '1.0.0',
+          appVersion:  '1.0.0',
+          created:     '2024-01-01',
+          annotations: {
             [CATALOG_ANNOTATIONS.EXPERIMENTAL]: 'true',
             [CATALOG_ANNOTATIONS.CERTIFIED]:    CATALOG_ANNOTATIONS._RANCHER,
           }
@@ -1076,7 +1076,9 @@ describe('page: UI plugins/Extensions', () => {
       const all: any[] = [{
         name:                'my-plugin',
         chart:               { repoName: 'rancher-charts' },
-        installableVersions: [{ version: '2.0.0', appVersion: '2.0.0', annotations: {} }],
+        installableVersions: [{
+          version: '2.0.0', appVersion: '2.0.0', annotations: {}
+        }],
       }];
 
       const pluginCR = { name: 'my-plugin', version: '1.0.0' };

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -256,224 +256,51 @@ export default {
     },
 
     available() {
-      let all = this.charts.filter((c) => isUIPlugin(c));
+      let all = this.charts
+        .filter((c) => isUIPlugin(c))
+        .filter((c) => !uiPluginHasAnnotation(c, CATALOG_ANNOTATIONS.HIDDEN, 'true'))
+        .map((chart) => this.mapChartToPluginItem(chart))
+        .filter((c) => c.versions.length > 0);
 
-      // Filter out hidden charts
-      all = all.filter((c) => !uiPluginHasAnnotation(c, CATALOG_ANNOTATIONS.HIDDEN, 'true'));
-
-      all = all.map((chart) => {
-        // Label can be overridden by chart annotation
-        const label = uiPluginAnnotation(chart, UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME) || chart.chartNameDisplay;
-        const item = {
-          name:        chart.chartName,
-          label,
-          description: chart.chartDescription,
-          id:          chart.id,
-          versions:    [],
-          installed:   false,
-          builtin:     false,
-        };
-
-        item.versions = [...chart.versions];
-        item.chart = chart;
-        item.incompatibilityMessage = '';
-
-        // Filter the versions available to install (plugins-api version and current dashboard version)
-        item.installableVersions = item.versions.filter((version) => isSupportedChartVersion({
-          version, rancherVersion: this.rancherVersion, kubeVersion: this.kubeVersion
-        }));
-
-        // add prop to version object if version is compatible with the current dashboard version
-        item.versions = item.versions.map((version) => isSupportedChartVersion({
-          version, rancherVersion: this.rancherVersion, kubeVersion: this.kubeVersion
-        }, true));
-
-        const latestCompatible = item.installableVersions?.[0];
-        const latestNotCompatible = item.versions.find((version) => !version.isVersionCompatible);
-
-        if (latestCompatible) {
-          item.primeOnly = latestCompatible?.annotations?.[CATALOG_ANNOTATIONS.PRIME_ONLY] === 'true';
-          item.experimental = latestCompatible?.annotations?.[CATALOG_ANNOTATIONS.EXPERIMENTAL] === 'true';
-          item.certified = latestCompatible?.annotations?.[CATALOG_ANNOTATIONS.CERTIFIED] === CATALOG_ANNOTATIONS._RANCHER;
-
-          item.displayVersion = latestCompatible.version;
-          item.displayVersionLabel = getPluginChartVersionLabel(latestCompatible);
-          item.icon = latestCompatible.icon;
-          item.created = latestCompatible.created;
-        } else {
-          item.primeOnly = uiPluginHasAnnotation(chart, CATALOG_ANNOTATIONS.PRIME_ONLY, 'true');
-          item.experimental = uiPluginHasAnnotation(chart, CATALOG_ANNOTATIONS.EXPERIMENTAL, 'true');
-          item.certified = uiPluginHasAnnotation(chart, CATALOG_ANNOTATIONS.CERTIFIED, CATALOG_ANNOTATIONS._RANCHER);
-
-          item.displayVersion = item.versions?.[0]?.version;
-          item.displayVersionLabel = getPluginChartVersionLabel(item.versions?.[0]);
-          item.icon = chart.icon || latestCompatible?.annotations?.['catalog.cattle.io/ui-icon'];
-          item.created = item.versions?.[0]?.created;
-        }
-
-        // add message of extension card if there's a newer version of the extension, but it's not available to be installed
-        if (latestNotCompatible && item.installableVersions.length && isChartVersionHigher(latestNotCompatible.version, item.installableVersions?.[0].version)) {
-          switch (latestNotCompatible.versionIncompatibilityData?.type) {
-          case EXTENSIONS_INCOMPATIBILITY_TYPES.HOST:
-            item.incompatibilityMessage = this.t(latestNotCompatible.versionIncompatibilityData?.cardMessageKey, {
-              version: latestNotCompatible.version, required: latestNotCompatible.versionIncompatibilityData?.required, mainHost: latestNotCompatible.versionIncompatibilityData?.mainHost
-            }, true);
-            break;
-          default:
-            item.incompatibilityMessage = this.t(latestNotCompatible.versionIncompatibilityData?.cardMessageKey, {
-              version:  latestNotCompatible.version,
-              required: latestNotCompatible.versionIncompatibilityData?.required
-            }, true);
-            break;
-          }
-        }
-
-        if (this.installing[item.id]) {
-          item.installing = this.installing[item.id];
-        }
-
-        return item;
-      });
-
-      // Remove charts with no installable versions
-      all = all.filter((c) => c.versions.length > 0);
-
-      // Check that all of the loaded plugins are represented
       this.uiplugins.forEach((p) => {
-        const chart = all.find((c) => c.name === p.name);
+        if (!all.find((c) => c.name === p.name)) {
+          const item = this.buildLoadedPluginItem(p);
 
-        if (!chart) {
-          // A plugin is loaded, but there is no chart, so add an item so that it shows up
-          const rancher = typeof p.metadata?.rancher === 'object' ? p.metadata.rancher : {};
-
-          const label = rancher.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME] || p.name;
-          const item = {
-            name:                p.name,
-            label,
-            description:         p.metadata?.description,
-            icon:                p.metadata?.icon,
-            id:                  p.id,
-            versions:            [],
-            displayVersion:      p.metadata?.version,
-            displayVersionLabel: p.metadata?.version || '-',
-            installed:           true,
-            installedVersion:    p.metadata?.version,
-            builtin:             !!p.builtin,
-            primeOnly:           rancher?.annotations?.[CATALOG_ANNOTATIONS.PRIME_ONLY] === 'true',
-            experimental:        rancher?.annotations?.[CATALOG_ANNOTATIONS.EXPERIMENTAL] === 'true',
-            certified:           rancher?.annotations?.[CATALOG_ANNOTATIONS.CERTIFIED] === CATALOG_ANNOTATIONS._RANCHER
-          };
-
-          // Built-in plugins can chose to be hidden - used where we implement as extensions
-          // but don't want to shows them individually on the extensions page
-          if (!(item.builtin && rancher[UI_PLUGIN_CHART_ANNOTATIONS.HIDDEN_BUILTIN])) {
+          if (item) {
             all.push(item);
           }
         }
       });
 
-      // Go through the CRs for the plugins and wire them into the catalog
-      this.plugins.forEach((p) => {
-        let chart;
-        const app = this.apps.find((a) => a.metadata.name === p.name && a.metadata.namespace === UI_PLUGIN_NAMESPACE);
-        const originalRepoName = app?.spec?.chart?.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_NAME] || app?.metadata?.labels?.[CATALOG_ANNOTATIONS.CLUSTER_REPO_NAME];
+      this.plugins.forEach((p) => this.wirePluginCRToChart(p, all));
 
-        // Find the chart from the original repo to avoid picking a wrong chart with the same name
-        if (originalRepoName) {
-          chart = all.find((c) => c.name === p.name && c.chart?.repoName === originalRepoName);
-        }
+      this.mergePluginErrors(all);
 
-        // If original repo was removed, don't fall back to another repo's chart (would break Available tab)
-        if (chart) {
-          chart.installed = true;
-          chart.uiplugin = p;
-          chart.installedVersion = p.version;
-
-          // Can't do this here
-          chart.installing = this.installing[chart.id];
-
-          // Check for upgrade
-          const latestInstallableVersion = chart.installableVersions?.[0];
-
-          if (latestInstallableVersion && p.version !== (latestInstallableVersion.appVersion ?? latestInstallableVersion.version)) {
-            // Use the currently installed version's metadata to show/hide the experimental and certified labels
-            const installedVersion = (chart.installableVersions || []).find((v) => (v.appVersion ?? v.version) === p.version);
-
-            if (installedVersion) {
-              chart.primeOnly = installedVersion?.annotations?.[CATALOG_ANNOTATIONS.PRIME_ONLY] === 'true';
-              chart.experimental = installedVersion?.annotations?.[CATALOG_ANNOTATIONS.EXPERIMENTAL] === 'true';
-              chart.certified = installedVersion?.annotations?.[CATALOG_ANNOTATIONS.CERTIFIED] === CATALOG_ANNOTATIONS._RANCHER;
-            }
-
-            chart.upgrade = getPluginChartVersionLabel(latestInstallableVersion);
-          }
-        } else {
-          // No chart available - original repo was removed or developer-loaded plugin
-          const appChartMeta = app?.spec?.chart?.metadata;
-          const appAnnotations = appChartMeta?.annotations || {};
-          let originalRepoDisplayName = null;
-
-          if (originalRepoName) {
-            originalRepoDisplayName = this.$store.getters['i18n/withFallback'](`catalog.repo.name."${ originalRepoName }"`, null, originalRepoName);
-          }
-
-          const item = {
-            name:                    p.name,
-            label:                   appAnnotations[UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME] || appChartMeta?.name || p.name,
-            description:             appChartMeta?.description || p.description || '-',
-            icon:                    appChartMeta?.icon || appAnnotations['catalog.cattle.io/ui-icon'],
-            id:                      `${ p.name }-${ p.version }`,
-            versions:                [],
-            displayVersion:          p.version,
-            displayVersionLabel:     p.version || '-',
-            isDeveloper:             p.isDeveloper,
-            installed:               true,
-            installedVersion:        p.version,
-            installing:              false,
-            builtin:                 false,
-            uiplugin:                p,
-            primeOnly:               appAnnotations[CATALOG_ANNOTATIONS.PRIME_ONLY] === 'true',
-            experimental:            appAnnotations[CATALOG_ANNOTATIONS.EXPERIMENTAL] === 'true',
-            certified:               appAnnotations[CATALOG_ANNOTATIONS.CERTIFIED] === CATALOG_ANNOTATIONS._RANCHER,
-            originalRepoNameDisplay: originalRepoDisplayName,
-          };
-
-          all.push(item);
-        }
-      });
-
-      // Merge in the plugin load errors
-      Object.keys(this.uiErrors).forEach((e) => {
-        const chart = all.find((c) => c.name === e);
-
-        if (chart) {
-          const error = this.uiErrors[e];
-
-          if (error && typeof error === 'string') {
-            chart.installedError = this.t(this.uiErrors[e]);
-          } else {
-            chart.installedError = '';
-          }
-        }
-      });
-
-      // Merge in the plugin load errors from help ops
-      Object.keys(this.errors).forEach((e) => {
-        const chart = all.find((c) => c.id === e);
-
-        if (chart) {
-          chart.helmError = !!this.errors[e];
-        }
-      });
+      // Remove duplicate installed plugins - keep only ones with uiplugin (correct CR data)
+      const installedByName = {};
 
       all.forEach((plugin) => {
-        // Clamp the lengths of the descriptions
         if (plugin.description && plugin.description.length > MAX_DESCRIPTION_LENGTH) {
           plugin.description = `${ plugin.description.substr(0, MAX_DESCRIPTION_LENGTH) } ...`;
         }
+
+        if (plugin.installed) {
+          const existing = installedByName[plugin.name];
+
+          if (!existing || plugin.uiplugin) {
+            installedByName[plugin.name] = plugin;
+          }
+        }
       });
 
-      // Sort by name
+      all = all.filter((plugin) => {
+        if (!plugin.installed) {
+          return true;
+        }
+
+        return installedByName[plugin.name] === plugin;
+      });
+
       return sortBy(all, 'name', false);
     }
   },
@@ -1021,6 +848,185 @@ export default {
       }
 
       return statuses;
+    },
+
+    extractCertificationFlags(annotations) {
+      return {
+        primeOnly:    annotations?.[CATALOG_ANNOTATIONS.PRIME_ONLY] === 'true',
+        experimental: annotations?.[CATALOG_ANNOTATIONS.EXPERIMENTAL] === 'true',
+        certified:    annotations?.[CATALOG_ANNOTATIONS.CERTIFIED] === CATALOG_ANNOTATIONS._RANCHER,
+      };
+    },
+
+    buildIncompatibilityMessage(versionData) {
+      const { versionIncompatibilityData, version } = versionData;
+      const params = {
+        version,
+        required: versionIncompatibilityData?.required,
+      };
+
+      if (versionIncompatibilityData?.type === EXTENSIONS_INCOMPATIBILITY_TYPES.HOST) {
+        params.mainHost = versionIncompatibilityData?.mainHost;
+      }
+
+      return this.t(versionIncompatibilityData?.cardMessageKey, params, true);
+    },
+
+    mapChartToPluginItem(chart) {
+      const label = uiPluginAnnotation(chart, UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME) || chart.chartNameDisplay;
+      const item = {
+        name:                   chart.chartName,
+        label,
+        description:            chart.chartDescription,
+        id:                     chart.id,
+        versions:               [...chart.versions],
+        installed:              false,
+        builtin:                false,
+        chart,
+        incompatibilityMessage: '',
+      };
+
+      item.installableVersions = item.versions.filter((version) => isSupportedChartVersion({
+        version, rancherVersion: this.rancherVersion, kubeVersion: this.kubeVersion
+      }));
+
+      item.versions = item.versions.map((version) => isSupportedChartVersion({
+        version, rancherVersion: this.rancherVersion, kubeVersion: this.kubeVersion
+      }, true));
+
+      const latestCompatible = item.installableVersions?.[0];
+      const latestNotCompatible = item.versions.find((version) => !version.isVersionCompatible);
+
+      if (latestCompatible) {
+        Object.assign(item, {
+          ...this.extractCertificationFlags(latestCompatible?.annotations),
+          displayVersion:      latestCompatible.version,
+          displayVersionLabel: getPluginChartVersionLabel(latestCompatible),
+          icon:                latestCompatible.icon,
+          created:             latestCompatible.created,
+        });
+      } else {
+        Object.assign(item, {
+          primeOnly:           uiPluginHasAnnotation(chart, CATALOG_ANNOTATIONS.PRIME_ONLY, 'true'),
+          experimental:        uiPluginHasAnnotation(chart, CATALOG_ANNOTATIONS.EXPERIMENTAL, 'true'),
+          certified:           uiPluginHasAnnotation(chart, CATALOG_ANNOTATIONS.CERTIFIED, CATALOG_ANNOTATIONS._RANCHER),
+          displayVersion:      item.versions?.[0]?.version,
+          displayVersionLabel: getPluginChartVersionLabel(item.versions?.[0]),
+          icon:                chart.icon || latestCompatible?.annotations?.['catalog.cattle.io/ui-icon'],
+          created:             item.versions?.[0]?.created,
+        });
+      }
+
+      if (latestNotCompatible && item.installableVersions.length && isChartVersionHigher(latestNotCompatible.version, item.installableVersions?.[0].version)) {
+        item.incompatibilityMessage = this.buildIncompatibilityMessage(latestNotCompatible);
+      }
+
+      if (this.installing[item.id]) {
+        item.installing = this.installing[item.id];
+      }
+
+      return item;
+    },
+
+    buildLoadedPluginItem(plugin) {
+      const rancher = typeof plugin.metadata?.rancher === 'object' ? plugin.metadata.rancher : {};
+      const label = rancher.annotations?.[UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME] || plugin.name;
+
+      if (plugin.builtin && rancher[UI_PLUGIN_CHART_ANNOTATIONS.HIDDEN_BUILTIN]) {
+        return null;
+      }
+
+      return {
+        name:                plugin.name,
+        label,
+        description:         plugin.metadata?.description,
+        icon:                plugin.metadata?.icon,
+        id:                  plugin.id,
+        versions:            [],
+        displayVersion:      plugin.metadata?.version,
+        displayVersionLabel: plugin.metadata?.version || '-',
+        installed:           true,
+        installedVersion:    plugin.metadata?.version,
+        builtin:             !!plugin.builtin,
+        ...this.extractCertificationFlags(rancher?.annotations),
+      };
+    },
+
+    wirePluginCRToChart(pluginCR, all) {
+      const app = this.apps.find((a) => a.metadata.name === pluginCR.name && a.metadata.namespace === UI_PLUGIN_NAMESPACE);
+      const originalRepoName = app?.spec?.chart?.metadata?.annotations?.[CATALOG_ANNOTATIONS.SOURCE_REPO_NAME] || app?.metadata?.labels?.[CATALOG_ANNOTATIONS.CLUSTER_REPO_NAME];
+
+      let chart;
+
+      if (originalRepoName) {
+        chart = all.find((c) => c.name === pluginCR.name && c.chart?.repoName === originalRepoName);
+      }
+
+      if (chart) {
+        chart.installed = true;
+        chart.uiplugin = pluginCR;
+        chart.installedVersion = pluginCR.version;
+        chart.installing = this.installing[chart.id];
+
+        const latestInstallableVersion = chart.installableVersions?.[0];
+
+        if (latestInstallableVersion && pluginCR.version !== (latestInstallableVersion.appVersion ?? latestInstallableVersion.version)) {
+          const installedVersion = (chart.installableVersions || []).find((v) => (v.appVersion ?? v.version) === pluginCR.version);
+
+          if (installedVersion) {
+            Object.assign(chart, this.extractCertificationFlags(installedVersion?.annotations));
+          }
+
+          chart.upgrade = getPluginChartVersionLabel(latestInstallableVersion);
+        }
+      } else {
+        const appChartMeta = app?.spec?.chart?.metadata;
+        const appAnnotations = appChartMeta?.annotations || {};
+        let originalRepoDisplayName = null;
+
+        if (originalRepoName) {
+          originalRepoDisplayName = this.$store.getters['i18n/withFallback'](`catalog.repo.name."${ originalRepoName }"`, null, originalRepoName);
+        }
+
+        all.push({
+          name:                    pluginCR.name,
+          label:                   appAnnotations[UI_PLUGIN_CHART_ANNOTATIONS.DISPLAY_NAME] || appChartMeta?.name || pluginCR.name,
+          description:             appChartMeta?.description || pluginCR.description || '-',
+          icon:                    appChartMeta?.icon || appAnnotations['catalog.cattle.io/ui-icon'],
+          id:                      `${ pluginCR.name }-${ pluginCR.version }`,
+          versions:                [],
+          displayVersion:          pluginCR.version,
+          displayVersionLabel:     pluginCR.version || '-',
+          isDeveloper:             pluginCR.isDeveloper,
+          installed:               true,
+          installedVersion:        pluginCR.version,
+          installing:              false,
+          builtin:                 false,
+          uiplugin:                pluginCR,
+          originalRepoNameDisplay: originalRepoDisplayName,
+          ...this.extractCertificationFlags(appAnnotations),
+        });
+      }
+    },
+
+    mergePluginErrors(all) {
+      Object.keys(this.uiErrors).forEach((errorName) => {
+        const chart = all.find((c) => c.name === errorName);
+
+        if (chart) {
+          const error = this.uiErrors[errorName];
+
+          chart.installedError = (error && typeof error === 'string') ? this.t(error) : '';
+        }
+      });
+
+      Object.keys(this.errors).forEach((errorId) => {
+        const chart = all.find((c) => c.id === errorId);
+
+        if (chart) {
+          chart.helmError = !!this.errors[errorId];
+        }
+      });
     }
   }
 };


### PR DESCRIPTION
### Summary
Fixes #17763 
<!-- Define findings related to the feature or bug issue. -->
Refactored the large and convoluted `available` computed property in the UI Plugins page and implemented deduplication logic to prevent phantom extension cards from appearing when navigating away and back to the Extensions page.

### Occurred changes and/or fixed issues



1. **Created helper methods** with single responsibility (refactor code):
   - `extractCertificationFlags()` - Extracts primeOnly, experimental, and certified flags from annotations
   - `buildIncompatibilityMessage()` - Handles both HOST and non-HOST incompatibility types with proper mainHost parameter handling
   - `mapChartToPluginItem()` - Maps chart data to plugin items with version filtering and compatibility checks
   - `buildLoadedPluginItem()` - Creates plugin items from loaded plugins, filtering hidden builtins
   - `wirePluginCRToChart()` - Wires plugin CustomResources to existing charts or creates new entries
   - `mergePluginErrors()` - Merges UI errors and Helm errors into appropriate chart items

2. **Implemented deduplication logic** to fix ghost card issue
   - Plugin items can originate from two sources: charts and loaded plugins
   - Added final deduplication step that prefers CR-backed entries over phantom loaded-plugin entries
   - Uses preference condition `!existing || plugin.uiplugin` to keep entries with management capabilities

3. **Added comprehensive unit tests** covering new methods from the refactoring done

### Technical notes summary
- The deduplication logic uses a `Map` structure keyed by `plugin.name` to track unique entries by name
- When multiple entries exist for the same extension, the condition `!existing || plugin.uiplugin` determines which to keep:
  - If no existing entry, keep the current one
  - If existing, keep the current one only if it has `uiplugin` property (CR-backed, has management capabilities)
  - Otherwise keep the existing entry
- This ensures CR-backed entries (with full management features) take precedence over phantom loaded-plugin entries
- Helper methods maintain separation of concerns with clear input/output contracts
- Certification flags (primeOnly, experimental, certified) are now consistently extracted in one place

### Areas or cases that should be tested
1. **Extension installation flow**
- Install the `ui-plugin-charts repo`, branch `main`
- Open the Extensions page in Rancher Dashboard
- Install a UI extension (e.g., SUSE OS Management/Elemental)
- Navigate away from the Extensions page (e.g., click on another menu item like the SUSE OS Management extension)
- Navigate back to the Extensions page
- Observe the extension card appearing twice or a phantom/stale card appearing

2. **Navigation away and back**
   - Install an extension
   - Navigate away from Extensions page (click another menu item)
   - Navigate back to Extensions page
   - Verify no duplicate or phantom cards appear
   - Verify the extension card shows correct status and actions

3. **Multiple extensions**
   - Install multiple UI extensions
   - Navigate away and back to Extensions page
   - Verify each extension shows exactly once with correct information

4. **Edge cases**
   - Chart removed but extension still installed - verify extension still appears
   - Extension with compatibility issues - verify correct incompatibility messaging
   - Prime-only extensions - verify shown correctly based on Rancher version
   - Builtin vs custom extensions - verify proper filtering and display


### Areas which could experience regressions
1. **Plugin listing and filtering**
   - Changes to `available` computed property affect all downstream filtering, sorting, and display
   - Test filtering by compatibility, installed/available status
   - Test search functionality

2. **Chart to extension mapping**
   - `mapChartToPluginItem()` handles compatibility checking with `isSupportedChartVersion()`
   - Verify version compatibility filtering still works correctly
   - Test incompatible version display and messaging

3. **Loaded plugins display**
   - `buildLoadedPluginItem()` handles hiding builtin extensions
   - Verify builtin extensions are properly hidden
   - Verify custom loaded plugins display correctly

4. **Error handling and messaging**
   - `mergePluginErrors()` combines UI and Helm errors
   - Verify error messages display correctly on cards
   - Test when both UI and Helm errors exist

5. **Certification flag display**
   - `extractCertificationFlags()` extracts primeOnly, experimental, certified badges
   - Verify correct badges display on extension cards
   - Test with extensions having different flag combinations

6. **Plugin CustomResource handling**
   - `wirePluginCRToChart()` connects plugin CRs to charts
   - Test plugin CRs that have matching charts
   - Test plugin CRs without matching charts (should create phantom entry that may be deduped)

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
[Add before/after screenshots showing phantom card no longer appearing after navigation]

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
