### PR TITLE
Changed the fallback behavior of webgl add on

### DIFF
--- a/shell/components/Window/ContainerShell.vue
+++ b/shell/components/Window/ContainerShell.vue
@@ -253,7 +253,6 @@ export default {
            !ua.includes('fxios') && // Firefox iOS
            !ua.includes('opr'); // Opera
 
-        console.log('isSafari', isSafari); // eslint-disable-line no-console
         if (!isSafari) {
           this.webglAddon = new addons.webgl.WebglAddon();
           terminal.loadAddon(this.webglAddon);

--- a/shell/components/Window/ContainerShell.vue
+++ b/shell/components/Window/ContainerShell.vue
@@ -80,6 +80,7 @@ export default {
       fitAddon:          null,
       searchAddon:       null,
       webglAddon:        null,
+      canvasAddon:       null,
       isOpen:            false,
       isOpening:         false,
       backlog:           [],
@@ -221,6 +222,7 @@ export default {
         webgl:    import(/* webpackChunkName: "xterm" */ '@xterm/addon-webgl'),
         weblinks: import(/* webpackChunkName: "xterm" */ '@xterm/addon-web-links'),
         search:   import(/* webpackChunkName: "xterm" */ '@xterm/addon-search'),
+        canvas:   import(/* webpackChunkName: "xterm" */ '@xterm/addon-canvas'),
       });
 
       const terminal = new xterm.Terminal({
@@ -240,28 +242,31 @@ export default {
       terminal.loadAddon(new addons.weblinks.WebLinksAddon());
       terminal.open(this.$refs.xterm);
 
-      // if user is using Safari with webGPU disabled, webglAddon will silently fail
-      // and we do not have a way to detect that.
-      // To avoid it, default to DOM rendering for Safari browsers
+      // The webgl renderer can fail without throwing: the context may be lost
+      // mid-session, or it can attach but silently never paint (e.g. Safari with
+      // webGPU disabled, or headless/software-GL environments), leaving the
+      // terminal's helper textarea at 0x0. Detect both cases and fall back to the
+      // canvas renderer so the terminal stays interactive.
       try {
-        const ua = window.navigator.userAgent.toLowerCase();
-        const isSafari = ua.includes('safari') &&
-           !ua.includes('chrome') && // Chrome / Edge / Opera desktop & Android (all include "safari")
-           !ua.includes('chromium') && // Chromium
-           !ua.includes('crios') && // Chrome iOS
-           !ua.includes('edg') && // Edge (desktop "edg", Android "edga", iOS "edgios")
-           !ua.includes('fxios') && // Firefox iOS
-           !ua.includes('opr'); // Opera
+        this.webglAddon = new addons.webgl.WebglAddon();
 
-        if (!isSafari) {
-          this.webglAddon = new addons.webgl.WebglAddon();
-          terminal.loadAddon(this.webglAddon);
-        }
+        this.webglAddon.onContextLoss(() => this.fallbackToCanvas(terminal, addons));
+
+        terminal.loadAddon(this.webglAddon);
+
+        // Detect the silent "attaches but never paints" failure after a render frame.
+        requestAnimationFrame(() => {
+          const textarea = this.$refs.xterm?.querySelector('.xterm-helper-textarea');
+          const hasPainted = textarea && textarea.getBoundingClientRect().height > 0;
+
+          if (this.webglAddon && !hasPainted) {
+            this.fallbackToCanvas(terminal, addons);
+            this.fit();
+          }
+        });
       } catch (e) {
-        // Some browsers (Safari) don't support the webgl renderer, so don't use it.
-        this.webglAddon = null;
-        this.canvasAddon = new addons.canvas.CanvasAddon();
-        terminal.loadAddon(this.canvasAddon);
+        // Some browsers (e.g. Safari) don't support the webgl renderer, so don't use it.
+        this.fallbackToCanvas(terminal, addons);
       }
       this.fit();
       this.flush();
@@ -273,6 +278,18 @@ export default {
       });
 
       this.terminal = terminal;
+    },
+
+    // Dispose the webgl renderer (if any) and switch to the canvas renderer.
+    // Used when webgl fails to construct, loses its context, or silently never paints.
+    fallbackToCanvas(terminal, addons) {
+      this.webglAddon?.dispose();
+      this.webglAddon = null;
+
+      if (!this.canvasAddon) {
+        this.canvasAddon = new addons.canvas.CanvasAddon();
+        terminal.loadAddon(this.canvasAddon);
+      }
     },
 
     write(msg) {

--- a/shell/components/Window/ContainerShell.vue
+++ b/shell/components/Window/ContainerShell.vue
@@ -243,8 +243,7 @@ export default {
       terminal.open(this.$refs.xterm);
 
       // The webgl renderer can fail without throwing: the context may be lost
-      // mid-session, or it can attach but silently never paint (e.g. Safari with
-      // webGPU disabled, or headless/software-GL environments), leaving the
+      // mid-session, or it can attach but silently never paint, leaving the
       // terminal's helper textarea at 0x0. Detect both cases and fall back to the
       // canvas renderer so the terminal stays interactive.
       try {

--- a/shell/components/Window/ContainerShell.vue
+++ b/shell/components/Window/ContainerShell.vue
@@ -91,7 +91,8 @@ export default {
       os:                undefined,
       retries:           0,
       currFocusedElem:   undefined,
-      xtermContainerRef: undefined
+      xtermContainerRef: undefined,
+      isUnmounted:       false
     };
   },
 
@@ -150,6 +151,8 @@ export default {
   },
 
   beforeUnmount() {
+    this.isUnmounted = true;
+
     document.removeEventListener('keyup', this.handleKeyPress);
     this.$refs?.containerShell?.$el?.removeEventListener('focusin', this.focusInHandler);
     this.$refs?.xterm.removeEventListener('focusout', this.focusOutHandler);
@@ -249,12 +252,20 @@ export default {
       try {
         this.webglAddon = new addons.webgl.WebglAddon();
 
-        this.webglAddon.onContextLoss(() => this.fallbackToCanvas(terminal, addons));
+        this.webglAddon.onContextLoss(() => {
+          if (!this.isUnmounted && this.terminal) {
+            this.fallbackToCanvas(terminal, addons);
+          }
+        });
 
         terminal.loadAddon(this.webglAddon);
 
         // Detect the silent "attaches but never paints" failure after a render frame.
         requestAnimationFrame(() => {
+          if (this.isUnmounted || !this.terminal) {
+            return;
+          }
+
           const textarea = this.$refs.xterm?.querySelector('.xterm-helper-textarea');
           const hasPainted = textarea && textarea.getBoundingClientRect().height > 0;
 
@@ -282,6 +293,10 @@ export default {
     // Dispose the webgl renderer (if any) and switch to the canvas renderer.
     // Used when webgl fails to construct, loses its context, or silently never paints.
     fallbackToCanvas(terminal, addons) {
+      if (this.isUnmounted) {
+        return;
+      }
+
       this.webglAddon?.dispose();
       this.webglAddon = null;
 
@@ -289,6 +304,7 @@ export default {
         this.canvasAddon = new addons.canvas.CanvasAddon();
         terminal.loadAddon(this.canvasAddon);
       }
+      this.fit();
     },
 
     write(msg) {

--- a/shell/components/Window/ContainerShell.vue
+++ b/shell/components/Window/ContainerShell.vue
@@ -463,6 +463,13 @@ export default {
         this.socket = null;
       }
 
+      // Dispose the renderer addons before the terminal. This is needed to avoid xterm throwing an error
+      this.webglAddon?.dispose();
+      this.webglAddon = null;
+
+      this.canvasAddon?.dispose();
+      this.canvasAddon = null;
+
       if (this.terminal) {
         this.terminal.dispose();
         this.terminal = null;

--- a/shell/components/Window/ContainerShell.vue
+++ b/shell/components/Window/ContainerShell.vue
@@ -246,11 +246,14 @@ export default {
       try {
         const ua = window.navigator.userAgent.toLowerCase();
         const isSafari = ua.includes('safari') &&
+           !ua.includes('chrome') && // Chrome / Edge / Opera desktop & Android (all include "safari")
+           !ua.includes('chromium') && // Chromium
            !ua.includes('crios') && // Chrome iOS
+           !ua.includes('edg') && // Edge (desktop "edg", Android "edga", iOS "edgios")
            !ua.includes('fxios') && // Firefox iOS
-           !ua.includes('edgios') && // Edge iOS
            !ua.includes('opr'); // Opera
 
+        console.log('isSafari', isSafari); // eslint-disable-line no-console
         if (!isSafari) {
           this.webglAddon = new addons.webgl.WebglAddon();
           terminal.loadAddon(this.webglAddon);

--- a/shell/components/Window/ContainerShell.vue
+++ b/shell/components/Window/ContainerShell.vue
@@ -80,6 +80,7 @@ export default {
       fitAddon:          null,
       searchAddon:       null,
       webglAddon:        null,
+      canvasAddon:       null,
       isOpen:            false,
       isOpening:         false,
       backlog:           [],
@@ -221,6 +222,7 @@ export default {
         webgl:    import(/* webpackChunkName: "xterm" */ '@xterm/addon-webgl'),
         weblinks: import(/* webpackChunkName: "xterm" */ '@xterm/addon-web-links'),
         search:   import(/* webpackChunkName: "xterm" */ '@xterm/addon-search'),
+        canvas:   import(/* webpackChunkName: "xterm" */ '@xterm/addon-canvas'),
       });
 
       const terminal = new xterm.Terminal({
@@ -240,26 +242,30 @@ export default {
       terminal.loadAddon(new addons.weblinks.WebLinksAddon());
       terminal.open(this.$refs.xterm);
 
-      // if user is using Safari with webGPU disabled, webglAddon will silently fail
-      // and we do not have a way to detect that.
-      // To avoid it, default to DOM rendering for Safari browsers
+      // The webgl renderer can fail without throwing: the context may be lost
+      // mid-session, or it can attach but silently never paint, leaving the
+      // terminal's helper textarea at 0x0. Detect both cases and fall back to the
+      // canvas renderer so the terminal stays interactive.
       try {
-        const ua = window.navigator.userAgent.toLowerCase();
-        const isSafari = ua.includes('safari') &&
-           !ua.includes('crios') && // Chrome iOS
-           !ua.includes('fxios') && // Firefox iOS
-           !ua.includes('edgios') && // Edge iOS
-           !ua.includes('opr'); // Opera
+        this.webglAddon = new addons.webgl.WebglAddon();
 
-        if (!isSafari) {
-          this.webglAddon = new addons.webgl.WebglAddon();
-          terminal.loadAddon(this.webglAddon);
-        }
+        this.webglAddon.onContextLoss(() => this.fallbackToCanvas(terminal, addons));
+
+        terminal.loadAddon(this.webglAddon);
+
+        // Detect the silent "attaches but never paints" failure after a render frame.
+        requestAnimationFrame(() => {
+          const textarea = this.$refs.xterm?.querySelector('.xterm-helper-textarea');
+          const hasPainted = textarea && textarea.getBoundingClientRect().height > 0;
+
+          if (this.webglAddon && !hasPainted) {
+            this.fallbackToCanvas(terminal, addons);
+            this.fit();
+          }
+        });
       } catch (e) {
-        // Some browsers (Safari) don't support the webgl renderer, so don't use it.
-        this.webglAddon = null;
-        this.canvasAddon = new addons.canvas.CanvasAddon();
-        terminal.loadAddon(this.canvasAddon);
+        // Some browsers (e.g. Safari) don't support the webgl renderer, so don't use it.
+        this.fallbackToCanvas(terminal, addons);
       }
       this.fit();
       this.flush();
@@ -271,6 +277,18 @@ export default {
       });
 
       this.terminal = terminal;
+    },
+
+    // Dispose the webgl renderer (if any) and switch to the canvas renderer.
+    // Used when webgl fails to construct, loses its context, or silently never paints.
+    fallbackToCanvas(terminal, addons) {
+      this.webglAddon?.dispose();
+      this.webglAddon = null;
+
+      if (!this.canvasAddon) {
+        this.canvasAddon = new addons.canvas.CanvasAddon();
+        terminal.loadAddon(this.canvasAddon);
+      }
     },
 
     write(msg) {

--- a/shell/components/Window/__tests__/ContainerShell.test.ts
+++ b/shell/components/Window/__tests__/ContainerShell.test.ts
@@ -28,6 +28,11 @@ const mockPaste = jest.fn();
 const mockDispose = jest.fn();
 const mockClear = jest.fn();
 
+const mockWebglDispose = jest.fn();
+let mockWebglShouldThrow = false;
+let mockOnContextLossCallback: (() => void) | undefined;
+let mockRafCallback: any;
+
 jest.mock(/* webpackChunkName: "xterm" */ '@xterm/xterm', () => {
   return {
     Terminal: class {
@@ -71,8 +76,34 @@ jest.mock(/* webpackChunkName: "@xterm" */ '@xterm/addon-search', () => {
 }, { virtual: true });
 
 jest.mock(/* webpackChunkName: "@xterm" */ '@xterm/addon-webgl', () => {
-  return { WebglAddon: class {} };
+  return {
+    WebglAddon: class {
+      constructor() {
+        if (mockWebglShouldThrow) {
+          throw new Error('webgl not supported');
+        }
+      }
+
+      onContextLoss = (cb: () => void) => {
+        mockOnContextLossCallback = cb;
+      };
+
+      dispose = mockWebglDispose;
+    }
+  };
 }, { virtual: true });
+
+jest.mock(/* webpackChunkName: "@xterm" */ '@xterm/addon-canvas', () => {
+  return { CanvasAddon: class {} };
+}, { virtual: true });
+
+// Capture the requestAnimationFrame callback so the "never paints" detection
+// in setupTerminal can be triggered deterministically from tests.
+window.requestAnimationFrame = ((cb: any): number => {
+  mockRafCallback = cb;
+
+  return 0;
+}) as unknown as typeof window.requestAnimationFrame;
 
 describe('component: ContainerShell', () => {
   const action = jest.fn();
@@ -115,6 +146,9 @@ describe('component: ContainerShell', () => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
     defaultContainerShellParams.propsData.pod.os = 'linux';
+    mockWebglShouldThrow = false;
+    mockOnContextLossCallback = undefined;
+    mockRafCallback = undefined;
   };
 
   const wrapperPostMounted = async(params: Object) => {
@@ -144,24 +178,53 @@ describe('component: ContainerShell', () => {
     expect(windowComponent.isVisible()).toBe(true);
   });
 
-  it('does not load webgl addon on Safari browser', async() => {
+  it('loads the webgl renderer by default when it is supported', async() => {
     resetMocks();
 
-    const originalUserAgent = window.navigator.userAgent;
+    const wrapper = await wrapperPostMounted(defaultContainerShellParams);
 
-    Object.defineProperty(window.navigator, 'userAgent', {
-      value:        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15',
-      configurable: true
-    });
+    expect(wrapper.vm.webglAddon).not.toBeNull();
+    expect(wrapper.vm.canvasAddon).toBeNull();
+  });
+
+  it('falls back to the canvas renderer when the webgl context is lost', async() => {
+    resetMocks();
+
+    const wrapper = await wrapperPostMounted(defaultContainerShellParams);
+
+    expect(wrapper.vm.webglAddon).not.toBeNull();
+
+    // Simulate the webgl renderer losing its context mid-session
+    mockOnContextLossCallback?.();
+
+    expect(mockWebglDispose).toHaveBeenCalledWith();
+    expect(wrapper.vm.webglAddon).toBeNull();
+    expect(wrapper.vm.canvasAddon).not.toBeNull();
+  });
+
+  it('falls back to the canvas renderer when the webgl renderer attaches but never paints', async() => {
+    resetMocks();
+
+    const wrapper = await wrapperPostMounted(defaultContainerShellParams);
+
+    expect(wrapper.vm.webglAddon).not.toBeNull();
+
+    // Simulate the post-render frame where the helper textarea has no size
+    mockRafCallback?.(0);
+
+    expect(wrapper.vm.webglAddon).toBeNull();
+    expect(wrapper.vm.canvasAddon).not.toBeNull();
+  });
+
+  it('falls back to the canvas renderer when the webgl addon fails to load', async() => {
+    resetMocks();
+
+    mockWebglShouldThrow = true;
 
     const wrapper = await wrapperPostMounted(defaultContainerShellParams);
 
     expect(wrapper.vm.webglAddon).toBeNull();
-
-    Object.defineProperty(window.navigator, 'userAgent', {
-      value:        originalUserAgent,
-      configurable: true
-    });
+    expect(wrapper.vm.canvasAddon).not.toBeNull();
   });
 
   it('the find action for the node is called if schemaFor finds a schema for NODE', async() => {

--- a/shell/components/Window/__tests__/ContainerShell.test.ts
+++ b/shell/components/Window/__tests__/ContainerShell.test.ts
@@ -29,6 +29,7 @@ const mockDispose = jest.fn();
 const mockClear = jest.fn();
 
 const mockWebglDispose = jest.fn();
+const mockCanvasDispose = jest.fn();
 let mockWebglShouldThrow = false;
 let mockOnContextLossCallback: (() => void) | undefined;
 let mockRafCallback: any;
@@ -94,7 +95,11 @@ jest.mock(/* webpackChunkName: "@xterm" */ '@xterm/addon-webgl', () => {
 }, { virtual: true });
 
 jest.mock(/* webpackChunkName: "@xterm" */ '@xterm/addon-canvas', () => {
-  return { CanvasAddon: class {} };
+  return {
+    CanvasAddon: class {
+      dispose = mockCanvasDispose;
+    }
+  };
 }, { virtual: true });
 
 // Capture the requestAnimationFrame callback so the "never paints" detection
@@ -225,6 +230,34 @@ describe('component: ContainerShell', () => {
 
     expect(wrapper.vm.webglAddon).toBeNull();
     expect(wrapper.vm.canvasAddon).not.toBeNull();
+  });
+
+  it('disposes the renderer addons before the terminal on cleanup', async() => {
+    resetMocks();
+
+    const wrapper = await wrapperPostMounted(defaultContainerShellParams);
+
+    // Fall back to canvas so both renderer addons have been exercised
+    mockOnContextLossCallback?.();
+
+    expect(wrapper.vm.webglAddon).toBeNull();
+    expect(wrapper.vm.canvasAddon).not.toBeNull();
+
+    wrapper.vm.cleanup();
+
+    // The canvas/webgl addons must be disposed before terminal.dispose() so xterm
+    // can recreate the DOM renderer while the terminal core is still alive.
+    const webglDisposeOrder = mockWebglDispose.mock.invocationCallOrder[0];
+    const canvasDisposeOrder = mockCanvasDispose.mock.invocationCallOrder[0];
+    const terminalDisposeOrder = mockDispose.mock.invocationCallOrder[0];
+
+    expect(mockCanvasDispose).toHaveBeenCalledWith();
+    expect(mockDispose).toHaveBeenCalledWith();
+    expect(canvasDisposeOrder).toBeLessThan(terminalDisposeOrder);
+    expect(webglDisposeOrder).toBeLessThan(terminalDisposeOrder);
+    expect(wrapper.vm.webglAddon).toBeNull();
+    expect(wrapper.vm.canvasAddon).toBeNull();
+    expect(wrapper.vm.terminal).toBeNull();
   });
 
   it('the find action for the node is called if schemaFor finds a schema for NODE', async() => {

--- a/shell/components/Window/__tests__/ContainerShell.test.ts
+++ b/shell/components/Window/__tests__/ContainerShell.test.ts
@@ -95,7 +95,11 @@ jest.mock(/* webpackChunkName: "@xterm" */ '@xterm/addon-webgl', () => {
 }, { virtual: true });
 
 jest.mock(/* webpackChunkName: "@xterm" */ '@xterm/addon-canvas', () => {
-  return { CanvasAddon: class {} };
+  return {
+    CanvasAddon: class {
+      dispose = mockCanvasDispose;
+    }
+  };
 }, { virtual: true });
 
 // Capture the requestAnimationFrame callback so the "never paints" detection

--- a/shell/components/Window/__tests__/ContainerShell.test.ts
+++ b/shell/components/Window/__tests__/ContainerShell.test.ts
@@ -100,6 +100,8 @@ jest.mock(/* webpackChunkName: "@xterm" */ '@xterm/addon-canvas', () => {
 
 // Capture the requestAnimationFrame callback so the "never paints" detection
 // in setupTerminal can be triggered deterministically from tests.
+const originalRequestAnimationFrame = window.requestAnimationFrame;
+
 window.requestAnimationFrame = ((cb: any): number => {
   mockRafCallback = cb;
 
@@ -160,6 +162,10 @@ describe('component: ContainerShell', () => {
 
     return wrapper;
   };
+
+  afterAll(() => {
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+  });
 
   it('test that we are calling the xterm terminal and fitAddon class method mocks correctly', async() => {
     resetMocks();
@@ -226,6 +232,66 @@ describe('component: ContainerShell', () => {
 
     expect(wrapper.vm.webglAddon).toBeNull();
     expect(wrapper.vm.canvasAddon).not.toBeNull();
+  });
+
+  it('disposes the renderer addons before the terminal on cleanup', async() => {
+    resetMocks();
+
+    const wrapper = await wrapperPostMounted(defaultContainerShellParams);
+
+    // Fall back to canvas so both renderer addons have been exercised
+    mockOnContextLossCallback?.();
+
+    expect(wrapper.vm.webglAddon).toBeNull();
+    expect(wrapper.vm.canvasAddon).not.toBeNull();
+
+    wrapper.vm.cleanup();
+
+    // The canvas/webgl addons must be disposed before terminal.dispose() so xterm
+    // can recreate the DOM renderer while the terminal core is still alive.
+    const webglDisposeOrder = mockWebglDispose.mock.invocationCallOrder[0];
+    const canvasDisposeOrder = mockCanvasDispose.mock.invocationCallOrder[0];
+    const terminalDisposeOrder = mockDispose.mock.invocationCallOrder[0];
+
+    expect(mockCanvasDispose).toHaveBeenCalledWith();
+    expect(mockDispose).toHaveBeenCalledWith();
+    expect(canvasDisposeOrder).toBeLessThan(terminalDisposeOrder);
+    expect(webglDisposeOrder).toBeLessThan(terminalDisposeOrder);
+    expect(wrapper.vm.webglAddon).toBeNull();
+    expect(wrapper.vm.canvasAddon).toBeNull();
+    expect(wrapper.vm.terminal).toBeNull();
+  });
+
+  it('does not attempt a canvas fallback in the render-frame check after the component is unmounted', async() => {
+    resetMocks();
+
+    const wrapper = await wrapperPostMounted(defaultContainerShellParams);
+    const vm = wrapper.vm;
+
+    expect(vm.webglAddon).not.toBeNull();
+    expect(vm.canvasAddon).toBeNull();
+
+    wrapper.unmount();
+
+    expect(vm.isUnmounted).toBe(true);
+
+    mockRafCallback?.(0);
+
+    expect(vm.canvasAddon).toBeNull();
+  });
+
+  it('does not attempt a canvas fallback when the webgl context is lost after teardown', async() => {
+    resetMocks();
+
+    const wrapper = await wrapperPostMounted(defaultContainerShellParams);
+
+    expect(wrapper.vm.webglAddon).not.toBeNull();
+
+    wrapper.vm.cleanup();
+
+    mockOnContextLossCallback?.();
+
+    expect(wrapper.vm.canvasAddon).toBeNull();
   });
 
   it('the find action for the node is called if schemaFor finds a schema for NODE', async() => {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17273
<!-- Define findings related to the feature or bug issue. -->
Instead of making a browser more strict, changed the way we detect that xterm failed and updated fallback behavior to be closer to the original

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Make sure shell terminal connects in different browsers and environments
### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
We should make sure this didn't reintroduce https://github.com/rancher/dashboard/issues/16371. I've tried using the dev build of this change in AWS workspaces and it seems to work

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
