### PR TITLE
Fixed to increase the amount of waiting time to 10m

### DIFF
--- a/shell/utils/__tests__/fleet-appco.test.ts
+++ b/shell/utils/__tests__/fleet-appco.test.ts
@@ -100,6 +100,29 @@ describe('fleet-appco utils', () => {
       expect(onStateChange).toHaveBeenCalledWith(expect.objectContaining({ repoName: 'my-repo', error: false }));
     });
 
+    it('should wait for the repo using a 10 minute timeout and 3s interval (#14627)', async() => {
+      // A cold OCI pull can take minutes; the wait must not give up early.
+      const waitForTestFn = jest.fn((fn: () => boolean) => {
+        fn();
+
+        return Promise.resolve();
+      });
+      const repo = buildRepo({
+        status: { conditions: [{ type: 'OCIDownloaded', status: 'True' }] },
+        waitForTestFn,
+      });
+      const store = buildStore(repo);
+
+      await fetchAppCoCharts(store as any, 'my-repo');
+
+      expect(waitForTestFn).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.stringContaining('my-repo'),
+        600000,
+        3000,
+      );
+    });
+
     it('should return no entries and an error state when the repo reports an error', async() => {
       const repo = buildRepo({ metadata: { state: { error: true, message: 'boom' } } });
       const store = buildStore(repo);

--- a/shell/utils/fleet-appco.ts
+++ b/shell/utils/fleet-appco.ts
@@ -198,7 +198,12 @@ export async function ensureAppCoResources(
   return true;
 }
 
-const REPO_WAIT_TIMEOUT_MS = 90000;
+// Cold/first OCI pulls of the AppCo catalog can take several minutes to download,
+// so we allow a generous window before giving up. Genuine repo/OCI errors still
+// short-circuit early via the `hasError` path below, so this only bounds how long
+// we tolerate a repo that is still downloading. Added as 10 minutes to consider
+// future increases on the size of the AppCo catalog.
+const REPO_WAIT_TIMEOUT_MS = 600000; // 10 minutes
 const REPO_WAIT_INTERVAL_MS = 3000;
 
 function getRepoState(repo: any, repoName: string): { state: RepoState; isReady: boolean; hasError: boolean } {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14627
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- QA reached the 1m30s timing added to wait to fetch the data.
- Increased to 10min to make sure it will trigger if the user waits that long. 10 min is just safe to consider future changes to increase of size of the catalog for example.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- AppCo Fleet Chart loading

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
