### PR TITLE
Set e2e tag to head

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -9,7 +9,7 @@
         "rancher-image": {
           "namespace": "rancher",
           "name": "rancher",
-          "tag": "v2.15-2cc6c46753bc8de0aa2f603515ffa854d1a6963d-head"
+          "tag": "head"
         }
       },
       "rancher-rancher-repo": {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This unpins the e2e test tag and sets it to head. This is being done as a follow-up to #17915.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Set e2e tag to head

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

In an out of band discussion, we arrived at the conclusion that the changes in the test behavior discovered in: 

- `rancher/rancher:v2.15-be6e739d612c0525f3f72ee1b8b7b55c39e0f85a-head`
- https://github.com/rancher/rancher/actions/runs/26638856471/job/78507996098
- https://github.com/rancher/rancher/pull/55317

are expected. The root cause of the failure is a change to webhooks[^1], which altered the settings behavior so that they are properly immutable when set by environment variables. 

[^1]: https://github.com/rancher/webhook/commit/9e3b9eafe8e54dd36c43aee06dcf82f4db012ef4 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

CI will still fail after this change. I am working on one more PR to follow-up with a proper fix for the failing test so that we can confirm that the fix is properly in place when testing agains head images. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

NA

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
