### PR TITLE
Prevent negative machine pool quantity

### DIFF
--- a/shell/models/__tests__/cluster.x-k8s.io.machinedeployment.test.ts
+++ b/shell/models/__tests__/cluster.x-k8s.io.machinedeployment.test.ts
@@ -1,0 +1,38 @@
+import CapiMachineDeployment from '@shell/models/cluster.x-k8s.io.machinedeployment';
+
+describe('class CapiMachineDeployment', () => {
+  describe('scalePool', () => {
+    it('should not allow quantity to become negative', () => {
+      const machinePool = {
+        machineConfigRef: { name: 'pool1' },
+        quantity:         0,
+      };
+      const cluster = {
+        spec: {
+          rkeConfig: {
+            machinePools: [machinePool]
+          }
+        }
+      };
+      const machineDeployment = new CapiMachineDeployment({
+        metadata: { namespace: 'fleet-default' },
+        spec:     {
+          clusterName: 'test-cluster',
+          template: {
+            spec: {
+              infrastructureRef: { name: 'pool1' }
+            }
+          }
+        }
+      }, {
+        rootGetters: {
+          'management/byId': jest.fn(() => cluster)
+        }
+      });
+
+      machineDeployment.scalePool(-1, false);
+
+      expect(machinePool.quantity).toBe(0);
+    });
+  });
+});

--- a/shell/models/__tests__/management.cattle.io.nodepool.ts
+++ b/shell/models/__tests__/management.cattle.io.nodepool.ts
@@ -1,6 +1,27 @@
 import MgmtNodePool from '@shell/models/management.cattle.io.nodepool';
 
 describe('class MgmtNodePool', () => {
+  describe('scalePool', () => {
+    it('should not allow quantity to become negative', () => {
+      const norman = {
+        quantity: 0,
+        save:     jest.fn()
+      };
+      const mgmtNodePool = new MgmtNodePool({
+        id:       'fleet-default:np1',
+        metadata: {}
+      }, {
+        rootGetters: {
+          'rancher/byId': () => norman
+        }
+      });
+
+      mgmtNodePool.scalePool(-1);
+
+      expect(mgmtNodePool.norman.quantity).toBe(0);
+    });
+  });
+
   describe('canScaleDownPool', () => {
     const mgmtClusterId = 'test';
     const nodeId = 'test/id';

--- a/shell/models/cluster.x-k8s.io.machinedeployment.js
+++ b/shell/models/cluster.x-k8s.io.machinedeployment.js
@@ -114,7 +114,7 @@ export default class CapiMachineDeployment extends CapiMachineRoot {
 
     const initialValue = this.cluster;
 
-    this.inClusterSpec.quantity += delta;
+    this.inClusterSpec.quantity = Math.max(0, (this.inClusterSpec.quantity || 0) + delta);
 
     if ( !save ) {
       return;

--- a/shell/models/management.cattle.io.nodepool.js
+++ b/shell/models/management.cattle.io.nodepool.js
@@ -64,7 +64,7 @@ export default class MgmtNodePool extends HybridModel {
   }
 
   scalePool(delta) {
-    this.norman.quantity += delta;
+    this.norman.quantity = Math.max(0, (this.norman.quantity || 0) + delta);
 
     if ( this.scaleTimer ) {
       clearTimeout(this.scaleTimer);


### PR DESCRIPTION
### Summary
Fixes rancher/dashboard#18179

### Occurred changes and/or fixed issues
- clamp machine pool quantity updates to a minimum of `0` for both CAPI and Norman-backed pool scaling models
- add focused model tests covering negative scale-down attempts

### Technical notes summary
- `scalePool()` previously decremented quantity directly and could drive it below zero during scale-down actions
- the fix keeps the existing behavior but guards the stored quantity with `Math.max(0, ...)`

### Areas or cases that should be tested
- from Cluster Management -> Machine Pools, scale down a failing machine pool and verify the desired quantity does not go below `0`
- scale down a CAPI-backed machine pool from `1` to `0` and verify the edit form continues to show `0`
- browser used for local testing: not run manually in this environment

### Areas which could experience regressions
- machine pool scale-up / scale-down behavior in Cluster Management
- model-driven quantity updates for node pools and machine deployments

### Screenshot/Video
- not included

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [ ] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

### Testing
- `corepack yarn test:ci shell/models/__tests__/management.cattle.io.nodepool.ts shell/models/__tests__/cluster.x-k8s.io.machinedeployment.test.ts shell/dialog/__tests__/ScaleMachineDownDialog.test.ts`