### PR TITLE
Prometheus rule release label

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5932,6 +5932,9 @@ projectNamespaces:
   isIstioInjectionEnabled: Istio automatic sidecar injection is enabled for this namespace
 
 prometheusRule:
+  releaseLabel:
+    label: Prometheus Release Label
+    tooltip: This label must match the Prometheus Operator's rule selector for these rules to be discovered and evaluated.
   alertingRules:
     addLabel: Add Alert
     annotations:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5932,9 +5932,9 @@ projectNamespaces:
   isIstioInjectionEnabled: Istio automatic sidecar injection is enabled for this namespace
 
 prometheusRule:
-  releaseLabel:
-    label: Prometheus Release Label
-    tooltip: This label must match the Prometheus Operator's rule selector for these rules to be discovered and evaluated.
+  labels:
+    title: Prometheus Match Labels
+    tooltip: These labels must match the ruleSelector configured on the Prometheus resource. The Prometheus Operator uses this selector to discover which PrometheusRule resources to evaluate.
   alertingRules:
     addLabel: Add Alert
     annotations:

--- a/shell/components/form/Labels.vue
+++ b/shell/components/form/Labels.vue
@@ -122,6 +122,11 @@ export default {
       default: true,
     },
 
+    showLabelDescription: {
+      type:    Boolean,
+      default: true,
+    },
+
     addIcon: {
       type:    String,
       default: '',
@@ -185,7 +190,10 @@ export default {
             :on-label="t('labels.labels.show')"
           />
         </div>
-        <p class="mt-10 mb-10">
+        <p
+          v-if="showLabelDescription"
+          class="mt-10 mb-10"
+        >
           <t k="labels.labels.description" />
         </p>
         <div :class="columnsClass">

--- a/shell/edit/__tests__/monitoring.coreos.com.prometheusrule.test.ts
+++ b/shell/edit/__tests__/monitoring.coreos.com.prometheusrule.test.ts
@@ -69,85 +69,6 @@ describe('edit: management.cattle.io.setting should', () => {
   });
 });
 
