### PR TITLE
[16905] Add additional configurations for color to be used, added secondary based on primary and added the other status as well

### DIFF
--- a/shell/utils/__tests__/color.test.ts
+++ b/shell/utils/__tests__/color.test.ts
@@ -191,9 +191,64 @@ describe('shell/utils/color', () => {
         '--primary-banner-bg',
         '--primary-light-bg',
         '--primary-keyboard-focus',
+        '--active',
+        '--active-nav',
+        '--active-hover',
+        '--on-active',
+        '--category-active',
+        '--non-primary-hover',
+        '--secondary-border',
+        '--on-secondary',
       ];
 
       expect(Object.keys(vars)).toStrictEqual(expectedKeys);
+    });
+
+    // Regression test for https://github.com/rancher/dashboard/issues/16905
+    // The side-nav / top-nav in the modern theme are painted with these vars, which don't
+    // derive from --primary, so a custom branding color must override them too.
+    it('overrides the modern-theme nav/active vars with the custom primary color', () => {
+      const vars = createCssVars('#4a90d9', 'light', 'primary');
+
+      expect(vars['--active']).toStrictEqual('#4a90d9');
+      expect(vars['--active-nav']).toStrictEqual('#4a90d9');
+      expect(vars['--active-hover']).toBeDefined();
+      expect(vars['--on-active']).toBeDefined();
+      expect(vars['--category-active']).toContain('rgba');
+      expect(vars['--non-primary-hover']).toContain('rgba');
+      expect(vars['--secondary-border']).toStrictEqual('#4a90d9');
+      expect(vars['--on-secondary']).toStrictEqual('#4a90d9');
+    });
+
+    it('does not emit primary-only nav/active vars for the link name', () => {
+      const vars = createCssVars('#4a90d9', 'light', 'link');
+
+      expect(vars).not.toHaveProperty('--active');
+      expect(vars).not.toHaveProperty('--active-nav');
+      expect(vars).not.toHaveProperty('--category-active');
+      expect(vars).not.toHaveProperty('--non-primary-hover');
+      expect(vars).not.toHaveProperty('--secondary-border');
+      expect(vars).not.toHaveProperty('--on-secondary');
+    });
+
+    // Regression test for https://github.com/rancher/dashboard/issues/16905
+    // The Prime (.suse) theme decouples the tertiary family from --link and hardcodes it green,
+    // so a custom link color must override the tertiary vars to reach the nav icons on Prime.
+    it('overrides the tertiary family with the custom link color for the link name', () => {
+      const vars = createCssVars('#bda400', 'light', 'link');
+
+      expect(vars['--on-tertiary']).toStrictEqual('#bda400');
+      expect(vars['--on-tertiary-hover']).toStrictEqual('#bda400');
+      expect(vars['--on-tertiary-header']).toStrictEqual('#bda400');
+      expect(vars['--on-tertiary-header-hover']).toStrictEqual('#bda400');
+      expect(vars['--tertiary-hover-app-bar']).toStrictEqual('#bda400');
+    });
+
+    it('does not emit tertiary vars for the primary name', () => {
+      const vars = createCssVars('#4a90d9', 'light', 'primary');
+
+      expect(vars).not.toHaveProperty('--on-tertiary');
+      expect(vars).not.toHaveProperty('--tertiary-hover-app-bar');
     });
 
     it('sets --primary to the input color', () => {

--- a/shell/utils/color.js
+++ b/shell/utils/color.js
@@ -18,7 +18,7 @@ import Color from 'color';
 export function createCssVars(color, theme = 'light', name = 'primary') {
   const contrastOpts = theme === 'light' ? LIGHT_CONTRAST_COLORS : DARK_CONTRAST_COLORS;
 
-  return {
+  const vars = {
     [`--${ name }`]:                color,
     [`--${ name }-text `]:          contrastColor(color, contrastOpts),
     [`--${ name }-hover-bg`]:       lighten(color, -10),
@@ -29,6 +29,45 @@ export function createCssVars(color, theme = 'light', name = 'primary') {
     [`--${ name }-light-bg`]:       opacity(color, 0.05),
     [`--${ name }-keyboard-focus`]: lighten(color, -10),
   };
+
+  // The "modern" theme (introduced in 2.13) paints the side-nav active item, the expanded
+  // category background and the header/nav hovers using a separate set of variables that are
+  // baked to build-time shades of the default primary color ($primary-*). Those don't derive
+  // from `--primary`, so overriding only the `--primary-*` vars above left the nav showing the
+  // default (prime) color. Derive them from the custom color so branding applies everywhere.
+  // See https://github.com/rancher/dashboard/issues/16905
+  if (name === 'primary') {
+    Object.assign(vars, {
+      '--active':            color,
+      '--active-nav':        color,
+      '--active-hover':      lighten(color, -10),
+      '--on-active':         contrastColor(color, contrastOpts),
+      '--category-active':   opacity(color, 0.15),
+      '--non-primary-hover': opacity(color, 0.1),
+      // Secondary (outlined/ghost) buttons draw their border and text from these, which the
+      // modern theme also bakes to a shade of the default primary color.
+      '--secondary-border':  color,
+      '--on-secondary':      color,
+    });
+  }
+
+  // In the base modern theme the tertiary family (side/top-nav icons, tertiary/ghost button
+  // text) is defined as `var(--link)`, so a custom link color already reaches it. The Prime
+  // (.suse) theme instead re-points these at its own hardcoded green (--non-primary-text),
+  // decoupling them from --link — so a custom link color never reached the nav icons on Prime.
+  // Re-tie them to the custom link color, restoring the base-theme behaviour.
+  // See https://github.com/rancher/dashboard/issues/16905
+  if (name === 'link') {
+    Object.assign(vars, {
+      '--on-tertiary':              color,
+      '--on-tertiary-hover':        color,
+      '--on-tertiary-header':       color,
+      '--on-tertiary-header-hover': color,
+      '--tertiary-hover-app-bar':   color,
+    });
+  }
+
+  return vars;
 }
 
 // scss 'lighten(color, percent)' increases color's hsl lightness by percent amount, not scaled


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16905
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- There are 2 problems 2 problems that I found, the colors for primary were not being passed to values that uses the primary relatively like the secondary and other ones.
- For prime there are specific cases where the link color was not being passed as well.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- Added additional overrides for the color to respect those changes.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Colors for the LINK/BRANDING Color on Community Version
- Colors for the LINK/BRANDING color on Prime Version

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- There are problems with the original colors for Community Version and Prime

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1654" height="1255" alt="image" src="https://github.com/user-attachments/assets/549e08ce-9862-45b4-b812-1398813764ec" />
Example of a prime version with RED branding and a YELLOWISH link

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
