### PR TITLE
Hide namespace move action when user cannot update

### DIFF
--- a/shell/models/__tests__/namespace.test.ts
+++ b/shell/models/__tests__/namespace.test.ts
@@ -150,6 +150,43 @@ describe('class Namespace', () => {
   it.todo('should disableAutoInjection');
   it.todo('should check if confirmRemove');
 
+  describe('move action availability', () => {
+    const SteveModelProto = Object.getPrototypeOf(Namespace.prototype);
+
+    const makeNamespace = ({ canUpdate }: { canUpdate: boolean }) => {
+      const namespace = new Namespace({});
+
+      jest.spyOn(namespace, '$rootGetters', 'get').mockReturnValue({
+        isRancher:       true,
+        isSingleProduct: false,
+        'i18n/t':        (key: string) => key,
+      });
+      Object.defineProperty(namespace, 'istioInstalled', { get: () => false, configurable: true });
+      Object.defineProperty(namespace, 'canUpdate', { get: () => canUpdate, configurable: true });
+      jest.spyOn(SteveModelProto, '_availableActions', 'get').mockReturnValue([]);
+
+      return namespace;
+    };
+
+    it('should include the move action when user can update the namespace', () => {
+      const namespace = makeNamespace({ canUpdate: true });
+
+      const moveAction = namespace._availableActions.find((a: any) => a.action === 'move');
+
+      expect(moveAction).toBeDefined();
+      expect(moveAction.enabled).toBe(true);
+    });
+
+    it('should disable the move action when user cannot update the namespace', () => {
+      const namespace = makeNamespace({ canUpdate: false });
+
+      const moveAction = namespace._availableActions.find((a: any) => a.action === 'move');
+
+      expect(moveAction).toBeDefined();
+      expect(moveAction.enabled).toBe(false);
+    });
+  });
+
   describe('handling listLocation', () => {
     it.each([
       ['c-cluster-product-projectsnamespaces', true],

--- a/shell/models/__tests__/namespace.test.ts
+++ b/shell/models/__tests__/namespace.test.ts
@@ -171,19 +171,18 @@ describe('class Namespace', () => {
     it('should include the move action when user can update the namespace', () => {
       const namespace = makeNamespace({ canUpdate: true });
 
-      const moveAction = namespace._availableActions.find((a: any) => a.action === 'move');
+      const moveAction = namespace.availableActions.find((a: any) => a.action === 'move');
 
       expect(moveAction).toBeDefined();
       expect(moveAction.enabled).toBe(true);
     });
 
-    it('should disable the move action when user cannot update the namespace', () => {
+    it('should exclude the move action when user cannot update the namespace', () => {
       const namespace = makeNamespace({ canUpdate: false });
 
-      const moveAction = namespace._availableActions.find((a: any) => a.action === 'move');
+      const moveAction = namespace.availableActions.find((a: any) => a.action === 'move');
 
-      expect(moveAction).toBeDefined();
-      expect(moveAction.enabled).toBe(false);
+      expect(moveAction).toBeUndefined();
     });
   });
 

--- a/shell/models/namespace.js
+++ b/shell/models/namespace.js
@@ -68,7 +68,7 @@ export default class Namespace extends SteveModel {
         label:      this.t('namespace.move'),
         bulkable:   true,
         bulkAction: 'move',
-        enabled:    true,
+        enabled:    this.canUpdate,
         icon:       'icon icon-fork',
         weight:     3,
       });


### PR DESCRIPTION
### Summary
Fixes #17709

### Occurred changes and/or fixed issues
- Namespace `Move` action was visible for users who lack update permission
- `enabled: true` changed to `enabled: this.canUpdate` in the move action definition

### Technical notes summary
- Unit tests added covering both enabled and disabled cases
- `canUpdate` isn't entirely sufficient. Moving a namespace also requires `manage-namespaces` on the target project. A user with namespace `update` but without `manage-namespaces` on the target project will see the action but get a server-side rejection when saving. We'd have to check each pairing to verify if a user can move to a particular project but we might as well do that check when they make the pairing.

### Areas or cases that should be tested
- Standard user with read-only project access: Move should not appear in context menu or toolbar
- Admin or project-owner: Move should still appear and work

### Areas which could experience regressions
- Namespace context menu actions in Cluster Explorer
- Bulk action toolbar on Projects/Namespaces page
- Namespace actions in Cluster Management hover menus

### Screenshot/Video

**Before** (read-only user sees Move action):

https://github.com/user-attachments/assets/e106d921-7427-45af-8286-cd400df3668a

**After** (Move action hidden for read-only user):

https://github.com/user-attachments/assets/abcff36e-4248-4b1f-b6c2-1b9e4ec9bcbd

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

