### PR TITLE
Fix resource class form validator translation keys

### DIFF
--- a/cypress/e2e/po/components/labeled-input.po.ts
+++ b/cypress/e2e/po/components/labeled-input.po.ts
@@ -66,6 +66,14 @@ export default class LabeledInputPo extends ComponentPo {
   }
 
   /**
+   * Return the validation tooltip message displayed on the input
+   * @returns Cypress chainable for the aria-label attribute on the tooltip
+   */
+  validationMessage(): Cypress.Chainable {
+    return this.self().closest('.labeled-input').find('[data-testid="labeledTooltip-info-icon"]').invoke('attr', 'aria-label');
+  }
+
+  /**
    * Return the input HTML element from given container
    * @returns HTML Element
    */

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -78,6 +78,20 @@ describe('Deployments', { testIsolation: 'off', tags: ['@explorer2', '@adminUser
       cy.intercept('POST', '/v1/apps.deployments').as('createDeployment');
     });
 
+    it('should show a translated field name in the required validation message when the name input is left empty', () => {
+      deploymentsCreatePage.goTo();
+      deploymentsCreatePage.waitForPage();
+
+      // Set container image but leave name empty
+      deploymentsCreatePage.containerImage().set(SMALL_CONTAINER.image);
+      deploymentsCreatePage.resourceDetail().createEditView().save();
+
+      // Validation error should use translated key "Name", not default "Value"
+      deploymentsCreatePage.resourceDetail().createEditView().errorBanner()
+        .should('contain.text', '"Name" is required')
+        .and('not.contain.text', '"Value" is required');
+    });
+
     it('should be able to create a new deployment with basic options', () => {
       deploymentCreateRequest.metadata.name = deploymentId;
       const { namespace } = deploymentCreateRequest.metadata;

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -82,14 +82,16 @@ describe('Deployments', { testIsolation: 'off', tags: ['@explorer2', '@adminUser
       deploymentsCreatePage.goTo();
       deploymentsCreatePage.waitForPage();
 
-      // Set container image but leave name empty
-      deploymentsCreatePage.containerImage().set(SMALL_CONTAINER.image);
-      deploymentsCreatePage.resourceDetail().createEditView().save();
+      const nameInput = deploymentsCreatePage.resourceDetail().createEditView().nameNsDescription().name();
 
-      // Validation error should use translated key "Name", not default "Value"
-      deploymentsCreatePage.resourceDetail().createEditView().errorBanner()
-        .should('contain.text', '"Name" is required')
-        .and('not.contain.text', '"Value" is required');
+      // Focus the name input then blur it to trigger inline validation
+      nameInput.self().focus();
+      deploymentsCreatePage.containerImage().self().focus();
+
+      // Validation error on the name input should use translated key "Name", not default "Value"
+      nameInput.validationMessage()
+        .should('contain', '"Name" is required')
+        .and('not.contain', '"Value" is required');
     });
 
     it('should be able to create a new deployment with basic options', () => {

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -74,8 +74,6 @@ describe('Deployments', { testIsolation: 'off', tags: ['@explorer2', '@adminUser
           cy.createRancherResource('v1', 'apps.deployments', JSON.stringify(scaleDeployment), false);
         });
       });
-
-      cy.intercept('POST', '/v1/apps.deployments').as('createDeployment');
     });
 
     it('should show a translated field name in the required validation message when the name input is left empty', () => {
@@ -95,6 +93,7 @@ describe('Deployments', { testIsolation: 'off', tags: ['@explorer2', '@adminUser
     });
 
     it('should be able to create a new deployment with basic options', () => {
+      cy.intercept('POST', '/v1/apps.deployments').as('createDeployment');
       deploymentCreateRequest.metadata.name = deploymentId;
       const { namespace } = deploymentCreateRequest.metadata;
       const containerImage = 'nginx';

--- a/shell/mixins/__tests__/form-validation.test.ts
+++ b/shell/mixins/__tests__/form-validation.test.ts
@@ -1,0 +1,71 @@
+import { mount } from '@vue/test-utils';
+import formValidation from '@shell/mixins/form-validation';
+
+describe('form-validation mixin', () => {
+  const mockT = (key: string, args?: any) => {
+    if (args) {
+      return JSON.stringify({ message: key, ...args });
+    }
+
+    return key;
+  };
+
+  function createComponent(fvFormRuleSets: any[]) {
+    const Component = {
+      render() {},
+      mixins: [formValidation],
+      data() {
+        return { fvFormRuleSets };
+      },
+      props: {
+        value: {
+          type:    Object,
+          default: () => ({})
+        }
+      },
+    };
+
+    return mount(Component, {
+      props:  { value: {} },
+      global: { mocks: { $store: { getters: { 'i18n/t': mockT } } } },
+    });
+  }
+
+  describe('fvRulesets', () => {
+    it('should pass translation keys to formRulesGenerator as "key" option', () => {
+      const wrapper = createComponent([{
+        path:           'metadata.name',
+        rules:          ['required'],
+        translationKey: 'generic.name',
+      }]);
+
+      const instance = wrapper.vm as any;
+      const rulesets = instance.fvRulesets;
+
+      expect(rulesets).toHaveLength(1);
+      expect(rulesets[0].path).toStrictEqual('metadata.name');
+
+      // Execute the required rule with a null value
+      const requiredRule = rulesets[0].rules[0];
+      const result = requiredRule(null);
+
+      // verify that the resulting message uses generic.name not the fallback "Value"
+      expect(result).toStrictEqual(JSON.stringify({ message: 'validation.required', key: 'generic.name' }));
+    });
+
+    it('should default to using "Value" in error messages when a translation key is not provided', () => {
+      const wrapper = createComponent([{
+        path:  'metadata.name',
+        rules: ['required'],
+      }]);
+
+      const instance = wrapper.vm as any;
+      const rulesets = instance.fvRulesets;
+
+      const requiredRule = rulesets[0].rules[0];
+      const result = requiredRule(null);
+
+      expect(result).toStrictEqual(JSON.stringify({ message: 'validation.required', key: 'Value' }));
+    });
+  });
+});

--- a/shell/mixins/form-validation.js
+++ b/shell/mixins/form-validation.js
@@ -140,7 +140,7 @@ export default {
           const formRules = {
             ...formRulesGenerator(
               this.$store.getters['i18n/t'],
-              { displayKey: ruleset?.translationKey ? this.$store.getters['i18n/t'](ruleset.translationKey) : 'Value' }),
+              { key: ruleset?.translationKey ? this.$store.getters['i18n/t'](ruleset.translationKey) : 'Value' }),
             ...this.fvExtraRules
           };
 

--- a/shell/plugins/dashboard-store/__tests__/resource-class.test.ts
+++ b/shell/plugins/dashboard-store/__tests__/resource-class.test.ts
@@ -762,4 +762,64 @@ describe('class: Resource', () => {
       await expect(resource.dryRunCreate()).rejects.toStrictEqual(apiError);
     });
   });
+
+  describe('getter: modelValidationRules', () => {
+    it('should pass translationKey to formRulesGenerator as "key" option', () => {
+      const mockT = (key: string, args?: any) => {
+        if (args) {
+          return JSON.stringify({ message: key, ...args });
+        }
+
+        return key;
+      };
+      const resource = new Resource({ type: 'test.resource' }, {
+        getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
+        dispatch:    jest.fn(),
+        rootGetters: { 'i18n/t': mockT, 'i18n/exists': () => true },
+      });
+
+      jest.spyOn(resource, 'customValidationRules', 'get').mockReturnValue([{
+        path:           'metadata.name',
+        required:       true,
+        translationKey: 'generic.name',
+      }]);
+
+      const rules = resource.modelValidationRules;
+
+      expect(rules).toHaveLength(1);
+      expect(rules[0].path).toStrictEqual('metadata.name');
+
+      // The 'required' rule should use the translated key, not "Value"
+      const requiredRule = rules[0].rules[0];
+      const result = requiredRule(null);
+
+      expect(result).toStrictEqual(JSON.stringify({ message: 'validation.required', key: 'generic.name' }));
+    });
+
+    it('should default to "Value" when translationKey is not provided', () => {
+      const mockT = (key: string, args?: any) => {
+        if (args) {
+          return JSON.stringify({ message: key, ...args });
+        }
+
+        return key;
+      };
+      const resource = new Resource({ type: 'test.resource' }, {
+        getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
+        dispatch:    jest.fn(),
+        rootGetters: { 'i18n/t': mockT, 'i18n/exists': () => true },
+      });
+
+      jest.spyOn(resource, 'customValidationRules', 'get').mockReturnValue([{
+        path:     'metadata.name',
+        required: true,
+      }]);
+
+      const rules = resource.modelValidationRules;
+      const requiredRule = rules[0].rules[0];
+      const result = requiredRule(null);
+
+      expect(result).toStrictEqual(JSON.stringify({ message: 'validation.required', key: 'Value' }));
+    });
+  });
 });

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -1839,7 +1839,7 @@ export default class Resource {
     const customValidationRulesets = this?.customValidationRules
       .filter((rule) => !!rule.validators || !!rule.required)
       .map((rule) => {
-        const formRules = formRulesGenerator(this.t, { displayKey: rule?.translationKey ? this.t(rule.translationKey) : 'Value' });
+        const formRules = formRulesGenerator(this.t, { key: rule?.translationKey ? this.t(rule.translationKey) : 'Value' });
 
         return {
           path:  rule.path,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #13881 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR fixes an issue with certain form validators where the custom translation key for the field name was not passed in correctly, resulting in messages that use the fallback of "Value." One prominent example is the name required validator in the workload form.

### Technical notes summary
Two uses of  the default export from `shell/utils/validators/formRules/index` (consistently imported as `formRulesGenerator`) had malformed arguments. `formRulesGenerator` expects a `key` argument (typed [here](https://github.com/rancher/dashboard/blob/a64ba3586429e0d87e10e8f4cd3427c1d681df7b/shell/utils/validators/formRules/index.ts#L80)) and was invoked with `displayKey` instead.

I searched the codebase and checked all imports from `shell/utils/validators/formRules/index`; these two were the only ones I saw using `displayKey`. Storybook is referencing the right call signature as well.

### Areas or cases that should be tested
1. Go to create a new deployment
2. Click the Name input then click away without filling anything in
3. Hover over the error icon to read the error message
4. Verify the message says `"Name" is required` 

### Areas which could experience regressions
Minimal chance of regression: this is a very straightforward syntax fix.


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
