### PR TITLE
Changes to Ipv6 validation

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2174,7 +2174,7 @@ cluster:
         label: Enable IPv6
       httpProtocolIpv6: 
         label: Enable IPv6 endpoint for instance metadata service
-      ipv6ValidationWarning: When one pool uses an IPv6 or dual-stack subnet/vpc, all pools must use an IPv6 or dual-stack subnet/vpc.
+      ipv6ValidationWarning: When one pool uses an IPv6 or dual-stack subnet/vpc, all pools must use the same networking configuration.
     pnap:
       serverLocation:
         label: Location

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2174,7 +2174,8 @@ cluster:
         label: Enable IPv6
       httpProtocolIpv6: 
         label: Enable IPv6 endpoint for instance metadata service
-      ipv6ValidationWarning: When one pool uses an IPv6 or dual-stack subnet/vpc, all pools must use the same networking configuration.
+      dualStackValidationWarning: When one pool enables dual-stack subnet/vpc, all pools must use the same networking configuration.
+      ipv6ValidationWarning: When one pool enables IPv6 subnet/vpc, all pools must use the same networking configuration.
     pnap:
       serverLocation:
         label: Location

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1627,9 +1627,10 @@ export default {
 
       const isDualStack = this.hasDualStackPools;
       const isIpv6 = this.hasOnlyIpv6Pools;
+      const isIpv4 = !isIpv6 && !isDualStack;
 
       const flannelMasqInvalid = isIpv6 && isK3s && !flannelMasqEnabled;
-      const stackPrefInvalid = (isIpv6 && stackPreference !== STACK_PREFS.IPV6) || (isDualStack && ![STACK_PREFS.IPV6, STACK_PREFS.DUAL].includes(stackPreference));
+      const stackPrefInvalid = (isIpv6 && stackPreference !== STACK_PREFS.IPV6) || (isDualStack && stackPreference !== STACK_PREFS.DUAL_STACK) || (isIpv4 && stackPreference !== STACK_PREFS.IPV4);
 
       const clusterCIDRInvalid = (isIpv6 || isDualStack) && !clusterCIDR.includes(':');
       const serviceCIDRInvalid = (isIpv6 || isDualStack) && !serviceCIDR.includes(':');

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1627,10 +1627,9 @@ export default {
 
       const isDualStack = this.hasDualStackPools;
       const isIpv6 = this.hasOnlyIpv6Pools;
-      const isIpv4 = !isIpv6 && !isDualStack;
 
       const flannelMasqInvalid = isIpv6 && isK3s && !flannelMasqEnabled;
-      const stackPrefInvalid = (isIpv6 && stackPreference !== STACK_PREFS.IPV6) || (isDualStack && stackPreference !== STACK_PREFS.DUAL_STACK) || (isIpv4 && stackPreference !== STACK_PREFS.IPV4);
+      const stackPrefInvalid = (isIpv6 && stackPreference !== STACK_PREFS.IPV6) || (isDualStack && stackPreference !== STACK_PREFS.DUAL);
 
       const clusterCIDRInvalid = (isIpv6 || isDualStack) && !clusterCIDR.includes(':');
       const serviceCIDRInvalid = (isIpv6 || isDualStack) && !serviceCIDR.includes(':');

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/networking/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/networking/index.vue
@@ -295,7 +295,7 @@ export default {
       <div class="col span-3">
         <LabeledSelect
           :key="hasSomeIpv6Pools"
-          :value="localValue?.spec?.rkeConfig?.networking?.stackPreference || STACK_PREFS.IPV4"
+          :value="localValue?.spec?.rkeConfig?.networking?.stackPreference || STACK_PREFS.DUAL"
           :mode="mode"
           :options="stackPreferenceOptions"
           data-testid="network-tab-stackpreferences"

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/networking/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/networking/index.vue
@@ -120,7 +120,7 @@ export default {
 
     stackPreference: {
       get() {
-        return this.localValue.spec?.networking?.stackPreference || STACK_PREFS.IPV4;
+        return this.localValue.spec?.networking?.stackPreference || STACK_PREFS.DUAL;
       },
       set(neu) {
         if (!this.localValue.spec.networking) {

--- a/shell/machine-config/components/EC2Networking.vue
+++ b/shell/machine-config/components/EC2Networking.vue
@@ -10,6 +10,7 @@ import { Banner } from '@components/Banner';
 import { scrollToBottom } from '@shell/utils/scroll';
 import { _CREATE } from '@shell/config/query-params';
 import { getSubnetDisplayName, getVpcDisplayName, isIpv4Network, isIpv6Network } from '@shell/utils/aws';
+import { STACK_PREFS } from '@shell/edit/provisioning.cattle.io.cluster/tabs/networking/index.vue';
 
 export default {
   name: 'Ec2MachinePoolNetworking',
@@ -298,9 +299,19 @@ export default {
     },
 
     poolsInvalid() {
-      const somePoolHasIpv4 = !!this.machinePools.find((p) => !p.isIpv6 && !p.isDualStack);
+      const poolNetworkModes = new Set(this.machinePools.map((p) => {
+        if (p.isDualStack) {
+          return STACK_PREFS.DUAL;
+        }
 
-      return this.somePoolisIpv6OrDual && somePoolHasIpv4;
+        if (p.isIpv6) {
+          return STACK_PREFS.IPV6;
+        }
+
+        return STACK_PREFS.IPV4;
+      }));
+
+      return poolNetworkModes.size > 1;
     },
 
     addressCountInvalid() {

--- a/shell/machine-config/components/EC2Networking.vue
+++ b/shell/machine-config/components/EC2Networking.vue
@@ -298,17 +298,24 @@ export default {
       return this.mode === _CREATE || (this.isNew && this.somePoolisIpv6OrDual) || this.enableIpv6;
     },
 
-    poolsInvalid() {
+    dualStackModeInvalid() {
       const poolNetworkModes = new Set(this.machinePools.map((p) => {
-        if (p.isDualStack) {
+        if (p.isDualStack || p.isIpv6) {
           return STACK_PREFS.DUAL;
         }
 
+        return STACK_PREFS.IPV4;
+      }));
+
+      return poolNetworkModes.size > 1;
+    },
+    ipv6ModeInvalid() {
+      const poolNetworkModes = new Set(this.machinePools.map((p) => {
         if (p.isIpv6) {
           return STACK_PREFS.IPV6;
         }
 
-        return STACK_PREFS.IPV4;
+        return 'other';
       }));
 
       return poolNetworkModes.size > 1;
@@ -319,7 +326,7 @@ export default {
     },
 
     allValid() {
-      return !this.poolsInvalid && !this.addressCountInvalid;
+      return !this.dualStackModeInvalid && !this.addressCountInvalid && !this.ipv6ModeInvalid;
     }
   },
 
@@ -367,10 +374,10 @@ export default {
 
 <template>
   <Banner
-    v-if="poolsInvalid"
+    v-if="dualStackModeInvalid"
     color="error"
-    :label="t('cluster.machineConfig.amazonEc2.ipv6ValidationWarning')"
-    data-testid="amazonEc2__ipv6Warning"
+    :label="t('cluster.machineConfig.amazonEc2.dualStackValidationWarning')"
+    data-testid="amazonEc2__dualStackWarning"
   />
   <div
     v-if="showIpv6Options"
@@ -421,6 +428,12 @@ export default {
       </LabeledSelect>
     </div>
   </div>
+  <Banner
+    v-if="enableIpv6 && ipv6ModeInvalid"
+    color="error"
+    :label="t('cluster.machineConfig.amazonEc2.ipv6ValidationWarning')"
+    data-testid="amazonEc2__ipv6Warning"
+  />
   <div
     v-if="enableIpv6"
     class="row mb-10 ipv6-row"

--- a/shell/machine-config/components/__tests__/EC2Networking.test.ts
+++ b/shell/machine-config/components/__tests__/EC2Networking.test.ts
@@ -16,6 +16,7 @@ describe('component: EC2Networking', () => {
     },
     global: {
       mocks: {
+        t:           (key: string) => key,
         $fetchState: { pending: false },
         $store:      { getters: defaultGetters },
       },
@@ -65,16 +66,9 @@ describe('component: EC2Networking', () => {
   });
 
   it('should render the ipv6 only checkbox when the selected network is dual-stack', async() => {
-    const wrapper = mount(EC2Networking, defaultCreateSetup);
-    const ipv6Checkbox = wrapper.findComponent('[data-testid="amazonEc2__enableIpv6"]');
+    const wrapper = shallowMount(EC2Networking, defaultCreateSetup);
 
-    ipv6Checkbox.vm.$emit('update:value', true);
-    await wrapper.vm.$nextTick();
-
-    const networkDropdown = wrapper.findComponent('[data-testid="amazonEc2__selectedNetwork"]');
-
-    networkDropdown.vm.$emit('selecting', 'subnet-321');
-    await wrapper.vm.$nextTick();
+    await wrapper.setData({ enableIpv6: true, selectedNetwork: 'vpc-12345' });
 
     const ipv6OnlyCheckbox = wrapper.findComponent('[data-testid="amazonEc2__ipv6AddressOnly"]');
 
@@ -83,9 +77,12 @@ describe('component: EC2Networking', () => {
 
   it.each([
     [[{ isIpv6: true }, { isIpv6: false }], true],
-    [[{ isIpv6: false }, { isIpv6: false }], false],
-    [[{ isIpv6: true }, { isIpv6: true }], false],
-  ])('should show an error banner if pools do not either all have ipv6 or all have ipv4', (pools, shouldShowError) => {
+    [[{ isIpv6: false, isDualStack: true }, { isIpv6: false, isDualStack: false }], true],
+    [[{ isIpv6: true, isDualStack: false }, { isIpv6: false, isDualStack: true }], true],
+    [[{ isIpv6: false, isDualStack: false }, { isIpv6: false, isDualStack: false }], false],
+    [[{ isIpv6: true, isDualStack: false }, { isIpv6: true, isDualStack: false }], false],
+    [[{ isIpv6: false, isDualStack: true }, { isIpv6: false, isDualStack: true }], false],
+  ])('should show an error banner when machine pools mix network modes', (pools, shouldShowError) => {
     const wrapper = shallowMount(EC2Networking, { ...defaultCreateSetup, propsData: { ...defaultCreateSetup.propsData, machinePools: pools } });
     const ipv6Warning = wrapper.findComponent('[data-testid="amazonEc2__ipv6Warning"]');
 
@@ -140,6 +137,30 @@ describe('component: EC2Networking', () => {
       propsData: {
         ...defaultCreateSetup.propsData,
         machinePools: [{ isIpv6: true }, { isIpv6: true }],
+      },
+    });
+
+    expect(wrapper.emitted('validationChanged')?.[0][0]).toBe(true);
+  });
+
+  it('should emit a validationChanged: false event when ipv6-only and dual-stack pools are mixed', async() => {
+    const wrapper = shallowMount(EC2Networking, {
+      ...defaultCreateSetup,
+      propsData: {
+        ...defaultCreateSetup.propsData,
+        machinePools: [{ isIpv6: true, isDualStack: false }, { isIpv6: false, isDualStack: true }],
+      },
+    });
+
+    expect(wrapper.emitted('validationChanged')?.[0][0]).toBe(false);
+  });
+
+  it('should emit a validationChanged: true event when all pools are dual-stack', async() => {
+    const wrapper = shallowMount(EC2Networking, {
+      ...defaultCreateSetup,
+      propsData: {
+        ...defaultCreateSetup.propsData,
+        machinePools: [{ isIpv6: false, isDualStack: true }, { isIpv6: false, isDualStack: true }],
       },
     });
 

--- a/shell/machine-config/components/__tests__/EC2Networking.test.ts
+++ b/shell/machine-config/components/__tests__/EC2Networking.test.ts
@@ -1,4 +1,4 @@
-import { mount, shallowMount } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import EC2Networking from '@shell/machine-config/components/EC2Networking.vue';
 
 import { vpcInfo, subnetInfo } from './utils/vpcSubnetMockData';

--- a/shell/machine-config/components/__tests__/EC2Networking.test.ts
+++ b/shell/machine-config/components/__tests__/EC2Networking.test.ts
@@ -76,17 +76,19 @@ describe('component: EC2Networking', () => {
   });
 
   it.each([
-    [[{ isIpv6: true }, { isIpv6: false }], true],
-    [[{ isIpv6: false, isDualStack: true }, { isIpv6: false, isDualStack: false }], true],
-    [[{ isIpv6: true, isDualStack: false }, { isIpv6: false, isDualStack: true }], true],
-    [[{ isIpv6: false, isDualStack: false }, { isIpv6: false, isDualStack: false }], false],
-    [[{ isIpv6: true, isDualStack: false }, { isIpv6: true, isDualStack: false }], false],
-    [[{ isIpv6: false, isDualStack: true }, { isIpv6: false, isDualStack: true }], false],
-  ])('should show an error banner when machine pools mix network modes', (pools, shouldShowError) => {
+    [[{ isIpv6: true }, { isIpv6: false }], true, true],
+    [[{ isIpv6: false, isDualStack: true }, { isIpv6: false, isDualStack: false }], true, false],
+    [[{ isIpv6: true, isDualStack: false }, { isIpv6: false, isDualStack: true }], false, true],
+    [[{ isIpv6: false, isDualStack: false }, { isIpv6: false, isDualStack: false }], false, false],
+    [[{ isIpv6: true, isDualStack: false }, { isIpv6: true, isDualStack: false }], false, false],
+    [[{ isIpv6: false, isDualStack: true }, { isIpv6: false, isDualStack: true }], false, false],
+  ])('should show the correct warning banner based on mixed machine pool network modes', (pools, shouldShowDualStackWarning, shouldShowIpv6Warning) => {
     const wrapper = shallowMount(EC2Networking, { ...defaultCreateSetup, propsData: { ...defaultCreateSetup.propsData, machinePools: pools } });
+    const dualStackWarning = wrapper.findComponent('[data-testid="amazonEc2__dualStackWarning"]');
     const ipv6Warning = wrapper.findComponent('[data-testid="amazonEc2__ipv6Warning"]');
 
-    expect(ipv6Warning.exists()).toBe(shouldShowError);
+    expect(dualStackWarning.exists()).toBe(shouldShowDualStackWarning);
+    expect(ipv6Warning.exists()).toBe(shouldShowIpv6Warning);
   });
 
   it('should show ipv6 inputs and automatically check the enable ipv6 checkbox when adding a new pool if some other pool in the cluster is using ipv6 or dual stack', () => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16788 
<!-- Define findings related to the feature or bug issue. -->
There are a couple issues we discovered as part of this issue that now have been fixed. Ipv6 stack preference is valid for Dual stack clusters, so we should not be prohibiting, but we recommend using dual stack as requested in the related bug, so the check logic has been updated

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
1. Cluster Configuration -> Networking -> Stack Preference -> default value has been changed to Dual stack as per rfd
2. We should not allow mixing dual stack and ipv6 only pools. The warning has been updated to reflect that
3. Changed the modal warning to remove ipv6 from recommended Stack Preference settings for dual stack clusters

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Check that the default Stack Preference has been changed to Dual stack
2. Check that a warning is shown if there are both ipv6 and dual stack pools within the same cluster
3. Check that modal recommends Dual stack Stack preference only for dual stack clusters

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Ipv4 clusters could be affected

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
