### PR TITLE
[18155] principal lookup fails for ad users with non ascii eg chinese characters in their dn unable to fetch principal info escape emits invalid u url encoding

### DIFF
--- a/shell/components/auth/Principal.vue
+++ b/shell/components/auth/Principal.vue
@@ -44,7 +44,12 @@ export default {
         return;
       }
 
-      const principalId = escape(this.value).replace(/\//g, '%2F');
+      // Use encodeURIComponent (not the deprecated escape()) so non-ASCII characters
+      // in the DN (e.g. Chinese) are emitted as valid UTF-8 percent-encoding rather
+      // than non-standard %uXXXX sequences that ingress controllers reject with a 400.
+      // encodeURIComponent encodes the whole principal id as a single path segment,
+      // including forward slashes (-> %2F), so they aren't treated as path separators.
+      const principalId = encodeURIComponent(this.value);
 
       try {
         this.principal = await this.$store.dispatch('rancher/find', {

--- a/shell/components/auth/__tests__/Principal.test.ts
+++ b/shell/components/auth/__tests__/Principal.test.ts
@@ -1,5 +1,6 @@
 import { mount, type VueWrapper } from '@vue/test-utils';
 import Principal from '@shell/components/auth/Principal.vue';
+import { NORMAN } from '@shell/config/types';
 
 describe('component: Principal', () => {
   it('should render the component', () => {
@@ -36,5 +37,41 @@ describe('component: Principal', () => {
     await wrapper.setProps({ value: 'second' });
 
     expect(wrapper.vm.principal.name).toStrictEqual('second name');
+  });
+
+  it('should encode the principal id with valid UTF-8 percent-encoding when fetching', async() => {
+    // DN containing non-ASCII (Chinese) characters and forward slashes
+    const value = 'activedirectory_user://CN=Zhang San 张三,OU=测试部门,DC=example';
+    const dispatch = jest.fn();
+    const wrapper: VueWrapper<any, any> = mount(Principal, {
+      props:  { value },
+      global: {
+        mocks: {
+          $fetchState: { pending: false },
+          $store:      {
+            getters:  { 'rancher/byId': () => null },
+            dispatch,
+          },
+        },
+      },
+    });
+
+    await wrapper.vm.loadData();
+
+    // encodeURIComponent encodes the whole id as a single path segment: slashes as
+    // %2F and non-ASCII (Chinese) as valid UTF-8 - never the deprecated escape() %uXXXX.
+    const expectedId = encodeURIComponent(value);
+    const calledUrl = dispatch.mock.calls[0][1].opt.url;
+
+    expect(dispatch).toHaveBeenCalledWith('rancher/find', {
+      type: NORMAN.PRINCIPAL,
+      id:   value,
+      opt:  { url: `/v3/principals/${ expectedId }` }
+    });
+    // Forward slashes encoded as %2F
+    expect(calledUrl).toContain('%2F%2F');
+    // Chinese characters encoded as valid UTF-8 (not the deprecated escape() %uXXXX)
+    expect(calledUrl).toContain('%E5%BC%A0%E4%B8%89');
+    expect(calledUrl).not.toMatch(/%u[0-9a-fA-F]{4}/);
   });
 });

--- a/shell/components/auth/__tests__/Principal.test.ts
+++ b/shell/components/auth/__tests__/Principal.test.ts
@@ -49,7 +49,7 @@ describe('component: Principal', () => {
         mocks: {
           $fetchState: { pending: false },
           $store:      {
-            getters:  { 'rancher/byId': () => null },
+            getters: { 'rancher/byId': () => null },
             dispatch,
           },
         },

--- a/shell/components/form/Members/ClusterPermissionsEditor.vue
+++ b/shell/components/form/Members/ClusterPermissionsEditor.vue
@@ -169,7 +169,7 @@ export default {
       ];
     },
     principal() {
-      const principalId = this.principalId.replace(/\//g, '%2F');
+      const principalId = encodeURIComponent(this.principalId);
 
       return this.$store.dispatch('rancher/find', {
         type: NORMAN.PRINCIPAL,

--- a/shell/dialog/AddProjectMemberDialog.vue
+++ b/shell/dialog/AddProjectMemberDialog.vue
@@ -51,7 +51,7 @@ export default {
 
   computed: {
     principal() {
-      const principalId = this.member.principalId.replace(/\//g, '%2F');
+      const principalId = encodeURIComponent(this.member.principalId);
 
       return this.$store.dispatch('rancher/find', {
         type: NORMAN.PRINCIPAL,

--- a/shell/models/management.cattle.io.clusterroletemplatebinding.js
+++ b/shell/models/management.cattle.io.clusterroletemplatebinding.js
@@ -28,7 +28,7 @@ export default class CRTB extends HybridModel {
   }
 
   get principal() {
-    const principalId = this.principalId.replace(/\//g, '%2F');
+    const principalId = encodeURIComponent(this.principalId);
 
     return this.$dispatch('rancher/find', {
       type: NORMAN.PRINCIPAL,

--- a/shell/models/management.cattle.io.projectroletemplatebinding.js
+++ b/shell/models/management.cattle.io.projectroletemplatebinding.js
@@ -20,7 +20,7 @@ export default class PRTB extends HybridModel {
   }
 
   get principal() {
-    const principalId = this.principalId.replace(/\//g, '%2F');
+    const principalId = encodeURIComponent(this.principalId);
 
     return this.$dispatch('rancher/find', {
       type: NORMAN.PRINCIPAL,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18155
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- The bug happens on CHINESE character cases, where the fetch doesn't provide the proper URL.
- To fix it make it consistent and correct URL encoding to make it work

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- To Test this I used the OpenLDAP which was enough for me to recreate the bug
- The case for the BUG is different because it uses AD directly, but since the replication is there, the assumption is that the bug and fix is the same.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Setup OpenLDAP on environment
- Create the user with Chinese characters and add it to the local Cluster as a member
- Login using the OpenLDAP provider
- Open the local Cluster Members
**- It should show properly (bug shows it wrong here)**

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Other Member that doesn't have chinese or different characters

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
[ASIS]

<img width="1470" height="966" alt="image" src="https://github.com/user-attachments/assets/53210f5c-49e5-4b04-9cb7-930472a9870a" />

[TOBE]
<img width="1742" height="966" alt="image" src="https://github.com/user-attachments/assets/24e2cc0a-5b4c-40f4-91fb-9ae3e2e67a2c" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
