### PR TITLE
Migrate AzureAD auth provider to vee-validate

### DIFF
--- a/shell/edit/auth/__tests__/azuread.test.ts
+++ b/shell/edit/auth/__tests__/azuread.test.ts
@@ -65,6 +65,30 @@ const requiredSetup = (modelOverrides = {}) => ({
   },
 });
 
+describe('edit: azureAD accessMode default', () => {
+  let wrapper: any;
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('should default accessMode to required when not set', async() => {
+    wrapper = mount(AzureAD, { ...requiredSetup({ accessMode: '' }) });
+    wrapper.setData({ model: { tenantId: 'trigger-watcher' } });
+    await nextTick();
+
+    expect(wrapper.vm.model.accessMode).toStrictEqual('unrestricted');
+  });
+
+  it('should not override accessMode when already set', async() => {
+    wrapper = mount(AzureAD, { ...requiredSetup({ accessMode: 'required' }) });
+    wrapper.setData({ model: { tenantId: 'trigger-watcher' } });
+    await nextTick();
+
+    expect(wrapper.vm.model.accessMode).toStrictEqual('required');
+  });
+});
+
 describe('edit: azureAD should', () => {
   let wrapper: any;
 

--- a/shell/edit/auth/__tests__/azuread.test.ts
+++ b/shell/edit/auth/__tests__/azuread.test.ts
@@ -1,6 +1,6 @@
 import { nextTick } from 'vue';
 /* eslint-disable jest/no-hooks */
-import { mount } from '@vue/test-utils';
+import { mount, flushPromises } from '@vue/test-utils';
 import AzureAD from '@shell/edit/auth/azuread.vue';
 import { _EDIT } from '@shell/config/query-params';
 import { SLO_OPTION_VALUES } from '@shell/mixins/auth-config';
@@ -68,8 +68,9 @@ const requiredSetup = (modelOverrides = {}) => ({
 describe('edit: azureAD should', () => {
   let wrapper: any;
 
-  beforeEach(() => {
+  beforeEach(async() => {
     wrapper = mount(AzureAD, { ...requiredSetup() });
+    await flushPromises();
   });
   afterEach(() => {
     wrapper.unmount();
@@ -121,7 +122,7 @@ describe('edit: azureAD should', () => {
     tenantIdInputField.setValue(testCase.tenantId);
     applicationIdInputField.setValue(testCase.applicationId);
     applicationSecretInputField.setValue(testCase.applicationSecret);
-    await nextTick();
+    await flushPromises();
 
     expect(saveButton.disabled).toBe(testCase.result);
   });
@@ -217,11 +218,11 @@ describe('edit: azureAD should', () => {
     tenantIdInputField.setValue(validTenantId);
     applicationIdInputField.setValue(validApplicationId);
     applicationSecretInputField.setValue(validAppSecret);
-    await nextTick();
+    await flushPromises();
 
     expect(saveButton.disabled).toBe(false);
     customButton.trigger('click');
-    await nextTick();
+    await flushPromises();
     expect(saveButton.disabled).toBe(true);
 
     const endpointInputField = wrapper.find('[data-testid="input-azureAD-endpoint"]');
@@ -233,7 +234,7 @@ describe('edit: azureAD should', () => {
     graphEndpointInputField.setValue(testCase.graphEndpoint);
     tokenEndpointInputField.setValue(testCase.tokenEndpoint);
     authEndpointInputField.setValue(testCase.authEndpoint);
-    await nextTick();
+    await flushPromises();
 
     expect(saveButton.disabled).toBe(testCase.result);
   });
@@ -287,7 +288,7 @@ describe('edit: azureAD SSO logout should', () => {
         };
       },
     });
-    await nextTick();
+    await flushPromises();
     const endSessionEndpointField = wrapper.find('[data-testid="azuread-endSessionEndpoint"]');
 
     expect(endSessionEndpointField.exists()).toBe(true);
@@ -303,7 +304,7 @@ describe('edit: azureAD SSO logout should', () => {
         };
       },
     });
-    await nextTick();
+    await flushPromises();
     const endSessionEndpointField = wrapper.find('[data-testid="azuread-endSessionEndpoint"]');
 
     expect(endSessionEndpointField.exists()).toBe(true);
@@ -358,7 +359,7 @@ describe('edit: azureAD SSO logout should', () => {
         };
       },
     });
-    await nextTick();
+    await flushPromises();
     const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
 
     expect(saveButton.disabled).toBe(testCase.disabled);

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -1,8 +1,9 @@
 <script>
+import { ref, computed } from 'vue';
+import { useStore } from 'vuex';
 import isEqual from 'lodash/isEqual';
 import Loading from '@shell/components/Loading';
 import CreateEditView from '@shell/mixins/create-edit-view';
-import FormValidation from '@shell/mixins/form-validation';
 import CruResource from '@shell/components/CruResource';
 import InfoBox from '@shell/components/InfoBox';
 import { RadioGroup } from '@components/Form/Radio';
@@ -16,6 +17,8 @@ import { AZURE_MIGRATED } from '@shell/config/labels-annotations';
 import { get } from '@shell/utils/object';
 import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBanners';
 import formRulesGenerator from '@shell/utils/validators/formRules/index';
+import { useFormValidation } from '@shell/composables/useFormValidation';
+import { useI18n } from '@shell/composables/useI18n';
 
 const TENANT_ID_TOKEN = '__[[TENANT_ID]]__';
 
@@ -68,7 +71,73 @@ export default {
     AuthProviderWarningBanners
   },
 
-  mixins: [CreateEditView, AuthConfig, FormValidation],
+  mixins: [CreateEditView, AuthConfig],
+
+  setup() {
+    const store = useStore();
+    const { t } = useI18n(store);
+
+    const editMemberConfigRef = ref(false);
+    const isLogoutAllSupported = ref(false);
+    const sloTypeRef = ref(null);
+    const sloEndSessionEndpointUiEnabled = computed(() => (
+      sloTypeRef.value === SLO_OPTION_VALUES.all || sloTypeRef.value === SLO_OPTION_VALUES.both
+    ));
+
+    const urlRule = formRulesGenerator(t, {}).url;
+
+    const extraRules = {
+      applicationSecretRequired: (value) => {
+        if (!editMemberConfigRef.value && !value) {
+          return t('validation.required', { key: t('authConfig.azuread.applicationSecret.label') });
+        }
+
+        return undefined;
+      },
+      endSessionEndpointRequiredAndValid: (value) => {
+        if (!isLogoutAllSupported.value || !sloEndSessionEndpointUiEnabled.value) {
+          return undefined;
+        }
+        if (!value) {
+          return t('validation.required', { key: t('authConfig.azuread.endSessionEndpoint.title') });
+        }
+
+        return urlRule(value);
+      },
+    };
+
+    const { getRules, isFormValid } = useFormValidation(t, [
+      {
+        path: 'tenantId', rules: ['required'], translationKey: 'authConfig.azuread.tenantId.label'
+      },
+      {
+        path: 'applicationId', rules: ['required'], translationKey: 'authConfig.azuread.applicationId.label'
+      },
+      { path: 'applicationSecret', rules: ['applicationSecretRequired'] },
+      {
+        path: 'endpoint', rules: ['required', 'url'], translationKey: 'authConfig.azuread.endpoint.label'
+      },
+      {
+        path: 'graphEndpoint', rules: ['required', 'url'], translationKey: 'authConfig.azuread.graphEndpoint.label'
+      },
+      {
+        path: 'tokenEndpoint', rules: ['required', 'url'], translationKey: 'authConfig.azuread.tokenEndpoint.label'
+      },
+      {
+        path: 'authEndpoint', rules: ['required', 'url'], translationKey: 'authConfig.azuread.authEndpoint.label'
+      },
+      { path: 'endSessionEndpoint', rules: ['endSessionEndpointRequiredAndValid'] },
+    ], extraRules);
+
+    return {
+      getRules,
+      isFormValid,
+      editMemberConfigRef,
+      isLogoutAllSupported,
+      sloTypeRef,
+      sloEndSessionEndpointUiEnabled,
+    };
+  },
 
   async fetch() {
     await this.reloadModel();
@@ -89,39 +158,11 @@ export default {
 
       // Storing the applicationSecret is necessary because norman doesn't support returning secrets and when we
       // override the steve authconfig with a norman config the applicationSecret is lost
-      applicationSecret: this.value.applicationSecret,
-      fvFormRuleSets:    [
-        { path: 'tenantId', rules: ['tenantIdRequired'] },
-        { path: 'applicationId', rules: ['applicationIdRequired'] },
-        { path: 'applicationSecret', rules: ['applicationSecretRequired'] },
-        { path: 'endpoint', rules: ['endpointRequired', 'endpointMustBeURL'] },
-        { path: 'graphEndpoint', rules: ['graphEndpointRequired', 'graphEndpointMustBeURL'] },
-        { path: 'tokenEndpoint', rules: ['tokenEndpointRequired', 'tokenEndpointMustBeURL'] },
-        { path: 'authEndpoint', rules: ['authEndpointRequired', 'authEndpointMustBeURL'] },
-        { path: 'endSessionEndpoint', rules: ['endSessionEndpointRequiredAndValid'] },
-      ]
+      applicationSecret: this.value.applicationSecret
     };
   },
 
   computed: {
-    // Cannot pass this.model as a rootObject because it is undefined at that point, so had to use a workaround
-    fvExtraRules() {
-      return {
-        tenantIdRequired:                   this.modelFieldRequired('tenantId', 'authConfig.azuread.tenantId.label'),
-        applicationIdRequired:              this.modelFieldRequired('applicationId', 'authConfig.azuread.applicationId.label'),
-        applicationSecretRequired:          this.applicationSecretRequired(),
-        endpointRequired:                   this.modelFieldRequired('endpoint', 'authConfig.azuread.endpoint.label'),
-        endpointMustBeURL:                  this.modelFieldURL('endpoint'),
-        graphEndpointRequired:              this.modelFieldRequired('graphEndpoint', 'authConfig.azuread.graphEndpoint.label'),
-        graphEndpointMustBeURL:             this.modelFieldURL('graphEndpoint'),
-        tokenEndpointRequired:              this.modelFieldRequired('tokenEndpoint', 'authConfig.azuread.tokenEndpoint.label'),
-        tokenEndpointMustBeURL:             this.modelFieldURL('tokenEndpoint'),
-        authEndpointRequired:               this.modelFieldRequired('authEndpoint', 'authConfig.azuread.authEndpoint.label'),
-        authEndpointMustBeURL:              this.modelFieldURL('authEndpoint'),
-        endSessionEndpointRequiredAndValid: this.endSessionEndpointRule(),
-      };
-    },
-
     tArgs() {
       return {
         baseUrl:  this.baseUrl,
@@ -172,10 +213,6 @@ export default {
       return this.model.enabled && !this.isEnabling && !this.editConfig;
     },
 
-    isLogoutAllSupported() {
-      return this.model?.logoutAllSupported;
-    },
-
     displayName() {
       return this.t('model.authConfig.name.azuread');
     },
@@ -194,12 +231,23 @@ export default {
       return sloOptionSelected?.label || '';
     },
 
-    sloEndSessionEndpointUiEnabled() {
-      return this.sloType === SLO_OPTION_VALUES.all || this.sloType === SLO_OPTION_VALUES.both;
-    },
   },
 
   watch: {
+    editMemberConfig: {
+      handler(val) {
+        this.editMemberConfigRef = val;
+      },
+      immediate: true,
+    },
+
+    'model.logoutAllSupported': {
+      handler(val) {
+        this.isLogoutAllSupported = !!val;
+      },
+      immediate: true,
+    },
+
     endpoint(value) {
       this.setEndpoints(value);
     },
@@ -211,22 +259,26 @@ export default {
     },
 
     // sloType is defined on shell/mixins/auth-config.js
-    sloType(neu) {
-      switch (neu) {
-      case SLO_OPTION_VALUES.rancher:
-        this.model.logoutAllEnabled = false;
-        this.model.logoutAllForced = false;
-        this.model.endSessionEndpoint = '';
-        break;
-      case SLO_OPTION_VALUES.all:
-        this.model.logoutAllEnabled = true;
-        this.model.logoutAllForced = true;
-        break;
-      case SLO_OPTION_VALUES.both:
-        this.model.logoutAllEnabled = true;
-        this.model.logoutAllForced = false;
-        break;
-      }
+    sloType: {
+      handler(neu) {
+        this.sloTypeRef = neu;
+        switch (neu) {
+        case SLO_OPTION_VALUES.rancher:
+          this.model.logoutAllEnabled = false;
+          this.model.logoutAllForced = false;
+          this.model.endSessionEndpoint = '';
+          break;
+        case SLO_OPTION_VALUES.all:
+          this.model.logoutAllEnabled = true;
+          this.model.logoutAllForced = true;
+          break;
+        case SLO_OPTION_VALUES.both:
+          this.model.logoutAllEnabled = true;
+          this.model.logoutAllForced = false;
+          break;
+        }
+      },
+      immediate: true,
     },
 
     model: {
@@ -328,37 +380,6 @@ export default {
           });
       }
     },
-    modelFieldRequired(path, label) {
-      return () => {
-        return !this.model[path] ? `${ this.t('validation.required', { key: this.t(label) }) }` : undefined;
-      };
-    },
-    applicationSecretRequired() {
-      return () => {
-        return !this.editMemberConfig && !this.model.applicationSecret ? `${ this.t('validation.required', { key: this.t('authConfig.azuread.applicationSecret.label') }) }` : undefined;
-      };
-    },
-    modelFieldURL(path) {
-      return () => {
-        const rule = formRulesGenerator(this.$store.getters['i18n/t'], {}).url;
-
-        return rule(this.model[path]);
-      };
-    },
-
-    endSessionEndpointRule() {
-      return () => {
-        if (!this.isLogoutAllSupported || !this.sloEndSessionEndpointUiEnabled) {
-          return undefined;
-        }
-        if (!this.model.endSessionEndpoint) {
-          return this.t('validation.required', { key: this.t('authConfig.azuread.endSessionEndpoint.title') });
-        }
-        const rule = formRulesGenerator(this.$store.getters['i18n/t'], {}).url;
-
-        return rule(this.model.endSessionEndpoint);
-      };
-    },
   }
 };
 </script>
@@ -371,7 +392,7 @@ export default {
       :mode="mode"
       :resource="model"
       :subtypes="[]"
-      :validation-passed="fvFormIsValid"
+      :validation-passed="isFormValid"
       :finish-button-mode="model && model.enabled ? 'edit' : 'enable'"
       :can-yaml="false"
       :errors="errors"
@@ -470,10 +491,11 @@ export default {
             <LabeledInput
               id="tenant-id"
               v-model:value="model.tenantId"
+              name="tenantId"
               :label="t('authConfig.azuread.tenantId.label')"
               :mode="mode"
               :required="true"
-              :rules="fvGetAndReportPathRules('tenantId')"
+              :rules="getRules('tenantId')"
               :tooltip="t('authConfig.azuread.tenantId.tooltip')"
               :placeholder="t('authConfig.azuread.tenantId.placeholder')"
               data-testid="input-azureAD-tenantId"
@@ -485,10 +507,11 @@ export default {
             <LabeledInput
               id="application-id"
               v-model:value="model.applicationId"
+              name="applicationId"
               :label="t('authConfig.azuread.applicationId.label')"
               :mode="mode"
               :required="true"
-              :rules="fvGetAndReportPathRules('applicationId')"
+              :rules="getRules('applicationId')"
               :placeholder="t('authConfig.azuread.applicationId.placeholder')"
               data-testid="input-azureAD-applcationId"
             />
@@ -497,10 +520,11 @@ export default {
             <LabeledInput
               id="application-secret"
               v-model:value="model.applicationSecret"
+              name="applicationSecret"
               type="password"
               :label="t('authConfig.azuread.applicationSecret.label')"
               :required="true"
-              :rules="fvGetAndReportPathRules('applicationSecret')"
+              :rules="getRules('applicationSecret')"
               :mode="mode"
               data-testid="input-azureAD-applicationSecret"
             />
@@ -552,19 +576,21 @@ export default {
             <div class="col span-6">
               <LabeledInput
                 v-model:value="model.endpoint"
+                name="endpoint"
                 :label="t('authConfig.azuread.endpoint.label')"
                 :mode="mode"
                 :required="true"
-                :rules="fvGetAndReportPathRules('endpoint')"
+                :rules="getRules('endpoint')"
                 data-testid="input-azureAD-endpoint"
               />
             </div>
             <div class="col span-6">
               <LabeledInput
                 v-model:value="model.graphEndpoint"
+                name="graphEndpoint"
                 :label="t('authConfig.azuread.graphEndpoint.label')"
                 :required="true"
-                :rules="fvGetAndReportPathRules('graphEndpoint')"
+                :rules="getRules('graphEndpoint')"
                 :mode="mode"
                 data-testid="input-azureAD-graphEndpoint"
               />
@@ -574,19 +600,21 @@ export default {
             <div class="col span-6">
               <LabeledInput
                 v-model:value="model.tokenEndpoint"
+                name="tokenEndpoint"
                 :label="t('authConfig.azuread.tokenEndpoint.label')"
                 :mode="mode"
                 :required="true"
-                :rules="fvGetAndReportPathRules('tokenEndpoint')"
+                :rules="getRules('tokenEndpoint')"
                 data-testid="input-azureAD-tokenEndpoint"
               />
             </div>
             <div class="col span-6">
               <LabeledInput
                 v-model:value="model.authEndpoint"
+                name="authEndpoint"
                 :label="t('authConfig.azuread.authEndpoint.label')"
                 :required="true"
-                :rules="fvGetAndReportPathRules('authEndpoint')"
+                :rules="getRules('authEndpoint')"
                 :mode="mode"
                 data-testid="input-azureAD-authEndpoint"
               />
@@ -623,10 +651,11 @@ export default {
             <div class="col span-6">
               <LabeledInput
                 v-model:value="model.endSessionEndpoint"
+                name="endSessionEndpoint"
                 :tooltip="t('authConfig.azuread.endSessionEndpoint.tooltip', { name: displayName, tenantId: `${ tenantId || 'tenant-id' }` }, true)"
                 :label="t('authConfig.azuread.endSessionEndpoint.title')"
                 :mode="mode"
-                :rules="fvGetAndReportPathRules('endSessionEndpoint')"
+                :rules="getRules('endSessionEndpoint')"
                 :required="true"
                 data-testid="azuread-endSessionEndpoint"
               />

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -84,7 +84,7 @@ export default {
       sloTypeRef.value === SLO_OPTION_VALUES.all || sloTypeRef.value === SLO_OPTION_VALUES.both
     ));
 
-    const urlRule = formRulesGenerator(t, {}).url;
+    const urlRule = formRulesGenerator(t, {}).genericUrl;
 
     const extraRules = {
       applicationSecretRequired: (value) => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This migrates the AzureAd auth provider away from the validation mixin over to vee-validate.

Fixes #17791
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Migrate AzureAD auth provider to vee-validate
- Update unit tests
- Update end session endpoint validation
- Resolve failing unit tests

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This utilizes the `useFormValidation()` bridge composable to help recycle existing validation logic and apply it to vee-validate. See #17441 for more details on how the bridge composable has been used for validating secrets.

See also #17738 for recent work for validating the OIDC auth provider form. This utilizes a pure vee-validate/zod approach, but it demonstrates some of the tradeoffs of working with the existing auth mixins:

> In order to get this to work with useForm from vee-validate, we need to find a way to sync values from the form's mixins with the composition API. This is currently accomplished via watchers that exist to sync values with the refs (https://github.com/rancher/dashboard/commit/99078ad9f823b10aeb1b9ac17686355044903a44). I think that the proper, long-term solution will be to migrate away from mixins to the composition API.

Any additional comments and observations on these approaches are welcome as we're working on migrating these first forms and solidifying patterns.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

AzureAD auth provider form should properly fail validation and relay validation messages to users.

The save button should be disabled when validation fails.

AzureAD auth provider form should properly pass validation when all required values are filled out.

The save button should be enabled when validation passes.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Validation logic could have changed in unintended ways. This should remain consistent with how it was before with a few enhancements for better validation across the board. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="1376" height="1215" alt="image" src="https://github.com/user-attachments/assets/c9a5c7ff-6ca8-4a73-88af-f49e224fa869" />

<img width="1376" height="1215" alt="image" src="https://github.com/user-attachments/assets/3bbae915-d884-48f9-974c-f220d3046137" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
