### PR TITLE
fix docs inconsistencies on TableColumn extension point

### DIFF
--- a/docusaurus/docs/extensions/api/table-columns.md
+++ b/docusaurus/docs/extensions/api/table-columns.md
@@ -58,8 +58,8 @@ plugin.addTableColumn(where: String, when: LocationConfig, column: TableColumn, 
 |`value`| String | Object property to obtain the value from |
 |`getValue`| Function | Same as "value", but it can be a function. Will supersede "value" |
 |`width`| Int | Column width (in `px`). Optional |
-|`sort`| boolean,string,Array | Object properties to be bound to the table sorting. Optional |
-|`search`| boolean,string,Array | Object properties to be bound to the table search. Optional |
+|`sort`| string, string[] | Object properties to be bound to the table sorting. Optional |
+|`search`| boolean (false to disable), string, string[] | Object properties to be bound to the table search. Optional |
 | `formatter`| string | Name of a `formatter` component used to render the cell. Components should be in the extension `formatters` folder
 | `formatterOpts`| any | Provide additional values to the `formatter` component via a `formatterOpts` component param
 

--- a/shell/types/store/type-map.ts
+++ b/shell/types/store/type-map.ts
@@ -11,7 +11,7 @@ export interface TableColumn {
   formatterOpts?: any,
   width?: number,
   tooltip?: string,
-  search?: string | boolean,
+  search?: string | string[] | boolean,
 }
 
 export const COLUMN_BREAKPOINTS = {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16044 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- fix docs inconsistencies on `TableColumn` extension point

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