-describe('edit: monitoring.coreos.com.prometheusrule prometheusReleaseLabel computed', () => {
-  const store = createStore({
-    getters: {
-      namespaces:                () => () => ({}),
-      currentStore:              () => () => 'current_store',
-      'current_store/schemaFor': () => jest.fn()
-    }
-  });
-
-  const requiredSetup = () => ({
-    global: {
-      provide: { store },
-      mocks:   {
-        $store: {
-          dispatch: jest.fn(),
-          getters:  {
-            currentStore:              () => 'current_store',
-            'current_store/schemaFor': jest.fn(),
-            'current_store/all':       jest.fn(),
-            'i18n/t':                  jest.fn(),
-            'i18n/exists':             jest.fn(),
-            namespaces:                () => ({})
-          }
-        },
-        $route:  { query: { AS: '' }, name: '' },
-        $router: { applyQuery: jest.fn() }
-      }
-    }
-  });
-
-  it('should return the release label value from metadata.labels', () => {
-    const wrapper = shallowMount(Monitoring, {
-      props: {
-        mode:  _EDIT,
-        value: { metadata: { labels: { release: 'my-release' } } },
-      },
-      ...requiredSetup()
-    });
-
-    expect((wrapper.vm as any).prometheusReleaseLabel).toBe('my-release');
-  });
-
-  it('should return an empty string when release label is not set', () => {
-    const wrapper = shallowMount(Monitoring, {
-      props: {
-        mode:  _EDIT,
-        value: { metadata: {} },
-      },
-      ...requiredSetup()
-    });
-
-    expect((wrapper.vm as any).prometheusReleaseLabel).toBe('');
-  });
-
-  it('should update metadata.labels.release when set', () => {
-    const value = { metadata: { labels: { release: 'old-release' } } };
-    const wrapper = shallowMount(Monitoring, {
-      props: { mode: _EDIT, value },
-      ...requiredSetup()
-    });
-
-    (wrapper.vm as any).prometheusReleaseLabel = 'new-release';
-
-    expect(value.metadata.labels.release).toBe('new-release');
-  });
-
-  it('should initialize labels object when setting release label if labels are undefined', () => {
-    const value: { metadata: { labels?: { release?: string } } } = { metadata: {} };
-    const wrapper = shallowMount(Monitoring, {
-      props: { mode: _EDIT, value },
-      ...requiredSetup()
-    });
-
-    (wrapper.vm as any).prometheusReleaseLabel = 'my-release';
-
-    expect(value.metadata.labels).toStrictEqual({ release: 'my-release' });
-  });
-});
-
 describe('edit: monitoring.coreos.com.prometheusrule created hook', () => {
   const store = createStore({
     getters: {
@@ -178,8 +99,17 @@ describe('edit: monitoring.coreos.com.prometheusrule created hook', () => {
     }
   });
 
+  const makeSetLabel = (value: any) => jest.fn((key: string, val: string) => {
+    if (!value.metadata.labels) {
+      value.metadata.labels = {};
+    }
+    value.metadata.labels[key] = val;
+  });
+
   it('should set default namespace and release label in CREATE mode', () => {
     const value: any = { metadata: {} };
+
+    value.setLabel = makeSetLabel(value);
 
     shallowMount(Monitoring, {
       props: { mode: _CREATE, value },
@@ -187,22 +117,26 @@ describe('edit: monitoring.coreos.com.prometheusrule created hook', () => {
     });
 
     expect(value.metadata.namespace).toBe('cattle-monitoring-system');
-    expect(value.metadata.labels?.['release']).toBe('kube-prometheus-stack');
+    expect(value.setLabel).toHaveBeenCalledWith('release', 'kube-prometheus-stack');
+    expect(value.metadata.labels?.release).toBe('kube-prometheus-stack');
   });
 
   it('should not override an existing release label in CREATE mode', () => {
     const value: any = { metadata: { labels: { release: 'custom-release' } } };
+
+    value.setLabel = makeSetLabel(value);
 
     shallowMount(Monitoring, {
       props: { mode: _CREATE, value },
       ...requiredSetup()
     });
 
+    expect(value.setLabel).not.toHaveBeenCalled();
     expect(value.metadata.labels.release).toBe('custom-release');
   });
 
   it('should not set default namespace or release label in EDIT mode', () => {
-    const value: any = { metadata: {} };
+    const value: any = { metadata: {}, setLabel: jest.fn() };
 
     shallowMount(Monitoring, {
       props: { mode: _EDIT, value },
@@ -210,6 +144,6 @@ describe('edit: monitoring.coreos.com.prometheusrule created hook', () => {
     });
 
     expect(value.metadata.namespace).toBeUndefined();
-    expect(value.metadata.labels).toBeUndefined();
+    expect(value.setLabel).not.toHaveBeenCalled();
   });
 });

--- a/shell/edit/__tests__/monitoring.coreos.com.prometheusrule.test.ts
+++ b/shell/edit/__tests__/monitoring.coreos.com.prometheusrule.test.ts
@@ -1,7 +1,7 @@
-import { mount } from '@vue/test-utils';
+import { mount, shallowMount } from '@vue/test-utils';
 import FormValidation from '@shell/mixins/form-validation';
 import Monitoring from '@shell/edit/monitoring.coreos.com.prometheusrule/index.vue';
-import { _EDIT } from '@shell/config/query-params';
+import { _CREATE, _EDIT } from '@shell/config/query-params';
 import { createStore } from 'vuex';
 
 describe('edit: management.cattle.io.setting should', () => {
@@ -66,5 +66,150 @@ describe('edit: management.cattle.io.setting should', () => {
       // Assert that an error banner is closed until the last one
       expect(resultErrorBanners).toHaveLength(MOCKED_ERRORS.length - 1 - i);
     }
+  });
+});
+
+describe('edit: monitoring.coreos.com.prometheusrule prometheusReleaseLabel computed', () => {
+  const store = createStore({
+    getters: {
+      namespaces:                () => () => ({}),
+      currentStore:              () => () => 'current_store',
+      'current_store/schemaFor': () => jest.fn()
+    }
+  });
+
+  const requiredSetup = () => ({
+    global: {
+      provide: { store },
+      mocks:   {
+        $store: {
+          dispatch: jest.fn(),
+          getters:  {
+            currentStore:              () => 'current_store',
+            'current_store/schemaFor': jest.fn(),
+            'current_store/all':       jest.fn(),
+            'i18n/t':                  jest.fn(),
+            'i18n/exists':             jest.fn(),
+            namespaces:                () => ({})
+          }
+        },
+        $route:  { query: { AS: '' }, name: '' },
+        $router: { applyQuery: jest.fn() }
+      }
+    }
+  });
+
+  it('should return the release label value from metadata.labels', () => {
+    const wrapper = shallowMount(Monitoring, {
+      props: {
+        mode:  _EDIT,
+        value: { metadata: { labels: { release: 'my-release' } } },
+      },
+      ...requiredSetup()
+    });
+
+    expect((wrapper.vm as any).prometheusReleaseLabel).toBe('my-release');
+  });
+
+  it('should return an empty string when release label is not set', () => {
+    const wrapper = shallowMount(Monitoring, {
+      props: {
+        mode:  _EDIT,
+        value: { metadata: {} },
+      },
+      ...requiredSetup()
+    });
+
+    expect((wrapper.vm as any).prometheusReleaseLabel).toBe('');
+  });
+
+  it('should update metadata.labels.release when set', () => {
+    const value = { metadata: { labels: { release: 'old-release' } } };
+    const wrapper = shallowMount(Monitoring, {
+      props: { mode: _EDIT, value },
+      ...requiredSetup()
+    });
+
+    (wrapper.vm as any).prometheusReleaseLabel = 'new-release';
+
+    expect(value.metadata.labels.release).toBe('new-release');
+  });
+
+  it('should initialize labels object when setting release label if labels are undefined', () => {
+    const value: { metadata: { labels?: { release?: string } } } = { metadata: {} };
+    const wrapper = shallowMount(Monitoring, {
+      props: { mode: _EDIT, value },
+      ...requiredSetup()
+    });
+
+    (wrapper.vm as any).prometheusReleaseLabel = 'my-release';
+
+    expect(value.metadata.labels).toStrictEqual({ release: 'my-release' });
+  });
+});
+
+describe('edit: monitoring.coreos.com.prometheusrule created hook', () => {
+  const store = createStore({
+    getters: {
+      namespaces:                () => () => ({}),
+      currentStore:              () => () => 'current_store',
+      'current_store/schemaFor': () => jest.fn()
+    }
+  });
+
+  const requiredSetup = () => ({
+    global: {
+      provide: { store },
+      mocks:   {
+        $store: {
+          dispatch: jest.fn(),
+          getters:  {
+            currentStore:              () => 'current_store',
+            'current_store/schemaFor': jest.fn(),
+            'current_store/all':       jest.fn(),
+            'i18n/t':                  jest.fn(),
+            'i18n/exists':             jest.fn(),
+            namespaces:                () => ({})
+          }
+        },
+        $route:  { query: { AS: '' }, name: '' },
+        $router: { applyQuery: jest.fn() }
+      }
+    }
+  });
+
+  it('should set default namespace and release label in CREATE mode', () => {
+    const value: any = { metadata: {} };
+
+    shallowMount(Monitoring, {
+      props: { mode: _CREATE, value },
+      ...requiredSetup()
+    });
+
+    expect(value.metadata.namespace).toBe('cattle-monitoring-system');
+    expect(value.metadata.labels?.['release']).toBe('kube-prometheus-stack');
+  });
+
+  it('should not override an existing release label in CREATE mode', () => {
+    const value: any = { metadata: { labels: { release: 'custom-release' } } };
+
+    shallowMount(Monitoring, {
+      props: { mode: _CREATE, value },
+      ...requiredSetup()
+    });
+
+    expect(value.metadata.labels.release).toBe('custom-release');
+  });
+
+  it('should not set default namespace or release label in EDIT mode', () => {
+    const value: any = { metadata: {} };
+
+    shallowMount(Monitoring, {
+      props: { mode: _EDIT, value },
+      ...requiredSetup()
+    });
+
+    expect(value.metadata.namespace).toBeUndefined();
+    expect(value.metadata.labels).toBeUndefined();
   });
 });

--- a/shell/edit/monitoring.coreos.com.prometheusrule/index.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/index.vue
@@ -4,6 +4,7 @@ import FormValidation from '@shell/mixins/form-validation';
 import { removeAt } from '@shell/utils/array';
 import { Banner } from '@components/Banner';
 import CruResource from '@shell/components/CruResource';
+import Labels from '@shell/components/form/Labels';
 import { LabeledInput } from '@components/Form/LabeledInput';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
 import Tab from '@shell/components/Tabbed/Tab';
@@ -20,6 +21,7 @@ export default {
     Banner,
     CruResource,
     GroupRules,
+    Labels,
     LabeledInput,
     NameNsDescription,
     Tab,
@@ -51,17 +53,6 @@ export default {
   },
 
   computed: {
-    prometheusReleaseLabel: {
-      get() {
-        return this.value?.metadata?.labels?.release || '';
-      },
-      set(val) {
-        if (!this.value.metadata.labels) {
-          this.value.metadata.labels = {};
-        }
-        this.value.metadata.labels['release'] = val;
-      }
-    },
     filteredGroups() {
       return this.value?.spec?.groups || [];
     },
@@ -87,11 +78,8 @@ export default {
     if (this.isCreate) {
       this.value.metadata['namespace'] = 'cattle-monitoring-system';
 
-      if (!this.value.metadata.labels) {
-        this.value.metadata.labels = {};
-      }
-      if (!this.value.metadata.labels['release']) {
-        this.value.metadata.labels['release'] = 'kube-prometheus-stack';
+      if (!this.value.metadata?.labels?.release) {
+        this.value.setLabel('release', 'kube-prometheus-stack');
       }
     }
   },
@@ -167,16 +155,22 @@ export default {
         />
       </div>
     </div>
-    <div class="row mb-20">
-      <div class="col span-6">
-        <LabeledInput
-          v-model:value="prometheusReleaseLabel"
-          :label="t('prometheusRule.releaseLabel.label')"
-          :tooltip="t('prometheusRule.releaseLabel.tooltip', null, true)"
-          :mode="mode"
-        />
-      </div>
-    </div>
+    <hr class="mt-20 mb-20">
+    <h3>
+      {{ t('prometheusRule.labels.title') }}
+      <i
+        v-clean-tooltip="t('prometheusRule.labels.tooltip')"
+        class="icon icon-info"
+      />
+    </h3>
+    <Labels
+      :value="value"
+      :mode="mode"
+      :show-annotations="false"
+      :show-label-title="false"
+      :show-label-description="false"
+      data-testid="v2-monitoring-prom-rules-labels"
+    />
     <div>
       <Tabbed
         v-if="filteredGroups.length > 0"

--- a/shell/edit/monitoring.coreos.com.prometheusrule/index.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/index.vue
@@ -9,7 +9,7 @@ import NameNsDescription from '@shell/components/form/NameNsDescription';
 import Tab from '@shell/components/Tabbed/Tab';
 import Tabbed from '@shell/components/Tabbed';
 import UnitInput from '@shell/components/form/UnitInput';
-import { _CREATE, _VIEW } from '@shell/config/query-params';
+import { _VIEW } from '@shell/config/query-params';
 import isString from 'lodash/isString';
 import isEmpty from 'lodash/isEmpty';
 import GroupRules from './GroupRules';
@@ -51,6 +51,17 @@ export default {
   },
 
   computed: {
+    prometheusReleaseLabel: {
+      get() {
+        return this.value?.metadata?.labels?.release || '';
+      },
+      set(val) {
+        if (!this.value.metadata.labels) {
+          this.value.metadata.labels = {};
+        }
+        this.value.metadata.labels['release'] = val;
+      }
+    },
     filteredGroups() {
       return this.value?.spec?.groups || [];
     },
@@ -73,8 +84,15 @@ export default {
   created() {
     this.registerBeforeHook(this.willSave, 'willSave');
 
-    if (this.mode === _CREATE) {
+    if (this.isCreate) {
       this.value.metadata['namespace'] = 'cattle-monitoring-system';
+
+      if (!this.value.metadata.labels) {
+        this.value.metadata.labels = {};
+      }
+      if (!this.value.metadata.labels['release']) {
+        this.value.metadata.labels['release'] = 'kube-prometheus-stack';
+      }
     }
   },
 
@@ -146,6 +164,16 @@ export default {
           :mode="mode"
           :rules="{ name: fvGetAndReportPathRules('metadata.name'), namespace: [], description: [] }"
           @change="name = value.metadata.name"
+        />
+      </div>
+    </div>
+    <div class="row mb-20">
+      <div class="col span-6">
+        <LabeledInput
+          v-model:value="prometheusReleaseLabel"
+          :label="t('prometheusRule.releaseLabel.label')"
+          :tooltip="t('prometheusRule.releaseLabel.tooltip', null, true)"
+          :mode="mode"
         />
       </div>
     </div>

--- a/shell/edit/monitoring.coreos.com.prometheusrule/index.vue
+++ b/shell/edit/monitoring.coreos.com.prometheusrule/index.vue
@@ -161,6 +161,8 @@ export default {
       <i
         v-clean-tooltip="t('prometheusRule.labels.tooltip')"
         class="icon icon-info"
+        role="img"
+        :aria-label="t('prometheusRule.labels.tooltip')"
       />
     </h3>
     <Labels
@@ -169,7 +171,7 @@ export default {
       :show-annotations="false"
       :show-label-title="false"
       :show-label-description="false"
-      data-testid="v2-monitoring-prom-rules-labels"
+      data-testid="monitoring-prom-rules-labels"
     />
     <div>
       <Tabbed


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18203

### Occurred changes and/or fixed issues
With the new monitoring chart decoupling Prometheus from the chart, users bring their own Prometheus instance which may have any `spec.ruleSelector` configured. PrometheusRule resources were not being discovered because they lacked the labels needed to match that selector.

Added a **Prometheus Match Labels** section to the PrometheusRule create/edit form so users can set any `metadata.labels` to match their Prometheus `spec.ruleSelector`. A default `release: kube-prometheus-stack` label is pre-populated on create to cover the common upgrade path.

### Technical notes summary
- Used `Labels.vue` to add the new **Prometheus Match Labels** section
- Extended `Labels.vue` with `showLabelDescription` prop (backward-compatible, safe defaults)

### Areas or cases that should be tested
1. Create a PrometheusRule — confirm the labels section is visible and pre-populated with `release: kube-prometheus-stack`
2. Add a label matching your Prometheus's `ruleSelector` — confirm the rule appears on the monitoring overview and external rules page
3. Edit an existing PrometheusRule — confirm existing labels are shown and editable without data loss
4. View mode — confirm labels render read-only

### Areas which could experience regressions
- **`Labels.vue`** — any page using this component should be spot-checked to confirm the description paragraph and title still render as before
- **PrometheusRule create flow** — namespace and default label initialisation
- **Monitoring overview and external Prometheus rules pages**

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

https://github.com/user-attachments/assets/32790cb2-9a98-403f-b0b8-5d426a9911d1


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
