### PR TITLE
Hide PNI checkbox for local (and imported) RKE2 and K3s clusters

### DIFF
--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -207,10 +207,11 @@ export default defineComponent({
     },
     enableNetworkPolicySupported() {
       // https://github.com/rancher/rancher/pull/33070/files
-      // Also check mgmt status provider for local clusters where spec.rkeConfig may not be set
+      // Also check mgmt status provider for local clusters where spec.rkeConfig may not be set (rke2)
+      // or where isK3s may not be set correctly
       const mgmtProvider = this.value.mgmt?.status?.provider;
 
-      return !this.isK3s && !this.isRke2 && !mgmtProvider?.startsWith('rke2');
+      return !this.isK3s && !this.isRke2 && !mgmtProvider?.startsWith('rke2') && mgmtProvider !== 'k3s';
     },
     isLocal() {
       return !!this.value.isLocal;

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -207,7 +207,10 @@ export default defineComponent({
     },
     enableNetworkPolicySupported() {
       // https://github.com/rancher/rancher/pull/33070/files
-      return !this.isK3s && !this.isRke2;
+      // Also check mgmt status provider for local clusters where spec.rkeConfig may not be set
+      const mgmtProvider = this.value.mgmt?.status?.provider;
+
+      return !this.isK3s && !this.isRke2 && !mgmtProvider?.startsWith('rke2');
     },
     isLocal() {
       return !!this.value.isLocal;

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -197,9 +197,7 @@ export default defineComponent({
       return this.mode === _CREATE;
     },
     isK3s() {
-      const mgmtProvider = this.value.mgmt?.status?.provider;
-
-      return !!(this.value.isK3s || mgmtProvider === 'k3s');
+      return !!this.value.isK3s;
     },
     isRKE1() {
       return !!this.value.isRke1;

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -207,11 +207,13 @@ export default defineComponent({
     },
     enableNetworkPolicySupported() {
       // https://github.com/rancher/rancher/pull/33070/files
-      // Also check mgmt status provider for local clusters where spec.rkeConfig may not be set (rke2)
-      // or where isK3s may not be set correctly
+      // Also check mgmt status provider for local clusters where spec.rkeConfig may not be set
+      // (local RKE2 clusters have no spec.rkeConfig so isRke2 is false, but status.provider is 'rke2')
       const mgmtProvider = this.value.mgmt?.status?.provider;
+      const isK3sCluster = this.isK3s || mgmtProvider === 'k3s';
+      const isRke2Cluster = this.isRke2 || mgmtProvider?.startsWith('rke2');
 
-      return !this.isK3s && !this.isRke2 && !mgmtProvider?.startsWith('rke2') && mgmtProvider !== 'k3s';
+      return !isK3sCluster && !isRke2Cluster;
     },
     isLocal() {
       return !!this.value.isLocal;

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -197,23 +197,23 @@ export default defineComponent({
       return this.mode === _CREATE;
     },
     isK3s() {
-      return !!this.value.isK3s;
+      const mgmtProvider = this.value.mgmt?.status?.provider;
+
+      return !!(this.value.isK3s || mgmtProvider === 'k3s');
     },
     isRKE1() {
       return !!this.value.isRke1;
     },
     isRke2() {
-      return !!this.value.isRke2;
-    },
-    enableNetworkPolicySupported() {
-      // https://github.com/rancher/rancher/pull/33070/files
       // Also check mgmt status provider for local clusters where spec.rkeConfig may not be set
       // (local RKE2 clusters have no spec.rkeConfig so isRke2 is false, but status.provider is 'rke2')
       const mgmtProvider = this.value.mgmt?.status?.provider;
-      const isK3sCluster = this.isK3s || mgmtProvider === 'k3s';
-      const isRke2Cluster = this.isRke2 || mgmtProvider?.startsWith('rke2');
 
-      return !isK3sCluster && !isRke2Cluster;
+      return !!(this.value.isRke2 || mgmtProvider?.startsWith('rke2'));
+    },
+    enableNetworkPolicySupported() {
+      // https://github.com/rancher/rancher/pull/33070/files
+      return !this.isK3s && !this.isRke2;
     },
     isLocal() {
       return !!this.value.isLocal;

--- a/pkg/imported/components/__tests__/CruImported.test.ts
+++ b/pkg/imported/components/__tests__/CruImported.test.ts
@@ -147,6 +147,27 @@ describe('cruImported component', () => {
 
       expect(networkAccordion.exists()).toBe(false);
     });
+    it('should hide the networking tab for local K3s clusters detected via mgmt status provider', () => {
+      const wrapper = shallowMount(CruImported, {
+        propsData: {
+          mode:  _EDIT,
+          value: {
+            id:                'cluster-id',
+            isRke1:            false,
+            isLocal:           true,
+            isK3s:             false,
+            isRke2:            false,
+            mgmt:              { status: { provider: 'k3s' } },
+            findNormanCluster: jest.fn().mockResolvedValue({})
+          }
+        },
+        ...defaultSetup
+      });
+
+      const networkAccordion = wrapper.find('[data-testid="network-accordion"]');
+
+      expect(networkAccordion.exists()).toBe(false);
+    });
 
     it('should not display the ACE component if cluster is local', () => {
       const wrapper = shallowMount(CruImported, {

--- a/pkg/imported/components/__tests__/CruImported.test.ts
+++ b/pkg/imported/components/__tests__/CruImported.test.ts
@@ -126,6 +126,28 @@ describe('cruImported component', () => {
       expect(networkAccordion.exists()).toBe(false);
     });
 
+    it('should hide the networking tab for local RKE2 clusters detected via mgmt status provider', () => {
+      const wrapper = shallowMount(CruImported, {
+        propsData: {
+          mode:  _EDIT,
+          value: {
+            id:                'cluster-id',
+            isRke1:            false,
+            isLocal:           true,
+            isK3s:             false,
+            isRke2:            false,
+            mgmt:              { status: { provider: 'rke2' } },
+            findNormanCluster: jest.fn().mockResolvedValue({})
+          }
+        },
+        ...defaultSetup
+      });
+
+      const networkAccordion = wrapper.find('[data-testid="network-accordion"]');
+
+      expect(networkAccordion.exists()).toBe(false);
+    });
+
     it('should not display the ACE component if cluster is local', () => {
       const wrapper = shallowMount(CruImported, {
         propsData: {

--- a/pkg/imported/components/__tests__/CruImported.test.ts
+++ b/pkg/imported/components/__tests__/CruImported.test.ts
@@ -147,6 +147,27 @@ describe('cruImported component', () => {
 
       expect(networkAccordion.exists()).toBe(false);
     });
+    it('should hide the networking tab for local special RKE2 clusters detected via mgmt status provider', () => {
+      const wrapper = shallowMount(CruImported, {
+        propsData: {
+          mode:  _EDIT,
+          value: {
+            id:                'cluster-id',
+            isRke1:            false,
+            isLocal:           true,
+            isK3s:             false,
+            isRke2:            false,
+            mgmt:              { status: { provider: 'rke2.windows' } },
+            findNormanCluster: jest.fn().mockResolvedValue({})
+          }
+        },
+        ...defaultSetup
+      });
+
+      const networkAccordion = wrapper.find('[data-testid="network-accordion"]');
+
+      expect(networkAccordion.exists()).toBe(false);
+    });
     it('should hide the networking tab for local K3s clusters detected via mgmt status provider', () => {
       const wrapper = shallowMount(CruImported, {
         propsData: {

--- a/pkg/imported/components/__tests__/CruImported.test.ts
+++ b/pkg/imported/components/__tests__/CruImported.test.ts
@@ -168,7 +168,7 @@ describe('cruImported component', () => {
 
       expect(networkAccordion.exists()).toBe(false);
     });
-    it('should hide the networking tab for local K3s clusters detected via mgmt status provider', () => {
+    it('should hide the networking tab for local K3s clusters', () => {
       const wrapper = shallowMount(CruImported, {
         propsData: {
           mode:  _EDIT,
@@ -176,9 +176,8 @@ describe('cruImported component', () => {
             id:                'cluster-id',
             isRke1:            false,
             isLocal:           true,
-            isK3s:             false,
+            isK3s:             true,
             isRke2:            false,
-            mgmt:              { status: { provider: 'k3s' } },
             findNormanCluster: jest.fn().mockResolvedValue({})
           }
         },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17530
Hides Enabled PNI checkbox for local/imported RKE2/K3s cluters.
Hides Networking section completely for Local k3s/rke2 clusters.

<!-- Define findings related to the feature or bug issue. -->
Note: For Local RKE2 Clusters Basics tab is now shown as RKE2 Options.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Copilot identified an oversight that allowed RKE2 and K3s to be incorrectly missed for local clusters.
Updated the check to cover the local cluster correctly.
Updated PNI check to hide that section for all K3s and RKE2 clusters.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Edit a local RKE2 cluster → Networking accordion should not be visible.
Edit a local K3s cluster → Networking accordion should not be visible.
Edit a non-local imported cluster (non-RKE2/K3s) → Networking accordion and Project Network Isolation checkbox should still be visible and functional.
Edit a provisioned RKE2 cluster  → existing behaviour unchanged; toggle still hidden.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Imported and local RKE2/K3s/Generic clusters could experience regressions due to the change in what is considered an RKE2 or K3s cluster

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
