### PR TITLE
fix modelextensionconstructor type

### DIFF
--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -545,7 +545,7 @@ export type ModelExtensionContext = {
 /**
  * Constructor signature for a model extension
  */
-export type ModelExtensionConstructor = (context: ModelExtensionContext) => Object;
+export type ModelExtensionConstructor = new (context: ModelExtensionContext) => Object;
 
 /**
  * Interface for a UI Extension


### PR DESCRIPTION
The ModelExtensionConstructor is typed incorrectly. This is testable with [this](https://github.com/rancher/prov-capi-ui-extensions/pull/6/changes#diff-8b2049044efb4da029e67282566bfd7def1b3dd1ba8091dc99a1c481f5fb387eR23) PR 

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
