### PR TITLE
Default auth provider accessMode to required and warn on unrestricted

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -498,6 +498,7 @@ authConfig:
     required: Restrict access to only the authorized users & groups
     restricted: 'Allow members of clusters and projects, plus authorized users & groups'
     unrestricted: Allow any valid user
+    unrestrictedWarning: '"Allow any valid user" allows any user who can authenticate with the external provider to log in to Rancher. Consider restricting access to only authorized users and groups to limit access.'
   allowedPrincipalIds:
     title: Authorized Users & Groups
   associatedWarning: 'The {provider} account that is used to enable the external provider will be granted permissions equal to the currently logged in Rancher user. See <a href="{docsBase}/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config#external-authentication-configuration-and-principal-users" target="_blank" rel="noopener noreferrer nofollow">External Authentication Configuration and Principal Users</a> to understand why.'

--- a/shell/components/auth/AllowedPrincipals.vue
+++ b/shell/components/auth/AllowedPrincipals.vue
@@ -1,6 +1,7 @@
 <script>
 import { RadioGroup } from '@components/Form/Radio';
 import ArrayList from '@shell/components/form/ArrayList';
+import { Banner } from '@components/Banner';
 import Principal from '@shell/components/auth/Principal';
 import SelectPrincipal from '@shell/components/auth/SelectPrincipal';
 import { _EDIT } from '@shell/config/query-params';
