### PR TITLE
Rename `ButtonSize` type to `RcButtonSize`

### DIFF
--- a/pkg/rancher-components/src/components/RcButton/index.ts
+++ b/pkg/rancher-components/src/components/RcButton/index.ts
@@ -1,2 +1,2 @@
 export { default as RcButton } from './RcButton.vue';
-export type { RcButtonType, ButtonSize } from './types';
+export type { RcButtonType, ButtonSize as RcButtonSize } from './types';

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownTrigger.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownTrigger.vue
@@ -3,11 +3,11 @@
  * A button that opens a menu. Used in conjunction with `RcDropdown.vue`.
  */
 import { inject, onMounted, ref } from 'vue';
-import { RcButton, RcButtonType, ButtonSize } from '@components/RcButton';
+import { RcButton, RcButtonType, RcButtonSize } from '@components/RcButton';
 import { DropdownContext, defaultContext } from './types';
 
 defineProps<{
-  size?: ButtonSize,
+  size?: RcButtonSize,
 }>();
 
 const {

--- a/shell/components/ActionDropdownShell.vue
+++ b/shell/components/ActionDropdownShell.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { RcDropdown, RcDropdownTrigger, RcDropdownItem } from '@components/RcDropdown';
-import { ButtonSize } from '@components/RcButton';
+import { RcButtonSize } from '@components/RcButton';
 type HiddenAction = {
   action: string;
   enabled: boolean;
@@ -16,7 +16,7 @@ withDefaults(defineProps<{
   disabled: boolean,
   hiddenActions: HiddenAction[],
   actionTooltip: unknown,
-  size?: ButtonSize,
+  size?: RcButtonSize,
 }>(), { size: 'large' });
 
 const emit = defineEmits(['click', 'mouseover', 'mouseleave']);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This is being done to consistently name bundled exports for the component library. This keeps it clear where the button size is originally defined.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Rename `ButtonSize` type to `RcButtonSize`

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

This is being done to address a comment from #18108:

https://github.com/rancher/dashboard/pull/18108#discussion_r3451329905

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

The scope of this change should be rather limited. Ensure that the buttons still render and are sized correctly.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Buttons should still be sized correctly, no errors in console. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
