### PR TITLE
[16870] Added e2e and unit tests

### DIFF
--- a/cypress/e2e/blueprints/fleet/gitrepos.ts
+++ b/cypress/e2e/blueprints/fleet/gitrepos.ts
@@ -27,8 +27,9 @@ export function gitRepoTargetAllClustersRequest(
   name: string,
   repo: string,
   branch: string,
-  path: string
-):object {
+  path: string,
+  targets?: object[]
+) {
   return {
     type:     'fleet.cattle.io.gitrepo',
     metadata: {
@@ -40,7 +41,7 @@ export function gitRepoTargetAllClustersRequest(
       branch,
       paths:        [path],
       correctDrift: { enabled: false },
-      targets:      [{
+      targets:      targets || [{
         clusterSelector: {
           matchExpressions: [{
             key: 'provider.cattle.io', operator: 'NotIn', values: ['harvester']

--- a/cypress/e2e/tests/pages/fleet/fleet-cluster-target-display-name.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-cluster-target-display-name.spec.ts
@@ -159,12 +159,9 @@ describe('Fleet Cluster Targets - Display Name', { testIsolation: 'off', tags: [
         gitRepoName = name;
 
         // Create a gitrepo with cluster target using metadata.name
-        const gitRepoBody = gitRepoTargetAllClustersRequest(workspace, name, repoInfo.repoUrl, repoInfo.branch, repoInfo.paths);
-
-        // Override targets to reference the cluster by metadata.name
-        gitRepoBody.spec.targets = [{ clusterName: METADATA_NAME }];
-
-        cy.createRancherResource('v1', 'fleet.cattle.io.gitrepos', gitRepoBody);
+        cy.createRancherResource('v1', 'fleet.cattle.io.gitrepos',
+          gitRepoTargetAllClustersRequest(workspace, name, repoInfo.repoUrl, repoInfo.branch, repoInfo.paths, [{ clusterName: METADATA_NAME }])
+        );
       });
     });
 

--- a/cypress/e2e/tests/pages/fleet/fleet-cluster-target-display-name.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-cluster-target-display-name.spec.ts
@@ -55,12 +55,17 @@ describe('Fleet Cluster Targets - Display Name', { testIsolation: 'off', tags: [
     it('should display cluster nameDisplay (not metadata.name) in the target selector dropdown', () => {
       interceptFleetClustersWithDisplayName();
 
+      // Select workspace from list page first, then navigate to create
+      const listPage = new FleetApplicationListPagePo();
+
+      listPage.goTo();
+      listPage.waitForPage();
+      headerPo.selectWorkspace(workspace);
+
       const gitRepoCreatePage = new FleetGitRepoCreateEditPo();
 
       gitRepoCreatePage.goTo();
       gitRepoCreatePage.waitForPage();
-
-      headerPo.selectWorkspace(workspace);
 
       // Step 1: Metadata
       cy.createE2EResourceName('display-name-dropdown').then((name) => {
@@ -101,12 +106,17 @@ describe('Fleet Cluster Targets - Display Name', { testIsolation: 'off', tags: [
     it('should use display name as clusterName value when selecting a cluster target', () => {
       interceptFleetClustersWithDisplayName();
 
+      // Select workspace from list page first, then navigate to create
+      const listPage = new FleetApplicationListPagePo();
+
+      listPage.goTo();
+      listPage.waitForPage();
+      headerPo.selectWorkspace(workspace);
+
       const gitRepoCreatePage = new FleetGitRepoCreateEditPo();
 
       gitRepoCreatePage.goTo();
       gitRepoCreatePage.waitForPage();
-
-      headerPo.selectWorkspace(workspace);
 
       // Step 1: Metadata
       cy.createE2EResourceName('display-name-value').as('createRepoName');

--- a/cypress/e2e/tests/pages/fleet/fleet-cluster-target-display-name.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-cluster-target-display-name.spec.ts
@@ -1,0 +1,204 @@
+import { FleetGitRepoCreateEditPo, FleetApplicationListPagePo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
+import { gitRepoTargetAllClustersRequest } from '@/cypress/e2e/blueprints/fleet/gitrepos';
+import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
+import { CYPRESS_SAFE_RESOURCE_REVISION } from '@/cypress/e2e/blueprints/blueprint.utils';
+
+const METADATA_NAME = 'c-m-e2etest';
+const DISPLAY_NAME = 'e2e-custom-display-cluster';
+const workspace = 'fleet-default';
+
+function interceptFleetClustersWithDisplayName() {
+  cy.intercept('GET', '/v1/fleet.cattle.io.clusters?*', (req) => {
+    req.continue((res) => {
+      const fakeFleetCluster = {
+        id:       `${ workspace }/${ METADATA_NAME }`,
+        type:     'fleet.cattle.io.cluster',
+        metadata: {
+          name:      METADATA_NAME,
+          namespace: workspace,
+          labels:    {
+            'management.cattle.io/cluster-display-name': DISPLAY_NAME,
+            'management.cattle.io/cluster-name':         METADATA_NAME,
+          },
+          state: {
+            name:          'active',
+            error:         false,
+            transitioning: false,
+            message:       'Resource is Ready'
+          },
+          resourceVersion: CYPRESS_SAFE_RESOURCE_REVISION,
+        },
+        spec:   {},
+        status: {
+          agent:   { lastSeen: '2026-01-01T00:00:00Z' },
+          display: {
+            readyBundles: '0/0',
+            state:        'Active',
+          },
+        },
+      };
+
+      res.body.data.push(fakeFleetCluster);
+      res.send(res.body);
+    });
+  }).as('fleetClustersWithDisplayName');
+}
+
+describe('Fleet Cluster Targets - Display Name', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] }, () => {
+  const headerPo = new HeaderPo();
+
+  before(() => {
+    cy.login();
+  });
+
+  describe('Create GitRepo - cluster target dropdown should show display name', () => {
+    it('should display cluster nameDisplay (not metadata.name) in the target selector dropdown', () => {
+      interceptFleetClustersWithDisplayName();
+
+      const gitRepoCreatePage = new FleetGitRepoCreateEditPo();
+
+      gitRepoCreatePage.goTo();
+      gitRepoCreatePage.waitForPage();
+
+      headerPo.selectWorkspace(workspace);
+
+      // Step 1: Metadata
+      cy.createE2EResourceName('display-name-dropdown').then((name) => {
+        gitRepoCreatePage.resourceDetail().createEditView().nameNsDescription()
+          .name()
+          .set(name);
+      });
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      // Step 2: Repository details
+      gitRepoCreatePage.setGitRepoUrl('https://github.com/rancher/fleet-examples.git');
+      gitRepoCreatePage.setBranchName('master');
+      gitRepoCreatePage.setGitRepoPath('simple');
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      // Step 3: Target selection
+      // Select "Manually selected clusters" (index 2: all=0, none=1, clusters=2)
+      gitRepoCreatePage.targetClusterOptions().set(2);
+
+      // Open cluster dropdown and verify display name is shown
+      gitRepoCreatePage.targetCluster().toggle();
+      gitRepoCreatePage.targetCluster().getOptions().should('contain', DISPLAY_NAME);
+
+      // Verify metadata.name is NOT shown as an option label
+      gitRepoCreatePage.targetCluster().getOptionsAsStrings().then((options) => {
+        const hasDisplayName = options.some((opt) => opt.includes(DISPLAY_NAME));
+        const hasMetadataName = options.some((opt) => opt === METADATA_NAME);
+
+        expect(hasDisplayName).to.eq(true);
+        expect(hasMetadataName).to.eq(false);
+      });
+    });
+
+    it('should use display name as clusterName value when selecting a cluster target', () => {
+      interceptFleetClustersWithDisplayName();
+
+      const gitRepoCreatePage = new FleetGitRepoCreateEditPo();
+
+      gitRepoCreatePage.goTo();
+      gitRepoCreatePage.waitForPage();
+
+      headerPo.selectWorkspace(workspace);
+
+      // Step 1: Metadata
+      cy.createE2EResourceName('display-name-value').as('createRepoName');
+
+      cy.get<string>('@createRepoName').then((name) => {
+        gitRepoCreatePage.resourceDetail().createEditView().nameNsDescription()
+          .name()
+          .set(name);
+      });
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      // Step 2: Repository details
+      gitRepoCreatePage.setGitRepoUrl('https://github.com/rancher/fleet-examples.git');
+      gitRepoCreatePage.setBranchName('master');
+      gitRepoCreatePage.setGitRepoPath('simple');
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      // Step 3: Target selection - select cluster by display name
+      gitRepoCreatePage.targetClusterOptions().set(2);
+      gitRepoCreatePage.targetCluster().toggle();
+      gitRepoCreatePage.targetCluster().clickLabel(DISPLAY_NAME);
+
+      // Intercept the create request and verify the payload uses display name
+      cy.intercept('POST', '/v1/fleet.cattle.io.gitrepos').as('createGitRepo');
+
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+      gitRepoCreatePage.resourceDetail().createEditView().create();
+
+      cy.wait('@createGitRepo').then(({ request }) => {
+        const targets = request.body.spec.targets;
+        const clusterTarget = targets.find((t: any) => t.clusterName);
+
+        expect(clusterTarget.clusterName).to.eq(DISPLAY_NAME);
+      });
+
+      // Cleanup
+      cy.get<string>('@createRepoName').then((name) => {
+        cy.deleteRancherResource('v1', 'fleet.cattle.io.gitrepo', `${ workspace }/${ name }`);
+      });
+    });
+  });
+
+  describe('Edit GitRepo - should resolve metadata.name targets to display name', () => {
+    const repoInfo = {
+      repoUrl: 'https://github.com/rancher/fleet-examples.git',
+      branch:  'master',
+      paths:   'simple'
+    };
+
+    let gitRepoName = '';
+
+    before(() => {
+      cy.createE2EResourceName('display-name-edit').then((name) => {
+        gitRepoName = name;
+
+        // Create a gitrepo with cluster target using metadata.name
+        const gitRepoBody = gitRepoTargetAllClustersRequest(workspace, name, repoInfo.repoUrl, repoInfo.branch, repoInfo.paths);
+
+        // Override targets to reference the cluster by metadata.name
+        gitRepoBody.spec.targets = [{ clusterName: METADATA_NAME }];
+
+        cy.createRancherResource('v1', 'fleet.cattle.io.gitrepos', gitRepoBody);
+      });
+    });
+
+    it('should show display name in cluster target selector when editing a gitrepo that references a cluster by metadata.name', () => {
+      interceptFleetClustersWithDisplayName();
+
+      const listPage = new FleetApplicationListPagePo();
+
+      listPage.goTo();
+      listPage.waitForPage();
+      headerPo.selectWorkspace(workspace);
+
+      listPage.list().actionMenu(gitRepoName).getMenuItem('Edit Config')
+        .click();
+
+      const editPage = new FleetGitRepoCreateEditPo(workspace, gitRepoName);
+
+      editPage.waitForPage('mode=edit');
+
+      // Navigate to target step
+      editPage.resourceDetail().createEditView().nextPage();
+      editPage.resourceDetail().createEditView().nextPage();
+
+      // Wait for clusters to load and resolve - the watcher should convert metadata.name to display name
+      cy.wait('@fleetClustersWithDisplayName');
+
+      // The selected cluster should show the display name, not metadata.name
+      editPage.targetCluster().checkOptionSelected(DISPLAY_NAME);
+    });
+
+    after(() => {
+      if (gitRepoName) {
+        cy.deleteRancherResource('v1', 'fleet.cattle.io.gitrepo', `${ workspace }/${ gitRepoName }`);
+      }
+    });
+  });
+});

--- a/cypress/e2e/tests/pages/fleet/fleet-cluster-target-display-name.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-cluster-target-display-name.spec.ts
@@ -77,7 +77,11 @@ describe('Fleet Cluster Targets - Display Name', { testIsolation: 'off', tags: [
       gitRepoCreatePage.resourceDetail().createEditView().nextPage();
 
       // Step 3: Target selection
-      // Select "Manually selected clusters" (index 2: all=0, none=1, clusters=2)
+      // Wait for fleet clusters to load before interacting with target options
+      cy.wait('@fleetClustersWithDisplayName');
+
+      // Wait for "Manually selected clusters" radio option to appear (index 2: all=0, none=1, clusters=2)
+      gitRepoCreatePage.targetClusterOptions().getOptionByIndex(2).should('be.visible');
       gitRepoCreatePage.targetClusterOptions().set(2);
 
       // Open cluster dropdown and verify display name is shown
@@ -121,6 +125,8 @@ describe('Fleet Cluster Targets - Display Name', { testIsolation: 'off', tags: [
       gitRepoCreatePage.resourceDetail().createEditView().nextPage();
 
       // Step 3: Target selection - select cluster by display name
+      cy.wait('@fleetClustersWithDisplayName');
+      gitRepoCreatePage.targetClusterOptions().getOptionByIndex(2).should('be.visible');
       gitRepoCreatePage.targetClusterOptions().set(2);
       gitRepoCreatePage.targetCluster().toggle();
       gitRepoCreatePage.targetCluster().clickLabel(DISPLAY_NAME);

--- a/cypress/e2e/tests/pages/fleet/fleet-cluster-target-display-name.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/fleet-cluster-target-display-name.spec.ts
@@ -82,11 +82,8 @@ describe('Fleet Cluster Targets - Display Name', { testIsolation: 'off', tags: [
       gitRepoCreatePage.resourceDetail().createEditView().nextPage();
 
       // Step 3: Target selection
-      // Wait for fleet clusters to load before interacting with target options
-      cy.wait('@fleetClustersWithDisplayName');
-
-      // Wait for "Manually selected clusters" radio option to appear (index 2: all=0, none=1, clusters=2)
-      gitRepoCreatePage.targetClusterOptions().getOptionByIndex(2).should('be.visible');
+      // Wait for fleet clusters to load and "Manually selected clusters" radio to appear
+      gitRepoCreatePage.targetClusterOptions().getAllOptions().should('have.length.gte', 3);
       gitRepoCreatePage.targetClusterOptions().set(2);
 
       // Open cluster dropdown and verify display name is shown
@@ -135,8 +132,7 @@ describe('Fleet Cluster Targets - Display Name', { testIsolation: 'off', tags: [
       gitRepoCreatePage.resourceDetail().createEditView().nextPage();
 
       // Step 3: Target selection - select cluster by display name
-      cy.wait('@fleetClustersWithDisplayName');
-      gitRepoCreatePage.targetClusterOptions().getOptionByIndex(2).should('be.visible');
+      gitRepoCreatePage.targetClusterOptions().getAllOptions().should('have.length.gte', 3);
       gitRepoCreatePage.targetClusterOptions().set(2);
       gitRepoCreatePage.targetCluster().toggle();
       gitRepoCreatePage.targetCluster().clickLabel(DISPLAY_NAME);

--- a/shell/components/fleet/__tests__/FleetClusterTargets.test.ts
+++ b/shell/components/fleet/__tests__/FleetClusterTargets.test.ts
@@ -1835,4 +1835,242 @@ describe('component: FleetClusterTargets', () => {
       expect(wrapper.vm.selectedClusterGroups).toStrictEqual([]);
     });
   });
+
+  describe('resolveClusterDisplayName', () => {
+    it.each([
+      ['c-m-abc123', 'my-production-cluster'],
+      ['c-m-def456', 'my-staging-cluster'],
+    ])('should return nameDisplay for metadata.name "%s"', (metadataName, expectedDisplay) => {
+      const mockClusters = [
+        {
+          metadata:    { namespace: 'fleet-default', name: 'c-m-abc123' },
+          nameDisplay: 'my-production-cluster'
+        },
+        {
+          metadata:    { namespace: 'fleet-default', name: 'c-m-def456' },
+          nameDisplay: 'my-staging-cluster'
+        }
+      ];
+
+      const wrapper = mountWithSetup(FleetClusterTargets, {
+        props: {
+          targets:   [],
+          namespace: 'fleet-default',
+          mode:      _EDIT
+        }
+      });
+
+      wrapper.setData({ allClusters: mockClusters });
+
+      expect(wrapper.vm.resolveClusterDisplayName(metadataName)).toStrictEqual(expectedDisplay);
+    });
+
+    it('should return the original name when no cluster matches', () => {
+      const mockClusters = [
+        {
+          metadata:    { namespace: 'fleet-default', name: 'c-m-abc123' },
+          nameDisplay: 'my-production-cluster'
+        }
+      ];
+
+      const wrapper = mountWithSetup(FleetClusterTargets, {
+        props: {
+          targets:   [],
+          namespace: 'fleet-default',
+          mode:      _EDIT
+        }
+      });
+
+      wrapper.setData({ allClusters: mockClusters });
+
+      expect(wrapper.vm.resolveClusterDisplayName('non-existent')).toStrictEqual('non-existent');
+    });
+
+    it('should not resolve cluster from a different namespace', () => {
+      const mockClusters = [
+        {
+          metadata:    { namespace: 'other-namespace', name: 'c-m-abc123' },
+          nameDisplay: 'my-production-cluster'
+        }
+      ];
+
+      const wrapper = mountWithSetup(FleetClusterTargets, {
+        props: {
+          targets:   [],
+          namespace: 'fleet-default',
+          mode:      _EDIT
+        }
+      });
+
+      wrapper.setData({ allClusters: mockClusters });
+
+      expect(wrapper.vm.resolveClusterDisplayName('c-m-abc123')).toStrictEqual('c-m-abc123');
+    });
+  });
+
+  describe('clustersOptions', () => {
+    it('should use nameDisplay for both label and value', () => {
+      const mockClusters = [
+        {
+          metadata:    { namespace: 'fleet-default', name: 'c-m-abc123' },
+          nameDisplay: 'my-production-cluster',
+          status:      { provider: 'rke2' }
+        },
+        {
+          metadata:    { namespace: 'fleet-default', name: 'c-m-def456' },
+          nameDisplay: 'my-staging-cluster',
+          status:      { provider: 'rke2' }
+        }
+      ];
+
+      const wrapper = mountWithSetup(FleetClusterTargets, {
+        props: {
+          targets:   [],
+          namespace: 'fleet-default',
+          mode:      _EDIT
+        }
+      });
+
+      wrapper.setData({ allClusters: mockClusters });
+
+      const options = wrapper.vm.clustersOptions;
+
+      expect(options).toStrictEqual([
+        { label: 'my-production-cluster', value: 'my-production-cluster' },
+        { label: 'my-staging-cluster', value: 'my-staging-cluster' }
+      ]);
+    });
+
+    it('should filter out clusters from other namespaces', () => {
+      const mockClusters = [
+        {
+          metadata:    { namespace: 'fleet-default', name: 'c-m-abc123' },
+          nameDisplay: 'my-cluster',
+          status:      { provider: 'rke2' }
+        },
+        {
+          metadata:    { namespace: 'other-namespace', name: 'c-m-other' },
+          nameDisplay: 'other-cluster',
+          status:      { provider: 'rke2' }
+        }
+      ];
+
+      const wrapper = mountWithSetup(FleetClusterTargets, {
+        props: {
+          targets:   [],
+          namespace: 'fleet-default',
+          mode:      _EDIT
+        }
+      });
+
+      wrapper.setData({ allClusters: mockClusters });
+
+      expect(wrapper.vm.clustersOptions).toStrictEqual([
+        { label: 'my-cluster', value: 'my-cluster' }
+      ]);
+    });
+  });
+
+  describe('allClusters watcher', () => {
+    it('should resolve selectedClusters metadata.name values to nameDisplay when clusters load', async() => {
+      const mockClusters = [
+        {
+          metadata:    { namespace: 'fleet-default', name: 'c-m-abc123' },
+          nameDisplay: 'my-production-cluster'
+        },
+        {
+          metadata:    { namespace: 'fleet-default', name: 'c-m-def456' },
+          nameDisplay: 'my-staging-cluster'
+        }
+      ];
+
+      const targets = [
+        { clusterName: 'c-m-abc123' },
+        { clusterName: 'c-m-def456' }
+      ];
+
+      const wrapper = mountWithSetup(FleetClusterTargets, {
+        props: {
+          targets,
+          namespace: 'fleet-default',
+          mode:      _EDIT
+        }
+      });
+
+      expect(wrapper.vm.selectedClusters).toStrictEqual(['c-m-abc123', 'c-m-def456']);
+
+      wrapper.setData({ allClusters: mockClusters });
+      await flushPromises();
+
+      expect(wrapper.vm.selectedClusters).toStrictEqual(['my-production-cluster', 'my-staging-cluster']);
+    });
+
+    it('should keep names that already match nameDisplay unchanged', async() => {
+      const mockClusters = [
+        {
+          metadata:    { namespace: 'fleet-default', name: 'my-cluster' },
+          nameDisplay: 'my-cluster'
+        }
+      ];
+
+      const targets = [{ clusterName: 'my-cluster' }];
+
+      const wrapper = mountWithSetup(FleetClusterTargets, {
+        props: {
+          targets,
+          namespace: 'fleet-default',
+          mode:      _EDIT
+        }
+      });
+
+      wrapper.setData({ allClusters: mockClusters });
+      await flushPromises();
+
+      expect(wrapper.vm.selectedClusters).toStrictEqual(['my-cluster']);
+    });
+
+    it('should keep unresolvable names as-is', async() => {
+      const mockClusters = [
+        {
+          metadata:    { namespace: 'fleet-default', name: 'c-m-abc123' },
+          nameDisplay: 'known-cluster'
+        }
+      ];
+
+      const targets = [
+        { clusterName: 'c-m-abc123' },
+        { clusterName: 'unknown-name' }
+      ];
+
+      const wrapper = mountWithSetup(FleetClusterTargets, {
+        props: {
+          targets,
+          namespace: 'fleet-default',
+          mode:      _EDIT
+        }
+      });
+
+      wrapper.setData({ allClusters: mockClusters });
+      await flushPromises();
+
+      expect(wrapper.vm.selectedClusters).toStrictEqual(['known-cluster', 'unknown-name']);
+    });
+
+    it('should not resolve when clusters array is empty', async() => {
+      const targets = [{ clusterName: 'c-m-abc123' }];
+
+      const wrapper = mountWithSetup(FleetClusterTargets, {
+        props: {
+          targets,
+          namespace: 'fleet-default',
+          mode:      _EDIT
+        }
+      });
+
+      wrapper.setData({ allClusters: [] });
+      await flushPromises();
+
+      expect(wrapper.vm.selectedClusters).toStrictEqual(['c-m-abc123']);
+    });
+  });
 });

--- a/shell/components/fleet/__tests__/FleetClusterTargets.test.ts
+++ b/shell/components/fleet/__tests__/FleetClusterTargets.test.ts
@@ -1852,7 +1852,8 @@ describe('component: FleetClusterTargets', () => {
         }
       ];
 
-      const wrapper = mountWithSetup(FleetClusterTargets, {
+      const wrapper = mount(FleetClusterTargets, {
+        ...requiredSetup(),
         props: {
           targets:   [],
           namespace: 'fleet-default',
@@ -1873,7 +1874,8 @@ describe('component: FleetClusterTargets', () => {
         }
       ];
 
-      const wrapper = mountWithSetup(FleetClusterTargets, {
+      const wrapper = mount(FleetClusterTargets, {
+        ...requiredSetup(),
         props: {
           targets:   [],
           namespace: 'fleet-default',
@@ -1894,7 +1896,8 @@ describe('component: FleetClusterTargets', () => {
         }
       ];
 
-      const wrapper = mountWithSetup(FleetClusterTargets, {
+      const wrapper = mount(FleetClusterTargets, {
+        ...requiredSetup(),
         props: {
           targets:   [],
           namespace: 'fleet-default',
@@ -1923,7 +1926,8 @@ describe('component: FleetClusterTargets', () => {
         }
       ];
 
-      const wrapper = mountWithSetup(FleetClusterTargets, {
+      const wrapper = mount(FleetClusterTargets, {
+        ...requiredSetup(),
         props: {
           targets:   [],
           namespace: 'fleet-default',
@@ -1936,8 +1940,12 @@ describe('component: FleetClusterTargets', () => {
       const options = wrapper.vm.clustersOptions;
 
       expect(options).toStrictEqual([
-        { label: 'my-production-cluster', value: 'my-production-cluster' },
-        { label: 'my-staging-cluster', value: 'my-staging-cluster' }
+        {
+          label: 'my-production-cluster', value: 'my-production-cluster', disabled: false
+        },
+        {
+          label: 'my-staging-cluster', value: 'my-staging-cluster', disabled: false
+        }
       ]);
     });
 
@@ -1955,7 +1963,8 @@ describe('component: FleetClusterTargets', () => {
         }
       ];
 
-      const wrapper = mountWithSetup(FleetClusterTargets, {
+      const wrapper = mount(FleetClusterTargets, {
+        ...requiredSetup(),
         props: {
           targets:   [],
           namespace: 'fleet-default',
@@ -1966,7 +1975,9 @@ describe('component: FleetClusterTargets', () => {
       wrapper.setData({ allClusters: mockClusters });
 
       expect(wrapper.vm.clustersOptions).toStrictEqual([
-        { label: 'my-cluster', value: 'my-cluster' }
+        {
+          label: 'my-cluster', value: 'my-cluster', disabled: false
+        }
       ]);
     });
   });
@@ -1989,7 +2000,8 @@ describe('component: FleetClusterTargets', () => {
         { clusterName: 'c-m-def456' }
       ];
 
-      const wrapper = mountWithSetup(FleetClusterTargets, {
+      const wrapper = mount(FleetClusterTargets, {
+        ...requiredSetup(),
         props: {
           targets,
           namespace: 'fleet-default',
@@ -2015,7 +2027,8 @@ describe('component: FleetClusterTargets', () => {
 
       const targets = [{ clusterName: 'my-cluster' }];
 
-      const wrapper = mountWithSetup(FleetClusterTargets, {
+      const wrapper = mount(FleetClusterTargets, {
+        ...requiredSetup(),
         props: {
           targets,
           namespace: 'fleet-default',
@@ -2042,7 +2055,8 @@ describe('component: FleetClusterTargets', () => {
         { clusterName: 'unknown-name' }
       ];
 
-      const wrapper = mountWithSetup(FleetClusterTargets, {
+      const wrapper = mount(FleetClusterTargets, {
+        ...requiredSetup(),
         props: {
           targets,
           namespace: 'fleet-default',
@@ -2059,7 +2073,8 @@ describe('component: FleetClusterTargets', () => {
     it('should not resolve when clusters array is empty', async() => {
       const targets = [{ clusterName: 'c-m-abc123' }];
 
-      const wrapper = mountWithSetup(FleetClusterTargets, {
+      const wrapper = mount(FleetClusterTargets, {
+        ...requiredSetup(),
         props: {
           targets,
           namespace: 'fleet-default',

--- a/shell/models/__tests__/fleet-application.test.ts
+++ b/shell/models/__tests__/fleet-application.test.ts
@@ -1,0 +1,159 @@
+import FleetApplication from '@shell/models/fleet-application.js';
+
+describe('class FleetApplication', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('targetClusters', () => {
+    function createFleetApplication(targets: any[] | undefined, clusters: any[], workspaceId = 'fleet-default', groups: any[] = []) {
+      const workspace = {
+        id: workspaceId,
+        clusters,
+        clusterGroups: groups,
+      };
+
+      jest.spyOn(FleetApplication.prototype, '$getters', 'get').mockReturnValue({ byId: () => workspace });
+
+      return new FleetApplication({
+        metadata: { namespace: workspaceId },
+        spec:     { targets },
+      });
+    }
+
+    it.each([
+      [
+        'metadata.name',
+        [{ clusterName: 'c-m-abc123' }],
+        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-cluster' }],
+        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-cluster' }],
+      ],
+      [
+        'nameDisplay when metadata.name does not match',
+        [{ clusterName: 'my-display-name' }],
+        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-display-name' }],
+        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-display-name' }],
+      ],
+    ])('should find cluster by %s', (_label, targets, clusters, expected) => {
+      const app = createFleetApplication(targets, clusters);
+
+      expect(app.targetClusters).toStrictEqual(expected);
+    });
+
+    it('should prefer metadata.name match over nameDisplay match', () => {
+      const clusters = [
+        {
+          id:          'fleet-default/exact-match',
+          metadata:    { name: 'exact-match' },
+          nameDisplay: 'display-a',
+        },
+        {
+          id:          'fleet-default/c-m-other',
+          metadata:    { name: 'c-m-other' },
+          nameDisplay: 'exact-match',
+        }
+      ];
+
+      const app = createFleetApplication([{ clusterName: 'exact-match' }], clusters);
+
+      expect(app.targetClusters).toStrictEqual([clusters[0]]);
+    });
+
+    it('should return empty array when no cluster matches by name or nameDisplay', () => {
+      const clusters = [
+        {
+          id:          'fleet-default/c-m-abc123',
+          metadata:    { name: 'c-m-abc123' },
+          nameDisplay: 'my-cluster',
+        }
+      ];
+
+      const app = createFleetApplication([{ clusterName: 'non-existent' }], clusters);
+
+      expect(app.targetClusters).toStrictEqual([]);
+    });
+
+    it('should handle multiple targets with mixed name and nameDisplay matches', () => {
+      const clusters = [
+        {
+          id:          'fleet-default/c-m-abc123',
+          metadata:    { name: 'c-m-abc123' },
+          nameDisplay: 'cluster-alpha',
+        },
+        {
+          id:          'fleet-default/c-m-def456',
+          metadata:    { name: 'c-m-def456' },
+          nameDisplay: 'cluster-beta',
+        }
+      ];
+
+      const targets = [
+        { clusterName: 'c-m-abc123' },
+        { clusterName: 'cluster-beta' },
+      ];
+
+      const app = createFleetApplication(targets, clusters);
+
+      expect(app.targetClusters).toStrictEqual([clusters[0], clusters[1]]);
+    });
+
+    it('should return empty array when targets is empty', () => {
+      const app = createFleetApplication([], []);
+
+      expect(app.targetClusters).toStrictEqual([]);
+    });
+
+    it('should return empty array when targets is undefined', () => {
+      const app = createFleetApplication(undefined, []);
+
+      expect(app.targetClusters).toStrictEqual([]);
+    });
+
+    it('should return empty array when workspace has no clusters', () => {
+      const app = createFleetApplication([{ clusterName: 'any-name' }], []);
+
+      expect(app.targetClusters).toStrictEqual([]);
+    });
+
+    it('should handle cluster with undefined nameDisplay gracefully', () => {
+      const clusters = [
+        {
+          id:          'fleet-default/c-m-abc123',
+          metadata:    { name: 'c-m-abc123' },
+          nameDisplay: undefined,
+        }
+      ];
+
+      const app = createFleetApplication([{ clusterName: 'c-m-abc123' }], clusters);
+
+      expect(app.targetClusters).toStrictEqual([clusters[0]]);
+    });
+
+    it('should return local cluster targets when workspace is fleet-local', () => {
+      const localTargetClusters = [
+        {
+          id:          'fleet-local/local',
+          metadata:    { name: 'local' },
+          nameDisplay: 'local',
+        }
+      ];
+
+      const groups = [
+        {
+          id:             'fleet-local/default',
+          targetClusters: localTargetClusters,
+        }
+      ];
+
+      const app = createFleetApplication([], [], 'fleet-local', groups);
+
+      expect(app.targetClusters).toStrictEqual(localTargetClusters);
+    });
+
+    it('should return empty array when workspace is fleet-local and default group is missing', () => {
+      const app = createFleetApplication([], [], 'fleet-local', []);
+
+      expect(app.targetClusters).toStrictEqual([]);
+    });
+  });
+});

--- a/shell/models/__tests__/fleet-application.test.ts
+++ b/shell/models/__tests__/fleet-application.test.ts
@@ -8,7 +8,7 @@ describe('class FleetApplication', () => {
   describe('targetClusters', () => {
     function createFleetApplication(targets: any[] | undefined, clusters: any[], workspaceId = 'fleet-default', groups: any[] = []) {
       const workspace = {
-        id: workspaceId,
+        id:            workspaceId,
         clusters,
         clusterGroups: groups,
       };
@@ -25,14 +25,22 @@ describe('class FleetApplication', () => {
       [
         'metadata.name',
         [{ clusterName: 'c-m-abc123' }],
-        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-cluster' }],
-        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-cluster' }],
+        [{
+          id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-cluster'
+        }],
+        [{
+          id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-cluster'
+        }],
       ],
       [
         'nameDisplay when metadata.name does not match',
         [{ clusterName: 'my-display-name' }],
-        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-display-name' }],
-        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-display-name' }],
+        [{
+          id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-display-name'
+        }],
+        [{
+          id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-display-name'
+        }],
       ],
     ])('should find cluster by %s', (_label, targets, clusters, expected) => {
       const app = createFleetApplication(targets, clusters);

--- a/shell/models/__tests__/fleet.cattle.io.bundle.test.ts
+++ b/shell/models/__tests__/fleet.cattle.io.bundle.test.ts
@@ -8,7 +8,7 @@ describe('class FleetBundle', () => {
   describe('targetClusters', () => {
     function createFleetBundle(targets: any[], clusters: any[], workspaceId = 'fleet-default', groups: any[] = []) {
       const workspace = {
-        id: workspaceId,
+        id:            workspaceId,
         clusters,
         clusterGroups: groups,
       };
@@ -25,14 +25,22 @@ describe('class FleetBundle', () => {
       [
         'metadata.name',
         [{ clusterName: 'c-m-abc123' }],
-        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-cluster' }],
-        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-cluster' }],
+        [{
+          id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-cluster'
+        }],
+        [{
+          id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-cluster'
+        }],
       ],
       [
         'nameDisplay when metadata.name does not match',
         [{ clusterName: 'my-display-name' }],
-        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-display-name' }],
-        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-display-name' }],
+        [{
+          id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-display-name'
+        }],
+        [{
+          id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-display-name'
+        }],
       ],
     ])('should find cluster by %s', (_label, targets, clusters, expected) => {
       const bundle = createFleetBundle(targets, clusters);

--- a/shell/models/__tests__/fleet.cattle.io.bundle.test.ts
+++ b/shell/models/__tests__/fleet.cattle.io.bundle.test.ts
@@ -1,0 +1,161 @@
+import FleetBundle from '@shell/models/fleet.cattle.io.bundle.js';
+
+describe('class FleetBundle', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('targetClusters', () => {
+    function createFleetBundle(targets: any[], clusters: any[], workspaceId = 'fleet-default', groups: any[] = []) {
+      const workspace = {
+        id: workspaceId,
+        clusters,
+        clusterGroups: groups,
+      };
+
+      jest.spyOn(FleetBundle.prototype, '$getters', 'get').mockReturnValue({ byId: () => workspace });
+
+      return new FleetBundle({
+        metadata: { namespace: workspaceId },
+        spec:     { targets },
+      });
+    }
+
+    it.each([
+      [
+        'metadata.name',
+        [{ clusterName: 'c-m-abc123' }],
+        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-cluster' }],
+        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-cluster' }],
+      ],
+      [
+        'nameDisplay when metadata.name does not match',
+        [{ clusterName: 'my-display-name' }],
+        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-display-name' }],
+        [{ id: 'fleet-default/c-m-abc123', metadata: { name: 'c-m-abc123' }, nameDisplay: 'my-display-name' }],
+      ],
+    ])('should find cluster by %s', (_label, targets, clusters, expected) => {
+      const bundle = createFleetBundle(targets, clusters);
+
+      expect(bundle.targetClusters).toStrictEqual(expected);
+    });
+
+    it('should prefer metadata.name match over nameDisplay match', () => {
+      const clusters = [
+        {
+          id:          'fleet-default/exact-match',
+          metadata:    { name: 'exact-match' },
+          nameDisplay: 'display-a',
+        },
+        {
+          id:          'fleet-default/c-m-other',
+          metadata:    { name: 'c-m-other' },
+          nameDisplay: 'exact-match',
+        }
+      ];
+
+      const bundle = createFleetBundle([{ clusterName: 'exact-match' }], clusters);
+
+      expect(bundle.targetClusters).toStrictEqual([clusters[0]]);
+    });
+
+    it('should return empty array when no cluster matches by name or nameDisplay', () => {
+      const clusters = [
+        {
+          id:          'fleet-default/c-m-abc123',
+          metadata:    { name: 'c-m-abc123' },
+          nameDisplay: 'my-cluster',
+        }
+      ];
+
+      const bundle = createFleetBundle([{ clusterName: 'non-existent' }], clusters);
+
+      expect(bundle.targetClusters).toStrictEqual([]);
+    });
+
+    it('should handle multiple targets with mixed name and nameDisplay matches', () => {
+      const clusters = [
+        {
+          id:          'fleet-default/c-m-abc123',
+          metadata:    { name: 'c-m-abc123' },
+          nameDisplay: 'cluster-alpha',
+        },
+        {
+          id:          'fleet-default/c-m-def456',
+          metadata:    { name: 'c-m-def456' },
+          nameDisplay: 'cluster-beta',
+        }
+      ];
+
+      const targets = [
+        { clusterName: 'c-m-abc123' },
+        { clusterName: 'cluster-beta' },
+      ];
+
+      const bundle = createFleetBundle(targets, clusters);
+
+      expect(bundle.targetClusters).toStrictEqual([clusters[0], clusters[1]]);
+    });
+
+    it('should return empty array when workspace has no clusters', () => {
+      const bundle = createFleetBundle([{ clusterName: 'any-name' }], []);
+
+      expect(bundle.targetClusters).toStrictEqual([]);
+    });
+
+    it('should handle cluster with undefined nameDisplay gracefully', () => {
+      const clusters = [
+        {
+          id:          'fleet-default/c-m-abc123',
+          metadata:    { name: 'c-m-abc123' },
+          nameDisplay: undefined,
+        }
+      ];
+
+      const bundle = createFleetBundle([{ clusterName: 'c-m-abc123' }], clusters);
+
+      expect(bundle.targetClusters).toStrictEqual([clusters[0]]);
+    });
+
+    it('should not match by nameDisplay when nameDisplay is undefined and target uses a different name', () => {
+      const clusters = [
+        {
+          id:          'fleet-default/c-m-abc123',
+          metadata:    { name: 'c-m-abc123' },
+          nameDisplay: undefined,
+        }
+      ];
+
+      const bundle = createFleetBundle([{ clusterName: 'some-other-name' }], clusters);
+
+      expect(bundle.targetClusters).toStrictEqual([]);
+    });
+
+    it('should return local cluster targets when workspace is fleet-local', () => {
+      const localTargetClusters = [
+        {
+          id:          'fleet-local/local',
+          metadata:    { name: 'local' },
+          nameDisplay: 'local',
+        }
+      ];
+
+      const groups = [
+        {
+          id:             'fleet-local/default',
+          targetClusters: localTargetClusters,
+        }
+      ];
+
+      const bundle = createFleetBundle([], [], 'fleet-local', groups);
+
+      expect(bundle.targetClusters).toStrictEqual(localTargetClusters);
+    });
+
+    it('should return empty array when workspace is fleet-local and default group is missing', () => {
+      const bundle = createFleetBundle([], [], 'fleet-local', []);
+
+      expect(bundle.targetClusters).toStrictEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16870 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- The test covers the three file changes. The unit tests now verifies the fallback on FleetApplication and FleetBundle to searching nameDisplay when there is no metadata.name match. Checking edge-cases of undefined, empty clusters and the local case. The FleetClusterTargets component tests verify that clusterOptions uses nameDisplay, and the resolveCLusterDisplayName as well maps to nameDisplay. The allClusters as well to make sure it uses the displayNames.
- For E2E tests, as well focus on the creation and editing flow, checking for clusterName added as displayName. So the tests are to make sure the resolves are correct.


### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
