### PR TITLE
fix cloud credential annotation path in SelectCredential

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -1,7 +1,7 @@
 <script>
 import Loading from '@shell/components/Loading';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
-import { NORMAN, DEFAULT_WORKSPACE } from '@shell/config/types';
+import { NORMAN } from '@shell/config/types';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import CruResource from '@shell/components/CruResource';
 import NameNsDescription from '@shell/components/form/NameNsDescription';

--- a/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -50,11 +50,8 @@ export default {
     const field = this.$store.getters['plugins/credentialFieldForDriver'](this.driverName);
 
     this.newCredential = await this.$store.dispatch('rancher/create', {
-      type:     NORMAN.CLOUD_CREDENTIAL,
-      metadata: {
-        namespace:   DEFAULT_WORKSPACE,
-        annotations: { [CAPI.CREDENTIAL_DRIVER]: this.driverName }
-      },
+      type:                           NORMAN.CLOUD_CREDENTIAL,
+      annotations:                    { [CAPI.CREDENTIAL_DRIVER]: this.driverName },
       [`${ field }credentialConfig`]: {}
     });
 

--- a/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -213,12 +213,6 @@ export default {
         }
       }
 
-      if ( this.newCredential.metadata.name ) {
-        delete this.newCredential.metadata.generateName;
-      } else {
-        this.newCredential.metadata.generateName = 'cloud-credential-';
-      }
-
       try {
         const res = await this.newCredential.save();
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18105 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR corrects initialization of cloud credentials in the SelectCredential component. Credentials are created through norman. Norman objects are not direct copies of kubernetes resources and do not have a metadata property, so everything in metadata was not saved. Also these resources are not namespaced so I dropped that line.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
The scenarios described in the issue should be tested - verify that cloud creds created from the list view and the provisioning view have the same payloads/responses.



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
