### PR TITLE
[backport 2.13] added qase ids to about page e2e test

### DIFF
--- a/cypress/e2e/tests/pages/generic/about.spec.ts
+++ b/cypress/e2e/tests/pages/generic/about.spec.ts
@@ -1,6 +1,7 @@
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 import AboutPagePo from '@/cypress/e2e/po/pages/about.po';
 import DiagnosticsPagePo from '@/cypress/e2e/po/pages/diagnostics.po';
+import { qase } from '@/cypress/support/qase';
 
 const aboutPage = new AboutPagePo();
 
@@ -9,19 +10,19 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
     cy.login();
   });
 
-  it('can navigate to About page', () => {
+  qase(1521, it('can navigate to About page', () => {
     HomePagePo.goToAndWaitForGet();
     AboutPagePo.navTo();
     aboutPage.waitForPage();
-  });
+  }));
 
-  it('no Prime info when community', { tags: '@noPrime' }, () => {
+  qase(8584, it('no Prime info when community', { tags: '@noPrime' }, () => {
     aboutPage.goTo();
     aboutPage.waitForPage();
     aboutPage.rancherPrimeInfo().should('not.exist');
-  });
+  }));
 
-  it('can navigate to Diagnostics page', () => {
+  qase(1519, it('can navigate to Diagnostics page', () => {
     aboutPage.goTo();
     aboutPage.waitForPage();
     aboutPage.diagnosticsBtn().click();
@@ -29,10 +30,10 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
     const diagnosticsPo = new DiagnosticsPagePo();
 
     diagnosticsPo.waitForPage();
-  });
+  }));
 
   // For v2.13.x, the prime links to release notes are not going to be implemented according to https://github.com/rancher/dashboard/issues/16323#issuecomment-4207507404
-  it('can View release notes', () => {
+  qase(1520, it('can View release notes', () => {
     aboutPage.goTo();
     aboutPage.waitForPage();
     const expectedOrigin = 'https://github.com';
@@ -42,7 +43,7 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
     cy.origin(expectedOrigin, { args: { expectedUrlPattern } }, ({ expectedUrlPattern }) => {
       cy.url().should('match', new RegExp(expectedUrlPattern));
     });
-  });
+  }));
 
   describe('Versions', () => {
     beforeEach(() => {
@@ -50,42 +51,42 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
       aboutPage.waitForPage();
     });
 
-    it('can see rancher version', () => {
+    qase(1506, it('can see rancher version', () => {
       // Check Rancher version
       cy.getRancherResource('v1', 'management.cattle.io.settings', 'server-version').then((resp: Cypress.Response<any>) => {
         const rancherVersion = resp.body['value'];
 
         cy.contains(rancherVersion).should('be.visible');
       });
-    });
+    }));
 
-    it('can navigate to /rancher/rancher', () => {
+    qase(1504, it('can navigate to /rancher/rancher', () => {
       aboutPage.clickVersionLink('Rancher');
       cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/rancher');
       });
-    });
+    }));
 
-    it('can navigate to /rancher/dashboard', () => {
+    qase(1507, it('can navigate to /rancher/dashboard', () => {
       aboutPage.clickVersionLink('Dashboard');
       cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/dashboard');
       });
-    });
+    }));
 
-    it('can navigate to /rancher/helm', () => {
+    qase(1508, it('can navigate to /rancher/helm', () => {
       aboutPage.clickVersionLink('Helm');
       cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/helm');
       });
-    });
+    }));
 
-    it('can navigate to /rancher/machine', () => {
+    qase(1505, it('can navigate to /rancher/machine', () => {
       aboutPage.clickVersionLink('Machine');
       cy.origin('https://github.com', () => {
         cy.url().should('include', 'https://github.com/rancher/machine');
       });
-    });
+    }));
   });
 
   describe('CLI Downloads', () => {
@@ -99,7 +100,7 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
       cy.intercept('GET', 'https://releases.rancher.com/cli2/**').as('download');
     });
 
-    it('can download macOS CLI', () => {
+    qase(1450, it('can download macOS CLI', () => {
       aboutPage.getLinkDestination('rancher-darwin').then((el) => {
         const macOsVersion = el.split('/')[5];
 
@@ -111,9 +112,9 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
           expect(request.url).includes(macOsVersion);
         });
       });
-    });
+    }));
 
-    it('can download Linux CLI', () => {
+    qase(1451, it('can download Linux CLI', () => {
       aboutPage.getLinkDestination('rancher-linux').then((el) => {
         const linuxVersion = el.split('/')[5];
 
@@ -125,9 +126,9 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
           expect(request.url).includes(linuxVersion);
         });
       });
-    });
+    }));
 
-    it('can download Windows CLI', () => {
+    qase(1449, it('can download Windows CLI', () => {
       aboutPage.getLinkDestination('rancher-windows').then((el) => {
         const windowsVersion = el.split('/')[5];
 
@@ -139,7 +140,7 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
           expect(request.url).includes(windowsVersion);
         });
       });
-    });
+    }));
   });
 
   describe('Rancher Prime', { tags: '@prime' }, () => {
@@ -158,7 +159,7 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
       interceptVersionAndSetToPrime().as('rancherVersion');
     });
 
-    it('should show prime panel on about page', () => {
+    qase(11248, it('should show prime panel on about page', () => {
       HomePagePo.goToAndWaitForGet();
 
       AboutPagePo.navTo();
@@ -168,6 +169,6 @@ describe('About Page', { testIsolation: 'on', tags: ['@generic', '@adminUser', '
       cy.wait('@rancherVersion');
 
       aboutPage.rancherPrimeInfo().should('exist');
-    });
+    }));
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->

### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2269

Addressing PR feedback from https://github.com/rancher/dashboard/pull/17403#pullrequestreview-4246650156, I'm raising this PR to add qase IDs to all the tests in about.spec.ts


### Occurred changes and/or fixed issues
added qase IDs to all the tests in about.spec.ts

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
Run the about.spec.ts to see if there're any regressions

### Areas which could experience regressions
The about.spec.ts test file

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
