### PR TITLE
Add `rancherVersion` field to `@rancher/shell/package.json` to declare the minimum compatible Rancher version for the shell

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@rancher/shell",
-  "version": "3.0.12-rc.7",
+  "version": "3.0.12-rc.8",
+  "rancherVersion": "2.15",
   "description": "Rancher Dashboard Shell",
   "repository": "https://github.com/rancher/dashboard",
   "license": "Apache-2.0",

--- a/shell/utils/versions.ts
+++ b/shell/utils/versions.ts
@@ -1,5 +1,33 @@
 import { setKubeVersionData, setVersionData } from '@shell/config/version';
 
+function checkVersionCompatibility(targetVersion: string, shellRancherVersion: string): void {
+  const targetMatch = targetVersion?.match(/^v?(\d+)\.(\d+)(?:\.(\d+))?/);
+  const shellMatch = shellRancherVersion.match(/^(\d+)\.(\d+)(?:\.(\d+))?/);
+
+  if (targetMatch && shellMatch) {
+    const targetMaj = parseInt(targetMatch[1], 10);
+    const targetMin = parseInt(targetMatch[2], 10);
+    const targetPatch = parseInt(targetMatch[3] ?? '0', 10);
+    const shellMaj = parseInt(shellMatch[1], 10);
+    const shellMin = parseInt(shellMatch[2], 10);
+    const shellPatch = parseInt(shellMatch[3] ?? '0', 10);
+
+    if (
+      targetMaj < shellMaj ||
+      (targetMaj === shellMaj && targetMin < shellMin) ||
+      (targetMaj === shellMaj && targetMin === shellMin && targetPatch < shellPatch)
+    ) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `Rancher version mismatch: target Rancher is ${ targetVersion } but this shell is compatible with v${ shellRancherVersion }.x.\n` +
+        `Whilst this may mostly work, there may be areas that won't (where the shell depends on version-dependent Rancher features).\n` +
+        `It's recommended to align your target Rancher and extension shell versions.\n` +
+        `This only affects \`yarn dev\` — building and loading extensions continues to work.`
+      );
+    }
+  }
+}
+
 class Versions {
     private promise?: Promise<any>;
 
@@ -14,6 +42,11 @@ class Versions {
         redirectUnauthorized: false
       }).then((response: any) => {
         setVersionData(response);
+
+        // check if the target Rancher version is compatible with the shell's Rancher version (only in dev mode)
+        if (process.env.NODE_ENV === 'dev' && process.env.UI_SHELL_RANCHER_VERSION) {
+          checkVersionCompatibility(response?.Version, process.env.UI_SHELL_RANCHER_VERSION);
+        }
       }).catch((e: Error) => {
         console.warn('Failed to fetch Rancher version metadata', e); // eslint-disable-line no-console
       });

--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -208,6 +208,65 @@ const getLoaders = (SHELL_ABS, dir) => [
   },
 ];
 
+function checkRancherVersionCompatibility(targetApi, shellRancherVersion) {
+  if (!shellRancherVersion) return;
+
+  const url = new URL('/rancherversion', targetApi);
+  const protocol = url.protocol === 'https:' ? require('https') : require('http');
+
+  const req = protocol.get(
+    {
+      hostname:           url.hostname,
+      port:               url.port || (url.protocol === 'https:' ? 443 : 80),
+      path:               '/rancherversion',
+      rejectUnauthorized: false,
+    },
+    (res) => {
+      let data = '';
+
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        try {
+          const { Version } = JSON.parse(data);
+          const targetMatch = Version?.match(/^v?(\d+)\.(\d+)(?:\.(\d+))?/);
+          const shellMatch = shellRancherVersion.match(/^(\d+)\.(\d+)(?:\.(\d+))?/);
+
+          if (targetMatch && shellMatch) {
+            const targetMaj = parseInt(targetMatch[1], 10);
+            const targetMin = parseInt(targetMatch[2], 10);
+            const targetPatch = parseInt(targetMatch[3] || '0', 10);
+            const shellMaj = parseInt(shellMatch[1], 10);
+            const shellMin = parseInt(shellMatch[2], 10);
+            const shellPatch = parseInt(shellMatch[3] || '0', 10);
+
+            if (
+              targetMaj < shellMaj ||
+              (targetMaj === shellMaj && targetMin < shellMin) ||
+              (targetMaj === shellMaj && targetMin === shellMin && targetPatch < shellPatch)
+            ) {
+              // eslint-disable-next-line no-console
+              console.warn([
+                '',
+                '⚠️  Rancher version mismatch detected!',
+                `   Target Rancher:        ${ Version }`,
+                `   Shell compatible with: v${ shellRancherVersion }.x`,
+                '   Whilst this may mostly work, there may be areas that won\'t',
+                '   (where the shell depends on version-dependent Rancher features).',
+                '   It\'s recommended to keep both target Rancher and app shell versions aligned.',
+                '   This only affects `yarn dev` — building and loading extensions continues to work.',
+                '',
+              ].join('\n'));
+            }
+          }
+        } catch { /* ignore malformed responses */ }
+      });
+    }
+  );
+
+  req.on('error', () => { /* ignore — proxy will surface connection errors */ });
+  req.end();
+}
+
 const getDevServerConfig = (proxy) => {
   const harFile = process.env.HAR_FILE;
   // HAR File support - load network responses from the specified .har file and use those rather than communicating to the Rancher server
@@ -288,6 +347,8 @@ const getDevServerConfig = (proxy) => {
           }
         }
       });
