### PR TITLE
Fix flakey e2e test (can create an oci repository with basic auth)

### DIFF
--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -45,6 +45,7 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
 
   beforeEach(() => {
     cy.createE2EResourceName('repo').as('repoName');
+    cy.createE2EResourceName('repoOci').as('ociRepoName');
   });
 
   it('can create a repository', function() {
@@ -233,8 +234,6 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
   });
 
   it('can create an oci repository with basic auth', function() {
-    const ociRepoName = `${ this.repoName }oci`;
-
     ChartRepositoriesPagePo.navTo();
     repositoriesPage.waitForPage();
     repositoriesPage.waitForGoTo(`${ CLUSTER_REPOS_BASE_URL }?*`);
@@ -245,8 +244,8 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     const ociMaxWait = '7';
     const refreshInterval = '12';
 
-    repositoriesPage.createEditRepositories().nameNsDescription().name().set(ociRepoName);
-    repositoriesPage.createEditRepositories().nameNsDescription().description().set(`${ ociRepoName }-description`);
+    repositoriesPage.createEditRepositories().nameNsDescription().name().set(this.ociRepoName);
+    repositoriesPage.createEditRepositories().nameNsDescription().description().set(`${ this.ociRepoName }-description`);
     repositoriesPage.createEditRepositories().selectOciUrlCard();
     repositoriesPage.createEditRepositories().ociUrl().set(ociUrl);
     repositoriesPage.createEditRepositories().refreshIntervalInput().setValue(refreshInterval);
@@ -274,10 +273,10 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     repositoriesPage.waitForPage();
 
     // check list details
-    repositoriesPage.list().details(ociRepoName, 2).should('be.visible');
+    repositoriesPage.list().details(this.ociRepoName, 2).should('be.visible');
 
     // delete repo
-    cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', ociRepoName);
+    cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', this.ociRepoName);
   });
 });
 

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -45,7 +45,7 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
 
   beforeEach(() => {
     cy.createE2EResourceName('repo').as('repoName');
-    cy.createE2EResourceName('repoOci').as('ociRepoName');
+    cy.createE2EResourceName('repo-oci').as('ociRepoName');
   });
 
   it('can create a repository', function() {

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -263,7 +263,7 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
       expect(req.response?.statusCode).to.equal(201);
       expect(req.request?.body?.spec.url).to.equal(ociUrl);
       expect(req.request?.body?.spec.exponentialBackOffValues.minWait).to.equal(Number(ociMinWait));
-      expect(req.request?.body?.spec.exponentialBackOffValues.maxWait).to.equal(Number(ociMaxWait));
+      expect(req.request?.body?.spec.exponentialBackOffValues.maxWait).to.equal(undefined);
       // insecurePlainHttp should always be included in the payload for oci repo creation
       expect(req.request?.body?.spec.insecurePlainHttp).to.equal(false);
       // check refreshInterval

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -233,6 +233,8 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
   });
 
   it('can create an oci repository with basic auth', function() {
+    const ociRepoName = `${ this.repoName }oci`;
+
     ChartRepositoriesPagePo.navTo();
     repositoriesPage.waitForPage();
     repositoriesPage.waitForGoTo(`${ CLUSTER_REPOS_BASE_URL }?*`);
@@ -243,8 +245,8 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     const ociMaxWait = '7';
     const refreshInterval = '12';
 
-    repositoriesPage.createEditRepositories().nameNsDescription().name().set(this.repoName);
-    repositoriesPage.createEditRepositories().nameNsDescription().description().set(`${ this.repoName }-description`);
+    repositoriesPage.createEditRepositories().nameNsDescription().name().set(ociRepoName);
+    repositoriesPage.createEditRepositories().nameNsDescription().description().set(`${ ociRepoName }-description`);
     repositoriesPage.createEditRepositories().selectOciUrlCard();
     repositoriesPage.createEditRepositories().ociUrl().set(ociUrl);
     repositoriesPage.createEditRepositories().refreshIntervalInput().setValue(refreshInterval);
@@ -262,7 +264,7 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
       expect(req.response?.statusCode).to.equal(201);
       expect(req.request?.body?.spec.url).to.equal(ociUrl);
       expect(req.request?.body?.spec.exponentialBackOffValues.minWait).to.equal(Number(ociMinWait));
-      expect(req.request?.body?.spec.exponentialBackOffValues.maxWait).to.equal(undefined);
+      expect(req.request?.body?.spec.exponentialBackOffValues.maxWait).to.equal(Number(ociMaxWait));
       // insecurePlainHttp should always be included in the payload for oci repo creation
       expect(req.request?.body?.spec.insecurePlainHttp).to.equal(false);
       // check refreshInterval
@@ -272,10 +274,10 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
     repositoriesPage.waitForPage();
 
     // check list details
-    repositoriesPage.list().details(this.repoName, 2).should('be.visible');
+    repositoriesPage.list().details(ociRepoName, 2).should('be.visible');
 
     // delete repo
-    cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', this.repoName);
+    cy.deleteRancherResource('v1', 'catalog.cattle.io.clusterrepos', ociRepoName);
   });
 });
 


### PR DESCRIPTION
### Summary

This PR fixes the flakey 'can create an oci repository with basic auth' test.

The issue is the test uses the same repo name as a previous test, so if that is still clearing up the previous repo, the API call gets a 409 rather than a 201.

The fix is to use a different repository name.

Note that the test was a little suspect in that it sets `ociMaxWait` when creating the OCI repository, but the check we had was checking this was `undefined` - which should not have passed. With this change, this is working correctly and the check now checks the newly created repository has the `ociMaxWait` value.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
