### PR TITLE
pin rancher version

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -9,7 +9,7 @@
         "rancher-image": {
           "namespace": "rancher",
           "name": "rancher",
-          "tag": "head"
+          "tag": "v2.15-af21cbeebe186a83e1c339357f91a640e7c655eb-head"
         },
         "rancher-agent": {
           "namespace": "rancher",

--- a/scripts/e2e-docker-start
+++ b/scripts/e2e-docker-start
@@ -7,6 +7,9 @@ DIR=$(cd $(dirname $0)/..; pwd)
 DASHBOARD_DIST=${DIR}/dist
 EMBER_DIST=${DIR}/dist_ember
 
+
+USE_LOCAL_BRANCH_METADATA=true # use an updated branch-metadata with pinned dashboard version
+
 # Container Image Defaults
 RANCHER_IMG_TAG=head
 RANCHER_IMG_REGISTRY=
@@ -27,8 +30,12 @@ if [ $# -eq 1 ]; then
   # When an image is specified, we use that image, including its front-end, so we don't want the volume args to mount the locally-built UI
   VOLUME_ARGS=""
 else
-  # Get container image from branch-metadata
-  BRANCH_DATA=$(./scripts/get-branch-metadata.sh ${GITHUB_BASE_REF:-${GITHUB_REF_NAME}})
+  # Get container image from branch-metadata. when testing locally update to pass in your target branch
+  if [ "$USE_LOCAL_BRANCH_METADATA" = "true" ]; then
+    BRANCH_DATA=$(./scripts/get-branch-metadata.sh --local ${GITHUB_BASE_REF:-${GITHUB_REF_NAME}})
+  else
+    BRANCH_DATA=$(./scripts/get-branch-metadata.sh ${GITHUB_BASE_REF:-${GITHUB_REF_NAME}})
+  fi
 
   if [ -n "$BRANCH_DATA" ]; then
     REGISTRY=$(echo "$BRANCH_DATA" | jq -r '.e2e["rancher-image"].registry // ""')


### PR DESCRIPTION
e2e tests related to fleet are consistently failing; 6 suites in total. See https://github.com/rancher/dashboard/actions/runs/28613557807/job/84882779245?pr=18257 for an example. These failures started sometime this morning; the last successful run appears to be using 2.15-af21cbeebe186a83e1c339357f91a640e7c655eb-head.

This PR pins the rancher version our tests use to the version used in the most recent runs that didn't have these fleet-related failures.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
