### PR TITLE
Restrict cluster switch shortcut to Cluster Explorer only

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -100,7 +100,7 @@ export default {
     },
 
     routeComboActive() {
-      if (!this.routeCombo) {
+      if (!this.routeCombo || !this.isCurrRouteClusterExplorer) {
         return false;
       }
 

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -12,6 +12,7 @@ import { KEY } from '@shell/utils/platform';
 import { getVersionInfo } from '@shell/utils/version';
 import { SETTING } from '@shell/config/settings';
 import { getProductFromRoute } from '@shell/utils/router';
+import { NAME as EXPLORER } from '@shell/config/product/explorer';
 import { isRancherPrime } from '@shell/config/version';
 import Pinned from '@shell/components/nav/Pinned';
 import sideNavService from '@shell/components/nav/TopLevelMenu.helper';
@@ -237,7 +238,7 @@ export default {
     },
 
     isCurrRouteClusterExplorer() {
-      return this.$route?.name?.startsWith('c-cluster');
+      return this.$route?.name?.startsWith('c-cluster') && this.productFromRoute === EXPLORER;
     },
 
     productFromRoute() {
@@ -393,6 +394,10 @@ export default {
     },
 
     handleKeyComboClick() {
+      if (!this.isCurrRouteClusterExplorer) {
+        return;
+      }
+
       this.routeCombo = !this.routeCombo;
     },
 
@@ -411,6 +416,8 @@ export default {
 
           return this.$router.push(clusterRoute);
         }
+
+        return;
       }
 
       return this.$router.push(cluster.clusterRoute);

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -416,8 +416,6 @@ export default {
 
           return this.$router.push(clusterRoute);
         }
-
-        return;
       }
 
       return this.$router.push(cluster.clusterRoute);

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -836,5 +836,121 @@ describe('topLevelMenu', () => {
         expect(wrapper.vm.routeComboActive).toBe(true);
       });
     });
