### PR TITLE
Add support for service links annotation

### DIFF
--- a/shell/components/formatter/ServiceTargets.vue
+++ b/shell/components/formatter/ServiceTargets.vue
@@ -60,8 +60,11 @@ export default {
           const [portStr, scheme] = entry.trim().split('/');
           const port = Number(portStr);
 
-          if (!isNaN(port)) {
-            serviceLinksMap.set(port, scheme || null);
+          const validSchemes = ['http', 'https'];
+          const normalizedScheme = scheme?.toLowerCase();
+
+          if (port > 0 && !isNaN(port)) {
+            serviceLinksMap.set(port, validSchemes.includes(normalizedScheme) ? normalizedScheme : null);
           }
         });
       }

--- a/shell/components/formatter/ServiceTargets.vue
+++ b/shell/components/formatter/ServiceTargets.vue
@@ -1,6 +1,6 @@
 <script>
 import isEmpty from 'lodash/isEmpty';
-import { CATTLE_PUBLIC_ENDPOINTS } from '@shell/config/labels-annotations';
+import { CATTLE_PUBLIC_ENDPOINTS, SERVICE_LINKS } from '@shell/config/labels-annotations';
 import Endpoints from '@shell/components/formatter/Endpoints';
 import has from 'lodash/has';
 import { isMaybeSecure } from '@shell/utils/url';
@@ -52,6 +52,20 @@ export default {
         return annotations[CATTLE_PUBLIC_ENDPOINTS];
       }
 
