### PR TITLE
switch from kubernetesIngressNginx to kubernetesIngressNGINX with traefik >= v40

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/Ingress.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/Ingress.test.ts
@@ -8,6 +8,30 @@ jest.mock('vuex', () => ({
   mapGetters: () => ({ t: (key: string) => key })
 }));
 
+jest.mock('@components/Banner', () => ({
+  Banner: {
+    name:     'Banner',
+    template: '<div class="banner-stub"></div>',
+    props:    ['color', 'labelKey']
+  }
+}));
+
+jest.mock('@shell/components/YamlEditor', () => {
+  const EDITOR_MODES = { VIEW_CODE: 'VIEW_CODE', EDIT_CODE: 'EDIT_CODE' };
+  const YamlEditor = {
+    name:     'YamlEditor',
+    template: '<div class="yaml-editor-stub"></div>',
+    props:    ['value', 'mode', 'scrolling', 'asObject', 'editorMode', 'hidePreviewButtons'],
+    methods:  { updateValue: jest.fn() }
+  };
+
+  YamlEditor.EDITOR_MODES = EDITOR_MODES;
+
+  return {
+    __esModule: true, default: YamlEditor, EDITOR_MODES
+  };
+});
+
 jest.mock('@shell/edit/provisioning.cattle.io.cluster/shared', () => ({
 
   INGRESS_NGINX:   'ingress-nginx',
@@ -63,10 +87,8 @@ describe('ingress.vue', () => {
     global: {
       stubs: {
         Checkbox:             true,
-        Banner:               true,
         IngressCards:         true,
         IngressConfiguration: true,
-        YamlEditor:           true,
         RichTranslation:      true
       }
     }
@@ -172,5 +194,146 @@ describe('ingress.vue', () => {
     const yamlEditor = wrapper.find('[data-testid="traefik-yaml-editor"]');
 
     expect(yamlEditor.exists()).toBe(true);
+  });
+
+  describe('traefikNginxKey', () => {
+    it('uses kubernetesIngressNginx when traefik chart version is below 40.0.0', () => {
+      const wrapper = createWrapper({
+        value:       TRAEFIK,
+        versionInfo: {
+          'rancher-ingress-nginx': { values: {} },
+          traefik:                 { chart: { version: '34.2.002' }, values: { providers: {} } }
+        }
+      });
+      const ingressCards = wrapper.findComponent({ name: 'IngressCards' });
+
+      ingressCards.vm.$emit('select', INGRESS_DUAL);
+
+      const emitted = wrapper.emitted('update-values');
+
+      expect(emitted).toBeTruthy();
+      const traefikValues = emitted?.find((e: any) => e[0] === 'traefik')?.[1] as any;
+
+      expect(traefikValues?.providers?.kubernetesIngressNginx).toBeDefined();
+      expect(traefikValues?.providers?.kubernetesIngressNGINX).toBeUndefined();
+    });
+
+    it('uses kubernetesIngressNGINX when traefik chart version is 40.0.0 or above', () => {
+      const wrapper = createWrapper({
+        value:       TRAEFIK,
+        versionInfo: {
+          'rancher-ingress-nginx': { values: {} },
+          traefik:                 { chart: { version: '40.1.003' }, values: { providers: {} } }
+        }
+      });
+      const ingressCards = wrapper.findComponent({ name: 'IngressCards' });
+
+      ingressCards.vm.$emit('select', INGRESS_DUAL);
+
+      const emitted = wrapper.emitted('update-values');
+
+      expect(emitted).toBeTruthy();
+      const traefikValues = emitted?.find((e: any) => e[0] === 'traefik')?.[1] as any;
+
+      expect(traefikValues?.providers?.kubernetesIngressNGINX).toBeDefined();
+      expect(traefikValues?.providers?.kubernetesIngressNginx).toBeUndefined();
+    });
+
+    it('defaults to kubernetesIngressNGINX when no chart version is available', () => {
+      const wrapper = createWrapper({
+        value:       TRAEFIK,
+        versionInfo: {
+          'rancher-ingress-nginx': { values: {} },
+          traefik:                 { values: { providers: {} } }
+        }
+      });
+      const ingressCards = wrapper.findComponent({ name: 'IngressCards' });
+
+      ingressCards.vm.$emit('select', INGRESS_DUAL);
+
+      const emitted = wrapper.emitted('update-values');
+
+      expect(emitted).toBeTruthy();
+      const traefikValues = emitted?.find((e: any) => e[0] === 'traefik')?.[1] as any;
+
+      expect(traefikValues?.providers?.kubernetesIngressNGINX).toBeDefined();
+      expect(traefikValues?.providers?.kubernetesIngressNginx).toBeUndefined();
+    });
+
+    it('migrates values from kubernetesIngressNginx to kubernetesIngressNGINX when version changes from below v40 to above v40', async() => {
+      const wrapper = createWrapper({
+        value:           TRAEFIK,
+        userChartValues: { traefik: { providers: { kubernetesIngressNginx: { enabled: true, ingressClass: 'test' } } } },
+        versionInfo:     {
+          'rancher-ingress-nginx': { values: {} },
+          traefik:                 { chart: { version: '34.2.002' }, values: { providers: { kubernetesIngressNginx: { enabled: true, ingressClass: 'test' } } } }
+        }
+      });
+
+      // Now update versionInfo to a version >= 40.0.0
+      await wrapper.setProps({
+        versionInfo: {
+          'rancher-ingress-nginx': { values: {} },
+          traefik:                 { chart: { version: '40.1.003' }, values: { providers: {} } }
+        }
+      });
+
+      // Watcher migrates key and emits because userChartValues had saved values under the old key
+      const emitted = wrapper.emitted('update-values') as any[];
+      const lastEmit = emitted[emitted.length - 1];
+
+      expect(lastEmit[0]).toBe('traefik');
+      expect(lastEmit[1]?.providers?.kubernetesIngressNGINX).toBeDefined();
+      expect(lastEmit[1]?.providers?.kubernetesIngressNginx).toBeUndefined();
+    });
+
+    it('migrates values from kubernetesIngressNGINX to kubernetesIngressNginx when version changes from above v40 to below v40', async() => {
+      const wrapper = createWrapper({
+        value:           TRAEFIK,
+        userChartValues: { traefik: { providers: { kubernetesIngressNGINX: { enabled: true, ingressClass: 'test' } } } },
+        versionInfo:     {
+          'rancher-ingress-nginx': { values: {} },
+          traefik:                 { chart: { version: '40.1.003' }, values: { providers: { kubernetesIngressNGINX: { enabled: true, ingressClass: 'test' } } } }
+        }
+      });
+
+      // Now update versionInfo to a version < 40.0.0
+      await wrapper.setProps({
+        versionInfo: {
+          'rancher-ingress-nginx': { values: {} },
+          traefik:                 { chart: { version: '34.2.002' }, values: { providers: {} } }
+        }
+      });
+
+      // Watcher migrates key and emits because userChartValues had saved values under the old key
+      const emitted = wrapper.emitted('update-values') as any[];
+      const lastEmit = emitted[emitted.length - 1];
+
+      expect(lastEmit[0]).toBe('traefik');
+      expect(lastEmit[1]?.providers?.kubernetesIngressNginx).toBeDefined();
+      expect(lastEmit[1]?.providers?.kubernetesIngressNGINX).toBeUndefined();
+    });
+
+    it('does not emit update-values when version changes but no saved user values exist under the old key', async() => {
+      const wrapper = createWrapper({
+        value:       TRAEFIK,
+        versionInfo: {
+          'rancher-ingress-nginx': { values: {} },
+          traefik:                 { chart: { version: '40.1.003' }, values: { providers: {} } }
+        }
+      });
+
+      // Switch to older version - no userChartValues saved, so watcher should NOT emit
+      await wrapper.setProps({
+        versionInfo: {
+          'rancher-ingress-nginx': { values: {} },
+          traefik:                 { chart: { version: '34.2.002' }, values: { providers: {} } }
+        }
+      });
+
+      const emitted = wrapper.emitted('update-values');
+
+      expect(emitted).toBeFalsy();
+    });
   });
 });

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/Ingress.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/Ingress.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { _CREATE, _VIEW, _EDIT } from '@shell/config/query-params';
-import { ref, computed, useTemplateRef } from 'vue';
+import { ref, computed, useTemplateRef, watch } from 'vue';
 import { useStore } from 'vuex';
+import semver from 'semver';
 import { useI18n } from '@shell/composables/useI18n';
 import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 import { Banner } from '@components/Banner';
@@ -51,6 +52,42 @@ const showTraefikBanner = ref<Boolean>(false);
 const traefikMerged = ref(initYamlEditor(traefikChart));
 const nginxMerged = ref(initYamlEditor(nginxChart));
 const showConfig = computed(() => !!versionInfo[traefikChart] || !!versionInfo[nginxChart]);
+
+// in traefik v40 the nginx key changed from kubernetesIngressNginx to kubernetesIngressNGINX
+const traefikNginxKey = computed(() => {
+  const chartVersion = versionInfo[traefikChart]?.chart?.version;
+
+  // regex: replace zeros that follow . and precede digits with just the .<digit> eg 32.1.002 -> 32.1.2
+  // semver coerce will return null if version has leading zeros
+  const cleaned = chartVersion?.replace(/\.0+(\d)/g, '.$1');
+  const coerced = cleaned ? semver.coerce(cleaned) : null;
+
+  if (coerced && semver.lt(coerced, '40.0.0')) {
+    return 'kubernetesIngressNginx';
+  }
+
+  return 'kubernetesIngressNGINX';
+});
+
+watch(traefikNginxKey, (newKey, oldKey) => {
+  if (oldKey && newKey !== oldKey) {
+    const oldValues = get(traefikMerged.value, `providers.${ oldKey }`);
+
+    if (oldValues) {
+      set(traefikMerged.value, `providers.${ newKey }`, oldValues);
+      delete (traefikMerged.value as any)?.providers?.[oldKey];
+
+      // Only emit if the user had previously saved values under the old key
+      // this will cover the scenario where a user is using 'dual mode' then upgrades k8s version to one that uses a newer traefik version
+      const savedOldValues = get(userChartValues[traefikChart], `providers.${ oldKey }`);
+
+      if (savedOldValues) {
+        emit('update-values', traefikChart, traefikMerged.value);
+        updateYaml(traefikYaml.value, traefikMerged.value);
+      }
+    }
+  }
+});
 
 const ingressSelection = computed(() => {
   if (Array.isArray(value) ) {
@@ -110,13 +147,15 @@ function initYamlEditor(chart: string) {
 }
 
 function setCompatibilityModeValues(val: boolean) {
-  set(traefikMerged.value, 'providers.kubernetesIngressNginx.enabled', val);
+  const key = traefikNginxKey.value;
+
+  set(traefikMerged.value, `providers.${ key }.enabled`, val);
   if (!val) {
-    set(traefikMerged.value, 'providers.kubernetesIngressNginx.ingressClass', INGRESS_CLASS_DEFAULT);
-    set(traefikMerged.value, 'providers.kubernetesIngressNginx.controllerClass', INGRESS_CONTROLLER_CLASS_DEFAULT);
+    set(traefikMerged.value, `providers.${ key }.ingressClass`, INGRESS_CLASS_DEFAULT);
+    set(traefikMerged.value, `providers.${ key }.controllerClass`, INGRESS_CONTROLLER_CLASS_DEFAULT);
   } else {
-    set(traefikMerged.value, 'providers.kubernetesIngressNginx.ingressClass', INGRESS_CLASS_MIGRATION);
-    set(traefikMerged.value, 'providers.kubernetesIngressNginx.controllerClass', INGRESS_CONTROLLER_CLASS_MIGRATION);
+    set(traefikMerged.value, `providers.${ key }.ingressClass`, INGRESS_CLASS_MIGRATION);
+    set(traefikMerged.value, `providers.${ key }.controllerClass`, INGRESS_CONTROLLER_CLASS_MIGRATION);
   }
 }
 
@@ -170,7 +209,7 @@ const traefikHttps = computed({
 
 const compatibilityMode = computed({
   get() {
-    return get(traefikMerged.value, 'providers.kubernetesIngressNginx.enabled');
+    return get(traefikMerged.value, `providers.${ traefikNginxKey.value }.enabled`);
   },
   set(val: boolean) {
     setCompatibilityModeValues(val);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18248 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR updates the RKE2 Ingress component to use a different key for ingress nginx configuration ('dual mode') depending on the traefik version in use. The traefik version is determined by reading kdm info

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
#### Old traefik versions
1. Open the form to create a new rke2 cluster (any node driver)
2. Use the 'show deprecated versions' checkbox to show more rke2 version options. Pick **v1.34.1+rke2r1** (this will use an older traefik version with the old key)
3. Fill in required fields, click save
4. Check the network request to create the provisioning cluster object: `rke2Config.chartValues.rke-traefik` should be an empty object
5. Once the cluster is running, edit and click the 'Dual Mode' card. Click save
6. Check the network request to update the provisioning cluster object: `rke2Config.chartValues.rke-traefik.providers.kubernetesIngressNginx` should be defined. `rke2Config.chartValues.rke-traefik.providers.kubernetesIngressNGINX` should not be defined.

#### Upgrading traefik versions
1. Edit the cluster from the previous section and select a new rke2 version. Click save
2. Check the network request to update the provisioning cluster object: `rke2Config.chartValues.rke-traefik.providers.kubernetesIngressNGINX` should be defined. `rke2Config.chartValues.rke-traefik.providers.kubernetesIngressNginx` should not be defined

#### Provisioning with newer Traefik versions
1. Open the form to create a new rke2 cluster (any node driver)
2. Stick with the latest rke2 version (this will use a newer traefik version with the new key)
3. Fill in required fields, click save
4. Check the network request to create the provisioning cluster object: `rke2Config.chartValues.rke-traefik` should be an empty object
5. Once the cluster is running, edit and click the 'Dual Mode' card. Click save
6. Check the network request to update the provisioning cluster object: `rke2Config.chartValues.rke-traefik.providers.kubernetesIngressNGINX` should be defined. `rke2Config.chartValues.rke-traefik.providers.kubernetesIngressNginx` should not be defined.

### Areas which could experience regressions
Testing behavior described above should be sufficient: these changes are fairly self-contained

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
