### PR TITLE
Fix RichTranslation TS compilation errors for extensions

### DIFF
--- a/shell/components/RichTranslation.vue
+++ b/shell/components/RichTranslation.vue
@@ -74,8 +74,11 @@ export default defineComponent({
           const content = enclosingTagName ? match[2] : '';
 
           if (slots[tagName]) {
-            // If a slot is provided for this tag, render the slot with the content.
-            children.push(slots[tagName]({ content: purifyHTML(content) }));
+            const slotContent = slots[tagName]({ content: purifyHTML(content) });
+
+            if (slotContent) {
+              children.push(...slotContent);
+            }
           } else if (ALLOWED_TAGS.includes(tagName.toLowerCase())) {
             // If it's an allowed HTML tag, render it directly.
             if (content) {

--- a/shell/plugins/clean-html.d.ts
+++ b/shell/plugins/clean-html.d.ts
@@ -1,0 +1,9 @@
+import { Config } from 'dompurify';
+
+export function purifyHTML(value: string, options?: Config): string;
+
+export function addLinkInterceptor(fn: (link: string) => string | undefined | void, name?: string): void;
+
+export function removeLinkInterceptor(fn: (link: string) => string | undefined | void): void;
+
+export function processLink(link: string): string;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18016 

This PR fixes RichTranslation component compilation errors when imported by UI extensions.

### Occurred changes and/or fixed issues
- Added a TypeScript declaration file (clean-html.d.ts) for @shell/plugins/clean-html to provide proper type definitions for purifyHTML (resolving TS7016).
- Fixed an array assignment error in RichTranslation.vue by spreading the array of VNode items returned by the scoped slot render function before pushing them into the children array (resolving TS2345).

### Technical notes summary
The issue was specific to how the @rancher/shell package is consumed by extensions. While the main dashboard application compiled fine with the existing code, extensions running their own TypeScript compilation step failed when encountering the untyped clean-html import and the strict VNode array assignment.

### Areas or cases that should be tested
- Verify that UI extensions can successfully import and use the RichTranslation component without build errors.
- Verify that RichTranslation continues to render correctly in the main dashboard UI.

### Areas which could experience regressions
- The RichTranslation component rendering logic for slotted content. Checking the empty state on Explorer > Apps > Charts page can be a good test for this.                                       

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
