### PR TITLE
Add a story for the RcDropdown component

### DIFF
--- a/storybook/src/stories/Components/RcDropdown.mdx
+++ b/storybook/src/stories/Components/RcDropdown.mdx
@@ -1,0 +1,85 @@
+import { Meta, Canvas, Controls } from '@storybook/blocks';
+import * as RcDropdownStories from './RcDropdown.stories';
+
+# RcDropdown
+
+Use RcDropdown to offer a list of choices to the user, such as a set of actions or
+filters, without permanently occupying space in the UI. The menu opens by activating
+an `RcDropdownTrigger` and closes on selection, escape, tab, or clicking outside.
+
+<Canvas of={RcDropdownStories.Default} layout="centered" />
+
+<Controls of={RcDropdownStories.Default} />
+
+## Usage Pattern
+
+`RcDropdown` is a composition of building blocks:
+
+- **`RcDropdown`** &mdash; the root component. Place the trigger in its default slot
+  and the menu content in its `dropdownCollection` slot.
+- **`RcDropdownTrigger`** &mdash; a button (built on `RcButton`) that opens the menu.
+  Accepts the same props as `RcButton` (`variant`, `size`, icons, etc.) and the
+  `before`/`default`/`after` slots.
+- **`RcDropdownItem`** &mdash; a clickable menu item. Supports a `disabled` prop and
+  a `before` slot for icons.
+- **`RcDropdownItemCheckbox`** &mdash; a menu item with an embedded checkbox, for
+  toggleable options.
+- **`RcDropdownItemSelect`** &mdash; a menu item with an embedded `LabeledSelect`,
+  for choosing one of several values without leaving the menu.
+- **`RcDropdownSeparator`** &mdash; a visual divider between groups of items.
+
+```html
+<RcDropdown aria-label="Row actions">
+  <RcDropdownTrigger>
+    Actions
+  </RcDropdownTrigger>
+  <template #dropdownCollection>
+    <RcDropdownItem @click="performAction()">
+      Action 1
+    </RcDropdownItem>
+    <RcDropdownSeparator />
+    <RcDropdownItem @click="performAction()">
+      Action 2
+    </RcDropdownItem>
+  </template>
+</RcDropdown>
+```
+
+## Icon-Only Trigger
+
+A common pattern is an icon-only trigger (e.g. a kebab menu) used as a row or card
+action menu. Always provide an `aria-label` on the trigger in this case, since it
+has no visible text for assistive technology to announce.
+
+<Canvas of={RcDropdownStories.IconOnlyTrigger} />
+
+## Checkbox and Select Items
+
+`RcDropdownItemCheckbox` and `RcDropdownItemSelect` let menu items carry interactive
+form controls while still participating in the dropdown's keyboard navigation and
+focus management.
+
+<Canvas of={RcDropdownStories.WithCheckboxAndSelectItems} />
+
+## Placement
+
+The `placement` prop controls where the menu appears relative to its trigger.
+
+<Canvas of={RcDropdownStories.Placements} />
+
+## RcDropdownMenu
+
+For data-driven action menus, `RcDropdownMenu` composes `RcDropdown`,
+`RcDropdownTrigger`, `RcDropdownItem`, and `RcDropdownSeparator` from a declarative
+`options` array, so you don't need to write out the trigger/menu markup by hand.
+
+<Canvas of={RcDropdownStories.RcDropdownMenuComposed} />
+
+## Accessibility
+
+- The dropdown menu container has `role="menu"`; items rendered via `RcDropdownItem`
+  have `role="menuitem"`, and `RcDropdownItemCheckbox` has `role="menuitemcheckbox"`.
+- Arrow keys move focus between items, `Escape` closes the menu and returns focus to
+  the trigger, and `Tab` closes the menu.
+- Always set `aria-label` on `RcDropdown` (and on `RcDropdownTrigger` when it has no
+  visible text) to describe the menu's purpose to screen reader users.

