### PR TITLE
Resize table action buttons

### DIFF
--- a/cypress/e2e/po/lists/machine-deployments-list.po.ts
+++ b/cypress/e2e/po/lists/machine-deployments-list.po.ts
@@ -1,12 +1,8 @@
 import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
 
 export default class MachineDeploymentsListPo extends BaseResourceList {
-  openBulkActionDropdown() {
-    return this.resourceTable().sortableTable().bulkActionDropDownOpen();
-  }
-
   bulkActionButton(name: string) {
-    return this.resourceTable().sortableTable().bulkActionDropDownButton(name);
+    return this.resourceTable().sortableTable().bulkActionButton(name);
   }
 
   details(name: string, index: number) {

--- a/cypress/e2e/po/lists/machine-set-list.po.ts
+++ b/cypress/e2e/po/lists/machine-set-list.po.ts
@@ -1,12 +1,8 @@
 import BaseResourceList from '@/cypress/e2e/po/lists/base-resource-list.po';
 
 export default class MachineSetsListPo extends BaseResourceList {
-  openBulkActionDropdown() {
-    return this.resourceTable().sortableTable().bulkActionDropDownOpen();
-  }
-
   bulkActionButton(name: string) {
-    return this.resourceTable().sortableTable().bulkActionDropDownButton(name);
+    return this.resourceTable().sortableTable().bulkActionButton(name);
   }
 
   details(name: string, index: number) {

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -720,8 +720,7 @@ describe('Cluster Manager', { testIsolation: 'off', tags: ['@manager', '@adminUs
     clusterList.list().resourceTable().sortableTable().rowElementWithName('local')
       .click();
     cy.intercept('POST', '/v1/ext.cattle.io.kubeconfigs').as('generateKubeConfig');
-    clusterList.list().openBulkActionDropdown();
-    clusterList.list().bulkActionButton('Download KubeConfig').click();
+    clusterList.list().downloadKubeConfig().click();
     cy.wait('@generateKubeConfig').its('response.statusCode').should('eq', 201);
     const downloadedFilename = path.join(downloadsFolder, 'local.yaml');
 

--- a/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
+++ b/cypress/e2e/tests/pages/manager/kontainer-drivers.spec.ts
@@ -309,8 +309,7 @@ describe('Kontainer Drivers', { testIsolation: 'off', tags: ['@manager', '@admin
       .set();
     driversPage.list().resourceTable().sortableTable().rowSelectCtlWithName(oracleDriver)
       .set();
-    driversPage.list().resourceTable().sortableTable().bulkActionDropDownOpen();
-    driversPage.list().resourceTable().sortableTable().bulkActionDropDownButton('Deactivate')
+    driversPage.list().resourceTable().sortableTable().bulkActionButton('Deactivate')
       .click();
 
     cy.intercept('POST', '/v3/kontainerDrivers/opentelekomcloudcontainerengine?action=deactivate' ).as('deactivateTelecomDriver');

--- a/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
@@ -186,7 +186,6 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
     // delete original MachineSet
     machineDeploymentsPage.list().resourceTable().sortableTable().rowSelectCtlWithName(`${ this.machineDeploymentsName }`)
       .set();
-    machineDeploymentsPage.list().openBulkActionDropdown();
 
     const machineName = `${ nsName }/${ this.machineDeploymentsName }`;
 

--- a/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
@@ -184,7 +184,6 @@ describe('MachineSets', { testIsolation: 'off', tags: ['@manager', '@adminUser']
     // delete original MachineSet
     machineSetsPage.list().resourceTable().sortableTable().rowSelectCtlWithName(this.machineSetName)
       .set();
-    machineSetsPage.list().openBulkActionDropdown();
 
     const name = `${ nsName }/${ this.machineSetName }`;
 

--- a/pkg/rancher-components/src/components/RcButton/index.ts
+++ b/pkg/rancher-components/src/components/RcButton/index.ts
@@ -1,2 +1,2 @@
 export { default as RcButton } from './RcButton.vue';
-export type { RcButtonType } from './types';
+export type { RcButtonType, ButtonSize } from './types';

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownTrigger.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownTrigger.vue
@@ -3,8 +3,12 @@
  * A button that opens a menu. Used in conjunction with `RcDropdown.vue`.
  */
 import { inject, onMounted, ref } from 'vue';
-import { RcButton, RcButtonType } from '@components/RcButton';
+import { RcButton, RcButtonType, ButtonSize } from '@components/RcButton';
 import { DropdownContext, defaultContext } from './types';
+
+defineProps<{
+  size?: ButtonSize,
+}>();
 
 const {
   showMenu,
@@ -32,6 +36,7 @@ defineExpose({ focus });
     role="button"
     aria-haspopup="menu"
     :aria-expanded="isMenuOpen"
+    :size="size"
     @keydown.enter.space="handleKeydown"
     @click="showMenu(true)"
   >

--- a/shell/assets/styles/global/_button.scss
+++ b/shell/assets/styles/global/_button.scss
@@ -8,7 +8,7 @@ $btn-sm-height: 30px;
 // -----------------------------------------------------------------------------
 .btn,
 button,
-[class^='btn-'] {
+[class^='btn-']:not(.btn-group) {
   align-items: center;
   display: inline-flex;
   text-align: center;

--- a/shell/components/ActionDropdownShell.vue
+++ b/shell/components/ActionDropdownShell.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { RcDropdown, RcDropdownTrigger, RcDropdownItem } from '@components/RcDropdown';
+import { ButtonSize } from '@components/RcButton';
 type HiddenAction = {
   action: string;
   enabled: boolean;
@@ -11,11 +12,12 @@ type HiddenAction = {
   anyEnabled: boolean;
 }
 
-defineProps<{
+withDefaults(defineProps<{
   disabled: boolean,
   hiddenActions: HiddenAction[],
   actionTooltip: unknown,
-}>();
+  size?: ButtonSize,
+}>(), { size: 'large' });
 
 const emit = defineEmits(['click', 'mouseover', 'mouseleave']);
 
@@ -35,7 +37,7 @@ const setBulkActionOfInterest = (act: HiddenAction | null, event: 'mouseover' | 
   >
     <rc-dropdown-trigger
       class="bulk-actions-dropdown"
-      size="large"
+      :size="size"
       :disabled="disabled"
     >
       <template #before>

--- a/shell/components/ButtonGroup.vue
+++ b/shell/components/ButtonGroup.vue
@@ -31,11 +31,25 @@ export default {
     disabled: {
       type:    Boolean,
       default: false,
-    }
+    },
+
+    size: {
+      type:      String,
+      default:   'large',
+      validator: (value) => ['small', 'medium', 'large'].includes(value),
+    },
 
   },
 
   computed: {
+    sizeClass() {
+      return {
+        small:  'btn-sm',
+        medium: 'btn-md',
+        large:  null,
+      }[this.size];
+    },
+
     optionObjects() {
       const value = this.value;
 
@@ -52,6 +66,7 @@ export default {
 
         out.class = {
           btn:                  true,
+          [this.sizeClass]:     !!this.sizeClass,
           [this.inactiveClass]: !active,
           [this.activeClass]:   active,
         };
@@ -122,3 +137,13 @@ export default {
     </button>
   </div>
 </template>
+
+<style lang="scss" scoped>
+.btn-group {
+  .btn-md {
+    padding: 0 12px;
+    min-height: 32px;
+    line-height: 32px;
+  }
+}
+</style>

--- a/shell/components/ResourceTable.vue
+++ b/shell/components/ResourceTable.vue
@@ -746,6 +746,7 @@ export default {
       <ButtonGroup
         v-model:value="group"
         :options="_groupOptions"
+        size="medium"
       />
     </template>
 

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1145,6 +1145,7 @@ export default {
                   :disabled="!selectedRows.length"
                   :hidden-actions="hiddenActions"
                   :action-tooltip="actionTooltip"
+                  size="medium"
                   @click="applyTableAction"
                   @mouseover="setBulkActionOfInterest"
                   @mouseleave="setBulkActionOfInterest"
@@ -1157,10 +1158,11 @@ export default {
                   :disable-button="!selectedRows.length"
                   size="sm"
                 >
-                  <template #button-content>
+                  <template #button-content="{ buttonSize }">
                     <button
                       ref="actionDropDown"
                       class="btn bg-primary mr-0"
+                      :class="buttonSize"
                       :disabled="!selectedRows.length"
                     >
                       <i class="icon icon-gear" />

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1873,7 +1873,7 @@ export default {
   }
 
   .search-box {
-    height: 40px;
+    height: 32px;
     margin-left: 10px;
     min-width: 180px;
   }

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -1125,7 +1125,6 @@ export default {
                 v-clean-tooltip="actionTooltip"
                 type="button"
                 variant="primary"
-                size="large"
                 :class="{[bulkActionClass]:true}"
                 :disabled="!act.enabled"
                 :data-testid="componentTestid + '-' + act.action"

--- a/shell/components/__tests__/ButtonGroup.test.ts
+++ b/shell/components/__tests__/ButtonGroup.test.ts
@@ -118,4 +118,60 @@ describe('component: ButtonGroup', () => {
     expect(wrapper.emitted('update:value')).toHaveLength(1);
     expect(wrapper.emitted('update:value')![0][0]).toBe('val1');
   });
+
+  it.each([
+    ['small', 'btn-sm'],
+    ['medium', 'btn-md'],
+  ])('should apply the size class to each button when size is %s', (size, sizeClass) => {
+    const options = [
+      {
+        label: 'label1',
+        value: 'val1'
+      },
+      {
+        label: 'label2',
+        value: 'val2'
+      },
+    ];
+
+    const wrapper = shallowMount(ButtonGroup, {
+      props: {
+        options,
+        value: 'val1',
+        size
+      }
+    });
+
+    const buttons = wrapper.findAll('button');
+
+    expect(buttons).toHaveLength(2);
+    buttons.forEach((button) => {
+      expect(button.classes()).toContain(sizeClass);
+    });
+  });
+
+  it.each([
+    [undefined],
+    ['large'],
+  ])('should not apply a size class when size is %s', (size) => {
+    const options = [
+      {
+        label: 'label1',
+        value: 'val1'
+      },
+    ];
+
+    const wrapper = shallowMount(ButtonGroup, {
+      props: {
+        options,
+        value: 'val1',
+        ...(size ? { size } : {})
+      }
+    });
+
+    const button = wrapper.find('button');
+
+    expect(button.classes()).not.toContain('btn-sm');
+    expect(button.classes()).not.toContain('btn-md');
+  });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This reduces the emphasis on the table action buttons by reducing their size.

Fixes #18109
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Resize table action buttons

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

For the action buttons and the filter input, is a fairly simple fix. The resize consists of removing the size prop and relying on the button defaults/supplying a custom height.

Regarding the GroupButton component, this adds a size prop to the button group that defaults to "large". This is done to ensure that the default button group behavior is not altered in other areas; only the button group in the resource table header is set to medium.

This also sticks to the buttons with classes for two reasons:

1. There are specific group button classes that do not match the design system for the existing RcButton component
2. There are class overrides that are fed to the button group via the `optionsObject()` computed prop. This method of overriding classes to control button styles is at increased risk of breaking if we migrate to RcButton at this time. Keeping the button helps with stability for the 2.15 release.


### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

All action buttons throughout Rancher Dashboard should now default to the medium size - the RcButton default. 

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

This affects tables all throughout Rancher Dashboard. We need to be aware of components that might supply their own buttons as slot content:

https://github.com/rancher/dashboard/blob/c0271168b1c12912b1b3c8e0870765289971e3fb/shell/components/SortableTable/index.vue#L1119-L1152

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Before

<img width="1376" height="1210" alt="image" src="https://github.com/user-attachments/assets/e3fbd8f1-22a6-4811-8284-012a70bdcdf5" />

#### After

<img width="1376" height="208" alt="image" src="https://github.com/user-attachments/assets/214a2cb7-fadd-4dc0-9e59-aaa1e4d7a3d4" />

<img width="1376" height="1215" alt="image" src="https://github.com/user-attachments/assets/180ad71c-9bb0-43ec-924f-a00e523ec55c" />

<img width="1376" height="1215" alt="image" src="https://github.com/user-attachments/assets/2eb7219b-28c7-4d53-9849-b07570486492" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
