### PR TITLE
XCCDF compliance report generation - metadata location update

### DIFF
--- a/shell/models/__tests__/compliance.cattle.io.clusterscan.test.ts
+++ b/shell/models/__tests__/compliance.cattle.io.clusterscan.test.ts
@@ -1,0 +1,144 @@
+import ClusterScan from '@shell/models/compliance.cattle.io.clusterscan';
+
+/**
+ * Build a ClusterScan model wired to a mocked store `dispatch`.
+ * `$dispatch` resolves to `this.$ctx.dispatch`, so injecting it via the
+ * constructor context is enough to exercise `_resolveExportMetadata`.
+ */
+const makeScan = (dispatch: jest.Mock) => new ClusterScan({}, {
+  getters:     {},
+  rootGetters: {},
+  dispatch,
+} as any) as any;
+
+const benchmarkWithConfigMap = {
+  spec: {
+    customBenchmarkConfigMapName:      'metadata-cm',
+    customBenchmarkConfigMapNamespace: 'compliance',
+  },
+};
+
+describe('class: ClusterScan', () => {
+  describe('method: _resolveExportMetadata', () => {
+    it('returns empty metadata and decorations when the benchmark is undefined', async() => {
+      const dispatch = jest.fn();
+      const scan = makeScan(dispatch);
+
+      const result = await scan._resolveExportMetadata(undefined);
+
+      expect(result).toStrictEqual({ metadata: {}, decorations: {} });
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('returns empty when the ConfigMap name is missing', async() => {
+      const dispatch = jest.fn();
+      const scan = makeScan(dispatch);
+
+      const result = await scan._resolveExportMetadata({ spec: { customBenchmarkConfigMapNamespace: 'compliance' } });
+
+      expect(result).toStrictEqual({ metadata: {}, decorations: {} });
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('returns empty when the ConfigMap namespace is missing', async() => {
+      const dispatch = jest.fn();
+      const scan = makeScan(dispatch);
+
+      const result = await scan._resolveExportMetadata({ spec: { customBenchmarkConfigMapName: 'metadata-cm' } });
+
+      expect(result).toStrictEqual({ metadata: {}, decorations: {} });
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('fetches the ConfigMap by namespace/name from the configmap type', async() => {
+      const dispatch = jest.fn().mockResolvedValue({ data: {} });
+      const scan = makeScan(dispatch);
+
+      await scan._resolveExportMetadata(benchmarkWithConfigMap);
+
+      expect(dispatch).toHaveBeenCalledWith('find', { type: 'configmap', id: 'compliance/metadata-cm' });
+    });
+
+    it('returns empty when the ConfigMap has no metadata.yaml data key', async() => {
+      const dispatch = jest.fn().mockResolvedValue({ data: { 'other.yaml': 'title: x' } });
+      const scan = makeScan(dispatch);
+
+      const result = await scan._resolveExportMetadata(benchmarkWithConfigMap);
+
+      expect(result).toStrictEqual({ metadata: {}, decorations: {} });
+    });
+
+    it('returns empty when the ConfigMap itself is not found', async() => {
+      const dispatch = jest.fn().mockResolvedValue(undefined);
+      const scan = makeScan(dispatch);
+
+      const result = await scan._resolveExportMetadata(benchmarkWithConfigMap);
+
+      expect(result).toStrictEqual({ metadata: {}, decorations: {} });
+    });
+
+    it('splits top-level fields into metadata and the checks map into decorations', async() => {
+      const yaml = [
+        'title: CIS Kubernetes Benchmark',
+        'description: A CIS profile',
+        'referenceType: cis',
+        'checks:',
+        '  "5.1.1":',
+        '    ruleId: CIS-5.1.1-rule',
+        '    severity: high',
+        '    idents:',
+        '      - system: https://www.cisecurity.org/controls/',
+        '        value: CIS-CSC-3',
+        '  "5.1.2":',
+        '    ruleId: CIS-5.1.2-rule',
+      ].join('\n');
+      const dispatch = jest.fn().mockResolvedValue({ data: { 'metadata.yaml': yaml } });
+      const scan = makeScan(dispatch);
+
+      const result = await scan._resolveExportMetadata(benchmarkWithConfigMap);
+
+      expect(result.metadata).toStrictEqual({
+        title:         'CIS Kubernetes Benchmark',
+        description:   'A CIS profile',
+        referenceType: 'cis',
+      });
+      expect(result.decorations).toStrictEqual({
+        '5.1.1': {
+          ruleId:   'CIS-5.1.1-rule',
+          severity: 'high',
+          idents:   [{ system: 'https://www.cisecurity.org/controls/', value: 'CIS-CSC-3' }],
+        },
+        '5.1.2': { ruleId: 'CIS-5.1.2-rule' },
+      });
+    });
+
+    it('returns empty decorations when metadata.yaml has no checks map', async() => {
+      const yaml = ['title: STIG', 'source: disa'].join('\n');
+      const dispatch = jest.fn().mockResolvedValue({ data: { 'metadata.yaml': yaml } });
+      const scan = makeScan(dispatch);
+
+      const result = await scan._resolveExportMetadata(benchmarkWithConfigMap);
+
+      expect(result.metadata).toStrictEqual({ title: 'STIG', source: 'disa' });
+      expect(result.decorations).toStrictEqual({});
+    });
+
+    it('returns empty when the ConfigMap lookup rejects', async() => {
+      const dispatch = jest.fn().mockRejectedValue(new Error('not found'));
+      const scan = makeScan(dispatch);
+
+      const result = await scan._resolveExportMetadata(benchmarkWithConfigMap);
+
+      expect(result).toStrictEqual({ metadata: {}, decorations: {} });
+    });
+
+    it('returns empty when metadata.yaml is malformed YAML', async() => {
+      const dispatch = jest.fn().mockResolvedValue({ data: { 'metadata.yaml': 'title: "unterminated' } });
+      const scan = makeScan(dispatch);
+
+      const result = await scan._resolveExportMetadata(benchmarkWithConfigMap);
+
+      expect(result).toStrictEqual({ metadata: {}, decorations: {} });
+    });
+  });
+});

--- a/shell/models/compliance.cattle.io.clusterscan.js
+++ b/shell/models/compliance.cattle.io.clusterscan.js
@@ -190,20 +190,52 @@ export default class ClusterScan extends SteveModel {
     return this.$dispatch('find', { type: COMPLIANCE.BENCHMARK, id: benchmarkId });
   }
 
+  // Fetches the kube-bench profile ConfigMap referenced by the benchmark and
+  // parses its metadata.yaml data key. Top-level fields become the XCCDF
+  // benchmark metadata; the checks: map becomes per-check decorations
+  // (framework-agnostic; STIG, CIS, BSI, etc. all populate the same shape).
+  async _resolveExportMetadata(benchmark) {
+    const name = benchmark?.spec?.customBenchmarkConfigMapName;
+    const namespace = benchmark?.spec?.customBenchmarkConfigMapNamespace;
+    const empty = { metadata: {}, decorations: {} };
+
+    if (!name || !namespace) {
+      return empty;
+    }
+
+    try {
+      const cm = await this.$dispatch('find', { type: 'configmap', id: `${ namespace }/${ name }` });
+      const raw = cm?.data?.['metadata.yaml'];
+
+      if (!raw) {
+        return empty;
+      }
+
+      const jsyaml = await import(/* webpackChunkName: "js-yaml" */'js-yaml');
+      const parsed = jsyaml.load(raw) || {};
+      const { checks = {}, ...rest } = parsed;
+
+      return { metadata: rest, decorations: checks };
+    } catch (e) {
+      return empty;
+    }
+  }
+
   async downloadLatestReportXCCDF() {
     const reports = await this.getReports() || [];
     const report = sortBy(reports, 'metadata.creationTimestamp', true)[0];
 
     try {
       const benchmark = await this._resolveBenchmark();
+      const { metadata, decorations } = await this._resolveExportMetadata(benchmark);
       const { generateXCCDFPerNode } = await import(/* webpackChunkName: "xccdf" */'@shell/utils/xccdf');
 
       const parsed = report.parsedReport || {};
       const common = {
         report:           parsed,
         benchmarkVersion: parsed.version || benchmark?.spec?.benchmarkVersion || '',
-        metadata:         benchmark?.spec?.benchmarkMetadata || {},
-        stigChecks:       benchmark?.spec?.stigChecks || {},
+        metadata,
+        decorations,
       };
 
       const toZip = {};
@@ -238,6 +270,7 @@ export default class ClusterScan extends SteveModel {
 
     try {
       const benchmark = await this._resolveBenchmark();
+      const { metadata, decorations } = await this._resolveExportMetadata(benchmark);
       const { generateXCCDFPerNode } = await import(/* webpackChunkName: "xccdf" */'@shell/utils/xccdf');
 
       const hasParsedNodes = reports.some((report) => Object.entries(report.parsedReport?.nodes || {}).length);
@@ -251,8 +284,8 @@ export default class ClusterScan extends SteveModel {
             const common = {
               report:           parsed,
               benchmarkVersion: parsed.version || benchmark?.spec?.benchmarkVersion || '',
-              metadata:         benchmark?.spec?.benchmarkMetadata || {},
-              stigChecks:       benchmark?.spec?.stigChecks || {},
+              metadata,
+              decorations,
             };
             const folder = labelFor(report);
 

--- a/shell/models/compliance.cattle.io.clusterscan.js
+++ b/shell/models/compliance.cattle.io.clusterscan.js
@@ -217,7 +217,7 @@ export default class ClusterScan extends SteveModel {
 
       return { metadata: rest, decorations: checks };
     } catch (e) {
-      console.error('[_resolveExportMetadata] failed to fetch or parse benchmark ConfigMap:', e);
+      console.error('[_resolveExportMetadata] failed to fetch or parse benchmark ConfigMap:', e); // eslint-disable-line no-console
 
       return empty;
     }

--- a/shell/models/compliance.cattle.io.clusterscan.js
+++ b/shell/models/compliance.cattle.io.clusterscan.js
@@ -217,6 +217,8 @@ export default class ClusterScan extends SteveModel {
 
       return { metadata: rest, decorations: checks };
     } catch (e) {
+      console.error('[_resolveExportMetadata] failed to fetch or parse benchmark ConfigMap:', e);
+
       return empty;
     }
   }

--- a/shell/utils/__tests__/xccdf.test.ts
+++ b/shell/utils/__tests__/xccdf.test.ts
@@ -157,34 +157,154 @@ describe('xccdf util: generateXCCDF', () => {
     expect(xml).toContain('<Group id="not-applicable">');
   });
 
-  it('uses STIG metadata to override rule id, version, severity, fix, check system, and CCI idents', () => {
+  it('applies a per-check decoration verbatim when the decoration key matches the check id exactly', () => {
     const xml = generateXCCDF({
       report: {
         ...baseReport,
         results: [{
-          id:          'g1',
+          id:          '5.1',
           description: 'g',
+          checks:      [{
+            id: '5.1.1', description: 'exact', scored: true, state: 'pass',
+          }],
+        }],
+      },
+      benchmarkVersion: 'cis-1.7',
+      decorations:      {
+        '5.1.1': {
+          ruleId: 'CIS-5.1.1-rule', version: '2024-01', severity: 'high', fixId: 'F-5.1.1', checkId: 'C-5.1.1',
+        },
+      },
+    });
+
+    expect(xml).toContain('id="CIS-5.1.1-rule"');
+    expect(xml).toContain('idref="CIS-5.1.1-rule"');
+    expect(xml).toMatch(/id="CIS-5\.1\.1-rule"[^>]*severity="high"/);
+    expect(xml).toContain('<version>2024-01</version>');
+    expect(xml).toContain('fixref="F-5.1.1"');
+    expect(xml).toContain('<check system="C-5.1.1">');
+  });
+
+  it('applies a group-keyed decoration with a suffix derived from the check id', () => {
+    const xml = generateXCCDF({
+      report: {
+        ...baseReport,
+        results: [{
+          id:          'V-254553',
+          description: 'STIG group',
           checks:      [{
             id: 'V-254553-TLS-apiserver', description: 'STIG check', scored: true, state: 'pass',
           }],
         }],
       },
       benchmarkVersion: 'rke2-stig-1.31',
-      stigChecks:       {
+      decorations:      {
         'V-254553': {
-          ruleId: 'SV-254553r1016525_rule', version: 'SV-254553r1016525_rule', severity: 'high', fixId: 'F-254553', checkId: 'C-254553', cci: ['CCI-000366'],
+          ruleId: 'SV-254553r1016525_rule', version: 'SV-254553r1016525_rule', severity: 'high', fixId: 'F-254553', checkId: 'C-254553',
         },
       },
     });
 
+    expect(xml).toContain('id="SV-254553r1016525_rule_TLS-apiserver"');
     expect(xml).toContain('idref="SV-254553r1016525_rule_TLS-apiserver"');
     expect(xml).toContain('severity="high"');
-    expect(xml).toContain('<ident system="http://cyber.mil/cci">CCI-000366</ident>');
     expect(xml).toContain('fixref="F-254553"');
     expect(xml).toContain('<check system="C-254553">');
   });
 
-  it('preserves the operator-style rule id when there is no STIG metadata', () => {
+  it('falls back to the full check id as suffix when the check id does not start with the group id', () => {
+    const xml = generateXCCDF({
+      report: {
+        ...baseReport,
+        results: [{
+          id:          'group-a',
+          description: 'g',
+          checks:      [{
+            id: 'unrelated-check', description: 'c', scored: true, state: 'pass',
+          }],
+        }],
+      },
+      benchmarkVersion: 'cis-1.7',
+      decorations:      { 'group-a': { ruleId: 'GROUP-A-rule' } },
+    });
+
+    expect(xml).toContain('id="GROUP-A-rule_unrelated-check"');
+    expect(xml).toContain('idref="GROUP-A-rule_unrelated-check"');
+  });
+
+  it('emits generic XCCDF idents from the decoration with their declared system unchanged', () => {
+    const xml = generateXCCDF({
+      report: {
+        ...baseReport,
+        results: [{
+          id:          '5.1.1',
+          description: 'g',
+          checks:      [{
+            id: '5.1.1', description: 'c', scored: true, state: 'pass',
+          }],
+        }],
+      },
+      benchmarkVersion: 'cis-1.7',
+      decorations:      {
+        '5.1.1': {
+          idents: [
+            { system: 'https://www.cisecurity.org/controls/', value: 'CIS-CSC-3' },
+            { system: 'http://cyber.mil/cci', value: 'CCI-000366' },
+          ],
+        },
+      },
+    });
+
+    expect(xml).toContain('<ident system="https://www.cisecurity.org/controls/">CIS-CSC-3</ident>');
+    expect(xml).toContain('<ident system="http://cyber.mil/cci">CCI-000366</ident>');
+  });
+
+  it('emits a not-applicable ident placeholder when the decoration has no idents', () => {
+    const xml = generateXCCDF({
+      report:           baseReport,
+      benchmarkVersion: 'cis-1.7',
+      decorations:      { '5.1.1': { ruleId: 'r-5.1.1' } },
+    });
+
+    expect(xml).toMatch(/id="r-5\.1\.1"[\s\S]*?<ident system="not-applicable">not-applicable<\/ident>/);
+  });
+
+  it('falls back to the operator-style rule id when no decoration matches either the check id or the group id', () => {
+    const xml = generateXCCDF({
+      report:           baseReport,
+      benchmarkVersion: 'cis-1.7',
+      decorations:      { 'no-match': { ruleId: 'should-not-apply' } },
+    });
+
+    expect(xml).toContain('id="xccdf_compliance-operator_rule_5.1.1"');
+    expect(xml).not.toContain('should-not-apply');
+  });
+
+  it('prefers a per-check decoration over a group-keyed decoration when both are present', () => {
+    const xml = generateXCCDF({
+      report: {
+        ...baseReport,
+        results: [{
+          id:          '5.1',
+          description: 'g',
+          checks:      [{
+            id: '5.1.1', description: 'c', scored: true, state: 'pass',
+          }],
+        }],
+      },
+      benchmarkVersion: 'cis-1.7',
+      decorations:      {
+        '5.1':   { ruleId: 'group-rule', severity: 'low' },
+        '5.1.1': { ruleId: 'check-rule', severity: 'high' },
+      },
+    });
+
+    expect(xml).toContain('id="check-rule"');
+    expect(xml).not.toContain('id="group-rule_5.1.1"');
+    expect(xml).toMatch(/id="check-rule"[^>]*severity="high"/);
+  });
+
+  it('preserves the operator-style rule id when no decorations are supplied', () => {
     const xml = generateXCCDF({
       report:           baseReport,
       benchmarkVersion: 'cis-1.7',

--- a/shell/utils/__tests__/xccdf.test.ts
+++ b/shell/utils/__tests__/xccdf.test.ts
@@ -294,7 +294,7 @@ describe('xccdf util: generateXCCDF', () => {
       },
       benchmarkVersion: 'cis-1.7',
       decorations:      {
-        '5.1':   { ruleId: 'group-rule', severity: 'low' },
+        5.1:     { ruleId: 'group-rule', severity: 'low' },
         '5.1.1': { ruleId: 'check-rule', severity: 'high' },
       },
     });

--- a/shell/utils/xccdf.ts
+++ b/shell/utils/xccdf.ts
@@ -61,16 +61,17 @@ export interface BenchmarkMetadata {
   source?: string;
 }
 
-export interface StigCheckMetadata {
+export interface CheckDecoration {
   ruleId?: string;
   version?: string;
   severity?: string;
   fixId?: string;
   checkId?: string;
-  cci?: string[];
+  /** Generic XCCDF idents — STIG populates with CCIs, CIS with control IDs, etc. */
+  idents?: { system: string; value: string }[];
 }
 
-export type StigChecks = Record<string, StigCheckMetadata>;
+export type CheckDecorations = Record<string, CheckDecoration>;
 
 export interface XccdfTargetFact {
   name: string;
@@ -82,7 +83,7 @@ export interface GenerateXccdfArgs {
   report: XccdfReport;
   benchmarkVersion: string;
   metadata?: BenchmarkMetadata;
-  stigChecks?: StigChecks;
+  decorations?: CheckDecorations;
   targetAddresses?: string[];
   targetFacts?: XccdfTargetFact[];
   /** Override the cluster name used for the <target> element. Falls back to metadata.clusterName, then derived node names. */
@@ -101,32 +102,27 @@ const fixIdFor = (checkId: string): string => `${ ruleIdFor(checkId) }_fix`;
 
 const profileIdFor = (benchmarkVersion: string): string => `${ ID_PREFIX }_profile_${ safeId(benchmarkVersion) }`;
 
-const stigGroupId = (checkId: string): string => {
-  const parts = checkId.split('-');
-
-  if (parts.length >= 2) {
-    return `${ parts[0] }-${ parts[1] }`;
-  }
-
-  return checkId;
-};
-
-const effectiveRuleId = (stig: StigCheckMetadata, checkId: string): string => {
-  if (!stig.ruleId) {
+const effectiveRuleId = (decoration: CheckDecoration, groupId: string, checkId: string, hitGroupKey: boolean): string => {
+  if (!decoration.ruleId) {
     return ruleIdFor(checkId);
   }
-  const gid = stigGroupId(checkId);
-
-  if (checkId === gid) {
-    return stig.ruleId;
+  if (!hitGroupKey) {
+    return decoration.ruleId;
   }
-  const suffix = checkId.startsWith(`${ gid }-`) ? checkId.slice(gid.length + 1) : checkId;
+  const suffix = checkId.startsWith(`${ groupId }-`) ? checkId.slice(groupId.length + 1) : checkId;
 
-  return `${ stig.ruleId }_${ suffix }`;
+  return `${ decoration.ruleId }_${ suffix }`;
 };
 
-const lookupStig = (stigChecks: StigChecks, checkId: string): StigCheckMetadata => {
-  return stigChecks[stigGroupId(checkId)] || {};
+const lookupDecoration = (decorations: CheckDecorations, groupId: string, checkId: string): { decoration: CheckDecoration; hitGroupKey: boolean } => {
+  if (decorations[checkId]) {
+    return { decoration: decorations[checkId], hitGroupKey: false };
+  }
+  if (decorations[groupId]) {
+    return { decoration: decorations[groupId], hitGroupKey: true };
+  }
+
+  return { decoration: {}, hitGroupKey: false };
 };
 
 const mapResult = (state?: string): string => {
@@ -142,18 +138,18 @@ const mapResult = (state?: string): string => {
 
 const severityFor = (scored?: boolean): string => (scored ? 'medium' : 'low');
 
-const stigSeverity = (stigSev: string | undefined, scored?: boolean): string => stigSev || severityFor(scored);
+const decorationSeverity = (sev: string | undefined, scored?: boolean): string => sev || severityFor(scored);
 
 const ruleWeight = (scored?: boolean): string => (scored ? '10' : '0');
 
 const ruleRole = (scored?: boolean): string => (scored ? 'full' : 'unscored');
 
-const stigIdents = (ccis?: string[]): { system: string; value: string }[] => {
-  if (!ccis || ccis.length === 0) {
+const decorationIdents = (idents?: { system: string; value: string }[]): { system: string; value: string }[] => {
+  if (!idents || idents.length === 0) {
     return [{ system: NA, value: NA }];
   }
 
-  return ccis.map((cci) => ({ system: 'http://cyber.mil/cci', value: cci }));
+  return idents;
 };
 
 const collectTargets = (report: XccdfReport): string[] => {
@@ -187,7 +183,7 @@ export function generateXCCDF({
   report,
   benchmarkVersion,
   metadata = {},
-  stigChecks = {},
+  decorations = {},
   targetAddresses,
   targetFacts,
   clusterName,
@@ -239,7 +235,7 @@ export function generateXCCDF({
   profile.ele('title').txt(benchmarkTitle);
   profile.ele('description').txt(na(metadata.description));
 
-  const ruleResults: { check: XccdfReportCheck; effectiveId: string; stig: StigCheckMetadata }[] = [];
+  const ruleResults: { check: XccdfReportCheck; effectiveId: string; decoration: CheckDecoration }[] = [];
   const groups = report.results || [];
 
   groups.forEach((group) => {
@@ -250,10 +246,11 @@ export function generateXCCDF({
 
     (group.checks || []).forEach((check) => {
       const checkId = check.id || '';
-      const stig = lookupStig(stigChecks, checkId);
-      const effectiveId = effectiveRuleId(stig, checkId);
-      const ruleFixId = stig.fixId || fixIdFor(checkId);
-      const ruleCheckSystem = stig.checkId || CHECK_SYSTEM;
+      const groupId = group.id || '';
+      const { decoration, hitGroupKey } = lookupDecoration(decorations, groupId, checkId);
+      const effectiveId = effectiveRuleId(decoration, groupId, checkId, hitGroupKey);
+      const ruleFixId = decoration.fixId || fixIdFor(checkId);
+      const ruleCheckSystem = decoration.checkId || CHECK_SYSTEM;
       const checkHref = na(metadata.checkHref);
       const checkName = na(metadata.checkName);
 
@@ -262,10 +259,10 @@ export function generateXCCDF({
         selected: 'true',
         weight:   ruleWeight(check.scored),
         role:     ruleRole(check.scored),
-        severity: stigSeverity(stig.severity, check.scored),
+        severity: decorationSeverity(decoration.severity, check.scored),
       });
 
-      rule.ele('version').txt(na(stig.version));
+      rule.ele('version').txt(na(decoration.version));
       rule.ele('title').txt(na(`${ checkId } ${ check.description || '' }`));
       rule.ele('description').txt(na(check.description));
 
@@ -277,7 +274,7 @@ export function generateXCCDF({
       ruleRef.ele('type').txt(na(metadata.referenceType));
       ruleRef.ele('identifier').txt(na(metadata.referenceIdentifier));
 
-      stigIdents(stig.cci).forEach((ident) => {
+      decorationIdents(decoration.idents).forEach((ident) => {
         rule.ele('ident', { system: ident.system }).txt(ident.value);
       });
 
@@ -290,7 +287,7 @@ export function generateXCCDF({
       ruleCheck.ele('check-content').txt(na(check.audit));
 
       ruleResults.push({
-        check, effectiveId, stig
+        check, effectiveId, decoration
       });
     });
   });
@@ -348,8 +345,8 @@ export function generateXCCDF({
     rrCheck.ele('check-content-ref', { name: NA, href: NA });
     rrCheck.ele('check-content').txt(NA);
   } else {
-    ruleResults.forEach(({ check, effectiveId, stig }) => {
-      const ruleCheckSystem = stig.checkId || CHECK_SYSTEM;
+    ruleResults.forEach(({ check, effectiveId, decoration }) => {
+      const ruleCheckSystem = decoration.checkId || CHECK_SYSTEM;
       const checkHref = na(metadata.checkHref);
       const checkName = na(metadata.checkName);
 
@@ -357,12 +354,12 @@ export function generateXCCDF({
         idref:    effectiveId,
         role:     ruleRole(check.scored),
         time:     timeStr,
-        severity: stigSeverity(stig.severity, check.scored),
-        version:  na(stig.version),
+        severity: decorationSeverity(decoration.severity, check.scored),
+        version:  na(decoration.version),
         weight:   ruleWeight(check.scored),
       });
 
-      stigIdents(stig.cci).forEach((ident) => {
+      decorationIdents(decoration.idents).forEach((ident) => {
         rr.ele('ident', { system: ident.system }).txt(ident.value);
       });
       rr.ele('result').txt(mapResult(check.state));


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes # https://github.com/rancher/compliance-operator/issues/319
Revision to # https://github.com/rancher/dashboard/pull/17629
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

This PR updates xccdf report generation (https://github.com/rancher/dashboard/pull/17629) based on feedback from the compliance operator team. This update makes the report extensible to other benchmarks beyond just STIGs. The primary changes in this PR are just updates to where the metadata is supplied in the compliance operator report, as this information now lives in 'metadata.yaml' as part of the compliance profile. Tests have also been updated accordingly. 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Closely follows existing architecture used for csv output of compliance scans. Metadata location and structure updated to be extensible to any type of benchmark, not just specific to STIG profiles. 

Benchmarks which do not contain additional metadata will NOT be affected by this change, as the behavior is to fall back to 'not-applicable' for elements of the xccdf spec that are not provided. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->

Changes isolated to compliance operator data processing. Should work in airgap scenarios. 

<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->

Safari

<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Some compliance operator changes were also required to gather more complete STIG data, see https://github.com/rancher/compliance-operator/pull/312. This PR allows the 'metadata.json' section to be handled by the compliance operator. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Investigated implementing in compliance operator only, however limitations to etcd storage would have made this faulty for larger clusters. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Testing/Repro Steps

1. Ensure compliance operator chart is installed (via Rancher Charts).

2. Build the dashboard locally, setting the API to the environment with compliance operator.

```bash
API=https://rancher.local yarn dev
```

3. In the UI, run a compliance scan. Once complete, click download report (xccdf) and observe a zip file with .xml reports for each node in the cluster. 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
