### PR TITLE
Ensure local cluster is filtered out given switch from PCIC to MCIC

### DIFF
--- a/shell/list/utils/management.cattle.io.cluster.utils.ts
+++ b/shell/list/utils/management.cattle.io.cluster.utils.ts
@@ -31,7 +31,7 @@ class ManagementClusterUtils {
     }
 
     const existingFilters = pagination.filters;
-    const requiredFilters = paginationFilterClusters($store, false);
+    const requiredFilters = paginationFilterClusters($store);
 
     for (let i = 0; i < requiredFilters.length; i++) {
       let found = false;


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18072
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- hide-local-cluster setting should hide the local cluster from side nav, home page and cluster management lists
- there's a helper function to do this that will create the filter param given the cluster type (PCIC vs MCIC)
- ensure when we're filtering MCIC we set the right flag to get the right filter


### Areas or cases that should be tested
- home and cluster management lists with, `hide-local-cluster` on and off

### Areas which could experience regressions
- ManagementClusterUtils.filterRowsApi is only called in the above two place


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
