### PR TITLE
Automation: Fix custom add-on config test

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -327,7 +327,8 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
           expect(obj.kind).to.equal('Cluster');
         });
       }));
-      it('preserves custom addon config values after saving cluster config', () => {
+
+      qase(48756, it('preserves custom addon config values after saving cluster config', () => {
         const customAddonConfig = `goodvalue: yay\nnested:\n  enabled: true`;
         const updatedDescription = `${ rke2CustomName }-addon-persist-check`;
 
@@ -354,8 +355,8 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         editCreatedClusterPage().clusterConfigurationTabs().clickTabWithSelector('#rke2-calico');
         editCreatedClusterPage().calicoAddonConfig().yamlEditor().input()
           .value()
-          .should('equal', customAddonConfig);
-      });
+          .should('include', customAddonConfig);
+      }));
 
       it('can navigate to Cluster Provisioning Log tab in the detail page', () => {
         const detailPage = detailRKE2ClusterPage();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2351

### Summary

Stabilizes flaky `preserves custom addon config values after saving cluster config` test:

 On re-edit, the Calico YAML editor renders the full default chart values merged with the user's custom values appended at the end (e.g. `goodvalue: yay\nnested:\n  enabled: true`). The custom values are correctly persisted, but the stored YAML is no longer byte-equal to what the test wrote, so `.should('equal', customAddonConfig)` fails. Relaxed the assertion to `.should('include', customAddonConfig)`, which still proves the custom keys persisted through save -> reload.

<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="737" height="286" alt="image" src="https://github.com/user-attachments/assets/556d387b-4698-4e8a-8148-db4a20f16732" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
