### PR TITLE
Automation: Fix cluster dashboard tests

### DIFF
--- a/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
@@ -315,7 +315,7 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
     });
   });
 
-  describe('Cluster dashboard with limited permissions', () => {
+  describe('Cluster dashboard with limited permissions', { testIsolation: 'on' }, () => {
     let stdProjectName;
     let stdNsName;
     let stdUsername;
@@ -405,7 +405,7 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
     status:  403,
   };
 
-  describe('Cluster dashboard - Fleet agent', () => {
+  describe('Cluster dashboard - Fleet agent', { testIsolation: 'on' }, () => {
     // Re-login as admin to ensure auth is restored after the 'limited permissions' tests
     // which log in as a standard user and may leave session cookies in an inconsistent state
     beforeEach(() => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2320

Enable test isolation for limited-permissions and Fleet agent describe blocks in cluster-dashboard spec

The `Cluster Dashboard` suite runs with `testIsolation: 'off'`, so cookies/storage persist across tests. The first request in the `beforeEach` of the nested `Cluster dashboard with limited permissions` and `Cluster dashboard - Fleet agent` blocks was intermittently failing with:

```
CypressError: cy.request() failed on:
https://<host>/v1/ext.cattle.io.selfuser
401: Unauthorized
```

`cy.login()` is cached via `cy.session()` with no `validate` callback, so leftover cookies cause the cached session to be restored instead of a real login, leaving auth state stale.

Enabling `testIsolation` on these two describe blocks clears cookies/storage between tests, forcing `cy.session()` to re-run the login flow. Test-only change.
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="2004" height="750" alt="image" src="https://github.com/user-attachments/assets/435b483e-3260-49e1-8aa0-f81951e4b113" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
