### PR TITLE
Fix project membership tab showing missing role bindings and duplicate prevention

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -483,6 +483,8 @@ addonConfigConfirmation:
 
 addProjectMemberDialog:
   title: Add Project Member
+  duplicateRolesError: This member already has all of the selected roles in this project. No new assignments were created.
+  duplicateRolesSkipped: "One or more selected roles were skipped because they are already assigned to this member in this project."
 
 authConfig:
   slo:

--- a/shell/components/ExplorerMembers.vue
+++ b/shell/components/ExplorerMembers.vue
@@ -62,16 +62,39 @@ export default {
       });
     }
 
-    if (projectRoleTemplateBindingSchema) {
-      this.$store.dispatch('rancher/findAll', { type: NORMAN.PROJECT_ROLE_TEMPLATE_BINDING, opt: { force: true } }, { root: true })
-        .then((bindings) => {
-          this['projectRoleTemplateBindings'] = bindings;
-          this.loadingProjectBindings = false;
-        });
-    }
+    // Fetch projects first so we can scope the PRTB request to this cluster's projects only.
+    // Fetching all PRTBs globally without a filter causes the Norman API's page limit to be
+    // hit before cluster-specific results are loaded, resulting in most bindings being invisible
+    // after client-side filtering.
+    const allProjects = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.PROJECT });
 
-    this.$store.dispatch('management/findAll', { type: MANAGEMENT.PROJECT })
-      .then((projects) => (this['projects'] = projects));
+    this['projects'] = allProjects;
+
+    if (projectRoleTemplateBindingSchema) {
+      const clusterId = this.$store.getters['currentCluster'].id;
+      // Norman projectId format is 'clusterId:projectNamespace' (e.g. 'local:p-v679w').
+      // Management project id format is 'clusterId/projectNamespace' — replace '/' with ':'.
+      // projectId is a proper Norman reference field and is safe to filter on; namespaceId is
+      // a mapper-moved field that may not be indexed for filtering.
+      const projectIds = allProjects
+        .filter((p) => p?.spec?.clusterName === clusterId)
+        .map((p) => p.id.replace('/', ':'))
+        .filter(Boolean);
+
+      if (projectIds.length > 0) {
+        // Norman's _in filter does not split comma-separated values — each value must be
+        // a separate repeated query parameter (e.g. ?projectId_in=a&projectId_in=b).
+        const url = `/v3/projectroletemplatebindings?${ projectIds.map((id) => `projectId_in=${ encodeURIComponent(id) }`).join('&') }`;
+
+        this.$store.dispatch('rancher/findAll', { type: NORMAN.PROJECT_ROLE_TEMPLATE_BINDING, opt: { force: true, url } }, { root: true })
+          .then((bindings) => {
+            this['projectRoleTemplateBindings'] = bindings;
+            this.loadingProjectBindings = false;
+          });
+      } else {
+        this.loadingProjectBindings = false;
+      }
+    }
 
     const hydration = {
       normanPrincipals:  this.$store.dispatch('rancher/findAll', { type: NORMAN.PRINCIPAL }),
@@ -186,7 +209,7 @@ export default {
       });
 
       // We need to group each of the TemplateRoleBindings by the user + project
