### PR TITLE
Charts loading more

### DIFF
--- a/pkg/rancher-components/src/components/RcItemCard/RcItemCard.test.ts
+++ b/pkg/rancher-components/src/components/RcItemCard/RcItemCard.test.ts
@@ -36,6 +36,24 @@ describe('rcItemCard', () => {
     expect(wrapper.findAll(`[data-testid="item-card-header-statuses-status"]`)).toHaveLength(2);
   });
 
+  // Regression: when image.src is falsy, LazyImage must still render so its own
+  // empty-src fallback (generic catalog icon) is shown. Previously the template
+  // was gated by `v-else-if="image.src"` and showed an empty box for missing icons.
+  it.each(['medium', 'small'] as const)('renders LazyImage with an empty src when image.src is falsy (%s variant)', (variant) => {
+    const wrapper = mount(RcItemCard, {
+      props: {
+        ...baseProps,
+        variant,
+        image: { src: '', alt: { text: 'Logo' } },
+      }
+    });
+
+    const lazy = wrapper.findComponent({ name: 'LazyImage' });
+
+    expect(lazy.exists()).toBe(true);
+    expect(lazy.props('src')).toBe('');
+  });
+
   it('renders pill only in medium variant', () => {
     const wrapper = mount(RcItemCard, {
       props: {

--- a/pkg/rancher-components/src/components/RcItemCard/RcItemCard.vue
+++ b/pkg/rancher-components/src/components/RcItemCard/RcItemCard.vue
@@ -208,7 +208,7 @@ const cursorValue = computed(() => props.clickable ? 'pointer' : 'auto');
                   size="xxlarge"
                 />
               </template>
-              <template v-else-if="image.src">
+              <template v-else>
                 <LazyImage
                   :src="image.src"
                   :alt="imageAlt"
@@ -255,7 +255,7 @@ const cursorValue = computed(() => props.clickable ? 'pointer' : 'auto');
                       size="xlarge"
                     />
                   </template>
-                  <template v-else-if="image.src">
+                  <template v-else>
                     <LazyImage
                       :src="image.src"
                       :alt="imageAlt"

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1228,6 +1228,7 @@ catalog:
       lastUpdatedDesc: Last updated
       alphaAscending: Chart name, A → Z
       alphaDescending: Chart name, Z → A
+    loadingMore: Loading more…
     refreshButton:
       label: Refresh all repositories
     findSimilar:

--- a/shell/pages/c/_cluster/apps/charts/__tests__/index.test.ts
+++ b/shell/pages/c/_cluster/apps/charts/__tests__/index.test.ts
@@ -52,4 +52,97 @@ describe('page: Charts Index', () => {
       expect(hasExtensionCategory).toBe(false);
     });
   });
+
+  describe('method: loadMore', () => {
+    const createContext = (overrides: Record<string, any> = {}) => ({
+      isLoadingMore:             false,
+      visibleChartsCount:        30,
+      initialVisibleChartsCount: 30,
+      filteredCharts:            new Array(100),
+      _loadMoreTimer:            null,
+      $nextTick:                 (cb: () => void) => cb(),
+      ...overrides,
+    });
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should set isLoadingMore, then increment visibleChartsCount and clear the flag after the delay', () => {
+      const ctx = createContext();
+
+      (Charts.methods!.loadMore as () => void).call(ctx);
+
+      expect(ctx.isLoadingMore).toBe(true);
+      expect(ctx.visibleChartsCount).toBe(30);
+      expect(ctx._loadMoreTimer).not.toBeNull();
+
+      jest.runAllTimers();
+
+      expect(ctx.visibleChartsCount).toBe(60);
+      expect(ctx.isLoadingMore).toBe(false);
+      expect(ctx._loadMoreTimer).toBeNull();
+    });
+
+    it('should do nothing when already loading', () => {
+      const ctx = createContext({ isLoadingMore: true });
+
+      (Charts.methods!.loadMore as () => void).call(ctx);
+
+      expect(ctx._loadMoreTimer).toBeNull();
+      expect(ctx.visibleChartsCount).toBe(30);
+    });
+
+    it('should do nothing when all charts are already visible', () => {
+      const ctx = createContext({ visibleChartsCount: 100 });
+
+      (Charts.methods!.loadMore as () => void).call(ctx);
+
+      expect(ctx.isLoadingMore).toBe(false);
+      expect(ctx._loadMoreTimer).toBeNull();
+    });
+  });
+
+  describe('method: resetLazyLoadState', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should reset state and cancel a pending loadMore so visibleChartsCount is not incremented after reset', () => {
+      const ctx: Record<string, any> = {
+        isLoadingMore:             false,
+        visibleChartsCount:        30,
+        initialVisibleChartsCount: 30,
+        observerInitialized:       true,
+        hasOverflow:               true,
+        filteredCharts:            new Array(100),
+        _loadMoreTimer:            null,
+        $nextTick:                 (cb: () => void) => cb(),
+      };
+
+      (Charts.methods!.loadMore as () => void).call(ctx);
+      expect(ctx._loadMoreTimer).not.toBeNull();
+
+      (Charts.methods!.resetLazyLoadState as () => void).call(ctx);
+
+      expect(ctx.visibleChartsCount).toBe(30);
+      expect(ctx.observerInitialized).toBe(false);
+      expect(ctx.hasOverflow).toBe(false);
+      expect(ctx.isLoadingMore).toBe(false);
+      expect(ctx._loadMoreTimer).toBeNull();
+
+      jest.runAllTimers();
+
+      // The cancelled timer must not have fired — count stays at the reset value.
+      expect(ctx.visibleChartsCount).toBe(30);
+    });
+  });
 });

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -871,7 +871,7 @@ export default {
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: var(--gap-sm);
+    gap: var(--gap);
     padding: 16px;
     font-size: 14px;
     color: var(--muted);

--- a/shell/pages/c/_cluster/apps/charts/index.vue
+++ b/shell/pages/c/_cluster/apps/charts/index.vue
@@ -37,6 +37,8 @@ const createInitialFilters = () => ({
   tags:       []
 });
 
+const LOAD_MORE_DELAY_MS = 500;
+
 export default {
   name:       'Charts',
   components: {
@@ -85,6 +87,10 @@ export default {
   beforeUnmount() {
     if (this.observer) {
       this.observer.disconnect();
+    }
+    if (this._loadMoreTimer) {
+      clearTimeout(this._loadMoreTimer);
+      this._loadMoreTimer = null;
     }
   },
 
@@ -147,6 +153,7 @@ export default {
       canCreateRepos:            false,
       showAppCollectionBanner:   true,
       isPrime:                   getVersionData().RancherPrime === 'true',
+      isLoadingMore:             false,
     };
   },
 
@@ -484,6 +491,11 @@ export default {
       this.visibleChartsCount = this.initialVisibleChartsCount;
       this.observerInitialized = false;
       this.hasOverflow = false;
+      this.isLoadingMore = false;
+      if (this._loadMoreTimer) {
+        clearTimeout(this._loadMoreTimer);
+        this._loadMoreTimer = null;
+      }
     },
 
     // The lazy loading implementation has two parts
@@ -531,10 +543,17 @@ export default {
     },
 
     loadMore() {
-      if (this.visibleChartsCount >= this.filteredCharts.length) {
+      if (this.isLoadingMore || this.visibleChartsCount >= this.filteredCharts.length) {
         return;
       }
-      this.visibleChartsCount += this.initialVisibleChartsCount;
+      this.isLoadingMore = true;
+      this._loadMoreTimer = setTimeout(() => {
+        this._loadMoreTimer = null;
+        this.visibleChartsCount += this.initialVisibleChartsCount;
+        this.$nextTick(() => {
+          this.isLoadingMore = false;
+        });
+      }, LOAD_MORE_DELAY_MS);
     },
 
     initIntersectionObserver() {
@@ -785,6 +804,16 @@ export default {
           </rc-item-card>
         </div>
         <div
+          v-if="isLoadingMore"
+          class="loading-more"
+          role="status"
+          aria-live="polite"
+          data-testid="charts-loading-more"
+        >
+          <i class="icon icon-spinner icon-spin" />
+          {{ t('catalog.charts.loadingMore') }}
+        </div>
+        <div
           ref="sentinel"
           class="sentinel-charts"
           data-testid="charts-lazy-load-sentinel"
@@ -836,6 +865,16 @@ export default {
 
   .sentinel-charts {
     height: 1px;
+  }
+
+  .loading-more {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--gap-sm);
+    padding: 16px;
+    font-size: 14px;
+    color: var(--muted);
   }
 }
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18093 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues

Adds a "Loading more…" spinner on the Cluster → Apps → Charts page so users get visual feedback while the next batch of lazy-loaded chart cards is being appended on scroll. No real network call — purely a UX cue with a short delay so it's perceivable. Also fixed a minor issue where charts placeholder icon would not show up.

### Technical notes summary

- New `isLoadingMore` state; spinner rendered between the cards grid and the IntersectionObserver sentinel.
- `loadMore()` schedules a 500 ms timeout (id stored on `this._loadMoreTimer`) before bumping `visibleChartsCount`.
- That timer is cleared in `resetLazyLoadState()` and `beforeUnmount()` so a filter/search change or unmount mid-load can't fire against fresh/dead state.
- Indicator has `role="status"` + `aria-live="polite"`.
- New i18n key `catalog.charts.loadingMore`. Unit tests added.
- Changed `v-else-if="image.src"` to `v-else` in `RcItemCard` so `<LazyImage>` always renders when no `image.icon` is set, letting its built-in `onError` fallback show the generic catalog SVG instead of an empty box. Regression test added.

### Areas or cases that should be tested

Use a repo with >30 charts (e.g. Rancher partner) so the grid overflows.

 - Scroll to the bottom — spinner appears briefly, next batch appends, spinner disappears.
 - Navigate away mid-load — no console errors.

### Areas which could experience regressions

- Charts page lazy-load flow (initial fill, scroll-triggered load, observer lifecycle).
- Filter / search / sort reset paths through `resetLazyLoadState`.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->


https://github.com/user-attachments/assets/30e16203-c7f4-4b3c-8c5e-eb3e3da7dee1


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
