### PR TITLE
Fix readme section pushing versions section out of view

### DIFF
--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -882,7 +882,7 @@ export default {
 
     &__readme {
       flex: 1;
-      min-width: 400px;
+      min-width: 0;
       padding: 12px 24px;
     }
     &__info {

--- a/shell/pages/c/_cluster/apps/charts/chart.vue
+++ b/shell/pages/c/_cluster/apps/charts/chart.vue
@@ -859,6 +859,7 @@ export default {
     .readme-wrapper {
       position: relative;
       flex: 1;
+      min-width: 0;
 
       .open-readme-button {
         display: flex;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14919 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
This fixes an issue caused by [this PR](https://github.com/rancher/dashboard/pull/17501) where the versions section was pushed out of the viewport.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- Added `min-width: 0;` to the `.readme-wrapper` CSS class. This allows the flex container to shrink below its content's intrinsic size, forcing the Readme to fit within the available space without breaking the page layout.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Go to Explorer > Apps > Charts
Find Kasten chart and go to its detail page.
The readme and the versions sections both should be displayed properly.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Make sure the standalone readme page is not changed (Click on "View Separately" button on the chart detail page)

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
Before:
<img width="1724" height="581" alt="Screenshot 2026-06-03 at 11 30 35 AM" src="https://github.com/user-attachments/assets/190f07f9-8abc-4188-a7d1-cac337a36926" />

After:
<img width="1728" height="663" alt="image" src="https://github.com/user-attachments/assets/0bfd5f14-202b-4574-8afe-a06c98b97b98" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
