### PR TITLE
Fixed false warning when selecting dual stack configuration

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -807,6 +807,117 @@ describe('component: rke2', () => {
     });
   });
 
+  describe('method: showIpv6Warning', () => {
+    const createWrapper = ({ mode = _CREATE, dispatch = jest.fn() } = {}) => {
+      return shallowMount(rke2, {
+        props: {
+          mode,
+          value: {
+            spec: {
+              ...defaultSpec,
+              rkeConfig: {
+                ...defaultSpec.rkeConfig,
+                networking: { stackPreference: 'ipv6' }
+              }
+            },
+            agentConfig: { 'cloud-provider-name': 'any' }
+          },
+          provider: 'custom'
+        },
+        global: {
+          mocks: {
+            ...defaultMocks,
+            $store:     { dispatch, getters: defaultGetters },
+            $extension: { getDynamic: jest.fn(() => undefined ) },
+          },
+          stubs: defaultStubs,
+        },
+      });
+    };
+
+    it('should not show modal when mode is not create', async() => {
+      const dispatch = jest.fn();
+      const wrapper = createWrapper({ mode: _EDIT, dispatch });
+
+      await wrapper.setData({ machinePools: [{ id: 'pool1' }] });
+
+      await (wrapper.vm as any).showIpv6Warning();
+
+      expect(dispatch).toHaveBeenCalledTimes(0);
+    });
+
+    it('should not show modal when networking values are valid', async() => {
+      const dispatch = jest.fn();
+      const wrapper = createWrapper({ dispatch });
+
+      await wrapper.setData({ machinePools: [{ id: 'pool1' }] });
+
+      Object.defineProperty(wrapper.vm, 'selectedVersion', { get: () => ({ label: 'v1.30.0+rke2r1' }) });
+      Object.defineProperty(wrapper.vm, 'hasOnlyIpv6Pools', { get: () => true });
+      Object.defineProperty(wrapper.vm, 'hasDualStackPools', { get: () => false });
+
+      wrapper.vm.value.spec.rkeConfig.networking.stackPreference = 'ipv6';
+      wrapper.vm.value.spec.rkeConfig.machineGlobalConfig['flannel-ipv6-masq'] = true;
+      wrapper.vm.value.spec.rkeConfig.machineGlobalConfig['cluster-cidr'] = '2001:db8::/64';
+      wrapper.vm.value.spec.rkeConfig.machineGlobalConfig['service-cidr'] = '2001:db8:1::/112';
+
+      await (wrapper.vm as any).showIpv6Warning();
+
+      expect(dispatch).toHaveBeenCalledTimes(0);
+    });
+
+    it('should show modal with all relevant warnings for invalid ipv6 settings', async() => {
+      const dispatch = jest.fn((_action, payload) => {
+        payload.componentProps.confirm(true);
+      });
+      const wrapper = createWrapper({ dispatch });
+
+      await wrapper.setData({ machinePools: [{ id: 'pool1' }] });
+
+      Object.defineProperty(wrapper.vm, 'selectedVersion', { get: () => ({ label: 'v1.30.0+k3s1' }) });
+      Object.defineProperty(wrapper.vm, 'hasOnlyIpv6Pools', { get: () => true });
+      Object.defineProperty(wrapper.vm, 'hasDualStackPools', { get: () => false });
+
+      wrapper.vm.value.spec.rkeConfig.networking.stackPreference = 'ipv4';
+      wrapper.vm.value.spec.rkeConfig.machineGlobalConfig['flannel-ipv6-masq'] = false;
+      wrapper.vm.value.spec.rkeConfig.machineGlobalConfig['cluster-cidr'] = '10.42.0.0/16';
+      wrapper.vm.value.spec.rkeConfig.machineGlobalConfig['service-cidr'] = '10.43.0.0/16';
+
+      await (wrapper.vm as any).showIpv6Warning();
+
+      expect(dispatch).toHaveBeenCalledWith('cluster/promptModal', expect.objectContaining({
+        component:      'Ipv6NetworkingDialog',
+        componentProps: expect.objectContaining({
+          isK3s:    true,
+          warnings: [
+            'cluster.rke2.modal.ipv6Warning.stackPrefInvalid',
+            'cluster.rke2.modal.ipv6Warning.flannelMasqInvalid',
+            'cluster.rke2.modal.ipv6Warning.cidrInvalidK3s'
+          ]
+        })
+      }));
+    });
+
+    it('should reject when user cancels ipv6 warning modal', async() => {
+      const dispatch = jest.fn((_action, payload) => {
+        payload.componentProps.confirm(false);
+      });
+      const wrapper = createWrapper({ dispatch });
+
+      await wrapper.setData({ machinePools: [{ id: 'pool1' }] });
+
+      Object.defineProperty(wrapper.vm, 'hasOnlyIpv6Pools', { get: () => true });
+      Object.defineProperty(wrapper.vm, 'hasDualStackPools', { get: () => false });
+
+      wrapper.vm.value.spec.rkeConfig.networking.stackPreference = 'ipv4';
+      wrapper.vm.value.spec.rkeConfig.machineGlobalConfig['cluster-cidr'] = '10.42.0.0/16';
+      wrapper.vm.value.spec.rkeConfig.machineGlobalConfig['service-cidr'] = '10.43.0.0/16';
+
+      await expect((wrapper.vm as any).showIpv6Warning()).rejects.toThrow('User Cancelled');
+      expect(dispatch).toHaveBeenCalledWith('cluster/promptModal', expect.any(Object));
+    });
+  });
+
   describe('computed: canEditAsYaml', () => {
     it('should return false when isUpstreamCAPIProvider is true', () => {
       const vm = { isUpstreamCAPIProvider: true } as any;

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1629,7 +1629,7 @@ export default {
       const isIpv6 = this.hasOnlyIpv6Pools;
 
       const flannelMasqInvalid = isIpv6 && isK3s && !flannelMasqEnabled;
-      const stackPrefInvalid = (isIpv6 && stackPreference !== STACK_PREFS.IPV6) || (isDualStack && stackPreference !== STACK_PREFS.DUAL);
+      const stackPrefInvalid = (isIpv6 && stackPreference !== STACK_PREFS.IPV6) || (isDualStack && (stackPreference && stackPreference !== STACK_PREFS.DUAL));
 
       const clusterCIDRInvalid = (isIpv6 || isDualStack) && !clusterCIDR.includes(':');
       const serviceCIDRInvalid = (isIpv6 || isDualStack) && !serviceCIDR.includes(':');


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16788 
<!-- Define findings related to the feature or bug issue. -->
With a switch of default behavior for network's stack preference, the unset default value, which is dual stack, wasn't counted towards dual stack's configuration validation. Updated the condition to count undefined as valid dual stack setting

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Refer to https://github.com/rancher/dashboard/issues/16788#issuecomment-4845401423

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
This is pretty self-contained so no regressions should occur

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
