### PR TITLE
Fix disabled Explore button size and styling in cluster list

### DIFF
--- a/pkg/rancher-components/src/components/RcButton/RcButton.vue
+++ b/pkg/rancher-components/src/components/RcButton/RcButton.vue
@@ -235,9 +235,12 @@ defineExpose({ focus });
     }
 
     &:disabled {
-      background: var(--primary);
-      color: var(--primary-text);
-      opacity: 0.5;
+      &, &:hover, &:focus {
+        color: var(--disabled-text);
+        background: var(--disabled-bg);
+        border-color: var(--disabled-bg);
+        cursor: not-allowed;
+      }
     }
   }
 
@@ -260,6 +263,15 @@ defineExpose({ focus });
       @include focus-outline;
       outline-offset: 2px;
     }
+
+    &:disabled {
+      &, &:hover, &:focus {
+        color: var(--disabled-text);
+        background: var(--disabled-bg);
+        border-color: var(--disabled-bg);
+        cursor: not-allowed;
+      }
+    }
   }
 
   &.variant-tertiary {
@@ -280,6 +292,15 @@ defineExpose({ focus });
     &:focus-visible {
       @include focus-outline;
       outline-offset: 2px;
+    }
+
+    &:disabled {
+      &, &:hover, &:focus {
+        color: var(--disabled-text);
+        background: var(--disabled-bg);
+        border-color: var(--disabled-bg);
+        cursor: not-allowed;
+      }
     }
   }
 

--- a/pkg/rancher-components/src/components/RcSection/RcSection.vue
+++ b/pkg/rancher-components/src/components/RcSection/RcSection.vue
@@ -231,7 +231,7 @@ button.btn-medium.toggle-button {
   flex-shrink: 0;
   font-size: 16px;
   color: var(--body-text, inherit);
-  padding: 0;
+  --rc-button-padding: 0;
   min-height: initial;
 }
 

--- a/pkg/rancher-components/src/components/RcSection/RcSection.vue
+++ b/pkg/rancher-components/src/components/RcSection/RcSection.vue
@@ -227,11 +227,12 @@ function toggle() {
   color: var(--body-text, inherit);
 }
 
