### PR TITLE
fix issue where extension card after installation showing as third-party

### DIFF
--- a/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
@@ -1174,7 +1174,7 @@ describe('page: UI plugins/Extensions', () => {
       expect(all[0].originalRepoNameDisplay).toBeNull();
     });
 
-    it('should not match chart from a different repo', () => {
+    it('should fall back to name-only match when repo name does not match', () => {
       const apps = [{
         metadata: {
           name:      'my-plugin',
@@ -1196,10 +1196,68 @@ describe('page: UI plugins/Extensions', () => {
 
       wireWrapper.vm.wirePluginCRToChart(pluginCR, all);
 
-      expect(all).toHaveLength(2);
-      expect(all[0].installed).toBeUndefined();
-      expect(all[1].installed).toBe(true);
-      expect(all[1].uiplugin).toBe(pluginCR);
+      expect(all).toHaveLength(1);
+      expect(all[0].installed).toBe(true);
+      expect(all[0].uiplugin).toBe(pluginCR);
+      expect(all[0].installedVersion).toBe('1.0.0');
+    });
+
+    it('should fall back to name-only match when originalRepoName is undefined', () => {
+      const apps = [{
+        metadata: {
+          name:      'my-plugin',
+          namespace: UI_PLUGIN_NAMESPACE,
+          labels:    {}
+        },
+        spec: { chart: { metadata: { annotations: {} } } }
+      }];
+
+      wireWrapper = createWireWrapper(apps);
+
+      const all: any[] = [{
+        name:                'my-plugin',
+        chart:               { repoName: 'rancher-charts' },
+        installableVersions: [],
+      }];
+
+      const pluginCR = { name: 'my-plugin', version: '1.0.0' };
+
+      wireWrapper.vm.wirePluginCRToChart(pluginCR, all);
+
+      expect(all).toHaveLength(1);
+      expect(all[0].installed).toBe(true);
+      expect(all[0].uiplugin).toBe(pluginCR);
+      expect(all[0].installedVersion).toBe('1.0.0');
+    });
+
+    it('should preserve certification flags from chart when falling back to name-only match', () => {
+      const apps = [{
+        metadata: {
+          name:      'my-plugin',
+          namespace: UI_PLUGIN_NAMESPACE,
+          labels:    {}
+        },
+        spec: { chart: { metadata: { annotations: {} } } }
+      }];
+
+      wireWrapper = createWireWrapper(apps);
+
+      const all: any[] = [{
+        name:                'my-plugin',
+        chart:               { repoName: 'rancher-charts' },
+        certified:           true,
+        primeOnly:           false,
+        experimental:        false,
+        installableVersions: [],
+      }];
+
+      const pluginCR = { name: 'my-plugin', version: '1.0.0' };
+
+      wireWrapper.vm.wirePluginCRToChart(pluginCR, all);
+
+      expect(all).toHaveLength(1);
+      expect(all[0].installed).toBe(true);
+      expect(all[0].certified).toBe(true);
     });
   });
 

--- a/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts
@@ -1174,7 +1174,7 @@ describe('page: UI plugins/Extensions', () => {
       expect(all[0].originalRepoNameDisplay).toBeNull();
     });
 
-    it('should fall back to name-only match when repo name does not match', () => {
+    it('should not match chart from a different repo', () => {
       const apps = [{
         metadata: {
           name:      'my-plugin',
@@ -1196,13 +1196,13 @@ describe('page: UI plugins/Extensions', () => {
 
       wireWrapper.vm.wirePluginCRToChart(pluginCR, all);
 
-      expect(all).toHaveLength(1);
-      expect(all[0].installed).toBe(true);
-      expect(all[0].uiplugin).toBe(pluginCR);
-      expect(all[0].installedVersion).toBe('1.0.0');
+      expect(all).toHaveLength(2);
+      expect(all[0].installed).toBeUndefined();
+      expect(all[1].installed).toBe(true);
+      expect(all[1].uiplugin).toBe(pluginCR);
     });
 
-    it('should fall back to name-only match when originalRepoName is undefined', () => {
+    it('should use install-time repo fallback when originalRepoName is undefined', () => {
       const apps = [{
         metadata: {
           name:      'my-plugin',
@@ -1213,6 +1213,7 @@ describe('page: UI plugins/Extensions', () => {
       }];
 
       wireWrapper = createWireWrapper(apps);
+      wireWrapper.vm.installedFromRepo = { 'my-plugin': 'rancher-charts' };
 
       const all: any[] = [{
         name:                'my-plugin',
@@ -1230,7 +1231,7 @@ describe('page: UI plugins/Extensions', () => {
       expect(all[0].installedVersion).toBe('1.0.0');
     });
 
-    it('should preserve certification flags from chart when falling back to name-only match', () => {
+    it('should preserve certification flags when using install-time repo fallback', () => {
       const apps = [{
         metadata: {
           name:      'my-plugin',
@@ -1241,6 +1242,7 @@ describe('page: UI plugins/Extensions', () => {
       }];
 
       wireWrapper = createWireWrapper(apps);
+      wireWrapper.vm.installedFromRepo = { 'my-plugin': 'rancher-charts' };
 
       const all: any[] = [{
         name:                'my-plugin',
@@ -1258,6 +1260,42 @@ describe('page: UI plugins/Extensions', () => {
       expect(all).toHaveLength(1);
       expect(all[0].installed).toBe(true);
       expect(all[0].certified).toBe(true);
+    });
+
+    it('should not cross-match to wrong repo when using install-time repo fallback with multiple repos', () => {
+      const apps = [{
+        metadata: {
+          name:      'my-plugin',
+          namespace: UI_PLUGIN_NAMESPACE,
+          labels:    {}
+        },
+        spec: { chart: { metadata: { annotations: {} } } }
+      }];
+
+      wireWrapper = createWireWrapper(apps);
+      wireWrapper.vm.installedFromRepo = { 'my-plugin': 'repo-a' };
+
+      const all: any[] = [
+        {
+          name:                'my-plugin',
+          chart:               { repoName: 'repo-a' },
+          installableVersions: [],
+        },
+        {
+          name:                'my-plugin',
+          chart:               { repoName: 'repo-b' },
+          installableVersions: [],
+        }
+      ];
+
+      const pluginCR = { name: 'my-plugin', version: '1.0.0' };
+
+      wireWrapper.vm.wirePluginCRToChart(pluginCR, all);
+
+      expect(all).toHaveLength(2);
+      expect(all[0].installed).toBe(true);
+      expect(all[0].uiplugin).toBe(pluginCR);
+      expect(all[1].installed).toBeUndefined();
     });
   });
 

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -66,6 +66,7 @@ export default {
       kubeVersion:                    null,
       activeTab:                      '',
       installing:                     {},
+      installedFromRepo:              {},
       errors:                         {},
       plugins:                        [], // The installed plugins
       helmOps:                        [], // Helm operations
@@ -528,6 +529,9 @@ export default {
             this.updatePluginInstallStatus(pluginId, type);
           },
           closed: (res) => {
+            if (res && plugin?.chart?.repoName) {
+              this.installedFromRepo[plugin.name] = plugin.chart.repoName;
+            }
             this.didInstall(res);
           }
         }
@@ -964,9 +968,13 @@ export default {
 
       // fallback to try and prevent https://github.com/rancher/dashboard/issues/17956
       // which we believe is due to a race condition
-      // so we try to find the chart without considering the repo, which is not ideal but should be better than missing the match entirely
+      // we fall back to plugin name which should be present when going through the "installed plugins" (uiplugins) and should be enough to find the correct chart in the majority of cases, as long as there are not multiple charts with the same name across different repos
       if (!chart) {
-        chart = all.find((c) => c.name === pluginCR.name);
+        const fallbackRepoName = this.installedFromRepo?.[pluginCR.name];
+
+        if (fallbackRepoName) {
+          chart = all.find((c) => c.name === pluginCR.name && c.chart?.repoName === fallbackRepoName);
+        }
       }
 
       if (chart) {

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -962,6 +962,13 @@ export default {
         chart = all.find((c) => c.name === pluginCR.name && c.chart?.repoName === originalRepoName);
       }
 
+      // fallback to try and prevent https://github.com/rancher/dashboard/issues/17956
+      // which we believe is due to a race condition
+      // so we try to find the chart without considering the repo, which is not ideal but should be better than missing the match entirely
+      if (!chart) {
+        chart = all.find((c) => c.name === pluginCR.name);
+      }
+
       if (chart) {
         chart.installed = true;
         chart.uiplugin = pluginCR;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17956

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix issue where extension card after installation showing as third-party after installation AND before full page refresh

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Probable root cause: `wirePluginCRToChart` relies on `originalRepoName` (from `catalog.cattle.io/ui-source-repo` or `catalog.cattle.io/cluster-repo-name`) to match a `UIPlugin CR` to its chart in the catalog. When the `App` resource hasn't been fully annotated yet by Rancher's backend controllers — which happens during the window between the `UIPlugin CR` arriving via websocket and the `App` being reconciled — `originalRepoName` is `undefined`, and the chart lookup is skipped entirely. This causes the method to create a fallback card from the App's chart metadata, which lacks the `catalog.cattle.io/certified annotation`, resulting in the extension incorrectly displaying as "Third-Party" with a missing description and generic icon.

The timing sensitivity explains why it's intermittent — it depends on how quickly the backend controller annotates the `App` resource relative to the websocket delivering the `UIPlugin CR`.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
**Very difficult to test locally and even remotely**

**Locally** I could never have the card to "stay" as a third party plugin, but if I throttle the network to `3G` in chrome, one can clearly notice the flicker on the card passing through the "third-party" state, then updating to the correct card.

**Remotely** there was a point that I could repro it consistently, but after a few tries it stopped to happen... I think it may have to do with the backend load being higher, then taking time to return information needed to populate the card correctly. Not easy to be 100% sure since locally I could repro the original state.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