+
+    describe('handleKeyComboClick', () => {
+      it('should not toggle routeCombo when route is not cluster explorer', async() => {
+        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+          global: {
+            mocks: {
+              $route:  { name: 'fleet-management', params: {} },
+              $router: { push: jest.fn() },
+              $store:  { ...generateStore([]) }
+            },
+            stubs: ['BrandImage', 'router-link'],
+          }
+        });
+
+        await waitForIt();
+
+        expect(wrapper.vm.routeCombo).toBe(false);
+        wrapper.vm.handleKeyComboClick();
+        expect(wrapper.vm.routeCombo).toBe(false);
+      });
+
+      it('should toggle routeCombo when route is cluster explorer', async() => {
+        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+          global: {
+            mocks: {
+              $route:  { name: 'c-cluster-explorer', params: { cluster: 'local', product: 'explorer' } },
+              $router: { push: jest.fn() },
+              $store:  { ...generateStore([]) }
+            },
+            stubs: ['BrandImage', 'router-link'],
+          }
+        });
+
+        await waitForIt();
+
+        expect(wrapper.vm.routeCombo).toBe(false);
+        wrapper.vm.handleKeyComboClick();
+        expect(wrapper.vm.routeCombo).toBe(true);
+      });
+    });
+
+    describe('clusterMenuClick', () => {
+      it('should not navigate when routeComboActive is true but route is not cluster explorer', async() => {
+        const mockPush = jest.fn();
+        const clusters = [
+          {
+            nameDisplay:  'cluster1',
+            id:           'an-id1',
+            mgmt:         { id: 'an-id1' },
+            canExplore:   true,
+            clusterRoute: { name: 'c-cluster-explorer' }
+          },
+          {
+            nameDisplay:  'cluster2',
+            id:           'an-id2',
+            mgmt:         { id: 'an-id2' },
+            canExplore:   true,
+            clusterRoute: { name: 'c-cluster-explorer' }
+          }
+        ];
+
+        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+          global: {
+            mocks: {
+              $route:  { name: 'fleet-management', params: {} },
+              $router: { push: mockPush },
+              $store:  { ...generateStore(clusters) }
+            },
+            stubs: ['BrandImage', 'router-link'],
+          }
+        });
+
+        await waitForIt();
+        await wrapper.setData({ routeCombo: true });
+
+        const ev = { preventDefault: jest.fn() };
+
+        wrapper.vm.clusterMenuClick(ev, clusters[1]);
+
+        expect(ev.preventDefault).toHaveBeenCalledWith();
+        expect(mockPush).not.toHaveBeenCalled();
+      });
+
+      it('should navigate to cluster route when routeComboActive is false', async() => {
+        const mockPush = jest.fn();
+        const clusterRoute = { name: 'c-cluster-explorer' };
+        const clusters = [
+          {
+            nameDisplay: 'cluster1',
+            id:          'an-id1',
+            mgmt:        { id: 'an-id1' },
+            canExplore:  true,
+            clusterRoute
+          }
+        ];
+
+        const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
+          global: {
+            mocks: {
+              $route:  { name: 'fleet-management', params: {} },
+              $router: { push: mockPush },
+              $store:  { ...generateStore(clusters) }
+            },
+            stubs: ['BrandImage', 'router-link'],
+          }
+        });
+
+        await waitForIt();
+
+        const ev = { preventDefault: jest.fn() };
+
+        wrapper.vm.clusterMenuClick(ev, clusters[0]);
+
+        expect(mockPush).toHaveBeenCalledWith(clusterRoute);
+      });
+    });
   });
 });

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -720,7 +720,7 @@ describe('topLevelMenu', () => {
         const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
           global: {
             mocks: {
-              $route: {},
+              $route: { name: 'c-cluster-explorer', params: { cluster: 'local', product: 'explorer' } },
               $store: {
                 ...generateStore([
                   {
@@ -823,7 +823,7 @@ describe('topLevelMenu', () => {
         const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
           global: {
             mocks: {
-              $route: {},
+              $route: { name: 'c-cluster-explorer', params: { cluster: 'local', product: 'explorer' } },
               $store: store
             },
             stubs: ['BrandImage', 'router-link'],
@@ -838,11 +838,11 @@ describe('topLevelMenu', () => {
     });
 
     describe('handleKeyComboClick', () => {
-      it('should not toggle routeCombo when route is not cluster explorer', async() => {
+      it('should not toggle routeCombo when route is a non-explorer c-cluster route', async() => {
         const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
           global: {
             mocks: {
-              $route:  { name: 'fleet-management', params: {} },
+              $route:  { name: 'c-cluster-fleet', params: { cluster: 'local', product: 'fleet' } },
               $router: { push: jest.fn() },
               $store:  { ...generateStore([]) }
             },
@@ -878,29 +878,30 @@ describe('topLevelMenu', () => {
     });
 
     describe('clusterMenuClick', () => {
-      it('should not navigate when routeComboActive is true but route is not cluster explorer', async() => {
+      it('should navigate normally on non-explorer c-cluster route even with routeCombo set', async() => {
         const mockPush = jest.fn();
+        const clusterRoute = { name: 'c-cluster-explorer' };
         const clusters = [
           {
-            nameDisplay:  'cluster1',
-            id:           'an-id1',
-            mgmt:         { id: 'an-id1' },
-            canExplore:   true,
-            clusterRoute: { name: 'c-cluster-explorer' }
+            nameDisplay: 'cluster1',
+            id:          'an-id1',
+            mgmt:        { id: 'an-id1' },
+            canExplore:  true,
+            clusterRoute
           },
           {
-            nameDisplay:  'cluster2',
-            id:           'an-id2',
-            mgmt:         { id: 'an-id2' },
-            canExplore:   true,
-            clusterRoute: { name: 'c-cluster-explorer' }
+            nameDisplay: 'cluster2',
+            id:          'an-id2',
+            mgmt:        { id: 'an-id2' },
+            canExplore:  true,
+            clusterRoute
           }
         ];
 
         const wrapper: Wrapper<InstanceType<typeof TopLevelMenu>> = mount(TopLevelMenu, {
           global: {
             mocks: {
-              $route:  { name: 'fleet-management', params: {} },
+              $route:  { name: 'c-cluster-fleet', params: { cluster: 'local', product: 'fleet' } },
               $router: { push: mockPush },
               $store:  { ...generateStore(clusters) }
             },
@@ -911,12 +912,13 @@ describe('topLevelMenu', () => {
         await waitForIt();
         await wrapper.setData({ routeCombo: true });
 
+        expect(wrapper.vm.routeComboActive).toBe(false);
+
         const ev = { preventDefault: jest.fn() };
 
         wrapper.vm.clusterMenuClick(ev, clusters[1]);
 
-        expect(ev.preventDefault).toHaveBeenCalledWith();
-        expect(mockPush).not.toHaveBeenCalled();
+        expect(mockPush).toHaveBeenCalledWith(clusterRoute);
       });
 
       it('should navigate to cluster route when routeComboActive is false', async() => {


### PR DESCRIPTION
### Summary
Fixes #13286

### Occurred changes and/or fixed issues

The Alt+Click cluster switch shortcut was activating on product-level extensions (Fleet, Global Settings) because `isCurrRouteClusterExplorer` only checked if the route started with `c-cluster`. Now it also checks the product is `explorer`. `handleKeyComboClick` is also gated so the combo mode never activates outside Cluster Explorer.

### Technical notes summary

- `isCurrRouteClusterExplorer` adds `productFromRoute === EXPLORER` check
- `handleKeyComboClick` returns early when not in Cluster Explorer
- `clusterMenuClick` returns early when combo is active but not in Explorer

### Areas or cases that should be tested

- Cluster Explorer: hold Alt, verify combo icon appears and cluster switching works
- Fleet / Global Settings: hold Alt, verify no combo icon appears
- Multiple pinned/unpinned clusters

### Areas which could experience regressions

- Cluster switching in Cluster Explorer

### Screenshot/Video

**Before (bug):** combo icon appears in Fleet and Global Settings

https://github.com/user-attachments/assets/77890ae5-76b8-4752-9734-13e190f16b2a

**After (fix):** combo icon only appears in Cluster Explorer

https://github.com/user-attachments/assets/6d79a56f-9908-4c75-a7da-1fde7dd61c99

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`