+
+      checkRancherVersionCompatibility(api, shellPkgData.rancherVersion);
 
       return middlewares;
     }
@@ -387,6 +448,7 @@ const createEnvVariablesPlugin = (routerBasePath, rancherEnv) => new webpack.Def
   'process.env.harvesterPkgUrl':           JSON.stringify(process.env.HARVESTER_PKG_URL),
   'process.env.api':                       JSON.stringify(api),
   'process.env.UI_EXTENSIONS_API_VERSION': JSON.stringify(shellPkgData.version),
+  'process.env.UI_SHELL_RANCHER_VERSION':  JSON.stringify(shellPkgData.rancherVersion || ''),
   // Store the Router Base as env variable that we can use in `shell/config/router.js`
   'process.env.routerBase':                JSON.stringify(routerBasePath),
   __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false',

--- a/shell/vue.config.js
+++ b/shell/vue.config.js
@@ -224,7 +224,9 @@ function checkRancherVersionCompatibility(targetApi, shellRancherVersion) {
     (res) => {
       let data = '';
 
-      res.on('data', (chunk) => { data += chunk; });
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
       res.on('end', () => {
         try {
           const { Version } = JSON.parse(data);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18208

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Add `rancherVersion` field to `@rancher/shell/package.json` to declare the minimum compatible Rancher version for the shell
- When running an extension in standalone dev mode (`yarn dev`) against a Rancher instance whose version is older than the shell's minimum compatible version, display:
  - A **terminal warning** printed to the dev server console at startup
  - A **browser `console.error`** printed when the app initialises and fetches `/rancherversion`
- No changes to the build or publish pipeline — `rancherVersion` is a static field updated manually when cutting a new release branch

### Technical notes summary
A `rancherVersion` field in `shell/package.json` declares the minimum compatible Rancher version (supports `"2.14"` or `"2.15.2"`). At `yarn dev` startup, the shell fetches `/rancherversion` from the target Rancher and compares it against this value. If the target is older, a warning is shown in the terminal and a `console.error` in the browser. The comparison is "less than" — newer Rancher versions never trigger a warning. Dev/nightly version strings (e.g. `v2.15-c8f173...`) are handled correctly. All failure paths (no network, missing field, older shell without the field) degrade silently.

### Areas or cases that should be tested
- Run an extension in standalone dev mode (`API=https://<rancher-v2.13> yarn dev`) with a shell whose `rancherVersion` is `"2.14"`:
  - **Terminal**: `Rancher version mismatch detected!` warning should appear a few seconds after server startup (async)
  - **Browser DevTools console**: `console.error` with mismatch details should appear on page load
- Run against a Rancher version **equal to or newer** than `rancherVersion` (e.g. `v2.14.x`, `v2.15.x`) — **no warning should appear** in terminal or browser
- Run against a Rancher nightly build (e.g. `v2.14-c8f173f805...`) that matches the shell's `rancherVersion` — **no warning should appear**
- Remove `rancherVersion` from `shell/package.json` and run `yarn dev` — server should start normally with no warning and no crash
- Disconnect the target Rancher before starting `yarn dev` — server should start normally with no crash

### Areas which could experience regressions
- `shell/vue.config.js` `setupMiddlewares`: the new call is fire-and-forget and cannot affect middleware setup, but worth confirming the dev server starts cleanly
- `shell/utils/versions.ts`: the new code runs inside the existing `.then()` handler for `/rancherversion`; if the request fails it is already handled by the existing `.catch()` — no regression risk

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
