### PR TITLE
Retain end session endpoint when toggling slo type

### DIFF
--- a/shell/edit/auth/__tests__/azuread.test.ts
+++ b/shell/edit/auth/__tests__/azuread.test.ts
@@ -406,7 +406,7 @@ describe('edit: azureAD SSO logout should', () => {
 
     expect(wrapper.vm.model.logoutAllEnabled).toBe(false);
     expect(wrapper.vm.model.logoutAllForced).toBe(false);
-    expect(wrapper.vm.model.endSessionEndpoint).toBe('');
+    expect(wrapper.vm.model.endSessionEndpoint).toBe(undefined);
   });
 
   it('sets logoutAllEnabled=true and logoutAllForced=true when sloType changes to all', async() => {

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -266,7 +266,6 @@ export default {
         case SLO_OPTION_VALUES.rancher:
           this.model.logoutAllEnabled = false;
           this.model.logoutAllForced = false;
-          this.model.endSessionEndpoint = '';
           break;
         case SLO_OPTION_VALUES.all:
           this.model.logoutAllEnabled = true;

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -268,7 +268,6 @@ export default {
       case SLO_OPTION_VALUES.rancher:
         this.model.logoutAllEnabled = false;
         this.model.logoutAllForced = false;
-        this.model.endSessionEndpoint = '';
         break;
       case SLO_OPTION_VALUES.all:
         this.model.logoutAllEnabled = true;


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This persists the end session endpoint when toggling the SLO type.

Fixes #18187
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Retain end session endpoint when toggling slo type

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The clearing of the value is not needed. Stale values will not impact behavior because the backend operates based on the flags that govern the actual behavior. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

For the impacted auth provider types (AzureAD & KeyCloak can cover both cases):

1. Configure SLO with a valid end session endpoint
2. Save and confirm that SLO behaves as expected
3. Toggle values, ensure that SLO is toggled off and back on in the form
4. The value should persist
5. Toggle SLO off and save
6. Log out of Rancher and log back in
7. Ensure that SLO disabled behaves as expected

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

The risk for regression is low in this area. Stale values will not impact behavior because the backend operates based on the flags that govern the actual behavior

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
