### PR TITLE
Expose Registries section in GKE provisioning

### DIFF
--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -122,6 +122,7 @@ const defaultGkeConfig = {
 };
 
 const defaultCluster = {
+  importedConfig:          {},
   dockerRootDir:           '/var/lib/docker',
   enableClusterAlerting:   false,
   enableClusterMonitoring: false,

--- a/pkg/gke/components/__tests__/CruGKE.test.ts
+++ b/pkg/gke/components/__tests__/CruGKE.test.ts
@@ -1,0 +1,70 @@
+import { shallowMount } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import CruGKE from '../CruGKE.vue';
+
+const mockedStore = () => {
+  return {
+    getters: {
+      'i18n/t':               (text: string) => text,
+      t:                      (text: string) => text,
+      currentStore:           () => 'current_store',
+      'management/byId':      () => ({ value: '' }),
+      'management/schemaFor': jest.fn(),
+      'auth/principalId':     'local://test',
+    },
+    dispatch: jest.fn((_action: string, resource: any) => {
+      // Mimic rancher/create: return the resource payload as-is
+      return Promise.resolve({ ...resource });
+    })
+  };
+};
+
+describe('CruGKE', () => {
+  it('renders the registries section when importing an existing cluster', async() => {
+    const store = mockedStore();
+
+    const wrapper = shallowMount(CruGKE, {
+      propsData: { value: {}, mode: 'create' },
+      global:    {
+        mocks: {
+          $store:      store,
+          $route:      { query: { mode: 'import' } },
+          $fetchState: { pending: false },
+        },
+        stubs: { CruResource: { template: '<div><slot /></div>' } }
+      }
+    });
+
+    await wrapper.vm.$options.fetch.call(wrapper.vm);
+    await flushPromises();
+    wrapper.vm.isAuthenticated = true;
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.normanCluster.importedConfig).toBeDefined();
+    expect(wrapper.find('[data-testid="registries-accordion"]').exists()).toBe(true);
+  });
+
+  it('renders the registries section when provisioning a new cluster', async() => {
+    const store = mockedStore();
+
+    const wrapper = shallowMount(CruGKE, {
+      propsData: { value: {}, mode: 'create' },
+      global:    {
+        mocks: {
+          $store:      store,
+          $route:      { query: {} },
+          $fetchState: { pending: false },
+        },
+        stubs: { CruResource: { template: '<div><slot /></div>' } }
+      }
+    });
+
+    await wrapper.vm.$options.fetch.call(wrapper.vm);
+    await flushPromises();
+    wrapper.vm.isAuthenticated = true;
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.normanCluster.importedConfig).toBeDefined();
+    expect(wrapper.find('[data-testid="registries-accordion"]').exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18211
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR corrects an error rendering the Registries section in the GKE provisioning form.

### Technical notes summary
The bug quoted in the linked issue accurately describes the problem; clusters need to be initialized with importedConfig defined for the component to properly render.

I've added some unit tests to cover this and verified enough component functionality is un-mocked to hit this error without the fix to the normanCluster default object.

### Areas or cases that should be tested
- the GKE provisioning form should have a Registries section matching what is shown in EKS, AKS provisioning
- the GKE import form should have the same registries section

### Areas which could experience regressions
Minimal chance of regression; the update matches functionality of AKS, EKS provisioning. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
