### PR TITLE
Automation: add standardUser tags to e2e tests

### DIFF
--- a/cypress/e2e/tests/components/yaml-editor.spec.ts
+++ b/cypress/e2e/tests/components/yaml-editor.spec.ts
@@ -2,7 +2,7 @@ import { WorkloadsDeploymentsListPagePo, WorkloadsDeploymentsCreatePagePo } from
 import ResourceYamlPo from '@/cypress/e2e/po/components/resource-yaml.po';
 import { deploymentCreateRequest } from '@/cypress/e2e/blueprints/explorer/workloads/deployments/deployment-create';
 
-describe('Yaml Editor', () => {
+describe('Yaml Editor', { tags: ['@components', '@adminUser', '@standardUser'] }, () => {
   const deploymentsCreatePage = new WorkloadsDeploymentsCreatePagePo('local');
   const deploymentsListPage = new WorkloadsDeploymentsListPagePo('local');
 

--- a/cypress/e2e/tests/components/yaml-editor.spec.ts
+++ b/cypress/e2e/tests/components/yaml-editor.spec.ts
@@ -1,6 +1,7 @@
 import { WorkloadsDeploymentsListPagePo, WorkloadsDeploymentsCreatePagePo } from '@/cypress/e2e/po/pages/explorer/workloads/workloads-deployments.po';
 import ResourceYamlPo from '@/cypress/e2e/po/components/resource-yaml.po';
 import { deploymentCreateRequest } from '@/cypress/e2e/blueprints/explorer/workloads/deployments/deployment-create';
+import { qase } from '@/cypress/support/qase';
 
 describe('Yaml Editor', { tags: ['@components', '@adminUser', '@standardUser'] }, () => {
   const deploymentsCreatePage = new WorkloadsDeploymentsCreatePagePo('local');
@@ -25,7 +26,7 @@ describe('Yaml Editor', { tags: ['@components', '@adminUser', '@standardUser'] }
   });
 
   describe('Edit mode', () => {
-    it('Check if body and footer are visible to human eye', { tags: ['@components', '@adminUser'] }, () => {
+    qase(2460, it('Check if body and footer are visible to human eye', { tags: ['@components', '@adminUser'] }, () => {
       deploymentsListPage.goTo();
       deploymentsListPage.listElementWithName(name).should('exist');
       deploymentsListPage.goToEditYamlPage(name);
@@ -35,7 +36,7 @@ describe('Yaml Editor', { tags: ['@components', '@adminUser', '@standardUser'] }
       resourceYaml.body().should('be.visible').then(() => {
         resourceYaml.footer().isVisible();
       });
-    });
+    }));
   });
 
   afterEach(() => {

--- a/cypress/e2e/tests/pages/explorer/apps/index.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/index.spec.ts
@@ -1,15 +1,16 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
+import { qase } from '@/cypress/support/qase';
 
 describe('Apps Index', { testIsolation: 'off', tags: ['@explorer', '@adminUser', '@standardUser'] }, () => {
   before(() => {
     cy.login();
   });
 
-  it('can redirect', () => {
+  qase(3286, it('can redirect', () => {
     const page = new PagePo('/c/local/apps');
 
     page.goTo();
 
     cy.url().should('includes', `${ Cypress.config().baseUrl }/c/local/apps/charts`);
-  });
+  }));
 });

--- a/cypress/e2e/tests/pages/explorer/apps/index.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/apps/index.spec.ts
@@ -1,6 +1,6 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 
-describe('Apps Index', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, () => {
+describe('Apps Index', { testIsolation: 'off', tags: ['@explorer', '@adminUser', '@standardUser'] }, () => {
   before(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer/service-discovery/horizontal-pod-autoscalers.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/service-discovery/horizontal-pod-autoscalers.spec.ts
@@ -3,7 +3,7 @@ import { generateHorizontalPodAutoscalersDataSmall, horizontalPodAutoScalersNoDa
 
 const horizontalPodAutoscalersPage = new HorizontalPodAutoscalersPagePo();
 
-describe('HorizontalPodAutoscalers', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, () => {
+describe('HorizontalPodAutoscalers', { testIsolation: 'off', tags: ['@explorer', '@adminUser', '@standardUser'] }, () => {
   before(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer/service-discovery/horizontal-pod-autoscalers.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/service-discovery/horizontal-pod-autoscalers.spec.ts
@@ -1,5 +1,6 @@
 import { HorizontalPodAutoscalersPagePo } from '@/cypress/e2e/po/pages/explorer/horizontal-pod-autoscalers.po';
 import { generateHorizontalPodAutoscalersDataSmall, horizontalPodAutoScalersNoData } from '@/cypress/e2e/blueprints/explorer/workloads/service-discovery/horizontal-pod-autoscalers-get';
+import { qase } from '@/cypress/support/qase';
 
 const horizontalPodAutoscalersPage = new HorizontalPodAutoscalersPagePo();
 
@@ -13,7 +14,7 @@ describe('HorizontalPodAutoscalers', { testIsolation: 'off', tags: ['@explorer',
       cy.updateNamespaceFilter('local', 'none', '{\"local\":[]}');
     });
 
-    it('validate HorizontalPodAutoscalers table in empty state', () => {
+    qase(4117, it('validate HorizontalPodAutoscalers table in empty state', () => {
       horizontalPodAutoScalersNoData();
       horizontalPodAutoscalersPage.goTo();
       horizontalPodAutoscalersPage.waitForPage();
@@ -31,9 +32,9 @@ describe('HorizontalPodAutoscalers', { testIsolation: 'off', tags: ['@explorer',
         });
 
       horizontalPodAutoscalersPage.list().resourceTable().sortableTable().checkRowCount(true, 1);
-    });
+    }));
 
-    it('flat list: validate HorizontalPodAutoscalers table', () => {
+    qase(4119, it('flat list: validate HorizontalPodAutoscalers table', () => {
       generateHorizontalPodAutoscalersDataSmall();
       horizontalPodAutoscalersPage.goTo();
       horizontalPodAutoscalersPage.waitForPage();
@@ -54,9 +55,9 @@ describe('HorizontalPodAutoscalers', { testIsolation: 'off', tags: ['@explorer',
       horizontalPodAutoscalersPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
       horizontalPodAutoscalersPage.list().resourceTable().sortableTable().noRowsShouldNotExist();
       horizontalPodAutoscalersPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
-    });
+    }));
 
-    it('group by namespace: validate HorizontalPodAutoscalers table', () => {
+    qase(4118, it('group by namespace: validate HorizontalPodAutoscalers table', () => {
       generateHorizontalPodAutoscalersDataSmall();
       horizontalPodAutoscalersPage.goTo();
       horizontalPodAutoscalersPage.waitForPage();
@@ -83,7 +84,7 @@ describe('HorizontalPodAutoscalers', { testIsolation: 'off', tags: ['@explorer',
       horizontalPodAutoscalersPage.list().resourceTable().sortableTable().groupElementWithName('Namespace: cattle-system')
         .should('be.visible');
       horizontalPodAutoscalersPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
-    });
+    }));
 
     after('clean up', () => {
       cy.updateNamespaceFilter('local', 'none', '{"local":["all://user"]}');

--- a/cypress/e2e/tests/pages/explorer2/index.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/index.spec.ts
@@ -1,15 +1,16 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
+import { qase } from '@/cypress/support/qase';
 
 describe('Explorer Index', { testIsolation: 'off', tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {
   before(() => {
     cy.login();
   });
 
-  it('can redirect', () => {
+  qase(3284, it('can redirect', () => {
     const page = new PagePo('/c/local/');
 
     page.goTo();
 
     cy.url().should('includes', `${ Cypress.config().baseUrl }/c/local/explorer`);
-  });
+  }));
 });

--- a/cypress/e2e/tests/pages/explorer2/index.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/index.spec.ts
@@ -1,6 +1,6 @@
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 
-describe('Explorer Index', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
+describe('Explorer Index', { testIsolation: 'off', tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {
   before(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer2/storage/configmap-detail-title-bar.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/configmap-detail-title-bar.spec.ts
@@ -5,7 +5,7 @@ const namespace = 'default';
 const shortName = `a`;
 const longName = `e2e-test-long-configmap-name-that-should-truncate-with-ellipsis`;
 
-describe('ConfigMap Detail Title Bar', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
+describe('ConfigMap Detail Title Bar', { testIsolation: 'off', tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {
   before(() => {
     cy.login();
     cy.createConfigMap(namespace, shortName);

--- a/cypress/e2e/tests/pages/explorer2/storage/persistent-volume-claims.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/persistent-volume-claims.spec.ts
@@ -5,7 +5,7 @@ import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dash
 const cluster = 'local';
 const persistentVolumeClaimsPage = new PersistentVolumeClaimsPagePo();
 
-describe('PersistentVolumeClaims', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
+describe('PersistentVolumeClaims', { testIsolation: 'off', tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {
   before(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer2/storage/persistent-volume-claims.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/persistent-volume-claims.spec.ts
@@ -1,6 +1,7 @@
 import { generatePersistentVolumeClaimsDataSmall, persistentVolumeClaimsNoData } from '@/cypress/e2e/blueprints/explorer/storage/persistent-volume-claims-get';
 import { PersistentVolumeClaimsPagePo } from '@/cypress/e2e/po/pages/explorer/persistent-volume-claims.po';
 import ClusterDashboardPagePo from '@/cypress/e2e/po/pages/explorer/cluster-dashboard.po';
+import { qase } from '@/cypress/support/qase';
 
 const cluster = 'local';
 const persistentVolumeClaimsPage = new PersistentVolumeClaimsPagePo();
@@ -15,7 +16,7 @@ describe('PersistentVolumeClaims', { testIsolation: 'off', tags: ['@explorer2', 
       cy.updateNamespaceFilter('local', 'none', '{\"local\":[]}');
     });
 
-    it('validate persistent volume claims table in empty state', () => {
+    qase(4102, it('validate persistent volume claims table in empty state', () => {
       ClusterDashboardPagePo.goToAndConfirmNsValues(cluster, { all: { is: true } } );
 
       const tag = 'persistentvolumeclaimsNoData';
@@ -34,9 +35,9 @@ describe('PersistentVolumeClaims', { testIsolation: 'off', tags: ['@explorer2', 
         });
 
       persistentVolumeClaimsPage.list().resourceTable().sortableTable().checkRowCount(true, 1);
-    });
+    }));
 
-    it('flat list: validate persistent volume claims table', () => {
+    qase(4104, it('flat list: validate persistent volume claims table', () => {
       const tag = 'persistentvolumeclaimsDataSmall';
 
       generatePersistentVolumeClaimsDataSmall(tag);
@@ -57,10 +58,10 @@ describe('PersistentVolumeClaims', { testIsolation: 'off', tags: ['@explorer2', 
       persistentVolumeClaimsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
       persistentVolumeClaimsPage.list().resourceTable().sortableTable().noRowsShouldNotExist();
       persistentVolumeClaimsPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
-    });
+    }));
 
     // storage/persistent-volume-claims.spec.ts
-    it('group by namespace: validate persistent volume claims table', () => {
+    qase(4103, it('group by namespace: validate persistent volume claims table', () => {
       const tag = 'persistentvolumeclaimsDataSmall';
 
       generatePersistentVolumeClaimsDataSmall(tag);
@@ -88,7 +89,7 @@ describe('PersistentVolumeClaims', { testIsolation: 'off', tags: ['@explorer2', 
         .scrollIntoView()
         .should('be.visible');
       persistentVolumeClaimsPage.list().resourceTable().sortableTable().checkRowCount(false, 1);
-    });
+    }));
 
     after('clean up', () => {
       cy.updateNamespaceFilter('local', 'none', '{"local":["all://user"]}');

--- a/cypress/e2e/tests/pages/explorer2/storage/secrets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/secrets.spec.ts
@@ -1,4 +1,5 @@
 import { SecretsListPagePo } from '@/cypress/e2e/po/pages/explorer/secrets.po';
+import { qase } from '@/cypress/support/qase';
 
 const secretsListPage = new SecretsListPagePo('local');
 
@@ -7,14 +8,18 @@ describe('Secrets', { testIsolation: 'off', tags: ['@explorer2', '@adminUser', '
     cy.login();
   });
 
-  it('has the correct title', () => {
+  qase(9688, it('has the correct title', () => {
     secretsListPage.goTo();
     secretsListPage.title().should('include', 'Secrets');
 
-    cy.title().should('eq', 'Rancher - local - Secrets');
-  });
+    cy.getRancherVersion().then((version) => {
+      const expectedTitle = version.RancherPrime === 'true' ? 'Rancher Prime - local - Secrets' : 'Rancher - local - Secrets';
 
-  it('displays the list of secrets and has a create button', () => {
+      cy.title().should('eq', expectedTitle);
+    });
+  }));
+
+  qase(27177, it('displays the list of secrets and has a create button', () => {
     secretsListPage.goTo();
     secretsListPage.waitForPage();
 
@@ -23,5 +28,5 @@ describe('Secrets', { testIsolation: 'off', tags: ['@explorer2', '@adminUser', '
 
     // Check that the table is present
     secretsListPage.list().checkVisible();
-  });
+  }));
 });

--- a/cypress/e2e/tests/pages/explorer2/storage/secrets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/secrets.spec.ts
@@ -2,7 +2,7 @@ import { SecretsListPagePo } from '@/cypress/e2e/po/pages/explorer/secrets.po';
 
 const secretsListPage = new SecretsListPagePo('local');
 
-describe('Secrets', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, () => {
+describe('Secrets', { testIsolation: 'off', tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });

--- a/cypress/e2e/tests/pages/explorer2/workloads/replicasets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/replicasets.spec.ts
@@ -1,5 +1,6 @@
 import { WorkloadsReplicasetsListPagePo, WorkloadsReplicasetsEditPagePo } from '@/cypress/e2e/po/pages/explorer/workloads-replicasets.po';
 import ResourceSearchDialog from '@/cypress/e2e/po/prompts/ResourceSearchDialog.po';
+import { qase } from '@/cypress/support/qase';
 
 describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {
   beforeEach(() => {
@@ -10,7 +11,7 @@ describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser', '@standardUser
     describe('Replicasets', () => {
       const replicasetName = '0000-replicaset-test';
 
-      it('should not be able to rollback a replicaset', () => {
+      qase(7800, it('should not be able to rollback a replicaset', () => {
         // list view for replicasets
         const workloadsReplicasetsListPage = new WorkloadsReplicasetsListPagePo('local');
         const resourceSearchDialog = new ResourceSearchDialog();
@@ -35,7 +36,7 @@ describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser', '@standardUser
         workloadsReplicasetsListPage.baseResourceList().actionMenu(replicasetName).menuItemNames().should('not.contain', 'Rollback');
 
         cy.deleteRancherResource('v1', 'apps.replicasets', `default/${ replicasetName }`);
-      });
+      }));
     });
   });
 });

--- a/cypress/e2e/tests/pages/explorer2/workloads/replicasets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/replicasets.spec.ts
@@ -1,7 +1,7 @@
 import { WorkloadsReplicasetsListPagePo, WorkloadsReplicasetsEditPagePo } from '@/cypress/e2e/po/pages/explorer/workloads-replicasets.po';
 import ResourceSearchDialog from '@/cypress/e2e/po/prompts/ResourceSearchDialog.po';
 
-describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser'] }, () => {
+describe('Cluster Explorer', { tags: ['@explorer2', '@adminUser', '@standardUser'] }, () => {
   beforeEach(() => {
     cy.login();
   });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2383

This PR 
- adds `@standardUser` tag to E2E spec files were missing it so they are included when running the standard user CI test suite. 
- adds qase ids
- make title test compatible to Prime builds
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
