### PR TITLE
[2.14] Remove sorry cypress upload

### DIFF
--- a/.github/workflows/extensions-compatibility-tests.yaml
+++ b/.github/workflows/extensions-compatibility-tests.yaml
@@ -10,7 +10,6 @@ env:
   TEST_BASE_URL: https://127.0.0.1:8005
   API: https://127.0.0.1
   TEST_PROJECT_ID: rancher-dashboard
-  CYPRESS_API_URL: http://139.59.134.103:1234/
   TEST_RUN_ID: ${{github.run_number}}-${{github.run_attempt}}-extensions-compatibility-tests
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ env:
   TEST_BASE_URL: https://127.0.0.1.sslip.io
   API: https://127.0.0.1.sslip.io
   TEST_PROJECT_ID: rancher-dashboard
-  TEST_DISABLE_DASHBOARD: ${{ vars.TEST_DISABLE_DASHBOARD }} # This is required to get it from the project configuration
+  TEST_DISABLE_DASHBOARD: true
   TEST_DISABLE_DASHBOARD_LABEL: "${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-cypress-dashboard')}}"
   TEST_RUN_ID: ${{github.run_number}}-${{github.run_attempt}}-${{github.event.pull_request.title || github.event.head_commit.message}}
   # Build the dashboard to use in tests. When set to false it will grab `latest` from CDN (useful for running e2e tests quickly)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,6 @@ env:
   TEST_PROJECT_ID: rancher-dashboard
   TEST_DISABLE_DASHBOARD: ${{ vars.TEST_DISABLE_DASHBOARD }} # This is required to get it from the project configuration
   TEST_DISABLE_DASHBOARD_LABEL: "${{ contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e-cypress-dashboard')}}"
-  CYPRESS_API_URL: http://139.59.134.103:1234/
   TEST_RUN_ID: ${{github.run_number}}-${{github.run_attempt}}-${{github.event.pull_request.title || github.event.head_commit.message}}
   # Build the dashboard to use in tests. When set to false it will grab `latest` from CDN (useful for running e2e tests quickly)
   BUILD_DASHBOARD: true

--- a/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
+++ b/cypress/e2e/tests/pages/virtualization-mgmt/harvester.spec.ts
@@ -130,6 +130,7 @@ describe('Harvester', { tags: ['@virtualizationMgmt', '@adminUser'] }, () => {
   });
 
   it('missing repo message should display when repo does NOT exist', () => {
+    cy.viewport(1280, 800); // Extra height so we see all versions in the drop-down list
     cy.intercept('POST', `${ CLUSTER_REPOS_BASE_URL }/${ harvesterGitRepoName }?action=install`).as('installHarvesterExtension');
     cy.intercept('PUT', `${ CLUSTER_REPOS_BASE_URL }/${ harvesterGitRepoName }`).as('updateHarvesterChart');
 

--- a/docusaurus/docs/internal/testing/e2e-test.md
+++ b/docusaurus/docs/internal/testing/e2e-test.md
@@ -85,8 +85,6 @@ The features are folder name based and can be found in `cypress/e2e/tests/pages`
 
 ### Self-hosted: Sorry Cypress
 
-Link to the dashboard: http://139.59.134.103:8080/
-
 E2E tests can be added and displayed in a dashboard by defining the project ID with the env var `TEST_PROJECT_ID`, then run the script:
 
 ```bash

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -24,7 +24,7 @@ else
 fi
 
 # Construct the full command
-E2E_COMMAND="CYPRESS_API_URL='http://139.59.134.103:1234' ${CYPRESS_COMMAND} --browser chrome"
+E2E_COMMAND="${CYPRESS_COMMAND} --browser chrome"
 
 # Execute the command
 eval $E2E_COMMAND

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -10,18 +10,7 @@ if [ $# -eq 1 ]; then
   SPEC_ARG="--spec ${1}"
 fi
 
-# Define the command to use (cy2 or cypress)
-# TEST_DISABLE_DASHBOARD: Disable Cypress dashboard using GH repository settings
-# TEST_DISABLE_DASHBOARD_LABEL: Disable Cypress dashboard using PR label `ci/skip-e2e-cypress-dashboard`
-echo "TEST_DISABLE_DASHBOARD: ${TEST_DISABLE_DASHBOARD}"
-echo "TEST_DISABLE_DASHBOARD_LABEL: ${TEST_DISABLE_DASHBOARD_LABEL}"
-if [ "${TEST_DISABLE_DASHBOARD}" = "true" ] || [ "${TEST_DISABLE_DASHBOARD_LABEL}" = "true" ]; then
-  echo "Running Cypress without dashboard"
-  CYPRESS_COMMAND="cypress run ${SPEC_ARG}"
-else
-  echo "Running Cypress with Sorry Cypress on dashboard"
-  CYPRESS_COMMAND="cy2 run ${SPEC_ARG} --ci-build-id \"$ID\" --record --key rancher-dashboard --parallel --group \"$GREP_TAGS\""
-fi
+CYPRESS_COMMAND="cypress run ${SPEC_ARG}"
 
 # Construct the full command
 E2E_COMMAND="${CYPRESS_COMMAND} --browser chrome"


### PR DESCRIPTION
### Summary

Fixes #18199

### Occurred changes and/or fixed issues

Removes upload of e2e tests to Sorry Cypress.

Tweaked one test to use a larger browser window, so all dropdown options are visible.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
