### PR TITLE
[backport 2.14.3] Automation: Fix custom add-on config test

### DIFF
--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -28,6 +28,7 @@ import {
 } from '@/cypress/support/utils/timeouts';
 import HostedProvidersPagePo from '@/cypress/e2e/po/pages/cluster-manager/hosted-providers.po';
 import { USERS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
+import { qase } from '@/cypress/support/qase';
 
 // At some point these will come from somewhere central, then we can make tools to remove resources from this or all runs
 const createClusterTestName = (suffix: string) => `e2e-test-${ +new Date() }-create-${ suffix }`;
@@ -326,7 +327,8 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
           expect(obj.kind).to.equal('Cluster');
         });
       });
-      it('preserves custom addon config values after saving cluster config', () => {
+
+      qase(48756, it('preserves custom addon config values after saving cluster config', () => {
         const customAddonConfig = `goodvalue: yay\nnested:\n  enabled: true`;
         const updatedDescription = `${ rke2CustomName }-addon-persist-check`;
 
@@ -353,8 +355,8 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
         editCreatedClusterPage().clusterConfigurationTabs().clickTabWithSelector('#rke2-calico');
         editCreatedClusterPage().calicoAddonConfig().yamlEditor().input()
           .value()
-          .should('equal', customAddonConfig);
-      });
+          .should('include', customAddonConfig);
+      }));
 
       it('can delete cluster', () => {
         clusterList.goTo();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2351

Backport of https://github.com/rancher/dashboard/pull/17857
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="756" height="297" alt="image" src="https://github.com/user-attachments/assets/e6dc6460-313c-42d9-b8b5-dc22386c5c95" />

<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
