### PR TITLE
Fix for credential mapping not being picked up from extensions

### DIFF
--- a/shell/core/types-provisioning.ts
+++ b/shell/core/types-provisioning.ts
@@ -192,6 +192,19 @@ export interface IClusterProvisioner {
   hidden?: boolean;
 
   /**
+   * Cloud credential driver this provisioner uses.
+   *
+   * Some providers share a common cloud credential type (e.g. the CAPA
+   * `awsmachinetemplate` provisioner uses the `aws` credential driver). The UI
+   * uses this to resolve the correct cloud credential schema and field names.
+   *
+   * Declaring it here (rather than mutating the host's driver map from the
+   * extension) ensures it is read reliably from the registered provisioner,
+   * including in production extension builds.
+   */
+  credentialDriver?: string;
+
+  /**
    * Custom Dashboard route to navigate to when the cluster provider card is clicked
    */
   link?: string;

--- a/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/SelectCredential.vue
@@ -115,12 +115,44 @@ export default {
     },
 
     driverName() {
+      // An extension provisioner can declare the cloud credential driver it
+      // uses. We read it from the registered provisioner so it works in
+      // production extension builds, where mutating the host's driver map from
+      // the extension (via mapDriver) is unreliable due to bundling.
+      const extDriver = this.provisionerCredentialDriver;
+
+      if (extDriver) {
+        return extDriver;
+      }
+
       let driver = this.provider;
 
       // Map providers that share a common credential to one driver
       driver = this.$store.getters['plugins/credentialDriverFor'](driver);
 
       return driver;
+    },
+
+    provisionerCredentialDriver() {
+      const extClass = this.$extension?.getDynamic?.('provisioner', this.provider);
+
+      if (!extClass) {
+        return null;
+      }
+
+      try {
+        const instance = new extClass({
+          dispatch:   this.$store.dispatch,
+          getters:    this.$store.getters,
+          axios:      this.$store.$axios,
+          $extension: this.$store.app.$extension,
+          t:          (...args) => this.t.apply(this, args),
+        });
+
+        return instance?.credentialDriver || null;
+      } catch (e) {
+        return null;
+      }
     },
 
     filteredCredentials() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18167 
<!-- Define findings related to the feature or bug issue. -->


### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added a new credentialDriver getter to the extension provisioner and updated cloud credential to check corresponding extension for that getter instead of relying on the store's deriver mapping

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
There is some issue with external extensions not updating shell's store. This might be a limitation of our existing extension mechanism and follow up investigation is needed.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Install CAPA extension (prov-capi-ui-extensions)
2. Verify that it correctly offers user existing AWS credentials on cluster creation and edit

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
1. Check that existing built-in extensions (aws, azure, gke) matches credentials correctly
2. Check that rke2 provisioning matches credentials correctly
3. Check that existing external extension (ali) matches credentials correctly

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