+      const serviceLinksAnnotation = annotations[SERVICE_LINKS];
+      const serviceLinksMap = new Map();
+
+      if (serviceLinksAnnotation) {
+        serviceLinksAnnotation.split(',').forEach((entry) => {
+          const [portStr, scheme] = entry.trim().split('/');
+          const port = Number(portStr);
+
+          if (!isNaN(port)) {
+            serviceLinksMap.set(port, scheme || null);
+          }
+        });
+      }
+
       // <CLUSTER_IP>:<PORT>/<PROTOCOL> > <TARGET PORT>
       if (isEmpty(ports)) {
         if (!isEmpty(parsedClusterIp)) {
@@ -70,12 +84,14 @@ export default {
 
           const stringPort = p.port.toString();
 
-          if (p?.protocol === 'TCP' && (stringPort.endsWith('80') || stringPort.endsWith('443'))) {
-            if (isMaybeSecure(p.port, p?.protocol)) {
-              proxyUrl = row.proxyUrl('https', p.port);
-            } else {
-              proxyUrl = row.proxyUrl('http', p.port);
-            }
+          const isDefaultPort = stringPort.endsWith('80') || stringPort.endsWith('443');
+          const hasServiceLink = serviceLinksMap.has(p.port);
+
+          if (p?.protocol === 'TCP' && (isDefaultPort || hasServiceLink)) {
+            const explicitScheme = hasServiceLink ? serviceLinksMap.get(p.port) : null;
+            const scheme = explicitScheme || (isMaybeSecure(p.port, p?.protocol) ? 'https' : 'http');
+
+            proxyUrl = row.proxyUrl(scheme, p.port);
           }
 
           const clusterIpAndPort = proxyUrl ? `<a href="${ proxyUrl }" target="_blank" rel="noopener noreferrer nofollow">${ p?.name ? p.name : `${ parsedClusterIp }${ p.port }` }</a>` : `${ parsedClusterIp }${ p.port }`;

--- a/shell/components/formatter/__tests__/ServiceTargets.test.ts
+++ b/shell/components/formatter/__tests__/ServiceTargets.test.ts
@@ -1,0 +1,374 @@
+import { shallowMount } from '@vue/test-utils';
+import ServiceTargets from '@shell/components/formatter/ServiceTargets.vue';
+
+describe('component: ServiceTargets', () => {
+  const proxyUrl = (scheme: string, port: number) => `https://rancher.test/k8s/clusters/local/api/v1/namespaces/default/services/${ scheme }:test-service:${ port }/proxy`;
+
+  function createRow(overrides: Record<string, any> = {}) {
+    return {
+      metadata: { annotations: {}, ...overrides.metadata },
+      spec:     {
+        clusterIP: '10.43.0.100',
+        ports:     [],
+        type:      'ClusterIP',
+        ...overrides.spec,
+      },
+      proxyUrl,
+    };
+  }
+
+  function mountComponent(row: Record<string, any>) {
+    return shallowMount(ServiceTargets, {
+      props: {
+        value: null,
+        row,
+        col:   {},
+      },
+      global: { directives: { 'clean-html': () => {} } },
+    });
+  }
+
+  describe('default port handling', () => {
+    it.each([
+      ['80', 80],
+      ['443', 443],
+      ['8080', 8080],
+      ['8443', 8443],
+    ])('should generate a clickable link for TCP port %s', (_label, port) => {
+      const row = createRow({
+        spec: {
+          ports: [{
+            port, protocol: 'TCP', targetPort: port
+          }]
+        }
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].label).toContain('<a href=');
+      expect(parsed[0].label).toContain(`proxy`);
+    });
+
+    it.each([
+      ['3000', 3000],
+      ['9090', 9090],
+      ['5000', 5000],
+    ])('should NOT generate a clickable link for TCP port %s without annotation', (_label, port) => {
+      const row = createRow({
+        spec: {
+          ports: [{
+            port, protocol: 'TCP', targetPort: port
+          }]
+        }
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].label).not.toContain('<a href=');
+    });
+
+    it('should NOT generate a clickable link for non-TCP protocol', () => {
+      const row = createRow({
+        spec: {
+          ports: [{
+            port: 80, protocol: 'UDP', targetPort: 80
+          }]
+        }
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].label).not.toContain('<a href=');
+    });
+  });
+
+  describe('service-links annotation', () => {
+    it('should generate a clickable link for a port listed in the annotation', () => {
+      const row = createRow({
+        metadata: { annotations: { 'ui.rancher/service-links': '3000' } },
+        spec:     {
+          ports: [{
+            port: 3000, protocol: 'TCP', targetPort: 3000
+          }]
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].label).toContain('<a href=');
+      expect(parsed[0].label).toContain('http:test-service:3000');
+    });
+
+    it('should generate clickable links for multiple ports in the annotation', () => {
+      const row = createRow({
+        metadata: { annotations: { 'ui.rancher/service-links': '3000,9090' } },
+        spec:     {
+          ports: [
+            {
+              port: 3000, protocol: 'TCP', targetPort: 3000
+            },
+            {
+              port: 9090, protocol: 'TCP', targetPort: 9090
+            },
+            {
+              port: 5000, protocol: 'TCP', targetPort: 5000
+            },
+          ],
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(3);
+      expect(parsed[0].label).toContain('<a href=');
+      expect(parsed[1].label).toContain('<a href=');
+      expect(parsed[2].label).not.toContain('<a href=');
+    });
+
+    it('should still generate links for default ports (80, 443) even without annotation', () => {
+      const row = createRow({
+        spec: {
+          ports: [
+            {
+              port: 80, protocol: 'TCP', targetPort: 80
+            },
+            {
+              port: 443, protocol: 'TCP', targetPort: 443
+            },
+          ],
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].label).toContain('<a href=');
+      expect(parsed[1].label).toContain('<a href=');
+    });
+
+    it('should handle whitespace in the annotation value', () => {
+      const row = createRow({
+        metadata: { annotations: { 'ui.rancher/service-links': ' 3000 , 9090 ' } },
+        spec:     {
+          ports: [
+            {
+              port: 3000, protocol: 'TCP', targetPort: 3000
+            },
+            {
+              port: 9090, protocol: 'TCP', targetPort: 9090
+            },
+          ],
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].label).toContain('<a href=');
+      expect(parsed[1].label).toContain('<a href=');
+    });
+
+    it('should handle an empty annotation value gracefully', () => {
+      const row = createRow({
+        metadata: { annotations: { 'ui.rancher/service-links': '' } },
+        spec:     {
+          ports: [{
+            port: 3000, protocol: 'TCP', targetPort: 3000
+          }]
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].label).not.toContain('<a href=');
+    });
+
+    it('should ignore non-numeric values in the annotation', () => {
+      const row = createRow({
+        metadata: { annotations: { 'ui.rancher/service-links': '3000,abc,9090' } },
+        spec:     {
+          ports: [
+            {
+              port: 3000, protocol: 'TCP', targetPort: 3000
+            },
+            {
+              port: 9090, protocol: 'TCP', targetPort: 9090
+            },
+          ],
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].label).toContain('<a href=');
+      expect(parsed[1].label).toContain('<a href=');
+    });
+
+    it('should not generate a link for annotated port with non-TCP protocol', () => {
+      const row = createRow({
+        metadata: { annotations: { 'ui.rancher/service-links': '3000' } },
+        spec:     {
+          ports: [{
+            port: 3000, protocol: 'UDP', targetPort: 3000
+          }]
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].label).not.toContain('<a href=');
+    });
+
+    it('should use https scheme for annotated port that isMaybeSecure considers secure', () => {
+      const row = createRow({
+        metadata: { annotations: { 'ui.rancher/service-links': '8443' } },
+        spec:     {
+          ports: [{
+            port: 8443, protocol: 'TCP', targetPort: 8443
+          }]
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].label).toContain('https:test-service:8443');
+    });
+
+    it('should use http scheme for annotated port that is not secure', () => {
+      const row = createRow({
+        metadata: { annotations: { 'ui.rancher/service-links': '3000' } },
+        spec:     {
+          ports: [{
+            port: 3000, protocol: 'TCP', targetPort: 3000
+          }]
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].label).toContain('http:test-service:3000');
+    });
+
+    it('should use explicit https scheme from annotation even for non-secure port', () => {
+      const row = createRow({
+        metadata: { annotations: { 'ui.rancher/service-links': '3000/https' } },
+        spec:     {
+          ports: [{
+            port: 3000, protocol: 'TCP', targetPort: 3000
+          }]
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].label).toContain('https:test-service:3000');
+    });
+
+    it('should use explicit http scheme from annotation even for secure port', () => {
+      const row = createRow({
+        metadata: { annotations: { 'ui.rancher/service-links': '8443/http' } },
+        spec:     {
+          ports: [{
+            port: 8443, protocol: 'TCP', targetPort: 8443
+          }]
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].label).toContain('http:test-service:8443');
+    });
+
+    it('should handle mixed format with and without explicit scheme', () => {
+      const row = createRow({
+        metadata: { annotations: { 'ui.rancher/service-links': '3000/https,9090' } },
+        spec:     {
+          ports: [
+            {
+              port: 3000, protocol: 'TCP', targetPort: 3000
+            },
+            {
+              port: 9090, protocol: 'TCP', targetPort: 9090
+            },
+          ],
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].label).toContain('https:test-service:3000');
+      expect(parsed[1].label).toContain('http:test-service:9090');
+    });
+  });
+
+  describe('empty ports', () => {
+    it('should show clusterIP when ports are empty', () => {
+      const row = createRow({ spec: { clusterIP: '10.43.0.100', ports: [] } });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].label).toBe('10.43.0.100:');
+    });
+
+    it('should show externalName for ExternalName service type', () => {
+      const row = createRow({
+        spec: {
+          clusterIP:    '',
+          ports:        [],
+          type:         'ExternalName',
+          externalName: 'my.external.service',
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].label).toBe('my.external.service');
+    });
+  });
+
+  describe('port label formatting', () => {
+    it('should use port name when available in clickable link', () => {
+      const row = createRow({
+        spec: {
+          ports: [{
+            port: 80, protocol: 'TCP', targetPort: 80, name: 'http-web',
+          }],
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed[0].label).toContain('>http-web</a>');
+    });
+
+    it('should include target port and protocol in label', () => {
+      const row = createRow({
+        spec: {
+          ports: [{
+            port: 3000, protocol: 'TCP', targetPort: 8080
+          }]
+        }
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed[0].label).toContain('10.43.0.100:3000');
+      expect(parsed[0].label).toContain('8080');
+      expect(parsed[0].label).toContain('/TCP');
+    });
+  });
+});

--- a/shell/components/formatter/__tests__/ServiceTargets.test.ts
+++ b/shell/components/formatter/__tests__/ServiceTargets.test.ts
@@ -290,6 +290,44 @@ describe('component: ServiceTargets', () => {
       expect(parsed[0].label).toContain('http:test-service:8443');
     });
 
+    it('should not add port 0 from trailing comma in annotation', () => {
+      const row = createRow({
+        metadata: { annotations: { 'ui.rancher/service-links': '3000,' } },
+        spec:     {
+          ports: [
+            {
+              port: 3000, protocol: 'TCP', targetPort: 3000
+            },
+            {
+              port: 0, protocol: 'TCP', targetPort: 0
+            },
+          ],
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].label).toContain('<a href=');
+      expect(parsed[1].label).not.toContain('<a href=');
+    });
+
+    it('should fall back to isMaybeSecure for invalid scheme values', () => {
+      const row = createRow({
+        metadata: { annotations: { 'ui.rancher/service-links': '3000/ftp' } },
+        spec:     {
+          ports: [{
+            port: 3000, protocol: 'TCP', targetPort: 3000
+          }]
+        },
+      });
+      const wrapper = mountComponent(row);
+      const parsed = (wrapper.vm as any).parsed;
+
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].label).toContain('http:test-service:3000');
+    });
+
     it('should handle mixed format with and without explicit scheme', () => {
       const row = createRow({
         metadata: { annotations: { 'ui.rancher/service-links': '3000/https,9090' } },

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -19,6 +19,7 @@ export const NODE_ARCHITECTURE = 'kubernetes.io/arch';
 export const IMPORTED_CLUSTER_VERSION_MANAGEMENT = 'rancher.io/imported-cluster-version-management';
 export const UI_PROJECT_SECRET = 'management.cattle.io/project-scoped-secret';
 export const UI_PROJECT_SECRET_COPY = 'management.cattle.io/project-scoped-secret-copy';
+export const SERVICE_LINKS = 'ui.rancher/service-links';
 
 export const KUBERNETES = {
   SERVICE_ACCOUNT_UID:  'kubernetes.io/service-account.uid',


### PR DESCRIPTION
### Summary
Fixes #17616

Add support for a new `ui.rancher/service-links` annotation on Kubernetes services that allows users to mark arbitrary ports as web service endpoints. The UI will generate clickable proxy URLs for these ports, regardless of port number.

### Occurred changes and/or fixed issues

- Added a new `SERVICE_LINKS` annotation constant (`ui.rancher/service-links`) to `shell/config/labels-annotations.js`.
- Updated `shell/components/formatter/ServiceTargets.vue` to read the annotation and generate clickable proxy links for any ports listed in it, in addition to the existing default behavior for ports ending in `80` or `443`.
- The annotation value is a comma-separated list of ports with an optional scheme: e.g., `"8080,3000/https,9090/http"`.
  - When a scheme is provided (e.g., `3000/https`), it is used directly.
  - When no scheme is provided (e.g., `8080`), the existing `isMaybeSecure` logic determines http vs https.
- The TCP protocol requirement is preserved — non-TCP ports do not get links even if annotated.

### Technical notes summary

- The annotation value is parsed into a `Map<number, string|null>` where the key is the port number and the value is the explicit scheme or `null` for auto-detection.
- Non-numeric entries in the annotation are silently ignored, and whitespace is trimmed.
- The `ui.rancher/` annotation prefix was chosen over `ui.cattle.io` because the codebase notes that `ui.cattle.io` annotations get stripped (see `CLUSTER_BADGE` in `labels-annotations.js`).

### Areas or cases that should be tested

- Verify default behavior is unchanged: services with ports ending in `80`/`443` still get clickable links without the annotation.
- Add the `ui.rancher/service-links` annotation to a service with a non-standard port (e.g., `"3000"`) and verify the Target column shows a clickable link.
- Test with multiple ports in the annotation (e.g., `"3000,9090"`) — only annotated ports and default ports should be clickable.
- Test explicit scheme override: annotate with `"3000/https"` and verify the link uses `https`.
- Test with an empty annotation value — should behave as if no annotation is present.
- Test with non-TCP protocol ports — should not generate links even if annotated.
- Tested locally with Chrome.

### Areas which could experience regressions

- Service Target column rendering in the cluster explorer Services list — this is the only component modified.
- Any existing services with the default port behavior (80, 443, 8080, 8443) should continue to work identically.

### Screenshot/Video
N/A — no visual changes beyond additional ports becoming clickable links.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
