### PR TITLE
Skip setting nested null values when parent path is already a primitive

### DIFF
--- a/shell/utils/__tests__/object.test.ts
+++ b/shell/utils/__tests__/object.test.ts
@@ -287,6 +287,28 @@ describe('fx: diff', () => {
     expect(result).toStrictEqual(expected);
     expect(result.parent.child.config).not.toHaveProperty('annotations', null);
   });
+
+  it('should handle type change from object in from to primitive in to without throwing', () => {
+    // from[k] is an object, to[k] is a string (e.g. a pre-existing secret name).
+    // The whole value was replaced; nested keys from from should not be nulled out.
+    const from = {
+      githubConfigSecret: { github_token: '' },
+      githubConfigUrl:    '',
+    };
+    const to = {
+      githubConfigUrl:    'https://github.com/abc',
+      githubConfigSecret: 'preexisting-secret',
+    };
+
+    expect(() => diff(from, to)).not.toThrow();
+
+    const result = diff(from, to);
+
+    expect(result.githubConfigSecret).toStrictEqual('preexisting-secret');
+    expect(result.githubConfigUrl).toStrictEqual('https://github.com/abc');
+    // No garbage nested null should be injected under the replaced key
+    expect(Object.keys(result)).not.toContain('githubConfigSecret.github_token');
+  });
 });
 
 describe('fx: definedKeys', () => {

--- a/shell/utils/object.js
+++ b/shell/utils/object.js
@@ -267,7 +267,7 @@ export function diff(from, to, preventNull = false) {
     }
 
     if (preventNull) {
-    // keys that come from "definedKeys" method are strings with "" chars inside... We need to clean them up
+      // keys that come from "definedKeys" method are strings with "" chars inside... We need to clean them up
       // so that we can access the value of the obj property
       let key = k;
 
@@ -282,7 +282,24 @@ export function diff(from, to, preventNull = false) {
         set(out, key, null);
       }
     } else {
-      set(out, k, null);
+      const parts = splitObjectPath(k);
+
+      // Skip any missing nested key whose parent path in out is already a
+      // non-object. We don't want to attempt to null out the key that appeared
+      // in the diff when a pre-defined key
+      // (githubConfigSecret.github_token: '') gets updated to
+      // (githubConfigSecret: 'preexisting-secret')
+      const skip = parts.some((part) => {
+        const existingVal = out?.[part];
+
+        if (existingVal !== undefined && !isObject(existingVal)) {
+          return true;
+        }
+      });
+
+      if (!skip) {
+        set(out, k, null);
+      }
     }
   }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This skips setting nested null values when parent path is already a primitive.

Fixes #17849
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Skip setting nested null values when parent path is already a primitive

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The primary aim for this fix is to resolve a scenario where `from.githubConfigSecret` was an object but `to.githubConfigSecret` was a string. `set` will traverse `out.githubConfigSecret` (the string  'preexisting-secret') as if it were an object and throw an error. The value is already specified, so there's no need to attempt to "null out" the "missing" key.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

See the associated issue for more details.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Existing app installs that do not touch upon this issue should behave as they did before.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
