### PR TITLE
Update cypress-qase-reporter to latest

### DIFF
--- a/cypress/package.json
+++ b/cypress/package.json
@@ -65,8 +65,5 @@
   "scripts": {
     "build-pkg": "./scripts/build.sh",
     "publish-pkg": "./scripts/publish.sh --npm"
-  },
-  "resolutions": {
-    "axios": "1.13.5"
   }
 }

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -42,7 +42,7 @@
     "cypress-delete-downloads-folder": "0.0.4",
     "cypress-mochawesome-reporter": "3.8.2",
     "cypress-multi-reporters": "1.6.4",
-    "cypress-qase-reporter": "3.0.0",
+    "cypress-qase-reporter": "3.6.3",
     "cypress-real-events": "1.14.0",
     "cypress-terminal-report": "^7.2.0",
     "dotenv": "^10.0.0",

--- a/cypress/yarn.lock
+++ b/cypress/yarn.lock
@@ -1109,14 +1109,15 @@ axios-retry@^4.5.0:
   dependencies:
     is-retry-allowed "^2.2.0"
 
-axios@1.13.5, axios@^1.16.0:
-  version "1.13.5"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.5.tgz#5e464688fa127e11a660a2c49441c009f6567a43"
-  integrity sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==
+axios@^1.16.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.17.0.tgz#ae5a1164a4f719942cd73c67e6a3f62d3ccb8f2b"
+  integrity sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==
   dependencies:
-    follow-redirects "^1.15.11"
+    follow-redirects "^1.16.0"
     form-data "^4.0.5"
-    proxy-from-env "^1.1.0"
+    https-proxy-agent "^5.0.1"
+    proxy-from-env "^2.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -2476,7 +2477,7 @@ flat@^5.0.2:
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-follow-redirects@^1.0.0, follow-redirects@^1.15.11:
+follow-redirects@^1.0.0, follow-redirects@^1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
@@ -4461,10 +4462,10 @@ proxy-from-env@1.0.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
   integrity sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 psl@^1.1.33:
   version "1.15.0"

--- a/cypress/yarn.lock
+++ b/cypress/yarn.lock
@@ -881,10 +881,20 @@ ajv-keywords@^5.1.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^8.0.0, ajv@^8.17.1, ajv@^8.6.2, ajv@^8.9.0:
+ajv@^8.0.0, ajv@^8.6.2, ajv@^8.9.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
   integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+
+ajv@^8.18.0:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
+  integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
   dependencies:
     fast-deep-equal "^3.1.3"
     fast-uri "^3.0.1"
@@ -1099,7 +1109,7 @@ axios-retry@^4.5.0:
   dependencies:
     is-retry-allowed "^2.2.0"
 
-axios@1.13.5, axios@^1.13.5:
+axios@1.13.5, axios@^1.16.0:
   version "1.13.5"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.5.tgz#5e464688fa127e11a660a2c49441c009f6567a43"
   integrity sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==
@@ -1671,13 +1681,13 @@ cypress-multi-reporters@1.6.4:
     debug "^4.3.4"
     lodash "^4.17.21"
 
-cypress-qase-reporter@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cypress-qase-reporter/-/cypress-qase-reporter-3.0.0.tgz#21a397979ac8ab4158f8d340cd7a68c90e9f1077"
-  integrity sha512-Xn9S6wTPPtzUUfZs1lXIcRDj547VxxX6pCvHYbAF3esu3X4lic0LWmEldAvBrqa31TfslAOJmGOkyYq30ZfW6g==
+cypress-qase-reporter@3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/cypress-qase-reporter/-/cypress-qase-reporter-3.6.3.tgz#89711133d33190eab15b378ef0e65869f6055142"
+  integrity sha512-Im9yCwRbFTiSepdB+iikle69PNQRegzKFgmP2ZsVD0EhZj0ns3Gw4jABaOXZVWW6W4jeLm5folKJQWWpzI3YFw==
   dependencies:
-    qase-javascript-commons "~2.4.0"
-    uuid "^9.0.1"
+    qase-javascript-commons "~2.7.2"
+    uuid "11.1.1"
 
 cypress-real-events@1.14.0:
   version "1.14.0"
@@ -4476,28 +4486,28 @@ punycode@^2.1.1, punycode@^2.3.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-qase-api-client@~1.1.1:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/qase-api-client/-/qase-api-client-1.1.5.tgz#95faaac65a8cd13e2fb510af9134240845cd5593"
-  integrity sha512-Ketwqmx2WURSFtMflIbwHM6naJZjssFPX0uBU6Xbdwi33i8pZLeJZFhL2cWFvELDNJdUSod7G8wMt84e+6cyeg==
+qase-api-client@~1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/qase-api-client/-/qase-api-client-1.1.8.tgz#4f9d6c97c9ff5cd018e91503af44245438d6dbea"
+  integrity sha512-0xhzI2sL1DalBFVdbq9QULiBl27Y40jTx6JAGE+35PI8xuXrv9h8PRU8fQeZsNcMcEvqHbQTb7Poft28CVXOUg==
   dependencies:
-    axios "^1.13.5"
+    axios "^1.16.0"
     axios-retry "^4.5.0"
 
-qase-api-v2-client@~1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/qase-api-v2-client/-/qase-api-v2-client-1.0.6.tgz#706a9d8eec6ce093fc443f05b85ccceee68ef947"
-  integrity sha512-wAZLIvJHwnhfurCBMCF8Rubzk9fcQgsYCPthSF7hYVCbArsUlfAsroBat8AIC1dcE7YP/8P2bb9RijDED06laA==
+qase-api-v2-client@~1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/qase-api-v2-client/-/qase-api-v2-client-1.0.8.tgz#0e57fb030622a788f6fc4a440837aa8021d56b6e"
+  integrity sha512-J0/zjW+d1q33/Hk01DHcXQtvZe636cAC6wpVXkat7SLiPD2qPUVeMHMqAwLI+ry1KUlCfnmt4+QwhXsFfhhA9A==
   dependencies:
-    axios "^1.13.5"
+    axios "^1.16.0"
     axios-retry "^4.5.0"
 
-qase-javascript-commons@~2.4.0:
-  version "2.4.18"
-  resolved "https://registry.yarnpkg.com/qase-javascript-commons/-/qase-javascript-commons-2.4.18.tgz#cf799f6293cac372c64465f1f302199e2660d61f"
-  integrity sha512-H/oU3AP/rD6AXh0O/bG52r/La5jrGV39HpZOvFzI7b7+G8Uuh1wip7HGSSpi/Tp9EI2gAPrx2IWAeH9gG6tKrw==
+qase-javascript-commons@~2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/qase-javascript-commons/-/qase-javascript-commons-2.7.2.tgz#ab827518c56318d60c5a57b0f275f58b34b614f5"
+  integrity sha512-+8HqQ9Bb4cJeyW0Ftv4ajQz7UTEqct8gaknLAFanrwj5x5H+1+lMot+YU1TAy1gHcqkyM1E4xt7+REVURihrHw==
   dependencies:
-    ajv "^8.17.1"
+    ajv "^8.18.0"
     async-mutex "~0.5.0"
     chalk "^4.1.2"
     env-schema "^5.2.1"
@@ -4506,10 +4516,10 @@ qase-javascript-commons@~2.4.0:
     lodash.merge "^4.6.2"
     lodash.mergewith "^4.6.2"
     mime-types "^2.1.35"
-    qase-api-client "~1.1.1"
-    qase-api-v2-client "~1.0.4"
+    qase-api-client "~1.1.8"
+    qase-api-v2-client "~1.0.8"
     strip-ansi "^6.0.1"
-    uuid "^9.0.1"
+    uuid "11.1.1"
 
 qs@~6.10.3:
   version "6.10.5"