@@ -10,6 +11,7 @@ export default {
   components: {
     SelectPrincipal,
     ArrayList,
+    Banner,
     RadioGroup,
     Principal,
   },
@@ -48,7 +50,7 @@ export default {
 
   created() {
     if ( !this.authConfig.accessMode ) {
-      this.authConfig['accessMode'] = 'restricted';
+      this.authConfig['accessMode'] = 'required';
     } if (!this.authConfig.allowedPrincipalIds) {
       this.authConfig['allowedPrincipalIds'] = [];
     }
@@ -64,6 +66,14 @@ export default {
 
 <template>
   <div>
+    <Banner
+      v-if="accessMode === 'unrestricted'"
+      color="error"
+      data-testid="auth-unrestricted-warning-banner"
+    >
+      <span v-clean-html="t('authConfig.accessMode.unrestrictedWarning', {}, true)" />
+    </Banner>
+
     <h3>{{ t('authConfig.accessMode.label', {provider: authConfig.nameDisplay}) }}</h3>
 
     <div class="row">

--- a/shell/components/auth/AllowedPrincipals.vue
+++ b/shell/components/auth/AllowedPrincipals.vue
@@ -68,7 +68,7 @@ export default {
   <div>
     <Banner
       v-if="accessMode === 'unrestricted'"
-      color="error"
+      color="warning"
       data-testid="auth-unrestricted-warning-banner"
     >
       <span v-clean-html="t('authConfig.accessMode.unrestrictedWarning', {}, true)" />

--- a/shell/components/auth/__tests__/AllowedPrincipals.test.ts
+++ b/shell/components/auth/__tests__/AllowedPrincipals.test.ts
@@ -76,11 +76,11 @@ describe('component: AllowedPrincipals', () => {
       expect(banner.exists()).toStrictEqual(false);
     });
 
-    it('should show error banner with error color', () => {
+    it('should show warning banner with warning color', () => {
       const wrapper = createWrapper({ accessMode: 'unrestricted' });
       const banner = wrapper.findComponent('[data-testid="auth-unrestricted-warning-banner"]');
 
-      expect(banner.props('color')).toStrictEqual('error');
+      expect(banner.props('color')).toStrictEqual('warning');
     });
   });
 });

--- a/shell/components/auth/__tests__/AllowedPrincipals.test.ts
+++ b/shell/components/auth/__tests__/AllowedPrincipals.test.ts
@@ -1,4 +1,3 @@
-import { nextTick } from 'vue';
 import { shallowMount } from '@vue/test-utils';
 import AllowedPrincipals from '@shell/components/auth/AllowedPrincipals.vue';
 

--- a/shell/components/auth/__tests__/AllowedPrincipals.test.ts
+++ b/shell/components/auth/__tests__/AllowedPrincipals.test.ts
@@ -1,0 +1,87 @@
+import { nextTick } from 'vue';
+import { shallowMount } from '@vue/test-utils';
+import AllowedPrincipals from '@shell/components/auth/AllowedPrincipals.vue';
+
+describe('component: AllowedPrincipals', () => {
+  const defaultProps = {
+    provider:   'github',
+    authConfig: {
+      nameDisplay:         'GitHub',
+      accessMode:          '',
+      allowedPrincipalIds: [],
+    },
+    mode: 'edit',
+  };
+
+  const globalMocks = {
+    mocks: {
+      $store: {
+        getters: {
+          'i18n/t':      (key: string) => key,
+          'i18n/exists': () => true,
+        }
+      }
+    },
+    directives: { 'clean-html': () => {} },
+    stubs:      {
+      RadioGroup:      true,
+      ArrayList:       true,
+      Banner:          { template: '<div data-testid="auth-unrestricted-warning-banner"><slot /></div>', props: ['color'] },
+      Principal:       true,
+      SelectPrincipal: true,
+    },
+  };
+
+  const createWrapper = (authConfigOverrides = {}) => {
+    const authConfig = { ...defaultProps.authConfig, ...authConfigOverrides };
+
+    return shallowMount(AllowedPrincipals, {
+      props:  { ...defaultProps, authConfig },
+      global: globalMocks,
+    });
+  };
+
+  describe('default accessMode', () => {
+    it('should default accessMode to required when not set', () => {
+      const wrapper = createWrapper({ accessMode: '' });
+
+      expect(wrapper.props('authConfig').accessMode).toStrictEqual('required');
+    });
+
+    it('should not override accessMode when already set', () => {
+      const wrapper = createWrapper({ accessMode: 'restricted' });
+
+      expect(wrapper.props('authConfig').accessMode).toStrictEqual('restricted');
+    });
+  });
+
+  describe('unrestricted warning banner', () => {
+    it('should show error banner when accessMode is unrestricted', () => {
+      const wrapper = createWrapper({ accessMode: 'unrestricted' });
+      const banner = wrapper.find('[data-testid="auth-unrestricted-warning-banner"]');
+
+      expect(banner.exists()).toStrictEqual(true);
+    });
+
+    it('should not show error banner when accessMode is required', () => {
+      const wrapper = createWrapper({ accessMode: 'required' });
+      const banner = wrapper.find('[data-testid="auth-unrestricted-warning-banner"]');
+
+      expect(banner.exists()).toStrictEqual(false);
+    });
+
+    it('should not show error banner when accessMode is restricted', () => {
+      const wrapper = createWrapper({ accessMode: 'restricted' });
+      const banner = wrapper.find('[data-testid="auth-unrestricted-warning-banner"]');
+
+      expect(banner.exists()).toStrictEqual(false);
+    });
+
+    it('should show error banner with error color', () => {
+      const wrapper = createWrapper({ accessMode: 'unrestricted' });
+      const banner = wrapper.findComponent('[data-testid="auth-unrestricted-warning-banner"]');
+
+      expect(banner.props('color')).toStrictEqual('error');
+    });
+  });
+});

--- a/shell/edit/auth/__tests__/azuread.test.ts
+++ b/shell/edit/auth/__tests__/azuread.test.ts
@@ -65,6 +65,30 @@ const requiredSetup = (modelOverrides = {}) => ({
   },
 });
 
+describe('edit: azureAD accessMode default', () => {
+  let wrapper: any;
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('should default accessMode to required when not set', async() => {
+    wrapper = mount(AzureAD, { ...requiredSetup({ accessMode: '' }) });
+    wrapper.vm.model.tenantId = 'trigger-watcher';
+    await nextTick();
+
+    expect(wrapper.vm.model.accessMode).toStrictEqual('required');
+  });
+
+  it('should not override accessMode when already set', async() => {
+    wrapper = mount(AzureAD, { ...requiredSetup({ accessMode: 'unrestricted' }) });
+    wrapper.vm.model.tenantId = 'trigger-watcher';
+    await nextTick();
+
+    expect(wrapper.vm.model.accessMode).toStrictEqual('unrestricted');
+  });
+});
+
 describe('edit: azureAD should', () => {
   let wrapper: any;
 

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -228,7 +228,7 @@ export default {
     model: {
       deep: true,
       handler() {
-        this.model.accessMode = this.model.accessMode || 'unrestricted';
+        this.model.accessMode = this.model.accessMode || 'required';
         this.model.rancherUrl = this.model.rancherUrl || this.replyUrl;
 
         if (this.model.applicationSecret) {

--- a/shell/mixins/__tests__/auth-config.test.ts
+++ b/shell/mixins/__tests__/auth-config.test.ts
@@ -1,8 +1,49 @@
 import { mount } from '@vue/test-utils';
 import authConfigMixin from '@shell/mixins/auth-config';
 import childHook from '@shell/mixins/child-hook';
-//
+
 describe('mixin: authConfigMixin', () => {
+  const FakeComponent = {
+    render() {},
+    mixins:  [authConfigMixin, childHook],
+    methods: { applyHooks: jest.fn() },
+  };
+
+  describe('method: applyDefaults', () => {
+    const createInstance = (configType: string, model: any = {}) => {
+      const instance = mount(FakeComponent, {
+        data: () => ({
+          value: { configType },
+          model: { id: configType, ...model },
+        }),
+        computed: { principal: () => ({ me: {} }) },
+        global:   {
+          mocks: {
+            $store: { dispatch: () => model },
+            $route: {
+              params: { id: configType },
+              query:  { mode: 'edit' },
+            },
+          }
+        }
+      }).vm as any;
+
+      instance.applyDefaults();
+
+      return instance;
+    };
+
+    it.each([
+      'oidc',
+      'saml',
+      'ldap',
+    ])('should set accessMode to required for %s config type', (configType) => {
+      const instance = createInstance(configType);
+
+      expect(instance.model.accessMode).toStrictEqual('required');
+    });
+  });
+
   describe('method: save', () => {
     const componentMock = (model: any) => ({
       data: () => ({
@@ -20,11 +61,6 @@ describe('mixin: authConfigMixin', () => {
         }
       }
     });
-    const FakeComponent = {
-      render() {},
-      mixins:  [authConfigMixin, childHook],
-      methods: { applyHooks: jest.fn() },
-    };
 
     it('should return error', async() => {
       const instance = mount(FakeComponent, componentMock({

--- a/shell/mixins/__tests__/auth-config.test.ts
+++ b/shell/mixins/__tests__/auth-config.test.ts
@@ -34,13 +34,18 @@ describe('mixin: authConfigMixin', () => {
     };
 
     it.each([
-      'oidc',
       'saml',
       'ldap',
     ])('should set accessMode to required for %s config type', (configType) => {
       const instance = createInstance(configType);
 
       expect(instance.model.accessMode).toStrictEqual('required');
+    });
+
+    it('should set accessMode to unrestricted for oidc config type', () => {
+      const instance = createInstance('oidc');
+
+      expect(instance.model.accessMode).toStrictEqual('unrestricted');
     });
   });
 

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -326,8 +326,7 @@ export default {
         const serverUrl = this.serverUrl.endsWith('/') ? this.serverUrl.slice(0, this.serverUrl.length - 1) : this.serverUrl;
 
         // AuthConfig
-        // testAndApply enforces accessMode before the user's principal is in allowedPrincipalIds
-        this.model.accessMode = 'unrestricted';
+        this.model.accessMode = 'unrestricted'; // testAndApply enforces accessMode before the user's principal is in allowedPrincipalIds
 
         // KeyCloakOIDCConfig --> OIDCConfig
         this.model.rancherUrl = `${ serverUrl }/verify-auth`;

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -326,7 +326,8 @@ export default {
         const serverUrl = this.serverUrl.endsWith('/') ? this.serverUrl.slice(0, this.serverUrl.length - 1) : this.serverUrl;
 
         // AuthConfig
-        this.model.accessMode = 'required';
+        // testAndApply enforces accessMode before the user's principal is in allowedPrincipalIds
+        this.model.accessMode = 'unrestricted';
 
         // KeyCloakOIDCConfig --> OIDCConfig
         this.model.rancherUrl = `${ serverUrl }/verify-auth`;

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -188,7 +188,7 @@ export default {
 
           if (configType === 'saml') {
             if (!this.model.accessMode) {
-              this.model.accessMode = 'unrestricted';
+              this.model.accessMode = 'required';
             }
             if (this.model.openLdapConfig && !this.showLdap) {
               this.model.openLdapConfig = null;
@@ -199,7 +199,7 @@ export default {
           } else {
             this.model.enabled = true;
             if (!this.model.accessMode) {
-              this.model.accessMode = 'unrestricted';
+              this.model.accessMode = 'required';
             }
             await this.model.doAction('testAndApply', obj, { redirectUnauthorized: false });
           }
@@ -326,7 +326,7 @@ export default {
         const serverUrl = this.serverUrl.endsWith('/') ? this.serverUrl.slice(0, this.serverUrl.length - 1) : this.serverUrl;
 
         // AuthConfig
-        this.model.accessMode = 'unrestricted'; // This should remain as unrestricted, enabling will fail otherwise
+        this.model.accessMode = 'required';
 
         // KeyCloakOIDCConfig --> OIDCConfig
         this.model.rancherUrl = `${ serverUrl }/verify-auth`;
@@ -342,11 +342,11 @@ export default {
       }
 
       case 'saml':
-        this.model.accessMode = 'unrestricted';
+        this.model.accessMode = 'required';
         break;
       case 'ldap':
         this.model.servers = [];
-        this.model.accessMode = 'unrestricted';
+        this.model.accessMode = 'required';
         this.model.starttls = false;
         if (this.model.id === 'activedirectory') {
           this.model.disabledStatusBitmask = 2;

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -326,7 +326,7 @@ export default {
         const serverUrl = this.serverUrl.endsWith('/') ? this.serverUrl.slice(0, this.serverUrl.length - 1) : this.serverUrl;
 
         // AuthConfig
-        this.model.accessMode = 'unrestricted'; // testAndApply enforces accessMode before the user's principal is in allowedPrincipalIds
+        this.model.accessMode = 'unrestricted'; // This should remain as unrestricted, enabling will fail otherwise. testAndApply enforces accessMode before the user's principal is in allowedPrincipalIds.
 
         // KeyCloakOIDCConfig --> OIDCConfig
         this.model.rancherUrl = `${ serverUrl }/verify-auth`;


### PR DESCRIPTION
### Summary
Fixes #17151

Default `accessMode` to `required` for all auth providers and show an error banner when `unrestricted` is selected.

### Occurred changes and/or fixed issues
- Default `accessMode` changed from `unrestricted` to `required` across all auth provider types
- Error banner shown above the access mode selector when "Allow any valid user" is selected

### Technical notes summary
- OIDC doesn't allow us to change the default access mode. If we make it stricter by default we end up getting a 401.

### Areas or cases that should be tested
- Enable each auth provider type and verify default is "Restrict access to only the authorized users & groups"
- Select "Allow any valid user" and verify the red error banner appears
- Select a different mode and verify the banner disappears

### Areas which could experience regressions
- Auth provider enable/test flow (OIDC, we can't change the default mode to restricted)
- Existing providers already configured with unrestricted mode

### Screenshot/Video

**GitHub - default (required):**
![github-required](https://github.com/codyrancher/dashboard/releases/download/issue-17151-artifacts/github-required.png)

**GitHub - unrestricted (error banner):**
![github-unrestricted](https://github.com/codyrancher/dashboard/releases/download/issue-17151-artifacts/github-unrestricted.png)

**Azure AD - default (required):**
![azuread-required](https://github.com/codyrancher/dashboard/releases/download/issue-17151-artifacts/azuread-required.png)

**Azure AD - unrestricted (error banner):**
![azuread-unrestricted](https://github.com/codyrancher/dashboard/releases/download/issue-17151-artifacts/azuread-unrestricted.png)

### How to test without a real auth provider

I tested e2e with github but I mocked enabling the providers elsewhere. You can omit the `accessMode` portion of these requests if you want to see what happens by default on the config page.

Mock-enable a provider via the Rancher API (no real OAuth/OIDC handshake needed):

```bash
# Enable GitHub with accessMode=required
curl -sk -X PUT "/v3/githubConfigs/github" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"enabled": true, "accessMode": "required", "allowedPrincipalIds": ["local://<admin-principal-id>"], "clientId": "mock", "clientSecret": "mock", "hostname": "github.com", "tls": true, "type": "githubConfig"}'

# Enable Azure AD with accessMode=required
curl -sk -X PUT "/v3/azureADConfigs/azuread" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"enabled": true, "accessMode": "required", "allowedPrincipalIds": ["local://<admin-principal-id>"], "tenantId": "mock", "applicationId": "mock", "applicationSecret": "mock", "endpoint": "https://login.microsoftonline.com/", "graphEndpoint": "https://graph.microsoft.com", "tokenEndpoint": "https://login.microsoftonline.com/mock/oauth2/v2.0/token", "authEndpoint": "https://login.microsoftonline.com/mock/oauth2/v2.0/authorize", "type": "azureADConfig"}'

# Disable when done
curl -sk -X PUT "/v3/githubConfigs/github" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"enabled": false, "type": "githubConfig"}'
```

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles Admin, Standard User and User Base