### PR TITLE
Expand inline object properties in kubectl-explain panel

### DIFF
--- a/pkg/kubectl-explain/__tests__/ExplainPanel.test.ts
+++ b/pkg/kubectl-explain/__tests__/ExplainPanel.test.ts
@@ -1,0 +1,66 @@
+import { shallowMount } from '@vue/test-utils';
+import ExplainPanel from '@pkg/kubectl-explain/components/ExplainPanel.vue';
+
+const podDefinition = {
+  properties: {
+    kind: { type: 'string' },
+    spec: {
+      $refName: 'io.k8s.api.core.v1.PodSpec',
+      $$ref:    { properties: { containers: { type: 'array' } } },
+    },
+  },
+};
+
+const deploymentDefinition = {
+  properties: {
+    kind: { type: 'string' },
+    spec: {
+      $refName: 'io.k8s.api.apps.v1.DeploymentSpec',
+      $$ref:    { properties: { replicas: { type: 'integer' } } },
+    },
+  },
+};
+
+// `data()` types `expanded` as an empty object, so reach for it through `any`.
+const mountPanel = (definition: any, expandAll = false): any => shallowMount(ExplainPanel, { props: { definition, expandAll } });
+
+describe('component: ExplainPanel', () => {
+  it('expands and collapses a field on demand', () => {
+    const wrapper = mountPanel(podDefinition);
+
+    wrapper.vm.expand('spec');
+    expect(wrapper.vm.expanded.spec).toBe(true);
+
+    wrapper.vm.expand('spec');
+    expect(wrapper.vm.expanded.spec).toBe(false);
+  });
+
+  it('collapses expanded fields when a different definition is shown', async() => {
+    const wrapper = mountPanel(podDefinition);
+
+    wrapper.vm.expand('spec');
+    expect(wrapper.vm.expanded.spec).toBe(true);
+
+    // Expansion is keyed by field name, so Pod's open 'spec' would otherwise
+    // leave Deployment's 'spec' open too.
+    await wrapper.setProps({ definition: deploymentDefinition });
+
+    expect(wrapper.vm.expanded).toStrictEqual({});
+  });
+
+  it('expands every expandable field when mounted with expandAll', () => {
+    const wrapper = mountPanel(podDefinition, true);
+
+    expect(wrapper.vm.expanded).toStrictEqual({ spec: true });
+  });
+
+  it('expands and collapses every expandable field when expandAll is toggled', async() => {
+    const wrapper = mountPanel(podDefinition);
+
+    await wrapper.setProps({ expandAll: true });
+    expect(wrapper.vm.expanded).toStrictEqual({ spec: true });
+
+    await wrapper.setProps({ expandAll: false });
+    expect(wrapper.vm.expanded).toStrictEqual({ spec: false });
+  });
+});

--- a/pkg/kubectl-explain/__tests__/ExplainPanel.test.ts
+++ b/pkg/kubectl-explain/__tests__/ExplainPanel.test.ts
@@ -21,8 +21,15 @@ const deploymentDefinition = {
   },
 };
 
+const POD_ID = 'io.k8s.api.core.v1.Pod';
+const DEPLOYMENT_ID = 'io.k8s.api.apps.v1.Deployment';
+
 // `data()` types `expanded` as an empty object, so reach for it through `any`.
