### PR TITLE
[Automation] - Stabilize imported generic cluster e2e spec

### DIFF
--- a/cypress/e2e/po/lists/provisioning.cattle.io.cluster.po.ts
+++ b/cypress/e2e/po/lists/provisioning.cattle.io.cluster.po.ts
@@ -33,12 +33,15 @@ export default class ProvClusterListPo extends BaseResourceList {
   }
 
   provider(clusterName: string) {
-    return this.resourceTable().sortableTable().rowWithName(clusterName).column(3);
+    return this.resourceTable().sortableTable().rowWithName(clusterName)
+      .self()
+      .find('.col-cluster-provider');
   }
 
   providerSubType(clusterName: string) {
-    return this.resourceTable().sortableTable().rowWithName(clusterName).column(3)
-      .find(`.text-muted`);
+    return this.resourceTable().sortableTable().rowWithName(clusterName)
+      .self()
+      .find('.col-cluster-provider .text-muted');
   }
 
   machines(clusterName: string) {

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -1,3 +1,4 @@
+import { qase } from '@/cypress/support/qase';
 import { isMatch } from 'lodash';
 
 import ClusterManagerCreatePagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create.po';
@@ -57,7 +58,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     });
   });
 
-  it('deactivating a hosted provider should hide its card from the cluster creation page', () => {
+  qase(16624, it('deactivating a hosted provider should hide its card from the cluster creation page', () => {
     cy.intercept('PUT', `v1/management.cattle.io.settings/kev2-operators`).as('updateProviders');
 
     const providersPage = new HostedProvidersPagePo();
@@ -94,7 +95,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     clusterList.checkIsCurrentPage();
     clusterList.createCluster();
     clusterCreatePage.gridElementExistanceByName('Azure AKS', 'exist');
-  });
+  }));
 
   describe('RKE2 providers', () => {
     providersList.forEach((prov) => {
@@ -119,7 +120,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     describe('RKE2 Custom', { tags: ['@jenkins', '@customCluster', '@provisioning'] }, () => {
       const editCreatedClusterPage = () => new ClusterManagerEditRke2CustomPagePo(undefined, rke2CustomName);
 
-      it('can create new cluster', { retries: 0 }, () => {
+      qase(1436, it('can create new cluster', { retries: 0 }, () => {
         rke2CustomName = createClusterTestName('rke2-custom');
         cy.intercept('POST', `/v1/${ type }s`).as('createRequest');
         const request = {
@@ -211,9 +212,9 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         clusterList.waitForPage();
         clusterList.list().state(rke2CustomName).should('contain.text', 'Updating');
         clusterList.list().state(rke2CustomName).contains('Active', VERY_LONG_TIMEOUT_OPT); // super long timeout needed for cluster provisioning to complete
-      });
+      }));
 
-      it('can copy config to clipboard', () => {
+      qase(2053, it('can copy config to clipboard', () => {
         // Stub clipboard methods to avoid permission prompts
         cy.visit('/', {
           onBeforeLoad(win) {
@@ -237,9 +238,9 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         // read text saved in the browser clipboard
         // cy.window().its('navigator.clipboard')
         //   .invoke('readText').should('include', rke2CustomName);
-      });
+      }));
 
-      it('can edit cluster and see changes afterwards', () => {
+      qase(1437, it('can edit cluster and see changes afterwards', () => {
         clusterList.goTo();
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit Config').click();
 
@@ -255,9 +256,9 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         editCreatedClusterPage().waitForPage('mode=edit', 'basic');
         editCreatedClusterPage().nameNsDescription().description().self()
           .should('have.value', rke2CustomName);
-      });
+      }));
 
-      it('will disable saving if an addon config has invalid data', () => {
+      qase(12214, it('will disable saving if an addon config has invalid data', () => {
         clusterList.goTo();
 
         clusterList.checkIsCurrentPage();
@@ -278,17 +279,17 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
         createRKE2ClusterPage.calicoAddonConfig().yamlEditor().input().set('goodvalue: yay');
         createRKE2ClusterPage.resourceDetail().createEditView().saveButtonPo().expectToBeEnabled();
-      });
+      }));
 
-      it('can view cluster YAML editor', () => {
+      qase(1435, it('can view cluster YAML editor', () => {
         clusterList.goTo();
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Edit YAML').click();
 
         editCreatedClusterPage().waitForPage('mode=edit&as=yaml');
         editCreatedClusterPage().resourceDetail().resourceYaml().checkVisible();
-      });
+      }));
 
-      it('can download KubeConfig', () => {
+      qase(1438, it('can download KubeConfig', () => {
         cy.deleteDownloadsFolder();
         clusterList.goTo();
         cy.intercept('POST', '/v1/ext.cattle.io.kubeconfigs').as('generateKubeconfig');
@@ -306,9 +307,9 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
           expect(obj.apiVersion).to.equal('v1');
           expect(obj.kind).to.equal('Config');
         });
-      });
+      }));
 
-      it('can download YAML', () => {
+      qase(2054, it('can download YAML', () => {
         // Delete downloads directory. Need a fresh start to avoid conflicting file names
         cy.deleteDownloadsFolder();
 
@@ -325,7 +326,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
           expect(obj.metadata.annotations['field.cattle.io/description']).to.equal(rke2CustomName);
           expect(obj.kind).to.equal('Cluster');
         });
-      });
+      }));
       it('preserves custom addon config values after saving cluster config', () => {
         const customAddonConfig = `goodvalue: yay\nnested:\n  enabled: true`;
         const updatedDescription = `${ rke2CustomName }-addon-persist-check`;
@@ -356,7 +357,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
           .should('equal', customAddonConfig);
       });
 
-      it('can delete cluster', () => {
+      qase(1434, it('can delete cluster', () => {
         clusterList.goTo();
         clusterList.sortableTable().rowElementWithName(rke2CustomName).should('exist', MEDIUM_TIMEOUT_OPT);
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Delete').click();
@@ -368,7 +369,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
         clusterList.waitForPage();
         clusterList.sortableTable().rowElementWithName(rke2CustomName).should('not.exist');
-      });
+      }));
     });
   });
 
@@ -379,13 +380,14 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     const privateRegistry = 'registry.io';
 
     describe('Generic', () => {
-      it('can create new cluster', () => {
+      qase(1436, it('can create new cluster', { retries: 0 }, () => {
         importGenericName = createClusterTestName('import-generic');
         cy.intercept('GET', `${ USERS_BASE_URL }?*`).as('getUsers');
         cy.intercept('POST', `/v3/${ importType }s`).as('importRequest');
 
         clusterList.goTo();
         clusterList.checkIsCurrentPage();
+        clusterList.list().checkVisible(MEDIUM_TIMEOUT_OPT);
         clusterList.importCluster();
 
         importClusterPage.waitForPage('mode=import');
@@ -424,7 +426,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         cy.getClusterIdByName(importGenericName).then((clusterId) => {
           const detailClusterPage = new ClusterManagerDetailImportedGenericPagePo(undefined, clusterId);
 
-          detailClusterPage.waitForPage(undefined, 'registration');
+          cy.url(EXTRA_LONG_TIMEOUT_OPT).should('include', `${ clusterId }#registration`);
           detailClusterPage.kubectlCommandForImported().contains('--insecure').then(($value) => {
             const kubectlCommand = $value.text();
 
@@ -444,15 +446,15 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
           .and(($el) => {
             const status = $el.text().trim();
 
-            expect(['Provisioning', 'Waiting']).to.include(status);
+            expect(['Pending', 'Provisioning', 'Waiting']).to.include(status);
           });
         clusterList.list().state(importGenericName).contains('Active', EXTRA_LONG_TIMEOUT_OPT);
         // Issue #6836: Provider field on Imported clusters states "Imported" instead of cluster type
         clusterList.list().provider(importGenericName).should('contain.text', 'Imported');
         clusterList.list().providerSubType(importGenericName).should('contain.text', 'K3s');
-      });
+      }));
 
-      it('can edit imported cluster and see changes afterwards', () => {
+      qase(6978, it('can edit imported cluster and see changes afterwards', () => {
         cy.getClusterIdByName(importGenericName).then((clusterId) => {
           const editImportedClusterPage = new ClusterManagerEditImportedPagePo(undefined, 'fleet-default', clusterId);
 
@@ -507,10 +509,11 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
           editImportedClusterPage.privateRegistryCheckbox().isChecked();
           editImportedClusterPage.privateRegistry().value().should('eq', privateRegistry);
         });
-      });
+      }));
 
-      it('can delete cluster by bulk actions', () => {
+      qase(1463, it('can delete cluster by bulk actions', () => {
         clusterList.goTo();
+        clusterList.list().checkVisible(MEDIUM_TIMEOUT_OPT);
         clusterList.sortableTable().rowElementWithName(importGenericName).should('exist', MEDIUM_TIMEOUT_OPT);
         clusterList.sortableTable().rowSelectCtlWithName(importGenericName).set();
         clusterList.sortableTable().bulkActionDropDownOpen();
@@ -523,11 +526,11 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
         clusterList.waitForPage();
         clusterList.sortableTable().rowElementWithName(importGenericName).should('not.exist');
-      });
+      }));
     });
   });
 
-  it('can navigate to Cluster Management Page', () => {
+  qase(2224, it('can navigate to Cluster Management Page', () => {
     HomePagePo.goTo();
     const burgerMenu = new BurgerMenuPo();
 
@@ -539,7 +542,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     const clusterList = new ClusterManagerListPagePo('_');
 
     clusterList.waitForPage();
-  });
+  }));
 
   describe('Cluster Details Page and Tabs', () => {
     const tabbedPo = new TabbedPo('[data-testid="tabbed-block"]');
@@ -556,36 +559,36 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
       clusterDetail.waitForPage();
     });
 
-    it('can navigate to Cluster Conditions Page', () => {
+    qase(3230, it('can navigate to Cluster Conditions Page', () => {
       clusterDetail.selectTab(tabbedPo, '[data-testid="btn-conditions"]');
 
       clusterDetail.waitForPage(undefined, 'conditions');
       clusterDetail.conditionsList().details('Created', 1).should('include.text', 'True');
-    });
+    }));
 
-    it('can navigate to Cluster Related Page', () => {
+    qase(3228, it('can navigate to Cluster Related Page', () => {
       clusterDetail.selectTab(tabbedPo, '[data-testid="btn-related"]');
 
       clusterDetail.waitForPage(undefined, 'related');
       clusterDetail.referredToList().details('Mgmt', 2).should('include.text', 'local');
-    });
+    }));
 
-    it('can navigate to Cluster Provisioning Log Page', () => {
+    qase(3227, it('can navigate to Cluster Provisioning Log Page', () => {
       clusterDetail.selectTab(tabbedPo, '[data-testid="btn-log"]');
 
       clusterDetail.waitForPage(undefined, 'log');
       clusterDetail.logsContainer().should('be.visible');
-    });
+    }));
 
-    it('can navigate to Cluster Machines Page', () => {
+    qase(3229, it('can navigate to Cluster Machines Page', () => {
       clusterDetail.selectTab(tabbedPo, '[data-testid="btn-node-pools"]');
 
       clusterDetail.waitForPage(undefined, 'node-pools');
       clusterDetail.poolsList('node').details('machine-', 2).should('be.visible');
       clusterDetail.poolsList('node').downloadYamlButton().should('be.disabled');
-    });
+    }));
 
-    it(`Show Configuration allows to edit config and view yaml for local cluster`, () => {
+    qase(12219, it(`Show Configuration allows to edit config and view yaml for local cluster`, () => {
       clusterDetail.openShowConfiguration();
       const drawer = clusterDetail.detailDrawer();
 
@@ -600,9 +603,9 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
       drawer.tabs().clickTabWithName('yaml-tab');
       drawer.saveButton().should('not.exist');
-    });
+    }));
 
-    it('can navigate to namespace from cluster detail view', () => {
+    qase(3348, it('can navigate to namespace from cluster detail view', () => {
       clusterDetail.namespace().should('contain.text', 'fleet-local');
       clusterDetail.namespace().click();
 
@@ -610,11 +613,11 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
       nsPage.waitForPage(undefined, 'Resources');
       nsPage.namespace().should('contain.text', 'fleet-local');
-    });
+    }));
   });
 
   describe('Local', () => {
-    it(`can open edit for local cluster`, () => {
+    qase(8592, it(`can open edit for local cluster`, () => {
       const editLocalClusterPage = new ClusterManagerEditImportedPagePo(undefined, 'fleet-local', 'local');
 
       cy.intercept('GET', `${ USERS_BASE_URL }?*`).as('pageLoad');
@@ -643,9 +646,9 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
       // We should be taken back to the list page if the save was successful
       clusterList.waitForPage();
-    });
+    }));
 
-    it(`can navigate to local cluster's explore product`, () => {
+    qase(1404, it(`can navigate to local cluster's explore product`, () => {
       const clusterName = 'local';
       const clusterDashboard = new ClusterDashboardPagePo(clusterName);
 
@@ -653,10 +656,10 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
       clusterList.list().explore(clusterName).click();
 
       clusterDashboard.waitForPage(undefined, 'cluster-events');
-    });
+    }));
   });
 
-  it('can download YAML via bulk actions', () => {
+  qase(2223, it('can download YAML via bulk actions', () => {
     // Delete downloads directory. Need a fresh start to avoid conflicting file names
     cy.deleteDownloadsFolder();
 
@@ -675,9 +678,9 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
       expect(obj.metadata.name).to.equal('local');
       expect(obj.kind).to.equal('Cluster');
     });
-  });
+  }));
 
