### PR TITLE
Update permissions of valid-milestone-change

### DIFF
--- a/.github/workflows/valid-milestone-change.yml
+++ b/.github/workflows/valid-milestone-change.yml
@@ -4,12 +4,16 @@ on:
   issues:
     types: [milestoned, demilestoned]
 
+# Restrictive baseline permissions for all jobs
 permissions:
   issues: read
  
 jobs:
   notify-on-milestone-change:
     if: github.repository_owner == 'rancher'
+    permissions:
+      issues: read
+      id-token: write
 
     runs-on: ubuntu-latest
     env:
@@ -18,6 +22,8 @@ jobs:
       ISSUE_URL: ''
       NEW_MILESTONE: ''
       OLD_MILESTONE: ''
+      APPID: ''
+      PRIVATEKEY: ''
     steps:
     - name: Set Event Data
       id: event_data


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Update permissions of valid-milestone-change
- resolve workflow failure `Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable`
  - https://github.com/rancher/dashboard/actions/runs/26629124185
- add baseline permissions as security feature
- remove some vscode lint errors (possible missing env vars)

### Occurred changes and/or fixed issues
Follows on from https://github.com/rancher/dashboard/pull/17787

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
