### PR TITLE
Automation: Fix JWT Auth visual test 401 in before hook

### DIFF
--- a/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
+++ b/cypress/e2e/tests/pages/manager/jwt-authentication.spec.ts
@@ -3,6 +3,7 @@ import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 import JWTAuthenticationPagePo from '@/cypress/e2e/po/pages/cluster-manager/jwt-authentication.po';
+import { qase } from '@/cypress/support/qase';
 
 const jwtAuthenticationPage = new JWTAuthenticationPagePo();
 
@@ -73,16 +74,16 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
     });
   });
 
-  it('should show the JWT Authentication list page', () => {
+  qase(3959, it('should show the JWT Authentication list page', () => {
     goToJWTAuthenticationPageAndSettle();
     jwtAuthenticationPage.list().masthead().title().should('contain', 'JWT Authentication');
     jwtAuthenticationPage.list().resourceTable().sortableTable().checkVisible();
     jwtAuthenticationPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
     jwtAuthenticationPage.list().resourceTable().resourceTableDetails(instance0, 1).should('contain', 'Disabled');
     jwtAuthenticationPage.list().resourceTable().resourceTableDetails(instance1, 1).should('contain', 'Disabled');
-  });
+  }));
 
-  it('should be able to enable JWT Authentication for a cluster', () => {
+  qase(3961, it('should be able to enable JWT Authentication for a cluster', () => {
     goToJWTAuthenticationPageAndSettle();
     cy.intercept('POST', `/v1/management.cattle.io.clusterproxyconfigs`).as('enableJWT');
     jwtAuthenticationPage.list().resourceTable().sortableTable().rowActionMenuOpen(instance0)
@@ -96,9 +97,9 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
 
     jwtAuthenticationPage.list().resourceTable().resourceTableDetails(instance0, 1).should('contain', 'Enabled');
     jwtAuthenticationPage.list().resourceTable().resourceTableDetails(instance1, 1).should('contain', 'Disabled');
-  });
+  }));
 
-  it('should be able to disable JWT Authentication for a cluster', () => {
+  qase(3962, it('should be able to disable JWT Authentication for a cluster', () => {
     goToJWTAuthenticationPageAndSettle();
 
     cy.intercept('PUT', `/v1/management.cattle.io.clusterproxyconfigs/**`).as('disableJWT');
@@ -113,9 +114,9 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
 
     jwtAuthenticationPage.list().resourceTable().resourceTableDetails(instance0, 1).should('contain', 'Disabled');
     jwtAuthenticationPage.list().resourceTable().resourceTableDetails(instance1, 1).should('contain', 'Disabled');
-  });
+  }));
 
-  it('should be able to enable JWT Authentication in bulk', () => {
+  qase(3958, it('should be able to enable JWT Authentication in bulk', () => {
     goToJWTAuthenticationPageAndSettle();
     cy.intercept('POST', `/v1/management.cattle.io.clusterproxyconfigs`).as('enableJWT');
 
@@ -132,9 +133,9 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
     });
     jwtAuthenticationPage.list().resourceTable().resourceTableDetails(instance0, 1).should('contain', 'Enabled');
     jwtAuthenticationPage.list().resourceTable().resourceTableDetails(instance1, 1).should('contain', 'Enabled');
-  });
+  }));
 
-  it('should be able to disable JWT Authentication in bulk', () => {
+  qase(4397, it('should be able to disable JWT Authentication in bulk', () => {
     goToJWTAuthenticationPageAndSettle();
     cy.intercept('PUT', `/v1/management.cattle.io.clusterproxyconfigs/**`).as('disableJWT');
 
@@ -152,7 +153,7 @@ describe('JWT Authentication', { testIsolation: 'off', tags: ['@manager', '@admi
 
     jwtAuthenticationPage.list().resourceTable().resourceTableDetails(instance0, 1).should('contain', 'Disabled');
     jwtAuthenticationPage.list().resourceTable().resourceTableDetails(instance1, 1).should('contain', 'Disabled');
-  });
+  }));
 
   after('clean up', () => {
     if (removeCluster0) {
@@ -173,7 +174,7 @@ describe('JWT Authentication (Standard User)', { testIsolation: 'off', tags: ['@
     HomePagePo.goTo();
   });
 
-  it('should not have JWT Authentication side menu entry', () => {
+  qase(5572, it('should not have JWT Authentication side menu entry', () => {
     const homePage = new HomePagePo();
     const clusterManagerPage = new ClusterManagerListPagePo('_');
 
@@ -185,7 +186,7 @@ describe('JWT Authentication (Standard User)', { testIsolation: 'off', tags: ['@
 
     sideNav.navToSideMenuGroupByLabel('Advanced');
     sideNav.checkSideMenuEntryByLabel('JWT Authentication', 'not.exist');
-  });
+  }));
 });
 
 describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () => {
@@ -194,7 +195,7 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
     cy.applyDefaultTestTheme();
   });
 
-  it('should display JWT Authentication empty list page', () => {
+  qase(18427, it('should display JWT Authentication empty list page', () => {
     const jwtAuthenticationPage = new JWTAuthenticationPagePo();
 
     JWTAuthenticationPagePo.goTo('_');
@@ -208,7 +209,7 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
 
     // takes percy snapshot.
     cy.percySnapshot('JWT Authentication list page');
-  });
+  }));
 
   describe('Populated list', { tags: ['@jenkins'] }, () => {
     let instance0 = '';
@@ -217,6 +218,7 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
     const namespace = 'fleet-default';
 
     before(() => {
+      cy.login();
       cy.createE2EResourceName('rke2cluster0').as('rke2Ec2ClusterName0');
 
       cy.get<string>('@rke2Ec2ClusterName0').then((name) => {
@@ -240,7 +242,7 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
       });
     });
 
-    it('should display JWT Authentication populated list page', () => {
+    qase(18428, it('should display JWT Authentication populated list page', () => {
       const jwtAuthenticationPage = new JWTAuthenticationPagePo();
 
       JWTAuthenticationPagePo.goTo('_');
@@ -258,7 +260,7 @@ describe('Visual Testing', { tags: ['@percy', '@manager', '@adminUser'] }, () =>
 
       // takes percy snapshot.
       cy.percySnapshot('JWT Authentication populated list page');
-    });
+    }));
 
     after('clean up', () => {
       if (removeCluster0) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2278

~~Sets testIsolation: 'off' on the Visual Testing describe block so the authenticated session from cy.login() is preserved for the nested Populated list before hook, fixing the 401 on /v3/cloudcredentials.~~

Add cy.login() to beforeAll step
Add qase ids

<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="1466" height="578" alt="image" src="https://github.com/user-attachments/assets/2d8c73c5-f818-4f47-bc5f-48b02ec0905b" />
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