-  it('can download KubeConfig via bulk actions', () => {
+  qase(2222, it('can download KubeConfig via bulk actions', () => {
     // Delete downloads directory. Need a fresh start to avoid conflicting file names
     cy.deleteDownloadsFolder();
 
@@ -698,9 +701,9 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
       expect(obj.clusters[1].name).to.equal('local');
       expect(obj.kind).to.equal('Config');
     });
-  });
+  }));
 
-  it('can connect to kubectl shell', () => {
+  qase(1975, it('can connect to kubectl shell', () => {
     ClusterManagerListPagePo.navTo();
     clusterList.list().actionMenu('local').getMenuItem('Kubectl Shell').click();
 
@@ -708,14 +711,14 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
 
     shellPo.terminalStatus('Connected');
     shellPo.closeTerminal();
-  });
+  }));
 
   describe('Credential Step', () => {
     const drivers = ['nutanix', 'oci'];
 
     Cypress._.each(drivers, (driver) => {
       describe(`should always show credentials for ${ driver } driver`, () => {
-        it('should show credential step when `addCloudCredential` is true', () => {
+        qase(2257, it('should show credential step when `addCloudCredential` is true', () => {
           cy.intercept({
             method: 'GET',
             path:   `/v1/management.cattle.io.nodedrivers*`,
@@ -730,9 +733,9 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
           clusterCreate.waitForPage();
 
           clusterCreate.credentialsBanner().checkExists();
-        });
+        }));
 
-        it('should show credential step when `addCloudCredential` is false', () => {
+        qase(5221, it('should show credential step when `addCloudCredential` is false', () => {
           cy.intercept({
             method: 'GET',
             path:   `/v1/management.cattle.io.nodedrivers*`,
@@ -747,14 +750,14 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
           clusterCreate.waitForPage();
 
           clusterCreate.credentialsBanner().checkExists();
-        });
+        }));
       });
     });
 
     const driver2 = 'outscale';
 
     describe('should show on condition of addCloudCredential', () => {
-      it('should show credential step when `addCloudCredential` is true', () => {
+      qase(2257, it('should show credential step when `addCloudCredential` is true', () => {
         cy.intercept({
           method: 'GET',
           path:   `/v1/management.cattle.io.nodedrivers*`,
@@ -769,9 +772,9 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         clusterCreate.waitForPage();
 
         clusterCreate.credentialsBanner().checkExists();
-      });
+      }));
 
-      it('should NOT show credential step when `addCloudCredential` is false', () => {
+      qase(2256, it('should NOT show credential step when `addCloudCredential` is false', () => {
         cy.intercept({
           method: 'GET',
           path:   `/v1/management.cattle.io.nodedrivers*`,
@@ -786,7 +789,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         clusterCreate.waitForPage();
 
         clusterCreate.credentialsBanner().checkNotExists();
-      });
+      }));
     });
   });
 
@@ -801,7 +804,7 @@ describe('Cluster Manager as standard user', { testIsolation: 'off', tags: ['@ma
   before(() => {
     cy.login();
   });
-  it('can navigate to Cluster Management Page', () => {
+  qase(2224, it('can navigate to Cluster Management Page', () => {
     HomePagePo.goTo();
     const burgerMenu = new BurgerMenuPo();
 
@@ -813,7 +816,7 @@ describe('Cluster Manager as standard user', { testIsolation: 'off', tags: ['@ma
     const clusterList = new ClusterManagerListPagePo('_');
 
     clusterList.waitForPage();
-  });
+  }));
 
   describe('Cluster Detail Page', () => {
     const clusterDetail = new ClusterManagerDetailImportedGenericPagePo(undefined, 'local');
@@ -826,7 +829,7 @@ describe('Cluster Manager as standard user', { testIsolation: 'off', tags: ['@ma
       clusterList.goToDetailsPage('local', '.cluster-link a');
     });
 
-    it(`Show Configuration allows to view but not edit config and yaml for local cluster`, () => {
+    qase(12222, it(`Show Configuration allows to view but not edit config and yaml for local cluster`, () => {
       clusterDetail.waitForPage();
       clusterDetail.openShowConfiguration();
       const drawer = clusterDetail.detailDrawer();
@@ -842,15 +845,15 @@ describe('Cluster Manager as standard user', { testIsolation: 'off', tags: ['@ma
 
       drawer.tabs().clickTabWithName('yaml-tab');
       drawer.saveButton().should('not.exist');
-    });
+    }));
 
-    it('Shows the explore button and navigates to the cluster explorer when clicked', () => {
+    qase(12451, it('Shows the explore button and navigates to the cluster explorer when clicked', () => {
       clusterDetail.waitForPage();
       clusterDetail.exploreButton().should('exist');
 
       clusterDetail.exploreButton().click();
       cy.url().should('include', '/c/local/explorer');
-    });
+    }));
   });
 });
 
@@ -860,7 +863,7 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
     cy.applyDefaultTestTheme();
   });
 
-  it('should display cluster manager page', () => {
+  qase(17812, it('should display cluster manager page', () => {
     const clusterList = new ClusterManagerListPagePo();
 
     clusterList.goTo();
@@ -874,7 +877,7 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
     cy.hideElementBySelector('[data-testid="nav_header_showUserMenu"]', 'td.col-live-date span.live-date');
     // takes percy snapshot.
     cy.percySnapshot('cluster manager list page');
-  });
+  }));
 
   after(() => {
     cy.restoreProductDefaultTestTheme();


### PR DESCRIPTION
### Summary
Fixes: rancher/qa-tasks#2317

Depends on: https://github.com/rancher/qa-infra-automation/pull/111

### Occurred changes and/or fixed issues

Fix flakiness on imported cluster create against Prime Rancher and wrap cluster manager tests with their Qase case IDs:

- accept Pending as a transient state alongside Provisioning/Waiting
- select provider column by `.col-cluster-provider` (formatter-derived) scoped with `find()`
- wait for cluster list visibility before `masthead/list` interactions
- extend cluster detail registration page wait to medium timeout
- disable Cypress retries on create to avoid stale clusters
- wrap eligible `it()` statements with `qase()` using the oldest matching **Qase** case ID per title


### Areas or cases that should be tested
Jenkins

### Areas which could experience regressions
Jenkins CI

### Screenshot/Video

### PRIME

<img width="938" height="850" alt="Screenshot from 2026-05-22 17-35-55" src="https://github.com/user-attachments/assets/bbcb016d-374e-4d1d-b420-c9b61c9af786" />

### COMMUNITY

<img width="938" height="850" alt="Screenshot from 2026-05-22 18-02-47" src="https://github.com/user-attachments/assets/5d543095-c32c-4e54-a417-83b4973872e0" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
