### PR TITLE
[10171][18238] Fix on model change, added deep check for nulls

### DIFF
--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -4,7 +4,7 @@ import FormValidation from '@shell/mixins/form-validation';
 import WorkLoadMixin from '@shell/edit/workload/mixins/workload';
 import { mapGetters } from 'vuex';
 import { FORM_TYPES } from '@shell/components/form/Security';
-import { NODE } from '@shell/config/types';
+import { NODE, POD } from '@shell/config/types';
 
 export default {
   name:   'Workload',
@@ -39,6 +39,16 @@ export default {
       const hasContainerErrors = this.allContainers.some(this.hasContainerError);
 
       return this.fvFormIsValid && !hasContainerErrors;
+    },
+
+    /**
+     * For Pods, render empty blocks (e.g. an unused podAntiAffinity the form
+     * seeds as empty) as `{}` in "Edit as YAML" instead of a valueless key that
+     * parses back to `null` - so the same pod data always yields the same YAML.
+     * See https://github.com/rancher/dashboard/issues/10171
+     */
+    yamlModifiers() {
+      return this.value.type === POD ? { collapseEmptyObjects: true } : undefined;
     }
   },
   methods: {
@@ -112,6 +122,7 @@ export default {
       :subtypes="workloadSubTypes"
       :apply-hooks="applyHooks"
       :value="value"
+      :yaml-modifiers="yamlModifiers"
       :errors-map="getErrorsMap(fvUnreportedValidationErrors)"
       @finish="save"
       @select-type="selectType"

--- a/shell/edit/workload/mixins/__tests__/workload-pod-shape.test.ts
+++ b/shell/edit/workload/mixins/__tests__/workload-pod-shape.test.ts
@@ -1,0 +1,96 @@
+import workloadMixin from '@shell/edit/workload/mixins/workload.js';
+import { POD } from '@shell/config/types';
+
+/**
+ * Prototype (tier 2) for https://github.com/rancher/dashboard/issues/10171
+ *
+ * A standalone Pod should be created/edited in its native shape (spec.*),
+ * NOT wrapped in a Workload's spec.template.spec. These tests invoke the real
+ * mixin computeds/methods with a controlled `this` to prove the pod branch keeps
+ * the native shape (so "Edit as YAML" serialises a valid Pod with no reshaping).
+ */
+describe('workload mixin: Pod uses native shape', () => {
+  const podCtx = () => {
+    const value: any = {
+      type:     POD,
+      metadata: { name: 'my-pod', namespace: 'default' },
+      spec:     { containers: [{ name: 'container-0', image: 'nginx' }], initContainers: [] },
+    };
+
+    // The model's `containers` getter prefers spec.containers when present
+    Object.defineProperty(value, 'containers', { get() {
+      return value.spec.containers;
+    } });
+
+    return {
+      value,
+      spec:     value.spec,
+      isPod:    true,
+      isCronJob: false,
+    } as any;
+  };
+
+  describe('computed: podTemplateSpec', () => {
+    it('get returns spec itself (not spec.template.spec)', () => {
+      const ctx = podCtx();
+
+      const out = (workloadMixin.computed as any).podTemplateSpec.get.call(ctx);
+
+      expect(out).toBe(ctx.spec);
+      expect(out.containers[0].name).toBe('container-0');
+      expect(out.template).toBeUndefined();
+    });
+
+    it('set writes back to spec and keeps value.spec in sync', () => {
+      const ctx = podCtx();
+      const neu = { containers: [{ name: 'replaced' }] };
+
+      (workloadMixin.computed as any).podTemplateSpec.set.call(ctx, neu);
+
+      expect(ctx.spec).toBe(neu);
+      expect(ctx.value.spec).toBe(neu);
+    });
+  });
+
+  describe('computed: podLabels / podAnnotations', () => {
+    it('read and write pod metadata directly', () => {
+      const ctx = podCtx();
+
+      const labels = (workloadMixin.computed as any).podLabels.get.call(ctx);
+
+      expect(labels).toBe(ctx.value.metadata.labels);
+
+      (workloadMixin.computed as any).podAnnotations.set.call(ctx, { foo: 'bar' });
+      expect(ctx.value.metadata.annotations).toStrictEqual({ foo: 'bar' });
+    });
+  });
+
+  describe('method: saveWorkload', () => {
+    it('saves a Pod in native shape with no template or selector', () => {
+      const ctx = {
+        ...podCtx(),
+        type:            POD,
+        mode:            'create',
+        realMode:        'create',
+        container:       undefined,
+        portsForServices: [],
+        fixNodeAffinity: jest.fn(),
+        fixPodAffinity:  jest.fn(),
+        nvidiaIsValid:   jest.fn(() => true),
+      } as any;
+
+      (workloadMixin.methods as any).saveWorkload.call(ctx);
+
+      // No workload wrapping and no workload-only selector on a Pod
+      expect(ctx.spec.template).toBeUndefined();
+      expect(ctx.spec.selector).toBeUndefined();
+
+      // Containers stay at spec.containers, and value.spec points at the pod spec
+      expect(ctx.spec.containers[0].name).toBe('container-0');
+      expect(ctx.value.spec).toBe(ctx.spec);
+
+      // Namespace is carried onto the pod metadata
+      expect(ctx.value.metadata.namespace).toBe('default');
+    });
+  });
+});

--- a/shell/edit/workload/mixins/__tests__/workload-pod-shape.test.ts
+++ b/shell/edit/workload/mixins/__tests__/workload-pod-shape.test.ts
@@ -18,14 +18,16 @@ describe('workload mixin: Pod uses native shape', () => {
     };
 
     // The model's `containers` getter prefers spec.containers when present
-    Object.defineProperty(value, 'containers', { get() {
-      return value.spec.containers;
-    } });
+    Object.defineProperty(value, 'containers', {
+      get() {
+        return value.spec.containers;
+      }
+    });
 
     return {
       value,
-      spec:     value.spec,
-      isPod:    true,
+      spec:      value.spec,
+      isPod:     true,
       isCronJob: false,
     } as any;
   };
@@ -69,14 +71,14 @@ describe('workload mixin: Pod uses native shape', () => {
     it('saves a Pod in native shape with no template or selector', () => {
       const ctx = {
         ...podCtx(),
-        type:            POD,
-        mode:            'create',
-        realMode:        'create',
-        container:       undefined,
+        type:             POD,
+        mode:             'create',
+        realMode:         'create',
+        container:        undefined,
         portsForServices: [],
-        fixNodeAffinity: jest.fn(),
-        fixPodAffinity:  jest.fn(),
-        nvidiaIsValid:   jest.fn(() => true),
+        fixNodeAffinity:  jest.fn(),
+        fixPodAffinity:   jest.fn(),
+        nvidiaIsValid:    jest.fn(() => true),
       } as any;
 
       (workloadMixin.methods as any).saveWorkload.call(ctx);

--- a/shell/edit/workload/mixins/__tests__/workload-pod-shape.test.ts
+++ b/shell/edit/workload/mixins/__tests__/workload-pod-shape.test.ts
@@ -2,12 +2,12 @@ import workloadMixin from '@shell/edit/workload/mixins/workload.js';
 import { POD } from '@shell/config/types';
 
 /**
- * Prototype (tier 2) for https://github.com/rancher/dashboard/issues/10171
+ * Unit tests for https://github.com/rancher/dashboard/issues/10171
  *
  * A standalone Pod should be created/edited in its native shape (spec.*),
  * NOT wrapped in a Workload's spec.template.spec. These tests invoke the real
  * mixin computeds/methods with a controlled `this` to prove the pod branch keeps
- * the native shape (so "Edit as YAML" serialises a valid Pod with no reshaping).
+ * the native shape so "Edit as YAML" serialises a valid Pod without reshaping.
  */
 describe('workload mixin: Pod uses native shape', () => {
   const podCtx = () => {
@@ -93,6 +93,37 @@ describe('workload mixin: Pod uses native shape', () => {
 
       // Namespace is carried onto the pod metadata
       expect(ctx.value.metadata.namespace).toBe('default');
+    });
+  });
+
+  describe('method: saveWorkload — edit mode', () => {
+    it('does not throw and preserves native shape when saving a Pod in edit mode', () => {
+      const ctx = {
+        ...podCtx(),
+        type:             POD,
+        mode:             'edit',
+        realMode:         'edit',
+        container:        undefined,
+        portsForServices: [],
+        fixNodeAffinity:  jest.fn(),
+        fixPodAffinity:   jest.fn(),
+        nvidiaIsValid:    jest.fn(() => true),
+      } as any;
+
+      // Seed the empty affinity shape that #18238 was triggered by
+      ctx.value.spec.affinity = {
+        podAntiAffinity: {
+          requiredDuringSchedulingIgnoredDuringExecution:  [],
+          preferredDuringSchedulingIgnoredDuringExecution: [],
+        },
+      };
+      ctx.spec = ctx.value.spec;
+
+      expect(() => (workloadMixin.methods as any).saveWorkload.call(ctx)).not.toThrow();
+
+      // Still native Pod shape — no template wrapping introduced
+      expect(ctx.spec.template).toBeUndefined();
+      expect(ctx.spec.selector).toBeUndefined();
     });
   });
 });

--- a/shell/edit/workload/mixins/workload.js
+++ b/shell/edit/workload/mixins/workload.js
@@ -184,25 +184,26 @@ export default {
           name:            `container-0`,
         }];
 
-        const metadata = { ...this.value.metadata };
-
-        const podSpec = { template: { spec: { containers: podContainers, initContainers: [] }, metadata } };
-
-        this.value['spec'] = podSpec;
+        // A standalone Pod keeps its spec in the native Pod shape (spec.*),
+        // NOT wrapped in a Workload's spec.template.spec. The shared form works
+        // on this shape via the podTemplateSpec/podLabels/podAnnotations
+        // computeds. See https://github.com/rancher/dashboard/issues/10171
+        this.value['spec'] = { containers: podContainers, initContainers: [] };
       }
     }
 
-    // EDIT view for POD
-    // Transform it from POD world to workload
-    if ((this.mode === _EDIT || this.mode === _VIEW || this.realMode === _CLONE ) && this.value.type === 'pod') {
-      const podSpec = { ...this.value.spec };
-      const metadata = { ...this.value.metadata };
-
-      this.value.spec['template'] = { spec: podSpec, metadata };
-    }
-
+    // Pods are read/edited/cloned in their native shape - no POD->workload
+    // wrapping needed. (Workloads legitimately nest under spec.template.spec.)
     const spec = this.value.spec;
-    let podTemplateSpec = type === WORKLOAD_TYPES.CRON_JOB ? spec.jobTemplate.spec.template.spec : spec?.template?.spec;
+    let podTemplateSpec;
+
+    if (type === WORKLOAD_TYPES.CRON_JOB) {
+      podTemplateSpec = spec.jobTemplate.spec.template.spec;
+    } else if (this.value.type === POD) {
+      podTemplateSpec = spec;
+    } else {
+      podTemplateSpec = spec?.template?.spec;
+    }
 
     // Area to add default value to securityContext on POD CREATE
     // Check if the securityContext has been setup, for None should be {} when cloning, for new should be empty.
@@ -212,10 +213,6 @@ export default {
 
     let containers = podTemplateSpec.containers || [];
     let container;
-
-    if (this.mode === _VIEW && this.value.type === 'pod' ) {
-      podTemplateSpec = spec;
-    }
 
     if (
       this.mode === _CREATE ||
@@ -365,14 +362,25 @@ export default {
       return this.type === WORKLOAD_TYPES.STATEFUL_SET;
     },
 
-    // if this is a cronjob, grab pod spec from within job template spec
+    // For a Pod the pod spec IS spec; a cronjob nests it within the job template
+    // spec; other workloads nest it under spec.template.spec.
     podTemplateSpec: {
       get() {
-        return this.isCronJob ? this.spec.jobTemplate.spec.template.spec : this.spec?.template?.spec;
+        if (this.isCronJob) {
+          return this.spec.jobTemplate.spec.template.spec;
+        }
+        if (this.isPod) {
+          return this.spec;
+        }
+
+        return this.spec?.template?.spec;
       },
       set(neu) {
         if (this.isCronJob) {
           this.spec.jobTemplate.spec.template['spec'] = neu;
+        } else if (this.isPod) {
+          this.spec = neu;
+          this.value['spec'] = neu;
         } else {
           this.spec.template['spec'] = neu;
         }
@@ -389,6 +397,17 @@ export default {
           return this.spec.jobTemplate.metadata.labels;
         }
 
+        if (this.isPod) {
+          if (!this.value.metadata) {
+            this.value['metadata'] = {};
+          }
+          if (!this.value.metadata.labels) {
+            this.value.metadata['labels'] = {};
+          }
+
+          return this.value.metadata.labels;
+        }
+
         if (!this.spec.template.metadata) {
           this.spec.template['metadata'] = { labels: {} };
         }
@@ -398,6 +417,8 @@ export default {
       set(neu) {
         if (this.isCronJob) {
           this.spec.jobTemplate.metadata['labels'] = neu;
+        } else if (this.isPod) {
+          this.value.metadata['labels'] = neu;
         } else {
           this.spec.template.metadata['labels'] = neu;
         }
@@ -413,6 +434,18 @@ export default {
 
           return this.spec.jobTemplate.metadata.annotations;
         }
+
+        if (this.isPod) {
+          if (!this.value.metadata) {
+            this.value['metadata'] = {};
+          }
+          if (!this.value.metadata.annotations) {
+            this.value.metadata['annotations'] = {};
+          }
+
+          return this.value.metadata.annotations;
+        }
+
         if (!this.spec.template.metadata) {
           this.spec.template['metadata'] = { annotations: {} };
         }
@@ -422,6 +455,8 @@ export default {
       set(neu) {
         if (this.isCronJob) {
           this.spec.jobTemplate.metadata['annotations'] = neu;
+        } else if (this.isPod) {
+          this.value.metadata['annotations'] = neu;
         } else {
           this.spec.template.metadata['annotations'] = neu;
         }
@@ -763,7 +798,9 @@ export default {
     },
 
     saveWorkload() {
+      // A Pod has no selector/template - it is saved in its native shape.
       if (
+        !this.isPod &&
         this.type !== WORKLOAD_TYPES.JOB &&
         this.type !== WORKLOAD_TYPES.CRON_JOB &&
         (this.mode === _CREATE || this.realMode === _CLONE)
@@ -776,12 +813,18 @@ export default {
 
       if (this.type === WORKLOAD_TYPES.CRON_JOB) {
         template = this.spec.jobTemplate;
+      } else if (this.isPod) {
+        // For a Pod, `spec` is the pod spec and `value.metadata` is the pod
+        // metadata - present them the same way the workload template is shaped
+        // so the shared logic below can operate on them uniformly.
+        template = { spec: this.spec, metadata: this.value.metadata };
       } else {
         template = this.spec.template;
       }
 
       // WORKLOADS
       if (
+        !this.isPod &&
         this.type !== WORKLOAD_TYPES.JOB &&
         this.type !== WORKLOAD_TYPES.CRON_JOB &&
         (this.mode === _CREATE || this.realMode === _CLONE)

--- a/shell/edit/workload/mixins/workload.js
+++ b/shell/edit/workload/mixins/workload.js
@@ -418,6 +418,9 @@ export default {
         if (this.isCronJob) {
           this.spec.jobTemplate.metadata['labels'] = neu;
         } else if (this.isPod) {
+          if (!this.value.metadata) {
+            this.value['metadata'] = {};
+          }
           this.value.metadata['labels'] = neu;
         } else {
           this.spec.template.metadata['labels'] = neu;
@@ -456,6 +459,9 @@ export default {
         if (this.isCronJob) {
           this.spec.jobTemplate.metadata['annotations'] = neu;
         } else if (this.isPod) {
+          if (!this.value.metadata) {
+            this.value['metadata'] = {};
+          }
           this.value.metadata['annotations'] = neu;
         } else {
           this.spec.template.metadata['annotations'] = neu;

--- a/shell/models/__tests__/workload.service.test.ts
+++ b/shell/models/__tests__/workload.service.test.ts
@@ -1,0 +1,37 @@
+import WorkloadService from '@shell/models/workload.service.js';
+import { WORKLOAD_TYPES } from '@shell/config/types';
+
+const ctx = {
+  getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
+  dispatch:    jest.fn(),
+  rootGetters: { 'i18n/t': jest.fn() },
+};
+
+describe('class: WorkloadService containers/initContainers getters', () => {
+  // Regression for https://github.com/rancher/dashboard/issues/10171
+  // A standalone Pod stores containers natively and often has no
+  // spec.initContainers key - the getter must not dive into spec.template.
+  it('returns native pod containers and does not throw when initContainers is absent', () => {
+    const pod = new WorkloadService({
+      type:     'pod',
+      metadata: { name: 'p', namespace: 'default' },
+      spec:     { containers: [{ name: 'container-0', image: 'nginx' }] }, // no initContainers, no template
+    }, ctx);
+
+    expect(pod.containers).toHaveLength(1);
+    expect(pod.containers[0].name).toBe('container-0');
+    expect(() => pod.initContainers).not.toThrow();
+    expect(pod.initContainers).toBeUndefined();
+  });
+
+  it('still reads workload containers nested under spec.template.spec', () => {
+    const deployment = new WorkloadService({
+      type:     WORKLOAD_TYPES.DEPLOYMENT,
+      metadata: { name: 'd', namespace: 'default' },
+      spec:     { template: { spec: { containers: [{ name: 'c0' }], initContainers: [{ name: 'i0' }] } } },
+    }, ctx);
+
+    expect(deployment.containers[0].name).toBe('c0');
+    expect(deployment.initContainers[0].name).toBe('i0');
+  });
+});

--- a/shell/models/workload.service.js
+++ b/shell/models/workload.service.js
@@ -129,13 +129,10 @@ export default class WorkloadService extends SteveModel {
       return containers;
     }
 
-    if ( this.spec.containers ) {
-      return this.spec.containers;
-    }
-
-    const { spec:{ template:{ spec:{ containers } } } } = this;
-
-    return containers;
+    // A standalone Pod stores containers natively (spec.containers); workloads
+    // nest them under spec.template.spec. Optional chaining keeps a native Pod
+    // that has no `template` from blowing up.
+    return this.spec?.containers ?? this.spec?.template?.spec?.containers;
   }
 
   get initContainers() {
@@ -146,13 +143,8 @@ export default class WorkloadService extends SteveModel {
       return initContainers;
     }
 
-    if (this.spec.initContainers) {
-      return this.spec.initContainers;
-    }
-
-    const { spec:{ template:{ spec:{ initContainers } } } } = this;
-
-    return initContainers;
+    // See `containers` above - a native Pod has no spec.template to fall back to.
+    return this.spec?.initContainers ?? this.spec?.template?.spec?.initContainers;
   }
 
   get workloadSelector() {

--- a/shell/utils/__tests__/create-yaml-collapse-empty.test.ts
+++ b/shell/utils/__tests__/create-yaml-collapse-empty.test.ts
@@ -27,25 +27,57 @@ describe('fx: isDeepEmpty', () => {
 describe('fx: createYaml collapseEmptyObjects', () => {
   // Mirrors the pod affinity shape: an object type whose sub-fields are arrays.
   const schemas = [
-    { id: 'test.pod', type: 'schema', resourceFields: { spec: { type: 'test.podSpec', create: true, update: true } } },
-    { id: 'test.podSpec', type: 'schema', resourceFields: { affinity: { type: 'test.affinity', create: true, update: true } } },
+    {
+      id:             'test.pod',
+      type:           'schema',
+      resourceFields: {
+        spec: {
+          type: 'test.podSpec', create: true, update: true
+        }
+      }
+    },
+    {
+      id:             'test.podSpec',
+      type:           'schema',
+      resourceFields: {
+        affinity: {
+          type: 'test.affinity', create: true, update: true
+        }
+      }
+    },
     {
       id:             'test.affinity',
       type:           'schema',
       resourceFields: {
-        podAffinity:     { type: 'test.podAffinity', create: true, update: true },
-        podAntiAffinity: { type: 'test.podAffinity', create: true, update: true },
+        podAffinity: {
+          type: 'test.podAffinity', create: true, update: true
+        },
+        podAntiAffinity: {
+          type: 'test.podAffinity', create: true, update: true
+        },
       }
     },
     {
       id:             'test.podAffinity',
       type:           'schema',
       resourceFields: {
-        requiredDuringSchedulingIgnoredDuringExecution:  { type: 'array[test.term]', create: true, update: true },
-        preferredDuringSchedulingIgnoredDuringExecution: { type: 'array[test.term]', create: true, update: true },
+        requiredDuringSchedulingIgnoredDuringExecution: {
+          type: 'array[test.term]', create: true, update: true
+        },
+        preferredDuringSchedulingIgnoredDuringExecution: {
+          type: 'array[test.term]', create: true, update: true
+        },
       }
     },
-    { id: 'test.term', type: 'schema', resourceFields: { topologyKey: { type: 'string', create: true, update: true } } },
+    {
+      id:             'test.term',
+      type:           'schema',
+      resourceFields: {
+        topologyKey: {
+          type: 'string', create: true, update: true
+        }
+      }
+    },
   ];
 
   const data = () => ({

--- a/shell/utils/__tests__/create-yaml-collapse-empty.test.ts
+++ b/shell/utils/__tests__/create-yaml-collapse-empty.test.ts
@@ -1,0 +1,90 @@
+import jsyaml from 'js-yaml';
+import { createYaml, createYamlWithOptions, isDeepEmpty } from '@shell/utils/create-yaml';
+
+describe('fx: isDeepEmpty', () => {
+  it.each([
+    [null, true],
+    [undefined, true],
+    ['', true],
+    [{}, true],
+    [[], true],
+    [{ a: null, b: undefined }, true],
+    [{ a: [], b: {} }, true],
+    [{ a: { b: { c: [] } } }, true],
+    [[[], {}, null], true],
+    [0, false],
+    [false, false],
+    ['x', false],
+    [{ a: 0 }, false],
+    [{ a: false }, false],
+    [{ a: { b: 'x' } }, false],
+    [[{ topologyKey: 'k' }], false],
+  ])('isDeepEmpty(%j) === %s', (val, expected) => {
+    expect(isDeepEmpty(val)).toBe(expected);
+  });
+});
+
+describe('fx: createYaml collapseEmptyObjects', () => {
+  // Mirrors the pod affinity shape: an object type whose sub-fields are arrays.
+  const schemas = [
+    { id: 'test.pod', type: 'schema', resourceFields: { spec: { type: 'test.podSpec', create: true, update: true } } },
+    { id: 'test.podSpec', type: 'schema', resourceFields: { affinity: { type: 'test.affinity', create: true, update: true } } },
+    {
+      id:             'test.affinity',
+      type:           'schema',
+      resourceFields: {
+        podAffinity:     { type: 'test.podAffinity', create: true, update: true },
+        podAntiAffinity: { type: 'test.podAffinity', create: true, update: true },
+      }
+    },
+    {
+      id:             'test.podAffinity',
+      type:           'schema',
+      resourceFields: {
+        requiredDuringSchedulingIgnoredDuringExecution:  { type: 'array[test.term]', create: true, update: true },
+        preferredDuringSchedulingIgnoredDuringExecution: { type: 'array[test.term]', create: true, update: true },
+      }
+    },
+    { id: 'test.term', type: 'schema', resourceFields: { topologyKey: { type: 'string', create: true, update: true } } },
+  ];
+
+  const data = () => ({
+    type: 'test.pod',
+    spec: {
+      affinity: {
+        podAffinity: {
+          requiredDuringSchedulingIgnoredDuringExecution:  [{ topologyKey: 'test/test' }],
+          preferredDuringSchedulingIgnoredDuringExecution: [],
+        },
+        // Deep-empty: the exact shape the PodAffinity form seeds when unused
+        podAntiAffinity: {
+          requiredDuringSchedulingIgnoredDuringExecution:  [],
+          preferredDuringSchedulingIgnoredDuringExecution: [],
+        },
+      }
+    }
+  });
+
+  it('without the flag, an empty podAntiAffinity serialises to an inconsistent null-children object', () => {
+    const yaml = createYaml(schemas as any, 'test.pod', data());
+    const parsed: any = jsyaml.load(yaml);
+
+    // The undesired representation: not a clean {}, but expanded null children
+    expect(parsed.spec.affinity.podAntiAffinity).not.toStrictEqual({});
+    expect(parsed.spec.affinity.podAntiAffinity).toStrictEqual({
+      requiredDuringSchedulingIgnoredDuringExecution:  null,
+      preferredDuringSchedulingIgnoredDuringExecution: null,
+    });
+    // real data is preserved
+    expect(parsed.spec.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey).toBe('test/test');
+  });
+
+  it('with collapseEmptyObjects, an empty podAntiAffinity renders as {}', () => {
+    const yaml = createYamlWithOptions(schemas as any, 'test.pod', data(), { collapseEmptyObjects: true });
+    const parsed: any = jsyaml.load(yaml);
+
+    expect(parsed.spec.affinity.podAntiAffinity).toStrictEqual({});
+    // objects that actually have content are still rendered in full
+    expect(parsed.spec.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey).toBe('test/test');
+  });
+});

--- a/shell/utils/create-yaml.js
+++ b/shell/utils/create-yaml.js
@@ -70,6 +70,27 @@ export const ACTIVELY_REMOVE = [
 
 const INDENT = 2;
 
+/**
+ * True when a value holds no meaningful data: null/undefined/'', an array whose
+ * items are all empty, or an object whose values are all empty (recursively).
+ * `0` and `false` count as meaningful.
+ */
+export function isDeepEmpty(val) {
+  if (val === null || val === undefined || val === '') {
+    return true;
+  }
+
+  if (Array.isArray(val)) {
+    return val.every(isDeepEmpty);
+  }
+
+  if (typeof val === 'object') {
+    return Object.values(val).every(isDeepEmpty);
+  }
+
+  return false;
+}
+
 export function createYamlWithOptions(schemas, type, data, options, commentFieldsOptions) {
   return createYaml(
     schemas,
@@ -404,6 +425,17 @@ export function createYaml(
 
     if ( subDef ) {
       let chunk;
+
+      // When the caller opts in, a defined-but-empty object (e.g. an affinity
+      // block the form seeded as `{ requiredDuring...: [], preferredDuring...: [] }`)
+      // is rendered as `{}` instead of recursing into commented placeholders -
+      // which would otherwise leave a valueless key that parses back to `null`.
+      // Keeps the same data serialising consistently (see annotations/resources).
+      if (dataOptions?.collapseEmptyObjects && data[key] && typeof data[key] === 'object' && !Array.isArray(data[key]) && isDeepEmpty(data[key])) {
+        out += ' {}';
+
+        return out;
+      }
 
       if (subDef?.resourceFields && !isEmpty(subDef?.resourceFields)) {
         chunk = createYaml(schemas, type, data[key], processAlwaysAdd, depth + 1, (path ? `${ path }.${ key }` : key), rootType, dataOptions, commentFieldsOptions);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #10171 
Fixes #18238 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- When creating a pod and clicking Edit with Yaml it generates a wrong Yaml that is based on the Workload

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- There were 2 ways of fixing this.
- We could fix the model, which would be the correct fix. But that would affect other areas, including the process on the FORM mode. Which could cause quite a good amount of regression. I tried and already faced problem with the EDIT.
- The second fix is just fixing the flattening of the data and make sure the spec is added to the correct place for Pod cases.

- First I am applying the first fix fixing the model. It needs to fix the https://github.com/rancher/dashboard/issues/18238 as well. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- POD EDIT/CREATE
- POD YAML EDIT/CREATE
- POD EDIT -> YAML
- POD CREATE -> YAML

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- Other Workload flows

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Comments
- Maybe could be interesting to implement the **second fix** which is less destructive, it only fixes the conversion of the EDIT CONFIG -> EDIT YAML making sure it just flatten from template.spec to spec. But if we are ok with the first fix, that would be preferential

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
