### PR TITLE
Fix deployment detail page performance with many services/pods

### DIFF
--- a/shell/detail/__tests__/workload.test.ts
+++ b/shell/detail/__tests__/workload.test.ts
@@ -18,7 +18,8 @@ describe('findMatchingIngresses', () => {
       ingressSchema:     true,
       allIngresses:      [],
       matchingIngresses: [],
-      value:             { metadata: { namespace: 'test' }, relatedServices: [] }
+      relatedServices:   [],
+      value:             { metadata: { namespace: 'test' } }
     };
 
     findMatchingIngresses.call(mockThis);
@@ -35,7 +36,8 @@ describe('findMatchingIngresses', () => {
         }
       ],
       matchingIngresses: [],
-      value:             { metadata: { namespace: 'test' }, relatedServices: [{ metadata: { name: 'service1' } }] }
+      relatedServices:   [{ metadata: { name: 'service1' } }],
+      value:             { metadata: { namespace: 'test' } }
     };
 
     findMatchingIngresses.call(mockThis);
@@ -53,7 +55,8 @@ describe('findMatchingIngresses', () => {
         }
       ],
       matchingIngresses: [],
-      value:             { metadata: { namespace: 'test' }, relatedServices: [{ metadata: { name: 'service1' } }] }
+      relatedServices:   [{ metadata: { name: 'service1' } }],
+      value:             { metadata: { namespace: 'test' } }
     };
 
     findMatchingIngresses.call(mockThis);
@@ -70,7 +73,8 @@ describe('findMatchingIngresses', () => {
         }
       ],
       matchingIngresses: [],
-      value:             { metadata: { namespace: 'test' }, relatedServices: [{ metadata: { name: 'service1' } }] }
+      relatedServices:   [{ metadata: { name: 'service1' } }],
+      value:             { metadata: { namespace: 'test' } }
     };
 
     findMatchingIngresses.call(mockThis);
@@ -87,7 +91,8 @@ describe('findMatchingIngresses', () => {
         }
       ],
       matchingIngresses: [],
-      value:             { metadata: { namespace: 'test' }, relatedServices: [{ metadata: { name: 'service1' } }] }
+      relatedServices:   [{ metadata: { name: 'service1' } }],
+      value:             { metadata: { namespace: 'test' } }
     };
 
     findMatchingIngresses.call(mockThis);
@@ -104,7 +109,8 @@ describe('findMatchingIngresses', () => {
         }
       ],
       matchingIngresses: [],
-      value:             { metadata: { namespace: 'test' }, relatedServices: [{ metadata: { name: 'service1' } }] }
+      relatedServices:   [{ metadata: { name: 'service1' } }],
+      value:             { metadata: { namespace: 'test' } }
     };
 
     findMatchingIngresses.call(mockThis);
@@ -121,7 +127,8 @@ describe('findMatchingIngresses', () => {
         }
       ],
       matchingIngresses: [],
-      value:             { metadata: { namespace: 'test' }, relatedServices: [{ metadata: { name: 'service1' } }] }
+      relatedServices:   [{ metadata: { name: 'service1' } }],
+      value:             { metadata: { namespace: 'test' } }
     };
 
     findMatchingIngresses.call(mockThis);
@@ -146,7 +153,8 @@ describe('findMatchingIngresses', () => {
         }
       ],
       matchingIngresses: [],
-      value:             { metadata: { namespace: 'test' }, relatedServices: [{ metadata: { name: 'service1' } }] }
+      relatedServices:   [{ metadata: { name: 'service1' } }],
+      value:             { metadata: { namespace: 'test' } }
     };
 
     findMatchingIngresses.call(mockThis);

--- a/shell/detail/workload/index.vue
+++ b/shell/detail/workload/index.vue
@@ -124,6 +124,10 @@ export default {
       return this.$store.getters['cluster/schemaFor'](SERVICE);
     },
 
