### PR TITLE
[backport 2.13.7] Automation: Fix cluster dashboard tests

### DIFF
--- a/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
@@ -10,6 +10,7 @@ import { EventsPageListPo } from '@/cypress/e2e/po/pages/explorer/events.po';
 import * as path from 'path';
 import { eventsNoDataset } from '@/cypress/e2e/blueprints/explorer/cluster/events';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
+import { qase } from '@/cypress/support/qase';
 
 const configMapYaml = `apiVersion: v1
 kind: ConfigMap
@@ -36,7 +37,7 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
     cy.login();
   });
 
-  it('can navigate to cluster dashboard', () => {
+  qase(2039, it('can navigate to cluster dashboard', () => {
     const clusterList = new ClusterManagerListPagePo('local');
 
     clusterList.goTo();
@@ -51,9 +52,9 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
 
     // check if burger menu nav is highlighted correctly for local cluster
     BurgerMenuPo.checkIfClusterMenuLinkIsHighlighted('local');
-  });
+  }));
 
-  it('has the correct title', () => {
+  qase(2361, it('has the correct title', () => {
     ClusterDashboardPagePo.navTo();
 
     cy.getRancherVersion().then((version) => {
@@ -61,15 +62,15 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
 
       cy.title().should('eq', expectedTitle);
     });
-  });
+  }));
 
-  it('shows fleet controller status', () => {
+  qase(5703, it('shows fleet controller status', () => {
     ClusterDashboardPagePo.navTo();
     clusterDashboard.waitForPage();
     clusterDashboard.fleetStatus().should('exist');
-  });
+  }));
 
-  it('can import a YAML successfully, using the header action "Import YAML"', () => {
+  qase(3046, it('can import a YAML successfully, using the header action "Import YAML"', () => {
     ClusterDashboardPagePo.navTo();
 
     header.importYamlHeaderAction().click();
@@ -84,16 +85,16 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
     header.importYaml().importYamlSortableTable().subRows().should('not.exist');
 
     header.importYaml().importYamlCloseClick();
-  });
+  }));
 
-  it('can open the kubectl shell from header', () => {
+  qase(3537, it('can open the kubectl shell from header', () => {
     ClusterDashboardPagePo.navTo();
 
     header.kubectlShell().openAndExecuteCommand('get no');
     header.kubectlShell().closeTerminal();
-  });
+  }));
 
-  it('can download kubeconfig from header', () => {
+  qase(3539, it('can download kubeconfig from header', () => {
     const downloadsFolder = Cypress.config('downloadsFolder');
     const downloadedFilename = path.join(downloadsFolder, 'local.yaml');
 
@@ -101,15 +102,15 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
 
     header.downloadKubeconfig().click();
     cy.readFile(downloadedFilename).should('contain', 'kind: Config');
-  });
+  }));
 
-  it('can copy the kubeconfig to clipboard', () => {
+  qase(3538, it('can copy the kubeconfig to clipboard', () => {
     ClusterDashboardPagePo.navTo();
     cy.intercept('POST', '*action=generateKubeconfig').as('copyKubeConfig');
     header.copyKubeconfig().click();
     header.copyKubeConfigCheckmark().should('be.visible');
     cy.wait('@copyKubeConfig');
-  });
+  }));
 
   // Skipping until issue resolved: https://github.com/rancher/dashboard/issues/15697
   // it('can add cluster badge', () => {
@@ -177,7 +178,7 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
   //   burgerMenu.clusterNotPinnedList().first().find('svg').should('have.class', 'cluster-local-logo');
   // });
 
-  it('can view deployments', () => {
+  qase(2040, it('can view deployments', () => {
     clusterDashboard.goTo();
     clusterDashboard.waitForPage();
     cy.getRancherResource('v1', 'apps.deployments', '?exclude=metadata.managedFields').then((resp: Cypress.Response<any>) => {
@@ -191,9 +192,9 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
 
       workloadDeployments.waitForPage();
     });
-  });
+  }));
 
-  it('can view nodes', () => {
+  qase(2037, it('can view nodes', () => {
     clusterDashboard.goTo();
     clusterDashboard.waitForPage();
 
@@ -214,14 +215,14 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
 
       nodesPage.waitForPage();
     });
-  });
+  }));
 
   let removePods = false;
   const podNames = ['e2e-test1', 'e2e-test2', 'e2e-test3', 'e2e-test4', 'e2e-test5', 'e2e-test6'];
   const projName = `project${ +new Date() }`;
   const nsName = `namespace${ +new Date() }`;
 
-  it('can view events and change events list count in cluster dashboard', () => {
+  qase(15329, it('can view events and change events list count in cluster dashboard', () => {
     // Create a pod to trigger events
 
     // get user id
@@ -269,9 +270,9 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
     events.waitForPage();
     events.list().resourceTable().sortableTable().rowElements()
       .should('have.length.gte', 12);
-  });
+  }));
 
-  it('can view events table empty if no events', { tags: ['@noVai', '@adminUser'] }, () => {
+  qase(3857, it('can view events table empty if no events', { tags: ['@noVai', '@adminUser'] }, () => {
     eventsNoDataset();
     clusterDashboard.goTo();
 
@@ -313,9 +314,9 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
           expect(el.text().trim()).to.eq(expectedFullHeaders[i]);
         });
     });
-  });
+  }));
 
-  describe('Cluster dashboard with limited permissions', () => {
+  describe('Cluster dashboard with limited permissions', { testIsolation: 'on' }, () => {
     let stdProjectName;
     let stdNsName;
     let stdUsername;
@@ -366,13 +367,13 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
     });
 
     // note - this would be 'fleet agent' on downstream clusters
-    it('does not show fleet controller status if the user does not have permission to view the fleet controller deployment', () => {
+    qase(5704, it('does not show fleet controller status if the user does not have permission to view the fleet controller deployment', () => {
       clusterDashboard.fleetStatus().should('not.exist');
 
       clusterDashboard.etcdStatus().should('exist');
       clusterDashboard.schedulerStatus().should('exist');
       clusterDashboard.controllerManagerStatus().should('exist');
-    });
+    }));
 
     // log back in as admin and delete the project, ns, and user from previous test
     afterEach(() => {
@@ -386,7 +387,7 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
       cy.get('@createUserRequest').then((req) => {
         const userId = req.body.id;
 
-        cy.deleteRancherResource('v3', 'users', userId);
+        cy.deleteRancherResource('v1', 'management.cattle.io.users', userId);
       });
     });
   });
@@ -405,8 +406,12 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
     status:  403,
   };
 
-  describe('Cluster dashboard - Fleet agent', () => {
-    it('does not show fleet controller status if a 403 is returned by the API', () => {
+  describe('Cluster dashboard - Fleet agent', { testIsolation: 'on' }, () => {
+    beforeEach(() => {
+      cy.login();
+    });
+
+    qase(8677, it('does not show fleet controller status if a 403 is returned by the API', () => {
       cy.intercept('GET', '/v1/apps.deployments/cattle-fleet-system/fleet-controller?*', reply(403, forbiddenResponse));
       cy.intercept('GET', '/v1/apps.deployments/cattle-fleet-local-system/fleet-agent?*', reply(403, forbiddenResponse));
 
@@ -419,9 +424,9 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
       clusterDashboard.etcdStatus().should('exist');
       clusterDashboard.schedulerStatus().should('exist');
       clusterDashboard.controllerManagerStatus().should('exist');
-    });
+    }));
 
-    it('does not show fleet controller status if a 404 is returned by the API', () => {
+    qase(8678, it('does not show fleet controller status if a 404 is returned by the API', () => {
       cy.intercept('GET', '/v1/apps.deployments/cattle-fleet-system/fleet-controller?*', reply(404, {}));
       cy.intercept('GET', '/v1/apps.deployments/cattle-fleet-local-system/fleet-agent?*', reply(404, {}));
 
@@ -434,7 +439,7 @@ describe('Cluster Dashboard', { testIsolation: 'off', tags: ['@explorer', '@admi
       clusterDashboard.etcdStatus().should('exist');
       clusterDashboard.schedulerStatus().should('exist');
       clusterDashboard.controllerManagerStatus().should('exist');
-    });
+    }));
   });
 
   after(function() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2320

Backport of https://github.com/rancher/dashboard/pull/17877
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="1120" height="403" alt="image" src="https://github.com/user-attachments/assets/da858e17-8c31-429e-bfc5-eb5e7351c366" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
