### PR TITLE
Handle inline CRD schemas in kubectl-explain panel

### DIFF
--- a/pkg/kubectl-explain/__tests__/open-api-utils.test.ts
+++ b/pkg/kubectl-explain/__tests__/open-api-utils.test.ts
@@ -1,0 +1,213 @@
+import { expandOpenAPIDefinition, getOpenAPISchemaName, makeOpenAPIBreadcrumb } from '../open-api-utils';
+
+describe('getOpenAPISchemaName', () => {
+  it('returns empty string when schema has no attributes', () => {
+    expect(getOpenAPISchemaName({})).toBe('');
+    expect(getOpenAPISchemaName(null)).toBe('');
+  });
+
+  it('builds name from core group', () => {
+    const schema = {
+      attributes: {
+        group: 'core', version: 'v1', kind: 'Pod'
+      }
+    };
+
+    expect(getOpenAPISchemaName(schema)).toBe('io.k8s.api.core.v1.Pod');
+  });
+
+  it('reverses dotted group names', () => {
+    const schema = {
+      attributes: {
+        group: 'cert-manager.io', version: 'v1', kind: 'Certificate'
+      }
+    };
+
+    expect(getOpenAPISchemaName(schema)).toBe('io.cert-manager.v1.Certificate');
+  });
+});
+
+describe('makeOpenAPIBreadcrumb', () => {
+  it('extracts the last segment as name', () => {
+    const result = makeOpenAPIBreadcrumb('io.k8s.api.core.v1.PodSpec');
+
+    expect(result).toStrictEqual({ name: 'PodSpec', id: 'io.k8s.api.core.v1.PodSpec' });
+  });
+});
+
+describe('expandOpenAPIDefinition', () => {
+  it('expands $ref properties using definitions lookup', () => {
+    const definitions = {
+      'io.k8s.api.core.v1.Container': {
+        description: 'A container',
+        properties:  { name: { type: 'string', description: 'Container name' } },
+      },
+    };
+    const definition = {
+      properties: {
+        containers: {
+          type:  'array',
+          items: { $ref: '#/definitions/io.k8s.api.core.v1.Container' },
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition, []);
+
+    const containers = definition.properties.containers as any;
+
+    expect(containers.$$ref).toBeDefined();
+    expect(containers.$$ref.properties.name.type).toBe('string');
+    expect(containers.$refName).toBe('io.k8s.api.core.v1.Container');
+    expect(containers.$refNameShort).toBe('Container');
+    expect(containers.$breadcrumbs).toStrictEqual([{ name: 'Container', id: 'io.k8s.api.core.v1.Container' }]);
+  });
+
+  it('warns and skips when $ref target is not found', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const definitions = {};
+    const definition = { properties: { missing: { $ref: '#/definitions/io.k8s.DoesNotExist' } } };
+
+    expandOpenAPIDefinition(definitions, definition, []);
+
+    expect((definition.properties.missing as any).$$ref).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith('Can not find definition for io.k8s.DoesNotExist');
+    warnSpy.mockRestore();
+  });
+
+  it('expands inline object properties (CRD-style schemas without $ref)', () => {
+    const definitions = {};
+    const definition = {
+      properties: {
+        spec: {
+          type:        'object',
+          description: 'The spec of the CRD',
+          properties:  {
+            replicas: {
+              type:        'integer',
+              description: 'Number of replicas',
+            },
+            selector: {
+              type:        'object',
+              description: 'Label selector',
+              properties:  { matchLabels: { type: 'object', description: 'Map of labels' } },
+            },
+          },
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition, []);
+
+    const spec = definition.properties.spec as any;
+
+    expect(spec.$$ref).toBeDefined();
+    expect(spec.$$ref.description).toBe('The spec of the CRD');
+    expect(spec.$$ref.properties.replicas.type).toBe('integer');
+    expect(spec.$refName).toBe('spec');
+    expect(spec.$refNameShort).toBe('spec');
+
+    // Nested inline objects should also be expanded recursively
+    const selector = spec.$$ref.properties.selector as any;
+
+    expect(selector.$$ref).toBeDefined();
+    expect(selector.$$ref.properties.matchLabels).toBeDefined();
+  });
+
+  it('expands inline array items with properties (CRD-style array of objects)', () => {
+    const definitions = {};
+    const definition = {
+      properties: {
+        additionalOutputFormats: {
+          type:        'array',
+          description: 'Extra output formats',
+          items:       {
+            description: 'CertificateAdditionalOutputFormat',
+            properties:  { type: { type: 'string', description: 'Format type' } },
+          },
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition, []);
+
+    const field = definition.properties.additionalOutputFormats as any;
+
+    expect(field.$$ref).toBeDefined();
+    expect(field.$$ref.properties.type.type).toBe('string');
+    expect(field.$refName).toBe('additionalOutputFormats');
+    expect(field.$refNameShort).toBe('additionalOutputFormats');
+  });
+
+  it('does not expand inline schemas when a $ref is present', () => {
+    const definitions = {
+      'io.k8s.api.core.v1.PodSpec': {
+        description: 'PodSpec',
+        properties:  { nodeName: { type: 'string' } },
+      },
+    };
+    const definition = {
+      properties: {
+        spec: {
+          $ref:       '#/definitions/io.k8s.api.core.v1.PodSpec',
+          properties: { extra: { type: 'string' } },
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition, []);
+
+    const spec = definition.properties.spec as any;
+
+    // Should use the $ref expansion, not the inline properties
+    expect(spec.$refName).toBe('io.k8s.api.core.v1.PodSpec');
+    expect(spec.$$ref.properties.nodeName).toBeDefined();
+  });
+
+  it('extracts More Info links from descriptions', () => {
+    const definitions = {};
+    const definition = {
+      properties: {
+        field: {
+          type:        'string',
+          description: 'A field. More info: https://example.com/docs',
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition, []);
+
+    const field = definition.properties.field as any;
+
+    expect(field.$moreInfo).toBe('https://example.com/docs');
+    expect(field.description).not.toContain('More info');
+  });
+
+  it('handles definition with no properties gracefully', () => {
+    expect(() => expandOpenAPIDefinition({}, {}, [])).not.toThrow();
+    expect(() => expandOpenAPIDefinition({}, { properties: {} }, [])).not.toThrow();
+    expect(() => expandOpenAPIDefinition({}, null, [])).not.toThrow();
+  });
+
+  it('deeply expands nested $ref chains', () => {
+    const definitions = {
+      'io.k8s.Meta': {
+        description: 'Metadata',
+        properties:  { name: { type: 'string' } },
+      },
+      'io.k8s.Spec': {
+        description: 'Spec',
+        properties:  { metadata: { $ref: '#/definitions/io.k8s.Meta' } },
+      },
+    };
+    const definition = { properties: { spec: { $ref: '#/definitions/io.k8s.Spec' } } };
+
+    expandOpenAPIDefinition(definitions, definition, []);
+
+    const spec = definition.properties.spec as any;
+
+    expect(spec.$$ref.properties.metadata.$$ref).toBeDefined();
+    expect(spec.$$ref.properties.metadata.$$ref.properties.name.type).toBe('string');
+    expect(spec.$$ref.properties.metadata.$breadcrumbs).toHaveLength(2);
+  });
+});

--- a/pkg/kubectl-explain/components/ExplainPanel.vue
+++ b/pkg/kubectl-explain/components/ExplainPanel.vue
@@ -119,7 +119,7 @@ export default {
           </a>
         </div>
         <div
-          v-if="field.type && field.type !== 'array'"
+          v-if="field.type && field.type !== 'array' && !field.$$ref"
           class="field-type"
         >
           <div>
@@ -171,7 +171,7 @@ export default {
           v-model:value="field.description"
         />
         <div
-          v-if="expanded[field.name]"
+          v-if="expanded[field.name] && field.$breadcrumbs"
           class="sub-name"
         >
           <a

--- a/pkg/kubectl-explain/open-api-utils.ts
+++ b/pkg/kubectl-explain/open-api-utils.ts
@@ -97,6 +97,16 @@ export function expandOpenAPIDefinition(definitions: OpenApIDefinitions, definit
       } else {
         console.warn(`Can not find definition for ${ id }`); // eslint-disable-line no-console
       }
+    } else if (!propRef && (prop.properties || prop.items?.properties)) {
+      // Inline object schema - common in CRDs which define schemas inline
+      // rather than using $ref to named definitions
+      const inlineDef = prop.properties ? prop : prop.items;
+
+      prop.$$ref = JSON.parse(JSON.stringify({ properties: inlineDef.properties, description: inlineDef.description }));
+      prop.$refName = propName;
+      prop.$refNameShort = propName;
+
+      expandOpenAPIDefinition(definitions, prop.$$ref, []);
     }
 
     extractMoreInfo(prop);


### PR DESCRIPTION
### Summary
Fixes #15249

The kubectl-explain drawer did not expand nested fields for Custom Resource Definitions (CRDs) because CRDs define their schemas inline rather than using `$ref` pointers to named definitions. This left CRD spec fields showing only as "object" with no way to drill into sub-fields.

### Occurred changes and/or fixed issues

- **`open-api-utils.ts`**: Added a new branch in `expandOpenAPIDefinition` that detects inline object schemas (properties defined directly on a field or on its `items`) and synthesizes `$$ref`, `$refName`, and `$refNameShort` so the template can render them identically to `$ref`-based fields. The expansion recurses into nested inline objects.
- **`ExplainPanel.vue`**: Two template guards:
  1. The "field-type" badge (showing "object" / "string" / etc.) is now hidden when `$$ref` is present, so inline-expanded objects show as expandable definitions rather than a bare type label.
  2. The breadcrumb link now checks `field.$breadcrumbs` before rendering, preventing a render error on inline fields that have no breadcrumb chain.
- **`open-api-utils.test.ts`**: New unit test suite covering `getOpenAPISchemaName`, `makeOpenAPIBreadcrumb`, and `expandOpenAPIDefinition` (including inline object expansion, inline array-of-object expansion, `$ref` precedence over inline, missing `$ref` warning, nested `$ref` chains, `More Info` link extraction, and null/empty input handling).

### Technical notes summary

CRDs served by the Kubernetes OpenAPI endpoint embed their schemas inline rather than placing them in the top-level `definitions` map with `$ref` pointers. The existing code only followed `$ref` links, so CRD fields with nested `properties` were never expanded. The fix detects `prop.properties` or `prop.items.properties` when no `$ref` is present and promotes the inline definition into the same `$$ref` structure the template already handles, then recurses so deeply nested inline objects also expand.

### Areas or cases that should be tested

- Open the kubectl-explain drawer for a CRD (e.g. cert-manager Certificate) and verify nested fields under `spec` are expandable and show descriptions
- Verify built-in resources (e.g. Service, Pod) still render correctly (no regression)
- Check both light and dark mode
- Tested locally in Chrome

### Areas which could experience regressions

- The kubectl-explain drawer for any resource type (CRD or built-in)
- The breadcrumb navigation within expanded definitions
- Any resource whose OpenAPI schema mixes inline properties with `$ref` pointers

### Screenshot/Video

**Before** (CRD spec fields not expandable):
_Screenshot: before-fix.png (local: /workspace/.artifacts/stage-2/before-fix.png) - Shows the explain drawer for a cert-manager Certificate where the `spec` field displays only as "object" with no nested fields visible_

**After** (CRD spec fields fully expanded):
_Screenshot: after-fix-expanded.png (local: /workspace/.artifacts/stage-7/after-fix-expanded.png) - Shows the explain drawer for a cert-manager Certificate with `spec` expanded to reveal all nested CRD fields including additionalOutputFormats, commonName, etc._

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [ ] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`