### PR TITLE
Update Kubewarden extension name

### DIFF
--- a/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
@@ -6,7 +6,7 @@ import KubewardenExtensionPo from '@/cypress/e2e/po/pages/extensions/kubewarden.
 import { catchTargetPageException } from '@/cypress/support/utils/exception-utils';
 import { qase } from '@/cypress/support/qase';
 
-const extensionName = 'kubewarden';
+const extensionName = 'SUSE Security Admission Controller';
 const gitRepoName = 'rancher-extensions';
 let removeExtensions = false;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This resolves failing gates in the e2e test suite by renaming the Kubewarden extension to "SUSE Security Admission Controller". 

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Update Kubewarden extension name

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Current e2e test runs for `cypress/e2e/tests/pages/extensions/kubewarden.spec.ts` fail:

```
  Kubewarden Extension
    1) Should install Kubewarden extension (Qase ID: 1430)
    ✓ Check Apps/Charts and Apps/Repo pages for route collisions (Qase ID: 1429)
    2) Side-nav should contain Kubewarden menu item (Qase ID: 1431)
    3) Kubewarden dashboard view should exist (Qase ID: 1432)
    4) Should uninstall Kubewarden (Qase ID: 1433)
cypress-terminal-report: Wrote html logs to /home/runner/work/dashboard/dashboard/browser-logs/out.html. (3ms)
  1 passing (3m)
  4 failing
  1) Kubewarden Extension
       Should install Kubewarden extension (Qase ID: 1430):
     AssertionError: Timed out retrying after 10000ms: Expected to find content: 'kubewarden' within the element: [ <h3.item-card-header-title.has-clean-tooltip>, 9 more... ] but never did.
      at ./cypress/e2e/po/components/rc-item-card.po.ts.RcItemCardPo.getCardByTitle (webpack:///./cypress/e2e/po/components/rc-item-card.po.ts:32:0)
      at ./cypress/e2e/po/pages/extensions.po.ts.ExtensionsPagePo.extensionCard (webpack:///./cypress/e2e/po/pages/extensions.po.ts:166:0)
      at ./cypress/e2e/po/pages/extensions.po.ts.ExtensionsPagePo.clickAction (webpack:///./cypress/e2e/po/pages/extensions.po.ts:169:0)
      at ./cypress/e2e/po/pages/extensions.po.ts.ExtensionsPagePo.extensionCardInstallClick (webpack:///./cypress/e2e/po/pages/extensions.po.ts:180:0)
      at ./cypress/e2e/po/pages/extensions.po.ts.ExtensionsPagePo.installExtensionFromCatalog (webpack:///./cypress/e2e/po/pages/extensions.po.ts:93:0)
      at Context.eval (webpack:///./cypress/e2e/tests/pages/extensions/kubewarden.spec.ts:47:0)
      at getRet (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:139235:20)
      at Context.thenFn (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:139249:63)
      at Context.then (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:139671:21)
  2) Kubewarden Extension
       Side-nav should contain Kubewarden menu item (Qase ID: 1431):
     AssertionError: Timed out retrying after 10000ms: Expected to find element: `.side-nav`, but never found it.
      at ComponentPo.self (webpack:///./cypress/e2e/po/components/component.po.ts:33:44)
      at ./cypress/e2e/po/side-bars/product-side-nav.po.ts.ProductNavPo.groups (webpack:///./cypress/e2e/po/side-bars/product-side-nav.po.ts:34:0)
      at Context.eval (webpack:///./cypress/e2e/tests/pages/extensions/kubewarden.spec.ts:81:0)
      at runnable.fn (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:158077:19)
      at callFn (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:107989:21)
      at <unknown> (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:165418:30)
      at PassThroughHandlerContext.finallyHandler (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:7881:23)
  3) Kubewarden Extension
       Kubewarden dashboard view should exist (Qase ID: 1432):
     AssertionError: Timed out retrying after 10000ms: Expected to find content: 'Kubewarden' within the element: <h1> but never did.
      at Context.eval (webpack:///./cypress/e2e/tests/pages/extensions/kubewarden.spec.ts:89:0)
      at runnable.fn (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:158077:19)
      at callFn (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:107989:21)
      at <unknown> (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:165418:30)
      at PassThroughHandlerContext.finallyHandler (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:7881:23)
      at Promise._settlePromiseFromHandler (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:9262:31)
      at Promise._settlePromise (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:9319:18)
  4) Kubewarden Extension
       Should uninstall Kubewarden (Qase ID: 1433):
     AssertionError: Timed out retrying after 10000ms: Expected to find element: `[data-testid="btn-installed"]`, but never found it.
      at ./cypress/e2e/po/components/tabbed.po.ts.TabbedPo.clickTabWithName (webpack:///./cypress/e2e/po/components/tabbed.po.ts:38:0)
      at ./cypress/e2e/po/pages/extensions.po.ts.ExtensionsPagePo.extensionTabInstalledClick (webpack:///./cypress/e2e/po/pages/extensions.po.ts:229:0)
      at Context.eval (webpack:///./cypress/e2e/tests/pages/extensions/kubewarden.spec.ts:97:0)
      at runnable.fn (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:158077:19)
      at callFn (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:107989:21)
      at <unknown> (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:165418:30)
      at PassThroughHandlerContext.finallyHandler (https://127.0.0.1.sslip.io/__cypress/runner/cypress_runner.js:7881:23)
```

The Kubewarden extension has been renamed to "SUSE Security Admission Controller". This change came in via https://github.com/rancher/ui-plugin-charts/pull/235/changes#diff-56a40d44375369dc7a28e6348a806e8e94c5b4e99870bec7176836a1ee7a387d and the e2e tests need to update to reflect this name change. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

All CI gates should pass.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

All CI gates should pass.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