@@ -5617,15 +5627,15 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
+
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-uuid@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "cypress-delete-downloads-folder": "0.0.4",
     "cypress-mochawesome-reporter": "3.8.2",
     "cypress-multi-reporters": "1.6.4",
-    "cypress-qase-reporter": "3.0.0",
+    "cypress-qase-reporter": "3.6.3",
     "cypress-real-events": "1.14.0",
     "cypress-terminal-report": "7.2.0",
     "eslint": "7.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4556,10 +4556,20 @@ ajv@^6.10.0, ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.0.1, ajv@^8.17.1, ajv@^8.6.2, ajv@^8.9.0:
+ajv@^8.0.0, ajv@^8.0.1, ajv@^8.6.2, ajv@^8.9.0:
   version "8.18.0"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
   integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+
+ajv@^8.18.0:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
+  integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
   dependencies:
     fast-deep-equal "^3.1.3"
     fast-uri "^3.0.1"
@@ -4920,13 +4930,23 @@ axios-retry@^4.5.0:
   dependencies:
     is-retry-allowed "^2.2.0"
 
-axios@1.16.0, axios@^1.13.2, axios@^1.13.5, axios@^1.7.9:
+axios@1.16.0, axios@^1.7.9:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
   integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
   dependencies:
     follow-redirects "^1.16.0"
     form-data "^4.0.5"
+    proxy-from-env "^2.1.0"
+
+axios@^1.16.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.17.0.tgz#ae5a1164a4f719942cd73c67e6a3f62d3ccb8f2b"
+  integrity sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==
+  dependencies:
+    follow-redirects "^1.16.0"
+    form-data "^4.0.5"
+    https-proxy-agent "^5.0.1"
     proxy-from-env "^2.1.0"
 
 babel-core@7.0.0-bridge.0:
@@ -6480,13 +6500,13 @@ cypress-multi-reporters@1.6.4:
     debug "^4.3.4"
     lodash "^4.17.21"
 
-cypress-qase-reporter@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cypress-qase-reporter/-/cypress-qase-reporter-3.0.0.tgz#21a397979ac8ab4158f8d340cd7a68c90e9f1077"
-  integrity sha512-Xn9S6wTPPtzUUfZs1lXIcRDj547VxxX6pCvHYbAF3esu3X4lic0LWmEldAvBrqa31TfslAOJmGOkyYq30ZfW6g==
+cypress-qase-reporter@3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/cypress-qase-reporter/-/cypress-qase-reporter-3.6.3.tgz#89711133d33190eab15b378ef0e65869f6055142"
+  integrity sha512-Im9yCwRbFTiSepdB+iikle69PNQRegzKFgmP2ZsVD0EhZj0ns3Gw4jABaOXZVWW6W4jeLm5folKJQWWpzI3YFw==
   dependencies:
-    qase-javascript-commons "~2.4.0"
-    uuid "^9.0.1"
+    qase-javascript-commons "~2.7.2"
+    uuid "11.1.1"
 
 cypress-real-events@1.14.0:
   version "1.14.0"
@@ -7652,6 +7672,7 @@ eslint-plugin-jest@27.9.0:
 
 "eslint-plugin-local-rules@link:./eslint-plugin-local-rules":
   version "0.0.0"
+  uid ""
 
 "eslint-plugin-local-rules@link:eslint-plugin-local-rules":
   version "0.0.0"
@@ -9161,9 +9182,9 @@ https-browserify@^1.0.0:
   resolved "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==
 
-https-proxy-agent@^5.0.0:
+https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
   dependencies:
     agent-base "6"
@@ -12812,28 +12833,28 @@ pvutils@^1.1.3, pvutils@^1.1.5:
   resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.1.5.tgz#84b0dea4a5d670249aa9800511804ee0b7c2809c"
   integrity sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==
 
