### PR TITLE
expose registries accordion in gke provisioning form

### DIFF
--- a/pkg/gke/components/__tests__/CruGKE.test.ts
+++ b/pkg/gke/components/__tests__/CruGKE.test.ts
@@ -1,0 +1,58 @@
+import { shallowMount } from '@vue/test-utils';
+import CruGKE from '../CruGKE.vue';
+
+const mockedStore = () => {
+  return {
+    getters: {
+      'i18n/t':                  (text: string) => text,
+      t:                         (text: string) => text,
+      currentStore:              () => 'current_store',
+      'current_store/schemaFor': jest.fn(),
+      'current_store/all':       jest.fn(),
+      'management/byId':         () => ({ value: '' }),
+      'management/schemaFor':    jest.fn(),
+      'auth/principalId':        'local://test',
+    },
+    dispatch: jest.fn(() => Promise.resolve({
+      gkeConfig:      {},
+      name:           '',
+      importedConfig: { privateRegistryURL: null },
+      annotations:    {}
+    }))
+  };
+};
+
+const requiredSetup = (isImport = false) => {
+  return {
+    global: {
+      mocks: {
+        $store:      mockedStore(),
+        $route:      { query: { mode: isImport ? 'import' : '' } },
+        $fetchState: { pending: false },
+      },
+      stubs: { CruResource: { template: '<div><slot /></div>' } }
+    }
+  };
+};
+
+describe('CruGKE', () => {
+  it('renders the registries section when importing an existing cluster', () => {
+    const wrapper = shallowMount(CruGKE, {
+      propsData: { value: { isImported: true }, mode: 'create' },
+      data:      () => ({ isAuthenticated: true }),
+      ...requiredSetup(false)
+    });
+
+    expect(wrapper.find('[data-testid="registries-accordion"]').exists()).toBe(true);
+  });
+
+  it('renders the registries section when provisioning a new cluster', () => {
+    const wrapper = shallowMount(CruGKE, {
+      propsData: { value: { isImported: false }, mode: 'create' },
+      data:      () => ({ isAuthenticated: true }),
+      ...requiredSetup(false)
+    });
+
+    expect(wrapper.find('[data-testid="registries-accordion"]').exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18211 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the GKE provisioning template so that the Private Registries component is rendered both during provisioning and import. Previously it was only rendered during import.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
- gke provisioning form should have a registries section
- gke import form should have a registries section
- the registries section should function just as it does in other provisioning forms, as described in https://github.com/rancher/dashboard/pull/18099

### Areas which could experience regressions
None, this is a straightforward correction to the gke template

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
