### PR TITLE
Disabled editing capi clusters as yaml from editing as config

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -806,4 +806,22 @@ describe('component: rke2', () => {
       expect(wrapper.vm.value.spec.rkeConfig.machineGlobalConfig[INGRESS_CONTROLLER]).toBe(INGRESS_NGINX);
     });
   });
+
+  describe('computed: canEditAsYaml', () => {
+    it('should return false when isUpstreamCAPIProvider is true', () => {
+      const vm = { isUpstreamCAPIProvider: true } as any;
+
+      const canEditAsYaml = rke2.computed!.canEditAsYaml.call(vm);
+
+      expect(canEditAsYaml).toBe(false);
+    });
+
+    it('should return true when isUpstreamCAPIProvider is false', () => {
+      const vm = { isUpstreamCAPIProvider: false } as any;
+
+      const canEditAsYaml = rke2.computed!.canEditAsYaml.call(vm);
+
+      expect(canEditAsYaml).toBe(true);
+    });
+  });
 });

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -919,6 +919,10 @@ export default {
       return this.needCredential && !this.credentialId;
     },
 
+    canEditAsYaml() {
+      return !(this.isUpstreamCAPIProvider);
+    },
+
     overallFormValidationPassed() {
       return this.validationPassed &&
             this.fvFormIsValid &&
@@ -2459,6 +2463,7 @@ export default {
     :done-route="doneRoute"
     :apply-hooks="applyHooks"
     :generate-yaml="generateYaml"
+    :can-yaml="canEditAsYaml"
     class="rke2"
     component-testid="rke2-custom-create"
     @done="done"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17679 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Disabled editing capi clusters as yaml when navigating from Cluster config. Cluster can still be edited as yaml as a direct action from the cluster manager

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Provision a CAPA cluster
Check that 'edit as YAML' action is available
Check that 'edit as config' action is available
Check that you cannot switch from editing as config to editing as yaml

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
non-capi rke2 clusters could be affected

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
