### PR TITLE
Change extension repo text

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5624,7 +5624,7 @@ plugins:
     banner: There are new extensions repositories available. To enable these repositories, click the button on the right.
     bannerBtn: Add repositories
     title: Add Extensions repositories
-    prompt: You can install multiple Rancher extension repositories to increase your extensions catalog
+    prompt: Enable additional repositories to access more extensions
   setup:
     installed: Already installed
     uninstalled: Already uninstalled
@@ -5640,7 +5640,7 @@ plugins:
       prompt: This will lead you to the page where you can enable the Feature Flag needed to enable Extension support.
       featuresButton: Go to Feature Flags
       airgap: Air-gapped installations should NOT enable this feature
-      addRancherRepo: Add Official Rancher Extensions Repository
+      addRancherRepo: Add Rancher Prime Extensions Repository
       addPartnersRancherRepo: Add Partners Extensions Repository
     remove:
       label: Disable Extension Support


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16632

### Occurred changes and/or fixed issues

Simple text changes for the add extension repository dialog.

Text changes: 

"Add Official Rancher Extensions Repository" -> "Add Rancher Prime Extensions Repository"
"You can install multiple Rancher extension repositories to increase your extensions catalog" -> "Enable additional repositories to access more extensions"

### Areas or cases that should be tested

See screenshot below.

For Prime, go to the extensions page, three dot menu, 'Add Extension Repositories'

### Screenshot/Video

<img width="611" height="250" alt="image" src="https://github.com/user-attachments/assets/89296582-35fd-47eb-9637-274ed54acca5" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
