### PR TITLE
Fix browser console error for removed support page

### DIFF
--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -1580,19 +1580,7 @@ export default {
       > * {
         flex: 1;
         color: var(--link);
-
-        &:first-child {
-          text-align: left;
-        }
-        &:last-child {
-          text-align: right;
-        }
-        text-align: center;
-      }
-
-      .support a:focus-visible {
-        @include focus-outline;
-        outline-offset: 4px;
+        text-align: left;
       }
 
       .version {

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -956,19 +956,6 @@ export default {
           class="footer"
         >
           <div
-            v-if="canEditSettings"
-            class="support"
-            @click="hide()"
-          >
-            <router-link
-              :to="{name: 'support'}"
-              role="link"
-              :aria-label="t('nav.ariaLabel.support')"
-            >
-              {{ t('nav.support', {hasSupport}) }}
-            </router-link>
-          </div>
-          <div
             class="version"
             :class="{'version-small': largeAboutText}"
             @click="hide()"
@@ -1573,10 +1560,6 @@ export default {
       .footer {
         margin: 20px 10px;
         width: 50px;
-
-        .support {
-          display: none;
-        }
 
         .version{
           text-align: center;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Follow on bug fix for #18008

There is a console warning, as we still have an unused ref to the support route:

```
entry-helpers.js:40 Error: No match for
 {"name":"support","params":{}}
    at createRouterError (vue-router.mjs:946:1)
    at Object.resolve (vue-router.mjs:1552:1)
    at Object.resolve (vue-router.mjs:3163:1)
    at ComputedRefImpl.fn (vue-router.mjs:2249:1)
    at refreshComputed (reactivity.esm-bundler.js:393:1)
    at get value (reactivity.esm-bundler.js:1717:1)
    at useLink (vue-router.mjs:2293:1)
    at setup (vue-router.mjs:2343:1)
    at callWithErrorHandling (runtime-core.esm-bundler.js:199:1)
    at setupStatefulComponent (runtime-core.esm-bundler.js:8073:1)
```

Removed unused code from `TopLevelMenu.vue`

We had a support link in the menu at the bottom when opened, but CSS styles meant this was always hidden.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
