### PR TITLE
WIP: Pre-cache container image to perform pull in parallel

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,6 +86,9 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
+      - name: Pre-cache Rancher container image
+        id: pre-cache-image
+        run: pull_pid=$(./scripts/e2e-docker-pull.sh)
       - name: Setup env
         uses: ./.github/actions/setup
 
@@ -107,6 +110,8 @@ jobs:
         with:
          name: ${{ env.E2E_BUILD_DIST_EMBER_NAME }}
          path: ${{ env.E2E_BUILD_DIST_EMBER_DIR }}
+      - name: Wait for pre-cache of Rancher container image
+        run: wait ${{ steps.pre-cache-image.outputs.pull_pid }}
       
       - name: Run Rancher
         run: yarn e2e:docker

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -88,7 +88,7 @@ jobs:
           fetch-depth: 1
       - name: Pre-cache Rancher container image
         id: pre-cache-image
-        run: pull_pid=$(./scripts/e2e-docker-pull.sh)
+        run: pull_pid=$(./scripts/e2e-docker-pull)
       - name: Setup env
         uses: ./.github/actions/setup
 

--- a/scripts/e2e-docker-pull
+++ b/scripts/e2e-docker-pull
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+DIR=$(cd $(dirname $0)/..; pwd)
+
+# Container Image Defaults
+RANCHER_IMG_TAG=head
+RANCHER_IMG_REGISTRY=
+RANCHER_IMG_NAMESPACE=rancher
+RANCHER_IMG_NAME=rancher
+
+# check if script invoke contains any argument. If so, adjust RANCHER_IMG_TAG
+if [ $# -eq 1 ]; then
+  RANCHER_IMG_TAG=$1
+else
+  # Get container image from branch-metadata
+  BRANCH_DATA=$(./scripts/get-branch-metadata.sh ${GITHUB_BASE_REF:-${GITHUB_REF_NAME}} > /dev/null 2>&1)
+
+  if [ -n "$BRANCH_DATA" ]; then
+    REGISTRY=$(echo "$BRANCH_DATA" | jq -r '.e2e["rancher-image"].registry // ""')
+    RANCHER_IMG_NAMESPACE=$(echo "$BRANCH_DATA" | jq -r '.e2e["rancher-image"].namespace')
+    RANCHER_IMG_NAME=$(echo "$BRANCH_DATA" | jq -r '.e2e["rancher-image"].name')
+    RANCHER_IMG_TAG=$(echo "$BRANCH_DATA" | jq -r '.e2e["rancher-image"].tag')
+
+    if [ -n "$REGISTRY" ]; then
+      RANCHER_IMG_REGISTRY="${REGISTRY}/"
+    fi
+  fi
+fi
+
+RANCHER_IMG=${RANCHER_IMG_REGISTRY}${RANCHER_IMG_NAMESPACE}/${RANCHER_IMG_NAME}:${RANCHER_IMG_TAG}
+
+docker pull ${RANCHER_IMG}> /dev/null 2>&1 &
+echo $!


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This is a small optimisation to the e2e test run workflow.

With this, we start the pull of the Rancher container image early, before we start the `yarn install` (for example). Thus, rather than be blocked later when we need to pull the image as part of running it in Docker, we start the pull early. When we then come to run the container image, it is already cached, so does not need to be pulled.

This saves anywhere from 30s to 1m or more per e2e test run.

QA/None - if the e2e test runs run and pass, then we're good.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