-qase-api-client@~1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/qase-api-client/-/qase-api-client-1.1.2.tgz#5ef9f86d1e52bceeb66fdd7794a775851c3d70e5"
-  integrity sha512-e7Uxt8KkjHnWr7btMJ37LJ9UF7wScDjcoBijEQWeSuYschoA4pYyTAL7tjOi+4BPmEN45cNbe1k5WC/imo/h0g==
+qase-api-client@~1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/qase-api-client/-/qase-api-client-1.1.8.tgz#4f9d6c97c9ff5cd018e91503af44245438d6dbea"
+  integrity sha512-0xhzI2sL1DalBFVdbq9QULiBl27Y40jTx6JAGE+35PI8xuXrv9h8PRU8fQeZsNcMcEvqHbQTb7Poft28CVXOUg==
   dependencies:
-    axios "^1.13.5"
+    axios "^1.16.0"
     axios-retry "^4.5.0"
 
-qase-api-v2-client@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/qase-api-v2-client/-/qase-api-v2-client-1.0.4.tgz#f8d62b3d329873197c3b28868f8be730f99902c4"
-  integrity sha512-Z9R/mc0sYcgRndTEJ632x46+Ra0g5LCJvE2/VoJnm9w9WhV6No/IzA51SubdRldjcdEGlLeERIhxRce+IJRqCw==
+qase-api-v2-client@~1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/qase-api-v2-client/-/qase-api-v2-client-1.0.8.tgz#0e57fb030622a788f6fc4a440837aa8021d56b6e"
+  integrity sha512-J0/zjW+d1q33/Hk01DHcXQtvZe636cAC6wpVXkat7SLiPD2qPUVeMHMqAwLI+ry1KUlCfnmt4+QwhXsFfhhA9A==
   dependencies:
-    axios "^1.13.2"
+    axios "^1.16.0"
     axios-retry "^4.5.0"
 
-qase-javascript-commons@~2.4.0:
-  version "2.4.18"
-  resolved "https://registry.yarnpkg.com/qase-javascript-commons/-/qase-javascript-commons-2.4.18.tgz#cf799f6293cac372c64465f1f302199e2660d61f"
-  integrity sha512-H/oU3AP/rD6AXh0O/bG52r/La5jrGV39HpZOvFzI7b7+G8Uuh1wip7HGSSpi/Tp9EI2gAPrx2IWAeH9gG6tKrw==
+qase-javascript-commons@~2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/qase-javascript-commons/-/qase-javascript-commons-2.7.2.tgz#ab827518c56318d60c5a57b0f275f58b34b614f5"
+  integrity sha512-+8HqQ9Bb4cJeyW0Ftv4ajQz7UTEqct8gaknLAFanrwj5x5H+1+lMot+YU1TAy1gHcqkyM1E4xt7+REVURihrHw==
   dependencies:
-    ajv "^8.17.1"
+    ajv "^8.18.0"
     async-mutex "~0.5.0"
     chalk "^4.1.2"
     env-schema "^5.2.1"
@@ -12842,10 +12863,10 @@ qase-javascript-commons@~2.4.0:
     lodash.merge "^4.6.2"
     lodash.mergewith "^4.6.2"
     mime-types "^2.1.35"
-    qase-api-client "~1.1.1"
-    qase-api-v2-client "~1.0.4"
+    qase-api-client "~1.1.8"
+    qase-api-v2-client "~1.0.8"
     strip-ansi "^6.0.1"
-    uuid "^9.0.1"
+    uuid "11.1.1"
 
 qs@6.7.0:
   version "6.7.0"
@@ -14801,15 +14822,15 @@ utils-merge@1.0.1:
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
+
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-uuid@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-compile-cache@^2.0.3:
   version "2.4.0"


### PR DESCRIPTION
### Occurred changes and/or fixed issues

Updates `cypress-qase-reporter` to the latest version, which ensures `axios` is also updated to latest.

### Areas which could experience regressions

Check integration of test reporting into Qase is still operational.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
