### PR TITLE
Handle CRD inline schemas in kubectl explain panel

### DIFF
--- a/pkg/kubectl-explain/__tests__/open-api-utils.test.ts
+++ b/pkg/kubectl-explain/__tests__/open-api-utils.test.ts
@@ -1,0 +1,437 @@
+import {
+  expandOpenAPIDefinition,
+  getOpenAPISchemaName,
+  makeOpenAPIBreadcrumb,
+} from '../open-api-utils';
+
+describe('getOpenAPISchemaName', () => {
+  it('returns empty string when schema has no attributes', () => {
+    expect(getOpenAPISchemaName({})).toBe('');
+    expect(getOpenAPISchemaName(null)).toBe('');
+    expect(getOpenAPISchemaName(undefined)).toBe('');
+  });
+
+  it('builds name from core group attributes', () => {
+    const schema = {
+      attributes: {
+        group:   'core',
+        version: 'v1',
+        kind:    'Service',
+      },
+    };
+
+    expect(getOpenAPISchemaName(schema)).toBe('io.k8s.api.core.v1.Service');
+  });
+
+  it('reverses dotted group names', () => {
+    const schema = {
+      attributes: {
+        group:   'apps.k8s.io',
+        version: 'v1',
+        kind:    'Deployment',
+      },
+    };
+
+    expect(getOpenAPISchemaName(schema)).toBe('io.k8s.apps.v1.Deployment');
+  });
+
+  it('treats empty group as core', () => {
+    const schema = {
+      attributes: {
+        group:   '',
+        version: 'v1',
+        kind:    'Pod',
+      },
+    };
+
+    expect(getOpenAPISchemaName(schema)).toBe('io.k8s.api.core.v1.Pod');
+  });
+});
+
+describe('makeOpenAPIBreadcrumb', () => {
+  it('extracts the last segment as name', () => {
+    const result = makeOpenAPIBreadcrumb('io.k8s.api.core.v1.ServiceSpec');
+
+    expect(result).toStrictEqual({
+      name: 'ServiceSpec',
+      id:   'io.k8s.api.core.v1.ServiceSpec',
+    });
+  });
+
+  it('handles single-segment id', () => {
+    const result = makeOpenAPIBreadcrumb('ObjectMeta');
+
+    expect(result).toStrictEqual({
+      name: 'ObjectMeta',
+      id:   'ObjectMeta',
+    });
+  });
+});
+
+describe('expandOpenAPIDefinition', () => {
+  it('does nothing when definition has no properties', () => {
+    const definitions = {};
+    const definition = {};
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    expect(definition).toStrictEqual({});
+  });
+
+  it('does nothing for null/undefined definitions', () => {
+    expect(() => expandOpenAPIDefinition({}, null)).not.toThrow();
+    expect(() => expandOpenAPIDefinition({}, undefined)).not.toThrow();
+  });
+
+  describe('$ref-based expansion (built-in resources)', () => {
+    it('expands a property with $ref', () => {
+      const definitions = {
+        'io.k8s.api.core.v1.ServiceSpec': {
+          properties: {
+            clusterIP: {
+              type:        'string',
+              description: 'The cluster IP',
+            },
+          },
+        },
+      };
+      const definition = {
+        properties: {
+          spec: {
+            $ref:        '#/definitions/io.k8s.api.core.v1.ServiceSpec',
+            description: 'Service spec',
+          },
+        },
+      };
+
+      expandOpenAPIDefinition(definitions, definition);
+
+      expect(definition.properties.spec.$$ref).toBeDefined();
+      expect(definition.properties.spec.$$ref.properties.clusterIP.type).toBe('string');
+      expect(definition.properties.spec.$refName).toBe('io.k8s.api.core.v1.ServiceSpec');
+      expect(definition.properties.spec.$refNameShort).toBe('ServiceSpec');
+      expect(definition.properties.spec.$breadcrumbs).toStrictEqual([
+        { name: 'ServiceSpec', id: 'io.k8s.api.core.v1.ServiceSpec' },
+      ]);
+    });
+
+    it('expands items.$ref for array-typed properties', () => {
+      const definitions = {
+        'io.k8s.api.core.v1.Container': {
+          properties: {
+            name: {
+              type:        'string',
+              description: 'Container name',
+            },
+          },
+        },
+      };
+      const definition = {
+        properties: {
+          containers: {
+            type:  'array',
+            items: { $ref: '#/definitions/io.k8s.api.core.v1.Container' },
+          },
+        },
+      };
+
+      expandOpenAPIDefinition(definitions, definition);
+
+      expect(definition.properties.containers.$$ref).toBeDefined();
+      expect(definition.properties.containers.$$ref.properties.name.type).toBe('string');
+      expect(definition.properties.containers.$refName).toBe('io.k8s.api.core.v1.Container');
+    });
+
+    it('warns and skips when $ref target is not found', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const definitions = {};
+      const definition = { properties: { spec: { $ref: '#/definitions/missing.Type' } } };
+
+      expandOpenAPIDefinition(definitions, definition);
+
+      expect(definition.properties.spec.$$ref).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith('Can not find definition for missing.Type');
+      warnSpy.mockRestore();
+    });
+
+    it('does not share $$ref objects between duplicate references', () => {
+      const definitions = { 'io.k8s.apimachinery.v1.ObjectMeta': { properties: { name: { type: 'string' } } } };
+      const definition = {
+        properties: {
+          metadata: { $ref: '#/definitions/io.k8s.apimachinery.v1.ObjectMeta' },
+          other:    { $ref: '#/definitions/io.k8s.apimachinery.v1.ObjectMeta' },
+        },
+      };
+
+      expandOpenAPIDefinition(definitions, definition);
+
+      expect(definition.properties.metadata.$$ref).not.toBe(definition.properties.other.$$ref);
+    });
+  });
+
+  describe('inline expansion (CRD schemas)', () => {
+    it('expands inline properties without $ref', () => {
+      const definition = {
+        properties: {
+          spec: {
+            type:        'object',
+            description: 'Spec for a custom resource',
+            properties:  {
+              replicas: {
+                type:        'integer',
+                description: 'Number of replicas',
+              },
+              selector: {
+                type:        'string',
+                description: 'Label selector',
+              },
+            },
+          },
+        },
+      };
+
+      expandOpenAPIDefinition({}, definition);
+
+      const spec = definition.properties.spec;
+
+      expect(spec.$$ref).toBeDefined();
+      expect(spec.$$ref.properties.replicas.type).toBe('integer');
+      expect(spec.$$ref.properties.selector.type).toBe('string');
+      expect(spec.$refName).toBe('spec');
+      expect(spec.$refNameShort).toBe('object');
+      expect(spec.$inline).toBe(true);
+      expect(spec.$breadcrumbs).toStrictEqual([]);
+    });
+
+    it('expands inline items.properties for array-typed CRD fields', () => {
+      const definition = {
+        properties: {
+          conditions: {
+            type:  'array',
+            items: {
+              type:       'object',
+              properties: {
+                type: {
+                  type:        'string',
+                  description: 'Condition type',
+                },
+                status: {
+                  type:        'string',
+                  description: 'Condition status',
+                },
+              },
+            },
+          },
+        },
+      };
+
+      expandOpenAPIDefinition({}, definition);
+
+      const conditions = definition.properties.conditions;
+
+      expect(conditions.$$ref).toBeDefined();
+      expect(conditions.$$ref.properties.type.type).toBe('string');
+      expect(conditions.$$ref.properties.status.type).toBe('string');
+      expect(conditions.$inline).toBe(true);
+      expect(conditions.$refName).toBe('conditions');
+    });
+
+    it('recursively expands nested inline properties', () => {
+      const definition = {
+        properties: {
+          spec: {
+            type:       'object',
+            properties: {
+              template: {
+                type:       'object',
+                properties: {
+                  image: {
+                    type:        'string',
+                    description: 'Container image',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      expandOpenAPIDefinition({}, definition);
+
+      const spec = definition.properties.spec;
+
+      expect(spec.$$ref).toBeDefined();
+
+      const template = spec.$$ref.properties.template;
+
+      expect(template.$$ref).toBeDefined();
+      expect(template.$$ref.properties.image.type).toBe('string');
+      expect(template.$inline).toBe(true);
+      expect(template.$refName).toBe('template');
+    });
+
+    it('does not apply inline expansion when $ref is present', () => {
+      const definitions = { 'io.k8s.apimachinery.v1.ObjectMeta': { properties: { name: { type: 'string' } } } };
+      const definition = {
+        properties: {
+          metadata: {
+            $ref:       '#/definitions/io.k8s.apimachinery.v1.ObjectMeta',
+            properties: { extra: { type: 'string' } },
+          },
+        },
+      };
+
+      expandOpenAPIDefinition(definitions, definition);
+
+      expect(definition.properties.metadata.$inline).toBeUndefined();
+      expect(definition.properties.metadata.$refName).toBe('io.k8s.apimachinery.v1.ObjectMeta');
+    });
+
+    it('makes a deep copy of inline properties so mutations do not leak', () => {
+      const originalProps = {
+        replicas: {
+          type:        'integer',
+          description: 'Number of replicas',
+        },
+      };
+      const definition = {
+        properties: {
+          spec: {
+            type:       'object',
+            properties: originalProps,
+          },
+        },
+      };
+
+      expandOpenAPIDefinition({}, definition);
+
+      definition.properties.spec.$$ref.properties.replicas.description = 'MUTATED';
+
+      expect(originalProps.replicas.description).toBe('Number of replicas');
+    });
+
+    it('preserves breadcrumbs through inline expansion', () => {
+      const definitions = {
+        'io.k8s.api.core.v1.ServiceSpec': {
+          properties: {
+            nested: {
+              type:       'object',
+              properties: { value: { type: 'string' } },
+            },
+          },
+        },
+      };
+      const definition = { properties: { spec: { $ref: '#/definitions/io.k8s.api.core.v1.ServiceSpec' } } };
+
+      expandOpenAPIDefinition(definitions, definition);
+
+      const nested = definition.properties.spec.$$ref.properties.nested;
+
+      expect(nested.$inline).toBe(true);
+      expect(nested.$breadcrumbs).toStrictEqual([
+        { name: 'ServiceSpec', id: 'io.k8s.api.core.v1.ServiceSpec' },
+      ]);
+    });
+  });
+
+  describe('More Info extraction', () => {
+    it('extracts More Info URLs from descriptions', () => {
+      const definition = {
+        properties: {
+          field: {
+            type:        'string',
+            description: 'A field. More info: https://example.com/docs',
+          },
+        },
+      };
+
+      expandOpenAPIDefinition({}, definition);
+
+      expect(definition.properties.field.$moreInfo).toBe('https://example.com/docs');
+      expect(definition.properties.field.description).toBe('A field.');
+    });
+
+    it('strips trailing dot from More Info URLs', () => {
+      const definition = {
+        properties: {
+          field: {
+            type:        'string',
+            description: 'Some text More info: https://example.com/docs.',
+          },
+        },
+      };
+
+      expandOpenAPIDefinition({}, definition);
+
+      expect(definition.properties.field.$moreInfo).toBe('https://example.com/docs');
+    });
+  });
+
+  describe('realistic CRD scenario', () => {
+    it('handles a CRD with mixed $ref and inline properties', () => {
+      const definitions = {
+        'io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta': {
+          properties: {
+            name:      { type: 'string', description: 'Object name' },
+            namespace: { type: 'string', description: 'Object namespace' },
+          },
+        },
+      };
+      const definition = {
+        properties: {
+          apiVersion: { type: 'string', description: 'API version' },
+          kind:       { type: 'string', description: 'Object kind' },
+          metadata:   { $ref: '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta' },
+          spec:       {
+            type:        'object',
+            description: 'CRD spec',
+            properties:  {
+              replicas: {
+                type:        'integer',
+                description: 'Number of desired replicas',
+              },
+              selector: {
+                type:        'string',
+                description: 'Label selector for pods',
+              },
+            },
+          },
+          status: {
+            type:        'object',
+            description: 'CRD status',
+            properties:  {
+              readyReplicas: {
+                type:        'integer',
+                description: 'Number of ready replicas',
+              },
+            },
+          },
+        },
+      };
+
+      expandOpenAPIDefinition(definitions, definition);
+
+      const {
+        metadata, spec, status, apiVersion, kind
+      } = definition.properties;
+
+      expect(metadata.$$ref).toBeDefined();
+      expect(metadata.$refName).toBe('io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta');
+      expect(metadata.$inline).toBeUndefined();
+
+      expect(spec.$$ref).toBeDefined();
+      expect(spec.$inline).toBe(true);
+      expect(spec.$refName).toBe('spec');
+      expect(spec.$$ref.properties.replicas.type).toBe('integer');
+      expect(spec.$$ref.properties.selector.type).toBe('string');
+
+      expect(status.$$ref).toBeDefined();
+      expect(status.$inline).toBe(true);
+      expect(status.$refName).toBe('status');
+      expect(status.$$ref.properties.readyReplicas.type).toBe('integer');
+
+      expect(apiVersion.$$ref).toBeUndefined();
+      expect(kind.$$ref).toBeUndefined();
+    });
+  });
+});

--- a/pkg/kubectl-explain/components/ExplainPanel.vue
+++ b/pkg/kubectl-explain/components/ExplainPanel.vue
@@ -119,7 +119,7 @@ export default {
           </a>
         </div>
         <div
-          v-if="field.type && field.type !== 'array'"
+          v-if="field.type && field.type !== 'array' && !field.$refName"
           class="field-type"
         >
           <div>
@@ -171,7 +171,7 @@ export default {
           v-model:value="field.description"
         />
         <div
-          v-if="expanded[field.name]"
+          v-if="expanded[field.name] && !field.$inline"
           class="sub-name"
         >
           <a

--- a/pkg/kubectl-explain/open-api-utils.ts
+++ b/pkg/kubectl-explain/open-api-utils.ts
@@ -99,6 +99,19 @@ export function expandOpenAPIDefinition(definitions: OpenApIDefinitions, definit
       }
     }
 
+    // CRDs embed schemas inline rather than using $ref
+    const inlineProperties = prop.properties || prop.items?.properties;
+
+    if (!propRef && inlineProperties) {
+      prop.$$ref = { properties: JSON.parse(JSON.stringify(inlineProperties)) };
+      prop.$refName = propName;
+      prop.$refNameShort = 'object';
+      prop.$inline = true;
+      prop.$breadcrumbs = [...breadcrumbs];
+
+      expandOpenAPIDefinition(definitions, prop.$$ref, prop.$breadcrumbs);
+    }
+
     extractMoreInfo(prop);
   });
 }


### PR DESCRIPTION
### Summary
Fixes #15249

The kubectl explain panel does not display nested field descriptions for Custom Resource Definitions (CRDs). Only top-level fields are shown, with `spec`/`status` displayed as plain "object" types that cannot be expanded. This fix adds inline schema expansion so CRD fields are navigable the same way built-in Kubernetes resources are.

### Occurred changes and/or fixed issues

- CRD properties with inline `properties` (or `items.properties` for arrays) are now recursively expanded, making their nested fields visible and navigable in the explain panel
- The `ExplainPanel.vue` template no longer shows a redundant plain type badge when the field already has an expandable `$refName`, and no longer renders a stale `$ref`-style drill-down link for inline-expanded fields (which would crash since there is no definition to look up)

### Technical notes summary

Built-in Kubernetes resources describe nested objects via `$ref` pointers into a shared `definitions` map. CRDs instead embed their schemas inline (the property itself carries `type: "object"` with `properties` directly nested). [`expandOpenAPIDefinition`](https://github.com/rancher/dashboard/blob/f43433596bda69e3d9dc8e81ea4d241887200276/pkg/kubectl-explain/open-api-utils.ts#L102-L113) now detects inline properties when no `$ref` is present, deep-copies them into `$$ref`, and marks the property with `$inline = true` so the template can distinguish the two expansion modes.

### Areas or cases that should be tested

- Open the explain panel for a CRD with nested spec fields and verify the spec is expandable with correct descriptions
- Verify built-in resources (e.g. Service, Deployment) still expand correctly via `$ref`
- Array-typed CRD fields with inline `items.properties` should also expand

### Areas which could experience regressions

- Explain panel rendering for any resource type (both CRDs and built-ins)
- Breadcrumb navigation in the explain panel

### Screenshot/Video

<!-- TODO(manual upload): browser sidecar / GitHub session was unavailable; drag-drop each file into this section. -->
- Before fix: `/workspace/screenshots/before-fix.png`, `/workspace/screenshots/before-fix-spec.png`
- After fix: `/workspace/screenshots/after-fix.png`, `/workspace/screenshots/after-fix-spec-expanded.png`

### Checklist
- [] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [] The PR has a Milestone
- [] The PR template has been filled out
- [] The PR has been self reviewed
- [] The PR has a reviewer assigned
- [] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [] The PR has been reviewed in terms of Accessibility
- [] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
