### PR TITLE
Rename stale issue manager to weekly, add project status check

### DIFF
--- a/.github/workflows/weekly-stale-issue-manager.lock.yml
+++ b/.github/workflows/weekly-stale-issue-manager.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f85f974183ae4b9abd447afabc44ddb60453446b778e36bc553f0bb59ee1b6c3","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"67bd989e1dd801237310f22f6df5119c227e494f7eb9f943b934683af85bcf88","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -24,7 +24,7 @@
 #
 # Manages stale `kind/enhancement` issues. Replaces the
 # actions/stale-based workflow with comment-aware staleness detection.
-# - Runs daily to label and close stale issues.
+# - Runs weekly to label and close stale issues.
 # - Only considers issues older than 548 days (1.5 years) to minimize API usage.
 # - Determines staleness by checking for recent comments or reopen events (not the
 # updated_at field, which is bumped by milestone and label changes).
@@ -32,6 +32,8 @@
 # - Closes and labels `bot/stale-issue-manager/closed` on issues that were already labeled `bot/stale-issue-manager/stale` with
 # no new activity since the label was applied.
 # - Removes the `bot/stale-issue-manager/stale` label if meaningful activity is found, so it self-corrects.
+# - Skips issues that are tracked on a GitHub Project board with a status at or beyond
+# Review, since those are actively being worked on.
 #
 # Secrets used:
 #   - COPILOT_GITHUB_TOKEN
@@ -56,8 +58,11 @@
 #   - ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959
 #   - node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
-name: "Stale Issue Manager"
+name: "Weekly Stale Issue Manager"
 "on":
+  schedule:
+  - cron: "37 12 * * 0"
+    # Friendly format: weekly (scattered)
   workflow_dispatch:
     inputs:
       aw_context:
@@ -71,7 +76,7 @@ permissions: {}
 concurrency:
   group: "gh-aw-${{ github.workflow }}"
 
-run-name: "Stale Issue Manager"
+run-name: "Weekly Stale Issue Manager"
 
 jobs:
   activation:
@@ -99,8 +104,8 @@ jobs:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Stale Issue Manager"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/daily-stale-issue-manager.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Weekly Stale Issue Manager"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/weekly-stale-issue-manager.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Generate agentic run info
         id: generate_aw_info
@@ -111,7 +116,7 @@ jobs:
           GH_AW_INFO_VERSION: "1.0.40"
           GH_AW_INFO_AGENT_VERSION: "1.0.40"
           GH_AW_INFO_CLI_VERSION: "v0.71.5"
-          GH_AW_INFO_WORKFLOW_NAME: "Stale Issue Manager"
+          GH_AW_INFO_WORKFLOW_NAME: "Weekly Stale Issue Manager"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
@@ -128,19 +133,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/generate_aw_info.cjs');
             await main(core, context);
-      - name: Add eyes reaction for immediate feedback
-        id: react
-        if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == github.repository_id || github.event_name == 'pull_request_review' && github.event.pull_request.head.repo.id == github.repository_id
-        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
-        env:
-          GH_AW_REACTION: "eyes"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/add_reaction.cjs');
-            await main();
       - name: Validate COPILOT_GITHUB_TOKEN secret
         id: validate-secret
         run: bash "${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh" COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
@@ -171,7 +163,7 @@ jobs:
         id: check-lock-file
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         env:
-          GH_AW_WORKFLOW_FILE: "daily-stale-issue-manager.lock.yml"
+          GH_AW_WORKFLOW_FILE: "weekly-stale-issue-manager.lock.yml"
           GH_AW_CONTEXT_WORKFLOW_REF: "${{ github.workflow_ref }}"
         with:
           script: |
@@ -206,21 +198,21 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_e9bc44b6ec3eb883_EOF'
+          cat << 'GH_AW_PROMPT_8f092e8a272d11f1_EOF'
           <system>