--- a/storybook/src/stories/Components/RcDropdown.stories.ts
+++ b/storybook/src/stories/Components/RcDropdown.stories.ts
@@ -1,0 +1,228 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import {
+  RcDropdown,
+  RcDropdownTrigger,
+  RcDropdownItem,
+  RcDropdownItemCheckbox,
+  RcDropdownItemSelect,
+  RcDropdownSeparator,
+  RcDropdownMenu,
+} from '@components/RcDropdown';
+import { ButtonVariant, ButtonSize } from '@components/RcButton/types';
+
+const meta: Meta<typeof RcDropdown> = {
+  component:  RcDropdown,
+  parameters: {
+    layout: 'centered',
+    docs:   {
+      description: {
+        component: `RcDropdown offers a list of choices to the user, such as a set of
+          actions or filters. It is opened by activating an \`RcDropdownTrigger\` placed
+          in its default slot, and renders its menu content (\`RcDropdownItem\`,
+          \`RcDropdownItemCheckbox\`, \`RcDropdownItemSelect\`, \`RcDropdownSeparator\`)
+          in the \`dropdownCollection\` slot. Keyboard navigation (arrow keys, escape,
+          tab) and focus management are handled automatically.`
+      }
+    }
+  },
+  argTypes: {
+    ariaLabel: {
+      control:     { type: 'text' },
+      description: 'Accessible label for the dropdown menu container (role="menu"). Falls back to "Dropdown Menu" when not provided.',
+    },
+    placement: {
+      options:     ['bottom-end', 'bottom-start', 'top-end', 'top-start'],
+      control:     { type: 'select' },
+      description: 'Placement of the dropdown menu relative to the trigger.',
+    },
+    distance: {
+      control:     { type: 'number' },
+      description: 'Distance between the dropdown menu and its trigger, in pixels.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RcDropdown>;
+
+const dropdownDecorator = () => ({ template: '<div style="min-width: 300px; padding: 20px; display: flex; justify-content: center;"><story /></div>' });
+
+export const Default: Story = {
+  decorators: [dropdownDecorator],
+  render:     (args: any) => ({
+    components: {
+      RcDropdown,
+      RcDropdownTrigger,
+      RcDropdownItem,
+      RcDropdownSeparator,
+    },
+    setup() {
+      return { args };
+    },
+    template: `
+      <RcDropdown v-bind="args">
+        <RcDropdownTrigger>
+          Actions
+        </RcDropdownTrigger>
+        <template #dropdownCollection>
+          <RcDropdownItem @click="() => console.log('Action 1')">Action 1</RcDropdownItem>
+          <RcDropdownItem @click="() => console.log('Action 2')">Action 2</RcDropdownItem>
+          <RcDropdownSeparator />
+          <RcDropdownItem disabled>Disabled Action</RcDropdownItem>
+        </template>
+      </RcDropdown>
+    `,
+  }),
+  args:       { placement: 'bottom-end' },
+  parameters: { docs: { story: { height: '250px' } } },
+};
+
+export const IconOnlyTrigger: Story = {
+  decorators: [dropdownDecorator],
+  render:     () => ({
+    components: {
+      RcDropdown,
+      RcDropdownTrigger,
+      RcDropdownItem,
+      RcDropdownSeparator,
+    },
+    template: `
+      <RcDropdown aria-label="Row actions">
+        <RcDropdownTrigger tertiary aria-label="Open row actions">
+          <i class="icon icon-actions" />
+        </RcDropdownTrigger>
+        <template #dropdownCollection>
+          <RcDropdownItem>Edit</RcDropdownItem>
+          <RcDropdownItem>Clone</RcDropdownItem>
+          <RcDropdownSeparator />
+          <RcDropdownItem>Delete</RcDropdownItem>
+        </template>
+      </RcDropdown>
+    `,
+  }),
+  parameters: {
+    controls: { disabled: true },
+    docs:     {
+      canvas:      { sourceState: 'none' },
+      story:       { height: '250px' },
+      description: { story: 'A common pattern: an icon-only trigger (e.g. a kebab menu) acting as an action menu for a table row or card. Always provide an `aria-label` on the trigger since it has no visible text.' },
+    },
+  },
+};
+
+export const WithCheckboxAndSelectItems: Story = {
+  decorators: [dropdownDecorator],
+  render:     () => ({
+    components: {
+      RcDropdown,
+      RcDropdownTrigger,
+      RcDropdownItemCheckbox,
+      RcDropdownItemSelect,
+      RcDropdownSeparator,
+    },
+    setup() {
+      const checked = false;
+      const sortOptions = [{ label: 'Name', value: 'name' }, { label: 'Date', value: 'date' }];
+
+      return { checked, sortOptions };
+    },
+    template: `
+      <RcDropdown aria-label="Filter and sort">
+        <RcDropdownTrigger>
+          Filter
+        </RcDropdownTrigger>
+        <template #dropdownCollection>
+          <RcDropdownItemCheckbox :model-value="checked" @click="(v) => console.log('Toggled:', v)">
+            Show only running
+          </RcDropdownItemCheckbox>
+          <RcDropdownSeparator />
+          <RcDropdownItemSelect
+            label="Sort by"
+            model-value="name"
+            :options="sortOptions"
+            @select="(v) => console.log('Selected:', v)"
+          />
+        </template>
+      </RcDropdown>
+    `,
+  }),
+  parameters: {
+    controls: { disabled: true },
+    docs:     {
+      canvas:      { sourceState: 'none' },
+      story:       { height: '320px' },
+      description: { story: '`RcDropdownItemCheckbox` and `RcDropdownItemSelect` allow menu items to carry interactive form controls (a checkbox and a `LabeledSelect`) while still participating in the dropdown\'s keyboard navigation and focus management.' },
+    },
+  },
+};
+
+export const Placements: Story = {
+  render: () => ({
+    components: {
+      RcDropdown,
+      RcDropdownTrigger,
+      RcDropdownItem,
+    },
+    setup() {
+      const placements = ['bottom-start', 'bottom-end', 'top-start', 'top-end'];
+
+      return { placements };
+    },
+    template: `
+      <div style="display: flex; gap: 60px; padding: 80px 40px;">
+        <div v-for="placement in placements" :key="placement" style="display: flex; flex-direction: column; align-items: center; gap: 12px;">
+          <div style="font-weight: bold;">{{ placement }}</div>
+          <RcDropdown :placement="placement">
+            <RcDropdownTrigger>Menu</RcDropdownTrigger>
+            <template #dropdownCollection>
+              <RcDropdownItem>Option 1</RcDropdownItem>
+              <RcDropdownItem>Option 2</RcDropdownItem>
+            </template>
+          </RcDropdown>
+        </div>
+      </div>
+    `,
+  }),
+  parameters: {
+    controls: { disabled: true },
+    docs:     {
+      canvas: { sourceState: 'none' },
+      story:  { height: '350px' },
+    },
+  },
+};
+
+export const RcDropdownMenuComposed: Story = {
+  decorators: [dropdownDecorator],
+  render:     (args: any) => ({
+    components: { RcDropdownMenu },
+    setup() {
+      return { args };
+    },
+    template: '<RcDropdownMenu v-bind="args" @select="(e, option) => console.log(\'Selected:\', option.label)" />',
+  }),
+  args: {
+    buttonVariant:     'tertiary' as ButtonVariant,
+    buttonSize:        'medium' as ButtonSize,
+    buttonAriaLabel:   'Open actions menu',
+    dropdownAriaLabel: 'Actions',
+    options:           [
+      {
+        label: 'Edit', icon: 'icon-edit', enabled: true
+      },
+      {
+        label: 'Clone', icon: 'icon-copy', enabled: true
+      },
+      { divider: true, enabled: true },
+      {
+        label: 'Delete', icon: 'icon-trash', enabled: true
+      },
+    ],
+  },
+  parameters: {
+    docs: {
+      story:       { height: '250px' },
+      description: { story: '`RcDropdownMenu` is a higher-level component that composes `RcDropdown`, `RcDropdownTrigger`, `RcDropdownItem`, and `RcDropdownSeparator` from a declarative `options` array. It is commonly used for action/kebab menus driven by data (e.g. resource list bulk actions).' },
+    },
+  },
+};

--- a/storybook/src/stories/Components/RcDropdown.stories.ts
+++ b/storybook/src/stories/Components/RcDropdown.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/vue3';
+import { ref } from 'vue';
 import {
   RcDropdown,
   RcDropdownTrigger,
@@ -121,10 +122,13 @@ export const WithCheckboxAndSelectItems: Story = {
       RcDropdownSeparator,
     },
     setup() {
-      const checked = false;
+      const checked = ref(false);
+      const sortBy = ref('name');
       const sortOptions = [{ label: 'Name', value: 'name' }, { label: 'Date', value: 'date' }];
 
-      return { checked, sortOptions };
+      return {
+        checked, sortBy, sortOptions
+      };
     },
     template: `
       <RcDropdown aria-label="Filter and sort">
@@ -132,15 +136,15 @@ export const WithCheckboxAndSelectItems: Story = {
           Filter
         </RcDropdownTrigger>
         <template #dropdownCollection>
-          <RcDropdownItemCheckbox :model-value="checked" @click="(v) => console.log('Toggled:', v)">
+          <RcDropdownItemCheckbox :model-value="checked" @click="checked = $event">
             Show only running
           </RcDropdownItemCheckbox>
           <RcDropdownSeparator />
           <RcDropdownItemSelect
             label="Sort by"
-            model-value="name"
+            :model-value="sortBy"
             :options="sortOptions"
-            @select="(v) => console.log('Selected:', v)"
+            @select="sortBy = $event"
           />
         </template>
       </RcDropdown>

--- a/storybook/tsconfig.json
+++ b/storybook/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This adds a story for the RcDropdown component. 

Fixes #13195
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add stories for RcDropdown
- Resolve issues with checkbox example

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

In order to resolve an issue with rendering the checkbox example, I had to add `esModuleInterop/allowSyntheticDefaultImports` directly to storybook's `storybook/tsconfig.json` `compilerOptions`. I'm not 100% clear on where the config for Storybook is failing here, but we might have a follow-up task to dig deeper on the overall storybook implementation. This appears to work for now. 

Before this change was in place, clicking on the checkbox would fail with the following error:

```
  function at ./node_modules/vue-docgen-loader/lib/index.js??ruleSet[1].rules[34]!./node_modules/ts-loader/index.js??clonedRuleSet-5.use[0]!./node_modules/vue-loader/dist/templateLoader.js??ruleSet[1].rules[6]!./node_modules/vue-loader/dist/index.js??ruleSet[0]!../pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue?vue&type=template&id=70b49ce6&scoped=true&ts=true/render/_cache[4] (/pkg_rancher-components_src_components_Form_Checkbox_Checkbox_vue.iframe.bundle.js:8040:81) at callWithErrorHandling (/vendors-node_modules_custom-event-polyfill_polyfill_js-node_modules_dompurify_dist_purify_es_-6de308.iframe.bundle.js:34985:19)
```

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

RcDropdown stories should render correctly.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

The change to `storybook/tsconfig.json` could have introduced errors in stories elsewhere. Test several existing stories alongside this change to ensure that we don't regress.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="1372" height="1215" alt="image" src="https://github.com/user-attachments/assets/0d167fe0-886b-4972-9f10-ca0e5fc183f9" />

<img width="1372" height="1215" alt="image" src="https://github.com/user-attachments/assets/47f26bfd-ad42-4456-9a34-55514a38af99" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
