### PR TITLE
Add size prop to LabeledSelect for medium (32px) variant (#18296)

### DIFF
--- a/shell/assets/styles/base/_variables.scss
+++ b/shell/assets/styles/base/_variables.scss
@@ -10,6 +10,8 @@ $unlabeled-input-height: 40px;
 $unlabaled-select-padding: 3px 0;
 $footer-height: 60px;
 
+$labeled-select-height-medium: 32px;
+
 $resource-detail-min-width: 740px;
 
 $input-padding-lg: 18px;

--- a/shell/components/fleet/__tests__/__snapshots__/AppCoVersionSelect.test.ts.snap
+++ b/shell/components/fleet/__tests__/__snapshots__/AppCoVersionSelect.test.ts.snap
@@ -25,6 +25,7 @@ exports[`component: AppCoVersionSelect should match snapshot 1`] = `
   rules=""
   searchable="true"
   selectable="[Function]"
+  size="large"
   value="1.2.0"
 />
 `;

--- a/shell/components/fleet/__tests__/__snapshots__/ClusterSelectionFields.test.ts.snap
+++ b/shell/components/fleet/__tests__/__snapshots__/ClusterSelectionFields.test.ts.snap
@@ -35,6 +35,7 @@ exports[`component: ClusterSelectionFields should match snapshot with appco vari
       rules=""
       searchable="false"
       selectable="[Function]"
+      size="large"
       taggable="true"
       value="cluster-1"
     />
@@ -98,6 +99,7 @@ exports[`component: ClusterSelectionFields should match snapshot with appco vari
       rules=""
       searchable="false"
       selectable="[Function]"
+      size="large"
       taggable="true"
       value=""
     />
@@ -138,6 +140,7 @@ exports[`component: ClusterSelectionFields should match snapshot with default va
       rules=""
       searchable="false"
       selectable="[Function]"
+      size="large"
       taggable="true"
       value="cluster-1"
     />
@@ -201,6 +204,7 @@ exports[`component: ClusterSelectionFields should match snapshot with default va
       rules=""
       searchable="false"
       selectable="[Function]"
+      size="large"
       taggable="true"
       value=""
     />

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -121,6 +121,11 @@ export default {
       type:    Array,
       default: () => []
     },
+    size: {
+      type:      String,
+      default:   'large',
+      validator: (value) => ['small', 'medium', 'large'].includes(value)
+    },
 
     name: {
       type:    String,
@@ -417,7 +422,8 @@ export default {
         taggable: $attrs.multiple,
         hoverable: hoverTooltip,
         'compact-input': isCompact,
-        'no-label': !hasLabel
+        'no-label': !hasLabel,
+        [`ls-${size}`]: true
       }
     ]"
     :tabindex="isView || disabled ? -1 : 0"
@@ -633,6 +639,48 @@ export default {
 
     :deep() .vs__actions:after {
       top: 0;
+    }
+  }
+
+  &.no-label.ls-medium {
+    height: $labeled-select-height-medium;
+    padding: 0;
+
+    .labeled-container {
+      height: 0;
+      padding: 0;
+      overflow: hidden;
+    }
+
+    :deep(.vs__dropdown-toggle) {
+      height: 100%;
+      box-sizing: border-box;
+      border: none;
+      padding: 0 $input-padding-sm;
+      align-items: center;
+    }
+
+    :deep(.vs__actions) {
+      &:after {
+        // reset large-mode sizing hacks (height, padding-top, top:-10px) so flexbox centers the icon
+        height: auto;
+        padding-top: 0;
+        line-height: 1;
+        top: 0;
+      }
+    }
+
+    :deep(.vs__selected-options) {
+      margin-top: 0; // reset global -5px
+    }
+
+    :deep(.vs__selected) {
+      margin-top: 0;
+      margin-left: 0;
+    }
+
+    :deep(.vs__search) {
+      margin-left: 0; // prevent text shift on open
     }
   }
 

--- a/shell/components/form/__tests__/LabeledSelect.test.ts
+++ b/shell/components/form/__tests__/LabeledSelect.test.ts
@@ -292,6 +292,29 @@ describe('component: LabeledSelect', () => {
     expect(spyPreventDefault).not.toHaveBeenCalled();
   });
 
+  describe('size prop', () => {
+    it.each([
+      ['small'],
+      ['medium'],
+      ['large'],
+    ])('should apply ls-%s class to root element when size is "%s"', (size) => {
+      const wrapper = mount(LabeledSelect, {
+        props: {
+          options: ['Option1'],
+          size,
+        }
+      });
+
+      expect(wrapper.find('.labeled-select').classes()).toContain(`ls-${ size }`);
+    });
+
+    it('should default to ls-large class when no size prop is provided', () => {
+      const wrapper = mount(LabeledSelect, { props: { options: ['Option1'] } });
+
+      expect(wrapper.find('.labeled-select').classes()).toContain('ls-large');
+    });
+  });
+
   describe('function: clickSelect', () => {
     it('should open dropdown when clickSelect is called and not disabled', async() => {
       const label = 'Foo';

--- a/shell/edit/auditlog.cattle.io.auditpolicy/__tests__/__snapshots__/General.test.ts.snap
+++ b/shell/edit/auditlog.cattle.io.auditpolicy/__tests__/__snapshots__/General.test.ts.snap
@@ -84,6 +84,7 @@ exports[`component: General rendering & initial state should render with default
               rules=""
               searchable="false"
               selectable="[Function]"
+              size="large"
               value="0"
             />
           </div>

--- a/storybook/src/stories/Form/LabeledSelect.stories.ts
+++ b/storybook/src/stories/Form/LabeledSelect.stories.ts
@@ -7,6 +7,10 @@ const meta: Meta<typeof LabeledSelect> = {
     label:       { control: 'text' },
     options:     { control: 'array' },
     placeholder: { control: 'text' },
+    size:        {
+      control: 'select',
+      options: ['small', 'medium', 'large'],
+    },
   },
 };
 
@@ -25,5 +29,14 @@ export const Default: Story = {
     label:       'System',
     options:     ['System01', 'System02', 'System03', 'System04'],
     placeholder: 'Select option',
+  },
+};
+
+export const SizeMedium: Story = {
+  ...Default,
+  args: {
+    options:     ['System01', 'System02', 'System03', 'System04'],
+    placeholder: 'Select option',
+    size:        'medium',
   },
 };


### PR DESCRIPTION
### Summary
Fixes #18296 

### Occurred changes and/or fixed issues

- Added `size` prop to `LabeledSelect` accepting `'small' | 'medium' | 'large'` (default `'large'`)
- Added `$labeled-select-height-medium: 32px` variable to `_variables.scss`
- When `size="medium"` is used in no-label mode, the component renders at 32px with properly centered text and chevron
- `size` prop only applies in no-label mode — labeled mode is unaffected

### Technical notes summary
- The `size` prop applies the class `ls-{size}` to the root `.labeled-select` element
- `ls-medium` targets `.no-label.ls-medium` only — labeled selects are unaffected
- The internal `v-select` element has `display: inline !important` (`.inline` class), so height cannot be set on it directly. Instead, height is fixed on the root, and `vs__dropdown-toggle` is stretched to `height: 100%`
- Several global `.labeled-select` overrides (negative `margin-top` on `vs__selected-options`, `top: -10px` on `vs__actions::after`, large-mode `height`/`padding-top` on the chevron pseudo-element) are explicitly reset within the medium scope to avoid centering regressions

### Areas or cases that should be tested
- `LabeledSelect` with `size="medium"` in no-label mode:
  - Placeholder text is vertically centered at 32px height
  - Chevron is vertically centered, both when closed and open
  - Selecting an option — selected text remains centered
  - Searchable mode — text does not shift on dropdown open
- `LabeledSelect` default (no `size` prop) — no regression in height or alignment
- `LabeledSelect` with a label (labeled mode) — no regression

### Areas which could experience regressions
- Any existing no-label `LabeledSelect` usage — the `ls-large` class is now applied but has no associated CSS, so behavior should be unchanged
- Labeled `LabeledSelect` — should be completely unaffected by the scoped `no-label.ls-medium` rules

### Screenshot/Video
<img width="1171" height="60" alt="Screenshot 2026-07-07 at 3 26 11 PM" src="https://github.com/user-attachments/assets/6b0e1470-c8c2-49de-8387-32fa3b826e1b" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