-          GH_AW_PROMPT_e9bc44b6ec3eb883_EOF
+          GH_AW_PROMPT_8f092e8a272d11f1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/repo_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e9bc44b6ec3eb883_EOF'
+          cat << 'GH_AW_PROMPT_8f092e8a272d11f1_EOF'
           <safe-output-tools>
-          Tools: add_comment(max:50), close_issue(max:50), add_labels(max:50), remove_labels(max:50), missing_tool, missing_data, noop
+          Tools: add_comment(max:80), close_issue(max:80), add_labels(max:80), remove_labels(max:80), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_e9bc44b6ec3eb883_EOF
+          GH_AW_PROMPT_8f092e8a272d11f1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_e9bc44b6ec3eb883_EOF'
+          cat << 'GH_AW_PROMPT_8f092e8a272d11f1_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -249,12 +241,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_e9bc44b6ec3eb883_EOF
+          GH_AW_PROMPT_8f092e8a272d11f1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e9bc44b6ec3eb883_EOF'
+          cat << 'GH_AW_PROMPT_8f092e8a272d11f1_EOF'
           </system>
-          {{#runtime-import .github/workflows/daily-stale-issue-manager.md}}
-          GH_AW_PROMPT_e9bc44b6ec3eb883_EOF
+          {{#runtime-import .github/workflows/weekly-stale-issue-manager.md}}
+          GH_AW_PROMPT_8f092e8a272d11f1_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -281,7 +273,7 @@ jobs:
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
-          GH_AW_MEMORY_BRANCH_NAME: 'memory/daily-stale-issue-manager'
+          GH_AW_MEMORY_BRANCH_NAME: 'memory/weekly-stale-issue-manager'
           GH_AW_MEMORY_CONSTRAINTS: "\n\n**Constraints:**\n- **Max File Size**: 10240 bytes (0.01 MB) per file\n- **Max File Count**: 100 files per commit\n- **Max Patch Size**: 10240 bytes (10 KB) total per push (max: 100 KB)\n"
           GH_AW_MEMORY_DESCRIPTION: ''
           GH_AW_MEMORY_DIR: '/tmp/gh-aw/repo-memory/default/'
@@ -343,13 +335,15 @@ jobs:
     needs: activation
     runs-on: ubuntu-latest
     permissions: read-all
+    concurrency:
+      group: "gh-aw-copilot-${{ github.workflow }}"
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
       GH_AW_ASSETS_BRANCH: ""
       GH_AW_ASSETS_MAX_SIZE_KB: 0
       GH_AW_MCP_LOG_DIR: /tmp/gh-aw/mcp-logs/safeoutputs
-      GH_AW_WORKFLOW_ID_SANITIZED: dailystaleissuemanager
+      GH_AW_WORKFLOW_ID_SANITIZED: weeklystaleissuemanager
     outputs:
       agentic_engine_timeout: ${{ steps.detect-copilot-errors.outputs.agentic_engine_timeout || 'false' }}
       checkout_pr_success: ${{ steps.checkout-pr.outputs.checkout_pr_success || 'true' }}
@@ -371,8 +365,8 @@ jobs:
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Stale Issue Manager"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/daily-stale-issue-manager.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Weekly Stale Issue Manager"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/weekly-stale-issue-manager.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Set runtime paths
         id: set-runtime-paths
@@ -397,7 +391,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_SERVER_URL: ${{ github.server_url }}
-          BRANCH_NAME: memory/daily-stale-issue-manager
+          BRANCH_NAME: memory/weekly-stale-issue-manager
           TARGET_REPO: ${{ github.repository }}
           MEMORY_DIR: /tmp/gh-aw/repo-memory/default
           CREATE_ORPHAN: true
@@ -460,18 +454,18 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_fb56a25da2e83585_EOF'
-          {"add_comment":{"max":50,"target":"*"},"add_labels":{"allowed":["bot/stale-issue-manager/stale","bot/stale-issue-manager/closed"],"max":50},"close_issue":{"max":50},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":10240,"max_patch_size":10240}]},"remove_labels":{"allowed":["bot/stale-issue-manager/stale"],"max":50},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_fb56a25da2e83585_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_cb0673f548a1747b_EOF'
+          {"add_comment":{"max":80,"target":"*"},"add_labels":{"allowed":["bot/stale-issue-manager/stale","bot/stale-issue-manager/closed"],"max":80},"close_issue":{"max":80},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"push_repo_memory":{"memories":[{"dir":"/tmp/gh-aw/repo-memory/default","id":"default","max_file_count":100,"max_file_size":10240,"max_patch_size":10240}]},"remove_labels":{"allowed":["bot/stale-issue-manager/stale"],"max":80},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_cb0673f548a1747b_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_comment": " CONSTRAINTS: Maximum 50 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
-                "add_labels": " CONSTRAINTS: Maximum 50 label(s) can be added. Only these labels are allowed: [\"bot/stale-issue-manager/stale\" \"bot/stale-issue-manager/closed\"].",
-                "close_issue": " CONSTRAINTS: Maximum 50 issue(s) can be closed.",
-                "remove_labels": " CONSTRAINTS: Maximum 50 label(s) can be removed. Only these labels can be removed: [bot/stale-issue-manager/stale]."
+                "add_comment": " CONSTRAINTS: Maximum 80 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading.",
+                "add_labels": " CONSTRAINTS: Maximum 80 label(s) can be added. Only these labels are allowed: [\"bot/stale-issue-manager/stale\" \"bot/stale-issue-manager/closed\"].",
+                "close_issue": " CONSTRAINTS: Maximum 80 issue(s) can be closed.",
+                "remove_labels": " CONSTRAINTS: Maximum 80 label(s) can be removed. Only these labels can be removed: [bot/stale-issue-manager/stale]."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -708,7 +702,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_93a16b2bee18291d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_09d9e0c10e7486b0_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -718,7 +712,7 @@ jobs:
                   "GITHUB_HOST": "\${GITHUB_SERVER_URL}",
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "\${GITHUB_MCP_SERVER_TOKEN}",
                   "GITHUB_READ_ONLY": "1",
-                  "GITHUB_TOOLSETS": "issues,search"
+                  "GITHUB_TOOLSETS": "issues,search,projects"
                 },
                 "guard-policies": {
                   "allow-only": {
@@ -752,7 +746,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_93a16b2bee18291d_EOF
+          GH_AW_MCP_CONFIG_09d9e0c10e7486b0_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1005,7 +999,7 @@ jobs:
       issues: write
       pull-requests: write
     concurrency:
-      group: "gh-aw-conclusion-daily-stale-issue-manager"
+      group: "gh-aw-conclusion-weekly-stale-issue-manager"
       cancel-in-progress: false
     outputs:
       incomplete_count: ${{ steps.report_incomplete.outputs.incomplete_count }}
@@ -1021,8 +1015,8 @@ jobs:
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Stale Issue Manager"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/daily-stale-issue-manager.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Weekly Stale Issue Manager"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/weekly-stale-issue-manager.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Download agent output artifact
         id: download-agent-output
@@ -1044,7 +1038,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "Stale Issue Manager"
+          GH_AW_WORKFLOW_NAME: "Weekly Stale Issue Manager"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_REPORT_AS_ISSUE: "true"
@@ -1060,7 +1054,7 @@ jobs:
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Stale Issue Manager"
+          GH_AW_WORKFLOW_NAME: "Weekly Stale Issue Manager"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
           GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
@@ -1077,7 +1071,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_MISSING_TOOL_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Stale Issue Manager"
+          GH_AW_WORKFLOW_NAME: "Weekly Stale Issue Manager"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1091,7 +1085,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_REPORT_INCOMPLETE_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Stale Issue Manager"
+          GH_AW_WORKFLOW_NAME: "Weekly Stale Issue Manager"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1105,10 +1099,10 @@ jobs:
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Stale Issue Manager"
+          GH_AW_WORKFLOW_NAME: "Weekly Stale Issue Manager"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_WORKFLOW_ID: "daily-stale-issue-manager"
+          GH_AW_WORKFLOW_ID: "weekly-stale-issue-manager"
           GH_AW_ACTION_FAILURE_ISSUE_EXPIRES_HOURS: "168"
           GH_AW_ENGINE_ID: "copilot"
           GH_AW_SECRET_VERIFICATION_RESULT: ${{ needs.activation.outputs.secret_verification_result }}
@@ -1159,8 +1153,8 @@ jobs:
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Stale Issue Manager"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/daily-stale-issue-manager.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Weekly Stale Issue Manager"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/weekly-stale-issue-manager.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Download agent output artifact
         id: download-agent-output
@@ -1226,8 +1220,8 @@ jobs:
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         env:
-          WORKFLOW_NAME: "Stale Issue Manager"
-          WORKFLOW_DESCRIPTION: "Manages stale `kind/enhancement` issues. Replaces the\nactions/stale-based workflow with comment-aware staleness detection.\n- Runs daily to label and close stale issues.\n- Only considers issues older than 548 days (1.5 years) to minimize API usage.\n- Determines staleness by checking for recent comments or reopen events (not the\n  updated_at field, which is bumped by milestone and label changes).\n- Adds the `bot/stale-issue-manager/stale` label and posts a warning comment when an issue becomes stale.\n- Closes and labels `bot/stale-issue-manager/closed` on issues that were already labeled `bot/stale-issue-manager/stale` with\n  no new activity since the label was applied.\n- Removes the `bot/stale-issue-manager/stale` label if meaningful activity is found, so it self-corrects."
+          WORKFLOW_NAME: "Weekly Stale Issue Manager"
+          WORKFLOW_DESCRIPTION: "Manages stale `kind/enhancement` issues. Replaces the\nactions/stale-based workflow with comment-aware staleness detection.\n- Runs weekly to label and close stale issues.\n- Only considers issues older than 548 days (1.5 years) to minimize API usage.\n- Determines staleness by checking for recent comments or reopen events (not the\n  updated_at field, which is bumped by milestone and label changes).\n- Adds the `bot/stale-issue-manager/stale` label and posts a warning comment when an issue becomes stale.\n- Closes and labels `bot/stale-issue-manager/closed` on issues that were already labeled `bot/stale-issue-manager/stale` with\n  no new activity since the label was applied.\n- Removes the `bot/stale-issue-manager/stale` label if meaningful activity is found, so it self-corrects.\n- Skips issues that are tracked on a GitHub Project board with a status at or beyond\n  Review, since those are actively being worked on."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1338,7 +1332,7 @@ jobs:
     permissions:
       contents: write
     concurrency:
-      group: "push-repo-memory-${{ github.repository }}|memory/daily-stale-issue-manager"
+      group: "push-repo-memory-${{ github.repository }}|memory/weekly-stale-issue-manager"
       cancel-in-progress: false
     outputs:
       patch_size_exceeded_default: ${{ steps.push_repo_memory_default.outputs.patch_size_exceeded }}
@@ -1353,8 +1347,8 @@ jobs:
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Stale Issue Manager"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/daily-stale-issue-manager.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Weekly Stale Issue Manager"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/weekly-stale-issue-manager.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1391,7 +1385,7 @@ jobs:
           ARTIFACT_DIR: /tmp/gh-aw/repo-memory/default
           MEMORY_ID: default
           TARGET_REPO: ${{ github.repository }}
-          BRANCH_NAME: memory/daily-stale-issue-manager
+          BRANCH_NAME: memory/weekly-stale-issue-manager
           MAX_FILE_SIZE: 10240
           MAX_FILE_COUNT: 100
           MAX_PATCH_SIZE: 10240
@@ -1417,15 +1411,15 @@ jobs:
       pull-requests: write
     timeout-minutes: 15
     env:
-      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/daily-stale-issue-manager"
+      GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/weekly-stale-issue-manager"
       GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
       GH_AW_ENGINE_VERSION: "1.0.40"
-      GH_AW_WORKFLOW_ID: "daily-stale-issue-manager"
-      GH_AW_WORKFLOW_NAME: "Stale Issue Manager"
+      GH_AW_WORKFLOW_ID: "weekly-stale-issue-manager"
+      GH_AW_WORKFLOW_NAME: "Weekly Stale Issue Manager"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
@@ -1444,8 +1438,8 @@ jobs:
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Stale Issue Manager"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/daily-stale-issue-manager.lock.yml@${{ github.ref }}
+          GH_AW_SETUP_WORKFLOW_NAME: "Weekly Stale Issue Manager"
+          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/weekly-stale-issue-manager.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Download agent output artifact
         id: download-agent-output
@@ -1478,7 +1472,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":50,\"target\":\"*\"},\"add_labels\":{\"allowed\":[\"bot/stale-issue-manager/stale\",\"bot/stale-issue-manager/closed\"],\"max\":50},\"close_issue\":{\"max\":50},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"remove_labels\":{\"allowed\":[\"bot/stale-issue-manager/stale\"],\"max\":50},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":80,\"target\":\"*\"},\"add_labels\":{\"allowed\":[\"bot/stale-issue-manager/stale\",\"bot/stale-issue-manager/closed\"],\"max\":80},\"close_issue\":{\"max\":80},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"remove_labels\":{\"allowed\":[\"bot/stale-issue-manager/stale\"],\"max\":80},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/weekly-stale-issue-manager.md
+++ b/.github/workflows/weekly-stale-issue-manager.md
@@ -2,7 +2,7 @@
 description: |
   Manages stale `kind/enhancement` issues. Replaces the
   actions/stale-based workflow with comment-aware staleness detection.
-  - Runs daily to label and close stale issues.
+  - Runs weekly to label and close stale issues.
   - Only considers issues older than 548 days (1.5 years) to minimize API usage.
   - Determines staleness by checking for recent comments or reopen events (not the
     updated_at field, which is bumped by milestone and label changes).
@@ -10,12 +10,12 @@ description: |
   - Closes and labels `bot/stale-issue-manager/closed` on issues that were already labeled `bot/stale-issue-manager/stale` with
     no new activity since the label was applied.
   - Removes the `bot/stale-issue-manager/stale` label if meaningful activity is found, so it self-corrects.
+  - Skips issues that are tracked on a GitHub Project board with a status at or beyond
+    Review, since those are actively being worked on.
 
 on:
   workflow_dispatch:
-  # TODO: switch back to `schedule: daily` once validated
-  #schedule: daily
-  reaction: "eyes"
+  schedule: weekly
 
 if: (github.repository_owner == 'rancher' || vars.ENABLE_AGENTIC_WORKFLOWS == 'true') && vars.DISABLE_AW_STALE_ISSUE_MANAGER != 'true'
 
@@ -32,27 +32,27 @@ safe-outputs:
     allowed:
       - bot/stale-issue-manager/stale
       - bot/stale-issue-manager/closed
-    max: 50
+    max: 80
   remove-labels:
     allowed:
       - bot/stale-issue-manager/stale
-    max: 50
+    max: 80
   add-comment:
     target: "*"
-    max: 50
+    max: 80
   close-issue:
-    max: 50
+    max: 80
 
 tools:
   bash: true
   github:
-    toolsets: [issues, search]
+    toolsets: [issues, search, projects]
     min-integrity: none
   repo-memory: true
 
 ---
 
-# Stale Issue Manager
+# Weekly Stale Issue Manager
 
 You are the Stale Issue Manager for `${{ github.repository }}`. Your job is to find `kind/enhancement` issues with no meaningful activity in over 548 days (1.5 years), warn them with the `bot/stale-issue-manager/stale`
 label, and close them if they remain inactive.
@@ -79,6 +79,18 @@ Milestone changes, label changes, assignment changes, and other metadata edits d
 **Last meaningful activity date**: the most recent date among all comments and reopen events. If none exist,
 fall back to the issue's `created_at`.
 
+**Active project status**: only the `rancher` org project **#57** ("UI Project Board") is
+considered. Look at the issue's project items and find the one whose `project.number` is
+`57` and `project.owner.login` is `rancher`. Ignore all other project boards.
+
+If the project 57 entry has a Status field value at or beyond the review stage, skip the
+issue. Specifically, skip if the Status matches any of these values (case-insensitive):
+`Review`, `QA Blocked`, `To Test`, `QA Working`, `QA Review`, `Reopened`, or `Done`.
+
+Issues with no project 57 association or with a project 57 status below this threshold
+(`To Triage`, `Backlog`, `Ice Box`, `Backend Blocked`, `Groomed`, `Next Up`, `Working`)
+remain candidates for staleness.
+
 ## Workflow
 
 ### Step 1: Search for candidate issues
@@ -99,11 +111,16 @@ For the `kind/enhancement` label:
 
 For each candidate issue:
 
-1. Fetch comments and issue events.
-2. Find the most recent date among:
+1. Check the issue's project status using the `projects_get` tool. Fetch project #57 owned
+   by `rancher` and look for the candidate issue among its items. If the issue appears
+   in the project, check its Status field value. If the Status matches an active project
+   status (see definition above), skip the issue entirely and move to the next candidate.
+   If the issue is not found in the project, continue processing it normally.
+2. Fetch comments and issue events.
+3. Find the most recent date among:
    - The latest comment's `created_at`
    - The latest `reopened` event's `created_at`
-3. If neither exists, use the issue's `created_at` as the last activity date.
+4. If neither exists, use the issue's `created_at` as the last activity date.
 
 ### Step 3: Apply labels and close
 
@@ -145,10 +162,13 @@ Update the cursor so the next run can resume where this one left off.
 
 ## Guidelines
 
-- **API budget**: process at most 50 issues per run. If there are more, save the cursor in memory and
+- **API budget**: process at most 80 issues per run. If there are more, save the cursor in memory and
   continue from that point on the next run.
 - **Idempotent**: running twice in a row should produce no changes the second time.
 - **One warning before closing**: always label with `bot/stale-issue-manager/stale` first. Only close on a subsequent run if the
   label is still present and no new meaningful activity has occurred.
 - **Self-correcting**: if someone comments on or reopens a stale issue, remove the `bot/stale-issue-manager/stale` label
   automatically on the next run.
+- **Project status**: if the `projects_get` tool call fails, stop the run immediately and
+  report the error. Do not silently skip the project check or continue processing issues
+  without it.


### PR DESCRIPTION
### Summary
Adding more filtering, and making it a weekly automation.

Mostly driven by this comment: https://github.com/rancher/dashboard/issues/9963#issuecomment-4632809314

### Occurred changes and/or fixed issues

- Rename to weekly, bump limits from 50 to 80, remove reaction trigger
- Skip issues with project #57 status >= Review using the `projects` MCP toolset
- Fail fast if the project status check fails



### Technical notes summary

- The `projects` toolset requires `GH_AW_GITHUB_MCP_SERVER_TOKEN` with `read:project` scope (classic PAT, not fine-grained). I don't know if rancher/dashboard actions already have this setup but other workflows do reference this token.
- Only project #57 ("UI Project Board") is checked; other boards are ignored
- Test run performed here: https://github.com/codyrancher/dashboard/actions/runs/27033839810

### Areas or cases that should be tested

- Issues with project status >= Review are skipped
- Issues below Review or not in the project are still marked stale
- Workflow fails if the token lacks `read:project` scope

### Areas which could experience regressions

- Existing stale issue detection (unchanged)

### Screenshot/Video

N/A 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels,
or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User
Base`