### PR TITLE
Add support for middle-click paste and copy from xterm

### DIFF
--- a/shell/components/Window/ContainerShell.vue
+++ b/shell/components/Window/ContainerShell.vue
@@ -13,6 +13,7 @@ import Socket, {
   //  EVENT_FRAME_TIMEOUT,
   EVENT_CONNECT_ERROR,
 } from '@shell/utils/socket';
+import { readTextFromClipboard } from '@shell/utils/clipboard';
 import Window from './Window';
 import dayjs from 'dayjs';
 
@@ -24,6 +25,9 @@ const commands = {
   ],
   windows: ['cmd']
 };
+
+// Button number for the middle button with a mousedown event
+const MIDDLE_BUTTON = 1;
 
 export default {
   components: { Window, Select },
@@ -157,6 +161,9 @@ export default {
     this.$refs?.containerShell?.$el?.removeEventListener('focusin', this.focusInHandler);
     this.$refs?.xterm.removeEventListener('focusout', this.focusOutHandler);
 
+    document.removeEventListener('mousedown', this.handleMouseDown);
+    document.removeEventListener('copy', this.handleCopyEvent);
+
     clearInterval(this.keepAliveTimer);
     this.cleanup();
   },
@@ -165,6 +172,8 @@ export default {
     document.addEventListener('keyup', this.handleKeyPress);
     this.$refs?.containerShell?.$el?.addEventListener('focusin', this.focusInHandler);
     this.$refs?.xterm.addEventListener('focusout', this.focusOutHandler);
+    document.addEventListener('mousedown', this.handleMouseDown);
+    document.addEventListener('copy', this.handleCopyEvent);
 
     const nodeId = this.pod.spec?.nodeName;
 
@@ -199,6 +208,20 @@ export default {
       this.currFocusedElem = undefined;
     },
 
+    handleMouseDown(ev) {
+      // Paste from clipboard on middle click if the xterm is focused. This is a common behavior in Linux terminals.
+      if (this.isXtermFocused && ev.button === MIDDLE_BUTTON) {
+        ev.preventDefault();
+        ev.stopPropagation();
+
+        readTextFromClipboard().then((text) => {
+          if (text) {
+            this.terminal.paste(text);
+          }
+        });
+      }
+    },
+
     handleKeyPress(ev) {
       ev.preventDefault();
       ev.stopPropagation();
@@ -213,6 +236,17 @@ export default {
       // if parent container is focused and we press a trigger, focus goes to the shell inside
       if (this.isXtermContainerFocused && (ev.code === 'Enter' || ev.code === 'Space')) {
         this.terminal?.textarea?.focus();
+      }
+    },
+
+    // Copy the selected text from the terminal to the clipboard when the user uses the browser copy
+    handleCopyEvent(ev) {
+      if (this.isXtermFocused && this.terminal?.hasSelection()) {
+        const txt = this.terminal.getSelection();
+
+        ev.clipboardData.setData('text/plain', txt);
+        ev.preventDefault();
+        ev.stopPropagation();
       }
     },
 

--- a/shell/components/Window/__tests__/ContainerShell.test.ts
+++ b/shell/components/Window/__tests__/ContainerShell.test.ts
@@ -5,6 +5,7 @@ import Socket, {
 } from '@shell/utils/socket';
 import Window from '@shell/components/Window/Window.vue';
 
+jest.mock('clipboard-polyfill', () => ({ writeText: jest.fn() }));
 jest.mock('@shell/utils/socket');
 jest.mock('@shell/utils/crypto', () => {
   const originalModule = jest.requireActual('@shell/utils/crypto');

--- a/shell/utils/clipboard.js
+++ b/shell/utils/clipboard.js
@@ -3,3 +3,7 @@ import * as Clipboard from 'clipboard-polyfill';
 export async function copyTextToClipboard(text) {
   await Clipboard.writeText(text);
 }
+
+export async function readTextFromClipboard() {
+  return await Clipboard.readText();
+}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17091

### Occurred changes and/or fixed issues

Added handler for middle button and also handler for the 'copy' event.

User can now middle-click in the container shell to paste the clipboard text in there. Also, they can select text in the shell window and use the browser 'Copy' from the right-click menu to copy this to the clipboard.

### Areas or cases that should be tested

Check copy and paste as described above.

### Screenshot/Video

N/A

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
