### PR TITLE
Fix broken comment keyboard shortcut

### DIFF
--- a/shell/plugins/codemirror.js
+++ b/shell/plugins/codemirror.js
@@ -27,6 +27,8 @@ import 'codemirror/addon/hint/show-hint.css';
 import 'codemirror/addon/hint/show-hint.js';
 import 'codemirror/addon/hint/anyword-hint.js';
 
+import 'codemirror/addon/comment/comment.js';
+
 import { strPad } from '@shell/utils/string';
 
 function isLineComment(cm, lineNo) {


### PR DESCRIPTION
### Summary
Fixes #16877

### Occurred changes and/or fixed issues
Pressing the comment-toggle keyboard shortcut (e.g. `Cmd-/` / `Ctrl-/`) in the YAML editor threw `TypeError: cm.toggleComment is not a function` and did nothing. The shortcut now correctly toggles line comments.

### Technical notes summary
The Sublime, Vim and Emacs keymaps loaded by `shell/plugins/codemirror.js` bind the comment shortcut to CodeMirror's `toggleCommentIndented` command, which calls `cm.toggleComment()`. That prototype method is supplied by CodeMirror's `addon/comment/comment.js`, but the addon was never imported, so the binding failed at runtime.

Added the missing import to `shell/plugins/codemirror.js`. The addon is dynamically loaded as part of the existing `codemirror` webpack chunk, so there is no impact on the main vendor bundle.

### Areas or cases that should be tested
- In any YAML editor (e.g. cluster YAML edit, workload edit-as-YAML, ConfigMap YAML), place the cursor on a line and press the comment shortcut for the active keymap:
  - Sublime (default): `Cmd-/` (macOS) / `Ctrl-/` (Windows/Linux)
  - Vim: `gc` motion
  - Emacs: `Alt-;`
- Verify the line(s) toggle between commented and uncommented.
- Verify multi-line selection toggles correctly.
- Verify no console error is produced.
- Tested locally in Chrome.

### Areas which could experience regressions
- Any consumer of the `CodeMirror.vue` component (YAML edit/view across clusters, workloads, ConfigMaps, Secrets; JSON editors; the shell webterm input where CodeMirror is used).
- Other CodeMirror keymap shortcuts should be unaffected.

### Screenshot/Video
N/A — keyboard-shortcut bug fix; behaviour is verified by the shortcut no longer throwing and toggling the comment correctly.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
