### PR TITLE
Fix RcTag sizing and vertical text centering in metadata tags

### DIFF
--- a/pkg/rancher-components/src/components/Pill/RcTag/RcTag.vue
+++ b/pkg/rancher-components/src/components/Pill/RcTag/RcTag.vue
@@ -28,7 +28,8 @@ const emit = defineEmits(['close']);
 <style lang="scss" scoped>
 .rc-tag {
     display: inline-flex;
-    padding: 1px 8px;
+    min-height: 24px;
+    padding: 2px 8px;
     align-items: center;
     gap: 8px;
 
@@ -41,7 +42,7 @@ const emit = defineEmits(['close']);
     font-size: 13px;
     font-style: normal;
     font-weight: 400;
-    line-height: 22px;
+    line-height: 20px;
     color: var(--body-text);
 
     button {

--- a/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
+++ b/shell/components/Resource/Detail/Metadata/IdentifyingInformation/index.vue
@@ -103,6 +103,8 @@ const getRowValueId = (row:Row): string => `value-${ row.label }:${ row.value }`
     flex-direction: column;
 
     .row {
+      display: flex;
+      align-items: center;
       gap: 8px;
 
       // Hide clearfix pseudo-elements inherited from the global .row class

--- a/shell/components/Resource/Detail/Metadata/KeyValue.vue
+++ b/shell/components/Resource/Detail/Metadata/KeyValue.vue
@@ -110,9 +110,12 @@ const showConfigurationMoreFocusSelector = computed(() => `[data-testid="${ show
     }
 
     .row {
-        display: block;
-        width: 100%;
         display: inline-block;
+        width: 100%;
+
+        &::before, &::after {
+            display: none;
+        }
 
         &:not(:nth-child(2)) {
             margin-top: 4px;

--- a/shell/components/Resource/Detail/Metadata/KeyValueRow.vue
+++ b/shell/components/Resource/Detail/Metadata/KeyValueRow.vue
@@ -92,18 +92,13 @@ const previewId = randomStr();
     max-width: calc(100%);
   }
 
-  .rc-tag {
-    display: inline-block;
-    line-height: normal;
-  }
-
   .tag-data {
     display: inline-block;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     max-width: calc(100%);
-    line-height: normal;
+    line-height: 1;
   }
 
   & .btn.btn-medium.rc-button.variant-ghost {

--- a/shell/components/Resource/Detail/Metadata/KeyValueRow.vue
+++ b/shell/components/Resource/Detail/Metadata/KeyValueRow.vue
@@ -97,6 +97,7 @@ const previewId = randomStr();
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    min-width: 0;
     max-width: calc(100%);
     line-height: 1;
   }


### PR DESCRIPTION
### Summary
Fix metadata label/annotation tags to match the [Figma design spec](https://www.figma.com/design/K3e7DHHM5TsS0vQELeoIFZ/Rancher-DS?node-id=1063-549&m=dev). Tags had incorrect dimensions and text that appeared visually shifted upward.

This was likely caused by https://github.com/rancher/dashboard/pull/17479. I'm just fixing it here instead of opening and targeting a whole new issue.

### Occurred changes and/or fixed issues

- **RcTag.vue**: Match design spec (24px min-height, 2px 8px padding, 20px line-height)
- **KeyValueRow.vue**: Remove style overrides that broke RcTag's flex centering; use `line-height: 1` on inner span so flexbox centers the text visually
- **KeyValue.vue**: Remove duplicate `display` declaration; suppress global `.row` clearfix pseudo-elements
- **IdentifyingInformation/index.vue**: Add explicit flex alignment on `.row`

### Technical notes summary

KeyValueRow overrode RcTag's `display: inline-flex` with `inline-block`, disabling flex centering. After restoring flex, Lato's asymmetric ascenders/descenders made text appear shifted up within the line box. Setting `line-height: 1` on the span makes it tight to the font-size so `align-items: center` centers the visual text mass correctly.

### Areas or cases that should be tested

- Labels and Annotations sections on resource detail pages
- Tags should be 24px tall with vertically centered text
- Ellipsis truncation, CopyToClipboard hover, tag preview popup
- Light and dark mode

### Areas which could experience regressions

- Any page using the RcTag component
- KeyValue row spacing
- IdentifyingInformation row alignment

### Screenshot/Video

![comparison](https://github.com/codyrancher/dashboard/releases/download/issue-bars-artifacts/comparison.png)


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`