### PR TITLE
Fix InternalExternalIP formatter compatibility with MgmtNode IP properties

### DIFF
--- a/shell/components/formatter/InternalExternalIP.vue
+++ b/shell/components/formatter/InternalExternalIP.vue
@@ -15,10 +15,16 @@ export default {
   computed: {
     ...mapGetters({ t: 'i18n/t' }),
     filteredExternalIps() {
-      return this.row.externalIps?.filter((ip) => this.isIp(ip)) || [];
+      const ips = this.row.externalIps ||
+        (this.row.externalIp && this.row.externalIp !== this.t('generic.none') ? [this.row.externalIp] : []);
+
+      return ips.filter((ip) => this.isIp(ip));
     },
     filteredInternalIps() {
-      return this.row.internalIps?.filter((ip) => this.isIp(ip)) || [];
+      const ips = this.row.internalIps ||
+        (this.row.internalIp ? [this.row.internalIp] : []);
+
+      return ips.filter((ip) => this.isIp(ip));
     },
     internalSameAsExternal() {
       return this.externalIp && this.internalIp && this.externalIp === this.internalIp;

--- a/shell/components/formatter/__tests__/InternalExternalIP.test.ts
+++ b/shell/components/formatter/__tests__/InternalExternalIP.test.ts
@@ -113,6 +113,39 @@ describe('component: InternalExternalIP', () => {
     });
   });
 
+  describe('fallback to singular IPs', () => {
+    it('should use singular externalIp and internalIp when arrays are not present', () => {
+      const wrapper = mountComponent({ row: { externalIp: '1.1.1.1', internalIp: '2.2.2.2' } });
+
+      expect(wrapper.vm.filteredExternalIps).toStrictEqual(['1.1.1.1']);
+      expect(wrapper.vm.filteredInternalIps).toStrictEqual(['2.2.2.2']);
+      expect(wrapper.find('[data-testid="external-ip"]').text()).toStrictEqual('1.1.1.1');
+      expect(wrapper.find('[data-testid="internal-ip"]').text()).toStrictEqual('2.2.2.2');
+    });
+
+    it('should ignore generic.none value for externalIp', () => {
+      // Assuming the mock translation for 'generic.none' returns 'generic.none'
+      const wrapper = mountComponent({ row: { externalIp: 'generic.none', internalIp: '2.2.2.2' } });
+
+      expect(wrapper.vm.filteredExternalIps).toStrictEqual([]);
+      expect(wrapper.vm.filteredInternalIps).toStrictEqual(['2.2.2.2']);
+    });
+
+    it('should prioritize array properties over singular strings', () => {
+      const wrapper = mountComponent({
+        row: {
+          externalIps: ['3.3.3.3'],
+          externalIp:  '1.1.1.1',
+          internalIps: ['4.4.4.4'],
+          internalIp:  '2.2.2.2'
+        }
+      });
+
+      expect(wrapper.vm.filteredExternalIps).toStrictEqual(['3.3.3.3']);
+      expect(wrapper.vm.filteredInternalIps).toStrictEqual(['4.4.4.4']);
+    });
+  });
+
   describe('invalid IPs', () => {
     it('should filter invalid IPs', () => {
       const wrapper = mountComponent({ row: { externalIps: ['1.1.1.1', 'not-an-ip'], internalIps: ['2.2.2.2'] } });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes  https://github.com/rancher/dashboard/issues/18021
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
The InternalExternalIP formatter assumes all node rows expose internalIps and externalIps.

This is true for downstream cluster Machine resources (cluster.x-k8s.io/Machine) where IPs are stored in:

```
status:
  addresses:
```

and exposed through the CapiMachine model.
However, local cluster nodes are represented by management.cattle.io/v3 Node resources where addresses are stored in:

```
status:
  internalNodeStatus:
    addresses:
```

The row object passed to the formatter is a MgmtNode, which exposes internalIp and externalIp but does not expose internalIps and externalIps.

As a result, the formatter computes empty IP lists and renders - / - despite valid IP information being available on the node model.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Proposed solution is to update InternalExternalIP.vue to support both singular and plural IP properties:
This preserves compatibility across both local and downstream cluster node representations.

internalIps / externalIps (CapiMachine)
internalIp / externalIp (MgmtNode)


### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1920" height="540" alt="image" src="https://github.com/user-attachments/assets/7382f3ab-ac38-44fc-bdbb-c87f685af548" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
