### PR TITLE
Set accessMode to required after enabling auth provider

### DIFF
--- a/shell/mixins/__tests__/auth-config.test.ts
+++ b/shell/mixins/__tests__/auth-config.test.ts
@@ -69,4 +69,94 @@ describe('mixin: authConfigMixin', () => {
       expect(instance.model.scope).toStrictEqual(scope);
     });
   });
+
+  describe('accessMode on enable', () => {
+    const FakeComponent = {
+      render() {},
+      mixins:  [authConfigMixin, childHook],
+      methods: { applyHooks: jest.fn() },
+    };
+
+    const createMock = (model: any, overrides: Record<string, any> = {}) => ({
+      data: () => ({
+        value: { configType: 'oidc' },
+        model,
+        ...overrides,
+      }),
+      computed: { principal: () => ({ me: {} }) },
+      global:   {
+        mocks: {
+          $store: { dispatch: () => model },
+          $route: {
+            params: { id: model.id || '123' },
+            query:  { mode: 'edit' },
+          },
+        }
+      }
+    });
+
+    it.each([
+      'github',
+      'githubapp',
+    ])('should default accessMode to restricted for %s on enable', async(id) => {
+      const model = {
+        id,
+        enabled:        false,
+        authConfigName: 'whatever',
+        doAction:       jest.fn(),
+        save:           jest.fn(),
+      };
+      const instance = mount(FakeComponent, createMock(model)).vm as any;
+
+      await instance.save(jest.fn());
+
+      expect(model.save).toHaveBeenCalled();
+      expect(instance.model.accessMode).toStrictEqual('required');
+    });
+
+    it('should default accessMode to unrestricted for non-github oauth on enable', async() => {
+      const model = {
+        id:             'googleoauth',
+        enabled:        false,
+        authConfigName: 'whatever',
+        doAction:       jest.fn(),
+        save:           jest.fn(),
+      };
+      const instance = mount(FakeComponent, createMock(model)).vm as any;
+
+      await instance.save(jest.fn());
+
+      expect(instance.model.accessMode).toStrictEqual('required');
+    });
+
+    it('should set accessMode to required after enabling a provider', async() => {
+      const model = {
+        enabled:        false,
+        accessMode:     'unrestricted',
+        authConfigName: 'whatever',
+        doAction:       jest.fn(),
+        save:           async() => {}
+      };
+      const instance = mount(FakeComponent, createMock(model)).vm as any;
+
+      await instance.save(jest.fn());
+
+      expect(instance.model.accessMode).toStrictEqual('required');
+    });
+
+    it('should not change accessMode when editing an already enabled provider', async() => {
+      const model = {
+        enabled:        true,
+        accessMode:     'unrestricted',
+        authConfigName: 'whatever',
+        doAction:       jest.fn(),
+        save:           async() => {}
+      };
+      const instance = mount(FakeComponent, createMock(model, { editConfig: true })).vm as any;
+
+      await instance.save(jest.fn());
+
+      expect(instance.model.accessMode).toStrictEqual('unrestricted');
+    });
+  });
 });

--- a/shell/mixins/auth-config.js
+++ b/shell/mixins/auth-config.js
@@ -201,6 +201,9 @@ export default {
             if (!this.model.accessMode) {
               this.model.accessMode = 'unrestricted';
             }
+            if (this.model.id === 'github' || this.model.id === 'githubapp') {
+              this.model.accessMode = 'restricted';
+            }
             await this.model.doAction('testAndApply', obj, { redirectUnauthorized: false });
           }
 
@@ -240,6 +243,10 @@ export default {
             this.$store.dispatch('auth/loggedInAs', this.principal.id);
           } else {
             console.warn(`Unable to find principal marked as 'me'`); // eslint-disable-line no-console
+          }
+
+          if (!wasEnabled) {
+            this.model.accessMode = 'required';
           }
         }
         if (wasEnabled && configType === 'oauth') {


### PR DESCRIPTION
### Summary
Fixes #17151

### Occurred changes and/or fixed issues
- When enabling any auth provider for the first time, `accessMode` is now set to `required` after the admin user is added to `allowedPrincipalIds`.
- GitHub and GitHubApp providers default to `restricted` before `testAndApply` (all others default to `unrestricted`).
- Editing an already-enabled provider does not change `accessMode`.

### Technical notes summary
The `accessMode` is set to `required` after `allowedPrincipalIds` is populated (not before) so the admin user is guaranteed to be in the allowed list before access is restricted.

### Areas or cases that should be tested
- Enable GitHub auth provider: verify accessMode becomes `required` and admin user is in the allowed list.
- Enable any other provider (OIDC, SAML/Ping, Google, etc.): same result.
- Edit an already-enabled provider: verify accessMode is not changed.

### Areas which could experience regressions
- Auth provider enable flow for all provider types.
- Access control behavior after enabling a provider.

### Screenshot/Video

https://github.com/user-attachments/assets/73258c04-43d5-4d41-9491-6127ae8c3a12

https://github.com/user-attachments/assets/498d5e3d-e4b1-4ba5-801a-f82aa56104b6

https://github.com/user-attachments/assets/9a7282fe-dfdd-4a3d-aacf-26d52b282f76





### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`