### PR TITLE
test(cypress): validate cy.session() login cache

### DIFF
--- a/cypress/support/commands/rancher-api-commands.ts
+++ b/cypress/support/commands/rancher-api-commands.ts
@@ -2,7 +2,7 @@ import { LoginPagePo } from '@/cypress/e2e/po/pages/login-page.po';
 import { CreateUserParams, CreateAmazonRke2ClusterParams, CreateAmazonRke2ClusterWithoutMachineConfigParams, UserPreferences } from '@/cypress/globals';
 import { groupByPayload } from '@/cypress/e2e/blueprints/user_preferences/group_by';
 import { CypressChainable } from '~/cypress/e2e/po/po.types';
-import { MEDIUM_API_DELAY } from '@/cypress/support/utils/api-endpoints';
+import { MEDIUM_API_DELAY, USERS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
 import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 import { base64Encode } from '@shell/utils/crypto/index.js';
 
@@ -66,7 +66,13 @@ Cypress.Commands.add('login', (
   };
 
   if (cacheSession) {
-    (cy as any).session([username, password], login);
+    (cy as any).session([username, password], login, {
+      validate: () => cy.request({
+        method:           'GET',
+        url:              `${ Cypress.env('api') }${ USERS_BASE_URL }?limit=1`,
+        failOnStatusCode: false
+      }).its('status').should('eq', 200)
+    });
     cy.getCookie('CSRF').then((c) => {
       token = c;
     });


### PR DESCRIPTION
### Summary
Fixes https://github.com/rancher/qa-tasks/issues/2380

This change hardens `cy.login()`'s `cy.session()` caching by adding a `validate` callback so Cypress will automatically re-run the login flow if the cached auth becomes invalid/expired.

### Occurred changes and/or fixed issues
- Add `validate` to the `cy.session([username, password], login, { ... })` call in `cypress/support/commands/rancher-api-commands.ts`.
- Validation request hits `GET ${Cypress.env('api')}/v1/users?limit=1` and asserts `status === 200`.
- If validation fails, Cypress re-runs the login setup instead of reusing bad cached auth.

### Technical notes summary
- `validate` runs before restoring a cached session.
- `failOnStatusCode: false` lets the validator treat non-200 responses as “refresh the session” instead of crashing inside the validator.

### Areas or cases that should be tested
- Cypress E2E flows that depend on `cy.login()` session caching.
- Especially cases where sessions can expire mid-run.

### Areas which could experience regressions
- E2E runtime: one small extra request on session restore.
- If the API endpoint is misconfigured/unavailable, session restore may re-run login more often.

### Screenshot/Video
N/A; test-only change.

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [ ] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`