### PR TITLE
Sort list state on name if equal on state

### DIFF
--- a/shell/config/pagination-table-headers.js
+++ b/shell/config/pagination-table-headers.js
@@ -37,7 +37,7 @@ export const STEVE_STATE_COL = {
   // Note, we're show the 'state' as per model, not the 'metadata.state.name' that's available in the model to remotely sort/filter
   // Need to investigate whether we should 'dumb down' the state we show to the native one (tracked via https://github.com/rancher/dashboard/issues/8527)
   // This means we'll show something different to what we sort and filter on.
-  sort:   ['metadata.state.name'],
+  sort:   ['metadata.state.name', 'metadata.name'],
   search: 'metadata.state.name',
 };
 
@@ -118,4 +118,9 @@ export const STEVE_AUTOSCALER_ENABLED = {
   ...AUTOSCALER_ENABLED,
   sort:   false,
   search: false,
+};
+
+export const STEVE_MGMT_STATE_COL = {
+  ...STEVE_STATE_COL,
+  sort: ['metadata.state.name', 'spec.displayName']
 };

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -20,7 +20,7 @@ import { DSL } from '@shell/store/type-map';
 import { BLANK_CLUSTER } from '@shell/store/store-types.js';
 import { markRaw } from 'vue';
 import {
-  STEVE_AGE_COL, STEVE_MGMT_CLUSTER_KUBE_VERSION, STEVE_MGMT_CLUSTER_PROVIDER, STEVE_NAMESPACE_COL, STEVE_STATE_COL
+  STEVE_AGE_COL, STEVE_MGMT_CLUSTER_KUBE_VERSION, STEVE_MGMT_CLUSTER_PROVIDER, STEVE_MGMT_STATE_COL, STEVE_NAMESPACE_COL
 } from '@shell/config/pagination-table-headers';
 
 export const NAME = 'manager';
@@ -201,7 +201,7 @@ export function init(store) {
     AGE,
     EXPLORER,
   ], [
-    STEVE_STATE_COL,
+    STEVE_MGMT_STATE_COL,
     {
       name:          'name',
       labelKey:      'tableHeaders.name',

--- a/shell/pages/home.vue
+++ b/shell/pages/home.vue
@@ -25,7 +25,7 @@ import TabTitle from '@shell/components/TabTitle.vue';
 import { ActionFindPageArgs } from '@shell/types/store/dashboard-store.types';
 
 import { SET_LOGIN_ACTION, SHOW_HIDE_BANNER_ACTION } from '@shell/config/page-actions';
-import { STEVE_MGMT_CLUSTER_KUBE_VERSION, STEVE_MGMT_CLUSTER_PROVIDER, STEVE_NAME_COL, STEVE_STATE_COL } from '@shell/config/pagination-table-headers';
+import { STEVE_MGMT_CLUSTER_KUBE_VERSION, STEVE_MGMT_CLUSTER_PROVIDER, STEVE_MGMT_STATE_COL, STEVE_NAME_COL } from '@shell/config/pagination-table-headers';
 import { PaginationParamFilter, FilterArgs, PaginationFilterField, PaginationArgs } from '@shell/types/store/pagination.types';
 import { PagTableFetchPageSecondaryResourcesOpts, PagTableFetchSecondaryResourcesOpts, PagTableFetchSecondaryResourcesReturns } from '@shell/types/components/paginatedResourceTable';
 import { CURRENT_RANCHER_VERSION, getVersionData } from '@shell/config/version';
@@ -159,7 +159,7 @@ export default defineComponent({
       ],
 
       paginationHeaders: [
-        STEVE_STATE_COL,
+        STEVE_MGMT_STATE_COL,
         {
           ...STEVE_NAME_COL,
           canBeVariable: true,


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18206
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- sorting lists on state currently only sorts on state name
- if multiple states have the same name then the result can be indeterminate
- to fix, and improve ux, fall back on sorting by name
- this change is applied generally to all steve vai enabled lists
- cluster lists have special fix, given their metadata.name is not their human name (i've double checked other places and clusters is the only type that does this)

### Technical notes summary
- this means sorting by state and name, if there's lots of results with the same state, should be very similar

### Areas or cases that should be tested
- home page and cluster management lists
- generic lists like pods or service lists



### Areas which could experience regressions
- other random lists in explorer

### Screenshot/Video

<img width="622" height="552" alt="image" src="https://github.com/user-attachments/assets/c603de26-33a3-4412-83ab-65ec8f53a07e" />

<img width="499" height="722" alt="image" src="https://github.com/user-attachments/assets/9589b528-a8a4-4aa6-bd18-208c41933b6e" />

<img width="618" height="678" alt="image" src="https://github.com/user-attachments/assets/5134493b-85ca-47cf-9825-40c6ce77670f" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
