### PR TITLE
[Backport v2.14.4] - Make projectmonitor show configuration view read-only

### DIFF
--- a/shell/components/Questions/index.vue
+++ b/shell/components/Questions/index.vue
@@ -474,6 +474,7 @@ export default {
             :value="get(value, q.variable)"
             :disabled="disabled"
             :chart-name="chartName"
+            :mode="mode"
             @update:value="update(q.variable, $event)"
           />
         </div>

--- a/shell/edit/helm.cattle.io.projecthelmchart.vue
+++ b/shell/edit/helm.cattle.io.projecthelmchart.vue
@@ -150,6 +150,7 @@ export default {
             tabbed="multiple"
             :target-namespace="value.metadata.namespace"
             :source="selectedNamespaceQuestions"
+            :mode="mode"
           />
         </Tabbed>
       </div>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18166 
<!-- Define findings related to the feature or bug issue. -->

Manual backport of PR: https://github.com/rancher/dashboard/pull/18078

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

The Projectmonitor edit page is reused inside the `Show Configuration` drawer to display configuration values.
This intended to be a read-only view, but the view mode was not passed down to the nested Questions components...Because of this, the form fields were rendered as editable inputs instead of read-only...

Passing `mode` through the Questions component it ensures all question types honor VIEW mode and render read-only...

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

<img width="1714" height="1118" alt="image" src="https://github.com/user-attachments/assets/eb8c1633-1d55-4bbd-ba82-72525936df52" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
