### PR TITLE
Added validation to the summary response

### DIFF
--- a/shell/pages/c/_cluster/explorer/workload-dashboard/__tests__/composable.test.ts
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/__tests__/composable.test.ts
@@ -4,9 +4,12 @@ import { WORKLOAD_TYPES } from '@shell/config/types';
 import { defineComponent, h } from 'vue';
 import { shallowMount, flushPromises } from '@vue/test-utils';
 
+const WORKLOAD_DASHBOARD_ROUTE = 'c-cluster-explorer-workload-dashboard';
+
 const mockGetters: Record<string, any> = {};
 const mockDispatch = jest.fn();
 const mockRouterPush = jest.fn();
+const mockCurrentRoute = { value: { name: WORKLOAD_DASHBOARD_ROUTE } };
 
 jest.mock('vuex', () => ({
   useStore: () => ({
@@ -19,7 +22,7 @@ jest.mock('vuex', () => ({
   }),
 }));
 
-jest.mock('vue-router', () => ({ useRouter: () => ({ push: mockRouterPush }) }));
+jest.mock('vue-router', () => ({ useRouter: () => ({ push: mockRouterPush, currentRoute: mockCurrentRoute }) }));
 
 jest.mock('@shell/composables/useI18n', () => ({ useI18n: () => ({ t: (key: string, args?: Record<string, any>) => `%${ key }%${ args ? JSON.stringify(args) : '' }` }) }));
 
@@ -106,6 +109,7 @@ describe('composable: useWorkloadDashboard', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     setupGetters();
+    mockCurrentRoute.value.name = WORKLOAD_DASHBOARD_ROUTE;
   });
 
   describe('namespaceSubtitle', () => {
@@ -648,6 +652,18 @@ describe('composable: useWorkloadDashboard', () => {
       const errorResponse = { summary: null, error: 'No access' };
 
       const { wrapper } = mountComposable({}, errorResponse);
+
+      await flushPromises();
+
+      expect(mockRouterPush).not.toHaveBeenCalled();
+      wrapper.unmount();
+    });
+
+    it('should not redirect when the user has already navigated away from the dashboard', async() => {
+      // The fetch resolves after the user left the workload dashboard.
+      mockCurrentRoute.value.name = 'c-cluster-product-resource';
+
+      const { wrapper } = mountComposable({ clusterId: 'c-navigated-away' }, malformedSummaryResponse);
 
       await flushPromises();
 

--- a/shell/pages/c/_cluster/explorer/workload-dashboard/__tests__/composable.test.ts
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/__tests__/composable.test.ts
@@ -1,5 +1,6 @@
 import { useWorkloadDashboard } from '@shell/pages/c/_cluster/explorer/workload-dashboard/composable';
 import { WORKLOAD_RESOURCE_TYPES } from '@shell/pages/c/_cluster/explorer/workload-dashboard/types';
+import { WORKLOAD_TYPES } from '@shell/config/types';
 import { defineComponent, h } from 'vue';
 import { shallowMount, flushPromises } from '@vue/test-utils';
 
@@ -556,6 +557,124 @@ describe('composable: useWorkloadDashboard', () => {
         query: { stateFilter: 'running,active' },
       });
       wrapper.unmount();
+    });
+  });
+
+  describe('response validation', () => {
+    // The composable caches malformed clusters in a module-level singleton, so each
+    // invalid-data test uses a unique cluster id to stay independent of the others.
+    function deploymentRouteFor(cluster: string) {
+      return {
+        name:   'c-cluster-product-resource',
+        params: {
+          cluster,
+          product:  'explorer',
+          resource: WORKLOAD_TYPES.DEPLOYMENT,
+        },
+      };
+    }
+
+    const malformedSummaryResponse = {
+      summary: [{
+        property: 'metadata.state.name',
+        counts:   { running: { namespace: { default: 5 } } },
+      }],
+      data: [],
+    };
+
+    it('should redirect to the deployment page when a count entry is missing total', async() => {
+      const { wrapper } = mountComposable({ clusterId: 'c-missing-total' }, malformedSummaryResponse);
+
+      await flushPromises();
+
+      expect(mockRouterPush).toHaveBeenCalledWith(deploymentRouteFor('c-missing-total'));
+      wrapper.unmount();
+    });
+
+    it('should redirect when the summary is empty but data is present', async() => {
+      const dataWithoutSummaryResponse = { summary: [], data: [{ id: 'pod-1' }] };
+
+      const { wrapper } = mountComposable({ clusterId: 'c-empty-summary-with-data' }, dataWithoutSummaryResponse);
+
+      await flushPromises();
+
+      expect(mockRouterPush).toHaveBeenCalledWith(deploymentRouteFor('c-empty-summary-with-data'));
+      wrapper.unmount();
+    });
+
+    it('should redirect when there is no summary but data is present', async() => {
+      const dataWithoutSummaryResponse = { data: [{ id: 'pod-1' }] };
+
+      const { wrapper } = mountComposable({ clusterId: 'c-no-summary-with-data' }, dataWithoutSummaryResponse);
+
+      await flushPromises();
+
+      expect(mockRouterPush).toHaveBeenCalledWith(deploymentRouteFor('c-no-summary-with-data'));
+      wrapper.unmount();
+    });
+
+    it('should not redirect when every count entry has a total', async() => {
+      const { wrapper } = mountComposable();
+
+      await flushPromises();
+
+      expect(mockRouterPush).not.toHaveBeenCalled();
+      wrapper.unmount();
+    });
+
+    it('should not redirect when the summary is empty and there is no data', async() => {
+      const emptyResponse = { summary: [], data: [] };
+
+      const { wrapper } = mountComposable({}, emptyResponse);
+
+      await flushPromises();
+
+      expect(mockRouterPush).not.toHaveBeenCalled();
+      wrapper.unmount();
+    });
+
+    it('should not redirect when there is no summary and no data', async() => {
+      const noSummaryResponse = { data: [] };
+
+      const { wrapper } = mountComposable({}, noSummaryResponse);
+
+      await flushPromises();
+
+      expect(mockRouterPush).not.toHaveBeenCalled();
+      wrapper.unmount();
+    });
+
+    it('should not redirect for entries returned with an error', async() => {
+      const errorResponse = { summary: null, error: 'No access' };
+
+      const { wrapper } = mountComposable({}, errorResponse);
+
+      await flushPromises();
+
+      expect(mockRouterPush).not.toHaveBeenCalled();
+      wrapper.unmount();
+    });
+
+    it('should skip fetching and redirect immediately for a cluster already known to be invalid', async() => {
+      const cluster = 'c-cached-invalid';
+
+      // First mount detects the malformed response and caches the cluster.
+      const first = mountComposable({ clusterId: cluster }, malformedSummaryResponse);
+
+      await flushPromises();
+      first.wrapper.unmount();
+
+      jest.clearAllMocks();
+
+      // Second mount returns a valid response, but the cache should short-circuit the
+      // fetch entirely and redirect without ever requesting the summaries again.
+      const second = mountComposable({ clusterId: cluster }, summaryResponse);
+
+      await flushPromises();
+
+      expect(mockDispatch).not.toHaveBeenCalledWith('cluster/request', expect.anything());
+      expect(mockRouterPush).toHaveBeenCalledWith(deploymentRouteFor(cluster));
+      second.wrapper.unmount();
     });
   });
 });

