### PR TITLE
[2.16] fix(azure) Fix cn azure default region

### DIFF
--- a/pkg/aks/components/CruAks.vue
+++ b/pkg/aks/components/CruAks.vue
@@ -366,7 +366,7 @@ export default defineComponent({
           if (res.find((r: any) => r.name === DEFAULT_REGION)) {
             this.config['resourceLocation'] = DEFAULT_REGION;
           } else {
-            this.config['resourceLocation'] = res[0]?.name;
+            this.config['resourceLocation'] = withAZ[0]?.name ?? withoutAZ[0]?.name ?? res[0]?.name;
           }
         }
         this.loadingLocations = false;


### PR DESCRIPTION
## Issue
Fixes https://github.com/rancher/dashboard/issues/17928

## Problem
The current implementation uses `res[0]?.name` as the default `resourceLocation`. However, the first region in the response is not guaranteed to be available or to have available AZs. This can cause the UI to select an invalid or unavailable default region.

## Solution
Update the default region selection logic to prefer regions with available AZs first:


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
