### PR TITLE
Fix vai sort order, and sort all State columns by pseudo type and then name

### DIFF
--- a/shell/config/pagination-table-headers.js
+++ b/shell/config/pagination-table-headers.js
@@ -33,11 +33,10 @@ export const STEVE_ID_COL = {
 };
 
 export const STEVE_STATE_COL = {
-  ...STATE,
   // Note, we're show the 'state' as per model, not the 'metadata.state.name' that's available in the model to remotely sort/filter
-  // Need to investigate whether we should 'dumb down' the state we show to the native one (tracked via https://github.com/rancher/dashboard/issues/8527)
-  // This means we'll show something different to what we sort and filter on.
-  sort:   ['metadata.state.name'],
+  ...STATE,
+  // non vai sort works on colour --> name. the best we can do here is error --> transitioning --> name
+  sort:   ['metadata.state.error:desc', 'metadata.state.transitioning:desc', 'metadata.state.name'],
   search: 'metadata.state.name',
 };
 

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -229,6 +229,8 @@ class StevePaginationUtils extends NamespaceProjectFilters {
       { field: 'metadata.namespace' },
       { field: 'id' },
       { field: 'metadata.state.name' },
+      { field: 'metadata.state.error' },
+      { field: 'metadata.state.transitioning' },
       { field: 'metadata.creationTimestamp' },
       { field: 'metadata.labels', startsWith: true },
     ],


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
