### PR TITLE
[Describe resource drawer] make sure we show the correct type for fields like []string

### DIFF
--- a/pkg/kubectl-explain/components/ExplainPanel.vue
+++ b/pkg/kubectl-explain/components/ExplainPanel.vue
@@ -161,7 +161,7 @@ export default {
             v-else
             class="field-type"
           >
-            {{ t('kubectl-explain.object') }}
+            {{ field.type === 'array' && field.items?.type ? field.items.type : t('kubectl-explain.object') }}
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/18124

I extracted the fix from my other PR https://github.com/rancher/dashboard/pull/15664 where I discovered the bug when attempting to resolve an issue with the CRD drawer. Hopefully, this makes it easier to review.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
Display the correct type if a field is a "simple" list (list of int/string) instead of the generic `Object` type.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Simply check whether the field is an array and whether the items have a defined type. If so, display it. Otherwise, default to 'Object' as before.

### Areas or cases that should be tested

Make sure the `Describe resource` display correct types for various fields

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
Before:
<img width="624" height="620" alt="image" src="https://github.com/user-attachments/assets/978eb41a-091d-407c-8e4d-735c8f7fe44b" />

After:
<img width="625" height="610" alt="image" src="https://github.com/user-attachments/assets/45133ff3-a595-4920-ae19-80931e50fe2b" />

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
