### PR TITLE
Fixed cluster provisioning log not populating with events

### DIFF
--- a/shell/detail/__tests__/provisioning.cattle.io.cluster.test.ts
+++ b/shell/detail/__tests__/provisioning.cattle.io.cluster.test.ts
@@ -241,4 +241,56 @@ describe('view: provisioning.cattle.io.cluster', () => {
       expect(wrapper.vm.fakeMachines).toHaveLength(0);
     });
   });
+
+  describe('computed: showLog', () => {
+    it('returns true when mgmt has a log link and extDetailTabs.logs is enabled', async() => {
+      const value = { mgmt: { hasLink: (link: string) => link === 'log' } };
+
+      const wrapper = shallowMount(ProvisioningCattleIoCluster, {
+        props:  { value },
+        global: { mocks },
+      });
+
+      await wrapper.setData({ extDetailTabs: { logs: true } });
+
+      expect(wrapper.vm.showLog).toStrictEqual(true);
+    });
+
+    it('returns false when mgmt does not have a log link', async() => {
+      const value = { mgmt: { hasLink: () => false } };
+
+      const wrapper = shallowMount(ProvisioningCattleIoCluster, {
+        props:  { value },
+        global: { mocks },
+      });
+
+      await wrapper.setData({ extDetailTabs: { logs: true } });
+
+      expect(wrapper.vm.showLog).toStrictEqual(false);
+    });
+
+    it('returns false when mgmt has a log link but extDetailTabs.logs is disabled', async() => {
+      const value = { mgmt: { hasLink: (link: string) => link === 'log' } };
+
+      const wrapper = shallowMount(ProvisioningCattleIoCluster, {
+        props:  { value },
+        global: { mocks },
+      });
+
+      await wrapper.setData({ extDetailTabs: { logs: false } });
+
+      expect(wrapper.vm.showLog).toStrictEqual(false);
+    });
+
+    it('returns false when mgmt is undefined', async() => {
+      const value = {};
+
+      const wrapper = shallowMount(ProvisioningCattleIoCluster, {
+        props:  { value },
+        global: { mocks },
+      });
+
+      expect(wrapper.vm.showLog).toBeFalsy();
+    });
+  });
 });

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -210,9 +210,7 @@ export default {
     if ( this.$store.getters['management/canList'](MANAGEMENT.RKE_TEMPLATE) ) {
       this.$store.dispatch('management/findAll', { type: MANAGEMENT.RKE_TEMPLATE });
     }
-  },
 
-  created() {
     if ( this.showLog ) {
       this.connectLog();
     }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17687 
<!-- Define findings related to the feature or bug issue. -->
Fixed cluster provisioning log not showing events

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
We were initializing log connection on create when management cluster wasn't always initialized yet. moved it to fetch to make sure mgmt is fetched before checking

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
I don't think we have a good way to automate testing this, so manual testing is required
Create a new cluster => cluster detail => provisioning log => make sure events are being populated

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
None, this is pretty isolated

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1613" height="810" alt="Screenshot 2026-06-23 at 12 09 00 PM" src="https://github.com/user-attachments/assets/1b692f26-6b9e-4d7d-a815-a7f1e415c8b6" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
