### PR TITLE
add vuex action to plugins store for the mapDriver function

### DIFF
--- a/docusaurus/docs/extensions/provisioning/hosted-provider/overview.md
+++ b/docusaurus/docs/extensions/provisioning/hosted-provider/overview.md
@@ -56,6 +56,6 @@ You can restrict which Rancher your extension is compatible with by setting a ["
 3. Cloud credentials can be shared between hosted providers and node drivers. If the provider for which you are creating an extension already has a cloud credential defined, you do not need to add a new one to your extension. If the name of the cloud credential doesn't match your provisioner id, you can map it inside provisioner.ts
 ```ts
   constructor(private context: ClusterProvisionerContext) {
-    mapDriver(this.id, '<exisiting-credential-id>' );
+    context.dispatch('plugins/mapDriver', { name: this.id, to: '<existing-credential-id>' }, { root: true });
   }
 ```

--- a/docusaurus/docs/internal/code-base-works/machine-drivers.md
+++ b/docusaurus/docs/internal/code-base-works/machine-drivers.md
@@ -31,7 +31,7 @@ Cloud Credentials store the username & password, or other similar information, n
 
 The cloud credential component lives in the top-level `cloud-credential` directory in the repo.  The file should be named the same as the driver, in all lowercase (e.g. `cloud-credential/digitalocean.vue`).
 
-If there is a reason to rename it or map multiple drivers to the same credential, configure that in `shell/store/plugins.js`.  There is also other info in there about how guesses are taken on what each field is for and how it should be displayed.  These can be customized for your driver by importing and calling `configureCredential()` and `mapDriver()`.
+If there is a reason to rename it or map multiple drivers to the same credential, configure that in `shell/store/plugins.js`.  There is also other info in there about how guesses are taken on what each field is for and how it should be displayed.  These can be customized for your driver by importing and calling `configureCredential()` from `@shell/store/plugins` and dispatching the `plugins/mapDriver` store action.
 
 Create a component which displays each field that is relevant to authentication and lets the user configure them.  Only the actual auth fields themselves, the rest of configuring the name, description, save buttons, etc is handled outside of the credential component.
 

--- a/docusaurus/extensions_versioned_docs/version-v2/api/components/node-drivers.md
+++ b/docusaurus/extensions_versioned_docs/version-v2/api/components/node-drivers.md
@@ -17,7 +17,7 @@ Cloud Credentials store the username & password, or other similar information, n
 
 The cloud credential component lives in the top-level `cloud-credential` directory in the repo.  The file should be named the same as the driver, in all lowercase (e.g. `cloud-credential/digitalocean.vue`).
 
-If there is a reason to rename it or map multiple drivers to the same credential, configure that in `shell/store/plugins.js`.  There is also other info in there about how guesses are taken on what each field is for and how it should be displayed.  These can be customized for your driver by importing and calling `configureCredential()` and `mapDriver()`.
+If there is a reason to rename it or map multiple drivers to the same credential, configure that in `shell/store/plugins.js`.  There is also other info in there about how guesses are taken on what each field is for and how it should be displayed.  These can be customized for your driver by importing and calling `configureCredential()` from `@shell/store/plugins` and dispatching the `plugins/mapDriver` store action.
 
 Create a component which displays each field that is relevant to authentication and lets the user configure them.  Only the actual auth fields themselves, the rest of configuring the name, description, save buttons, etc is handled outside of the credential component.
 

--- a/shell/store/plugins.js
+++ b/shell/store/plugins.js
@@ -129,6 +129,12 @@ export const state = function() {
   return {};
 };
 
+export const actions = {
+  mapDriver(ctx, { name, to }) {
+    mapDriver(name, to);
+  },
+};
+
 export const getters = {
   credentialOptions() {
     return (name) => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18167 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR adds a vuex action that calls `mapDriver` and updates documentation to reference it. 

I looked into the same fix for `configureCredential` but it looks like that might be dead code? It'll be a little more work to validate that change so I have filed a follow-on issue for 2.16: https://github.com/rancher/dashboard/issues/18171

### Technical notes summary
When extensions call mapDriver directly they are modifying their own instance of driverMap instead of the instance used when dashboard code calls getters from shell/store/plugins

### Areas or cases that should be tested
The scenario described in the linked issue should be tested. A new @rancher/shell RC and capa ui extension RC will be required to test this, once https://github.com/rancher/prov-capi-ui-extensions/pull/11 is merged

### Areas which could experience regressions
None: this PR adds a new method for extensions to call without modifying existing dashboard functionality.


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