--- a/shell/pages/c/_cluster/explorer/workload-dashboard/composable.ts
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/composable.ts
@@ -360,10 +360,10 @@ export function useWorkloadDashboard() {
    */
   function isValidResponse(res: { summary?: WorkloadDashboardSummaryEntry['summary']; data?: unknown }): boolean {
     const summary = res?.summary;
-    const hasData = Array.isArray(res?.data) ? res.data.length > 0 : !!res?.data;
 
     if (!Array.isArray(summary) || summary.length === 0) {
-      return !hasData;
+      // With no summary, the response is only valid when there is also no data.
+      return Array.isArray(res?.data) ? res.data.length === 0 : !res?.data;
     }
 
     return summary.every((item) => Object.values(item.counts || {})
@@ -371,6 +371,10 @@ export function useWorkloadDashboard() {
   }
 
   function redirectToDeployment(): void {
+    // Logged to help triage "where's my workload summary page?" style questions:
+    // the summary response was malformed, so we fall back to the deployments list.
+    console.info(`Workload dashboard: unexpected summary response for cluster "${ clusterId.value }", redirecting to the deployments list.`); // eslint-disable-line no-console
+
     stopPollTimer();
     router.push(resourceRoute(WORKLOAD_TYPES.DEPLOYMENT));
   }
@@ -403,7 +407,7 @@ export function useWorkloadDashboard() {
 
           const res = await store.dispatch('cluster/request', { url });
 
-          if (!isValidResponse(res)) {
+          if (!hasInvalidResponse && !isValidResponse(res)) {
             hasInvalidResponse = true;
           }
 

--- a/shell/pages/c/_cluster/explorer/workload-dashboard/composable.ts
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/composable.ts
@@ -26,6 +26,8 @@ import {
   type WorkloadDashboardByNamespaceCard,
 } from './types';
 
+const WORKLOAD_DASHBOARD_ROUTE = 'c-cluster-explorer-workload-dashboard';
+
 /**
  * Singleton (module-level) cache of cluster ids whose workload summary responses
  * have been found to be malformed. Once a cluster is flagged we skip re-fetching
@@ -371,6 +373,12 @@ export function useWorkloadDashboard() {
   }
 
   function redirectToDeployment(): void {
+    // The redirect can fire from an async fetch or poll that resolves after the
+    // user has already navigated away — only redirect if still on the dashboard.
+    if (router.currentRoute.value.name !== WORKLOAD_DASHBOARD_ROUTE) {
+      return;
+    }
+
     // Logged to help triage "where's my workload summary page?" style questions:
     // the summary response was malformed, so we fall back to the deployments list.
     console.info(`Workload dashboard: unexpected summary response for cluster "${ clusterId.value }", redirecting to the deployments list.`); // eslint-disable-line no-console

--- a/shell/pages/c/_cluster/explorer/workload-dashboard/composable.ts
+++ b/shell/pages/c/_cluster/explorer/workload-dashboard/composable.ts
@@ -3,7 +3,7 @@ import {
 } from 'vue';
 import { useStore } from 'vuex';
 import { useRouter, type RouteLocationRaw } from 'vue-router';
-import { NAMESPACE } from '@shell/config/types';
+import { NAMESPACE, WORKLOAD_TYPES } from '@shell/config/types';
 import type { StateColor } from '@shell/utils/style';
 import { useI18n } from '@shell/composables/useI18n';
 import { useStateColor } from '@shell/composables/useStateColor';
@@ -25,6 +25,13 @@ import {
   type WorkloadDashboardByTypeCard,
   type WorkloadDashboardByNamespaceCard,
 } from './types';
+
+/**
+ * Singleton (module-level) cache of cluster ids whose workload summary responses
+ * have been found to be malformed. Once a cluster is flagged we skip re-fetching
+ * and redirect straight away. Held in memory only, so it is cleared on reload.
+ */
+const invalidDataClusters = new Set<string>();
 
 export function useWorkloadDashboard() {
   const store = useStore();
@@ -344,11 +351,46 @@ export function useWorkloadDashboard() {
 
   // ── Fetching & polling ──
 
+  /**
+   * Validates the shape of a successfully fetched response.
+   * - An empty/absent summary is only valid when there is also no `data`
+   *   (a populated `data` with no summary means we got the wrong response).
+   * - When a summary is present, every state entry under `counts` must
+   *   include a `total`; a count key without `total` is invalid.
+   */
+  function isValidResponse(res: { summary?: WorkloadDashboardSummaryEntry['summary']; data?: unknown }): boolean {
+    const summary = res?.summary;
+    const hasData = Array.isArray(res?.data) ? res.data.length > 0 : !!res?.data;
+
+    if (!Array.isArray(summary) || summary.length === 0) {
+      return !hasData;
+    }
+
+    return summary.every((item) => Object.values(item.counts || {})
+      .every((detail) => typeof detail?.total === 'number'));
+  }
+
+  function redirectToDeployment(): void {
+    stopPollTimer();
+    router.push(resourceRoute(WORKLOAD_TYPES.DEPLOYMENT));
+  }
+
   async function fetchSummaries(): Promise<void> {
+    // If this cluster's data was already found to be malformed, skip the requests
+    // and redirect straight away (cleared on reload via the in-memory singleton).
+    if (invalidDataClusters.has(clusterId.value)) {
+      redirectToDeployment();
+
+      return;
+    }
+
     try {
       const accessibleTypes = WORKLOAD_RESOURCE_TYPES.filter(
         (type) => store.getters['cluster/canList'](type)
       );
+
+      // Set when a successfully fetched response has an unexpected shape.
+      let hasInvalidResponse = false;
 
       const workloadPromises = accessibleTypes.map(async(type): Promise<WorkloadDashboardSummaryEntry> => {
         try {
@@ -360,6 +402,10 @@ export function useWorkloadDashboard() {
           url += `&summary=metadata.state.name&summaryonly&summarynamespaced`;
 
           const res = await store.dispatch('cluster/request', { url });
+
+          if (!isValidResponse(res)) {
+            hasInvalidResponse = true;
+          }
 
           return {
             type, summary: res.summary || [], error: null
@@ -374,6 +420,16 @@ export function useWorkloadDashboard() {
       });
 
       const results = await Promise.all(workloadPromises);
+
+      // Only successful responses are validated (errors are caught above). If any
+      // had an unexpected shape, remember it so we skip future requests, then
+      // stop polling and redirect to the deployment list page.
+      if (hasInvalidResponse) {
+        invalidDataClusters.add(clusterId.value);
+        redirectToDeployment();
+
+        return;
+      }
 
       await resolveStateColors(results);
       summaries.value = results;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #11513
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Added  logic based on the response from summary
- If the data is not valid it should redirect to Deployments

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- The check is to analyse the content. To differentiate from 2.14 it checks for the inside of the summary and needs to have the TOTAL inside, which is a new feature from 2.15.
- To differentiate from 2.13 it checks if summary is there when there is data.
- If there is empty data and no summary (or empty) it is a valid case.
- Added a singleton cache to make sure it is not required to load the data always
- There is a small bug when you open the page first time on an invalid one with no data, it shows as no data (it is ideally a valid case so it can be good, as soon as it captures is invalid it saves on the cache)

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Click on workload on multiple different cases
- First case is the happy case, a 2.15 cluster or donwstream cluster.
  - For empty cases it should still show the error for empty worload
- Second case is for cases with 2.14 harvester clusters (the only case we found was harvester)
  - It should redirect to deployment
- Third case is for cases with 2.13 harvester clusters
  - It should redirect to deployment
  - For empty cases it should show the page (if it is the first time opening), as soon as change to a filter with data and no summary it saves to redirect to deployment and the behavior disappears even if moving for a simple case
- After one is deemed invalid it should not do requests anymore when opening workload page

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Happy case for workload page

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
