### PR TITLE
Assert that `can update password-min-length` is immutable when set by env

### DIFF
--- a/cypress/e2e/po/pages/global-settings/settings.po.ts
+++ b/cypress/e2e/po/pages/global-settings/settings.po.ts
@@ -63,6 +63,15 @@ export class SettingsPagePo extends RootClusterPage {
   }
 
   /**
+   * Get "Set by Environment Variable" label per setting name
+   * @param label
+   * @returns
+   */
+  environmentLabel(label: string) {
+    return cy.getId(`advanced-setting-env-label-${ label }`);
+  }
+
+  /**
    * Get modified label per setting name
    * @param label
    * @returns

--- a/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings-p2.spec.ts
@@ -40,6 +40,16 @@ describe('Settings', { testIsolation: 'off' }, () => {
     // only checking that the api request is sent and that the reset button is disabled
 
     SettingsPagePo.navTo();
+    settingsPage.waitForUrlPathWithoutContext();
+
+    // When CATTLE_SERVER_URL is set on the server the setting is read-only and cannot be edited via the UI
+    if (settingsOriginal['server-url']?.source === 'env') {
+      settingsPage.environmentLabel('server-url').should('be.visible');
+      settingsPage.actionButtonByLabel('server-url').should('not.exist');
+
+      return;
+    }
+
     settingsPage.settingsValue('server-url').then((el: any) => {
       const value = el.text();
 
@@ -75,6 +85,15 @@ describe('Settings', { testIsolation: 'off' }, () => {
 
   it('can validate server-url', { tags: ['@globalSettings', '@adminUser'] }, () => {
     SettingsPagePo.navTo();
+    settingsPage.waitForUrlPathWithoutContext();
+
+    // When CATTLE_SERVER_URL is set on the server the setting is read-only and cannot be edited via the UI
+    if (settingsOriginal['server-url']?.source === 'env') {
+      settingsPage.environmentLabel('server-url').should('be.visible');
+      settingsPage.actionButtonByLabel('server-url').should('not.exist');
+
+      return;
+    }
 
     settingsPage.editSettingsByLabel('server-url');
 
@@ -180,8 +199,18 @@ describe('Settings', { testIsolation: 'off' }, () => {
   });
 
   it('can update ui-offline-preferred', { tags: ['@globalSettings', '@adminUser'] }, () => {
-    // Update setting: Local
     SettingsPagePo.navTo();
+    settingsPage.waitForUrlPathWithoutContext();
+
+    // When CATTLE_UI_OFFLINE_PREFERRED is set on the server the setting is read-only and cannot be edited via the UI
+    if (settingsOriginal['ui-offline-preferred']?.source === 'env') {
+      settingsPage.environmentLabel('ui-offline-preferred').should('be.visible');
+      settingsPage.actionButtonByLabel('ui-offline-preferred').should('not.exist');
+
+      return;
+    }
+
+    // Update setting: Local
     settingsPage.editSettingsByLabel('ui-offline-preferred');
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'ui-offline-preferred');

--- a/cypress/e2e/tests/pages/global-settings/settings.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings.spec.ts
@@ -215,8 +215,18 @@ describe('Settings', { testIsolation: 'off' }, () => {
   });
 
   it('can update password-min-length', { tags: ['@globalSettings', '@adminUser'] }, () => {
-    // Update setting
     SettingsPagePo.navTo();
+    settingsPage.waitForUrlPathWithoutContext();
+
+    // When CATTLE_PASSWORD_MIN_LENGTH is set on the server the setting is read-only and cannot be edited via the UI
+    if (settingsOriginal['password-min-length']?.source === 'env') {
+      settingsPage.environmentLabel('password-min-length').should('be.visible');
+      settingsPage.actionButtonByLabel('password-min-length').should('not.exist');
+
+      return;
+    }
+
+    // Update setting
     settingsPage.editSettingsByLabel('password-min-length');
 
     const settingsEdit = settingsPage.editSettings(settingsClusterId, 'password-min-length');
@@ -228,30 +238,6 @@ describe('Settings', { testIsolation: 'off' }, () => {
     settingsPage.waitForUrlPathWithoutContext();
     settingsPage.settingsValue('password-min-length').contains(settings['password-min-length'].new);
 
-    // this just causes problems
-    // Check new password requirement
-    // const banner = new BannersPo('.text-error');
-
-    // accountPage.waitForRequests();
-    // accountPage.changePassword();
-    // accountPage.currentPassword().set(Cypress.env('password'));
-    // accountPage.newPassword().set('NewPassword1');
-    // accountPage.confirmPassword().set('NewPassword1');
-
-    // // Note: For some odd reason, when running this test in CI,
-    // // the expected network error is not thrown
-    // // so we need to stub status code and body here to force the error
-    // // to prevent the user from updating the password.
-    // // To be clear, this is not a bug, the issue is specific to Cypress automation
-    // // cy.intercept('POST', '/v1/ext.cattle.io.passwordchangerequests', {
-    // //   statusCode: 422,
-    // //   body:       { message: `Password must be at least ${ settings['password-min-length'].new } characters` }
-    // // }).as('changePwError');
-    // cy.intercept('POST', '/v1/ext.cattle.io.passwordchangerequests').as('changePwError');
-
-    // accountPage.apply();
-    // cy.wait('@changePwError');
-    // banner.banner().contains(`Password must be at least ${ settings['password-min-length'].new } characters`).should('be.visible');
     // Reset
     SettingsPagePo.navTo();
     settingsPage.waitForUrlPathWithoutContext();

--- a/shell/components/Setting.vue
+++ b/shell/components/Setting.vue
@@ -29,6 +29,7 @@ export default {
           <span
             v-if="value.fromEnv"
             class="modified"
+            :data-testid="`advanced-setting-env-label-${value.id}`"
           >{{ t('advancedSettings.setEnv') }}</span>
           <span
             v-else-if="value.customized"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves an issue where the "can update password-min-length" attempts to edit an immutable variable that has been set by an environment variable. 

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Assert that can update password-min-length is immutable when set by env

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

In an out of band discussion, we arrived at the conclusion that the changes in the test behavior discovered in: 

- `rancher/rancher:v2.15-be6e739d612c0525f3f72ee1b8b7b55c39e0f85a-head`
- https://github.com/rancher/rancher/actions/runs/26638856471/job/78507996098
- https://github.com/rancher/rancher/pull/55317

are expected. The root cause of the failure is a change to webhooks[^1], which altered the settings behavior so that they are properly immutable when set by environment variables. 

[^1]: https://github.com/rancher/webhook/commit/9e3b9eafe8e54dd36c43aee06dcf82f4db012ef4 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

CI should pass all gates.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

NA

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
