### PR TITLE
[Automation] - Add E2E test for node scheduling regression #16092

### DIFF
--- a/cypress/e2e/po/components/workloads/node-scheduling.po.ts
+++ b/cypress/e2e/po/components/workloads/node-scheduling.po.ts
@@ -1,0 +1,44 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import RadioGroupInputPo from '@/cypress/e2e/po/components/radio-group-input.po';
+
+export default class NodeSchedulingPo extends ComponentPo {
+  constructor(selector = '[data-testid="node-scheduling-selectNode"]') {
+    super(selector);
+  }
+
+  selectNodeRadio(): RadioGroupInputPo {
+    return new RadioGroupInputPo('[data-testid="node-scheduling-selectNode"]');
+  }
+
+  selectAnyNode() {
+    return this.selectNodeRadio().set(0);
+  }
+
+  selectSpecificNode() {
+    return this.selectNodeRadio().set(1);
+  }
+
+  selectSchedulingRules() {
+    return this.selectNodeRadio().set(2);
+  }
+
+  isAnyNodeChecked() {
+    return this.selectNodeRadio().isChecked(0);
+  }
+
+  isSpecificNodeChecked() {
+    return this.selectNodeRadio().isChecked(1);
+  }
+
+  isSchedulingRulesChecked() {
+    return this.selectNodeRadio().isChecked(2);
+  }
+
+  nodeSelector(): Cypress.Chainable {
+    return cy.get('[data-testid="node-scheduling-nodeSelector"]');
+  }
+
+  nodeSelectorNotExist(): Cypress.Chainable {
+    return cy.get('[data-testid="node-scheduling-nodeSelector"]').should('not.exist');
+  }
+}

--- a/cypress/e2e/tests/pages/explorer2/workloads/workloads.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/workloads.spec.ts
@@ -1,41 +1,126 @@
-import { WorkloadsPodsListPagePo } from '@/cypress/e2e/po/pages/explorer/workloads-pods.po';
 import { createPodBlueprint } from '@/cypress/e2e/blueprints/explorer/workload-pods';
-import PodPo from '@/cypress/e2e/po/components/workloads/pod.po';
+import { WorkloadsPodsListPagePo, WorkLoadsPodDetailsPagePo } from '@/cypress/e2e/po/pages/explorer/workloads-pods.po';
 import WorkloadPagePo from '@/cypress/e2e/po/pages/explorer/workloads.po';
