### PR TITLE
Feature/18058 disable local auth crud

### DIFF
--- a/shell/config/product/auth.js
+++ b/shell/config/product/auth.js
@@ -64,7 +64,14 @@ export function init(store) {
     }
   });
 
-  configureType(MANAGEMENT.USER, { showListMasthead: false });
+  configureType(MANAGEMENT.USER, {
+    showListMasthead: false,
+    isCreatable:      () => {
+      // Prevent local user creation when hide-local-auth-provider feature is enabled
+      // AND there's at least one non-local auth provider enabled
+      return store.getters['auth/canCreateLocalUsers'];
+    }
+  });
 
   configureType(MANAGEMENT.OIDC_CLIENT, {
     listCreateButtonLabelKey: 'oidcclient.listViewCreate',

--- a/shell/config/product/auth.js
+++ b/shell/config/product/auth.js
@@ -64,14 +64,7 @@ export function init(store) {
     }
   });
 
-  configureType(MANAGEMENT.USER, {
-    showListMasthead: false,
-    isCreatable:      () => {
-      // Prevent local user creation when hide-local-auth-provider feature is enabled
-      // AND there's at least one non-local auth provider enabled
-      return store.getters['auth/canCreateLocalUsers'];
-    }
-  });
+  configureType(MANAGEMENT.USER, { showListMasthead: false });
 
   configureType(MANAGEMENT.OIDC_CLIENT, {
     listCreateButtonLabelKey: 'oidcclient.listViewCreate',

--- a/shell/list/management.cattle.io.user.vue
+++ b/shell/list/management.cattle.io.user.vue
@@ -87,6 +87,12 @@ export default {
 
     isAdmin() {
       return isAdminUser(this.$store.getters);
+    },
+
+    canCreateUsers() {
+      // Prevent local user creation when hide-local-auth-provider feature is enabled
+      // AND there's at least one non-local auth provider enabled
+      return this.$store.getters['auth/canCreateLocalUsers'];
     }
   },
 
@@ -114,6 +120,7 @@ export default {
       :show-incremental-loading-indicator="incrementalLoadingIndicator"
       :load-resources="loadResources"
       :load-indeterminate="loadIndeterminate"
+      :is-creatable="canCreateUsers"
     >
       <template #extraActions>
         <AsyncButton

--- a/shell/list/management.cattle.io.user.vue
+++ b/shell/list/management.cattle.io.user.vue
@@ -8,6 +8,8 @@ import ResourceFetch from '@shell/mixins/resource-fetch';
 import { isAdminUser } from '@shell/store/type-map';
 import TableDataUserIcon from '@shell/components/TableDataUserIcon';
 import { RcButton } from '@components/RcButton';
+import { allHash } from '@shell/utils/promise';
+import Loading from '@shell/components/Loading.vue';
 
 export default {
   components: {
@@ -15,7 +17,8 @@ export default {
     ResourceTable,
     Masthead,
     TableDataUserIcon,
-    RcButton
+    RcButton,
+    Loading
   },
   mixins: [ResourceFetch],
   props:  {
@@ -40,9 +43,16 @@ export default {
     }
   },
   async fetch() {
-    await this.$fetchType(this.resource);
+    const promises = {
+      resources:                 this.$fetchType(this.resource),
+      localProviderEnabled:      this.$store.dispatch('auth/getLocalProviderEnabled'),
+      membershipRefreshRequests: this.$store.dispatch('management/create', { type: EXT.GROUP_MEMBERSHIP_REFRESH_REQUESTS }),
+    };
 
-    this.membershipRefreshRequests = await this.$store.dispatch('management/create', { type: EXT.GROUP_MEMBERSHIP_REFRESH_REQUESTS });
+    const res = await allHash(promises);
+
+    this.localProviderEnabled = res.localProviderEnabled;
+    this.membershipRefreshRequests = res.membershipRefreshRequests;
     this.canRefreshMemberships = !!this.membershipRefreshRequests?.canRefreshMemberships;
   },
 
@@ -90,10 +100,11 @@ export default {
     },
 
     canCreateUsers() {
-      // Prevent local user creation when hide-local-auth-provider feature is enabled
-      // AND there's at least one non-local auth provider enabled
-      return this.$store.getters['auth/canCreateLocalUsers'];
-    }
+      const userCan = !!this.schema?.collectionMethods?.find((x) => x.toLowerCase() === 'post');
+      const systemCan = this.localProviderEnabled;
+
+      return userCan && systemCan;
+    },
   },
 
   methods: {
@@ -113,7 +124,8 @@ export default {
 </script>
 
 <template>
-  <div>
+  <Loading v-if="$fetchState.pending" />
+  <div v-else>
     <Masthead
       :schema="schema"
       :resource="resource"

--- a/shell/store/__tests__/auth.test.ts
+++ b/shell/store/__tests__/auth.test.ts
@@ -1,4 +1,4 @@
-import { actions } from '@shell/store/auth';
+import { actions, getters } from '@shell/store/auth';
 import { createStore } from 'vuex';
 
 // jest.mock('@shell/utils/url', () => ({
@@ -131,6 +131,113 @@ describe('action: test', () => {
       await actions.test(store, { provider, body });
 
       expect(dispatchSpy.mock.calls[0][1]).toStrictEqual(options);
+    });
+  });
+});
+
+describe('getter: canCreateLocalUsers', () => {
+  const createMockRootGetters = (featureEnabled: boolean, authConfigsLoaded: boolean, authConfigs: any[] = []) => ({
+    'features/get': jest.fn(() => featureEnabled),
+    'management/haveAll': jest.fn(() => authConfigsLoaded),
+    'management/all': jest.fn(() => authConfigs),
+  });
+
+  describe('when feature flag is disabled', () => {
+    it('should allow user creation regardless of auth providers', () => {
+      const rootGetters = createMockRootGetters(false, true, [
+        { id: 'github', enabled: true },
+        { id: 'local', enabled: true }
+      ]);
+
+      const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
+
+      expect(result).toBe(true);
+    });
+
+    it('should allow user creation even if auth configs are not loaded', () => {
+      const rootGetters = createMockRootGetters(false, false, []);
+
+      const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('when feature flag is enabled', () => {
+    describe('and auth configs are not loaded yet', () => {
+      it('should prevent user creation (safe default)', () => {
+        const rootGetters = createMockRootGetters(true, false, []);
+
+        const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('and auth configs are loaded', () => {
+      it('should prevent user creation when a non-local auth provider is enabled', () => {
+        const rootGetters = createMockRootGetters(true, true, [
+          { id: 'github', enabled: true },
+          { id: 'local', enabled: true }
+        ]);
+
+        const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
+
+        expect(result).toBe(false);
+      });
+
+      it('should allow user creation when only local auth provider is enabled', () => {
+        const rootGetters = createMockRootGetters(true, true, [
+          { id: 'local', enabled: true }
+        ]);
+
+        const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
+
+        expect(result).toBe(true);
+      });
+
+      it('should allow user creation when no auth providers are enabled', () => {
+        const rootGetters = createMockRootGetters(true, true, [
+          { id: 'github', enabled: false },
+          { id: 'local', enabled: false }
+        ]);
+
+        const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
+
+        expect(result).toBe(true);
+      });
+
+      it('should allow user creation when auth configs list is empty', () => {
+        const rootGetters = createMockRootGetters(true, true, []);
+
+        const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
+
+        expect(result).toBe(true);
+      });
+
+      it('should prevent user creation when multiple non-local providers are enabled', () => {
+        const rootGetters = createMockRootGetters(true, true, [
+          { id: 'github', enabled: true },
+          { id: 'azuread', enabled: true },
+          { id: 'local', enabled: true }
+        ]);
+
+        const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
+
+        expect(result).toBe(false);
+      });
+
+      it('should allow user creation when non-local providers exist but are disabled', () => {
+        const rootGetters = createMockRootGetters(true, true, [
+          { id: 'github', enabled: false },
+          { id: 'azuread', enabled: false },
+          { id: 'local', enabled: true }
+        ]);
+
+        const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
+
+        expect(result).toBe(true);
+      });
     });
   });
 });

--- a/shell/store/__tests__/auth.test.ts
+++ b/shell/store/__tests__/auth.test.ts
@@ -1,4 +1,4 @@
-import { actions, getters } from '@shell/store/auth';
+import { actions } from '@shell/store/auth';
 import { createStore } from 'vuex';
 
 // jest.mock('@shell/utils/url', () => ({
@@ -135,109 +135,20 @@ describe('action: test', () => {
   });
 });
 
-describe('getter: canCreateLocalUsers', () => {
-  const createMockRootGetters = (featureEnabled: boolean, authConfigsLoaded: boolean, authConfigs: any[] = []) => ({
-    'features/get': jest.fn(() => featureEnabled),
-    'management/haveAll': jest.fn(() => authConfigsLoaded),
-    'management/all': jest.fn(() => authConfigs),
+describe('action: getLocalProviderEnabled', () => {
+  it('should return true if local auth provider exists', async() => {
+    const dispatch = jest.fn().mockResolvedValue({ id: 'local' });
+    const result = await actions.getLocalProviderEnabled({ dispatch } as any);
+
+    expect(dispatch).toHaveBeenCalledWith('getAuthProvider', 'local');
+    expect(result).toBe(true);
   });
 
-  describe('when feature flag is disabled', () => {
-    it('should allow user creation regardless of auth providers', () => {
-      const rootGetters = createMockRootGetters(false, true, [
-        { id: 'github', enabled: true },
-        { id: 'local', enabled: true }
-      ]);
+  it('should return false if local auth provider does not exist', async() => {
+    const dispatch = jest.fn().mockResolvedValue(undefined);
+    const result = await actions.getLocalProviderEnabled({ dispatch } as any);
 
-      const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
-
-      expect(result).toBe(true);
-    });
-
-    it('should allow user creation even if auth configs are not loaded', () => {
-      const rootGetters = createMockRootGetters(false, false, []);
-
-      const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
-
-      expect(result).toBe(true);
-    });
-  });
-
-  describe('when feature flag is enabled', () => {
-    describe('and auth configs are not loaded yet', () => {
-      it('should prevent user creation (safe default)', () => {
-        const rootGetters = createMockRootGetters(true, false, []);
-
-        const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
-
-        expect(result).toBe(false);
-      });
-    });
-
-    describe('and auth configs are loaded', () => {
-      it('should prevent user creation when a non-local auth provider is enabled', () => {
-        const rootGetters = createMockRootGetters(true, true, [
-          { id: 'github', enabled: true },
-          { id: 'local', enabled: true }
-        ]);
-
-        const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
-
-        expect(result).toBe(false);
-      });
-
-      it('should allow user creation when only local auth provider is enabled', () => {
-        const rootGetters = createMockRootGetters(true, true, [
-          { id: 'local', enabled: true }
-        ]);
-
-        const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
-
-        expect(result).toBe(true);
-      });
-
-      it('should allow user creation when no auth providers are enabled', () => {
-        const rootGetters = createMockRootGetters(true, true, [
-          { id: 'github', enabled: false },
-          { id: 'local', enabled: false }
-        ]);
-
-        const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
-
-        expect(result).toBe(true);
-      });
-
-      it('should allow user creation when auth configs list is empty', () => {
-        const rootGetters = createMockRootGetters(true, true, []);
-
-        const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
-
-        expect(result).toBe(true);
-      });
-
-      it('should prevent user creation when multiple non-local providers are enabled', () => {
-        const rootGetters = createMockRootGetters(true, true, [
-          { id: 'github', enabled: true },
-          { id: 'azuread', enabled: true },
-          { id: 'local', enabled: true }
-        ]);
-
-        const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
-
-        expect(result).toBe(false);
-      });
-
-      it('should allow user creation when non-local providers exist but are disabled', () => {
-        const rootGetters = createMockRootGetters(true, true, [
-          { id: 'github', enabled: false },
-          { id: 'azuread', enabled: false },
-          { id: 'local', enabled: true }
-        ]);
-
-        const result = getters.canCreateLocalUsers({}, {}, {}, rootGetters);
-
-        expect(result).toBe(true);
-      });
-    });
+    expect(dispatch).toHaveBeenCalledWith('getAuthProvider', 'local');
+    expect(result).toBe(false);
   });
 });

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -77,30 +77,6 @@ export const getters = {
   selfUser(state) {
     return state.selfUser;
   },
-
-  canCreateLocalUsers(_state, _getters, _rootState, rootGetters) {
-    // Check if the feature flag is enabled
-    const featureEnabled = rootGetters['features/get']('hide-local-auth-provider');
-
-    if (!featureEnabled) {
-      return true; // Feature flag not enabled, allow local user creation
-    }
-
-    // Check if auth configs are loaded
-    const authConfigsLoaded = rootGetters['management/haveAll']('management.cattle.io.authconfig');
-
-    if (!authConfigsLoaded) {
-      // Auth configs not loaded yet, prevent creation until we know
-      return false;
-    }
-
-    // Check if there's at least one non-local auth provider enabled
-    const authConfigs = rootGetters['management/all']('management.cattle.io.authconfig') || [];
-    const hasEnabledNonLocalProvider = authConfigs.some((config) => config.enabled && config.id !== 'local');
-
-    // Allow local user creation only if no other provider is enabled
-    return !hasEnabledNonLocalProvider;
-  }
 };
 
 export const mutations = {
@@ -230,6 +206,16 @@ export const actions = {
     const authConfigs = await dispatch('getAuthConfigs');
 
     return findBy(authConfigs, 'id', id);
+  },
+
+  /**
+   * Is the local auth provider enabled?
+   */
+  async getLocalProviderEnabled({ dispatch }) {
+    // If it exists as an option to log in --> enabled
+    const localProvider = await dispatch('getAuthProvider', 'local');
+
+    return !!localProvider;
   },
 
   /**

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -86,6 +86,14 @@ export const getters = {
       return true; // Feature flag not enabled, allow local user creation
     }
 
+    // Check if auth configs are loaded
+    const authConfigsLoaded = rootGetters['management/haveAll']('management.cattle.io.authconfig');
+
+    if (!authConfigsLoaded) {
+      // Auth configs not loaded yet, prevent creation until we know
+      return false;
+    }
+
     // Check if there's at least one non-local auth provider enabled
     const authConfigs = rootGetters['management/all']('management.cattle.io.authconfig') || [];
     const hasEnabledNonLocalProvider = authConfigs.some((config) => config.enabled && config.id !== 'local');

--- a/shell/store/auth.js
+++ b/shell/store/auth.js
@@ -76,6 +76,22 @@ export const getters = {
 
   selfUser(state) {
     return state.selfUser;
+  },
+
+  canCreateLocalUsers(_state, _getters, _rootState, rootGetters) {
+    // Check if the feature flag is enabled
+    const featureEnabled = rootGetters['features/get']('hide-local-auth-provider');
+
+    if (!featureEnabled) {
+      return true; // Feature flag not enabled, allow local user creation
+    }
+
+    // Check if there's at least one non-local auth provider enabled
+    const authConfigs = rootGetters['management/all']('management.cattle.io.authconfig') || [];
+    const hasEnabledNonLocalProvider = authConfigs.some((config) => config.enabled && config.id !== 'local');
+
+    // Allow local user creation only if no other provider is enabled
+    return !hasEnabledNonLocalProvider;
   }
 };
 

--- a/shell/store/features.js
+++ b/shell/store/features.js
@@ -43,6 +43,7 @@ export const AUTOSCALER = create('cluster-autoscaling', false);
 export const CLUSTER_SHELL = create('cluster-shell', true);
 export const NODE_SHELL = create('node-shell', true);
 export const POD_SHELL = create('pod-shell', true);
+export const HIDE_LOCAL_AUTH_PROVIDER = create('hide-local-auth-provider', false);
 
 // Not currently used.. no point defining ones we don't use
 // export const EMBEDDED_CLUSTER_API = create('embedded-cluster-api', true);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18058

Removed the "create" button if local auth is hidden and auth provider is on.

### Occurred changes and/or fixed issues
- create a new auth action to return true if local provider is enabled (and not disabled given FF and supplementary provider)
- fetch local provider enabled state alongside other async calls when listing users
- use new enabled state alongside user permissions to show/hide create button


### Areas or cases that should be tested


#### Create User
user | feature flag | auth config configured | create button visible
--|--|--|--
admin| off | no | yes
admin | off | yes | yes
admin | on | no | yes
admin | on | yes | no
standard user | all scenarios | all scenarios | no
standard user + manage user role| off | no | yes
standard user + manage user role | off | yes | yes
standard user + manage user role | on | no | yes
standard user + manage user role | on | yes | no

#### Edit / Delete
- Users should be able to edit or delete if they are admin or have manage user roles

### Areas which could experience regressions
- testing above covers any possible areas of regression

### Screenshot/Video

https://github.com/user-attachments/assets/9d6db435-4fd8-4a53-a424-073dbdbbbfaa



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`