### PR TITLE
Automation: Preserve service port name test

### DIFF
--- a/cypress/e2e/tests/pages/explorer/service-discovery/ingress.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/service-discovery/ingress.spec.ts
@@ -283,6 +283,82 @@ describe('Ingresses', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] 
         .should('contain.text', 'Active');
     });
 
+    // Testing https://github.com/rancher/dashboard/issues/17105 - the Ingress form previously
+    // collapsed named service ports to numeric or dropped them on save. Verifies a named port is
+    // persisted as `port.name` (not `port.number`) and survives a load -> save round-trip.
+    it('preserves a named service port on create and edit', () => {
+      const namedPortServiceName = Cypress._.uniqueId(`named-port-svc-${ Date.now().toString() }`);
+      const ingressNamedPortName = Cypress._.uniqueId(`ingress-named-port-${ Date.now().toString() }`);
+
+      cy.createService(namespace, namedPortServiceName, {
+        spec: {
+          ports: [{
+            name:       'http',
+            port:       8080,
+            protocol:   'TCP',
+            targetPort: 80
+          }],
+          type: 'ClusterIP'
+        }
+      });
+
+      ingressListPagePo.goTo();
+      ingressListPagePo.waitForPage();
+      ingressListPagePo.list().resourceTable().sortableTable().checkVisible();
+      ingressListPagePo.baseResourceList().masthead().create();
+
+      const ingressCreatePagePo = new IngressCreateEditPo();
+
+      ingressCreatePagePo.waitForPage(null, 'rules');
+      ingressCreatePagePo.resourceDetail().createEditView().nameNsDescription().name()
+        .set(ingressNamedPortName);
+      ingressCreatePagePo.resourceDetail().createEditView().nameNsDescription().namespace()
+        .toggle();
+      ingressCreatePagePo.resourceDetail().createEditView().nameNsDescription().namespace()
+        .clickOptionWithLabel(namespace);
+
+      ingressCreatePagePo.setRuleRequestHostValue(0, 'example-named.com');
+      ingressCreatePagePo.setPathTypeByLabel(0, 'ImplementationSpecific');
+      ingressCreatePagePo.setTargetServiceValueByLabel(0, namedPortServiceName);
+      // Select the port by NAME ("http") rather than by number ("8080").
+      ingressCreatePagePo.setPortValueByLabel(0, 'http');
+
+      ingressCreatePagePo.resourceDetail().createEditView().saveAndWaitForRequests('POST', '/v1/networking.k8s.io.ingresses')
+        .then(({ response }) => {
+          expect(response?.statusCode).to.eq(201);
+
+          const path = response?.body?.spec?.rules?.[0]?.http?.paths?.[0];
+
+          expect(path.backend.service).to.deep.include({
+            name: namedPortServiceName,
+            port: { name: 'http' }
+          });
+          expect(path.backend.service.port).to.not.have.property('number');
+        });
+
+      // Round-trip: re-open in Edit mode and save without changes to confirm the named
+      // port survives the load -> save cycle and isn't silently rewritten as port.number.
+      ingressListPagePo.waitForPage();
+      ingressListPagePo.list().actionMenu(ingressNamedPortName).getMenuItem('Edit Config').click();
+
+      const ingressEditPage = new IngressCreateEditPo('local', namespace, ingressNamedPortName);
+
+      ingressEditPage.waitForPage('mode=edit', 'rules');
+
+      ingressEditPage.resourceDetail().createEditView().saveAndWaitForRequests('PUT', `/v1/networking.k8s.io.ingresses/${ namespace }/${ ingressNamedPortName }`)
+        .then(({ response }) => {
+          expect(response?.statusCode).to.eq(200);
+
+          const path = response?.body?.spec?.rules?.[0]?.http?.paths?.[0];
+
+          expect(path.backend.service.port).to.deep.eq({ name: 'http' });
+        });
+
+      ingressListPagePo.waitForPage();
+      ingressListPagePo.list().resourceTable().sortableTable().rowWithName(ingressNamedPortName)
+        .checkVisible();
+    });
+
     after('clean up namespaced resources', () => {
       if (namespace) {
         cy.deleteNamespace([namespace]);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2378
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
