### PR TITLE
[16533] Added beforeNext to cruResource to use with the steps. Added beforeGo…

### DIFF
--- a/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
@@ -225,7 +225,10 @@ describe('Git Repo', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] }, (
       gitRepoCreatePage.goTo();
       gitRepoCreatePage.waitForPage();
 
-      cy.get<string>('@gitRepo').then((name) => {
+      // Use a unique name for this create: the shared '@gitRepo' name is already
+      // created by the `before()` hook, and the new dryRunCreate step validation
+      // would reject it with a 409 (name already exists), blocking navigation.
+      cy.createE2EResourceName('git-repo-github-app').then((name) => {
         // Metadata step
         gitRepoCreatePage.resourceDetail().createEditView().nameNsDescription()
           .name()

--- a/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo.spec.ts
@@ -88,6 +88,9 @@ describe('Git Repo', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] }, (
 
       // Target selection step
       gitRepoCreatePage.targetClusterOptions().set(1);
+      // The "Manually selected clusters" option only renders once the async fleet-cluster
+      // data has loaded; wait for it before selecting to avoid flaking on slow fetches.
+      gitRepoCreatePage.targetClusterOptions().getAllOptions().should('have.length.gte', 3);
       gitRepoCreatePage.targetClusterOptions().set(2);
       gitRepoCreatePage.targetCluster().toggle();
       gitRepoCreatePage.targetCluster().clickLabel(fakeProvClusterId);
@@ -243,6 +246,9 @@ describe('Git Repo', { testIsolation: 'off', tags: ['@fleet', '@adminUser'] }, (
 
         // Target selection step
         gitRepoCreatePage.targetClusterOptions().set(1);
+        // The "Manually selected clusters" option only renders once the async fleet-cluster
+        // data has loaded; wait for it before selecting to avoid flaking on slow fetches.
+        gitRepoCreatePage.targetClusterOptions().getAllOptions().should('have.length.gte', 3);
         gitRepoCreatePage.targetClusterOptions().set(2);
         gitRepoCreatePage.targetCluster().toggle();
         gitRepoCreatePage.targetCluster().clickLabel(fakeProvClusterId);

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -127,6 +127,12 @@ export default {
       default: () => []
     },
 
+    // Used to be called before going to the next step in the wizard.
+    beforeNext: {
+      type:    Function,
+      default: null
+    },
+
     stepsOptions: {
       type:    Object,
       default: () => ({ editFirstStep: true })
@@ -200,6 +206,7 @@ export default {
       tocContainerHeight:                 0,
       mainLayoutEl:                       null,
       throttledComputeTocContainerHeight: null,
+      nextValidating:                     false,
       /**
        * Initialised on demand (given that it needs to make a request to fetch schema definition)
        */
@@ -488,6 +495,47 @@ export default {
       return slot !== 'default' && typeof this.$slots[slot] === 'function';
     },
 
+    async wizardBeforeGoToStep(fromStep, toStep) {
+      if (!this.beforeNext) {
+        return;
+      }
+
+      const fromIdx = this.steps.findIndex((s) => s.name === fromStep.name);
+      const toIdx = this.steps.findIndex((s) => s.name === toStep.name);
+
+      if (toIdx <= fromIdx) {
+        return;
+      }
+
+      try {
+        await this.beforeNext(fromStep);
+        this.$emit('error', []);
+      } catch (err) {
+        this.$emit('error', exceptionToErrorsArray(err));
+        throw err;
+      }
+    },
+
+    async handleNext(nextFn, activeStep) {
+      if (!this.beforeNext) {
+        nextFn();
+
+        return;
+      }
+
+      this.nextValidating = true;
+
+      try {
+        await this.beforeNext(activeStep);
+        this.$emit('error', []);
+        nextFn();
+      } catch (err) {
+        this.$emit('error', exceptionToErrorsArray(err));
+      } finally {
+        this.nextValidating = false;
+      }
+    },
+
     formatError(err) {
       if ( typeof err === 'string') {
         return err;
@@ -751,6 +799,7 @@ export default {
             :edit-first-step="stepsOptions.editFirstStep"
             :errors="errors"
             :finish-mode="finishMode"
+            :before-go-to-step="wizardBeforeGoToStep"
             class="wizard"
             @error="e=>errors = e"
           >
@@ -834,10 +883,10 @@ export default {
                     name="next"
                   >
                     <button
-                      :disabled="!canNext"
+                      :disabled="!canNext || nextValidating"
                       type="button"
                       class="btn role-primary"
-                      @click="next()"
+                      @click="handleNext(next, activeStep)"
                     >
                       <t k="wizard.next" />
                     </button>

--- a/shell/components/Wizard.vue
+++ b/shell/components/Wizard.vue
@@ -124,6 +124,11 @@ export default {
     errors: {
       type:    Array,
       default: null,
+    },
+
+    beforeGoToStep: {
+      type:    Function,
+      default: null
     }
   },
 
@@ -217,7 +222,7 @@ export default {
   },
 
   methods: {
-    goToStep(number, fromNav) {
+    async goToStep(number, fromNav) {
       if (number < 1) {
         return;
       }
@@ -231,6 +236,14 @@ export default {
 
       if ( !selected || (!this.isAvailable(selected) && number !== 1)) {
         return;
+      }
+
+      if (this.beforeGoToStep && fromNav) {
+        try {
+          await this.beforeGoToStep(this.activeStep, selected);
+        } catch {
+          return;
+        }
       }
 
       this.activeStep = selected;

--- a/shell/components/fleet/GitRepoMetadataTab.vue
+++ b/shell/components/fleet/GitRepoMetadataTab.vue
@@ -14,6 +14,10 @@ defineProps({
   isView: {
     type:    Boolean,
     default: false
+  },
+  nameRules: {
+    type:    Array,
+    default: () => []
   }
 });
 
@@ -31,6 +35,7 @@ const updateValue = (event) => {
       :value="value"
       :namespaced="false"
       :mode="mode"
+      :rules="{ name: nameRules }"
       @update:value="updateValue"
     />
     <Labels

--- a/shell/components/fleet/HelmOpAppCoConfigTab.vue
+++ b/shell/components/fleet/HelmOpAppCoConfigTab.vue
@@ -50,6 +50,7 @@ const props = withDefaults(defineProps<{
   hideTarget?: boolean;
   hideAdvanced?: boolean;
   hideChartConfig?: boolean;
+  nameRules?: ((val: any) => string | undefined)[];
 }>(), {
   appCoChartEntries:        () => ({} as Record<string, ChartEntry[]>),
   appCoChartsLoading:       false,
@@ -69,6 +70,7 @@ const props = withDefaults(defineProps<{
   hideTarget:               false,
   hideAdvanced:             false,
   hideChartConfig:          false,
+  nameRules:                () => [],
 });
 
 // eslint-disable-next-line func-call-spacing
@@ -309,6 +311,7 @@ defineExpose({ refreshYamlEditor });
           :mode="mode"
           :name-label="'fleet.helmOp.appCoConfig.name'"
           :no-bottom-margin="true"
+          :rules="{ name: nameRules }"
           data-testid="appco-config-name-ns-description"
           @update:value="emit('update:value', $event)"
         />
@@ -354,6 +357,7 @@ defineExpose({ refreshYamlEditor });
           :namespaced="false"
           :mode="mode"
           :name-label="'fleet.helmOp.appCoConfig.name'"
+          :rules="{ name: nameRules }"
           data-testid="appco-config-name-ns-description"
           @update:value="emit('update:value', $event)"
         />

--- a/shell/components/fleet/HelmOpMetadataTab.vue
+++ b/shell/components/fleet/HelmOpMetadataTab.vue
@@ -14,6 +14,10 @@ defineProps({
   isView: {
     type:    Boolean,
     default: false
+  },
+  nameRules: {
+    type:    Array,
+    default: () => []
   }
 });
 
@@ -31,6 +35,7 @@ const updateValue = (value) => {
       :value="value"
       :namespaced="false"
       :mode="mode"
+      :rules="{ name: nameRules }"
       @update:value="updateValue"
     />
     <Labels

--- a/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
+++ b/shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts
@@ -362,3 +362,60 @@ describe('view: fleet.cattle.io.gitrepo, GitHub App auth - should', () => {
     expect(fakeSecret.save).toHaveBeenCalledWith();
   });
 });
+
+describe('view: fleet.cattle.io.gitrepo, beforeNext dryRun validation', () => {
+  it('should call dryRunCreate when leaving stepMetadata in create mode', async() => {
+    const wrapper = mount(GitRepoComponent, initGitRepo({ mode: _CREATE }));
+    const vm = wrapper.vm as any;
+
+    vm.value.dryRunCreate = jest.fn().mockResolvedValue({});
+
+    await vm.beforeNext({ name: 'stepMetadata' });
+
+    expect(vm.value.dryRunCreate).toHaveBeenCalledWith(expect.objectContaining({
+      type:     'fleet.cattle.io.gitrepo',
+      metadata: expect.objectContaining({
+        name:      'test',
+        namespace: 'test',
+      }),
+      spec: expect.objectContaining({ repo: 'https://example.com/placeholder' }),
+    }));
+  });
+
+  it('should not call dryRunCreate for non-metadata steps', async() => {
+    const wrapper = mount(GitRepoComponent, initGitRepo({ mode: _CREATE }));
+    const vm = wrapper.vm as any;
+
+    vm.value.dryRunCreate = jest.fn();
+
+    await vm.beforeNext({ name: 'stepRepo' });
+
+    expect(vm.value.dryRunCreate).not.toHaveBeenCalled();
+  });
+
+  it('should not call dryRunCreate in edit mode', async() => {
+    const wrapper = mount(GitRepoComponent, initGitRepo({ mode: _EDIT }));
+    const vm = wrapper.vm as any;
+
+    vm.value.dryRunCreate = jest.fn();
+
+    await vm.beforeNext({ name: 'stepMetadata' });
+
+    expect(vm.value.dryRunCreate).not.toHaveBeenCalled();
+  });
+
+  it('should reject with API errors when dryRunCreate fails', async() => {
+    const apiError = {
+      _status:    409,
+      message:    'gitrepos.fleet.cattle.io "test" already exists',
+      statusText: 'Conflict',
+    };
+
+    const wrapper = mount(GitRepoComponent, initGitRepo({ mode: _CREATE }));
+    const vm = wrapper.vm as any;
+
+    vm.value.dryRunCreate = jest.fn().mockRejectedValue(apiError);
+
+    await expect(vm.beforeNext({ name: 'stepMetadata' })).rejects.toStrictEqual(apiError);
+  });
+});

--- a/shell/edit/__tests__/fleet.cattle.io.helmop.test.ts
+++ b/shell/edit/__tests__/fleet.cattle.io.helmop.test.ts
@@ -421,6 +421,12 @@ describe.each([
     expect(wrapper.vm.value.spec.downstreamResources).toStrictEqual([{ name: 'configMap2', kind: 'ConfigMap' }, { name: 'configMap3', kind: 'ConfigMap' }]);
   });
 
+  it('should have a beforeNext method', () => {
+    const wrapper = mount(HelmOpComponent, initHelmOp({ mode }));
+
+    expect(typeof wrapper.vm.beforeNext).toBe('function');
+  });
+
   if (mode === _CREATE) {
     it('should set created-by-user-id label when updateBeforeSave is called in CREATE mode', () => {
       const mockCurrentUser = { id: 'user-123' };
@@ -474,4 +480,99 @@ describe.each([
       expect(wrapper.vm.value.metadata.labels['fleet.cattle.io/created-by-user-id']).toBeUndefined();
     });
   }
+});
+
+describe('view: fleet.cattle.io.helmop, beforeNext dryRun validation', () => {
+  const initHelmOpWithMetadata = (props: any) => {
+    const value = new HelmOp({
+      ...mockHelmOp,
+      metadata: {
+        name:      'test-helmop',
+        namespace: 'fleet-default',
+      },
+    }, {
+      getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
+      dispatch:    jest.fn(),
+      rootGetters: { 'i18n/t': jest.fn() },
+    });
+
+    value.applyDefaults = () => {};
+
+    return {
+      props: {
+        value,
+        ...props
+      },
+      provide: {
+        store: createStore({
+          getters: {
+            currentStore:                   () => 'current_store',
+            'management/paginationEnabled': () => () => false
+          }
+        })
+      },
+      computed: mockComputed,
+      global:   { mocks },
+    };
+  };
+
+  it('should call dryRunCreate when leaving basics step in create mode', async() => {
+    const wrapper = mount(HelmOpComponent, initHelmOpWithMetadata({ mode: _CREATE }));
+    const vm = wrapper.vm as any;
+
+    vm.value.dryRunCreate = jest.fn().mockResolvedValue({});
+
+    await vm.beforeNext({ name: 'basics' });
+
+    expect(vm.value.dryRunCreate).toHaveBeenCalledWith(expect.objectContaining({
+      type:     'fleet.cattle.io.helmop',
+      metadata: expect.objectContaining({
+        name:      'test-helmop',
+        namespace: 'fleet-default',
+      }),
+      spec: expect.objectContaining({
+        helm: expect.objectContaining({
+          chart: 'placeholder',
+          repo:  'https://example.com',
+        }),
+      }),
+    }));
+  });
+
+  it('should not call dryRunCreate for non-basics steps', async() => {
+    const wrapper = mount(HelmOpComponent, initHelmOpWithMetadata({ mode: _CREATE }));
+    const vm = wrapper.vm as any;
+
+    vm.value.dryRunCreate = jest.fn();
+
+    await vm.beforeNext({ name: 'chart' });
+
+    expect(vm.value.dryRunCreate).not.toHaveBeenCalled();
+  });
+
+  it('should not call dryRunCreate in edit mode', async() => {
+    const wrapper = mount(HelmOpComponent, initHelmOpWithMetadata({ mode: _EDIT }));
+    const vm = wrapper.vm as any;
+
+    vm.value.dryRunCreate = jest.fn();
+
+    await vm.beforeNext({ name: 'basics' });
+
+    expect(vm.value.dryRunCreate).not.toHaveBeenCalled();
+  });
+
+  it('should reject with API errors when dryRunCreate fails', async() => {
+    const apiError = {
+      _status:    409,
+      message:    'helmops.fleet.cattle.io "test-helmop" already exists',
+      statusText: 'Conflict',
+    };
+
+    const wrapper = mount(HelmOpComponent, initHelmOpWithMetadata({ mode: _CREATE }));
+    const vm = wrapper.vm as any;
+
+    vm.value.dryRunCreate = jest.fn().mockRejectedValue(apiError);
+
+    await expect(vm.beforeNext({ name: 'basics' })).rejects.toStrictEqual(apiError);
+  });
 });

--- a/shell/edit/fleet.cattle.io.gitrepo.vue
+++ b/shell/edit/fleet.cattle.io.gitrepo.vue
@@ -97,10 +97,19 @@ export default {
       refValue,
       displayHelmRepoUrlRegex: false,
       targetsCreated:          '',
-      fvFormRuleSets:          [{
-        path:  'spec.repo',
-        rules: ['urlRepository'],
-      }],
+      fvFormRuleSets:          [
+        {
+          step:           'stepMetadata',
+          path:           'metadata.name',
+          rules:          ['subDomain'],
+          translationKey: 'nameNsDescription.name.label'
+        },
+        {
+          step:  'stepRepo',
+          path:  'spec.repo',
+          rules: ['urlRepository'],
+        },
+      ],
       touched: null,
     };
   },
@@ -129,7 +138,7 @@ export default {
           label:          this.t('fleet.gitRepo.add.steps.metadata.label'),
           subtext:        this.t('fleet.gitRepo.add.steps.metadata.subtext'),
           descriptionKey: 'fleet.gitRepo.add.steps.metadata.description',
-          ready:          this.isView || !!this.value.metadata.name,
+          ready:          this.isView || (!!this.value.metadata.name && this.stepPathErrors('stepMetadata').length === 0),
           weight:         1
         },
         {
@@ -206,6 +215,15 @@ export default {
   },
 
   methods: {
+    stepPathErrors(stepName) {
+      // Helper is used to check which validations is for each step
+      const paths = this.fvFormRuleSets
+        .filter((rule) => rule.step === stepName)
+        .map((rule) => rule.path);
+
+      return this.fvGetPathErrors(paths);
+    },
+
     updatePaths(value) {
       const { paths, bundles } = value;
 
@@ -428,6 +446,25 @@ export default {
       }
     },
 
+    async beforeNext(activeStep) {
+      if (activeStep.name !== 'stepMetadata' || !this.isCreate) {
+        return;
+      }
+
+      await this.value.dryRunCreate({
+        type:     this.value.type,
+        metadata: {
+          name:      this.value.metadata.name,
+          namespace: this.value.metadata.namespace,
+        },
+        spec: {
+          repo:   'https://example.com/placeholder',
+          branch: 'master',
+          paths:  [],
+        }
+      });
+    },
+
     durationSeconds(value) {
       return `${ value }s`;
     }
@@ -447,6 +484,7 @@ export default {
     :errors="errors"
     :steps="!isView ? steps : undefined"
     :finish-mode="'finish'"
+    :before-next="beforeNext"
     class="wizard"
     @cancel="done"
     @error="e=>errors = e"
@@ -457,6 +495,7 @@ export default {
         :value="value"
         :mode="mode"
         :is-view="isView"
+        :name-rules="fvGetAndReportPathRules('metadata.name')"
         @input="$emit('input', $event)"
       />
     </template>

--- a/shell/edit/fleet.cattle.io.helmop.vue
+++ b/shell/edit/fleet.cattle.io.helmop.vue
@@ -796,7 +796,7 @@ export default {
     :mode="mode"
     :resource="value"
     :subtypes="[]"
-    :validation-passed="true"
+    :validation-passed="fvFormIsValid"
     :errors="errors"
     :steps="!isView ? steps : undefined"
     :finish-mode="'finish'"
@@ -1094,6 +1094,7 @@ export default {
       >
         <HelmOpAppCoConfigTab
           v-bind="appCoConfigProps"
+          :name-rules="fvGetAndReportPathRules('metadata.name')"
           data-testid="helmop-appco-edit-config-tab"
           v-on="appCoConfigListeners"
         />

--- a/shell/edit/fleet.cattle.io.helmop.vue
+++ b/shell/edit/fleet.cattle.io.helmop.vue
@@ -196,7 +196,7 @@ export default {
           label:          this.t('fleet.helmOp.add.steps.metadata.label'),
           subtext:        this.t('fleet.helmOp.add.steps.metadata.subtext'),
           descriptionKey: 'fleet.helmOp.add.steps.metadata.description',
-          ready:          this.isView || !!this.value.metadata.name,
+          ready:          this.isView || (!!this.value.metadata.name && this.stepPathErrors('basics').length === 0),
           weight:         1
         },
         {
@@ -443,6 +443,15 @@ export default {
       this.done();
     },
 
+    stepPathErrors(stepName) {
+      // Helper is used to check which validations is for each step
+      const paths = this.fvFormRuleSets
+        .filter((rule) => rule.step === stepName)
+        .map((rule) => rule.path);
+
+      return this.fvGetPathErrors(paths);
+    },
+
     onSourceTypeSelect(type) {
       if (this.isSuseAppCollection) {
         return;
@@ -659,35 +668,49 @@ export default {
     },
 
     updateValidationRules(sourceType) {
+      const nameRule = {
+        step:           'basics',
+        path:           'metadata.name',
+        rules:          ['subDomain'],
+        translationKey: 'nameNsDescription.name.label'
+      };
+
       switch (sourceType) {
       case SOURCE_TYPE.REPO:
-        this.fvFormRuleSets = [{
+        this.fvFormRuleSets = [nameRule, {
+          step:  'chart',
           path:  'spec.helm.repo',
           rules: ['urlRepository'],
         }, {
+          step:  'chart',
           path:  'spec.helm.chart',
           rules: ['required'],
         }, {
+          step:  'chart',
           path:  'spec.helm.version',
           rules: ['semanticVersion'],
         }];
         break;
       case SOURCE_TYPE.OCI:
-        this.fvFormRuleSets = [{
+        this.fvFormRuleSets = [nameRule, {
+          step:  'chart',
           path:  'spec.helm.repo',
           rules: ['ociRegistry'],
         },
         ...(this.isSuseAppCollection ? [{
+          step:  'chart',
           path:  'spec.helm.chart',
           rules: ['required'],
         }] : []),
         {
+          step:  'chart',
           path:  'spec.helm.version',
           rules: this.isSuseAppCollection ? ['required', 'semanticVersion'] : ['semanticVersion'],
         }];
         break;
       case SOURCE_TYPE.TARBALL:
-        this.fvFormRuleSets = [{
+        this.fvFormRuleSets = [nameRule, {
+          step:  'chart',
           path:  'spec.helm.chart',
           rules: ['urlRepository'],
         }];
@@ -739,6 +762,26 @@ export default {
         break;
       }
     },
+
+    async beforeNext(activeStep) {
+      if (activeStep.name !== 'basics' || !this.isCreate) {
+        return;
+      }
+
+      await this.value.dryRunCreate({
+        type:     this.value.type,
+        metadata: {
+          name:      this.value.metadata.name,
+          namespace: this.value.metadata.namespace,
+        },
+        spec: {
+          helm: {
+            chart: 'placeholder',
+            repo:  'https://example.com',
+          },
+        }
+      });
+    },
   },
 };
 </script>
@@ -758,6 +801,7 @@ export default {
     :steps="!isView ? steps : undefined"
     :finish-mode="'finish'"
     :cancel-event="true"
+    :before-next="beforeNext"
     class="wizard"
     data-testid="helmop-cru-resource"
     @cancel="onCancel"
@@ -773,6 +817,7 @@ export default {
         :mode="mode"
         :is-view="isView"
         data-testid="helmop-metadata-tab"
+        :name-rules="fvGetAndReportPathRules('metadata.name')"
         @update:value="$emit('input', $event)"
       />
     </template>

--- a/shell/plugins/dashboard-store/__tests__/resource-class.test.ts
+++ b/shell/plugins/dashboard-store/__tests__/resource-class.test.ts
@@ -678,4 +678,88 @@ describe('class: Resource', () => {
       expect(viewYaml.enabled).toBe(true);
     });
   });
+
+  describe('method: dryRunCreate', () => {
+    const collectionUrl = '/v1/test.resources';
+
+    it('should dispatch a request with dryRun=All query param', async() => {
+      const dispatch = jest.fn().mockResolvedValue({});
+      const resource = new Resource({
+        type:     'test.resource',
+        metadata: {
+          name:      'my-resource',
+          namespace: 'my-ns',
+        },
+      }, {
+        getters: {
+          schemaFor: () => ({
+            linkFor:    (link: string) => (link === 'collection' ? collectionUrl : ''),
+            attributes: { namespaced: true },
+          })
+        },
+        dispatch,
+        rootGetters: { 'i18n/t': jest.fn() },
+      });
+
+      await resource.dryRunCreate();
+
+      expect(dispatch).toHaveBeenCalledWith('request', {
+        opt: expect.objectContaining({
+          method: 'post',
+          url:    `${ collectionUrl }/my-ns?dryRun=All`,
+        }),
+        type: 'test.resource'
+      });
+    });
+
+    it('should use provided data instead of resource state when given', async() => {
+      const dispatch = jest.fn().mockResolvedValue({});
+      const resource = new Resource({
+        type:     'test.resource',
+        metadata: { name: 'original', namespace: 'ns' },
+      }, {
+        getters: {
+          schemaFor: () => ({
+            linkFor:    () => collectionUrl,
+            attributes: { namespaced: true },
+          })
+        },
+        dispatch,
+        rootGetters: { 'i18n/t': jest.fn() },
+      });
+
+      const customData = {
+        type:     'test.resource',
+        metadata: { name: 'custom' },
+        spec:     {}
+      };
+
+      await resource.dryRunCreate(customData);
+
+      expect(dispatch).toHaveBeenCalledWith('request', {
+        opt:  expect.objectContaining({ data: customData }),
+        type: 'test.resource'
+      });
+    });
+
+    it('should propagate API errors', async() => {
+      const apiError = { _status: 409, message: 'already exists' };
+      const dispatch = jest.fn().mockRejectedValue(apiError);
+      const resource = new Resource({
+        type:     'test.resource',
+        metadata: { name: 'dup', namespace: 'ns' },
+      }, {
+        getters: {
+          schemaFor: () => ({
+            linkFor:    () => collectionUrl,
+            attributes: { namespaced: true },
+          })
+        },
+        dispatch,
+        rootGetters: { 'i18n/t': jest.fn() },
+      });
+
+      await expect(resource.dryRunCreate()).rejects.toStrictEqual(apiError);
+    });
+  });
 });

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -1191,6 +1191,36 @@ export default class Resource {
     return this._save(...arguments);
   }
 
+  _collectionUrl() {
+    const schema = this.$getters['schemaFor'](this.type);
+    let url = schema.linkFor('collection');
+
+    if ( schema.attributes && schema.attributes.namespaced && this.metadata && this.metadata.namespace ) {
+      url += `/${ this.metadata.namespace }`;
+    }
+
+    return url;
+  }
+
+  async dryRunCreate(data) {
+    const url = this._collectionUrl();
+    const separator = url.includes('?') ? '&' : '?';
+    const body = data || this.cleanForSave(this.toSave() || JSON.parse(JSON.stringify(this)), true);
+
+    return this.$dispatch('request', {
+      opt: {
+        method:  'post',
+        url:     `${ url }${ separator }dryRun=All`,
+        data:    body,
+        headers: {
+          'content-type': 'application/json',
+          accept:         'application/json'
+        }
+      },
+      type: this.type
+    });
+  }
+
   /**
    * Remove any unwanted properties from the object that will be saved
    */
@@ -1222,15 +1252,7 @@ export default class Resource {
 
     if ( !opt.url ) {
       if ( forNew ) {
-        const schema = this.$getters['schemaFor'](this.type);
-
-        let url = schema.linkFor('collection');
-
-        if ( schema.attributes && schema.attributes.namespaced && this.metadata && this.metadata.namespace ) {
-          url += `/${ this.metadata.namespace }`;
-        }
-
-        opt.url = url;
+        opt.url = this._collectionUrl();
       } else {
         opt.url = this.linkFor('update') || this.linkFor('self');
       }


### PR DESCRIPTION
…ToStep to handle nav click. Added validation to the validation. Added rules to NameNsDescription. Added dryRun request on the resource-class to be used globally.

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16533
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Added to the GitRepo and the HelmOp wizard a validation to the name on the Next Button and Wizard Nav.
- Changed to the CruResource to have a handleNext function and to add a wizardBeforeGoToStep which uses the same handleNext. They are coupled together so the handleNext runs inside the wizardBeforeGoToStep to have similar usage.
- Changed resource-class to add the function to execute the dryRun. Changed the save to use a similar function to build the url.
- Changed Wizard to use the beforeGoToStep to handle interactions on the navigation.
- Additionally added a simple validation to the Name field.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Fleet GitRepo flow, should test validation to the name field. It should test the validation with simple wrong input, like `///` or `AAA`, it should disable the NEXT and trigger the same flow.
- Fleet GitRepo flow, should test validation to the name field. Testing sending the same name as another already created AppBundle. It will trigger the DRYRUN which will do the request without saving the data.
- Execute same check for Fleet HelmOp flow.
- Different test cases is doing different ways to navigate in the Wizard.
- One test case is writing down the proper name, than coming back and adding a name that already has an AppBundle, and trying to navigate OUT of the flow.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
