### PR TITLE
fix: remove isReady logic to inherit from parent model in Virt. Mgmt page

### DIFF
--- a/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
+++ b/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
@@ -27,13 +27,18 @@ export default class HciCluster extends ProvCluster {
   }
 
   get isReady() {
+    const conditions = this.mgmt?.status?.conditions || [];
+    const connected = conditions.find((c) => c.type === 'Connected');
+
     // If the Connected condition exists, use that (2.6+)
-    if ( this.hasCondition('Connected') ) {
-      return this.isCondition('Connected');
+    if (connected) {
+      return connected.status === 'True';
     }
 
     // Otherwise use Ready (older)
-    return this.isCondition('Ready');
+    const ready = conditions.find((c) => c.type === 'Ready');
+
+    return ready?.status === 'True';
   }
 
   get canEdit() {

--- a/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
+++ b/pkg/harvester-manager/models/harvesterhci.io.management.cluster.js
@@ -26,21 +26,6 @@ export default class HciCluster extends ProvCluster {
     }
   }
 
-  get isReady() {
-    const conditions = this.mgmt?.status?.conditions || [];
-    const connected = conditions.find((c) => c.type === 'Connected');
-
-    // If the Connected condition exists, use that (2.6+)
-    if (connected) {
-      return connected.status === 'True';
-    }
-
-    // Otherwise use Ready (older)
-    const ready = conditions.find((c) => c.type === 'Ready');
-
-    return ready?.status === 'True';
-  }
-
   get canEdit() {
     return this.canUpdate && this.canCustomEdit;
   }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/rancher/issues/55160


### Occurred changes and/or fixed issues
Since some status are removed in provisioning API. https://github.com/rancher/rancher/pull/55112
After discuss with rancher backend engineer, we can check imported cluster ready from `management.cattle.io.clusters`.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video

https://github.com/user-attachments/assets/0356757a-60e6-4ff6-aa50-bbe70dad29be



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
