### PR TITLE
fixed GKE timeout flakiness

### DIFF
--- a/cypress/e2e/tests/pages/manager/gke-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/gke-cluster-provisioning.spec.ts
@@ -76,13 +76,16 @@ describe('Deploy GKE cluster with default settings', { tags: ['@manager', '@admi
     const cloudCredForm = createGKEClusterPage.cloudCredentialsForm();
 
     // Select GKE and create GKE cluster page
-    ClusterManagerListPagePo.navTo();
+    // Navigate directly to avoid CI flakiness when the side menu is not rendered yet.
+    ClusterManagerListPagePo.goTo('_');
     clusterList.waitForPage();
     clusterList.createCluster();
     createGKEClusterPage.selectKubeProvider(2);
     loadingPo.checkNotExists();
     createGKEClusterPage.rke2PageTitle().should('include', 'Create Google GKE');
     createGKEClusterPage.waitForPage('type=gke&rkeType=rke2');
+    // Wait for the inline cloud credential form's async fetch to complete before interacting with it.
+    loadingPo.checkNotExists();
 
     // create GKE cloud credential
     cloudCredForm.saveButton().expectToBeDisabled();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2318

### Occurred changes and/or fixed issues
Fixing timeout flakiness in GKE test: AssertionError: Timed out retrying after 10000ms: Expected to find element: [data-testid="side-menu"], but never found it.
`Changed ClusterManagerListPagePo.navTo();` to `goTo()` to avoid non-relevant UI navigation and instead navigate straight to the page. Also, another loadingPo.checkNotExists(); to make sure the cloud cred form is fully rendered before proceeding with the test.


### Areas or cases that should be tested
`gke-cluster-provisioning.spec.ts`

### Areas which could experience regressions
Low impact changes to cause regressions elsewhere

### Screenshot/Video
<img width="1700" height="972" alt="Screenshot 2026-05-19 at 4 28 31 PM" src="https://github.com/user-attachments/assets/9ee9b979-b4ce-47db-89b4-e01ceec84fc4" />

In jenkins:
https://github.com/rancher/dashboard/issues/17283

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