-button.btn-medium.toggle-button {
+// TODO: Considering removing specificity override when RcButton sizes are refactored (#18062)
+.left-wrapper :deep(button.toggle-button.btn-medium:not(.btn-sm)) {
   flex-shrink: 0;
   font-size: 16px;
   color: var(--body-text, inherit);
-  --rc-button-padding: 0;
+  padding: 0;
   min-height: initial;
 }
 

--- a/shell/list/provisioning.cattle.io.cluster.vue
+++ b/shell/list/provisioning.cattle.io.cluster.vue
@@ -343,14 +343,14 @@ export default {
           >
             {{ t('cluster.explore') }}
           </rc-button>
-          <button
+          <rc-button
             v-else
+            variant="secondary"
             data-testid="cluster-manager-list-explore"
             :disabled="true"
-            class="btn btn-sm role-secondary"
           >
             {{ t('cluster.explore') }}
-          </button>
+          </rc-button>
         </template>
       </PaginatedResourceTable>
     </template>

--- a/storybook/src/stories/Components/RcButton.mdx
+++ b/storybook/src/stories/Components/RcButton.mdx
@@ -17,6 +17,12 @@ Different button variants for different purposes and visual hierarchy:
 
 <Canvas of={RcButtonStories.AllVariants} />
 
+## Disabled Variants
+
+Each variant in its disabled state. All variants share the same muted colors when disabled:
+
+<Canvas of={RcButtonStories.DisabledVariants} />
+
 ## As Router Link
 
 When the `to` prop is provided, RcButton renders as an `<a>` tag (via Vue Router's `<RouterLink>`) instead of a `<button>`.

--- a/storybook/src/stories/Components/RcButton.stories.ts
+++ b/storybook/src/stories/Components/RcButton.stories.ts
@@ -26,6 +26,10 @@ const meta: Meta<typeof RcButton> = {
       control:     { type: 'select' },
       description: 'Icon to display on the right side of the button text.'
     },
+    disabled: {
+      control:     { type: 'boolean' },
+      description: 'When true, the button is visually muted and non-interactive.'
+    },
     to: {
       control:     { type: 'text' },
       description: 'When provided, renders the button as a RouterLink for client-side navigation instead of a plain button element.'
@@ -45,8 +49,9 @@ export const Default: Story = {
     template: '<RcButton v-bind="args">Button Text</RcButton>',
   }),
   args: {
-    variant: 'primary',
-    size:    'medium',
+    variant:  'primary',
+    size:     'medium',
+    disabled: false,
   },
 };
 

--- a/storybook/src/stories/Components/RcButton.stories.ts
+++ b/storybook/src/stories/Components/RcButton.stories.ts
@@ -86,6 +86,37 @@ export const AllVariants: Story = {
   },
 };
 
+export const DisabledVariants: Story = {
+  render: () => ({
+    components: { RcButton },
+    setup() {
+      const variants: ButtonVariant[] = ['primary', 'secondary', 'tertiary', 'link', 'multiAction', 'ghost'];
+
+      return { variants };
+    },
+    template: `<div style="display: flex; flex-direction: column; gap: 20px; max-width: 800px;">
+      <div v-for="variant in variants" :key="variant" style="display: flex; align-items: center; gap: 20px;">
+        <div style="min-width: 120px; font-weight: bold;">{{ variant }}</div>
+        <RcButton :variant="variant" size="medium" :disabled="true">{{ variant }}</RcButton>
+      </div>
+    </div>`,
+  }),
+  parameters: {
+    controls: { disabled: true },
+    docs:     {
+      source: {
+        code: `<RcButton variant="primary" :disabled="true">Primary</RcButton>
+<RcButton variant="secondary" :disabled="true">Secondary</RcButton>
+<RcButton variant="tertiary" :disabled="true">Tertiary</RcButton>
+<RcButton variant="link" :disabled="true">Link</RcButton>
+<RcButton variant="multiAction" :disabled="true">MultiAction</RcButton>
+<RcButton variant="ghost" :disabled="true">Ghost</RcButton>`,
+        language: 'html',
+      }
+    }
+  },
+};
+
 export const AsRouterLink: Story = {
   render: () => ({
     components: { RcButton },


### PR DESCRIPTION
### Summary

- The disabled Explore button on pending clusters used a legacy `<button class="btn btn-sm">` instead of `<rc-button>`, causing a size mismatch. The disabled state also kept blue text and responded to hover.
  - We still have many other places that need to be converted to rc-button and I didn't see an issue so I opened this to track. https://github.com/rancher/dashboard/issues/18062
- The RcSection toggle button had extra horizontal padding because `padding: 0` was overridden by `.btn-medium`'s higher-specificity rule.

### Changes

- Use `<rc-button variant="secondary" :disabled="true">` for the disabled Explore button in the cluster list
- Add consistent `:disabled` styles to the primary, secondary, and tertiary RcButton variants (uses `--disabled-text` / `--disabled-bg`, suppresses hover/focus)
- Add a `disabled` boolean control to the RcButton Storybook story
- Add a DisabledVariants story showing all variants in their disabled state
- Use `:deep()` specificity override in RcSection toggle button to zero out `.btn-medium` padding

### Screenshot/Video

**Explore button (cluster list)**

![explore-comparison](https://github.com/codyrancher/dashboard/releases/download/issue-explore-button-artifacts/comparison-final.png)

**RcSection toggle button padding**

![rcsection-comparison](https://github.com/codyrancher/dashboard/releases/download/issue-explore-button-artifacts/rcsection-comparison.png)

### Areas or cases that should be tested

- Cluster Management list with Active and Pending clusters
- Hover over the disabled Explore button (should not change color)
- RcButton disabled state across primary, secondary, tertiary variants
- RcSection expandable sections (toggle button should have no extra padding)

### Areas which could experience regressions

- Any page using disabled `RcButton variant="primary"` (visual change from opacity to disabled-bg)
- Expandable RcSection header alignment

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`