### PR TITLE
Fix three bugs that can result in an empty cluster list after returning from edit

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -87,7 +87,7 @@ export default {
       await this.$store.dispatch('management/watch', { type: MANAGEMENT.CLUSTER, registerType: true });
       await this.$store.dispatch('management/watch', { type: CAPI.RANCHER_CLUSTER, registerType: true });
     } else {
-      hash.mgmtClusters = this.value.waitForMgmt();
+      hash.mgmtCluster = this.value.waitForMgmt();
     }
 
     // No need to fetch charts when editing an RKE1 cluster

--- a/shell/mixins/resource-fetch.js
+++ b/shell/mixins/resource-fetch.js
@@ -35,7 +35,7 @@ export default {
     // Normally owner components supply `resource` and `inStore` as part of their data, however these are needed here before parent data runs
     // So set up both here
     const params = { ...this.$route.params };
-    const resource = params.resource || this.schema?.id; // Resource can either be on a page showing single list, or a page of a resource showing a list of another resource
+    const resource = this.schema?.id || params.resource; // Resource can either be on a page showing single list, or a page of a resource showing a list of another resource
     const inStore = this.$store.getters['currentStore'](resource);
 
     return {

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -834,6 +834,17 @@ const defaultActions = {
     state.debugSocket && console.debug(`Subscribe Flush [${ getters.storeName }]`, queue.length, 'items'); // eslint-disable-line no-console
 
     for ( const { action, event, body } of queue ) {
+      const havePage = getters['havePage'](body?.type);
+
+      if (havePage) {
+        // eslint-disable-next-line no-console
+        console.warn(`Prevented watch \`flush\` data from polluting the cache for type "${ body?.type }" (currently represents a page)`, {
+          action, event, body
+        });
+
+        continue;
+      }
+
       if ( action === 'dispatch' && event === 'load' ) {
         // Group loads into one loadMulti when possible
         toLoad.push(body);

--- a/shell/utils/async.ts
+++ b/shell/utils/async.ts
@@ -5,6 +5,8 @@ export const waitFor = (testFn: Function, msg = '', timeoutMs = 3000000, interva
     if (testFn()) {
       gatedLog('Wait for', msg || 'unknown', 'done immediately');
       resolve(this);
+
+      return;
     }
     const timeout = setTimeout(() => {
       gatedLog('Wait for', msg, 'timed out');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18075
Fixes #17867


<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Bug - Prevent waitFor repeating the request to find mgmt cluster
  - After user edits a v2prov cluster we call model v2prov waitForMgmt
  - if this already exists in cache it passes waitForTest
  - HOWEVER does not return, so kicks off a 1 second wait before running test again
  - which calls find + watch
  - however if we're already on the mgmt cluster list page any events from watch will clear the store of the list's page (it now no-longer represents it)
  - FIX - in waitFor return if we've passed the test instead of waiting a second and retrying
- Bug - Pages with a resource param would override sub lists resource type
  - paginatedresourcetable data take schema and assigns it it `resource`
  - however before that happens resource-fetch data takes the page resource and uses that
  - BUG - on pages that contain a param but we want to override (prov cluster list + mgmt cluster content) we use the wrong time
  - FIX - prefer schema component param over page url param
- Bug - race condition meant we cleared page given errant watch
  - We have a process in place to guard the store if it represents a page
    - i.e. don't push in watches related to individual resources that would mean the store did not contain a page
  - The process works by stopping resource.change events if store contains a page
  - BUG - store becomes a page after resource.change is added to queue, but before queue is flushed
  - FIX - guard both resource.change BEFORE adding to queue and flush AFTER queue processed

### Technical notes summary
@yonasberhe23  I'm not 100% sure this solves #17867, however it's in a highly connected area and given the validation will be automated would like to give it a go. Can you let me know as soon as you're happy that it does / doesn't solve the issue?

### Areas or cases that should be tested
Best steps i've found to create the core issue are below, executed quickly together
- Cluster Management --> refresh -->
- Create --> Custom --> enter `aaa` for name --> create -->
- Cluster Management --> find created cluster --> three dot menu --> Edit Config -->
- Registries tab --> `Enable cluster scoped container registry...` --> aaa for Container Registry --> Image Pull Secret 'http basic auth' --> aaa for username, aaa for password --> save
- within less than a second the Cluster Management cluster list should be empty

### Areas which could experience regressions
- Bug - Prevent waitFor repeating the request to find mgmt cluster
  - used in lots of places, if this broke we would know
- Bug - Pages with a resource param would override sub lists resource type
  - Regression tests should include pages that show lists that aren't of the same type than the type in the url
  - For example Workloads --> Deployments --> click on a deployment
  - url type is deployments, pods list type is pods
- Bug - race condition meant we cleared page given errant watch
  - Regression tests should include any page that watches an individual resource... and see updates to it triggered by changes outside of that tab

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
