### PR TITLE
Migrate saml auth provider to vee-validate/zod

### DIFF
--- a/shell/edit/auth/__tests__/saml.test.ts
+++ b/shell/edit/auth/__tests__/saml.test.ts
@@ -1,0 +1,196 @@
+import { nextTick } from 'vue';
+import { mount, type VueWrapper, flushPromises } from '@vue/test-utils';
+import { _EDIT } from '@shell/config/query-params';
+import Saml from '@shell/edit/auth/saml.vue';
+
+const REQUIRED_FIELDS = [
+  'displayNameField',
+  'userNameField',
+  'uidField',
+  'groupsField',
+  'rancherApiHost',
+  'spKey',
+  'spCert',
+  'idpMetadataContent',
+] as const;
+
+type RequiredField = typeof REQUIRED_FIELDS[number];
+
+const validModel = {
+  enabled:            false,
+  id:                 'shibboleth',
+  displayNameField:   'givenName',
+  userNameField:      'uid',
+  uidField:           'uid',
+  groupsField:        'memberOf',
+  rancherApiHost:     'https://rancher.example.com',
+  spKey:              '-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----',
+  spCert:             '-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----',
+  idpMetadataContent: '<EntityDescriptor/>',
+};
+
+const emptyRequiredFields: Record<RequiredField, string> = {
+  displayNameField:   '',
+  userNameField:      '',
+  uidField:           '',
+  groupsField:        '',
+  rancherApiHost:     '',
+  spKey:              '',
+  spCert:             '',
+  idpMetadataContent: '',
+};
+
+const mountOptions = (model: object) => ({
+  data() {
+    return {
+      isEnabling:     false,
+      editConfig:     false,
+      model:          { ...model },
+      serverSetting:  null,
+      errors:         [],
+      originalModel:  null,
+      principals:     [],
+      authConfigName: 'shibboleth',
+    } as any;
+  },
+  global: {
+    mocks: {
+      $fetchState: { pending: false },
+      $store:      {
+        getters: {
+          currentStore:              () => 'current_store',
+          'current_store/schemaFor': jest.fn(),
+          'current_store/all':       jest.fn(),
+          'i18n/t':                  (val: string) => val,
+          'i18n/exists':             jest.fn(),
+        },
+        dispatch: jest.fn(),
+      },
+      $route:  { query: { AS: '' }, params: { id: 'shibboleth' } },
+      $router: { applyQuery: jest.fn() },
+    },
+  },
+  props: {
+    value: {},
+    mode:  _EDIT,
+  },
+});
+
+describe('saml.vue', () => {
+  describe('validationPassed computed', () => {
+    let wrapper: VueWrapper<any, any>;
+
+    afterEach(() => {
+      wrapper.unmount();
+    });
+
+    it('returns true when all required fields are filled', async() => {
+      wrapper = mount(Saml, mountOptions(validModel));
+      await flushPromises();
+
+      expect(wrapper.vm.validationPassed).toBe(true);
+    });
+
+    it('returns false when all required fields are empty', async() => {
+      wrapper = mount(Saml, mountOptions({ ...validModel, ...emptyRequiredFields }));
+      await wrapper.vm.validateAllFields();
+      await flushPromises();
+
+      expect(wrapper.vm.validationPassed).toBe(false);
+    });
+
+    it('returns true when provider is enabled and not editing config, regardless of field state', async() => {
+      wrapper = mount(Saml, mountOptions({
+        ...validModel, ...emptyRequiredFields, enabled: true
+      }));
+      await wrapper.vm.validateAllFields();
+      await flushPromises();
+
+      expect(wrapper.vm.validationPassed).toBe(true);
+    });
+
+    it('returns false when provider is enabled but editConfig is true and required fields are empty', async() => {
+      wrapper = mount(Saml, {
+        ...mountOptions({
+          ...validModel, ...emptyRequiredFields, enabled: true
+        }),
+        data() {
+          return {
+            isEnabling: false,
+            editConfig: true,
+            model:      {
+              ...validModel, ...emptyRequiredFields, enabled: true
+            },
+            serverSetting:  null,
+            errors:         [],
+            originalModel:  null,
+            principals:     [],
+            authConfigName: 'shibboleth',
+          } as any;
+        },
+      });
+      await wrapper.vm.validateAllFields();
+      await flushPromises();
+
+      expect(wrapper.vm.validationPassed).toBe(false);
+    });
+  });
+
+  describe('Enable button', () => {
+    describe('is disabled', () => {
+      let wrapper: VueWrapper<any, any>;
+
+      afterEach(() => {
+        wrapper.unmount();
+      });
+
+      it('when all required fields are empty', async() => {
+        wrapper = mount(Saml, mountOptions({ ...validModel, ...emptyRequiredFields }));
+        await wrapper.vm.validateAllFields();
+        await flushPromises();
+
+        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+
+        expect(saveButton.disabled).toBe(true);
+      });
+
+      it.each([...REQUIRED_FIELDS])('when only %s is empty', async(field: RequiredField) => {
+        wrapper = mount(Saml, mountOptions({ ...validModel, [field]: '' }));
+        await wrapper.vm.validateAllFields();
+        await flushPromises();
+
+        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+
+        expect(saveButton.disabled).toBe(true);
+      });
+    });
+
+    describe('is enabled', () => {
+      let wrapper: VueWrapper<any, any>;
+
+      afterEach(() => {
+        wrapper.unmount();
+      });
+
+      it('when all required fields are filled', async() => {
+        wrapper = mount(Saml, mountOptions(validModel));
+        await flushPromises();
+
+        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+
+        expect(saveButton.disabled).toBe(false);
+      });
+
+      it('when provider is already enabled and not editing config', async() => {
+        wrapper = mount(Saml, mountOptions({
+          ...validModel, ...emptyRequiredFields, enabled: true
+        }));
+        await nextTick();
+
+        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+
+        expect(saveButton.disabled).toBe(false);
+      });
+    });
+  });
+});

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -66,6 +66,7 @@ export default {
 
     const coerce = (schema) => z.preprocess((v) => v ?? '', schema);
     const requiredField = (key) => coerce(z.string().min(1, t('validation.required', { key: t(key) })));
+    const requiredUrlField = (key) => coerce(z.string().min(1, t('validation.required', { key: t(key) })).url(t('validation.genericUrl')));
 
     const validationSchema = computed(() => toTypedSchema(
       z.object({
@@ -73,7 +74,7 @@ export default {
         userNameField:      requiredField('authConfig.saml.userName'),
         uidField:           requiredField('authConfig.saml.UID'),
         groupsField:        requiredField('authConfig.saml.groups'),
-        rancherApiHost:     requiredField('authConfig.saml.api'),
+        rancherApiHost:     requiredUrlField('authConfig.saml.api'),
         spKey:              requiredField('authConfig.saml.key.label'),
         spCert:             requiredField('authConfig.saml.cert.label'),
         idpMetadataContent: requiredField('authConfig.saml.metadata.label'),

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -1,4 +1,9 @@
 <script>
+import { ref, computed, provide } from 'vue';
+import { useStore } from 'vuex';
+import { useForm } from 'vee-validate';
+import { toTypedSchema } from '@vee-validate/zod';
+import * as z from 'zod';
 import Loading from '@shell/components/Loading';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import AuthConfig, { SLO_OPTION_VALUES } from '@shell/mixins/auth-config';
@@ -13,6 +18,7 @@ import config, { OKTA, SHIBBOLETH } from '@shell/edit/auth/ldap/config';
 import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBanners';
 import RadioGroup from '@components/Form/Radio/RadioGroup.vue';
 import { RcButton } from '@components/RcButton';
+import { useI18n } from '@shell/composables/useI18n';
 
 // Standard LDAP defaults
 const LDAP_DEFAULTS = {
@@ -53,6 +59,42 @@ export default {
   },
 
   mixins: [CreateEditView, AuthConfig],
+
+  setup() {
+    const store = useStore();
+    const { t } = useI18n(store);
+
+    const coerce = (schema) => z.preprocess((v) => v ?? '', schema);
+    const requiredField = (key) => coerce(z.string().min(1, t('validation.required', { key: t(key) })));
+
+    const validationSchema = computed(() => toTypedSchema(
+      z.object({
+        displayNameField:   requiredField('authConfig.saml.displayName'),
+        userNameField:      requiredField('authConfig.saml.userName'),
+        uidField:           requiredField('authConfig.saml.UID'),
+        groupsField:        requiredField('authConfig.saml.groups'),
+        rancherApiHost:     requiredField('authConfig.saml.api'),
+        spKey:              requiredField('authConfig.saml.key.label'),
+        spCert:             requiredField('authConfig.saml.cert.label'),
+        idpMetadataContent: requiredField('authConfig.saml.metadata.label'),
+      })
+    ));
+
+    const showAllErrors = ref(false);
+
+    provide('vee-show-all-errors', showAllErrors);
+
+    const { errors, validate } = useForm({ validationSchema });
+    const isFormValid = computed(() => Object.keys(errors.value).length === 0);
+
+    const validateAllFields = async() => {
+      await validate();
+      showAllErrors.value = true;
+    };
+
+    return { isFormValid, validateAllFields };
+  },
+
   data() {
     return {
       showLdap:        false,
@@ -60,7 +102,19 @@ export default {
     };
   },
 
+  created() {
+    this.registerBeforeHook(this.validateAllFields, 'willSave');
+  },
+
   computed: {
+    validationPassed() {
+      if (this.model?.enabled && !this.editConfig) {
+        return true;
+      }
+
+      return this.isFormValid;
+    },
+
     tArgs() {
       return {
         baseUrl:  this.serverSetting,
@@ -154,7 +208,7 @@ export default {
       :mode="mode"
       :resource="model"
       :subtypes="[]"
-      :validation-passed="true"
+      :validation-passed="validationPassed"
       :finish-button-mode="model.enabled ? 'edit' : 'enable'"
       :can-yaml="false"
       :errors="errors"
@@ -250,6 +304,7 @@ export default {
           <div class="col span-6">
             <LabeledInput
               v-model:value="model.displayNameField"
+              name="displayNameField"
               :label="t(`authConfig.saml.displayName`)"
               :mode="mode"
               required
@@ -258,6 +313,7 @@ export default {
           <div class="col span-6">
             <LabeledInput
               v-model:value="model.userNameField"
+              name="userNameField"
               :label="t(`authConfig.saml.userName`)"
               :mode="mode"
               required
@@ -269,6 +325,7 @@ export default {
           <div class="col span-6">
             <LabeledInput
               v-model:value="model.uidField"
+              name="uidField"
               :label="t(`authConfig.saml.UID`)"
               :mode="mode"
               required
@@ -277,6 +334,7 @@ export default {
           <div class="col span-6">
             <LabeledInput
               v-model:value="model.groupsField"
+              name="groupsField"
               :label="t(`authConfig.saml.groups`)"
               :mode="mode"
               required
@@ -298,6 +356,7 @@ export default {
           <div class="col span-6">
             <LabeledInput
               v-model:value="model.rancherApiHost"
+              name="rancherApiHost"
               :label="t(`authConfig.saml.api`)"
               :mode="mode"
               required
@@ -309,6 +368,7 @@ export default {
           <div class="col span-4">
             <LabeledInput
               v-model:value="model.spKey"
+              name="spKey"
               :label="t(`authConfig.saml.key.label`)"
               :placeholder="t(`authConfig.saml.key.placeholder`)"
               :mode="mode"
@@ -325,6 +385,7 @@ export default {
           <div class="col span-4">
             <LabeledInput
               v-model:value="model.spCert"
+              name="spCert"
               :label="t(`authConfig.saml.cert.label`)"
               :placeholder="t(`authConfig.saml.cert.placeholder`)"
               :mode="mode"
@@ -341,6 +402,7 @@ export default {
           <div class="col span-4">
             <LabeledInput
               v-model:value="model.idpMetadataContent"
+              name="idpMetadataContent"
               :label="t(`authConfig.saml.metadata.label`)"
               :placeholder="t(`authConfig.saml.metadata.placeholder`)"
               :mode="mode"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds form validation using vee-validate/zod to the SAML auth provider. 

Fixes #17777 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Migrate saml auth provider to vee-validate/zod

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The patterns represented in this PR are very similar to what we have done before in #17982 and #17738.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

When the SAML auth provider form fails validation for any fields, an inline error message should be rendered and the save button should be disabled.

When the SAML auth provider form passes validation, the save button should be enabled. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This is adding validation, ensure that the form can properly pass validation and that the save button is properly enabled.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="1379" height="1212" alt="image" src="https://github.com/user-attachments/assets/13bc7f6d-2793-456a-8451-d0f5e9ab7f03" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
