### PR TITLE
Increase time to wait for Rancher start-up

### DIFF
--- a/scripts/e2e-docker-start
+++ b/scripts/e2e-docker-start
@@ -80,7 +80,7 @@ echo "Waiting for dashboard UI to be reachable ..."
 okay=0
 
 # 60 * 5 seconds should be around 5 minutes that we wait in total 
-while [ $okay -lt 48 ]; do
+while [ $okay -lt 60 ]; do
   if [ "$RANCHER_HOST_HTTPS_PORT" == "443" ]; then
     HEALTH_URL="https://127.0.0.1/dashboard/"
   else

--- a/scripts/e2e-docker-start
+++ b/scripts/e2e-docker-start
@@ -79,7 +79,7 @@ echo "Waiting for dashboard UI to be reachable ..."
 
 okay=0
 
-# 48 * 5 seconds should be around 4 minutes that we wait in total 
+# 60 * 5 seconds should be around 5 minutes that we wait in total 
 while [ $okay -lt 48 ]; do
   if [ "$RANCHER_HOST_HTTPS_PORT" == "443" ]; then
     HEALTH_URL="https://127.0.0.1/dashboard/"

--- a/scripts/e2e-docker-start
+++ b/scripts/e2e-docker-start
@@ -79,7 +79,8 @@ echo "Waiting for dashboard UI to be reachable ..."
 
 okay=0
 
-while [ $okay -lt 30 ]; do
+# 48 * 5 seconds should be around 4 minutes that we wait in total 
+while [ $okay -lt 48 ]; do
   if [ "$RANCHER_HOST_HTTPS_PORT" == "443" ]; then
     HEALTH_URL="https://127.0.0.1/dashboard/"
   else


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

Simple PR to increase start-up time for Rancher in our e2e tests.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