-const mountPanel = (definition: any, expandAll = false): any => shallowMount(ExplainPanel, { props: { definition, expandAll } });
+const mountPanel = (definition: any, expandAll = false, definitionId = POD_ID): any => shallowMount(ExplainPanel, {
+  props: {
+    definition, expandAll, definitionId
+  }
+});
 
 describe('component: ExplainPanel', () => {
   it('expands and collapses a field on demand', () => {
@@ -35,7 +42,7 @@ describe('component: ExplainPanel', () => {
     expect(wrapper.vm.expanded.spec).toBe(false);
   });
 
-  it('collapses expanded fields when a different definition is shown', async() => {
+  it('collapses expanded fields when a different type is shown', async() => {
     const wrapper = mountPanel(podDefinition);
 
     wrapper.vm.expand('spec');
@@ -43,9 +50,29 @@ describe('component: ExplainPanel', () => {
 
     // Expansion is keyed by field name, so Pod's open 'spec' would otherwise
     // leave Deployment's 'spec' open too.
-    await wrapper.setProps({ definition: deploymentDefinition });
+    await wrapper.setProps({ definition: deploymentDefinition, definitionId: DEPLOYMENT_ID });
 
     expect(wrapper.vm.expanded).toStrictEqual({});
+  });
+
+  it('keeps expanded fields when the same type is rebuilt', async() => {
+    const wrapper = mountPanel(podDefinition);
+
+    wrapper.vm.expand('spec');
+
+    // Navigating re-runs expandOpenAPIDefinition, which rebuilds every
+    // definition object. Same type, so the user's expansion should survive.
+    await wrapper.setProps({ definition: JSON.parse(JSON.stringify(podDefinition)) });
+
+    expect(wrapper.vm.expanded.spec).toBe(true);
+  });
+
+  it('names inline types by position and named types by their ref', () => {
+    const wrapper = mountPanel(podDefinition);
+
+    expect(wrapper.vm.fieldTypeId({ name: 'spec', $refName: 'io.k8s.api.core.v1.PodSpec' }))
+      .toStrictEqual('io.k8s.api.core.v1.PodSpec');
+    expect(wrapper.vm.fieldTypeId({ name: 'spec' })).toStrictEqual(`${ POD_ID }.spec`);
   });
 
   it('expands every expandable field when mounted with expandAll', () => {

--- a/pkg/kubectl-explain/__tests__/open-api-utils.test.ts
+++ b/pkg/kubectl-explain/__tests__/open-api-utils.test.ts
@@ -1,0 +1,200 @@
+import { expandOpenAPIDefinition, getOpenAPISchemaName, makeOpenAPIBreadcrumb } from '@pkg/kubectl-explain/open-api-utils';
+
+describe('fx: getOpenAPISchemaName', () => {
+  it('returns empty string when schema has no attributes', () => {
+    expect(getOpenAPISchemaName({})).toStrictEqual('');
+    expect(getOpenAPISchemaName(null)).toStrictEqual('');
+  });
+
+  it('builds name from core group', () => {
+    const schema = {
+      attributes: {
+        group: 'core', version: 'v1', kind: 'Service'
+      }
+    };
+
+    expect(getOpenAPISchemaName(schema)).toStrictEqual('io.k8s.api.core.v1.Service');
+  });
+
+  it('reverses dotted group names', () => {
+    const schema = {
+      attributes: {
+        group: 'cert-manager.io', version: 'v1', kind: 'Certificate'
+      }
+    };
+
+    expect(getOpenAPISchemaName(schema)).toStrictEqual('io.cert-manager.v1.Certificate');
+  });
+});
+
+describe('fx: makeOpenAPIBreadcrumb', () => {
+  it('extracts the last segment as name', () => {
+    const result = makeOpenAPIBreadcrumb('io.k8s.api.core.v1.ServiceSpec');
+
+    expect(result).toStrictEqual({ name: 'ServiceSpec', id: 'io.k8s.api.core.v1.ServiceSpec' });
+  });
+});
+
+describe('fx: expandOpenAPIDefinition', () => {
+  it('expands $ref properties using the definitions map', () => {
+    const definitions = { 'io.k8s.api.core.v1.ServiceSpec': { properties: { clusterIP: { type: 'string', description: 'IP address of the service' } } } };
+
+    const definition = {
+      properties: {
+        spec: {
+          $ref:        '#/definitions/io.k8s.api.core.v1.ServiceSpec',
+          description: 'Service spec',
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    expect(definition.properties.spec.$$ref).toBeDefined();
+    expect(definition.properties.spec.$$ref.properties.clusterIP).toBeDefined();
+    expect(definition.properties.spec.$refName).toStrictEqual('io.k8s.api.core.v1.ServiceSpec');
+    expect(definition.properties.spec.$refNameShort).toStrictEqual('ServiceSpec');
+    expect(definition.properties.spec.$breadcrumbs).toHaveLength(1);
+  });
+
+  it('warns and does not set $$ref when $ref target is missing', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const definitions = {};
+    const definition = { properties: { spec: { $ref: '#/definitions/io.k8s.missing.Type', description: 'missing' } } };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    expect(definition.properties.spec.$$ref).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('io.k8s.missing.Type'));
+
+    warnSpy.mockRestore();
+  });
+
+  it('expands inline properties on CRD-style fields (no $ref)', () => {
+    const definitions = {};
+    const definition = {
+      properties: {
+        spec: {
+          type:        'object',
+          description: 'Specification of the desired behavior.',
+          properties:  {
+            secretName: { type: 'string', description: 'Name of the secret' },
+            issuerRef:  {
+              type:       'object',
+              properties: {
+                name:  { type: 'string', description: 'Name of the issuer' },
+                kind:  { type: 'string', description: 'Kind of the issuer' },
+                group: { type: 'string', description: 'Group of the issuer' },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    const spec = definition.properties.spec;
+
+    expect(spec.$$ref).toBeDefined();
+    expect(spec.$$ref.properties.secretName).toBeDefined();
+    expect(spec.$$ref.properties.secretName.type).toStrictEqual('string');
+    expect(spec.$$ref.properties.issuerRef).toBeDefined();
+    expect(spec.$$ref.properties.issuerRef.$$ref).toBeDefined();
+    expect(spec.$$ref.properties.issuerRef.$$ref.properties.name.type).toStrictEqual('string');
+  });
+
+  it('expands inline properties inside items (array of objects)', () => {
+    const definitions = {};
+    const definition = {
+      properties: {
+        containers: {
+          type:  'array',
+          items: {
+            properties: {
+              name:  { type: 'string', description: 'Container name' },
+              image: { type: 'string', description: 'Container image' },
+            },
+          },
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    const containers = definition.properties.containers;
+
+    expect(containers.$$ref).toBeDefined();
+    expect(containers.$$ref.properties.name.type).toStrictEqual('string');
+    expect(containers.$$ref.properties.image.type).toStrictEqual('string');
+  });
+
+  it('does not set $refName or $refNameShort for inline properties', () => {
+    const definitions = {};
+    const definition = {
+      properties: {
+        spec: {
+          type:       'object',
+          properties: { field1: { type: 'string' } },
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    expect(definition.properties.spec.$$ref).toBeDefined();
+    expect(definition.properties.spec.$refName).toBeUndefined();
+    expect(definition.properties.spec.$refNameShort).toBeUndefined();
+  });
+
+  it('does not expand scalar properties without $ref or inline properties', () => {
+    const definitions = {};
+    const definition = {
+      properties: {
+        name: { type: 'string', description: 'A simple string' },
+        age:  { type: 'integer', description: 'A number' },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    expect(definition.properties.name.$$ref).toBeUndefined();
+    expect(definition.properties.age.$$ref).toBeUndefined();
+  });
+
+  it('extracts More info URLs from descriptions', () => {
+    const definitions = {};
+    const definition = {
+      properties: {
+        field: {
+          type:        'string',
+          description: 'Some description. More info: https://example.com/docs',
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    expect(definition.properties.field.$moreInfo).toStrictEqual('https://example.com/docs');
+  });
+
+  it('deeply clones inline properties so mutations do not leak', () => {
+    const definitions = {};
+    const original = { type: 'string', description: 'original' };
+    const definition = {
+      properties: {
+        spec: {
+          type:       'object',
+          properties: { inner: original },
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    definition.properties.spec.$$ref.properties.inner.description = 'mutated';
+
+    expect(original.description).toStrictEqual('original');
+  });
+});

--- a/pkg/kubectl-explain/__tests__/open-api-utils.test.ts
+++ b/pkg/kubectl-explain/__tests__/open-api-utils.test.ts
@@ -110,9 +110,11 @@ describe('fx: expandOpenAPIDefinition', () => {
     const definition: any = {
       properties: {
         containers: {
-          type:  'array',
-          items: {
-            properties: {
+          type:        'array',
+          description: 'List of containers',
+          items:       {
+            description: 'Container is a single application container',
+            properties:  {
               name:  { type: 'string', description: 'Container name' },
               image: { type: 'string', description: 'Container image' },
             },
@@ -128,6 +130,29 @@ describe('fx: expandOpenAPIDefinition', () => {
     expect(containers.$$ref).toBeDefined();
     expect(containers.$$ref.properties.name.type).toStrictEqual('string');
     expect(containers.$$ref.properties.image.type).toStrictEqual('string');
+    // The type of the items has its own description, which is shown when the field is expanded
+    expect(containers.$$ref.description).toStrictEqual('Container is a single application container');
+    // No short name, so the UI falls back to showing the field as an object
+    expect(containers.$refNameShort).toBeUndefined();
+  });
+
+  it('does not repeat the description of an inline object when it is expanded', () => {
+    const definitions = {};
+    const definition: any = {
+      properties: {
+        spec: {
+          type:        'object',
+          description: 'Specification of the desired behavior.',
+          properties:  { secretName: { type: 'string', description: 'Name of the secret' } },
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    // The description is shown for the field itself, so it must not be repeated in the expanded panel
+    expect(definition.properties.spec.description).toStrictEqual('Specification of the desired behavior.');
+    expect(definition.properties.spec.$$ref.description).toBeUndefined();
   });
 
   it('does not set $refName or $refNameShort for inline properties', () => {
@@ -177,24 +202,5 @@ describe('fx: expandOpenAPIDefinition', () => {
     expandOpenAPIDefinition(definitions, definition);
 
     expect(definition.properties.field.$moreInfo).toStrictEqual('https://example.com/docs');
-  });
-
-  it('deeply clones inline properties so mutations do not leak', () => {
-    const definitions = {};
-    const original = { type: 'string', description: 'original' };
-    const definition: any = {
-      properties: {
-        spec: {
-          type:       'object',
-          properties: { inner: original },
-        },
-      },
-    };
-
-    expandOpenAPIDefinition(definitions, definition);
-
-    definition.properties.spec.$$ref.properties.inner.description = 'mutated';
-
-    expect(original.description).toStrictEqual('original');
   });
 });

--- a/pkg/kubectl-explain/__tests__/open-api-utils.test.ts
+++ b/pkg/kubectl-explain/__tests__/open-api-utils.test.ts
@@ -1,0 +1,200 @@
+import { expandOpenAPIDefinition, getOpenAPISchemaName, makeOpenAPIBreadcrumb } from '@pkg/kubectl-explain/open-api-utils';
+
+describe('fx: getOpenAPISchemaName', () => {
+  it('returns empty string when schema has no attributes', () => {
+    expect(getOpenAPISchemaName({})).toStrictEqual('');
+    expect(getOpenAPISchemaName(null)).toStrictEqual('');
+  });
+
+  it('builds name from core group', () => {
+    const schema = {
+      attributes: {
+        group: 'core', version: 'v1', kind: 'Service'
+      }
+    };
+
+    expect(getOpenAPISchemaName(schema)).toStrictEqual('io.k8s.api.core.v1.Service');
+  });
+
+  it('reverses dotted group names', () => {
+    const schema = {
+      attributes: {
+        group: 'cert-manager.io', version: 'v1', kind: 'Certificate'
+      }
+    };
+
+    expect(getOpenAPISchemaName(schema)).toStrictEqual('io.cert-manager.v1.Certificate');
+  });
+});
+
+describe('fx: makeOpenAPIBreadcrumb', () => {
+  it('extracts the last segment as name', () => {
+    const result = makeOpenAPIBreadcrumb('io.k8s.api.core.v1.ServiceSpec');
+
+    expect(result).toStrictEqual({ name: 'ServiceSpec', id: 'io.k8s.api.core.v1.ServiceSpec' });
+  });
+});
+
+describe('fx: expandOpenAPIDefinition', () => {
+  it('expands $ref properties using the definitions map', () => {
+    const definitions = { 'io.k8s.api.core.v1.ServiceSpec': { properties: { clusterIP: { type: 'string', description: 'IP address of the service' } } } };
+
+    const definition: any = {
+      properties: {
+        spec: {
+          $ref:        '#/definitions/io.k8s.api.core.v1.ServiceSpec',
+          description: 'Service spec',
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    expect(definition.properties.spec.$$ref).toBeDefined();
+    expect(definition.properties.spec.$$ref.properties.clusterIP).toBeDefined();
+    expect(definition.properties.spec.$refName).toStrictEqual('io.k8s.api.core.v1.ServiceSpec');
+    expect(definition.properties.spec.$refNameShort).toStrictEqual('ServiceSpec');
+    expect(definition.properties.spec.$breadcrumbs).toHaveLength(1);
+  });
+
+  it('warns and does not set $$ref when $ref target is missing', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const definitions = {};
+    const definition: any = { properties: { spec: { $ref: '#/definitions/io.k8s.missing.Type', description: 'missing' } } };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    expect(definition.properties.spec.$$ref).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('io.k8s.missing.Type'));
+
+    warnSpy.mockRestore();
+  });
+
+  it('expands inline properties on CRD-style fields (no $ref)', () => {
+    const definitions = {};
+    const definition: any = {
+      properties: {
+        spec: {
+          type:        'object',
+          description: 'Specification of the desired behavior.',
+          properties:  {
+            secretName: { type: 'string', description: 'Name of the secret' },
+            issuerRef:  {
+              type:       'object',
+              properties: {
+                name:  { type: 'string', description: 'Name of the issuer' },
+                kind:  { type: 'string', description: 'Kind of the issuer' },
+                group: { type: 'string', description: 'Group of the issuer' },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    const spec = definition.properties.spec;
+
+    expect(spec.$$ref).toBeDefined();
+    expect(spec.$$ref.properties.secretName).toBeDefined();
+    expect(spec.$$ref.properties.secretName.type).toStrictEqual('string');
+    expect(spec.$$ref.properties.issuerRef).toBeDefined();
+    expect(spec.$$ref.properties.issuerRef.$$ref).toBeDefined();
+    expect(spec.$$ref.properties.issuerRef.$$ref.properties.name.type).toStrictEqual('string');
+  });
+
+  it('expands inline properties inside items (array of objects)', () => {
+    const definitions = {};
+    const definition: any = {
+      properties: {
+        containers: {
+          type:  'array',
+          items: {
+            properties: {
+              name:  { type: 'string', description: 'Container name' },
+              image: { type: 'string', description: 'Container image' },
+            },
+          },
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    const containers = definition.properties.containers;
+
+    expect(containers.$$ref).toBeDefined();
+    expect(containers.$$ref.properties.name.type).toStrictEqual('string');
+    expect(containers.$$ref.properties.image.type).toStrictEqual('string');
+  });
+
+  it('does not set $refName or $refNameShort for inline properties', () => {
+    const definitions = {};
+    const definition: any = {
+      properties: {
+        spec: {
+          type:       'object',
+          properties: { field1: { type: 'string' } },
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    expect(definition.properties.spec.$$ref).toBeDefined();
+    expect(definition.properties.spec.$refName).toBeUndefined();
+    expect(definition.properties.spec.$refNameShort).toBeUndefined();
+  });
+
+  it('does not expand scalar properties without $ref or inline properties', () => {
+    const definitions = {};
+    const definition: any = {
+      properties: {
+        name: { type: 'string', description: 'A simple string' },
+        age:  { type: 'integer', description: 'A number' },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    expect(definition.properties.name.$$ref).toBeUndefined();
+    expect(definition.properties.age.$$ref).toBeUndefined();
+  });
+
+  it('extracts More info URLs from descriptions', () => {
+    const definitions = {};
+    const definition: any = {
+      properties: {
+        field: {
+          type:        'string',
+          description: 'Some description. More info: https://example.com/docs',
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    expect(definition.properties.field.$moreInfo).toStrictEqual('https://example.com/docs');
+  });
+
+  it('deeply clones inline properties so mutations do not leak', () => {
+    const definitions = {};
+    const original = { type: 'string', description: 'original' };
+    const definition: any = {
+      properties: {
+        spec: {
+          type:       'object',
+          properties: { inner: original },
+        },
+      },
+    };
+
+    expandOpenAPIDefinition(definitions, definition);
+
+    definition.properties.spec.$$ref.properties.inner.description = 'mutated';
+
+    expect(original.description).toStrictEqual('original');
+  });
+});

--- a/pkg/kubectl-explain/components/ExplainPanel.vue
+++ b/pkg/kubectl-explain/components/ExplainPanel.vue
@@ -119,7 +119,7 @@ export default {
           </a>
         </div>
         <div
-          v-if="field.type && field.type !== 'array'"
+          v-if="field.type && field.type !== 'array' && !field.$$ref"
           class="field-type"
         >
           <div>
@@ -137,7 +137,7 @@ export default {
             []
           </span>
           <div
-            v-if="field.$refName"
+            v-if="field.$$ref"
             class="field-type field-expander"
             tabindex="0"
             role="button"
@@ -145,7 +145,7 @@ export default {
             @click="expand(field.name)"
             @keyup.enter.space="expand(field.name)"
           >
-            {{ field.$refNameShort }}
+            {{ field.$refNameShort || field.type || t('kubectl-explain.object') }}
             <i
               v-if="!expanded[field.name]"
               class="icon icon-chevron-down"
@@ -171,7 +171,7 @@ export default {
           v-model:value="field.description"
         />
         <div
-          v-if="expanded[field.name]"
+          v-if="expanded[field.name] && field.$refName"
           class="sub-name"
         >
           <a

--- a/pkg/kubectl-explain/components/ExplainPanel.vue
+++ b/pkg/kubectl-explain/components/ExplainPanel.vue
@@ -17,6 +17,14 @@ export default {
       type:     Boolean,
       required: true,
     },
+    /**
+     * Identity of the type being shown. Named types use their definition id,
+     * inline ones are identified by where they sit in the parent.
+     */
+    definitionId: {
+      type:    String,
+      default: '',
+    },
   },
 
   data() {
@@ -37,10 +45,12 @@ export default {
   },
 
   watch: {
-    // Expansion is keyed by field name, so it would otherwise carry over to the
-    // next definition shown in this panel - a Pod with 'spec' open would leave
-    // Deployment's 'spec' open too.
-    definition() {
+    // Expansion is keyed by field name, so it has to be dropped when a
+    // different type is shown - a Pod left with 'spec' open would otherwise
+    // leave Deployment's 'spec' open too. Keyed on the id rather than the
+    // definition itself because navigating rebuilds every definition object,
+    // so watching those would also collapse sections the user never closed.
+    definitionId() {
       this.expanded = {};
     },
 
@@ -77,6 +87,13 @@ export default {
      */
     expand(field) {
       this.expanded[field] = !this.expanded[field];
+    },
+    /**
+     * Identity of a field's type, for the panel that renders it. Inline types
+     * have no name of their own, so they take one from their position.
+     */
+    fieldTypeId(field) {
+      return field.$refName || `${ this.definitionId }.${ field.name }`;
     },
     /**
      * Navigate to a field type - this loads it in place of the current definition,
@@ -206,6 +223,7 @@ export default {
           v-if="expanded[field.name]"
           :expand-all="expandAll"
           :definition="field.$$ref"
+          :definition-id="fieldTypeId(field)"
           class="embedded"
           @navigate="navigate"
         />

--- a/pkg/kubectl-explain/components/ExplainPanel.vue
+++ b/pkg/kubectl-explain/components/ExplainPanel.vue
@@ -37,6 +37,13 @@ export default {
   },
 
   watch: {
+    // Expansion is keyed by field name, so it would otherwise carry over to the
+    // next definition shown in this panel - a Pod with 'spec' open would leave
+    // Deployment's 'spec' open too.
+    definition() {
+      this.expanded = {};
+    },
+
     expandAll(neu, old) {
       if (neu !== old) {
         this.fields.forEach((field) => {

--- a/pkg/kubectl-explain/components/ExplainPanel.vue
+++ b/pkg/kubectl-explain/components/ExplainPanel.vue
@@ -169,7 +169,7 @@ export default {
             @click="expand(field.name)"
             @keyup.enter.space="expand(field.name)"
           >
-            {{ field.$refNameShort || field.type || t('kubectl-explain.object') }}
+            {{ field.$refNameShort || t('kubectl-explain.object') }}
             <i
               v-if="!expanded[field.name]"
               class="icon icon-chevron-down"

--- a/pkg/kubectl-explain/components/SlideInPanel.vue
+++ b/pkg/kubectl-explain/components/SlideInPanel.vue
@@ -53,6 +53,13 @@ export default {
 
   computed: {
 
+    /**
+     * Id of the type on screen - navigate() lands on the last breadcrumb
+     */
+    definitionId() {
+      return this.breadcrumbs?.[this.breadcrumbs.length - 1]?.id || '';
+    },
+
     top() {
       const banner = document.getElementById('banner-header');
       let height = HEADER_HEIGHT;
@@ -298,6 +305,7 @@ export default {
           ref="main"
           :expand-all="expandAll"
           :definition="definition"
+          :definition-id="definitionId"
           class="explain-panel"
           @navigate="navigate"
         />

--- a/pkg/kubectl-explain/components/SlideInPanel.vue
+++ b/pkg/kubectl-explain/components/SlideInPanel.vue
@@ -178,7 +178,6 @@ export default {
 
       this.breadcrumbs = breadcrumbs;
       this.definition = this.definitions[goto.id];
-      this.expanded = {};
       this.expandAll = false;
       this.notFound = false;
 

--- a/pkg/kubectl-explain/open-api-utils.ts
+++ b/pkg/kubectl-explain/open-api-utils.ts
@@ -97,6 +97,13 @@ export function expandOpenAPIDefinition(definitions: OpenApIDefinitions, definit
       } else {
         console.warn(`Can not find definition for ${ id }`); // eslint-disable-line no-console
       }
+    } else if (!propRef) {
+      const inlineProperties = prop.properties || prop.items?.properties;
+
+      if (inlineProperties) {
+        prop.$$ref = { properties: JSON.parse(JSON.stringify(inlineProperties)) };
+        expandOpenAPIDefinition(definitions, prop.$$ref, breadcrumbs);
+      }
     }
 
     extractMoreInfo(prop);

--- a/pkg/kubectl-explain/open-api-utils.ts
+++ b/pkg/kubectl-explain/open-api-utils.ts
@@ -97,13 +97,14 @@ export function expandOpenAPIDefinition(definitions: OpenApIDefinitions, definit
       } else {
         console.warn(`Can not find definition for ${ id }`); // eslint-disable-line no-console
       }
-    } else if (!propRef) {
-      const inlineProperties = prop.properties || prop.items?.properties;
+    } else if (prop.properties || prop.items?.properties) {
+      // CRD schemas often declare object types inline, rather than referencing a definition, so use
+      // the inline schema itself as the reference - no copy is needed, as it is used in only one place
+      // For an array, the item schema is used, as it has its own description for the type of the items
+      // For an object, only the properties are used, as its description is already shown for the field itself
+      prop.$$ref = prop.items?.properties ? prop.items : { properties: prop.properties };
 
-      if (inlineProperties) {
-        prop.$$ref = { properties: JSON.parse(JSON.stringify(inlineProperties)) };
-        expandOpenAPIDefinition(definitions, prop.$$ref, breadcrumbs);
-      }
+      expandOpenAPIDefinition(definitions, prop.$$ref, breadcrumbs);
     }
 
     extractMoreInfo(prop);


### PR DESCRIPTION
### Summary
Fixes #15249

### Occurred changes and/or fixed issues
- [`open-api-utils.ts`](https://github.com/codyrancher/dashboard/blob/73b10140921a939f62992ad9d382d08dbd3c2939/pkg/kubectl-explain/open-api-utils.ts#L100-L107): expand inline schemas, not just `$ref` ones, referencing the schema so the item description survives.
- [`ExplainPanel.vue`](https://github.com/codyrancher/dashboard/blob/73b10140921a939f62992ad9d382d08dbd3c2939/pkg/kubectl-explain/components/ExplainPanel.vue#L146-L198): chevron keyed on `$$ref`, labelled `Object` when the type has no name.
- [`SlideInPanel.vue`](https://github.com/codyrancher/dashboard/blob/73b10140921a939f62992ad9d382d08dbd3c2939/pkg/kubectl-explain/components/SlideInPanel.vue#L56-L62): pass the type id, so expansion resets when the type changes.
- [`open-api-utils.test.ts`](https://github.com/codyrancher/dashboard/blob/73b10140921a939f62992ad9d382d08dbd3c2939/pkg/kubectl-explain/__tests__/open-api-utils.test.ts) and [`ExplainPanel.test.ts`](https://github.com/codyrancher/dashboard/blob/73b10140921a939f62992ad9d382d08dbd3c2939/pkg/kubectl-explain/__tests__/ExplainPanel.test.ts): inline, array-of-objects and expansion-reset coverage.

### Technical notes summary
- Built-in types point at a shared definition, so the chevron had a name. CRDs inline theirs, so an unnamed inline type is labelled `Object`.
- The inline schema is referenced, not copied: unlike a shared `$ref` definition it lives in one place, and the reference keeps the item description.

### Areas or cases that should be tested
No fixture to install. Every Rancher install already ships CRDs that hit this path, for example Fleet's GitRepo:

```
/dashboard/c/local/explorer/fleet.cattle.io.gitrepo  ->  "Explain ..." in the header
```

Correct result: `spec` has an expand chevron, and expanding it lists `targets`, `correctDrift`, `paths` and the rest with their descriptions. `targets` is an array of objects and expands again into `clusterName`, `clusterSelector`, `clusterGroup`.

- Built-in resources (Service, Pod) still show their named types, for example `ServiceSpec`, with the chevron they had before.
- A CRD nested several levels deep still expands all the way down.

```bash
npx jest --ci pkg/kubectl-explain
```

### Areas which could experience regressions
- The explain panel for every resource type, since the condition that renders the chevron changed.
- Large CRD schemas now recurse and clone where they previously stopped at the first level.

### Screenshot/Video

**Before** - a Certificate CRD: `spec` reads "object" and will not expand; a Service on the same build shows `ServiceSpec`.

![before-fix](https://github.com/codyrancher/dashboard/releases/download/issue-15249-artifacts/before-fix.png)

![before-fix-service](https://github.com/codyrancher/dashboard/releases/download/issue-15249-artifacts/before-fix-service-comparison.png)

**After** - the same Certificate, now expandable with its nested fields.

![after-fix](https://github.com/codyrancher/dashboard/releases/download/issue-15249-artifacts/after-fix.png)

![after-fix-expanded](https://github.com/codyrancher/dashboard/releases/download/issue-15249-artifacts/after-fix-expanded-fields.png)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
