### PR TITLE
Implement a `zod-helpers` util for common validations

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7468,6 +7468,7 @@ validation:
       url: Server URL must be an URL.
       awsStyleEndpoint: Endpoint URL has to be a valid domain-based endpoint and cannot start with a protocol (e.g https:// or http://)
   genericUrl: Field must be a valid URL
+  url: '"{key}" must be a valid URL'
   stringLength:
     between: '"{key}" should be between {min} and {max} {max, plural, =1 {character} other {characters}}'
     exactly: '"{key}" should be {count, plural, =1 {# character} other {# characters}}'

--- a/shell/edit/auth/github.vue
+++ b/shell/edit/auth/github.vue
@@ -20,6 +20,7 @@ import GithubSteps from '@shell/edit/auth/github-steps.vue';
 import GithubAppSteps from '@shell/edit/auth/github-app-steps.vue';
 import { useI18n } from '@shell/composables/useI18n';
 import { RcSeparator } from '@components/RcSeparator';
+import { createZodHelpers } from '@shell/utils/validators/zod-helpers';
 
 export default {
   components: {
@@ -46,18 +47,15 @@ export default {
     const isGithubAppRef = ref(false);
     const isPublicRef = ref(true);
 
-    const coerce = (schema) => z.preprocess((v) => v ?? '', schema);
-    const requiredField = (key) => coerce(z.string().min(1, t('validation.required', { key: t(key) })));
-    const requiredUrlField = (key) => coerce(z.string().min(1, t('validation.required', { key: t(key) })).url(t('validation.genericUrl')));
-    const optionalField = coerce(z.string());
+    const { field } = createZodHelpers(t);
 
     const validationSchema = computed(() => toTypedSchema(
       z.object({
-        clientId:     requiredField('authConfig.github.clientId.label'),
-        clientSecret: requiredField('authConfig.github.clientSecret.label'),
-        appId:        isGithubAppRef.value ? requiredField('authConfig.githubapp.githubAppId.label') : optionalField,
-        privateKey:   isGithubAppRef.value ? requiredField('authConfig.githubapp.privateKey.label') : optionalField,
-        targetUrl:    !isPublicRef.value ? requiredUrlField('authConfig.github.host.label') : optionalField,
+        clientId:     field('authConfig.github.clientId.label').required(),
+        clientSecret: field('authConfig.github.clientSecret.label').required(),
+        appId:        isGithubAppRef.value ? field('authConfig.githubapp.githubAppId.label').required() : field(),
+        privateKey:   isGithubAppRef.value ? field('authConfig.githubapp.privateKey.label').required() : field(),
+        targetUrl:    !isPublicRef.value ? field('authConfig.github.host.label').required().url() : field(),
       })
     ));
 

--- a/shell/edit/auth/github.vue
+++ b/shell/edit/auth/github.vue
@@ -20,7 +20,7 @@ import GithubSteps from '@shell/edit/auth/github-steps.vue';
 import GithubAppSteps from '@shell/edit/auth/github-app-steps.vue';
 import { useI18n } from '@shell/composables/useI18n';
 import { RcSeparator } from '@components/RcSeparator';
-import { createZodHelpers } from '@shell/utils/validators/zod-helpers';
+import { zodValidators } from '@shell/utils/validators/zod-helpers';
 
 export default {
   components: {
@@ -47,7 +47,7 @@ export default {
     const isGithubAppRef = ref(false);
     const isPublicRef = ref(true);
 
-    const { field } = createZodHelpers(t);
+    const { field } = zodValidators(t);
 
     const validationSchema = computed(() => toTypedSchema(
       z.object({

--- a/shell/edit/auth/ldap/index.vue
+++ b/shell/edit/auth/ldap/index.vue
@@ -16,7 +16,7 @@ import Password from '@shell/components/form/Password';
 import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBanners';
 import { useI18n } from '@shell/composables/useI18n';
 import { RcSeparator } from '@components/RcSeparator';
-import { zodValidators } from 'utils/validators/zod-helpers';
+import { zodValidators } from '@shell/utils/validators/zod-helpers';
 
 const AUTH_TYPE = 'ldap';
 

--- a/shell/edit/auth/ldap/index.vue
+++ b/shell/edit/auth/ldap/index.vue
@@ -16,6 +16,7 @@ import Password from '@shell/components/form/Password';
 import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBanners';
 import { useI18n } from '@shell/composables/useI18n';
 import { RcSeparator } from '@components/RcSeparator';
+import { zodValidators } from 'utils/validators/zod-helpers';
 
 const AUTH_TYPE = 'ldap';
 
@@ -37,26 +38,23 @@ export default {
   setup() {
     const store = useStore();
     const { t } = useI18n(store);
-
-    const coerce = (schema) => z.preprocess((v) => (v === null || v === undefined) ? '' : String(v), schema);
-    const requiredField = (key) => coerce(z.string().min(1, t('validation.required', { key: t(key) })));
-    const optionalField = coerce(z.string());
+    const { field } = zodValidators(t);
 
     const tlsEnabledRef = ref(false);
     const isActiveDirectoryRef = ref(false);
 
     const validationSchema = computed(() => toTypedSchema(
       z.object({
-        hostname:                        requiredField('authConfig.ldap.hostname.label'),
-        port:                            requiredField('authConfig.ldap.port'),
-        certificate:                     tlsEnabledRef.value ? requiredField('authConfig.ldap.cert') : optionalField,
-        connectionTimeout:               requiredField('authConfig.ldap.serverConnectionTimeout'),
-        serviceAccountUsername:          isActiveDirectoryRef.value ? requiredField('authConfig.ldap.serviceAccountDN') : optionalField,
-        serviceAccountDistinguishedName: !isActiveDirectoryRef.value ? requiredField('authConfig.ldap.serviceAccountDN') : optionalField,
-        serviceAccountPassword:          requiredField('authConfig.ldap.serviceAccountPassword'),
-        userSearchBase:                  requiredField('authConfig.ldap.userSearchBase.label'),
-        username:                        requiredField(`authConfig.${ AUTH_TYPE }.username`),
-        password:                        requiredField(`authConfig.${ AUTH_TYPE }.password`),
+        hostname:                        field('authConfig.ldap.hostname.label').required(),
+        port:                            field('authConfig.ldap.port').required(),
+        certificate:                     tlsEnabledRef.value ? field('authConfig.ldap.cert').required() : field(),
+        connectionTimeout:               field('authConfig.ldap.serverConnectionTimeout').required(),
+        serviceAccountUsername:          isActiveDirectoryRef.value ? field('authConfig.ldap.serviceAccountDN').required() : field(),
+        serviceAccountDistinguishedName: !isActiveDirectoryRef.value ? field('authConfig.ldap.serviceAccountDN').required() : field(),
+        serviceAccountPassword:          field('authConfig.ldap.serviceAccountPassword').required(),
+        userSearchBase:                  field('authConfig.ldap.userSearchBase.label').required(),
+        username:                        field(`authConfig.${ AUTH_TYPE }.username`).required(),
+        password:                        field(`authConfig.${ AUTH_TYPE }.password`).required(),
       })
     ));
 

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -22,6 +22,7 @@ import { BASE_SCOPES } from '@shell/store/auth';
 import CopyToClipboardText from '@shell/components/CopyToClipboardText.vue';
 import { useI18n } from '@shell/composables/useI18n';
 import { RcSeparator } from '@components/RcSeparator';
+import { createZodHelpers } from '@shell/utils/validators/zod-helpers';
 
 const PKCE_S256 = 'S256';
 
@@ -70,29 +71,24 @@ export default {
     const requiresAuthEndpoint = computed(() => ['genericoidc', 'keycloakoidc'].includes(modelId.value));
     const sloEndSessionEndpointUiEnabled = computed(() => [SLO_OPTION_VALUES.all, SLO_OPTION_VALUES.both].includes(sloTypeRef.value));
 
-    // z.preprocess coerces null/undefined to '' before validation. This
-    // prevents the raw "Expected string, received null" zod message.
-    const coerce = (schema) => z.preprocess((v) => v ?? '', schema);
-    const requiredField = (key) => coerce(z.string().min(1, t('validation.required', { key: t(key) })));
-    const requiredUrlField = (key) => coerce(z.string().min(1, t('validation.required', { key: t(key) })).url(t('validation.genericUrl')));
-    const optionalField = coerce(z.string());
+    const { field } = createZodHelpers(t);
 
     // Reactive schema uses computed to reshape when provider or endpoint mode
     // changes.
     const validationSchema = computed(() => toTypedSchema(
       z.object({
-        clientId:     requiredField('authConfig.oidc.clientId'),
-        clientSecret: requiredField('authConfig.oidc.clientSecret'),
+        clientId:     field('authConfig.oidc.clientId').required(),
+        clientSecret: field('authConfig.oidc.clientSecret').required(),
 
-        url:   !customEndpointEnabled.value && !isAmazonCognito.value ? requiredUrlField('authConfig.oidc.url') : optionalField,
-        realm: !customEndpointEnabled.value && !isAmazonCognito.value ? requiredField('authConfig.oidc.realm') : optionalField,
+        url:   !customEndpointEnabled.value && !isAmazonCognito.value ? field('authConfig.oidc.url').required().url() : field(),
+        realm: !customEndpointEnabled.value && !isAmazonCognito.value ? field('authConfig.oidc.realm').required() : field(),
 
-        rancherUrl: customEndpointEnabled.value && !isAmazonCognito.value ? requiredField('authConfig.oidc.rancherUrl') : optionalField,
-        issuer:     customEndpointEnabled.value || isAmazonCognito.value ? requiredField('authConfig.oidc.issuer') : optionalField,
+        rancherUrl: customEndpointEnabled.value && !isAmazonCognito.value ? field('authConfig.oidc.rancherUrl').required() : field(),
+        issuer:     customEndpointEnabled.value || isAmazonCognito.value ? field('authConfig.oidc.issuer').required() : field(),
 
-        authEndpoint: requiresAuthEndpoint.value ? requiredUrlField('authConfig.oidc.authEndpoint') : optionalField,
+        authEndpoint: requiresAuthEndpoint.value ? field('authConfig.oidc.authEndpoint').required().url() : field(),
 
-        endSessionEndpoint: sloEndSessionEndpointUiEnabled.value ? requiredUrlField('authConfig.oidc.endSessionEndpoint.title') : optionalField,
+        endSessionEndpoint: sloEndSessionEndpointUiEnabled.value ? field('authConfig.oidc.endSessionEndpoint.title').required().url() : field(),
 
         scope: z.preprocess(
           (v) => (Array.isArray(v) ? v : []),

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -22,7 +22,7 @@ import { BASE_SCOPES } from '@shell/store/auth';
 import CopyToClipboardText from '@shell/components/CopyToClipboardText.vue';
 import { useI18n } from '@shell/composables/useI18n';
 import { RcSeparator } from '@components/RcSeparator';
-import { createZodHelpers } from '@shell/utils/validators/zod-helpers';
+import { zodValidators } from '@shell/utils/validators/zod-helpers';
 
 const PKCE_S256 = 'S256';
 
@@ -71,7 +71,7 @@ export default {
     const requiresAuthEndpoint = computed(() => ['genericoidc', 'keycloakoidc'].includes(modelId.value));
     const sloEndSessionEndpointUiEnabled = computed(() => [SLO_OPTION_VALUES.all, SLO_OPTION_VALUES.both].includes(sloTypeRef.value));
 
-    const { field } = createZodHelpers(t);
+    const { field } = zodValidators(t);
 
     // Reactive schema uses computed to reshape when provider or endpoint mode
     // changes.

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -20,7 +20,7 @@ import RadioGroup from '@components/Form/Radio/RadioGroup.vue';
 import { RcButton } from '@components/RcButton';
 import { useI18n } from '@shell/composables/useI18n';
 import { RcSeparator } from '@components/RcSeparator';
-import { zodValidators } from 'utils/validators/zod-helpers';
+import { zodValidators } from '@shell/utils/validators/zod-helpers';
 
 // Standard LDAP defaults
 const LDAP_DEFAULTS = {

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -20,6 +20,7 @@ import RadioGroup from '@components/Form/Radio/RadioGroup.vue';
 import { RcButton } from '@components/RcButton';
 import { useI18n } from '@shell/composables/useI18n';
 import { RcSeparator } from '@components/RcSeparator';
+import { zodValidators } from 'utils/validators/zod-helpers';
 
 // Standard LDAP defaults
 const LDAP_DEFAULTS = {
@@ -65,21 +66,18 @@ export default {
   setup() {
     const store = useStore();
     const { t } = useI18n(store);
-
-    const coerce = (schema) => z.preprocess((v) => v ?? '', schema);
-    const requiredField = (key) => coerce(z.string().min(1, t('validation.required', { key: t(key) })));
-    const requiredUrlField = (key) => coerce(z.string().min(1, t('validation.required', { key: t(key) })).url(t('validation.genericUrl')));
+    const { field } = zodValidators(t);
 
     const validationSchema = computed(() => toTypedSchema(
       z.object({
-        displayNameField:   requiredField('authConfig.saml.displayName'),
-        userNameField:      requiredField('authConfig.saml.userName'),
-        uidField:           requiredField('authConfig.saml.UID'),
-        groupsField:        requiredField('authConfig.saml.groups'),
-        rancherApiHost:     requiredUrlField('authConfig.saml.api'),
-        spKey:              requiredField('authConfig.saml.key.label'),
-        spCert:             requiredField('authConfig.saml.cert.label'),
-        idpMetadataContent: requiredField('authConfig.saml.metadata.label'),
+        displayNameField:   field('authConfig.saml.displayName').required(),
+        userNameField:      field('authConfig.saml.userName').required(),
+        uidField:           field('authConfig.saml.UID').required(),
+        groupsField:        field('authConfig.saml.groups').required(),
+        rancherApiHost:     field('authConfig.saml.api').url().required(),
+        spKey:              field('authConfig.saml.key.label').required(),
+        spCert:             field('authConfig.saml.cert.label').required(),
+        idpMetadataContent: field('authConfig.saml.metadata.label').required(),
       })
     ));
 

--- a/shell/utils/validators/__tests__/zod-helpers.test.ts
+++ b/shell/utils/validators/__tests__/zod-helpers.test.ts
@@ -11,7 +11,8 @@ const mockT = (key: string, args?: Record<string, unknown>): string => {
 const { field } = createZodHelpers(mockT);
 
 const REQUIRED_MSG = (fieldKey: string) => `validation.required[${ fieldKey }]`;
-const URL_MSG = 'validation.genericUrl';
+const URL_MSG = (fieldKey: string) => `validation.url[${ fieldKey }]`;
+const GENERIC_URL_MSG = 'validation.genericUrl';
 
 describe('createZodHelpers', () => {
   describe('builder style — field(key).chain()', () => {
@@ -64,7 +65,29 @@ describe('createZodHelpers', () => {
         const result = schema.safeParse('not-a-url');
 
         expect(result.success).toBe(false);
-        expect(result.error?.issues[0].message).toBe(URL_MSG);
+        expect(result.error?.issues[0].message).toBe(URL_MSG('myKey'));
+      });
+    });
+
+    describe('field().url() — no key falls back to the generic URL message', () => {
+      const schema = field().url();
+
+      it('fails for an invalid URL', () => {
+        const result = schema.safeParse('not-a-url');
+
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(GENERIC_URL_MSG);
+      });
+    });
+
+    describe('field(key).url(keyOverride) — key override', () => {
+      const schema = field('myKey').url('overrideKey');
+
+      it('uses the override key in the URL error message', () => {
+        const result = schema.safeParse('not-a-url');
+
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(URL_MSG('overrideKey'));
       });
     });
 
@@ -86,7 +109,7 @@ describe('createZodHelpers', () => {
         const result = schema.safeParse('not-a-url');
 
         expect(result.success).toBe(false);
-        expect(result.error?.issues[0].message).toBe(URL_MSG);
+        expect(result.error?.issues[0].message).toBe(URL_MSG('myKey'));
       });
     });
 
@@ -104,7 +127,7 @@ describe('createZodHelpers', () => {
         const result = schema.safeParse('not-a-url');
 
         expect(result.success).toBe(false);
-        expect(result.error?.issues[0].message).toBe(URL_MSG);
+        expect(result.error?.issues[0].message).toBe(URL_MSG('myKey'));
       });
     });
 

--- a/shell/utils/validators/__tests__/zod-helpers.test.ts
+++ b/shell/utils/validators/__tests__/zod-helpers.test.ts
@@ -1,0 +1,139 @@
+import { createZodHelpers } from '@shell/utils/validators/zod-helpers';
+
+const mockT = (key: string, args?: Record<string, unknown>): string => {
+  if (args) {
+    return `${ key }[${ Object.values(args).join(',') }]`;
+  }
+
+  return key;
+};
+
+const { field } = createZodHelpers(mockT);
+
+const REQUIRED_MSG = (fieldKey: string) => `validation.required[${ fieldKey }]`;
+const URL_MSG = 'validation.genericUrl';
+
+describe('createZodHelpers', () => {
+  describe('builder style — field(key).chain()', () => {
+    describe('field(key) — optional string', () => {
+      it.each([
+        ['empty string', ''],
+        ['any string', 'hello'],
+        [null, null],
+        [undefined, undefined],
+      ])('passes for %s', (_label, value) => {
+        expect(field('myKey').safeParse(value).success).toBe(true);
+      });
+    });
+
+    describe('field(key).required() — required string', () => {
+      const schema = field('myKey').required();
+
+      it('passes when value is provided', () => {
+        expect(schema.safeParse('hello').success).toBe(true);
+      });
+
+      it.each([
+        ['empty string', ''],
+        [null, null],
+        [undefined, undefined],
+      ])('fails for %s', (_label, value) => {
+        const result = schema.safeParse(value);
+
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(REQUIRED_MSG('myKey'));
+      });
+    });
+
+    describe('field(key).url() — optional URL', () => {
+      const schema = field('myKey').url();
+
+      it.each([
+        ['empty string', ''],
+        [null, null],
+        [undefined, undefined],
+      ])('passes for %s (field is optional)', (_label, value) => {
+        expect(schema.safeParse(value).success).toBe(true);
+      });
+
+      it('passes for a valid URL', () => {
+        expect(schema.safeParse('https://example.com').success).toBe(true);
+      });
+
+      it('fails for an invalid URL', () => {
+        const result = schema.safeParse('not-a-url');
+
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(URL_MSG);
+      });
+    });
+
+    describe('field(key).required().url() — required URL', () => {
+      const schema = field('myKey').required().url();
+
+      it('passes for a valid URL', () => {
+        expect(schema.safeParse('https://example.com').success).toBe(true);
+      });
+
+      it('fails with required message when empty', () => {
+        const result = schema.safeParse('');
+
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(REQUIRED_MSG('myKey'));
+      });
+
+      it('fails with URL message for a non-empty invalid URL', () => {
+        const result = schema.safeParse('not-a-url');
+
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(URL_MSG);
+      });
+    });
+
+    describe('field(key).url().required() — chain order does not affect behaviour', () => {
+      const schema = field('myKey').url().required();
+
+      it('fails with required message when empty', () => {
+        const result = schema.safeParse('');
+
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(REQUIRED_MSG('myKey'));
+      });
+
+      it('fails with URL message for a non-empty invalid URL', () => {
+        const result = schema.safeParse('not-a-url');
+
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(URL_MSG);
+      });
+    });
+
+    describe('field(key).required(keyOverride) — key override', () => {
+      it('uses the override key in the required error message', () => {
+        const schema = field('myKey').required('overrideKey');
+        const result = schema.safeParse('');
+
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(REQUIRED_MSG('overrideKey'));
+      });
+
+      it('falls back to the field key when no override is given', () => {
+        const schema = field('myKey').required();
+        const result = schema.safeParse('');
+
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(REQUIRED_MSG('myKey'));
+      });
+    });
+
+    describe('immutability — chaining off a base does not mutate it', () => {
+      it('base remains optional after branching', () => {
+        const base = field('myKey').url();
+        const withReq = base.required();
+
+        expect(base.safeParse('').success).toBe(true);
+        expect(withReq.safeParse('').success).toBe(false);
+      });
+    });
+  });
+});

--- a/shell/utils/validators/__tests__/zod-helpers.test.ts
+++ b/shell/utils/validators/__tests__/zod-helpers.test.ts
@@ -46,6 +46,25 @@ describe('createZodHelpers', () => {
       });
     });
 
+    describe('field().required() — required with no static key', () => {
+      const schema = field().required();
+
+      it('passes when value is provided', () => {
+        expect(schema.safeParse('hello').success).toBe(true);
+      });
+
+      it.each([
+        ['empty string', ''],
+        [null, null],
+        [undefined, undefined],
+      ])('fails for %s', (_label, value) => {
+        const result = schema.safeParse(value);
+
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(REQUIRED_MSG(''));
+      });
+    });
+
     describe('field(key).url() — optional URL', () => {
       const schema = field('myKey').url();
 

--- a/shell/utils/validators/__tests__/zod-helpers.test.ts
+++ b/shell/utils/validators/__tests__/zod-helpers.test.ts
@@ -1,4 +1,4 @@
-import { createZodHelpers } from '@shell/utils/validators/zod-helpers';
+import { zodValidators } from '@shell/utils/validators/zod-helpers';
 
 const mockT = (key: string, args?: Record<string, unknown>): string => {
   if (args) {
@@ -8,13 +8,13 @@ const mockT = (key: string, args?: Record<string, unknown>): string => {
   return key;
 };
 
-const { field } = createZodHelpers(mockT);
+const { field } = zodValidators(mockT);
 
 const REQUIRED_MSG = (fieldKey: string) => `validation.required[${ fieldKey }]`;
 const URL_MSG = (fieldKey: string) => `validation.url[${ fieldKey }]`;
 const GENERIC_URL_MSG = 'validation.genericUrl';
 
-describe('createZodHelpers', () => {
+describe('zodValidators', () => {
   describe('builder style — field(key).chain()', () => {
     describe('field(key) — optional string', () => {
       it.each([

--- a/shell/utils/validators/__tests__/zod-helpers.test.ts
+++ b/shell/utils/validators/__tests__/zod-helpers.test.ts
@@ -38,6 +38,7 @@ describe('createZodHelpers', () => {
         ['empty string', ''],
         [null, null],
         [undefined, undefined],
+        ['whitespace-only string', '   '],
       ])('fails for %s', (_label, value) => {
         const result = schema.safeParse(value);
 

--- a/shell/utils/validators/__tests__/zod-helpers.test.ts
+++ b/shell/utils/validators/__tests__/zod-helpers.test.ts
@@ -100,17 +100,6 @@ describe('zodValidators', () => {
       });
     });
 
-    describe('field(key).url(keyOverride) — key override', () => {
-      const schema = field('myKey').url('overrideKey');
-
-      it('uses the override key in the URL error message', () => {
-        const result = schema.safeParse('not-a-url');
-
-        expect(result.success).toBe(false);
-        expect(result.error?.issues[0].message).toBe(URL_MSG('overrideKey'));
-      });
-    });
-
     describe('field(key).required().url() — required URL', () => {
       const schema = field('myKey').required().url();
 
@@ -148,24 +137,6 @@ describe('zodValidators', () => {
 
         expect(result.success).toBe(false);
         expect(result.error?.issues[0].message).toBe(URL_MSG('myKey'));
-      });
-    });
-
-    describe('field(key).required(keyOverride) — key override', () => {
-      it('uses the override key in the required error message', () => {
-        const schema = field('myKey').required('overrideKey');
-        const result = schema.safeParse('');
-
-        expect(result.success).toBe(false);
-        expect(result.error?.issues[0].message).toBe(REQUIRED_MSG('overrideKey'));
-      });
-
-      it('falls back to the field key when no override is given', () => {
-        const schema = field('myKey').required();
-        const result = schema.safeParse('');
-
-        expect(result.success).toBe(false);
-        expect(result.error?.issues[0].message).toBe(REQUIRED_MSG('myKey'));
       });
     });
 

--- a/shell/utils/validators/zod-helpers.ts
+++ b/shell/utils/validators/zod-helpers.ts
@@ -41,6 +41,12 @@ export function createZodHelpers(t: I18n['t']) {
   };
 
   function buildSchema(transforms: Transform[], requiredKey?: string): ZodTypeAny {
+    // Plain optional case (field() with no chained validators). Skip the
+    // superRefine wrapper entirely since it would always be a no-op.
+    if (transforms.length === 0 && requiredKey === undefined) {
+      return z.preprocess((v) => v ?? '', z.string());
+    }
+
     // Compiled once per builder state, then reused across every superRefine call
     // (e.g. every keystroke revalidation) since none of these depend on `v`.
     const compiledTransforms = transforms.map((transform) => transform(z.string()));

--- a/shell/utils/validators/zod-helpers.ts
+++ b/shell/utils/validators/zod-helpers.ts
@@ -40,7 +40,7 @@ export type FieldBuilder = ZodTypeAny & {
   [K in keyof TransformFactories]: (...args: Parameters<TransformFactories[K]>) => FieldBuilder;
 };
 
-export function createZodHelpers(t: I18n['t']) {
+export function zodValidators(t: I18n['t']) {
   const firstIssue = (schemas: ZodTypeAny[], v: string) => {
     return schemas
       .map((schema) => schema.safeParse(v))

--- a/shell/utils/validators/zod-helpers.ts
+++ b/shell/utils/validators/zod-helpers.ts
@@ -53,7 +53,7 @@ export function zodValidators(t: I18n['t']) {
     // Plain optional case (field() with no chained validators). Skip the
     // superRefine wrapper entirely since it would always be a no-op.
     if (transforms.length === 0 && requiredKey === undefined) {
-      return z.preprocess((v) => v ?? '', z.string());
+      return z.preprocess((v) => (v ?? '').toString(), z.string());
     }
 
     // Compiled once per builder state, then reused across every superRefine call
@@ -62,7 +62,7 @@ export function zodValidators(t: I18n['t']) {
     const requiredSchema = requiredKey !== undefined ? z.string().refine((val) => val.trim().length > 0, t('validation.required', { key: t(requiredKey) })) : undefined;
 
     return z.preprocess(
-      (v) => v ?? '',
+      (v) => (v ?? '').toString(),
       z.string().superRefine((v: string, ctx) => {
         const requiredResult = requiredSchema?.safeParse(v);
         const hasIssue = requiredResult?.success === false ? requiredResult.error.issues[0] : (!v ? undefined : firstIssue(compiledTransforms, v));

--- a/shell/utils/validators/zod-helpers.ts
+++ b/shell/utils/validators/zod-helpers.ts
@@ -32,21 +32,25 @@ export type FieldBuilder = ZodTypeAny & {
 };
 
 export function createZodHelpers(t: I18n['t']) {
-  const firstIssue = (transforms: Transform[], v: string) => {
-    return transforms
-      .map((transform) => transform(z.string()).safeParse(v))
+  const firstIssue = (schemas: ZodTypeAny[], v: string) => {
+    return schemas
+      .map((schema) => schema.safeParse(v))
       .find((result) => !result.success)
       ?.error
       .issues[0];
   };
 
   function buildSchema(transforms: Transform[], requiredKey?: string): ZodTypeAny {
+    // Compiled once per builder state, then reused across every superRefine call
+    // (e.g. every keystroke revalidation) since none of these depend on `v`.
+    const compiledTransforms = transforms.map((transform) => transform(z.string()));
+    const requiredSchema = requiredKey !== undefined ? z.string().refine((val) => val.trim().length > 0, t('validation.required', { key: t(requiredKey) })) : undefined;
+
     return z.preprocess(
       (v) => v ?? '',
       z.string().superRefine((v: string, ctx) => {
-        const requiredResult = requiredKey !== undefined ? z.string().refine((val) => val.trim().length > 0, t('validation.required', { key: t(requiredKey) })).safeParse(v) : undefined;
-
-        const hasIssue = requiredResult?.success === false ? requiredResult.error.issues[0] : (!v ? undefined : firstIssue(transforms, v));
+        const requiredResult = requiredSchema?.safeParse(v);
+        const hasIssue = requiredResult?.success === false ? requiredResult.error.issues[0] : (!v ? undefined : firstIssue(compiledTransforms, v));
 
         if (hasIssue) {
           ctx.addIssue(hasIssue);

--- a/shell/utils/validators/zod-helpers.ts
+++ b/shell/utils/validators/zod-helpers.ts
@@ -4,21 +4,22 @@ import type { I18n } from '@shell/composables/useI18n';
 
 export type Transform = (schema: ZodString) => ZodTypeAny;
 
-// Erased view of a transform factory used only when iterating the registry
-// below - individual factories keep their real parameter types via
-// TransformFactories/FieldBuilder.
+// Untyped alias used for iterating factories; callers see the real signatures
+// through FieldBuilder.
 type TransformFactory = (...args: any[]) => Transform;
 
-// Factories for validators that simply append a Transform to a field's
-// pipeline. Each closes over the field's own key so it can default messages to
-// it (e.g. url's keyOverride || fieldKey || undefined). Add new transform-style
+// Factories for validators that append a Transform to a field's pipeline. Each
+// closes over the field's own key so it can default messages to it (e.g. url's
+// keyOverride || fieldKey || undefined). Add new transform-style
 // validators here. FieldBuilder and makeBuilder pick them up automatically.
 function createTransformFactories(t: I18n['t'], fieldKey: string) {
+  const key = (override?: string) => override || fieldKey;
+
   return {
     url: (keyOverride?: string): Transform => {
-      const key = keyOverride || fieldKey || undefined;
+      const k = key(keyOverride) || undefined;
 
-      return (s) => s.url(key ? t('validation.url', { key: t(key) }) : t('validation.genericUrl'));
+      return (s) => s.url(k ? t('validation.url', { key: t(k) }) : t('validation.genericUrl'));
     },
   };
 }
@@ -56,8 +57,9 @@ export function zodValidators(t: I18n['t']) {
       return z.preprocess((v) => (v ?? '').toString(), z.string());
     }
 
-    // Compiled once per builder state, then reused across every superRefine call
-    // (e.g. every keystroke revalidation) since none of these depend on `v`.
+    // Compiled once per builder state, then reused across every superRefine
+    // call (e.g. every keystroke revalidation) since none of these depend on
+    // `v`.
     const compiledTransforms = transforms.map((transform) => transform(z.string()));
     const requiredSchema = requiredKey !== undefined ? z.string().refine((val) => val.trim().length > 0, t('validation.required', { key: t(requiredKey) })) : undefined;
 

--- a/shell/utils/validators/zod-helpers.ts
+++ b/shell/utils/validators/zod-helpers.ts
@@ -1,0 +1,52 @@
+import * as z from 'zod';
+import type { ZodString, ZodTypeAny } from 'zod';
+import type { I18n } from '@shell/composables/useI18n';
+
+export type Transform = (schema: ZodString) => ZodTypeAny;
+
+export type FieldBuilder = ZodTypeAny & {
+  url(): FieldBuilder;
+  required(keyOverride?: string): FieldBuilder;
+};
+
+export function createZodHelpers(t: I18n['t']) {
+  const url: Transform = (s) => s.url(t('validation.genericUrl'));
+
+  const firstIssue = (transforms: Transform[], v: string) => {
+    return transforms
+      .map((transform) => transform(z.string()).safeParse(v))
+      .find((result) => !result.success)
+      ?.error
+      .issues[0];
+  };
+
+  function buildSchema(transforms: Transform[], requiredKey?: string): ZodTypeAny {
+    return z.preprocess(
+      (v) => v ?? '',
+      z.string().superRefine((v: string, ctx) => {
+        const requiredResult = requiredKey ? z.string().min(1, t('validation.required', { key: t(requiredKey) })).safeParse(v) : undefined;
+
+        const hasIssue = requiredResult?.success === false ? requiredResult.error.issues[0] : (!v ? undefined : firstIssue(transforms, v));
+
+        if (hasIssue) {
+          ctx.addIssue(hasIssue);
+        }
+      })
+    );
+  }
+
+  function makeBuilder(key: string, transforms: Transform[], requiredKey?: string): FieldBuilder {
+    const schema = buildSchema(transforms, requiredKey) as FieldBuilder;
+
+    schema.url = () => makeBuilder(key, [...transforms, url], requiredKey);
+    schema.required = (keyOverride?: string) => makeBuilder(key, transforms, keyOverride ?? key);
+
+    return schema;
+  }
+
+  function field(key = ''): FieldBuilder {
+    return makeBuilder(key, []);
+  }
+
+  return { field };
+}

--- a/shell/utils/validators/zod-helpers.ts
+++ b/shell/utils/validators/zod-helpers.ts
@@ -25,6 +25,15 @@ function createTransformFactories(t: I18n['t'], fieldKey: string) {
 
 type TransformFactories = ReturnType<typeof createTransformFactories>;
 
+// NOTE: builder methods (required, url, and anything added to
+// createTransformFactories) must be the last calls in a chain. Each is
+// implemented by bolting extra methods onto a real Zod schema instance, so
+// chaining a genuine ZodTypeAny method afterwards (.refine(), .optional(),
+// .transform(), etc.) returns a plain Zod schema without these extras - any
+// further .required()/.url() calls on that result will be undefined at
+// runtime. If a field needs that kind of composition, apply it to the
+// resulting z.object({...}) shape as a whole, or add a transform-style
+// validator to createTransformFactories instead.
 export type FieldBuilder = ZodTypeAny & {
   required(keyOverride?: string): FieldBuilder;
 } & {

--- a/shell/utils/validators/zod-helpers.ts
+++ b/shell/utils/validators/zod-helpers.ts
@@ -4,14 +4,34 @@ import type { I18n } from '@shell/composables/useI18n';
 
 export type Transform = (schema: ZodString) => ZodTypeAny;
 
+// Erased view of a transform factory used only when iterating the registry
+// below - individual factories keep their real parameter types via
+// TransformFactories/FieldBuilder.
+type TransformFactory = (...args: any[]) => Transform;
+
+// Factories for validators that simply append a Transform to a field's
+// pipeline. Each closes over the field's own key so it can default messages to
+// it (e.g. url's keyOverride || fieldKey || undefined). Add new transform-style
+// validators here. FieldBuilder and makeBuilder pick them up automatically.
+function createTransformFactories(t: I18n['t'], fieldKey: string) {
+  return {
+    url: (keyOverride?: string): Transform => {
+      const key = keyOverride || fieldKey || undefined;
+
+      return (s) => s.url(key ? t('validation.url', { key: t(key) }) : t('validation.genericUrl'));
+    },
+  };
+}
+
+type TransformFactories = ReturnType<typeof createTransformFactories>;
+
 export type FieldBuilder = ZodTypeAny & {
-  url(): FieldBuilder;
   required(keyOverride?: string): FieldBuilder;
+} & {
+  [K in keyof TransformFactories]: (...args: Parameters<TransformFactories[K]>) => FieldBuilder;
 };
 
 export function createZodHelpers(t: I18n['t']) {
-  const url: Transform = (s) => s.url(t('validation.genericUrl'));
-
   const firstIssue = (transforms: Transform[], v: string) => {
     return transforms
       .map((transform) => transform(z.string()).safeParse(v))
@@ -36,12 +56,19 @@ export function createZodHelpers(t: I18n['t']) {
   }
 
   function makeBuilder(key: string, transforms: Transform[], requiredKey?: string): FieldBuilder {
-    const schema = buildSchema(transforms, requiredKey) as FieldBuilder;
+    const schema = buildSchema(transforms, requiredKey);
+    const factories = Object.entries(createTransformFactories(t, key)) as [string, TransformFactory][];
 
-    schema.url = () => makeBuilder(key, [...transforms, url], requiredKey);
-    schema.required = (keyOverride?: string) => makeBuilder(key, transforms, keyOverride ?? key);
+    const transformMethods = Object.fromEntries(factories.map(([name, factory]) => [
+      name,
+      (...args: unknown[]) => makeBuilder(key, [...transforms, factory(...args)], requiredKey),
+    ]));
 
-    return schema;
+    return Object.assign(
+      schema,
+      transformMethods,
+      { required: (keyOverride?: string) => makeBuilder(key, transforms, keyOverride ?? key) }
+    ) as unknown as FieldBuilder;
   }
 
   function field(key = ''): FieldBuilder {

--- a/shell/utils/validators/zod-helpers.ts
+++ b/shell/utils/validators/zod-helpers.ts
@@ -44,7 +44,7 @@ export function createZodHelpers(t: I18n['t']) {
     return z.preprocess(
       (v) => v ?? '',
       z.string().superRefine((v: string, ctx) => {
-        const requiredResult = requiredKey ? z.string().min(1, t('validation.required', { key: t(requiredKey) })).safeParse(v) : undefined;
+        const requiredResult = requiredKey !== undefined ? z.string().min(1, t('validation.required', { key: t(requiredKey) })).safeParse(v) : undefined;
 
         const hasIssue = requiredResult?.success === false ? requiredResult.error.issues[0] : (!v ? undefined : firstIssue(transforms, v));
 

--- a/shell/utils/validators/zod-helpers.ts
+++ b/shell/utils/validators/zod-helpers.ts
@@ -44,7 +44,7 @@ export function createZodHelpers(t: I18n['t']) {
     return z.preprocess(
       (v) => v ?? '',
       z.string().superRefine((v: string, ctx) => {
-        const requiredResult = requiredKey !== undefined ? z.string().min(1, t('validation.required', { key: t(requiredKey) })).safeParse(v) : undefined;
+        const requiredResult = requiredKey !== undefined ? z.string().refine((val) => val.trim().length > 0, t('validation.required', { key: t(requiredKey) })).safeParse(v) : undefined;
 
         const hasIssue = requiredResult?.success === false ? requiredResult.error.issues[0] : (!v ? undefined : firstIssue(transforms, v));
 

--- a/shell/utils/validators/zod-helpers.ts
+++ b/shell/utils/validators/zod-helpers.ts
@@ -9,17 +9,16 @@ export type Transform = (schema: ZodString) => ZodTypeAny;
 type TransformFactory = (...args: any[]) => Transform;
 
 // Factories for validators that append a Transform to a field's pipeline. Each
-// closes over the field's own key so it can default messages to it (e.g. url's
-// keyOverride || fieldKey || undefined). Add new transform-style
-// validators here. FieldBuilder and makeBuilder pick them up automatically.
+// closes over the field's own key so its message names the field it belongs to,
+// falling back to a generic message when the field has no key. Add new
+// transform-style validators here. FieldBuilder and makeBuilder pick them up
+// automatically. Validators must not accept a key override - a message that
+// needs to read differently for a given field warrants its own translation key,
+// not a different key passed at the call site.
 function createTransformFactories(t: I18n['t'], fieldKey: string) {
-  const key = (override?: string) => override || fieldKey;
-
   return {
-    url: (keyOverride?: string): Transform => {
-      const k = key(keyOverride) || undefined;
-
-      return (s) => s.url(k ? t('validation.url', { key: t(k) }) : t('validation.genericUrl'));
+    url: (): Transform => {
+      return (s) => s.url(fieldKey ? t('validation.url', { key: t(fieldKey) }) : t('validation.genericUrl'));
     },
   };
 }
@@ -36,7 +35,7 @@ type TransformFactories = ReturnType<typeof createTransformFactories>;
 // resulting z.object({...}) shape as a whole, or add a transform-style
 // validator to createTransformFactories instead.
 export type FieldBuilder = ZodTypeAny & {
-  required(keyOverride?: string): FieldBuilder;
+  required(): FieldBuilder;
 } & {
   [K in keyof TransformFactories]: (...args: Parameters<TransformFactories[K]>) => FieldBuilder;
 };
@@ -50,10 +49,10 @@ export function zodValidators(t: I18n['t']) {
       .issues[0];
   };
 
-  function buildSchema(transforms: Transform[], requiredKey?: string): ZodTypeAny {
+  function buildSchema(key: string, transforms: Transform[], isRequired: boolean): ZodTypeAny {
     // Plain optional case (field() with no chained validators). Skip the
     // superRefine wrapper entirely since it would always be a no-op.
-    if (transforms.length === 0 && requiredKey === undefined) {
+    if (transforms.length === 0 && !isRequired) {
       return z.preprocess((v) => (v ?? '').toString(), z.string());
     }
 
@@ -61,7 +60,7 @@ export function zodValidators(t: I18n['t']) {
     // call (e.g. every keystroke revalidation) since none of these depend on
     // `v`.
     const compiledTransforms = transforms.map((transform) => transform(z.string()));
-    const requiredSchema = requiredKey !== undefined ? z.string().refine((val) => val.trim().length > 0, t('validation.required', { key: t(requiredKey) })) : undefined;
+    const requiredSchema = isRequired ? z.string().refine((val) => val.trim().length > 0, t('validation.required', { key: t(key) })) : undefined;
 
     return z.preprocess(
       (v) => (v ?? '').toString(),
@@ -76,24 +75,24 @@ export function zodValidators(t: I18n['t']) {
     );
   }
 
-  function makeBuilder(key: string, transforms: Transform[], requiredKey?: string): FieldBuilder {
-    const schema = buildSchema(transforms, requiredKey);
+  function makeBuilder(key: string, transforms: Transform[], isRequired: boolean): FieldBuilder {
+    const schema = buildSchema(key, transforms, isRequired);
     const factories = Object.entries(createTransformFactories(t, key)) as [string, TransformFactory][];
 
     const transformMethods = Object.fromEntries(factories.map(([name, factory]) => [
       name,
-      (...args: unknown[]) => makeBuilder(key, [...transforms, factory(...args)], requiredKey),
+      (...args: unknown[]) => makeBuilder(key, [...transforms, factory(...args)], isRequired),
     ]));
 
     return Object.assign(
       schema,
       transformMethods,
-      { required: (keyOverride?: string) => makeBuilder(key, transforms, keyOverride ?? key) }
+      { required: () => makeBuilder(key, transforms, true) }
     ) as unknown as FieldBuilder;
   }
 
   function field(key = ''): FieldBuilder {
-    return makeBuilder(key, []);
+    return makeBuilder(key, [], false);
   }
 
   return { field };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds a new zod helpers utility to reduce the amount of boilerplate/duplication for common validators.

Fixes #18020
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Create zod helpers to assist with common validators
- Simplify creation of new validation with factory for transforms
- Ensure that required triggers when no key exists
- Ensure whitespace fails validation
- Move building of schema outside of `superRefine()`
- Short-circuit optional fields with no validators
- Add note about util usage with chaining zod methods
- Rename `createZodHelpers()` to `zodValidators()`
- Migrate ldap and saml forms to option-chaining pattern
- Fix failing unit tests
- Clean up key overrides and comments

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This only implements `url()` at the moment. The intent is that we can add more validations as we work on migrating/adding validation to other forms. The end result would be something like this:

```
const { field } = zodValidators(t);

toTypedSchema(
  z.object({
    inputToValidate: field('my.translation.key').required().url().min(4).endHyphen(),
  })
);
```

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

This will impact existing validations for the Auth Provider forms. Ensure that they still behave the same as they did before this change.  

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

The Auth Provider forms.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA - there's no real visual changes represented here; this only affects the underlying validation patterns.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
