### PR TITLE
[15411] investigate fleet interaction with resources with high counts

### DIFF
--- a/shell/components/ForceDirectedTreeChart/index.vue
+++ b/shell/components/ForceDirectedTreeChart/index.vue
@@ -18,7 +18,7 @@ export default {
   },
 
   async fetch() {
-    this.canViewChart = await this.fdcConfig.checkSchemaPermissions(this.$store);
+    this.canViewChart = await this.fdcConfig.checkSchemaPermissions(this.$store, this.data);
 
     if (this.canViewChart) {
       // set watcher for the chart data

--- a/shell/components/fleet/FleetBundles.vue
+++ b/shell/components/fleet/FleetBundles.vue
@@ -1,5 +1,6 @@
 <script>
-import { FLEET } from '@shell/config/types';
+import { FLEET, VIRTUAL_HARVESTER_PROVIDER } from '@shell/config/types';
+import { CAPI } from '@shell/config/labels-annotations';
 import { Banner } from '@components/Banner';
 import Loading from '@shell/components/Loading';
 import ResourceTable from '@shell/components/ResourceTable';
@@ -46,6 +47,15 @@ export default {
     useQueryParamsForSimpleFiltering: {
       type:    Boolean,
       default: false
+    },
+
+    /**
+     * When provided (detail usage), use these clusters for the Harvester filter instead of
+     * fetching every cluster - the owning page already fetched just the relevant clusters.
+     */
+    clusters: {
+      type:    Array,
+      default: null,
     }
   },
 
@@ -53,14 +63,9 @@ export default {
     let hash;
 
     try {
-      const toFetch = {
-        cluster: {
-          inStoreType: 'management',
-          type:        FLEET.CLUSTER
-        }
-      };
+      const toFetch = {};
 
-      // Only fetch bundles if in list mode
+      // Only fetch bundles if in list mode (the list's own resource)
       if (this.isListMode) {
         toFetch.bundle = {
           inStoreType: 'management',
@@ -68,7 +73,9 @@ export default {
         };
       }
 
-      hash = await checkSchemasForFindAllHash(toFetch, this.$store);
+      if (Object.keys(toFetch).length) {
+        hash = await checkSchemasForFindAllHash(toFetch, this.$store);
+      }
     } catch (e) {
     }
 
@@ -78,7 +85,19 @@ export default {
       this.rows = hash.bundle;
     }
 
-    this.allFleet = hash?.cluster || [];
+    // Clusters are only needed to hide single-target Harvester bundles. Skip entirely when the
+    // parent already provided clusters or when Harvester hosts are visible; otherwise fetch ONLY the
+    // Harvester clusters (server-side, by provider label) rather than every cluster.
+    if (!this.clusters && !this.$store.getters['features/get'](HARVESTER_CONTAINER) && this.$store.getters['management/schemaFor'](FLEET.CLUSTER)) {
+      try {
+        this.allFleet = await this.$store.dispatch('management/findLabelSelector', {
+          type:     FLEET.CLUSTER,
+          matching: { labelSelector: { matchLabels: { [CAPI.PROVIDER]: VIRTUAL_HARVESTER_PROVIDER } } },
+        }) || [];
+      } catch (e) {
+        this.allFleet = [];
+      }
+    }
   },
 
   data() {
@@ -118,7 +137,7 @@ export default {
     harvesterClusters() {
       const harvester = {};
 
-      this.allFleet.forEach((c) => {
+      (this.clusters || this.allFleet).forEach((c) => {
         if (isHarvesterCluster(c)) {
           harvester[c.metadata.name] = c;
         }

--- a/shell/components/fleet/FleetClusterTargets/ClusterSelectionFields.vue
+++ b/shell/components/fleet/FleetClusterTargets/ClusterSelectionFields.vue
@@ -3,7 +3,14 @@ import { computed, nextTick, ref } from 'vue';
 import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
 import { Selector } from '@shell/types/fleet';
+import { FLEET, VIRTUAL_HARVESTER_PROVIDER } from '@shell/config/types';
+import { FLEET as FLEET_LABELS, CAPI } from '@shell/config/labels-annotations';
+import { isHarvesterCluster } from '@shell/utils/cluster';
+import { PaginationParamFilter, PaginationParamProjectOrNamespace, PaginationFilterEquality } from '@shell/types/store/pagination.types';
+import { LabelSelectPaginationFunctionOptions } from '@shell/components/form/labeled-select-utils/labeled-select.utils';
+import { ResourceLabeledSelectPaginateSettings, ResourceLabeledSelectSettings } from '@shell/types/components/resourceLabeledSelect';
 import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
+import ResourceLabeledSelect from '@shell/components/form/ResourceLabeledSelect.vue';
 import MatchExpressions from '@shell/components/form/MatchExpressions.vue';
 import { RcButton } from '@components/RcButton';
 
@@ -17,21 +24,29 @@ const props = withDefaults(defineProps<{
   selectedClusters?: string[];
   selectedClusterGroups?: string[];
   clusterSelectors?: Selector[];
-  clustersOptions?: SelectOption[];
   clusterGroupsOptions?: SelectOption[];
+  /**
+   * Workspace namespace - scopes the paginated cluster select server-side.
+   */
+  namespace?: string;
+  /**
+   * When false, Harvester clusters are excluded from the cluster select.
+   */
+  areHarvesterHostsVisible?: boolean;
   mode: string;
   isView?: boolean;
   variant?: 'appco' | 'default';
   compact?: boolean;
 }>(), {
-  selectedClusters:      () => [],
-  selectedClusterGroups: () => [],
-  clusterSelectors:      () => [],
-  clustersOptions:       () => [],
-  clusterGroupsOptions:  () => [],
-  isView:                false,
-  variant:               'default',
-  compact:               false,
+  selectedClusters:         () => [],
+  selectedClusterGroups:    () => [],
+  clusterSelectors:         () => [],
+  clusterGroupsOptions:     () => [],
+  namespace:                '',
+  areHarvesterHostsVisible: false,
+  isView:                   false,
+  variant:                  'default',
+  compact:                  false,
 });
 
 // eslint-disable-next-line func-call-spacing
@@ -45,6 +60,47 @@ const emit = defineEmits<{
 
 const store = useStore();
 const { t } = useI18n(store);
+
+// Cluster options use the friendly display name for both label and value (preserving the existing
+// target round-trip), so map raw/paginated cluster resources to that shape.
+const clusterDisplayName = (c: any): string => c?.nameDisplay ?? (c?.metadata?.labels?.[FLEET_LABELS.CLUSTER_DISPLAY_NAME] || c?.metadata?.name);
+
+const clusterOptionFromResource = (c: any): SelectOption => {
+  const name = clusterDisplayName(c);
+
+  return { label: name, value: name };
+};
+
+// Mirrors Fleet's own "exclude harvester" rule - provider.cattle.io NOT IN (harvester). Only the
+// label column is filterable server-side (status.provider isn't an indexed column for fleet clusters).
+const harvesterFilterField = () => PaginationParamFilter.createSingleField({
+  field:    `metadata.labels[${ CAPI.PROVIDER }]`,
+  value:    VIRTUAL_HARVESTER_PROVIDER,
+  equality: PaginationFilterEquality.NOT_IN,
+});
+
+// Paginated path: scope the request to the workspace namespace and (optionally) exclude Harvester
+// clusters server-side, then map results to select options.
+const paginatedClusterSettings = computed<ResourceLabeledSelectPaginateSettings>(() => ({
+  requestSettings: (opts: LabelSelectPaginationFunctionOptions) => ({
+    ...opts,
+    groupByNamespace: false,
+    filters:          [
+      ...(opts.filters || []),
+      new PaginationParamProjectOrNamespace({ projectOrNamespace: [props.namespace] }),
+      ...(props.areHarvesterHostsVisible ? [] : [harvesterFilterField()]),
+    ],
+  }),
+  updateResources: (rows: any[]) => rows.map(clusterOptionFromResource),
+}));
+
+// Non-paginated fallback (SSP off): findAll returns every cluster, so filter to namespace + Harvester
+// visibility client-side, matching the previous behaviour.
+const allClusterSettings = computed<ResourceLabeledSelectSettings>(() => ({
+  updateResources: (all: any[]) => all
+    .filter((c) => c.metadata?.namespace === props.namespace && (props.areHarvesterHostsVisible || !isHarvesterCluster(c)))
+    .map(clusterOptionFromResource),
+}));
 
 const isAppco = computed(() => props.variant === 'appco');
 
@@ -92,21 +148,27 @@ defineExpose({ focusMatchExpression });
 <template>
   <div :class="isAppco ? 'appco-select-clusters' : undefined">
     <!-- Select by cluster name -->
-    <div>
+    <!-- The underlying select doesn't preventDefault on Enter, so inside a <form> it would trigger an
+         implicit submit (firing the first button, e.g. "Add cluster selector"). Catch Enter in the
+         capture phase - before the select stops propagation - and prevent that default submit. -->
+    <div @keydown.enter.capture.prevent>
       <h4 v-if="isAppco">
         {{ t('fleet.clusterTargets.clusters.byName.title') }}
       </h4>
-      <LabeledSelect
+      <ResourceLabeledSelect
         data-testid="fleet-target-cluster-name-selector"
         :class="{ 'mmt-4': !isAppco && !compact }"
+        :resource-type="FLEET.CLUSTER"
+        in-store="management"
         :value="selectedClusters"
         :label="t('fleet.clusterTargets.clusters.byName.label')"
-        :options="clustersOptions"
-        :taggable="true"
+        :taggable="false"
         :close-on-select="false"
         :mode="mode"
         :multiple="true"
         :placeholder="t('fleet.clusterTargets.clusters.byName.placeholder')"
+        :paginated-resource-settings="paginatedClusterSettings"
+        :all-resources-settings="allClusterSettings"
         @update:value="emit('select-clusters', $event)"
       />
     </div>

--- a/shell/components/fleet/FleetClusterTargets/index.vue
+++ b/shell/components/fleet/FleetClusterTargets/index.vue
@@ -4,8 +4,16 @@ import { isEmpty } from 'lodash';
 import { checkSchemasForFindAllHash } from '@shell/utils/auth';
 import { isHarvesterCluster } from '@shell/utils/cluster';
 import { HARVESTER_CONTAINER } from '@shell/store/features';
-import { FLEET } from '@shell/config/types';
+import { FLEET, VIRTUAL_HARVESTER_PROVIDER } from '@shell/config/types';
+import { CAPI } from '@shell/config/labels-annotations';
 import FleetUtils from '@shell/utils/fleet';
+import {
+  FilterArgs,
+  PaginationArgs,
+  PaginationParamFilter,
+  PaginationParamProjectOrNamespace,
+  PaginationFilterEquality,
+} from '@shell/types/store/pagination.types';
 import { Expression, Selector, Target, TargetMode } from '@shell/types/fleet';
 import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
 import { Banner } from '@components/Banner';
@@ -31,7 +39,8 @@ interface FleetResource {
 
 interface DataType {
   targetMode: TargetMode,
-  allClusters: FleetResource[],
+  resolvedClusters: FleetResource[],
+  clusterCount: number,
   allClusterGroups: FleetResource[],
   selectedClusters: string[],
   selectedClusterGroups: string[],
@@ -92,25 +101,32 @@ export default {
   },
 
   async fetch() {
+    // Clusters can be very numerous (thousands for admins) so they're no longer bulk-loaded here - the
+    // cluster select paginates them on demand and the "all" count comes from a bounded count query.
+    // Cluster groups are a small, bounded collection, so a findAll is still fine.
     const hash = await checkSchemasForFindAllHash({
-      allClusters: {
-        inStoreType: 'management',
-        type:        FLEET.CLUSTER
-      },
       allClusterGroups: {
         inStoreType: 'management',
         type:        FLEET.CLUSTER_GROUP
       },
-    }, this.$store) as { allClusters: FleetResource[], allClusterGroups: FleetResource[] };
+    }, this.$store) as { allClusterGroups: FleetResource[] };
 
-    this.allClusters = hash.allClusters || [];
     this.allClusterGroups = hash.allClusterGroups || [];
   },
 
   data(): DataType {
     return {
       targetMode:               'all',
-      allClusters:              [],
+      /**
+       * The subset of clusters we've resolved by name (from existing targets) so their friendly
+       * `nameDisplay` can be shown for pre-selected clusters without loading every cluster.
+       */
+      resolvedClusters:         [],
+      /**
+       * Total number of clusters in the workspace (respecting Harvester visibility). Used for the
+       * "all clusters" label count and to gate the "manually selected clusters" option.
+       */
+      clusterCount:             0,
       allClusterGroups:         [],
       selectedClusters:         [],
       selectedClusterGroups:    [],
@@ -128,6 +144,9 @@ export default {
     this.areHarvesterHostsVisible = this.$store.getters['features/get'](HARVESTER_CONTAINER);
 
     this.fromTargets();
+
+    this.fetchClusterCount();
+    this.resolveSelectedClusters();
 
     if (this.mode === _CREATE) {
       // Restore the targetMode from parent component; this is the case of edit targets in CREATE mode, go to YAML editor and come back to the form
@@ -151,9 +170,12 @@ export default {
       if (this.mode !== _VIEW) {
         this.update();
       }
+
+      this.fetchClusterCount();
+      this.resolveSelectedClusters();
     },
 
-    allClusters(clusters: FleetResource[]) {
+    resolvedClusters(clusters: FleetResource[]) {
       if (clusters.length) {
         // Resolve metadata.name values to nameDisplay for UI display
         this.selectedClusters = this.selectedClusters.map(
@@ -172,7 +194,9 @@ export default {
         }];
       }
 
-      const allLabel = this.compact ? this.t('fleet.clusterTargets.targetMode.allCompact', { namespace: this.namespace, count: this.clustersOptions.length }, { raw: true }) : this.t('fleet.clusterTargets.targetMode.all');
+      // Use the same "All Clusters in the <workspace> (<count>)" text as the AppCo/compact UI in both
+      // layouts, now that the cluster count is available without loading every cluster.
+      const allLabel = this.t('fleet.clusterTargets.targetMode.allCompact', { namespace: this.namespace, count: this.clusterCount }, { raw: true });
 
       const out: { label: string, value: TargetMode }[] = [
         {
@@ -185,7 +209,7 @@ export default {
         },
       ];
 
-      if (this.clustersOptions.length) {
+      if (this.clusterCount) {
         out.push({
           label: this.t('fleet.clusterTargets.targetMode.clusters'),
           value: 'clusters'
@@ -193,16 +217,6 @@ export default {
       }
 
       return out;
-    },
-
-    clustersOptions() {
-      return this.allClusters
-        .filter((x) => x.metadata.namespace === this.namespace && (this.areHarvesterHostsVisible || !isHarvesterCluster(x) || this.selectedClusters.includes(x.name)))
-        .map((x) => ({
-          label:    x.nameDisplay,
-          value:    x.nameDisplay,
-          disabled: !this.areHarvesterHostsVisible && isHarvesterCluster(x)
-        }));
     },
 
     clusterGroupsOptions() {
@@ -396,11 +410,115 @@ export default {
     },
 
     resolveClusterDisplayName(name: string): string {
-      const cluster = this.allClusters.find(
+      const cluster = this.resolvedClusters.find(
         (c: FleetResource) => c.metadata.namespace === this.namespace && c.metadata.name === name
       );
 
       return cluster ? cluster.nameDisplay : name;
+    },
+
+    /**
+     * Mirrors Fleet's own "exclude harvester" rule - provider.cattle.io NOT IN (harvester). Only the
+     * label column is filterable server-side (status.provider isn't an indexed column), so we use it
+     * here rather than the broader `paginationFilterOnlyKubernetesClusters` helper.
+     */
+    harvesterFilterField(equality: string) {
+      return PaginationParamFilter.createSingleField({
+        field: `metadata.labels[${ CAPI.PROVIDER }]`,
+        value: VIRTUAL_HARVESTER_PROVIDER,
+        equality,
+      });
+    },
+
+    /**
+     * Cluster select is paginated, so the "all clusters" label/gate can't count loaded clusters.
+     * Fetch just the total count (respecting Harvester visibility) via a bounded request.
+     */
+    async fetchClusterCount() {
+      if (this.isLocal) {
+        this.clusterCount = 0;
+
+        return;
+      }
+
+      const paginationEnabled = this.$store.getters['management/paginationEnabled'](FLEET.CLUSTER);
+
+      if (paginationEnabled) {
+        try {
+          const { pagination } = await this.$store.dispatch('management/findPage', {
+            type: FLEET.CLUSTER,
+            opt:  {
+              transient:  true,
+              watch:      false,
+              pagination: new PaginationArgs({
+                page:                 1,
+                pageSize:             1,
+                projectsOrNamespaces: new PaginationParamProjectOrNamespace({ projectOrNamespace: [this.namespace] }),
+                filters:              this.areHarvesterHostsVisible ? [] : [this.harvesterFilterField(PaginationFilterEquality.NOT_IN)],
+              })
+            }
+          });
+
+          this.clusterCount = pagination?.result?.count || 0;
+
+          return;
+        } catch (e) {
+          // Fall through to the non-paginated count below
+        }
+      }
+
+      try {
+        const all = await this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER, opt: { namespaced: this.namespace } });
+
+        this.clusterCount = (all || []).filter((c: FleetResource) => this.areHarvesterHostsVisible || !isHarvesterCluster(c)).length;
+      } catch (e) {
+        this.clusterCount = 0;
+      }
+    },
+
+    /**
+     * Pre-selected clusters (from existing targets) are stored by `metadata.name` but shown by
+     * `nameDisplay`. Fetch just those clusters so `resolveClusterDisplayName` can map them, without
+     * loading the whole collection.
+     */
+    async resolveSelectedClusters() {
+      const names = [...new Set(this.selectedClusters)].filter((name) => !!name);
+
+      if (this.isLocal || !names.length) {
+        return;
+      }
+
+      const paginationEnabled = this.$store.getters['management/paginationEnabled'](FLEET.CLUSTER);
+
+      if (paginationEnabled) {
+        try {
+          const { data } = await this.$store.dispatch('management/findPage', {
+            type: FLEET.CLUSTER,
+            opt:  {
+              transient:  true,
+              watch:      false,
+              pagination: new FilterArgs({
+                projectsOrNamespaces: new PaginationParamProjectOrNamespace({ projectOrNamespace: [this.namespace] }),
+                filters:              PaginationParamFilter.createSingleField({
+                  field: 'metadata.name', value: names.join(','), equality: PaginationFilterEquality.IN
+                }),
+              })
+            }
+          });
+
+          this.resolvedClusters = data || [];
+
+          return;
+        } catch (e) {
+          // Fall through to the non-paginated resolution below
+        }
+      }
+
+      try {
+        this.resolvedClusters = await this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER, opt: { namespaced: this.namespace } }) || [];
+      } catch (e) {
+        this.resolvedClusters = [];
+      }
     },
 
     reset() {
@@ -471,7 +589,8 @@ export default {
                 :selected-clusters="selectedClusters"
                 :selected-cluster-groups="selectedClusterGroups"
                 :cluster-selectors="clusterSelectors"
-                :clusters-options="clustersOptions"
+                :namespace="namespace"
+                :are-harvester-hosts-visible="areHarvesterHostsVisible"
                 :cluster-groups-options="clusterGroupsOptions"
                 :mode="mode"
                 :is-view="isView"
@@ -514,7 +633,8 @@ export default {
           :selected-clusters="selectedClusters"
           :selected-cluster-groups="selectedClusterGroups"
           :cluster-selectors="clusterSelectors"
-          :clusters-options="clustersOptions"
+          :namespace="namespace"
+          :are-harvester-hosts-visible="areHarvesterHostsVisible"
           :cluster-groups-options="clusterGroupsOptions"
           :mode="mode"
           :is-view="isView"
@@ -531,20 +651,6 @@ export default {
           class="target-list"
           :clusters="matching"
           :empty-label="t('fleet.clusterTargets.rules.matching.placeholder')"
-        />
-      </div>
-    </div>
-
-    <!-- All mode: compact intentionally omits the target list since the parent handles cluster visibility -->
-    <div
-      v-if="targetMode === 'all' && !isLocal && !compact"
-      class="row"
-    >
-      <div class="col span-6">
-        <TargetsList
-          class="target-list"
-          :clusters="matching"
-          :compact="compact"
         />
       </div>
     </div>

--- a/shell/components/fleet/FleetClusters.vue
+++ b/shell/components/fleet/FleetClusters.vue
@@ -2,7 +2,9 @@
 import ResourceTable from '@shell/components/ResourceTable';
 import Tag from '@shell/components/Tag.vue';
 import { STATE, NAME, AGE, FLEET_SUMMARY } from '@shell/config/table-headers';
+import { STEVE_STATE_COL, STEVE_AGE_COL } from '@shell/config/pagination-table-headers';
 import { FLEET, MANAGEMENT } from '@shell/config/types';
+import { FLEET as FLEET_LABELS } from '@shell/config/labels-annotations';
 
 export default {
   components: { ResourceTable, Tag },
@@ -33,6 +35,15 @@ export default {
     ignoreFilter: {
       type:    Boolean,
       default: false,
+    },
+
+    /**
+     * When true the list is server-side paginated (list page only). Detail/dashboard usages leave
+     * this false so their behaviour is unchanged.
+     */
+    canPaginate: {
+      type:    Boolean,
+      default: false,
     }
   },
 
@@ -42,45 +53,69 @@ export default {
     },
 
     headers() {
-      const out = [
+      const reposReady = {
+        name:     'reposReady',
+        labelKey: 'tableHeaders.reposReady',
+        value:    'status.readyGitRepos',
+        sort:     'status.summary.ready',
+        search:   false,
+      };
+      const helmOpsReady = {
+        name:     'helmOpsReady',
+        labelKey: 'tableHeaders.helmOpsReady',
+        value:    'status.readyHelmOps',
+        sort:     'status.summary.ready',
+        search:   false,
+      };
+      const bundlesReady = {
+        name:     'bundlesReady',
+        labelKey: 'tableHeaders.bundlesReady',
+        value:    'status.display.readyBundles',
+        sort:     'status.summary.ready',
+        search:   false,
+      };
+      const lastSeen = {
+        name:          'lastSeen',
+        labelKey:      'tableHeaders.lastSeen',
+        value:         'status.agent.lastSeen',
+        sort:          'status.agent.lastSeen',
+        search:        false,
+        formatter:     'LiveDate',
+        formatterOpts: { addSuffix: true },
+        width:         120,
+      };
+
+      // Server-side pagination: state/name/age use raw STEVE fields. The repos/helmops/bundles ready
+      // columns sort on their own raw status count fields (the base sort is the ambiguous shared
+      // status.summary.ready, so override per column). The Name column keeps nameDisplay but
+      // sorts/searches on the cluster-display-name label (falling back to the resource name).
+      if (this.canPaginate) {
+        return [
+          STEVE_STATE_COL,
+          {
+            ...NAME,
+            sort:   [`metadata.labels[${ FLEET_LABELS.CLUSTER_DISPLAY_NAME }]`, 'metadata.name'],
+            search: [`metadata.labels[${ FLEET_LABELS.CLUSTER_DISPLAY_NAME }]`, 'metadata.name'],
+          },
+          { ...reposReady, sort: 'status.readyGitRepos' },
+          { ...helmOpsReady, sort: 'status.readyHelmOps' },
+          { ...bundlesReady, sort: 'status.summary.ready' },
+          FLEET_SUMMARY,
+          lastSeen,
+          STEVE_AGE_COL,
+        ];
+      }
+
+      return [
         STATE,
         NAME,
-        {
-          name:     'reposReady',
-          labelKey: 'tableHeaders.reposReady',
-          value:    'status.readyGitRepos',
-          sort:     'status.summary.ready',
-          search:   false,
-        },
-        {
-          name:     'helmOpsReady',
-          labelKey: 'tableHeaders.helmOpsReady',
-          value:    'status.readyHelmOps',
-          sort:     'status.summary.ready',
-          search:   false,
-        },
-        {
-          name:     'bundlesReady',
-          labelKey: 'tableHeaders.bundlesReady',
-          value:    'status.display.readyBundles',
-          sort:     'status.summary.ready',
-          search:   false,
-        },
+        reposReady,
+        helmOpsReady,
+        bundlesReady,
         FLEET_SUMMARY,
-        {
-          name:          'lastSeen',
-          labelKey:      'tableHeaders.lastSeen',
-          value:         'status.agent.lastSeen',
-          sort:          'status.agent.lastSeen',
-          search:        false,
-          formatter:     'LiveDate',
-          formatterOpts: { addSuffix: true },
-          width:         120,
-        },
+        lastSeen,
         AGE,
       ];
-
-      return out;
     },
 
     pagingParams() {
@@ -111,6 +146,7 @@ export default {
     :loading="loading"
     :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
     :ignore-filter="ignoreFilter"
+    :groupable="canPaginate ? false : null"
     key-field="_key"
   >
     <template #cell:workspace="{row}">

--- a/shell/components/fleet/__tests__/ClusterSelectionFields.test.ts
+++ b/shell/components/fleet/__tests__/ClusterSelectionFields.test.ts
@@ -1,5 +1,7 @@
 import { shallowMount } from '@vue/test-utils';
 import ClusterSelectionFields from '@shell/components/fleet/FleetClusterTargets/ClusterSelectionFields.vue';
+import ResourceLabeledSelect from '@shell/components/form/ResourceLabeledSelect.vue';
+import { FLEET } from '@shell/config/types';
 import { _EDIT, _VIEW } from '@shell/config/query-params';
 
 describe('component: ClusterSelectionFields', () => {
@@ -7,8 +9,8 @@ describe('component: ClusterSelectionFields', () => {
     selectedClusters:      ['cluster-1'],
     selectedClusterGroups: [],
     clusterSelectors:      [],
-    clustersOptions:       [{ label: 'cluster-1', value: 'cluster-1' }],
     clusterGroupsOptions:  [],
+    namespace:             'fleet-default',
     mode:                  _EDIT,
   };
 
@@ -46,6 +48,61 @@ describe('component: ClusterSelectionFields', () => {
     await wrapper.findComponent({ name: 'RcButton' }).vm.$emit('click');
 
     expect(wrapper.emitted('add-match-expressions')).toBeTruthy();
+  });
+
+  it('should render a paginated cluster select scoped to the management store', () => {
+    const wrapper = shallowMount(ClusterSelectionFields, { props: defaultProps });
+
+    const select = wrapper.findComponent(ResourceLabeledSelect);
+
+    expect(select.props('resourceType')).toBe(FLEET.CLUSTER);
+    expect(select.props('inStore')).toBe('management');
+  });
+
+  it('should map clusters to display-name options, filtered by namespace and harvester visibility', () => {
+    const wrapper = shallowMount(ClusterSelectionFields, {
+      props: {
+        ...defaultProps, namespace: 'fleet-default', areHarvesterHostsVisible: false
+      }
+    });
+
+    const { updateResources } = wrapper.findComponent(ResourceLabeledSelect).props('allResourcesSettings');
+
+    const mapped = updateResources([
+      {
+        metadata: {
+          namespace: 'fleet-default', name: 'c1', labels: { 'management.cattle.io/cluster-display-name': 'Prod' }
+        }
+      },
+      { metadata: { namespace: 'other-namespace', name: 'c2' } },
+      {
+        metadata: {
+          namespace: 'fleet-default', name: 'hv', labels: { 'provider.cattle.io': 'harvester' }
+        }
+      },
+    ]);
+
+    expect(mapped).toStrictEqual([{ label: 'Prod', value: 'Prod' }]);
+  });
+
+  it('should include harvester clusters when they are visible', () => {
+    const wrapper = shallowMount(ClusterSelectionFields, {
+      props: {
+        ...defaultProps, namespace: 'fleet-default', areHarvesterHostsVisible: true
+      }
+    });
+
+    const { updateResources } = wrapper.findComponent(ResourceLabeledSelect).props('allResourcesSettings');
+
+    const mapped = updateResources([
+      {
+        metadata: {
+          namespace: 'fleet-default', name: 'hv', labels: { 'provider.cattle.io': 'harvester' }
+        }
+      },
+    ]);
+
+    expect(mapped).toStrictEqual([{ label: 'hv', value: 'hv' }]);
   });
 
   it('should hide add button in view mode', () => {

--- a/shell/components/fleet/__tests__/FleetClusterTargets.test.ts
+++ b/shell/components/fleet/__tests__/FleetClusterTargets.test.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
 import FleetClusterTargets from '@shell/components/fleet/FleetClusterTargets/index.vue';
 import { _CREATE, _EDIT } from '@shell/config/query-params';
@@ -7,14 +7,23 @@ import { Selector } from '@shell/types/fleet';
 const mockedStore = () => {
   return {
     getters: {
-      'i18n/t':       (text: string) => text,
-      'features/get': () => false,
+      'i18n/t':                       (text: string) => text,
+      'features/get':                 () => false,
+      'management/paginationEnabled': () => false,
     },
+    dispatch: jest.fn().mockResolvedValue([]),
   };
 };
 
 const requiredSetup = () => {
-  return { global: { mocks: { $store: mockedStore() } } };
+  return {
+    global: {
+      mocks: {
+        $store: mockedStore(),
+        t:      (key: string) => key,
+      }
+    }
+  };
 };
 
 describe('component: FleetClusterTargets', () => {
@@ -27,7 +36,7 @@ describe('component: FleetClusterTargets', () => {
           clusterName:     'fleet-5-france',
           clusterSelector: { matchLabels: { foo: 'true' } }
         };
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -56,7 +65,7 @@ describe('component: FleetClusterTargets', () => {
             }]
           }
         };
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -79,7 +88,7 @@ describe('component: FleetClusterTargets', () => {
 
         const target2 = { clusterSelector: { matchLabels: { foo: 'true' } } };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1, target2],
@@ -105,7 +114,7 @@ describe('component: FleetClusterTargets', () => {
         const target1 = { clusterSelector: { matchLabels: { foo: 'true' } } };
         const target2 = { clusterSelector: { matchLabels: { hci: 'true' } } };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1, target2],
@@ -134,7 +143,7 @@ describe('component: FleetClusterTargets', () => {
       it('should set targetMode to "advanced" and return early if clusterGroupSelector is present', () => {
         const target1 = { clusterGroupSelector: {} };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -176,7 +185,7 @@ describe('component: FleetClusterTargets', () => {
           name: 'tt1',
         };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -196,7 +205,7 @@ describe('component: FleetClusterTargets', () => {
       });
 
       it('should return early and not modify state if targets is empty', () => {
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [],
@@ -216,7 +225,7 @@ describe('component: FleetClusterTargets', () => {
 
       it('should return targetMode local if namespace is fleet-local', () => {
         const target1 = { clusterSelector: { matchLabels: { foo: 'true' } } };
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -233,7 +242,7 @@ describe('component: FleetClusterTargets', () => {
       it('should handle targets with multiple clusterName', () => {
         const target1 = { clusterName: 'prod-cluster' };
         const target2 = { clusterName: 'test-cluster' };
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1, target2],
@@ -266,7 +275,7 @@ describe('component: FleetClusterTargets', () => {
           }
         };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -295,7 +304,7 @@ describe('component: FleetClusterTargets', () => {
       it('should correctly process targets when targetMode is "all" and no clusterName or clusterSelector is present', () => {
         const target1 = { name: 'simple-target' };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -325,7 +334,7 @@ describe('component: FleetClusterTargets', () => {
           name: 'simple-target'
         };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -350,7 +359,7 @@ describe('component: FleetClusterTargets', () => {
           clusterName:     'fleet-5-france',
           clusterSelector: { matchLabels: { foo: 'true' } }
         };
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -376,7 +385,7 @@ describe('component: FleetClusterTargets', () => {
             }]
           }
         };
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -402,7 +411,7 @@ describe('component: FleetClusterTargets', () => {
 
         const target2 = { clusterSelector: { matchLabels: { foo: 'true' } } };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1, target2],
@@ -421,7 +430,7 @@ describe('component: FleetClusterTargets', () => {
         const target1 = { clusterSelector: { matchLabels: { foo: 'true' } } };
         const target2 = { clusterSelector: { matchLabels: { hci: 'true' } } };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1, target2],
@@ -439,7 +448,7 @@ describe('component: FleetClusterTargets', () => {
       it('should emit advanced cases untouched', async() => {
         const target1 = { clusterGroupSelector: {} };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -477,7 +486,7 @@ describe('component: FleetClusterTargets', () => {
           name: 'tt1',
         };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -509,7 +518,7 @@ describe('component: FleetClusterTargets', () => {
       });
 
       it('should emit harvester rule from empty targets source', async() => {
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [], // targetMode === 'none'
@@ -527,7 +536,7 @@ describe('component: FleetClusterTargets', () => {
       it('should emit untouched targets from source when operating in fleet-local workspace', async() => {
         const target1 = { clusterSelector: { matchLabels: { foo: 'true' } } };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -557,7 +566,7 @@ describe('component: FleetClusterTargets', () => {
           }
         };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -581,7 +590,7 @@ describe('component: FleetClusterTargets', () => {
       it('should emit targets excluding target names and adding harvester rule', async() => {
         const target1 = { name: 'simple-target' };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -614,7 +623,7 @@ describe('component: FleetClusterTargets', () => {
           name: 'simple-target'
         };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -646,7 +655,7 @@ describe('component: FleetClusterTargets', () => {
           clusterName:     'fleet-5-france',
           clusterSelector: { matchLabels: { foo: 'true' } }
         };
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -676,7 +685,7 @@ describe('component: FleetClusterTargets', () => {
             }]
           }
         };
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -699,7 +708,7 @@ describe('component: FleetClusterTargets', () => {
 
         const target2 = { clusterSelector: { matchLabels: { foo: 'true' } } };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1, target2],
@@ -726,7 +735,7 @@ describe('component: FleetClusterTargets', () => {
         const target1 = { clusterSelector: { matchLabels: { foo: 'true' } } };
         const target2 = { clusterSelector: { matchLabels: { hci: 'true' } } };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1, target2],
@@ -756,7 +765,7 @@ describe('component: FleetClusterTargets', () => {
       it('should set targetMode to "advanced" and return early if clusterGroupSelector is present', () => {
         const target1 = { clusterGroupSelector: {} };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -799,7 +808,7 @@ describe('component: FleetClusterTargets', () => {
           name: 'tt1',
         };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -820,7 +829,7 @@ describe('component: FleetClusterTargets', () => {
       });
 
       it('should return early and not modify state if targets is empty', () => {
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [],
@@ -841,7 +850,7 @@ describe('component: FleetClusterTargets', () => {
 
       it('should return targetMode local if namespace is fleet-local', () => {
         const target1 = { clusterSelector: { matchLabels: { foo: 'true' } } };
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -859,7 +868,7 @@ describe('component: FleetClusterTargets', () => {
       it('should handle targets with multiple clusterName', () => {
         const target1 = { clusterName: 'prod-cluster' };
         const target2 = { clusterName: 'test-cluster' };
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1, target2],
@@ -893,7 +902,7 @@ describe('component: FleetClusterTargets', () => {
           }
         };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -923,7 +932,7 @@ describe('component: FleetClusterTargets', () => {
       it('should correctly process targets when targetMode is "all" and no clusterName or clusterSelector is present', () => {
         const target1 = { name: 'simple-target' };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -953,7 +962,7 @@ describe('component: FleetClusterTargets', () => {
           name: 'simple-target'
         };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -978,7 +987,7 @@ describe('component: FleetClusterTargets', () => {
           clusterName:     'fleet-5-france',
           clusterSelector: { matchLabels: { foo: 'true' } }
         };
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -1006,7 +1015,7 @@ describe('component: FleetClusterTargets', () => {
             }]
           }
         };
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -1032,7 +1041,7 @@ describe('component: FleetClusterTargets', () => {
 
         const target2 = { clusterSelector: { matchLabels: { foo: 'true' } } };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1, target2],
@@ -1053,7 +1062,7 @@ describe('component: FleetClusterTargets', () => {
         const target1 = { clusterSelector: { matchLabels: { foo: 'true' } } };
         const target2 = { clusterSelector: { matchLabels: { hci: 'true' } } };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1, target2],
@@ -1073,7 +1082,7 @@ describe('component: FleetClusterTargets', () => {
       it('should emit advanced cases untouched', async() => {
         const target1 = { clusterGroupSelector: {} };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -1113,7 +1122,7 @@ describe('component: FleetClusterTargets', () => {
           name: 'tt1',
         };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -1147,7 +1156,7 @@ describe('component: FleetClusterTargets', () => {
       });
 
       it('should emit harvester rule from empty targets source', async() => {
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [], // targetMode === 'none'
@@ -1167,7 +1176,7 @@ describe('component: FleetClusterTargets', () => {
       it('should emit untouched targets from source when operating in fleet-local workspace', async() => {
         const target1 = { clusterSelector: { matchLabels: { foo: 'true' } } };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -1199,7 +1208,7 @@ describe('component: FleetClusterTargets', () => {
           }
         };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -1225,7 +1234,7 @@ describe('component: FleetClusterTargets', () => {
       it('should emit targets excluding target names and adding harvester rule', async() => {
         const target1 = { name: 'simple-target' };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -1258,7 +1267,7 @@ describe('component: FleetClusterTargets', () => {
           name: 'simple-target'
         };
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [target1],
@@ -1284,7 +1293,7 @@ describe('component: FleetClusterTargets', () => {
   describe('clusterGroup Functionality Tests', () => {
     describe('clusterGroup Data Management', () => {
       it('should initialize with empty selectedClusterGroups', () => {
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [],
@@ -1308,7 +1317,7 @@ describe('component: FleetClusterTargets', () => {
           }
         ];
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [],
@@ -1339,7 +1348,7 @@ describe('component: FleetClusterTargets', () => {
           }
         ];
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [],
@@ -1362,7 +1371,7 @@ describe('component: FleetClusterTargets', () => {
 
     describe('clusterGroup Selection Methods', () => {
       it('should update selectedClusterGroups when selectClusterGroups is called', async() => {
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [],
@@ -1381,7 +1390,7 @@ describe('component: FleetClusterTargets', () => {
       });
 
       it('should emit update:value when selectClusterGroups is called', async() => {
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [],
@@ -1397,7 +1406,7 @@ describe('component: FleetClusterTargets', () => {
       });
 
       it('should handle empty array in selectClusterGroups', async() => {
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [],
@@ -1418,7 +1427,7 @@ describe('component: FleetClusterTargets', () => {
       });
 
       it('should replace existing selectedClusterGroups on new selection', async() => {
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [],
@@ -1447,7 +1456,7 @@ describe('component: FleetClusterTargets', () => {
           { clusterName: 'specific-cluster' }
         ];
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets,
@@ -1461,7 +1470,7 @@ describe('component: FleetClusterTargets', () => {
       });
 
       it('should include clusterGroups in normalizeTargets output', () => {
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [],
@@ -1485,7 +1494,7 @@ describe('component: FleetClusterTargets', () => {
       });
 
       it('should handle only clusterGroups in normalizeTargets', () => {
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [],
@@ -1503,7 +1512,7 @@ describe('component: FleetClusterTargets', () => {
       });
 
       it('should return undefined when normalizeTargets has no inputs', () => {
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [],
@@ -1518,7 +1527,7 @@ describe('component: FleetClusterTargets', () => {
       });
 
       it('should include clusterGroups in toTargets when targetMode is clusters', () => {
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets:   [],
@@ -1550,7 +1559,7 @@ describe('component: FleetClusterTargets', () => {
           { clusterGroup: 'test-group' }
         ];
 
-        const wrapper = mount(FleetClusterTargets, {
+        const wrapper = shallowMount(FleetClusterTargets, {
           ...requiredSetup(),
           props: {
             targets,
@@ -1572,7 +1581,7 @@ describe('component: FleetClusterTargets', () => {
         { clusterGroup: 'development-group' }
       ];
 
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets,
@@ -1588,7 +1597,7 @@ describe('component: FleetClusterTargets', () => {
     });
 
     it('should reset selectedClusterGroups when reset method is called', () => {
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets:   [],
@@ -1617,7 +1626,7 @@ describe('component: FleetClusterTargets', () => {
 
   describe('clusterGroup Event Handling and Updates', () => {
     it('should emit correct targets when both clusters and clusterGroups are selected', async() => {
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets:   [],
@@ -1645,7 +1654,7 @@ describe('component: FleetClusterTargets', () => {
     });
 
     it('should handle clusterGroup selection in CREATE mode with proper event emission', async() => {
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets:   [],
@@ -1673,7 +1682,7 @@ describe('component: FleetClusterTargets', () => {
     it('should update component state correctly when clusterGroups prop changes', async() => {
       const initialTargets = [{ clusterGroup: 'initial-group' }];
 
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets:   initialTargets,
@@ -1708,7 +1717,7 @@ describe('component: FleetClusterTargets', () => {
         { clusterName: 'cluster-1' }
       ];
 
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets:   targets as any,
@@ -1726,7 +1735,7 @@ describe('component: FleetClusterTargets', () => {
         { clusterGroup: 'valid-group' }
       ];
 
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets:   targets as any,
@@ -1739,7 +1748,7 @@ describe('component: FleetClusterTargets', () => {
     });
 
     it('should handle empty allClusterGroups data', () => {
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets:   [],
@@ -1766,7 +1775,7 @@ describe('component: FleetClusterTargets', () => {
         }
       ];
 
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets:   [],
@@ -1788,7 +1797,7 @@ describe('component: FleetClusterTargets', () => {
 
   describe('clusterGroup Component Lifecycle', () => {
     it('should preserve clusterGroup selections during component updates', async() => {
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets:   [],
@@ -1810,7 +1819,7 @@ describe('component: FleetClusterTargets', () => {
     });
 
     it('should clear clusterGroup selections on namespace change in CREATE mode', async() => {
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets:   [],
@@ -1852,7 +1861,7 @@ describe('component: FleetClusterTargets', () => {
         }
       ];
 
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets:   [],
@@ -1861,7 +1870,7 @@ describe('component: FleetClusterTargets', () => {
         }
       });
 
-      wrapper.setData({ allClusters: mockClusters });
+      wrapper.setData({ resolvedClusters: mockClusters });
 
       expect(wrapper.vm.resolveClusterDisplayName(metadataName)).toStrictEqual(expectedDisplay);
     });
@@ -1874,7 +1883,7 @@ describe('component: FleetClusterTargets', () => {
         }
       ];
 
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets:   [],
@@ -1883,7 +1892,7 @@ describe('component: FleetClusterTargets', () => {
         }
       });
 
-      wrapper.setData({ allClusters: mockClusters });
+      wrapper.setData({ resolvedClusters: mockClusters });
 
       expect(wrapper.vm.resolveClusterDisplayName('non-existent')).toStrictEqual('non-existent');
     });
@@ -1896,7 +1905,7 @@ describe('component: FleetClusterTargets', () => {
         }
       ];
 
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets:   [],
@@ -1905,84 +1914,13 @@ describe('component: FleetClusterTargets', () => {
         }
       });
 
-      wrapper.setData({ allClusters: mockClusters });
+      wrapper.setData({ resolvedClusters: mockClusters });
 
       expect(wrapper.vm.resolveClusterDisplayName('c-m-abc123')).toStrictEqual('c-m-abc123');
     });
   });
 
-  describe('clustersOptions', () => {
-    it('should use nameDisplay for both label and value', () => {
-      const mockClusters = [
-        {
-          metadata:    { namespace: 'fleet-default', name: 'c-m-abc123' },
-          nameDisplay: 'my-production-cluster',
-          status:      { provider: 'rke2' }
-        },
-        {
-          metadata:    { namespace: 'fleet-default', name: 'c-m-def456' },
-          nameDisplay: 'my-staging-cluster',
-          status:      { provider: 'rke2' }
-        }
-      ];
-
-      const wrapper = mount(FleetClusterTargets, {
-        ...requiredSetup(),
-        props: {
-          targets:   [],
-          namespace: 'fleet-default',
-          mode:      _EDIT
-        }
-      });
-
-      wrapper.setData({ allClusters: mockClusters });
-
-      const options = wrapper.vm.clustersOptions;
-
-      expect(options).toStrictEqual([
-        {
-          label: 'my-production-cluster', value: 'my-production-cluster', disabled: false
-        },
-        {
-          label: 'my-staging-cluster', value: 'my-staging-cluster', disabled: false
-        }
-      ]);
-    });
-
-    it('should filter out clusters from other namespaces', () => {
-      const mockClusters = [
-        {
-          metadata:    { namespace: 'fleet-default', name: 'c-m-abc123' },
-          nameDisplay: 'my-cluster',
-          status:      { provider: 'rke2' }
-        },
-        {
-          metadata:    { namespace: 'other-namespace', name: 'c-m-other' },
-          nameDisplay: 'other-cluster',
-          status:      { provider: 'rke2' }
-        }
-      ];
-
-      const wrapper = mount(FleetClusterTargets, {
-        ...requiredSetup(),
-        props: {
-          targets:   [],
-          namespace: 'fleet-default',
-          mode:      _EDIT
-        }
-      });
-
-      wrapper.setData({ allClusters: mockClusters });
-
-      expect(wrapper.vm.clustersOptions).toStrictEqual([
-        {
-          label: 'my-cluster', value: 'my-cluster', disabled: false
-        }
-      ]);
-    });
-  });
-
-  describe('allClusters watcher', () => {
+  describe('resolvedClusters watcher', () => {
     it('should resolve selectedClusters metadata.name values to nameDisplay when clusters load', async() => {
       const mockClusters = [
         {
@@ -2000,7 +1938,7 @@ describe('component: FleetClusterTargets', () => {
         { clusterName: 'c-m-def456' }
       ];
 
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets,
@@ -2011,7 +1949,7 @@ describe('component: FleetClusterTargets', () => {
 
       expect(wrapper.vm.selectedClusters).toStrictEqual(['c-m-abc123', 'c-m-def456']);
 
-      wrapper.setData({ allClusters: mockClusters });
+      wrapper.setData({ resolvedClusters: mockClusters });
       await flushPromises();
 
       expect(wrapper.vm.selectedClusters).toStrictEqual(['my-production-cluster', 'my-staging-cluster']);
@@ -2027,7 +1965,7 @@ describe('component: FleetClusterTargets', () => {
 
       const targets = [{ clusterName: 'my-cluster' }];
 
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets,
@@ -2036,7 +1974,7 @@ describe('component: FleetClusterTargets', () => {
         }
       });
 
-      wrapper.setData({ allClusters: mockClusters });
+      wrapper.setData({ resolvedClusters: mockClusters });
       await flushPromises();
 
       expect(wrapper.vm.selectedClusters).toStrictEqual(['my-cluster']);
@@ -2055,7 +1993,7 @@ describe('component: FleetClusterTargets', () => {
         { clusterName: 'unknown-name' }
       ];
 
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets,
@@ -2064,7 +2002,7 @@ describe('component: FleetClusterTargets', () => {
         }
       });
 
-      wrapper.setData({ allClusters: mockClusters });
+      wrapper.setData({ resolvedClusters: mockClusters });
       await flushPromises();
 
       expect(wrapper.vm.selectedClusters).toStrictEqual(['known-cluster', 'unknown-name']);
@@ -2073,7 +2011,7 @@ describe('component: FleetClusterTargets', () => {
     it('should not resolve when clusters array is empty', async() => {
       const targets = [{ clusterName: 'c-m-abc123' }];
 
-      const wrapper = mount(FleetClusterTargets, {
+      const wrapper = shallowMount(FleetClusterTargets, {
         ...requiredSetup(),
         props: {
           targets,
@@ -2082,10 +2020,85 @@ describe('component: FleetClusterTargets', () => {
         }
       });
 
-      wrapper.setData({ allClusters: [] });
+      wrapper.setData({ resolvedClusters: [] });
       await flushPromises();
 
       expect(wrapper.vm.selectedClusters).toStrictEqual(['c-m-abc123']);
+    });
+  });
+
+  describe('cluster count', () => {
+    const setupWith = (paginationEnabled: boolean, dispatch: any) => ({
+      global: {
+        mocks: {
+          $store: {
+            getters: {
+              'i18n/t':                       (text: string) => text,
+              'features/get':                 () => false,
+              'management/paginationEnabled': () => paginationEnabled,
+            },
+            dispatch,
+          },
+          t: (key: string) => key,
+        }
+      }
+    });
+
+    it('reads clusterCount from the paginated count query', async() => {
+      const dispatch = jest.fn().mockResolvedValue({ pagination: { result: { count: 5 } } });
+
+      const wrapper = shallowMount(FleetClusterTargets, {
+        ...setupWith(true, dispatch),
+        props: {
+          targets: [], namespace: 'fleet-default', mode: _EDIT
+        }
+      });
+
+      await flushPromises();
+
+      expect(wrapper.vm.clusterCount).toBe(5);
+      expect(dispatch).toHaveBeenCalledWith('management/findPage', expect.objectContaining({ type: expect.any(String) }));
+    });
+
+    it('falls back to a namespaced findAll count, excluding harvester clusters', async() => {
+      const clusters = [
+        { metadata: { namespace: 'fleet-default', name: 'a' }, status: { provider: 'rke2' } },
+        {
+          metadata: {
+            namespace: 'fleet-default', name: 'b', labels: { 'provider.cattle.io': 'harvester' }
+          }
+        },
+      ];
+      const dispatch = jest.fn().mockResolvedValue(clusters);
+
+      const wrapper = shallowMount(FleetClusterTargets, {
+        ...setupWith(false, dispatch),
+        props: {
+          targets: [], namespace: 'fleet-default', mode: _EDIT
+        }
+      });
+
+      await flushPromises();
+
+      expect(dispatch).toHaveBeenCalledWith('management/findAll', expect.objectContaining({ type: expect.any(String) }));
+      expect(wrapper.vm.clusterCount).toBe(1);
+    });
+
+    it('gates the "clusters" target option on clusterCount', async() => {
+      const wrapper = shallowMount(FleetClusterTargets, {
+        ...requiredSetup(),
+        props: {
+          targets: [], namespace: 'fleet-default', mode: _EDIT
+        }
+      });
+
+      await flushPromises();
+
+      wrapper.setData({ clusterCount: 0 });
+      expect(wrapper.vm.targetModeOptions.map((o: { value: string }) => o.value)).not.toContain('clusters');
+
+      wrapper.setData({ clusterCount: 3 });
+      expect(wrapper.vm.targetModeOptions.map((o: { value: string }) => o.value)).toContain('clusters');
     });
   });
 });

--- a/shell/components/fleet/__tests__/__snapshots__/ClusterSelectionFields.test.ts.snap
+++ b/shell/components/fleet/__tests__/__snapshots__/ClusterSelectionFields.test.ts.snap
@@ -5,37 +5,27 @@ exports[`component: ClusterSelectionFields should match snapshot with appco vari
   class="appco-select-clusters"
 >
   <!-- Select by cluster name -->
+  <!-- The underlying select doesn't preventDefault on Enter, so inside a &lt;form&gt; it would trigger an
+         implicit submit (firing the first button, e.g. "Add cluster selector"). Catch Enter in the
+         capture phase - before the select stops propagation - and prevent that default submit. -->
   <div>
     <h4>
-      %fleet.clusterTargets.clusters.byName.title%
+      fleet.clusterTargets.clusters.byName.title
     </h4>
-    <labeled-select-stub
-      appendtobody="true"
+    <resource-labeled-select-stub
+      allresourcessettings="[object Object]"
       class=""
-      clearable="false"
-      closeonselect="false"
+      close-on-select="false"
       data-testid="fleet-target-cluster-name-selector"
-      disabled="false"
-      filterable="true"
-      hovertooltip="true"
-      instore="cluster"
-      label="%fleet.clusterTargets.clusters.byName.label%"
-      loading="false"
-      localizedlabel="false"
-      lockedoptions=""
+      instore="management"
+      label="fleet.clusterTargets.clusters.byName.label"
       mode="edit"
       multiple="true"
-      nooptionslabelkey="labelSelect.noOptions.empty"
-      optionlabel="label"
-      options="[object Object]"
-      placeholder="%fleet.clusterTargets.clusters.byName.placeholder%"
-      reduce="[Function]"
-      required="false"
-      requiredirty="true"
-      rules=""
-      searchable="false"
-      selectable="[Function]"
-      taggable="true"
+      paginatedresourcesettings="[object Object]"
+      paginatemode="DYNAMIC"
+      placeholder="fleet.clusterTargets.clusters.byName.placeholder"
+      resourcetype="fleet.cattle.io.cluster"
+      taggable="false"
       value="cluster-1"
     />
   </div>
@@ -46,7 +36,7 @@ exports[`component: ClusterSelectionFields should match snapshot with appco vari
     <h4
       class=""
     >
-      %fleet.clusterTargets.clusters.byLabel.title%
+      fleet.clusterTargets.clusters.byLabel.title
     </h4>
     
     
@@ -70,7 +60,7 @@ exports[`component: ClusterSelectionFields should match snapshot with appco vari
     <h4
       class=""
     >
-      %fleet.clusterTargets.clusterGroups.title%
+      fleet.clusterTargets.clusterGroups.title
     </h4>
     <labeled-select-stub
       appendtobody="true"
@@ -82,7 +72,7 @@ exports[`component: ClusterSelectionFields should match snapshot with appco vari
       filterable="true"
       hovertooltip="true"
       instore="cluster"
-      label="%fleet.clusterTargets.clusterGroups.byName.label%"
+      label="fleet.clusterTargets.clusterGroups.byName.label"
       loading="false"
       localizedlabel="false"
       lockedoptions=""
@@ -91,7 +81,7 @@ exports[`component: ClusterSelectionFields should match snapshot with appco vari
       nooptionslabelkey="labelSelect.noOptions.empty"
       optionlabel="label"
       options=""
-      placeholder="%fleet.clusterTargets.clusterGroups.byName.placeholder%"
+      placeholder="fleet.clusterTargets.clusterGroups.byName.placeholder"
       reduce="[Function]"
       required="false"
       requiredirty="true"
@@ -110,35 +100,25 @@ exports[`component: ClusterSelectionFields should match snapshot with default va
   class=""
 >
   <!-- Select by cluster name -->
+  <!-- The underlying select doesn't preventDefault on Enter, so inside a &lt;form&gt; it would trigger an
+         implicit submit (firing the first button, e.g. "Add cluster selector"). Catch Enter in the
+         capture phase - before the select stops propagation - and prevent that default submit. -->
   <div>
     <!--v-if-->
-    <labeled-select-stub
-      appendtobody="true"
+    <resource-labeled-select-stub
+      allresourcessettings="[object Object]"
       class="mmt-4"
-      clearable="false"
-      closeonselect="false"
+      close-on-select="false"
       data-testid="fleet-target-cluster-name-selector"
-      disabled="false"
-      filterable="true"
-      hovertooltip="true"
-      instore="cluster"
-      label="%fleet.clusterTargets.clusters.byName.label%"
-      loading="false"
-      localizedlabel="false"
-      lockedoptions=""
+      instore="management"
+      label="fleet.clusterTargets.clusters.byName.label"
       mode="edit"
       multiple="true"
-      nooptionslabelkey="labelSelect.noOptions.empty"
-      optionlabel="label"
-      options="[object Object]"
-      placeholder="%fleet.clusterTargets.clusters.byName.placeholder%"
-      reduce="[Function]"
-      required="false"
-      requiredirty="true"
-      rules=""
-      searchable="false"
-      selectable="[Function]"
-      taggable="true"
+      paginatedresourcesettings="[object Object]"
+      paginatemode="DYNAMIC"
+      placeholder="fleet.clusterTargets.clusters.byName.placeholder"
+      resourcetype="fleet.cattle.io.cluster"
+      taggable="false"
       value="cluster-1"
     />
   </div>
@@ -149,7 +129,7 @@ exports[`component: ClusterSelectionFields should match snapshot with default va
     <h4
       class="m-0"
     >
-      %fleet.clusterTargets.clusters.byLabel.title%
+      fleet.clusterTargets.clusters.byLabel.title
     </h4>
     
     
@@ -173,7 +153,7 @@ exports[`component: ClusterSelectionFields should match snapshot with default va
     <h3
       class="m-0"
     >
-      %fleet.clusterTargets.clusterGroups.title%
+      fleet.clusterTargets.clusterGroups.title
     </h3>
     <labeled-select-stub
       appendtobody="true"
@@ -185,7 +165,7 @@ exports[`component: ClusterSelectionFields should match snapshot with default va
       filterable="true"
       hovertooltip="true"
       instore="cluster"
-      label="%fleet.clusterTargets.clusterGroups.byName.label%"
+      label="fleet.clusterTargets.clusterGroups.byName.label"
       loading="false"
       localizedlabel="false"
       lockedoptions=""
@@ -194,7 +174,7 @@ exports[`component: ClusterSelectionFields should match snapshot with default va
       nooptionslabelkey="labelSelect.noOptions.empty"
       optionlabel="label"
       options=""
-      placeholder="%fleet.clusterTargets.clusterGroups.byName.placeholder%"
+      placeholder="fleet.clusterTargets.clusterGroups.byName.placeholder"
       reduce="[Function]"
       required="false"
       requiredirty="true"

--- a/shell/components/fleet/dashboard/ResourceCardSummary.vue
+++ b/shell/components/fleet/dashboard/ResourceCardSummary.vue
@@ -30,11 +30,17 @@ export default {
     },
 
     countsPerCluster() {
-      return ((this.value.targetClusters || []) as { id: string }[]).map(({ id }) => this.value.status?.perClusterResourceCounts?.[id] || { desiredReady: 0 });
+      // The dashboard only loads state-count summaries, so the application's clusters aren't in the
+      // store and `targetClusters` is empty. Read the per-cluster counts straight from status (keyed
+      // by cluster id) so the cluster count is correct without needing the cluster objects loaded.
+      return Object.values(this.value.status?.perClusterResourceCounts || {}) as { desiredReady?: number, ready?: number }[];
     },
 
     summary() {
-      const { desiredReady, ready } = this.counts;
+      // `ready` is omitted from `resourceCounts` when nothing is ready, so coerce both to numbers to
+      // avoid `desiredReady - undefined` producing NaN.
+      const desiredReady = this.counts.desiredReady || 0;
+      const ready = this.counts.ready || 0;
 
       const partial = desiredReady === ready ? ready : desiredReady - ready;
       const total = desiredReady;

--- a/shell/components/fleet/dashboard/ResourceDetails.vue
+++ b/shell/components/fleet/dashboard/ResourceDetails.vue
@@ -11,6 +11,12 @@ import Drawer from '@shell/components/Drawer/Chrome.vue';
 import DrawerCard from '@shell/components/Drawer/DrawerCard.vue';
 import suseAppCoLogo from '@shell/assets/images/content/suse.svg';
 import suseAppCoLogoDark from '@shell/assets/images/content/dark/suse.svg';
+import {
+  FilterArgs,
+  PaginationParamFilter,
+  PaginationParamProjectOrNamespace,
+  PaginationFilterEquality,
+} from '@shell/types/store/pagination.types';
 
 export default {
   name: 'FleetDashboardResourceDetails',
@@ -57,6 +63,15 @@ export default {
     this.clusterId = '';
   },
 
+  watch: {
+    'value.id': {
+      immediate: true,
+      handler() {
+        this.loadApplicationClusters();
+      }
+    }
+  },
+
   computed: {
     noResources() {
       return !this.value.resourcesStatuses?.length;
@@ -83,6 +98,43 @@ export default {
   methods: {
     closePanel() {
       this.$store.commit('slideInPanel/close');
+    },
+
+    /**
+     * The dashboard only loads state-count summaries, so this application's clusters aren't in the
+     * store and `value.targetClusters` / `value.resourcesStatuses` resolve to nothing. Load just the
+     * clusters it's deployed to - their ids are already in the application's status - so both tabs
+     * resolve. Once loaded the model getters recompute reactively.
+     */
+    async loadApplicationClusters() {
+      const ids = [...new Set(Object.keys(this.value.status?.perClusterResourceCounts || {}))].filter((id: string) => id.includes('/'));
+
+      if (!ids.length) {
+        return;
+      }
+
+      const namespaces = [...new Set(ids.map((id: string) => id.split('/')[0]))];
+      const names = [...new Set(ids.map((id: string) => id.split('/')[1]))];
+
+      try {
+        await this.$store.dispatch('management/findPage', {
+          type: FLEET.CLUSTER,
+          opt:  {
+            pagination: new FilterArgs({
+              projectsOrNamespaces: new PaginationParamProjectOrNamespace({ projectOrNamespace: namespaces }),
+              filters:              PaginationParamFilter.createSingleField({
+                field: 'metadata.name', value: names.join(','), equality: PaginationFilterEquality.IN
+              }),
+            })
+          }
+        });
+      } catch (e) {
+        // Fallback (e.g. pagination api unavailable): namespace-scoped list.
+        try {
+          await this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER, opt: { namespaced: namespaces[0] } });
+        } catch (e2) {
+        }
+      }
     }
   }
 };

--- a/shell/components/fleet/dashboard/__tests__/ResourceCardSummary.test.ts
+++ b/shell/components/fleet/dashboard/__tests__/ResourceCardSummary.test.ts
@@ -1,0 +1,88 @@
+import { shallowMount } from '@vue/test-utils';
+import ResourceCardSummary from '@shell/components/fleet/dashboard/ResourceCardSummary.vue';
+
+const mountSummary = (value: Record<string, unknown>, noClusters = false) => {
+  return shallowMount(ResourceCardSummary as any, {
+    props:  { value, noClusters },
+    global: {
+      mocks: {
+        t:      (k: string) => k,
+        $store: { getters: { 'i18n/withFallback': () => '' } },
+      },
+    },
+  });
+};
+
+describe('component: FleetDashboardResourceCardSummary', () => {
+  describe('summary counts', () => {
+    it('coerces a missing ready count to 0 instead of producing NaN', () => {
+      // The backend omits `ready` from resourceCounts when nothing is ready - this used to make
+      // `desiredReady - ready` evaluate to NaN on the card.
+      const wrapper = mountSummary({ status: { resourceCounts: { desiredReady: 2, notReady: 2 } } });
+
+      const { summary } = wrapper.vm as any;
+
+      expect(summary.partial).toBe(2);
+      expect(summary.total).toBe(2);
+      expect(Number.isNaN(summary.partial)).toBe(false);
+    });
+
+    it('shows the not-ready count out of the total when partially ready', () => {
+      const wrapper = mountSummary({ status: { resourceCounts: { desiredReady: 31, ready: 23 } } });
+
+      const { summary } = wrapper.vm as any;
+
+      expect(summary.partial).toBe(8);
+      expect(summary.total).toBe(31);
+    });
+
+    it('returns zeroed counts when resourceCounts is absent', () => {
+      const wrapper = mountSummary({ status: {} });
+
+      const { summary } = wrapper.vm as any;
+
+      expect(summary.partial).toBe(0);
+      expect(summary.total).toBe(0);
+    });
+  });
+
+  describe('cluster count', () => {
+    it('derives the cluster count from status.perClusterResourceCounts, not loaded clusters', () => {
+      // On the dashboard the application's clusters aren't loaded (targetClusters is empty), so the
+      // count must come from per-cluster status keyed by cluster id.
+      const wrapper = mountSummary({
+        targetClusters: [],
+        status:         {
+          resourceCounts:           { desiredReady: 7, ready: 7 },
+          perClusterResourceCounts: {
+            'fleet-default/cluster-a': { desiredReady: 7, ready: 7 },
+            'fleet-default/cluster-b': { desiredReady: 7, ready: 7 },
+          },
+        },
+      });
+
+      expect((wrapper.vm as any).summary.clusters).toBe(2);
+    });
+
+    it('counts only the not-ready clusters when the application is partially ready', () => {
+      const wrapper = mountSummary({
+        targetClusters: [],
+        status:         {
+          resourceCounts:           { desiredReady: 14, ready: 7 },
+          perClusterResourceCounts: {
+            'fleet-default/cluster-a': { desiredReady: 7, ready: 7 },
+            'fleet-default/cluster-b': { desiredReady: 7, ready: 0 },
+          },
+        },
+      });
+
+      expect((wrapper.vm as any).summary.clusters).toBe(1);
+    });
+
+    it('reports zero clusters when nothing has been deployed yet', () => {
+      const wrapper = mountSummary({ targetClusters: [], status: { resourceCounts: { desiredReady: 0 } } });
+
+      expect((wrapper.vm as any).summary.clusters).toBe(0);
+    });
+  });
+});

--- a/shell/components/formatter/FleetSummaryGraph.vue
+++ b/shell/components/formatter/FleetSummaryGraph.vue
@@ -31,7 +31,16 @@ export default {
     },
 
     show() {
-      return this.stateParts.length > 0 && (this.row.type === FLEET.CLUSTER || this.row.targetClusters?.length);
+      // `targetClusters` requires the workspace's clusters to be loaded. On list pages we avoid that
+      // fetch, so fall back to status fields already on the row that indicate the row targets/has
+      // clusters: desiredReadyClusters for applications (gitrepo/helmop), clusterCount for cluster
+      // groups. Detail/cluster views still have targetClusters populated.
+      return this.stateParts.length > 0 && (
+        this.row.type === FLEET.CLUSTER ||
+        this.row.targetClusters?.length ||
+        this.row.status?.desiredReadyClusters ||
+        this.row.status?.clusterCount
+      );
     },
 
     stateParts() {

--- a/shell/detail/__tests__/fleet.cattle.io.bundle.test.ts
+++ b/shell/detail/__tests__/fleet.cattle.io.bundle.test.ts
@@ -157,8 +157,10 @@ describe('view: fleet.cattle.io.bundle', () => {
       global: fullMountGlobal,
     });
 
-    // Simulate fetch completion by setting allBundleDeployments
+    // Simulate fetch completion by setting allBundleDeployments + the clusters they reference
+    // (fetched by id from the deployment labels).
     (wrapper.vm as any).allBundleDeployments = mockBundleDeployments;
+    (wrapper.vm as any).clusters = mockValueWithResources.targetClusters;
     await wrapper.vm.$nextTick();
 
     expect(wrapper.html()).toMatchSnapshot();

--- a/shell/detail/fleet.cattle.io.bundle.vue
+++ b/shell/detail/fleet.cattle.io.bundle.vue
@@ -2,11 +2,16 @@
 import { FLEET } from '@shell/config/types';
 import FleetResources from '@shell/components/fleet/FleetResources';
 import FleetUtils from '@shell/utils/fleet';
-import { checkSchemasForFindAllHash } from '@shell/utils/auth';
 import Loading from '@shell/components/Loading.vue';
 import { FLEET as FLEET_ANNOTATIONS } from '@shell/config/labels-annotations';
 import ResourceTabs from '@shell/components/form/ResourceTabs';
 import Tab from '@shell/components/Tabbed/Tab';
+import {
+  FilterArgs,
+  PaginationParamFilter,
+  PaginationParamProjectOrNamespace,
+  PaginationFilterEquality,
+} from '@shell/types/store/pagination.types';
 
 export default {
   name: 'FleetBundleDetail',
@@ -22,22 +27,10 @@ export default {
   },
 
   data() {
-    return { allBundleDeployments: [] };
+    return { allBundleDeployments: [], clusters: [] };
   },
 
   async fetch() {
-    await checkSchemasForFindAllHash({
-      // must be loaded for bundle.targetClusters to work
-      allFleetClusters: {
-        inStoreType: 'management',
-        type:        FLEET.CLUSTER
-      },
-      clusterGroups: {
-        inStoreType: 'management',
-        type:        FLEET.CLUSTER_GROUP
-      }
-    }, this.$store);
-
     // Only this bundle's deployments (server-side filtered by the bundle-name / bundle-namespace
     // labels) rather than every BundleDeployment in the cluster. findLabelSelector uses the
     // paginated sql-cache api when available and falls back to a native labelSelector list.
@@ -52,28 +45,68 @@ export default {
             }
           }
         },
-      });
+      }) || [];
     } catch (e) {
       this.allBundleDeployments = [];
     }
+
+    // The deployments already name the clusters they target (in their labels), so fetch only those
+    // clusters - by id - for display. This drops the previous "all clusters" + "all cluster-groups"
+    // findAll (cluster-groups only existed to resolve bundle.targetClusters, no longer needed here).
+    this.clusters = await this.fetchClustersForDeployments();
+  },
+
+  methods: {
+    async fetchClustersForDeployments() {
+      const ids = [...new Set(
+        (this.allBundleDeployments || [])
+          .map((bd) => FleetUtils.clusterIdFromBundleDeploymentLabels(bd.metadata?.labels))
+          .filter((id) => id && id.includes('/'))
+      )];
+
+      if (!ids.length) {
+        return [];
+      }
+
+      const namespaces = [...new Set(ids.map((id) => id.split('/')[0]))];
+      const names = [...new Set(ids.map((id) => id.split('/')[1]))];
+
+      try {
+        return await this.$store.dispatch('management/findPage', {
+          type: FLEET.CLUSTER,
+          opt:  {
+            pagination: new FilterArgs({
+              projectsOrNamespaces: new PaginationParamProjectOrNamespace({ projectOrNamespace: namespaces }),
+              filters:              PaginationParamFilter.createSingleField({
+                field: 'metadata.name', value: names.join(','), equality: PaginationFilterEquality.IN
+              }),
+            })
+          }
+        }) || [];
+      } catch (e) {
+        // Fallback (e.g. pagination api unavailable): namespace-scoped list - still far narrower
+        // than every cluster in the cluster.
+        try {
+          return await this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER, opt: { namespaced: namespaces[0] } }) || [];
+        } catch (e2) {
+          return [];
+        }
+      }
+    },
   },
 
   computed: {
     bundleResources() {
-      if (!this.allBundleDeployments) {
-        return [];
-      }
-
-      const bundleDeploymentsByClusterId = this.allBundleDeployments
+      const bundleDeploymentsByClusterId = (this.allBundleDeployments || [])
         .reduce((res, bd) => {
-          if (this.value.id === FleetUtils.bundleIdFromBundleDeploymentLabels(bd.metadata?.labels)) {
-            res[FleetUtils.clusterIdFromBundleDeploymentLabels(bd.metadata?.labels)] = bd;
-          }
+          res[FleetUtils.clusterIdFromBundleDeploymentLabels(bd.metadata?.labels)] = bd;
 
           return res;
         }, {});
 
-      return this.value.targetClusters.reduce((res, cluster) => {
+      // Drive off the clusters the deployments actually reference (fetched by id), not
+      // value.targetClusters - so the page no longer needs every cluster loaded to resolve targets.
+      return (this.clusters || []).reduce((res, cluster) => {
         const bd = bundleDeploymentsByClusterId[cluster.id];
 
         if (bd) {

--- a/shell/detail/fleet.cattle.io.bundle.vue
+++ b/shell/detail/fleet.cattle.io.bundle.vue
@@ -26,12 +26,7 @@ export default {
   },
 
   async fetch() {
-    const allDispatches = await checkSchemasForFindAllHash({
-      allBundleDeployments: {
-        inStoreType: 'management',
-        type:        FLEET.BUNDLE_DEPLOYMENT,
-      },
-
+    await checkSchemasForFindAllHash({
       // must be loaded for bundle.targetClusters to work
       allFleetClusters: {
         inStoreType: 'management',
@@ -43,7 +38,24 @@ export default {
       }
     }, this.$store);
 
-    this.allBundleDeployments = allDispatches.allBundleDeployments || [];
+    // Only this bundle's deployments (server-side filtered by the bundle-name / bundle-namespace
+    // labels) rather than every BundleDeployment in the cluster. findLabelSelector uses the
+    // paginated sql-cache api when available and falls back to a native labelSelector list.
+    try {
+      this.allBundleDeployments = await this.$store.dispatch('management/findLabelSelector', {
+        type:     FLEET.BUNDLE_DEPLOYMENT,
+        matching: {
+          labelSelector: {
+            matchLabels: {
+              [FLEET_ANNOTATIONS.BUNDLE_NAME]:      this.value.metadata.name,
+              [FLEET_ANNOTATIONS.BUNDLE_NAMESPACE]: this.value.metadata.namespace,
+            }
+          }
+        },
+      });
+    } catch (e) {
+      this.allBundleDeployments = [];
+    }
   },
 
   computed: {

--- a/shell/detail/fleet.cattle.io.cluster.vue
+++ b/shell/detail/fleet.cattle.io.cluster.vue
@@ -39,7 +39,20 @@ export default {
       helmOps:           this.$store.dispatch('management/findAll', { type: FLEET.HELM_OP }),
       workspaces:        this.$store.dispatch('management/findAll', { type: FLEET.WORKSPACE }),
       clusterGroups:     this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER_GROUP }), // Needed for calculating targetClusters
-      bundleDeployments: this.$store.dispatch('management/findAll', { type: FLEET.BUNDLE_DEPLOYMENT })
+      // Only this cluster's deployments (server-side filtered by the cluster / cluster-namespace
+      // labels) rather than every BundleDeployment in the cluster. findLabelSelector uses the
+      // paginated sql-cache api when available and falls back to a native labelSelector list.
+      bundleDeployments: this.$store.dispatch('management/findLabelSelector', {
+        type:     FLEET.BUNDLE_DEPLOYMENT,
+        matching: {
+          labelSelector: {
+            matchLabels: {
+              [FLEET_LABELS.CLUSTER]:           this.value.metadata.name,
+              [FLEET_LABELS.CLUSTER_NAMESPACE]: this.value.metadata.namespace,
+            }
+          }
+        },
+      })
     });
 
     this.rancherCluster = hash.rancherCluster;

--- a/shell/detail/fleet.cattle.io.clustergroup.vue
+++ b/shell/detail/fleet.cattle.io.clustergroup.vue
@@ -28,12 +28,21 @@ export default {
   },
 
   async fetch() {
-    const hash = {
-      workspaces:    this.$store.dispatch('cluster/findAll', { type: FLEET.WORKSPACE }),
-      FleetClusters: this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER }),
-    };
+    const selector = this.value.spec?.selector || {};
+    const hasSelector = Object.keys(selector.matchLabels || {}).length > 0 || (selector.matchExpressions || []).length > 0;
 
-    await allHash(hash);
+    await allHash({
+      // Needed by the group's targetClusters getter (it reads workspace.clusters).
+      workspaces: this.$store.dispatch('cluster/findAll', { type: FLEET.WORKSPACE }),
+
+      // Fetch only the clusters this group selects (server-side, by its own spec.selector) rather
+      // than every cluster. An empty selector matches all clusters in the workspace, so in that
+      // case scope to the workspace namespace instead (findLabelSelector rejects empty selectors).
+      fleetClusters: hasSelector ? this.$store.dispatch('management/findLabelSelector', {
+        type:     FLEET.CLUSTER,
+        matching: { namespace: this.value.metadata.namespace, labelSelector: selector },
+      }) : this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER, opt: { namespaced: this.value.metadata.namespace } }),
+    });
   },
 
   computed: {

--- a/shell/detail/fleet.cattle.io.gitrepo.vue
+++ b/shell/detail/fleet.cattle.io.gitrepo.vue
@@ -6,9 +6,17 @@ import { Banner } from '@components/Banner';
 import FleetResources from '@shell/components/fleet/FleetResources';
 import Tab from '@shell/components/Tabbed/Tab';
 import { FLEET } from '@shell/config/types';
+import { FLEET as FLEET_ANNOTATIONS } from '@shell/config/labels-annotations';
+import FleetUtils from '@shell/utils/fleet';
 import { isHarvesterCluster } from '@shell/utils/cluster';
 import FleetBundles from '@shell/components/fleet/FleetBundles.vue';
 import { checkSchemasForFindAllHash } from '@shell/utils/auth';
+import {
+  FilterArgs,
+  PaginationParamFilter,
+  PaginationParamProjectOrNamespace,
+  PaginationFilterEquality,
+} from '@shell/types/store/pagination.types';
 import DetailPage from '@shell/components/Resource/Detail/Page.vue';
 import Masthead from '@shell/components/Resource/Detail/Masthead/index.vue';
 import { useDefaultMastheadProps } from '@shell/components/Resource/Detail/Masthead/composable';
@@ -55,8 +63,9 @@ export default {
 
   data() {
     return {
-      allFleetClusters: [],
-      allBundles:       [],
+      clusters:          [],
+      allBundles:        [],
+      bundleDeployments: [],
     };
   },
 
@@ -71,13 +80,10 @@ export default {
     gitRepoHasClusters() {
       return this.value.status?.desiredReadyClusters;
     },
-    clusterSchema() {
-      return this.$store.getters['management/schemaFor'](FLEET.CLUSTER);
-    },
     harvesterClusters() {
       const harvester = {};
 
-      this.allFleetClusters.forEach((c) => {
+      this.clusters.forEach((c) => {
         if (isHarvesterCluster(c)) {
           harvester[c.metadata.name] = c;
         }
@@ -101,29 +107,109 @@ export default {
 
       return bundles;
     },
+
+    // Resources deployed by this repo, derived from its BundleDeployments (same approach as the
+    // Bundle detail page). Each BD carries its cluster id in its labels, so we don't need the repo's
+    // targetClusters - and therefore not the all-cluster / all-cluster-group fetch it required.
+    resources() {
+      const bdByClusterId = (this.bundleDeployments || []).reduce((res, bd) => {
+        res[FleetUtils.clusterIdFromBundleDeploymentLabels(bd.metadata?.labels)] = bd;
+
+        return res;
+      }, {});
+
+      return (this.clusters || []).reduce((res, cluster) => {
+        const bd = bdByClusterId[cluster.id];
+
+        if (bd) {
+          FleetUtils.resourcesFromBundleDeploymentStatus(bd.status).forEach((r) => {
+            const type = FleetUtils.resourceType(r);
+            const key = `${ cluster.id }-${ type }-${ r.namespace }-${ r.name }`;
+
+            res.push({
+              ...r,
+              key,
+              type,
+              id:             FleetUtils.resourceId(r),
+              clusterId:      cluster.id,
+              clusterName:    cluster.nameDisplay,
+              detailLocation: FleetUtils.detailLocation(r, cluster.metadata.labels[FLEET_ANNOTATIONS.CLUSTER_NAME]),
+            });
+          });
+        }
+
+        return res;
+      }, []);
+    },
   },
   async fetch() {
-    const allDispatches = await checkSchemasForFindAllHash({
-      allBundles: {
-        inStoreType: 'management',
-        type:        FLEET.BUNDLE,
-        opt:         { excludeFields: ['metadata.managedFields', 'spec.resources'] },
-      },
+    // Bundles power the FleetSummary + Bundles tab.
+    try {
+      const hash = await checkSchemasForFindAllHash({
+        allBundles: {
+          inStoreType: 'management',
+          type:        FLEET.BUNDLE,
+          opt:         { excludeFields: ['metadata.managedFields', 'spec.resources'] },
+        },
+      }, this.$store);
 
-      allFleetClusters: {
-        inStoreType: 'management',
-        type:        FLEET.CLUSTER
-      },
-      clusterGroups: {
-        inStoreType: 'management',
-        type:        FLEET.CLUSTER_GROUP
-      }
-    }, this.$store);
+      this.allBundles = hash.allBundles || [];
+    } catch (e) {
+    }
 
-    this.allBundles = allDispatches.allBundles || [];
-    this.allFleetClusters = allDispatches.allFleetClusters || [];
+    // This repo's BundleDeployments drive the Resources tab and name exactly which clusters are
+    // involved (their cluster id is in the labels).
+    try {
+      this.bundleDeployments = await this.$store.dispatch('management/findLabelSelector', {
+        type:     FLEET.BUNDLE_DEPLOYMENT,
+        matching: { labelSelector: { matchLabels: { [FLEET_ANNOTATIONS.REPO_NAME]: this.value.name } } },
+      }) || [];
+    } catch (e) {
+      this.bundleDeployments = [];
+    }
+
+    // Only the clusters those deployments reference, fetched by id (resource display + harvester).
+    this.clusters = await this.fetchClustersForDeployments();
   },
 
+  methods: {
+    async fetchClustersForDeployments() {
+      const ids = [...new Set(
+        (this.bundleDeployments || [])
+          .map((bd) => FleetUtils.clusterIdFromBundleDeploymentLabels(bd.metadata?.labels))
+          .filter((id) => id && id.includes('/'))
+      )];
+
+      if (!ids.length) {
+        return [];
+      }
+
+      const namespaces = [...new Set(ids.map((id) => id.split('/')[0]))];
+      const names = [...new Set(ids.map((id) => id.split('/')[1]))];
+
+      try {
+        return await this.$store.dispatch('management/findPage', {
+          type: FLEET.CLUSTER,
+          opt:  {
+            pagination: new FilterArgs({
+              projectsOrNamespaces: new PaginationParamProjectOrNamespace({ projectOrNamespace: namespaces }),
+              filters:              PaginationParamFilter.createSingleField({
+                field: 'metadata.name', value: names.join(','), equality: PaginationFilterEquality.IN
+              }),
+            })
+          }
+        }) || [];
+      } catch (e) {
+        // Fallback (e.g. pagination api unavailable): namespace-scoped list, still far narrower
+        // than every cluster in the cluster.
+        try {
+          return await this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER, opt: { namespaced: namespaces[0] } }) || [];
+        } catch (e2) {
+          return [];
+        }
+      }
+    },
+  },
 };
 </script>
 
@@ -168,14 +254,17 @@ export default {
             name="bundles"
             :weight="30"
           >
-            <FleetBundles :value="value" />
+            <FleetBundles
+              :value="value"
+              :clusters="clusters"
+            />
           </Tab>
           <Tab
             label="Resources"
             name="resources"
             :weight="20"
           >
-            <FleetResources :rows="value.resourcesStatuses" />
+            <FleetResources :rows="resources" />
           </Tab>
         </ResourceTabs>
       </template>

--- a/shell/detail/fleet.cattle.io.helmop.vue
+++ b/shell/detail/fleet.cattle.io.helmop.vue
@@ -6,9 +6,17 @@ import { Banner } from '@components/Banner';
 import FleetResources from '@shell/components/fleet/FleetResources';
 import Tab from '@shell/components/Tabbed/Tab';
 import { FLEET } from '@shell/config/types';
+import { FLEET as FLEET_ANNOTATIONS } from '@shell/config/labels-annotations';
+import FleetUtils from '@shell/utils/fleet';
 import { isHarvesterCluster } from '@shell/utils/cluster';
 import FleetBundles from '@shell/components/fleet/FleetBundles.vue';
 import { checkSchemasForFindAllHash } from '@shell/utils/auth';
+import {
+  FilterArgs,
+  PaginationParamFilter,
+  PaginationParamProjectOrNamespace,
+  PaginationFilterEquality,
+} from '@shell/types/store/pagination.types';
 import DetailPage from '@shell/components/Resource/Detail/Page.vue';
 import Masthead from '@shell/components/Resource/Detail/Masthead/index.vue';
 import { useDefaultMastheadProps } from '@shell/components/Resource/Detail/Masthead/composable';
@@ -55,8 +63,9 @@ export default {
 
   data() {
     return {
-      allFleetClusters: [],
-      allBundles:       [],
+      clusters:          [],
+      allBundles:        [],
+      bundleDeployments: [],
     };
   },
 
@@ -71,13 +80,10 @@ export default {
     helmOpHasClusters() {
       return this.value.status?.desiredReadyClusters;
     },
-    clusterSchema() {
-      return this.$store.getters['management/schemaFor'](FLEET.CLUSTER);
-    },
     harvesterClusters() {
       const harvester = {};
 
-      this.allFleetClusters.forEach((c) => {
+      this.clusters.forEach((c) => {
         if (isHarvesterCluster(c)) {
           harvester[c.metadata.name] = c;
         }
@@ -101,29 +107,109 @@ export default {
 
       return bundles;
     },
+
+    // Resources deployed by this HelmOp, derived from its BundleDeployments (same approach as the
+    // Bundle detail page). Each BD carries its cluster id in its labels, so we don't need the app's
+    // targetClusters - and therefore not the all-cluster / all-cluster-group fetch it required.
+    resources() {
+      const bdByClusterId = (this.bundleDeployments || []).reduce((res, bd) => {
+        res[FleetUtils.clusterIdFromBundleDeploymentLabels(bd.metadata?.labels)] = bd;
+
+        return res;
+      }, {});
+
+      return (this.clusters || []).reduce((res, cluster) => {
+        const bd = bdByClusterId[cluster.id];
+
+        if (bd) {
+          FleetUtils.resourcesFromBundleDeploymentStatus(bd.status).forEach((r) => {
+            const type = FleetUtils.resourceType(r);
+            const key = `${ cluster.id }-${ type }-${ r.namespace }-${ r.name }`;
+
+            res.push({
+              ...r,
+              key,
+              type,
+              id:             FleetUtils.resourceId(r),
+              clusterId:      cluster.id,
+              clusterName:    cluster.nameDisplay,
+              detailLocation: FleetUtils.detailLocation(r, cluster.metadata.labels[FLEET_ANNOTATIONS.CLUSTER_NAME]),
+            });
+          });
+        }
+
+        return res;
+      }, []);
+    },
   },
   async fetch() {
-    const allDispatches = await checkSchemasForFindAllHash({
-      allBundles: {
-        inStoreType: 'management',
-        type:        FLEET.BUNDLE,
-        opt:         { excludeFields: ['metadata.managedFields', 'spec.resources'] },
-      },
+    // Bundles power the FleetSummary + Bundles tab.
+    try {
+      const hash = await checkSchemasForFindAllHash({
+        allBundles: {
+          inStoreType: 'management',
+          type:        FLEET.BUNDLE,
+          opt:         { excludeFields: ['metadata.managedFields', 'spec.resources'] },
+        },
+      }, this.$store);
 
-      allFleetClusters: {
-        inStoreType: 'management',
-        type:        FLEET.CLUSTER
-      },
-      clusterGroups: {
-        inStoreType: 'management',
-        type:        FLEET.CLUSTER_GROUP
-      }
-    }, this.$store);
+      this.allBundles = hash.allBundles || [];
+    } catch (e) {
+    }
 
-    this.allBundles = allDispatches.allBundles || [];
-    this.allFleetClusters = allDispatches.allFleetClusters || [];
+    // This HelmOp's BundleDeployments drive the Resources tab and name exactly which clusters are
+    // involved (their cluster id is in the labels).
+    try {
+      this.bundleDeployments = await this.$store.dispatch('management/findLabelSelector', {
+        type:     FLEET.BUNDLE_DEPLOYMENT,
+        matching: { labelSelector: { matchLabels: { [FLEET_ANNOTATIONS.HELM_NAME]: this.value.name } } },
+      }) || [];
+    } catch (e) {
+      this.bundleDeployments = [];
+    }
+
+    // Only the clusters those deployments reference, fetched by id (resource display + harvester).
+    this.clusters = await this.fetchClustersForDeployments();
   },
 
+  methods: {
+    async fetchClustersForDeployments() {
+      const ids = [...new Set(
+        (this.bundleDeployments || [])
+          .map((bd) => FleetUtils.clusterIdFromBundleDeploymentLabels(bd.metadata?.labels))
+          .filter((id) => id && id.includes('/'))
+      )];
+
+      if (!ids.length) {
+        return [];
+      }
+
+      const namespaces = [...new Set(ids.map((id) => id.split('/')[0]))];
+      const names = [...new Set(ids.map((id) => id.split('/')[1]))];
+
+      try {
+        return await this.$store.dispatch('management/findPage', {
+          type: FLEET.CLUSTER,
+          opt:  {
+            pagination: new FilterArgs({
+              projectsOrNamespaces: new PaginationParamProjectOrNamespace({ projectOrNamespace: namespaces }),
+              filters:              PaginationParamFilter.createSingleField({
+                field: 'metadata.name', value: names.join(','), equality: PaginationFilterEquality.IN
+              }),
+            })
+          }
+        }) || [];
+      } catch (e) {
+        // Fallback (e.g. pagination api unavailable): namespace-scoped list, still far narrower
+        // than every cluster in the cluster.
+        try {
+          return await this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER, opt: { namespaced: namespaces[0] } }) || [];
+        } catch (e2) {
+          return [];
+        }
+      }
+    },
+  },
 };
 </script>
 
@@ -169,14 +255,17 @@ export default {
               name="bundles"
               :weight="30"
             >
-              <FleetBundles :value="value" />
+              <FleetBundles
+                :value="value"
+                :clusters="clusters"
+              />
             </Tab>
             <Tab
               label="Resources"
               name="resources"
               :weight="20"
             >
-              <FleetResources :rows="value.resourcesStatuses" />
+              <FleetResources :rows="resources" />
             </Tab>
           </ResourceTabs>
         </div>

--- a/shell/edit/fleet.cattle.io.clustergroup.vue
+++ b/shell/edit/fleet.cattle.io.clustergroup.vue
@@ -33,18 +33,18 @@ export default {
   async fetch() {
     const _hash = {};
 
-    if (this.$store.getters['management/schemaFor'](FLEET.CLUSTER)) {
-      _hash.allClusters = await this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER });
-    }
-
     if (this.$store.getters['management/schemaFor'](FLEET.WORKSPACE)) {
       _hash.allWorkspaces = this.$store.dispatch('management/findAll', { type: FLEET.WORKSPACE });
     }
 
     const hash = await allHash(_hash);
 
-    this.allClusters = hash.allClusters || [];
     this.allWorkspaces = hash.allWorkspaces || [];
+
+    // The "matches N of M clusters" preview only looks at the selected workspace's clusters
+    // (clustersForWorkspace -> workspace.clusters), so load just that namespace's clusters rather
+    // than every cluster. Re-fetched when the workspace changes (see the namespace watcher).
+    await this.fetchClustersForWorkspace();
 
     if ( !this.value.spec?.selector ) {
       this.value.spec = this.value.spec || {};
@@ -64,7 +64,6 @@ export default {
 
   data() {
     return {
-      allClusters:      null,
       allWorkspaces:    null,
       matchingClusters: null,
       expressions:      null,
@@ -93,10 +92,27 @@ export default {
     },
   },
 
-  watch: { 'value.metadata.namespace': 'updateMatchingClusters' },
+  watch: { 'value.metadata.namespace': 'workspaceChanged' },
 
   methods: {
     set,
+
+    /**
+     * Load only the selected workspace's clusters (the preview is scoped to that workspace) instead
+     * of every cluster. Populates the store that `workspace.clusters` (clustersForWorkspace) reads.
+     */
+    async fetchClustersForWorkspace() {
+      const namespace = this.value.metadata?.namespace;
+
+      if ( namespace && this.$store.getters['management/schemaFor'](FLEET.CLUSTER) ) {
+        await this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER, opt: { namespaced: namespace } });
+      }
+    },
+
+    async workspaceChanged() {
+      await this.fetchClustersForWorkspace();
+      this.updateMatchingClusters();
+    },
 
     matchChanged(expressions) {
       const { matchLabels, matchExpressions } = simplify(expressions);

--- a/shell/edit/management.cattle.io.fleetworkspace.vue
+++ b/shell/edit/management.cattle.io.fleetworkspace.vue
@@ -5,7 +5,7 @@ import CruResource from '@shell/components/CruResource';
 import Labels from '@shell/components/form/Labels';
 import Loading from '@shell/components/Loading';
 import NameNsDescription from '@shell/components/form/NameNsDescription';
-import { FLEET, MANAGEMENT, SCHEMA } from '@shell/config/types';
+import { FLEET, SCHEMA } from '@shell/config/types';
 import { FLEET as FLEET_ANNOTATIONS } from '@shell/config/labels-annotations';
 // import RoleBindings from '@shell/components/RoleBindings';
 import Tabbed from '@shell/components/Tabbed';
@@ -41,12 +41,6 @@ export default {
   mixins: [CreateEditView],
 
   async fetch() {
-    this.rancherClusters = await this.$store.dispatch('management/findAll', { type: MANAGEMENT.CLUSTER });
-
-    if (this.$store.getters['management/schemaFor']( FLEET.CLUSTER )) {
-      this.fleetClusters = await this.$store.dispatch('management/findAll', { type: FLEET.CLUSTER });
-    }
-
     if (this.hasRepoRestrictionSchema) {
       const restrictions = await this.$store.dispatch('management/findAll', { type: FLEET.GIT_REPO_RESTRICTION });
 
@@ -67,8 +61,6 @@ export default {
     this.value['spec'] = this.value.spec || {};
 
     return {
-      fleetClusters:            null,
-      rancherClusters:          null,
       workSpaceRestriction:     null,
       restrictions:             [],
       targetNamespaces:         [],

--- a/shell/list/fleet.cattle.io.cluster.vue
+++ b/shell/list/fleet.cattle.io.cluster.vue
@@ -1,14 +1,23 @@
 <script>
 import FleetClusters from '@shell/components/fleet/FleetClusters';
-import { FLEET, MANAGEMENT } from '@shell/config/types';
+import { FLEET, VIRTUAL_HARVESTER_PROVIDER } from '@shell/config/types';
+import { CAPI } from '@shell/config/labels-annotations';
 import { filterOnlyKubernetesClusters } from '@shell/utils/cluster';
+import { HARVESTER_CONTAINER } from '@shell/store/features';
 import { Banner } from '@components/Banner';
 import ResourceFetch from '@shell/mixins/resource-fetch';
+import FleetListPagination from '@shell/mixins/fleet-list-pagination';
+import {
+  PaginationArgs,
+  PaginationParamFilter,
+  PaginationParamProjectOrNamespace,
+  PaginationFilterEquality,
+} from '@shell/types/store/pagination.types';
 
 export default {
   name:       'ListCluster',
   components: { Banner, FleetClusters },
-  mixins:     [ResourceFetch],
+  mixins:     [ResourceFetch, FleetListPagination],
   props:      {
     resource: {
       type:     String,
@@ -27,46 +36,112 @@ export default {
   async fetch() {
     this.$initializeFetchData(this.resource);
 
-    this.$fetchType(FLEET.WORKSPACE);
     await this.$fetchType(this.resource);
-    this.allMgmt = await this.$fetchType(MANAGEMENT.CLUSTER);
   },
 
   data() {
-    return { allMgmt: [] };
+    return { harvesterCount: 0 };
   },
 
   computed: {
-    allClusters() {
-      const out = this.rows.slice();
-
-      const known = {};
-
-      for ( const c of out ) {
-        known[c.metadata.name] = true;
-      }
-
-      for ( const c of this.allMgmt ) {
-        if ( !known[c.metadata.name] ) {
-          out.push(c);
-        }
-      }
-
-      return out;
-    },
-
-    filteredRows() {
-      return filterOnlyKubernetesClusters(this.fleetClusters, this.$store);
+    areHarvesterHostsVisible() {
+      return this.$store.getters['features/get'](HARVESTER_CONTAINER);
     },
 
     fleetClusters() {
-      return this.allClusters.filter((c) => c.type === FLEET.CLUSTER);
+      // Under server-side pagination the rows are already FLEET.CLUSTER; filter defensively for the
+      // non-paginated path too. (The previous management-cluster merge was a no-op - those rows
+      // were appended then removed again by this type filter.)
+      return this.rows.filter((c) => c.type === FLEET.CLUSTER);
+    },
+
+    // Harvester clusters are hidden unless the harvester feature is enabled. Under pagination this
+    // is done server-side (see applyHarvesterFilter) so the page/counts stay correct; the
+    // non-paginated fallback filters the rows client-side.
+    filteredRows() {
+      return this.canPaginate ? this.fleetClusters : filterOnlyKubernetesClusters(this.fleetClusters, this.$store);
     },
 
     hiddenHarvesterCount() {
-      return this.fleetClusters.length - this.filteredRows.length;
+      // Under pagination the page is filtered server-side, so use the dedicated count query result;
+      // otherwise count what was filtered out of the local page.
+      return this.canPaginate ? this.harvesterCount : this.fleetClusters.length - this.filteredRows.length;
     },
   },
+
+  watch: {
+    canPaginate: {
+      immediate: true,
+      handler() {
+        this.applyHarvesterFilter();
+        this.fetchHarvesterCount();
+      }
+    },
+    areHarvesterHostsVisible() {
+      this.applyHarvesterFilter();
+      this.fetchHarvesterCount();
+    },
+    fleetWorkspace() {
+      this.fetchHarvesterCount();
+    },
+  },
+
+  methods: {
+    /**
+     * Exclude Harvester clusters from the paginated request (rather than filtering them out of the
+     * page client-side, which would leave the page short and the totals wrong). Mirrors Fleet's own
+     * "exclude harvester" rule - provider.cattle.io NOT IN (harvester).
+     */
+    applyHarvesterFilter() {
+      if (this.canPaginate && !this.areHarvesterHostsVisible) {
+        this.requestFilters.filters = [this.harvesterFilterField(PaginationFilterEquality.NOT_IN)];
+      } else {
+        this.requestFilters.filters = [];
+      }
+    },
+
+    harvesterFilterField(equality) {
+      return PaginationParamFilter.createSingleField({
+        field: `metadata.labels[${ CAPI.PROVIDER }]`,
+        value: VIRTUAL_HARVESTER_PROVIDER,
+        equality,
+      });
+    },
+
+    /**
+     * The Harvester clusters are excluded server-side, so to drive the "hidden" banner we ask the
+     * server how many there are (in the current workspace) with a minimal count-only query.
+     */
+    async fetchHarvesterCount() {
+      if (!this.canPaginate || this.areHarvesterHostsVisible) {
+        this.harvesterCount = 0;
+
+        return;
+      }
+
+      const workspace = this.$store.getters.workspace;
+
+      try {
+        const res = await this.$store.dispatch('management/findPage', {
+          type: FLEET.CLUSTER,
+          opt:  {
+            transient:  true,
+            pagination: new PaginationArgs({
+              page:                 1,
+              pageSize:             1,
+              projectsOrNamespaces: workspace ? [new PaginationParamProjectOrNamespace({ projectOrNamespace: [workspace] })] : [],
+              filters:              [this.harvesterFilterField(PaginationFilterEquality.IN)],
+            }),
+          },
+        });
+
+        this.harvesterCount = res?.pagination?.result?.count || 0;
+      } catch (e) {
+        this.harvesterCount = 0;
+      }
+    },
+  },
+
   // override with relevant info for the loading indicator since this doesn't use it's own masthead
   $loadingResources() {
     return {
@@ -88,8 +163,12 @@ export default {
       :rows="filteredRows"
       :schema="schema"
       :loading="loading"
+      :can-paginate="canPaginate"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
       :force-update-live-and-delayed="forceUpdateLiveAndDelayed"
+      :external-pagination-enabled="canPaginate"
+      :external-pagination-result="paginationResult"
+      @pagination-changed="paginationChanged"
     />
   </div>
 </template>

--- a/shell/list/fleet.cattle.io.clusterregistrationtoken.vue
+++ b/shell/list/fleet.cattle.io.clusterregistrationtoken.vue
@@ -1,11 +1,11 @@
 <script>
-import { FLEET } from '@shell/config/types';
+import { FLEET, VIRTUAL_HARVESTER_PROVIDER } from '@shell/config/types';
+import { CAPI } from '@shell/config/labels-annotations';
 import { Banner } from '@components/Banner';
 import ResourceTable from '@shell/components/ResourceTable';
 import { isHarvesterCluster } from '@shell/utils/cluster';
 import ResourceFetch from '@shell/mixins/resource-fetch';
 import { HARVESTER_CONTAINER } from '@shell/store/features';
-import { checkSchemasForFindAllHash } from '@shell/utils/auth';
 
 export default {
   name:       'ListClusterGroup',
@@ -27,19 +27,22 @@ export default {
   },
 
   async fetch() {
-    try {
-      await checkSchemasForFindAllHash({
-        cluster: {
-          inStoreType: 'management',
-          type:        FLEET.CLUSTER
-        },
-      }, this.$store);
-    } catch (e) {
-    }
-
     await this.$fetchType(this.resource);
-    if (this.$store.getters['management/schemaFor']( FLEET.CLUSTER )) {
-      this.allFleet = await this.$store.getters['management/all'](FLEET.CLUSTER);
+
+    // Clusters are only needed to hide Harvester-owned tokens. When Harvester hosts are visible we
+    // don't filter at all, so skip the fetch entirely; otherwise fetch ONLY the Harvester clusters
+    // (server-side, by the provider label) rather than every cluster.
+    const harvesterVisible = this.$store.getters['features/get'](HARVESTER_CONTAINER);
+
+    if (!harvesterVisible && this.$store.getters['management/schemaFor']( FLEET.CLUSTER )) {
+      try {
+        this.allFleet = await this.$store.dispatch('management/findLabelSelector', {
+          type:     FLEET.CLUSTER,
+          matching: { labelSelector: { matchLabels: { [CAPI.PROVIDER]: VIRTUAL_HARVESTER_PROVIDER } } },
+        }) || [];
+      } catch (e) {
+        this.allFleet = [];
+      }
     }
   },
 

--- a/shell/list/fleet.cattle.io.gitrepo.vue
+++ b/shell/list/fleet.cattle.io.gitrepo.vue
@@ -43,16 +43,10 @@ export default {
 
   async fetch() {
     try {
+      // Clusters / cluster-groups are intentionally NOT fetched here: the summary column only needs
+      // to know whether the repo targets any clusters, which FleetSummaryGraph now derives from
+      // status (status.desiredReadyClusters) instead of the (expensive) targetClusters getter.
       const hash = await checkSchemasForFindAllHash({
-        cluster: {
-          inStoreType: 'management',
-          type:        FLEET.CLUSTER
-        },
-        clusterGroups: {
-          inStoreType: 'management',
-          type:        FLEET.CLUSTER_GROUP
-        },
-
         gitRepos: {
           inStoreType: 'management',
           type:        FLEET.GIT_REPO

--- a/shell/list/fleet.cattle.io.helmop.vue
+++ b/shell/list/fleet.cattle.io.helmop.vue
@@ -43,16 +43,10 @@ export default {
 
   async fetch() {
     try {
+      // Clusters / cluster-groups are intentionally NOT fetched here: the summary column only needs
+      // to know whether the HelmOp targets any clusters, which FleetSummaryGraph now derives from
+      // status (status.desiredReadyClusters) instead of the (expensive) targetClusters getter.
       const hash = await checkSchemasForFindAllHash({
-        cluster: {
-          inStoreType: 'management',
-          type:        FLEET.CLUSTER
-        },
-        clusterGroups: {
-          inStoreType: 'management',
-          type:        FLEET.CLUSTER_GROUP
-        },
-
         helmOps: {
           inStoreType: 'management',
           type:        FLEET.HELM_OP

--- a/shell/mixins/fleet-list-pagination.ts
+++ b/shell/mixins/fleet-list-pagination.ts
@@ -1,0 +1,39 @@
+import { PaginationParamProjectOrNamespace } from '@shell/types/store/pagination.types';
+
+interface FleetListPaginationContext {
+  $store: any;
+  canPaginate: boolean;
+  requestFilters: { projectsOrNamespaces: PaginationParamProjectOrNamespace[] };
+}
+
+/**
+ * Companion mixin for Fleet list pages that use server-side pagination.
+ *
+ * Fleet uses a workspace switcher rather than the standard namespace filter. The selected
+ * workspace (which maps 1:1 to a namespace) lives in the root `workspace` getter rather than in
+ * `namespaceFilters`, so the `resource-fetch` pagination mixin's namespace handling doesn't pick
+ * it up. This translates the selected workspace into a server-side `projectsornamespaces` filter
+ * on the paginated request, and re-issues the request when the workspace changes.
+ *
+ * Use alongside the `resource-fetch` mixin (which provides `requestFilters` and `canPaginate`).
+ */
+export default {
+  computed: {
+    fleetWorkspace(this: FleetListPaginationContext): string | undefined {
+      return this.$store.getters.workspace;
+    },
+  },
+
+  watch: {
+    fleetWorkspace: {
+      immediate: true,
+      handler(this: FleetListPaginationContext, workspace: string | null): void {
+        if (!this.canPaginate) {
+          return;
+        }
+
+        this.requestFilters.projectsOrNamespaces = workspace ? [new PaginationParamProjectOrNamespace({ projectOrNamespace: [workspace] })] : [];
+      }
+    },
+  },
+};

--- a/shell/pages/c/_cluster/fleet/application/index.vue
+++ b/shell/pages/c/_cluster/fleet/application/index.vue
@@ -39,17 +39,10 @@ export default {
 
   async fetch() {
     try {
+      // Clusters / cluster-groups are intentionally NOT fetched here: the summary column only needs
+      // to know whether an application targets any clusters, which FleetSummaryGraph now derives
+      // from status (status.desiredReadyClusters) instead of the (expensive) targetClusters getter.
       const hash = await checkSchemasForFindAllHash({
-        cluster: {
-          inStoreType: 'management',
-          type:        FLEET.CLUSTER
-        },
-
-        clusterGroups: {
-          inStoreType: 'management',
-          type:        FLEET.CLUSTER_GROUP
-        },
-
         gitRepos: {
           inStoreType: 'management',
           type:        FLEET.GIT_REPO

--- a/shell/pages/c/_cluster/fleet/graph/config.js
+++ b/shell/pages/c/_cluster/fleet/graph/config.js
@@ -1,5 +1,6 @@
 import { STATES } from '@shell/plugins/dashboard-store/resource-class';
 import { FLEET } from '@shell/config/types';
+import { FLEET as FLEET_ANNOTATIONS } from '@shell/config/labels-annotations';
 import { checkSchemasForFindAllHash } from '@shell/utils/auth';
 
 // TODO use Rancher icons
@@ -255,7 +256,7 @@ export const graphConfig = {
     return moreInfo;
   },
 
-  checkSchemaPermissions: async(store) => {
+  checkSchemaPermissions: async(store, data) => {
     const schemas = await checkSchemasForFindAllHash({
       cluster: {
         inStoreType: 'management',
@@ -265,13 +266,28 @@ export const graphConfig = {
         inStoreType: 'management',
         type:        FLEET.BUNDLE,
         opt:         { excludeFields: ['metadata.managedFields', 'spec.resources'] },
-      },
-      bundleDeployment: {
-        inStoreType: 'management',
-        type:        FLEET.BUNDLE_DEPLOYMENT
       }
     }, store);
 
-    return schemas.cluster && schemas.bundle && schemas.bundleDeployment;
+    // BundleDeployments scoped to the graphed application (server-side filtered by the GitRepo's
+    // repo-name / HelmOp's helm-name label) rather than every BundleDeployment in the cluster.
+    // findLabelSelector uses the paginated sql-cache api when available and falls back to a native
+    // labelSelector list. data.bundleDeployments (matching getter) then reads them from the store.
+    let bundleDeployment = false;
+
+    try {
+      const labelKey = data?.type === FLEET.HELM_OP ? FLEET_ANNOTATIONS.HELM_NAME : FLEET_ANNOTATIONS.REPO_NAME;
+
+      await store.dispatch('management/findLabelSelector', {
+        type:     FLEET.BUNDLE_DEPLOYMENT,
+        matching: { labelSelector: { matchLabels: { [labelKey]: data?.metadata?.name } } },
+      });
+
+      bundleDeployment = true;
+    } catch (e) {
+      bundleDeployment = false;
+    }
+
+    return schemas.cluster && schemas.bundle && bundleDeployment;
   }
 };

--- a/shell/pages/c/_cluster/fleet/graph/config.js
+++ b/shell/pages/c/_cluster/fleet/graph/config.js
@@ -260,7 +260,10 @@ export const graphConfig = {
     const schemas = await checkSchemasForFindAllHash({
       cluster: {
         inStoreType: 'management',
-        type:        FLEET.CLUSTER
+        type:        FLEET.CLUSTER,
+        // The graphed application's clusters all live in its workspace namespace, so scope the
+        // fetch there instead of loading every cluster in the cluster.
+        opt:         { namespaced: data?.metadata?.namespace },
       },
       bundle: {
         inStoreType: 'management',

--- a/shell/pages/c/_cluster/fleet/index.vue
+++ b/shell/pages/c/_cluster/fleet/index.vue
@@ -4,6 +4,7 @@ import { getVersionData } from '@shell/config/version';
 import { mapState, mapGetters } from 'vuex';
 import { isEmpty } from '@shell/utils/object';
 import { FLEET } from '@shell/config/types';
+import { colorForState, stateDisplay, stateSort } from '@shell/plugins/dashboard-store/resource-class';
 import { WORKSPACE } from '@shell/store/prefs';
 import Loading from '@shell/components/Loading.vue';
 import { checkPermissions, checkSchemasForFindAllHash } from '@shell/utils/auth';
@@ -51,15 +52,6 @@ export default {
           return !!schema?.links?.collection;
         }
       },
-      clusterGroups: {
-        inStoreType: 'management',
-        type:        FLEET.CLUSTER_GROUP
-      },
-      allBundles: {
-        inStoreType: 'management',
-        type:        FLEET.BUNDLE,
-        opt:         { excludeFields: ['metadata.managedFields', 'spec.resources'] },
-      },
       gitRepos: {
         inStoreType: 'management',
         type:        FLEET.GIT_REPO,
@@ -67,10 +59,6 @@ export default {
       helmOps: {
         inStoreType: 'management',
         type:        FLEET.HELM_OP,
-      },
-      fleetClusters: {
-        inStoreType: 'management',
-        type:        FLEET.CLUSTER,
       }
     };
 
@@ -80,6 +68,11 @@ export default {
 
     this[FLEET.GIT_REPO] = hash.gitRepos || [];
     this[FLEET.HELM_OP] = hash.helmOps || [];
+
+    // The cluster / cluster-group panels only show a per-workspace state breakdown (not individual,
+    // selectable resources), so fetch aggregated state counts via the Steve summary API instead of
+    // every cluster object. Falls back to a full fetch when VAI (ui-sql-cache) is unavailable.
+    await this.fetchClusterSummaries();
 
     try {
       const permissionsSchemas = {
@@ -109,6 +102,9 @@ export default {
       [FLEET.GIT_REPO]: [],
       [FLEET.HELM_OP]:  [],
       fleetWorkspaces:  [],
+      // Per-workspace state breakdowns from the summary API (null = fall back to fetched objects).
+      clusterStateSummary:      null as Record<string, any[]> | null,
+      clusterGroupStateSummary: null as Record<string, any[]> | null,
       VIEW_MODE,
       viewModeOptions:  [
         {
@@ -192,11 +188,12 @@ export default {
     },
 
     clusterStates() {
-      return this._groupByWorkspace((ws) => this._resourceStates(ws.clusters));
+      // Prefer the server-side summary (no objects fetched); fall back to deriving from objects.
+      return this.clusterStateSummary || this._groupByWorkspace((ws) => this._resourceStates(ws.clusters));
     },
 
     clusterGroupsStates() {
-      return this._groupByWorkspace((ws) => this._resourceStates(ws.clusterGroups));
+      return this.clusterGroupStateSummary || this._groupByWorkspace((ws) => this._resourceStates(ws.clusterGroups));
     },
 
     cardResources() {
@@ -372,6 +369,79 @@ export default {
         ...acc,
         [ws.id]: callback(ws)
       }), {});
+    },
+
+    /**
+     * Fetch per-workspace state counts for clusters + cluster groups via the Steve summary API
+     * (no resource data, just counts). Falls back to fetching the objects when VAI is unavailable.
+     */
+    async fetchClusterSummaries() {
+      const opt = { summaryField: 'metadata.state.name', namespaceCounts: true };
+
+      const [clusters, clusterGroups] = await Promise.all([
+        this.$store.dispatch('management/fetchResourceSummary', { type: FLEET.CLUSTER, opt }).catch(() => undefined),
+        this.$store.dispatch('management/fetchResourceSummary', { type: FLEET.CLUSTER_GROUP, opt }).catch(() => undefined),
+      ]);
+
+      if (clusters) {
+        this.clusterStateSummary = this._summaryToWorkspaceStates(clusters);
+      } else {
+        // VAI unavailable - fall back to the objects (clusterStates derives from them).
+        await checkSchemasForFindAllHash({
+          fleetClusters: { inStoreType: 'management', type: FLEET.CLUSTER, opt: { excludeFields: ['metadata.managedFields'] } }
+        }, this.$store);
+      }
+
+      if (clusterGroups) {
+        this.clusterGroupStateSummary = this._summaryToWorkspaceStates(clusterGroups);
+      } else {
+        await checkSchemasForFindAllHash({
+          clusterGroups: { inStoreType: 'management', type: FLEET.CLUSTER_GROUP }
+        }, this.$store);
+      }
+    },
+
+    /**
+     * Convert a summary API result ({ summary: [{ counts: { <state>: { namespace: { <ns>: n } } } }] })
+     * into the per-workspace `states` shape ResourcePanel expects ({ [ws]: [{ statePanel, resources }] }).
+     * ResourcePanel only reads `statePanel` + `resources.length`, so a sized placeholder array is enough.
+     */
+    _summaryToWorkspaceStates(summaryResult: any): Record<string, any[]> {
+      const counts = summaryResult?.summary?.[0]?.counts || {};
+      const out: Record<string, any[]> = {};
+
+      Object.entries(counts).forEach(([stateName, info]: [string, any]) => {
+        const color = colorForState(stateName);
+        const display = stateDisplay(stateName);
+        const statePanel = FleetUtils.getDashboardState({ stateColor: color });
+
+        Object.entries(info?.namespace || {}).forEach(([ns, count]: [string, any]) => {
+          if (!out[ns]) {
+            out[ns] = [];
+          }
+
+          out[ns].push({
+            stateDisplay: display,
+            stateSort:    stateSort(color, display),
+            statePanel,
+            resources:    new Array(count), // ResourcePanel only uses resources.length
+          });
+        });
+      });
+
+      return out;
+    },
+
+    _stateCountForWorkspace(states: Record<string, any[]>, workspaceId: string): number {
+      return (states?.[workspaceId] || []).reduce((acc: number, s: any) => acc + s.resources.length, 0);
+    },
+
+    workspaceClusterCount(workspaceId: string): number {
+      return this._stateCountForWorkspace(this.clusterStates, workspaceId);
+    },
+
+    workspaceClusterGroupCount(workspaceId: string): number {
+      return this._stateCountForWorkspace(this.clusterGroupsStates, workspaceId);
     },
 
     _stateExistsInWorkspace(workspace, state) {
@@ -556,7 +626,7 @@ export default {
                 @click:state="selectStates(workspace.id, $event)"
               />
               <ResourcePanel
-                v-if="workspace.clusters?.length"
+                v-if="workspaceClusterCount(workspace.id)"
                 :data-testid="'resource-panel-clusters'"
                 :states="clusterStates[workspace.id]"
                 :workspace="workspace.id"
@@ -564,7 +634,7 @@ export default {
                 :selectable="false"
               />
               <ResourcePanel
-                v-if="workspace.clusterGroups?.length"
+                v-if="workspaceClusterGroupCount(workspace.id)"
                 :data-testid="'resource-panel-cluster-groups'"
                 :states="clusterGroupsStates[workspace.id]"
                 :workspace="workspace.id"

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -15,7 +15,8 @@ import {
   INGRESS,
   WORKLOAD_TYPES,
   HPA,
-  SECRET
+  SECRET,
+  FLEET
 } from '@shell/config/types';
 import { CAPI as CAPI_LAB_AND_ANO, CATTLE_PUBLIC_ENDPOINTS, STORAGE, UI_PROJECT_SECRET_COPY } from '@shell/config/labels-annotations';
 import { Schema } from '@shell/plugins/steve/schema';
@@ -781,7 +782,8 @@ export const PAGINATION_SETTINGS_STORE_DEFAULTS: PaginationSettingsStores = {
           { resource: CAPI.RANCHER_CLUSTER, context: ['side-bar', 'home', 'cluster-management'] },
           { resource: MANAGEMENT.CLUSTER, context: ['side-bar', 'home', 'cluster-management'] },
           { resource: CATALOG.APP, context: ['branding'] },
-          SECRET
+          SECRET,
+          FLEET.CLUSTER,
         ],
         generic: false,
       }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15411
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- I did some changes as part of the investigation, the idea is to change the bundledeployment and the clusters.
- FIxed the dashboard to use the summary
- Fixed the select for the Target Clusters on AppBundle Create/Edit to use a different select
- For resources, removes the use of Cluster and change to Bundledeployment because it is better on the query
- Added query to check for Harvester clusters instead of filtering on the Client side, so it is used as a count as well
- Pagination on Cluster list

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- For now that is not the final change, I want to get the concept first of the changes

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