-
-const podName = 'some-pod-name';
+import { WorkloadsDeploymentsListPagePo, WorkloadsDeploymentsCreatePagePo } from '@/cypress/e2e/po/pages/explorer/workloads/workloads-deployments.po';
+import { createDeploymentBlueprint } from '@/cypress/e2e/blueprints/explorer/workloads/deployments/deployment-create';
+import NodeSchedulingPo from '@/cypress/e2e/po/components/workloads/node-scheduling.po';
+import { qase } from '@/cypress/support/qase';
 
 describe('Workloads', { tags: ['@noVai', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });
 
-  it('creating a simple pod should appear on the workloads list page', () => {
-    // create a new "simple" Pod (without deployments, replicaSets, Pv's, etc)
-    const workloadsPodPage = new WorkloadsPodsListPagePo('local');
+  describe('Pod creation', () => {
+    let podId: string;
 
-    workloadsPodPage.goTo();
+    before(() => {
+      cy.login();
+      cy.createE2EResourceName('pod').then((name) => {
+        podId = name;
 
-    const createPodPo = new PodPo();
+        // Clean up leftover from a previous run and wait until fully gone
+        cy.deleteRancherResource('v1', 'pods', `default/${ podId }`, false);
+        cy.waitForRancherResource('v1', 'pods', `default/${ podId }`, (resp: any) => resp.status === 404, 20, { failOnStatusCode: false });
 
-    createPodBlueprint.metadata.name = podName;
-    createPodPo.createPodViaKubectl(createPodBlueprint);
+        const podBlueprint: any = structuredClone(createPodBlueprint);
 
-    // check if Pod is in the Workloads list
-    const workload = new WorkloadPagePo('local');
+        podBlueprint.metadata.name = podId;
 
-    // Simple test to assert we haven't broken Workloads detail page
-    // https://github.com/rancher/dashboard/issues/10490
-    workload.goTo();
-    workload.goToDetailsPage(podName);
+        // Create pod via API — deterministic and faster than kubectl terminal
+        cy.createRancherResource('v1', 'pods', JSON.stringify(podBlueprint));
 
-    workload.mastheadTitle().should('contain', podName);
+        // Poll API until pod exists before checking the UI table
+        cy.waitForRancherResource('v1', 'pods', `default/${ podId }`, (resp: any) => resp.status === 200);
+      });
+    });
+
+    after(() => {
+      if (podId) {
+        cy.deleteRancherResource('v1', 'pods', `default/${ podId }`, false);
+      }
+    });
+
+    qase(1403, it('creating a simple pod should appear on the workloads list page', () => {
+      // Navigate to Pods list page and click through to details
+      const podsListPage = new WorkloadsPodsListPagePo('local');
+
+      podsListPage.goTo();
+      podsListPage.waitForPage();
+      podsListPage.goToDetailsPage(podId);
+
+      // Assert detail page shows pod name — https://github.com/rancher/dashboard/issues/10490
+      const podDetailsPage = new WorkLoadsPodDetailsPagePo(podId);
+
+      podDetailsPage.mastheadTitle().should('contain', podId);
+    }));
   });
-  it('Validation errors should not be shown when form is just opened', () => {
+  qase(5538, it('Validation errors should not be shown when form is just opened', () => {
     const workload = new WorkloadPagePo('local');
 
     workload.goTo();
     workload.clickCreate();
     workload.createWorkloadsForm().errorBanner().should('not.exist');
+  }));
+
+  // https://github.com/rancher/dashboard/issues/16092
+  describe('Node Scheduling', () => {
+    const deploymentsListPage = new WorkloadsDeploymentsListPagePo('local');
+    const deploymentEditConfigPage = new WorkloadsDeploymentsCreatePagePo('local');
+
+    let nodeSchedulingDeploymentId: string;
+
+    after(() => {
+      if (nodeSchedulingDeploymentId) {
+        cy.deleteRancherResource('v1', 'apps.deployment', `default/${ nodeSchedulingDeploymentId }`, false);
+      }
+    });
+
+    qase(48753, it('should clear nodeName when switching node scheduling back to any node', () => {
+      // Create a deployment that already has nodeName set (simulating "Run pods on specific nodes")
+      cy.createE2EResourceName('node-sched').then((name) => {
+        nodeSchedulingDeploymentId = name;
+
+        // Clean up any leftover from a previous retry
+        cy.deleteRancherResource('v1', 'apps.deployment', `default/${ nodeSchedulingDeploymentId }`, false);
+
+        const deployment: any = structuredClone(createDeploymentBlueprint);
+
+        deployment.metadata.name = nodeSchedulingDeploymentId;
+        deployment.spec.template.spec.nodeName = 'some-node';
+
+        cy.createRancherResource('v1', 'apps.deployment', JSON.stringify(deployment));
+
+        // Navigate to the deployments list and edit the deployment
+        deploymentsListPage.goTo();
+        deploymentsListPage.waitForPage();
+        deploymentsListPage.goToEditConfigPage(nodeSchedulingDeploymentId);
+
+        // Navigate to Pod tab > Node Scheduling tab
+        deploymentEditConfigPage.horizontalTabs().clickTabWithSelector('li#pod');
+        deploymentEditConfigPage.podTabs().clickTabWithSelector('li#nodeScheduling-pod');
+
+        const nodeScheduling = new NodeSchedulingPo();
+
+        // The radio group should currently be on "Run pods on specific nodes"
+        nodeScheduling.isSpecificNodeChecked();
+
+        // Switch back to "Run pods on any available node"
+        nodeScheduling.selectAnyNode();
+
+        // The node selector dropdown should disappear when switching to "any node"
+        nodeScheduling.nodeSelectorNotExist();
+
+        // Intercept the PUT request and save
+        cy.intercept('PUT', `/v1/apps.deployments/default/${ nodeSchedulingDeploymentId }`).as('editDeployment');
+        deploymentEditConfigPage.resourceDetail().cruResource().saveOrCreate().click();
+
+        // Verify nodeName is cleared from the request body
+        cy.wait('@editDeployment').then(({ request, response }) => {
+          expect(response?.statusCode).to.eq(200);
+          expect(request.body.spec.template.spec).to.not.have.property('nodeName');
+        });
+      });
+    }));
   });
 });


### PR DESCRIPTION
### Summary
Fixes https://github.com/rancher/qa-tasks/issues/2135

Adds a Cypress E2E test covering the bug where switching node scheduling back to "any node" did not clear `nodeName` from the pod template spec (dashboard#16092).

### Occurred changes and/or fixed issues
- New E2E test in `workloads.spec.ts` that creates a deployment with `nodeName` set, edits it via UI to switch back to "any node", and asserts `nodeName` is removed from the PUT request body.
- New `NodeSchedulingPo` page object for interacting with the node scheduling radio group and node selector.
- Added `qase()` wrappers to all `it()` blocks in the spec.
- Hardened: `creating a simple pod should appear on the workloads list page`

### Technical notes summary
N/A

### Areas or cases that should be tested
- Run `workloads.spec.ts` against a Rancher instance with at least one cluster node.
- Tested locally with Chrome headless.

### Areas which could experience regressions
- None expected. This is a new test only no production code changes.

### Screenshot/Video

<img width="917" height="629" alt="image" src="https://github.com/user-attachments/assets/ad197792-dd8e-4960-b49c-83ed7cdd7a25" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles