### PR TITLE
Locate an active template for empty pools

### DIFF
--- a/shell/detail/__tests__/provisioning.cattle.io.cluster.test.ts
+++ b/shell/detail/__tests__/provisioning.cattle.io.cluster.test.ts
@@ -127,4 +127,118 @@ describe('view: provisioning.cattle.io.cluster', () => {
       expect(wrapper.vm.showRegistration).toStrictEqual(false);
     });
   });
+
+  describe('fakeMachines', () => {
+    const clusterName = 'my-cluster';
+    const poolName = 'pool1';
+    const namespace = 'fleet-default';
+    const poolFullName = `${ clusterName }-${ poolName }`;
+
+    const wrongTemplate = { metadata: { name: `${ poolFullName }-aaaa1111`, namespace } };
+    const correctTemplate = { metadata: { name: `${ poolFullName }-bbbb2222`, namespace } };
+
+    const baseValue = {
+      name:        clusterName,
+      nameDisplay: clusterName,
+      namespace,
+      machines:    [],
+      spec:        {
+        rkeConfig: {
+          machinePools: [
+            {
+              name:             poolName,
+              machineConfigRef: { name: `nc-${ poolFullName }-xyz`, kind: 'Amazonec2Config' },
+            },
+          ],
+        },
+      },
+    };
+
+    it('uses MachineDeployment infrastructureRef to select the correct template for an empty pool', async() => {
+      const machineDeployment = {
+        metadata: { name: poolFullName, namespace },
+        spec:     { template: { spec: { infrastructureRef: { name: correctTemplate.metadata.name } } } },
+      };
+
+      const wrapper = shallowMount(ProvisioningCattleIoCluster, {
+        props:  { value: baseValue },
+        global: { mocks },
+      });
+
+      await wrapper.setData({
+        allMachineDeployments: [machineDeployment],
+        machineTemplates:      [wrongTemplate, correctTemplate],
+      });
+
+      const [fakeMachine] = wrapper.vm.fakeMachines;
+
+      expect(fakeMachine.pool._template).toStrictEqual(correctTemplate);
+    });
+
+    it('returns the first prefix-matching template when no MachineDeployment exists for the pool', async() => {
+      const wrapper = shallowMount(ProvisioningCattleIoCluster, {
+        props:  { value: baseValue },
+        global: { mocks },
+      });
+
+      await wrapper.setData({
+        allMachineDeployments: [],
+        machineTemplates:      [wrongTemplate, correctTemplate],
+      });
+
+      const [fakeMachine] = wrapper.vm.fakeMachines;
+
+      expect(fakeMachine.pool._template).toStrictEqual(wrongTemplate);
+    });
+
+    it('returns undefined template when MachineDeployment infrastructureRef does not match any template', async() => {
+      const machineDeployment = {
+        metadata: { name: poolFullName, namespace },
+        spec:     { template: { spec: { infrastructureRef: { name: `${ poolFullName }-nonexistent` } } } },
+      };
+
+      const wrapper = shallowMount(ProvisioningCattleIoCluster, {
+        props:  { value: baseValue },
+        global: { mocks },
+      });
+
+      await wrapper.setData({
+        allMachineDeployments: [machineDeployment],
+        machineTemplates:      [wrongTemplate, correctTemplate],
+      });
+
+      const [fakeMachine] = wrapper.vm.fakeMachines;
+
+      expect(fakeMachine.pool._template).toBeUndefined();
+    });
+
+    it('does not include a pool in fakeMachines when it has active machines', async() => {
+      const valueWithMachines = {
+        ...baseValue,
+        machines: [
+          {
+            metadata: {
+              labels: {
+                'cluster.x-k8s.io/cluster-name':       clusterName,
+                'rke.cattle.io/rke-machine-pool-name': poolName,
+              },
+            },
+            spec: { infrastructureRef: { apiGroup: 'rke-machine.cattle.io', name: `${ poolFullName }-bbbb2222` } },
+          },
+        ],
+      };
+
+      const wrapper = shallowMount(ProvisioningCattleIoCluster, {
+        props:  { value: valueWithMachines },
+        global: { mocks },
+      });
+
+      await wrapper.setData({
+        allMachineDeployments: [],
+        machineTemplates:      [wrongTemplate, correctTemplate],
+      });
+
+      expect(wrapper.vm.fakeMachines).toHaveLength(0);
+    });
+  });
 });

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -402,8 +402,23 @@ export default {
 
         const templateNamePrefix = `${ pool.metadata.name }-`;
 
+        // The MachineDeployment still exists for empty pools. The
+        // infrastructureRef points to the template that matches the current
+        // config. Fallback to the prefix-match to return an arbitrary template
+        // when multiple exist
+        const machineDeployment = this.allMachineDeployments.find(
+          (d) => d.metadata.name === pool.metadata.name && d.metadata.namespace === pool.metadata.namespace
+        );
+        const activeTemplateName = machineDeployment?.spec?.template?.spec?.infrastructureRef?.name;
+
         // All of these properties are needed to ensure the pool displays correctly and that we can scale up and down
-        pool._template = this.machineTemplates.find((t) => t.metadata.name.startsWith(templateNamePrefix));
+        pool._template = this.machineTemplates.find((t) => {
+          if (activeTemplateName) {
+            return t.metadata.name === activeTemplateName;
+          }
+
+          return t.metadata.name.startsWith(templateNamePrefix);
+        });
         pool._cluster = this.value;
         pool._clusterSpec = mp;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This locates the proper matching template for empty machine pools.

Fixes #17872
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

When working with empty pools, look up the MachineDeployment by pool name, read its `infrastructureRef.name`, and find the matching template. This is similar to how non-empty pools are located.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

> Note: in order for the reproduction to be successful, I often need to alter the instance type multiple times before the failure can be observed. It fails consistently after that.

See the Repro steps in the associated issue.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

The risk for regression should be quite small. We fallback to the original behavior if an active template name cannot be located.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before (t3a.nano is active, but t3a.2xlarge is displayed for prak-test3-pool2)

<img width="1219" height="1349" alt="image" src="https://github.com/user-attachments/assets/274ba68e-594a-4937-8fa8-230deac95929" />


#### After (t3a.nano is displayed for prak-test3-pool2)

<img width="1219" height="1349" alt="image" src="https://github.com/user-attachments/assets/c402cfa3-91c0-4c73-bab2-99558c7e5454" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
