### PR TITLE
Replace `line-height: 140%` with size-specific unitless ratios

### DIFF
--- a/pkg/rancher-components/src/components/RcButton/RcButton.vue
+++ b/pkg/rancher-components/src/components/RcButton/RcButton.vue
@@ -333,7 +333,11 @@ defineExpose({ focus });
   &.btn-small {
     //:not(.btn-sm) is being used to make the style more specific to override global styles. We may want to get rid of those styles at some point.
     &, &:not(.btn-sm) {
-      line-height: 140%;
+      // Unitless ratio chosen so font-size * line-height (12px * 4/3 = 16px)
+      // is a whole pixel value. A fractional computed line-height (e.g. the
+      // previous 140% = 16.8px) shifts text ~1px off-center within the
+      // flex-centered button in Chrome, but not in Firefox.
+      line-height: calc(4 / 3);
       font-size: 12px;
       min-height: 24px;
 
@@ -345,7 +349,9 @@ defineExpose({ focus });
   &.btn-medium {
     //:not(.btn-sm) is being used to make the style more specific to override global styles. We may want to get rid of those styles at some point.
     &, &:not(.btn-sm) {
-      line-height: 140%;
+      // Unitless ratio chosen so font-size * line-height (14px * 10/7 = 20px)
+      // is a whole pixel value. See note in .btn-small for why this matters.
+      line-height: calc(10 / 7);
       font-size: 14px;
       min-height: 32px;
 
@@ -357,7 +363,9 @@ defineExpose({ focus });
   &.btn-large {
     // This is the default size brought by the global button styling
     &, &:not(.btn-sm) {
-      line-height: 140%;
+      // Unitless ratio chosen so font-size * line-height (16px * 1.5 = 24px)
+      // is a whole pixel value. See note in .btn-small for why this matters.
+      line-height: 1.5;
       font-size: 16px;
       min-height: 40px;
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This resolves an issue in chrome where text alignment for the `RcButton` medium variant would be offset by ~`1px`.

Fixes #18024

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Replace `line-height: 140%` with size-specific unitless ratios

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Each ratio resolves to whole number pixel line-height and fits the existing spacing scale. The old value of 140% of `14px` would resolve to a fractional value of `19.6px`.  Chrome has different behavior than Firefox when dealing with sub-pixel rounding, so the vertical alignment of the button text would be offset by about `1px`. Avoiding fractional values ensures that we render buttons consistently across browsers while also maintaining the desired line heights.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Anywhere that the medium variant of `RcButton` is used should render consistently between both Firefox and Chrome. The button text should be aligned properly:

- Home
- Cluster --> Projects/Namespace page, Group by namespace --> Create Namespace Button

Also assert that the storybook style guide also renders the buttons consistently across Firefox and Chrome:

- https://rancher.github.io/storybook/?path=/story/stories-components-rcbutton--all-sizes

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This adjusts line heights slightly, but I think that the risk is low, as buttons should render their contents in a single line and should not contain line-breaks.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before (Chrome)
<img width="1428" height="1168" alt="image" src="https://github.com/user-attachments/assets/8e13dbe4-ea4b-436b-a112-262d3f1f79a6" />

<img width="524" height="64" alt="image" src="https://github.com/user-attachments/assets/4dafccce-bd49-4a00-9502-91309102c0c3" />

#### After (Chrome)
<img width="1428" height="1168" alt="image" src="https://github.com/user-attachments/assets/094b9f3c-aa07-4b13-96fd-9406e590bf7d" />

<img width="524" height="64" alt="image" src="https://github.com/user-attachments/assets/4f1f360f-d290-419b-b5fa-d3806f51f357" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