-      const userRoles = [...fakeRows, ...this.filteredProjectRoleTemplateBindings].reduce((rows, curr) => {
+      const userRoles = this.filteredProjectRoleTemplateBindings.reduce((rows, curr) => {
         const {
           userId, groupPrincipalId, roleTemplate, projectId
         } = curr;
@@ -211,7 +234,9 @@ export default {
         return rows;
       }, {});
 
-      return Object.values(userRoles);
+      // fakeRows must be added outside the reduce — they have no userId/groupPrincipalId
+      // and would be silently dropped if included in the reduce input.
+      return [...Object.values(userRoles), ...fakeRows];
     },
     canManageMembers() {
       return canViewClusterPermissionsEditor(this.$store);

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -191,7 +191,7 @@ export function init(store) {
   configureType(MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING, { isEditable: false, depaginate: dePaginateBindings });
   configureType(MANAGEMENT.PROJECT, { displayName: store.getters['i18n/t']('namespace.project.label') });
   configureType(NORMAN.CLUSTER_ROLE_TEMPLATE_BINDING, { depaginate: dePaginateNormanBindings });
-  configureType(NORMAN.PROJECT_ROLE_TEMPLATE_BINDING, { depaginate: dePaginateNormanBindings });
+  configureType(NORMAN.PROJECT_ROLE_TEMPLATE_BINDING, { depaginate: true });
   configureType(SNAPSHOT, { depaginate: true });
 
   configureType(SECRET, { showListMasthead: false });

--- a/shell/dialog/AddProjectMemberDialog.vue
+++ b/shell/dialog/AddProjectMemberDialog.vue
@@ -45,7 +45,8 @@ export default {
         principalId:     '',
         roleTemplateIds: []
       },
-      error: null
+      error:            null,
+      duplicateWarning: null
     };
   },
 
@@ -77,12 +78,35 @@ export default {
       this.close();
     },
 
+    // Returns the subset of roleTemplateIds that already exist for this principal+project.
+    existingRoleTemplateIds(principalProperty, principalId) {
+      const all = this.$store.getters['rancher/all'](NORMAN.PROJECT_ROLE_TEMPLATE_BINDING);
+
+      return this.member.roleTemplateIds.filter((roleTemplateId) => all.some(
+        (b) => b.projectId === this.projectId &&
+               b.roleTemplateId === roleTemplateId &&
+               b[principalProperty] === principalId
+      ));
+    },
+
     async createBindings() {
       const principalProperty = await this.principalProperty();
-      const promises = this.member.roleTemplateIds.map((roleTemplateId) => this.$store.dispatch(`rancher/create`, {
+      const principalId = this.member.principalId;
+      const duplicates = this.existingRoleTemplateIds(principalProperty, principalId);
+      const newRoleTemplateIds = this.member.roleTemplateIds.filter((id) => !duplicates.includes(id));
+
+      if (newRoleTemplateIds.length === 0) {
+        throw new Error(this.t('addProjectMemberDialog.duplicateRolesError'));
+      }
+
+      if (duplicates.length > 0) {
+        this.duplicateWarning = this.t('addProjectMemberDialog.duplicateRolesSkipped');
+      }
+
+      const promises = newRoleTemplateIds.map((roleTemplateId) => this.$store.dispatch(`rancher/create`, {
         type:                NORMAN.PROJECT_ROLE_TEMPLATE_BINDING,
         roleTemplateId,
-        [principalProperty]: this.member.principalId,
+        [principalProperty]: principalId,
         projectId:           this.projectId,
       }));
 
@@ -91,6 +115,7 @@ export default {
 
     saveBindings(btnCB) {
       this.error = null;
+      this.duplicateWarning = null;
       this.createBindings()
         .then((bindings) => {
           return Promise.all(bindings.map((b) => b.save()));
@@ -128,6 +153,12 @@ export default {
           color="error"
         >
           {{ error }}
+        </Banner>
+        <Banner
+          v-if="duplicateWarning"
+          color="warning"
+        >
+          {{ duplicateWarning }}
         </Banner>
         <ProjectMemberEditor
           v-model:value="member"


### PR DESCRIPTION
### Summary
Fixes #17808
Fixes #17809

### Occurred changes and/or fixed issues

Three co-dependent bugs in `shell/components/ExplorerMembers.vue` and related files caused the Project Membership tab to display incomplete data at scale and allowed duplicate role assignments to be created.

**Bug 1 — Missing role bindings at scale (#17808)**
The Norman PRTB fetch loaded all bindings across every cluster globally (no filter), then filtered client-side. With 65+ clusters the API returns only the first ~200 of 5,000+ global PRTBs, of which perhaps 10–20 belong to the current cluster. Combined with `configureConditionalDepaginate` suppressing pagination when the global count exceeds 5,000, the tab appeared almost empty on large installations.

Fixed by scoping the fetch to the current cluster's projects using repeated `projectId_in` query parameters. Note: Norman's Go backend uses `net/url.ParseQuery` which does not split comma-separated values — each project ID must be a separate repeated parameter. `depaginate` is set to `true` because the result set is now bounded by the cluster scope.

**Bug 2 — Projects with no role bindings missing from table (#17808)**
`rowsWithFakeProjects` spread placeholder rows for empty projects into the `reduce` input alongside real PRTB rows. Because fakeRows have no `userId`/`groupPrincipalId`, the early-return guard silently dropped them and they never appeared in the output. Fixed by appending fakeRows directly to the return value outside the reduce.

**Bug 3 — Duplicate role assignments allowed (#17809)**
`AddProjectMemberDialog.vue` dispatched `rancher/create` for every selected `roleTemplateId` without checking whether an identical binding already existed. Fixed by checking the loaded PRTBs in the store before creating, matching on `projectId` + `roleTemplateId` + `principalId`. Shows an error if all selected roles are duplicates, or a warning and skips only duplicates if some are new.

### Technical notes summary

- Norman's `_in` filter requires repeated query parameters, not comma-separated values. `?projectId_in=a&projectId_in=b` works; `?projectId_in=a,b` returns zero results because Go's `net/url.ParseQuery` treats the comma-separated string as a single literal.
- `depaginate: true` in `explorer.js` is safe here because the PRTB fetch is now scoped server-side to the current cluster's projects. The previous conditional depagination (`maxResourceCount: 5000`) was only necessary to avoid loading all global PRTBs — that risk is gone with scoping.
- Duplicate check in `AddProjectMemberDialog.vue` is keyed on `projectId` (not project display name), so projects with identical names in different clusters are correctly distinguished.

### Areas or cases that should be tested

1. Navigate to a cluster with multiple projects → **Cluster and Project Members** → **Project Membership** tab
   - All role bindings for the current cluster's projects should be visible
   - Projects with no role bindings should appear as group headers with a "No roles assigned" row
2. Repeat on a large Rancher instance where total global PRTB count exceeds 5,000 — the tab should still show all bindings for the current cluster
3. Click **Add Project Member**, select a user/group and a role they already hold in that project, click **Create**
   - Error banner should appear; no duplicate binding should be created
4. Click **Add Project Member**, select a mix of new and already-assigned roles, click **Create**
   - Warning banner should appear; only new bindings should be created
5. Add a brand new member with roles — should proceed as normal with no warnings

Tested locally using Chrome against `https://rancher-di.rnd-odinpf.asgard.capi`.

### Areas which could experience regressions

- **Project Membership tab** — any change to how PRTBs are fetched or filtered
- **Add Project Member dialog** — role creation flow; ensure the happy path (no duplicates) is unaffected
- **Other membership tabs** (Cluster Membership) — they use the same `ExplorerMembers.vue` component; confirm they are unaffected by the PRTB scoping change

### Screenshot/Video

<!-- Attach screenshot or video of the changes if available -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