+    relatedServices() {
+      return this.value.relatedServices;
+    },
+
     podTemplateSpec() {
       if ( this.value.type === WORKLOAD_TYPES.CRON_JOB ) {
         return this.value.spec.jobTemplate.spec.template.spec;
@@ -214,10 +218,15 @@ export default {
         return [];
       }
 
-      // Find Ingresses that forward traffic to Services
-      // that select this workload.
+      const workloadNamespace = this.value.metadata?.namespace;
+      const relatedServiceNames = new Set(
+        this.relatedServices.map((s) => s?.metadata?.name)
+      );
+
       const matchingIngresses = this.allIngresses.filter((ingress) => {
         try {
+          if (ingress.metadata?.namespace !== workloadNamespace) return false;
+
           const rules = ingress.spec.rules;
 
           if (!rules || !Array.isArray(rules)) return false;
@@ -226,21 +235,12 @@ export default {
             const paths = rules[i]?.http?.paths;
 
             if (!paths || !Array.isArray(paths)) continue;
-            // For each Ingress, check if any Services that match
-            // this workload are also target backends for the Ingress.
+
             for (let j = 0; j < paths.length; j++) {
-              const pathData = paths[j];
-              const targetServiceName = pathData?.backend?.service?.name;
+              const targetServiceName = paths[j]?.backend?.service?.name;
 
-              if (!targetServiceName) continue;
-
-              for (let k = 0; k < this.value.relatedServices.length; k++) {
-                const service = this.value.relatedServices[k];
-                const matchingServiceName = service?.metadata?.name;
-
-                if (ingress.metadata?.namespace === this.value.metadata?.namespace && matchingServiceName === targetServiceName) {
-                  return true;
-                }
+              if (targetServiceName && relatedServiceNames.has(targetServiceName)) {
+                return true;
               }
             }
           }
@@ -348,7 +348,7 @@ export default {
           {{ t('workload.detail.cannotViewServices') }}
         </p>
         <p
-          v-else-if="value.relatedServices.length === 0"
+          v-else-if="relatedServices.length === 0"
           class="caption"
         >
           {{ t('workload.detail.cannotFindServices') }}
@@ -360,8 +360,8 @@ export default {
           {{ t('workload.detail.serviceListCaption') }}
         </p>
         <ResourceTable
-          v-if="serviceSchema && value.relatedServices.length > 0"
-          :rows="value.relatedServices"
+          v-if="serviceSchema && relatedServices.length > 0"
+          :rows="relatedServices"
           :headers="serviceHeaders"
           key-field="id"
           :schema="serviceSchema"

--- a/shell/detail/workload/index.vue
+++ b/shell/detail/workload/index.vue
@@ -220,8 +220,14 @@ export default {
 
       const workloadNamespace = this.value.metadata?.namespace;
       const relatedServiceNames = new Set(
-        this.relatedServices.map((s) => s?.metadata?.name)
+        this.relatedServices.map((s) => s?.metadata?.name).filter(Boolean)
       );
+
+      if (!workloadNamespace || relatedServiceNames.size === 0) {
+        this.matchingIngresses = [];
+
+        return;
+      }
 
       const matchingIngresses = this.allIngresses.filter((ingress) => {
         try {

--- a/shell/models/__tests__/workload.test.ts
+++ b/shell/models/__tests__/workload.test.ts
@@ -160,12 +160,7 @@ describe('class: Workload', () => {
   });
 
   describe('getter: relatedServices', () => {
-    it('should return services that match workload pods', () => {
-      const mockPod = {
-        metadata: {
-          name: 'pod-1', namespace: 'default', labels: { app: 'my-app' }
-        }
-      };
+    it('should return services that match workload pod template labels', () => {
       const mockService = {
         metadata: { name: 'my-service', namespace: 'default' },
         spec:     { selector: { app: 'my-app' } }
@@ -173,7 +168,7 @@ describe('class: Workload', () => {
       const workload = new Workload({
         type:     WORKLOAD_TYPES.DEPLOYMENT,
         metadata: { name: 'test', namespace: 'default' },
-        spec:     {}
+        spec:     { template: { metadata: { labels: { app: 'my-app' } } } }
       }, {
         getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
         dispatch:    jest.fn(),
@@ -182,9 +177,6 @@ describe('class: Workload', () => {
           'cluster/all': (type: string) => (type === SERVICE ? [mockService] : [])
         },
       });
-
-      // Mock pods getter
-      Object.defineProperty(workload, 'pods', { get: () => [mockPod] });
 
       const related = workload.relatedServices;
 
@@ -192,11 +184,6 @@ describe('class: Workload', () => {
     });
 
     it('should not return services from different namespace', () => {
-      const mockPod = {
-        metadata: {
-          name: 'pod-1', namespace: 'default', labels: { app: 'my-app' }
-        }
-      };
       const mockService = {
         metadata: { name: 'my-service', namespace: 'other-namespace' },
         spec:     { selector: { app: 'my-app' } }
@@ -204,7 +191,7 @@ describe('class: Workload', () => {
       const workload = new Workload({
         type:     WORKLOAD_TYPES.DEPLOYMENT,
         metadata: { name: 'test', namespace: 'default' },
-        spec:     {}
+        spec:     { template: { metadata: { labels: { app: 'my-app' } } } }
       }, {
         getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
         dispatch:    jest.fn(),
@@ -213,8 +200,6 @@ describe('class: Workload', () => {
           'cluster/all': (type: string) => (type === SERVICE ? [mockService] : [])
         },
       });
-
-      Object.defineProperty(workload, 'pods', { get: () => [mockPod] });
 
       const related = workload.relatedServices;
 
@@ -222,11 +207,6 @@ describe('class: Workload', () => {
     });
 
     it('should not return services with non-matching selectors', () => {
-      const mockPod = {
-        metadata: {
-          name: 'pod-1', namespace: 'default', labels: { app: 'my-app' }
-        }
-      };
       const mockService = {
         metadata: { name: 'my-service', namespace: 'default' },
         spec:     { selector: { app: 'different-app' } }
@@ -234,7 +214,7 @@ describe('class: Workload', () => {
       const workload = new Workload({
         type:     WORKLOAD_TYPES.DEPLOYMENT,
         metadata: { name: 'test', namespace: 'default' },
-        spec:     {}
+        spec:     { template: { metadata: { labels: { app: 'my-app' } } } }
       }, {
         getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
         dispatch:    jest.fn(),
@@ -244,7 +224,28 @@ describe('class: Workload', () => {
         },
       });
 
-      Object.defineProperty(workload, 'pods', { get: () => [mockPod] });
+      const related = workload.relatedServices;
+
+      expect(related).toHaveLength(0);
+    });
+
+    it('should return empty array when pod template has no labels', () => {
+      const mockService = {
+        metadata: { name: 'my-service', namespace: 'default' },
+        spec:     { selector: { app: 'my-app' } }
+      };
+      const workload = new Workload({
+        type:     WORKLOAD_TYPES.DEPLOYMENT,
+        metadata: { name: 'test', namespace: 'default' },
+        spec:     { template: { metadata: {} } }
+      }, {
+        getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
+        dispatch:    jest.fn(),
+        rootGetters: {
+          'i18n/t':      jest.fn(),
+          'cluster/all': (type: string) => (type === SERVICE ? [mockService] : [])
+        },
+      });
 
       const related = workload.relatedServices;
 

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -3,7 +3,7 @@ import { CATTLE_PUBLIC_ENDPOINTS } from '@shell/config/labels-annotations';
 import { WORKLOAD_TYPES, SERVICE, POD } from '@shell/config/types';
 import { set } from '@shell/utils/object';
 import day from 'dayjs';
-import { convertSelectorObj, parse, matches } from '@shell/utils/selector';
+import { convertSelectorObj, parse, matches, convert } from '@shell/utils/selector';
 import { SEPARATOR } from '@shell/config/workload';
 import WorkloadService from '@shell/models/workload.service';
 import { matching } from '@shell/utils/selector-typed';
@@ -747,19 +747,22 @@ export default class Workload extends WorkloadService {
   }
 
   get relatedServices() {
-    // Find Services that have selectors that match this workload's Pod(s).
+    const podTemplateLabels = this.spec?.template?.metadata?.labels;
+
+    if (!podTemplateLabels || Object.keys(podTemplateLabels).length === 0) {
+      return [];
+    }
+
+    const templateAsObj = { metadata: { labels: podTemplateLabels } };
+
     return this.servicesInNamespace.filter((service) => {
       const selector = service.spec.selector;
 
-      for (let i = 0; i < this.pods.length; i++) {
-        const pod = this.pods[i];
-
-        if (service.metadata?.namespace === this.metadata?.namespace && matches(pod, selector)) {
-          return true;
-        }
+      if (!selector || typeof selector !== 'object') {
+        return false;
       }
 
-      return false;
+      return matches(templateAsObj, convert(selector));
     });
   }
 

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -747,6 +747,10 @@ export default class Workload extends WorkloadService {
   }
 
   get relatedServices() {
+    if (this.type === WORKLOAD_TYPES.JOB || this.type === WORKLOAD_TYPES.CRON_JOB) {
+      return [];
+    }
+
     const podTemplateLabels = this.spec?.template?.metadata?.labels;
 
     if (!podTemplateLabels || Object.keys(podTemplateLabels).length === 0) {


### PR DESCRIPTION
### Summary
Fixes #17488

### Occurred changes and/or fixed issues
The deployment detail page hangs when a namespace has many services and pods.

- `relatedServices` in `workload.js` iterated all pods for every service (O(services * pods)). Now matches against pod template labels directly (O(services)).
- `findMatchingIngresses` in `detail/workload/index.vue` used a triple-nested loop. Now uses a Set for O(1) service name lookups.

### Test File
- [`perf-test-resources.yaml`](https://github.com/codyrancher/dashboard/releases/download/issue-17488-artifacts/perf-test-resources.yaml) - apply with `kubectl apply -f perf-test-resources.yaml`
- To clean up the resources `kubectl delete namespace perf-test`

### Technical notes summary
- `relatedServices` uses `this.spec?.template?.metadata?.labels` instead of iterating `this.pods`, eliminating the pods store dependency.
- `findMatchingIngresses` pre-computes a `Set` of related service names and filters by namespace early.

### Areas or cases that should be tested
- Deployment detail page in a namespace with many resources (300 deployments, 280 services, 500 pods, 230 ingresses) should load without hanging.
- Services and Ingresses tabs show correct results.

### Areas which could experience regressions
- Workload detail pages (deployment, daemonset, statefulset) that display related services or matching ingresses.

### Screenshot/Video

Before:

![deployment-list](https://github.com/codyrancher/dashboard/releases/download/issue-17488-artifacts/deployment-list.png)

After:

![deployment-detail](https://github.com/codyrancher/dashboard/releases/download/issue-17488-artifacts/deployment-detail.png)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`