### PR TITLE
fix aks and gke pool weight so pools dont change order when re-named

### DIFF
--- a/pkg/aks/components/Config.vue
+++ b/pkg/aks/components/Config.vue
@@ -898,7 +898,7 @@ export default defineComponent({
         <Tab
           v-for="(pool, i) in nodePools"
           :key="i"
-          :weight="-1 * idx"
+          :weight="-1 * i"
           :name="pool._id || pool.name"
           :label="pool.name || t('aks.nodePools.notNamed')"
           :error="!poolIsValid(pool)"

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -825,7 +825,7 @@ export default defineComponent({
           @removeTab="removePool($event)"
         >
           <Tab
-            v-for="(pool) in nodePools"
+            v-for="(pool, idx) in nodePools"
             :key="pool._id"
             :weight="-1 * idx"
             :name="pool._id || pool.name"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17125 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR corrects the weights in AKS and GKE node pool Tab components so that they don't change order when pool names change.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
Go to the aks cluster provisioning form
Add several pools
Re-name a pool that is not the first pool to aaaa and verify the order of the tabs doesn't change
Re-name the pool to zzzzz and verify that the order of the tabs doesn't change

Repeat the above steps in the GKE provisioning form

### Areas which could experience regressions
none

### Screenshot/Video

https://github.com/user-attachments/assets/e79a1bbe-236d-4187-9d53-320a03394c37



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
