### PR TITLE
Remove `toRef()` when setting the namespace value with `forceNamespace`

### DIFF
--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -310,8 +310,8 @@ export default {
 
     if (props.namespaced) {
       if (props.forceNamespace) {
-        namespace.value = toRef(props.forceNamespace);
-        updateNamespace(namespace);
+        namespace.value = props.forceNamespace;
+        updateNamespace(namespace.value);
       } else if (props.namespaceKey) {
         namespace.value = get(v.value, props.namespaceKey);
       } else {
@@ -321,7 +321,7 @@ export default {
       if (!namespace.value && !props.noDefaultNamespace) {
         namespace.value = store.getters['defaultNamespace'];
         if (metadata) {
-          metadata.namespace = namespace;
+          metadata.namespace = namespace.value;
         }
       }
     }

--- a/shell/components/form/__tests__/NameNsDescription.test.ts
+++ b/shell/components/form/__tests__/NameNsDescription.test.ts
@@ -170,6 +170,81 @@ describe('component: NameNsDescription', () => {
     expect(nameInput.element.value).toBe('Default');
   });
 
+  it('should set namespace to a plain string when forceNamespace prop is provided', () => {
+    const forcedNs = 'cert-manager';
+    const store = createStore({
+      getters: {
+        allowedNamespaces:   () => () => ({}),
+        currentStore:        () => () => 'cluster',
+        'cluster/schemaFor': () => jest.fn()
+      }
+    });
+
+    const wrapper = mount(NameNsDescription, {
+      props: {
+        value: {
+          setAnnotation: jest.fn(),
+          metadata:      { namespace: '' }
+        },
+        mode:           'create',
+        forceNamespace: forcedNs,
+      },
+      global: {
+        provide: { store },
+        mocks:   {
+          $store: {
+            dispatch: jest.fn(),
+            getters:  {
+              namespaces: jest.fn(),
+              'i18n/t':   jest.fn(),
+            },
+          },
+        },
+      },
+    });
+
+    expect(typeof (wrapper.vm as any).namespace).toBe('string');
+    expect((wrapper.vm as any).namespace).toBe(forcedNs);
+  });
+
+  it('should set metadata.namespace to a plain string when falling back to defaultNamespace', () => {
+    const defaultNs = 'default';
+    const metadata: Record<string, unknown> = {};
+    const store = createStore({
+      getters: {
+        allowedNamespaces:   () => () => ({}),
+        currentStore:        () => () => 'cluster',
+        'cluster/schemaFor': () => jest.fn(),
+        defaultNamespace:    () => defaultNs,
+      }
+    });
+
+    mount(NameNsDescription, {
+      props: {
+        value: {
+          setAnnotation: jest.fn(),
+          metadata,
+        },
+        mode: 'create',
+      },
+      global: {
+        provide: { store },
+        mocks:   {
+          $store: {
+            dispatch: jest.fn(),
+            getters:  {
+              namespaces: jest.fn(),
+              'i18n/t':   jest.fn(),
+            },
+          },
+        },
+      },
+    });
+
+    expect(typeof metadata.namespace).toBe('string');
+    expect(metadata.namespace).toBe(defaultNs);
+  });
+
   it('sets the name using the nameKey prop', () => {
     const namespaceName = 'test';
     const store = createStore({


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This resolves an issue where the namespace selector would fail to properly set a value when working with a "forced" namespace value.

Fixes #18052
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This error can be identified with errors printed to the console:

```
TypeError: cyclic object value
    t vue-select.es.js:573
    findOptionFromReducedValue vue-select.es.js:573
    setInternalValueFromOptions vue-select.es.js:533
    options vue-select.es.js:513
```

The root cause can be traced to the usage of `toRef(primitiveValue)`, which returns a full `RefImpl`. Assigning that to `namespace.value` nested a `Ref` inside a `Ref`, causing the circular `dep.subs` errors when accessing vue-select options.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

See the associated issue for steps to repro.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This is resolving a regression introduced in for a specific case in `NameNsDescription.vue`. 68e046e5ed4922746c04cdf52392c56b1f6838f8 was introduced as a part of a larger effort to resolve issues with complexity id data props. This worked fine until recent refactoring of LabeledSelect to adopt more composition API patterns altered the access behavior: 59696954b34f771432355eca655ae7e1bc44b614

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before (value is absent from namespace)

<img width="1219" height="656" alt="image" src="https://github.com/user-attachments/assets/11f854a1-6ca8-42c2-930c-d701e083b7f1" />

#### After (namespace has a value)

<img width="1219" height="656" alt="image" src="https://github.com/user-attachments/assets/23bd98f5-6b1c-4b01-8c08-e593b022faa9" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
