### PR TITLE
Updates to Day 2 Ops

### DIFF
--- a/pkg/imported/components/Basics.vue
+++ b/pkg/imported/components/Basics.vue
@@ -13,7 +13,7 @@ import VersionManagement from '@pkg/imported/components/VersionManagement.vue';
 import DayTwoOps from '@pkg/imported/components/DayTwoOps.vue';
 import Banner from '@components/Banner/Banner.vue';
 import { compare } from '@shell/utils/version';
-import { VERSION_MANAGEMENT_DEFAULT } from '@pkg/imported/util/shared.ts';
+import { VERSION_MANAGEMENT_DEFAULT, DEFAULT } from '@pkg/imported/util/shared.ts';
 
 export default defineComponent({
   name:       'Basics',
@@ -88,13 +88,17 @@ export default defineComponent({
       type:     String,
       required: true
     },
+    dayTwoOpsOld: {
+      type:    String,
+      default: DEFAULT
+    },
     isLocal: {
       type:    Boolean,
       default: false
     },
-    dayTwoOpsEnabled: {
-      type:    Boolean,
-      default: false
+    dayTwoOps: {
+      type:    String,
+      default: DEFAULT
     },
     rules: {
       default: () => ({
@@ -251,9 +255,10 @@ export default defineComponent({
   </div>
   <DayTwoOps
     v-if="!isLocal && dayTwoOpsFlag"
-    :value="dayTwoOpsEnabled"
+    :value="dayTwoOps"
     :global-setting="dayTwoOpsGlobalSetting"
     :mode="mode"
+    :old-value="dayTwoOpsOld"
     @update:value="$emit('enable-day-two-ops-changed', $event)"
   />
 </template>

--- a/pkg/imported/components/Basics.vue
+++ b/pkg/imported/components/Basics.vue
@@ -13,7 +13,7 @@ import VersionManagement from '@pkg/imported/components/VersionManagement.vue';
 import DayTwoOps from '@pkg/imported/components/DayTwoOps.vue';
 import Banner from '@components/Banner/Banner.vue';
 import { compare } from '@shell/utils/version';
-import { VERSION_MANAGEMENT_DEFAULT, DEFAULT } from '@pkg/imported/util/shared.ts';
+import { VERSION_MANAGEMENT_DEFAULT, DAY_2_OPS_DEFAULT as DEFAULT } from '@pkg/imported/util/shared.ts';
 
 export default defineComponent({
   name:       'Basics',

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -32,10 +32,9 @@ import { PRIVATE_REGISTRY_CONTEXT } from '@shell/components/form/PrivateRegistry
 import { privateRegistryRequired } from '@shell/utils/validators/private-registry';
 import { IMPORTED_CLUSTER_VERSION_MANAGEMENT, OPERATION_ANNOTATIONS } from '@shell/config/labels-annotations';
 import cloneDeep from 'lodash/cloneDeep';
-import { VERSION_MANAGEMENT_DEFAULT } from '@pkg/imported/util/shared.ts';
+import { VERSION_MANAGEMENT_DEFAULT, DEFAULT } from '@pkg/imported/util/shared.ts';
 import SchedulingCustomization from '@shell/components/form/SchedulingCustomization';
 import { IMPORTED_DAY_2_OPS } from '@shell/config/features';
-
 const HARVESTER_HIDE_KEY = 'cm-harvester-import';
 const defaultCluster = {
   agentEnvVars:   [],
@@ -121,6 +120,7 @@ export default defineComponent({
       defaultVersion:                           '',
       versionManagementGlobalSetting:           false,
       versionManagementOld:                     VERSION_MANAGEMENT_DEFAULT,
+      dayTwoOpsOld:                             DEFAULT,
       schedulingCustomizationFeatureEnabled:    false,
       schedulingCustomizationOriginallyEnabled: false,
       clusterAgentDefaultPC:                    null,
@@ -183,16 +183,20 @@ export default defineComponent({
         privateRegistryRequired:     privateRegistryRequired(this),
       };
     },
-    dayTwoOpsEnabled: {
+    dayTwoOps: {
       get() {
         if (this.normanCluster?.annotations?.[OPERATION_ANNOTATIONS.ENABLED]) {
-          return this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED] === true || this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED] === 'true';
+          return this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED] ;
         }
 
-        return this.dayTwoOpsGlobalSetting;
+        return DEFAULT;
       },
       set(newValue) {
-        this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED] = !!newValue ? 'true' : 'false';
+        if (newValue === DEFAULT) {
+          delete this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED];
+        } else {
+          this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED] = newValue;
+        }
       }
     },
 
@@ -431,9 +435,7 @@ export default defineComponent({
       }
 
       this.dayTwoOpsGlobalSetting = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.IMPORTED_CLUSTER_DAY2_OPS_DEFAULT)?.value === 'true';
-      if (this.isCreate && this.dayTwoOpsFlagEnabled) {
-        this.dayTwoOpsEnabled = this.dayTwoOpsGlobalSetting;
-      }
+      this.dayTwoOpsOld = !this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED] ? '' : this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED];
     },
     setSchedulingCustomization({ event, agentType }) {
       if (event) {
@@ -528,7 +530,8 @@ export default defineComponent({
           :day-two-ops-flag="dayTwoOpsFlagEnabled"
           :version-management="versionManagement"
           :version-management-old="versionManagementOld"
-          :day-two-ops-enabled="dayTwoOpsEnabled"
+          :day-two-ops="dayTwoOps"
+          :day-two-ops-old="dayTwoOpsOld"
           :rules="{workerConcurrency: fvGetAndReportPathRules('workerConcurrency'), controlPlaneConcurrency: fvGetAndReportPathRules('controlPlaneConcurrency') }"
           @kubernetes-version-changed="kubernetesVersionChanged"
           @drain-server-nodes-changed="(val)=>upgradeStrategy.drainServerNodes = val"
@@ -536,7 +539,7 @@ export default defineComponent({
           @server-concurrency-changed="(val)=>upgradeStrategy.serverConcurrency = val"
           @worker-concurrency-changed="(val)=>upgradeStrategy.workerConcurrency = val"
           @version-management-changed="(val)=>versionManagement=val"
-          @enable-day-two-ops-changed="(val)=>dayTwoOpsEnabled=val"
+          @enable-day-two-ops-changed="(val)=>dayTwoOps=val"
         />
       </Accordion>
       <Accordion

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -436,7 +436,7 @@ export default defineComponent({
       }
 
       this.dayTwoOpsGlobalSetting = this.$store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.IMPORTED_CLUSTER_DAY2_OPS_DEFAULT)?.value === 'true';
-      this.dayTwoOpsOld = !this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED] ? '' : this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED];
+      this.dayTwoOpsOld = !this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED] ? DAY_2_OPS_DEFAULT : this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED];
     },
     setSchedulingCustomization({ event, agentType }) {
       if (event) {

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -193,11 +193,7 @@ export default defineComponent({
         return DAY_2_OPS_DEFAULT;
       },
       set(newValue) {
-        if (newValue === DAY_2_OPS_DEFAULT) {
-          delete this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED];
-        } else {
-          this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED] = newValue;
-        }
+        this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED] = newValue;
       }
     },
 

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -32,9 +32,10 @@ import { PRIVATE_REGISTRY_CONTEXT } from '@shell/components/form/PrivateRegistry
 import { privateRegistryRequired } from '@shell/utils/validators/private-registry';
 import { IMPORTED_CLUSTER_VERSION_MANAGEMENT, OPERATION_ANNOTATIONS } from '@shell/config/labels-annotations';
 import cloneDeep from 'lodash/cloneDeep';
-import { VERSION_MANAGEMENT_DEFAULT, DEFAULT } from '@pkg/imported/util/shared.ts';
+import { VERSION_MANAGEMENT_DEFAULT, DAY_2_OPS_DEFAULT } from '@pkg/imported/util/shared.ts';
 import SchedulingCustomization from '@shell/components/form/SchedulingCustomization';
 import { IMPORTED_DAY_2_OPS } from '@shell/config/features';
+
 const HARVESTER_HIDE_KEY = 'cm-harvester-import';
 const defaultCluster = {
   agentEnvVars:   [],
@@ -120,7 +121,7 @@ export default defineComponent({
       defaultVersion:                           '',
       versionManagementGlobalSetting:           false,
       versionManagementOld:                     VERSION_MANAGEMENT_DEFAULT,
-      dayTwoOpsOld:                             DEFAULT,
+      dayTwoOpsOld:                             DAY_2_OPS_DEFAULT,
       schedulingCustomizationFeatureEnabled:    false,
       schedulingCustomizationOriginallyEnabled: false,
       clusterAgentDefaultPC:                    null,
@@ -189,10 +190,10 @@ export default defineComponent({
           return this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED] ;
         }
 
-        return DEFAULT;
+        return DAY_2_OPS_DEFAULT;
       },
       set(newValue) {
-        if (newValue === DEFAULT) {
+        if (newValue === DAY_2_OPS_DEFAULT) {
           delete this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED];
         } else {
           this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED] = newValue;

--- a/pkg/imported/components/CruImported.vue
+++ b/pkg/imported/components/CruImported.vue
@@ -185,7 +185,7 @@ export default defineComponent({
     },
     dayTwoOps: {
       get() {
-        if (this.normanCluster?.annotations?.[OPERATION_ANNOTATIONS.ENABLED]) {
+        if (typeof this.normanCluster?.annotations?.[OPERATION_ANNOTATIONS.ENABLED] !== 'undefined') {
           return this.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED] ;
         }
 

--- a/pkg/imported/components/DayTwoOps.vue
+++ b/pkg/imported/components/DayTwoOps.vue
@@ -75,6 +75,9 @@ const showBanner = computed(() => {
 <template>
   <div class="mt-10">
     <h3>{{ t('imported.basics.dayTwoOpsEnabled.title') }}</h3>
+    <p class="mb-10">
+      {{ t('imported.basics.dayTwoOpsEnabled.description') }}
+    </p>
     <Banner
       v-if="showBanner"
       color="info"

--- a/pkg/imported/components/DayTwoOps.vue
+++ b/pkg/imported/components/DayTwoOps.vue
@@ -4,7 +4,7 @@ import { _EDIT } from '@shell/config/query-params';
 import Banner from '@components/Banner/Banner.vue';
 import { RadioGroup } from '@components/Form/Radio';
 import { useStore } from 'vuex';
-import { DEFAULT } from '@pkg/imported/util/shared.ts';
+import { DAY_2_OPS_DEFAULT as DEFAULT } from '@pkg/imported/util/shared.ts';
 
 defineOptions({ name: 'DayTwoOps' });
 const props = defineProps({

--- a/pkg/imported/components/DayTwoOps.vue
+++ b/pkg/imported/components/DayTwoOps.vue
@@ -1,45 +1,103 @@
 <script setup>
 import { computed } from 'vue';
 import { _EDIT } from '@shell/config/query-params';
-import { Checkbox } from '@components/Form/Checkbox';
+import Banner from '@components/Banner/Banner.vue';
+import { RadioGroup } from '@components/Form/Radio';
 import { useStore } from 'vuex';
+import { DEFAULT } from '@pkg/imported/util/shared.ts';
 
 defineOptions({ name: 'DayTwoOps' });
-
 const props = defineProps({
   mode: {
     type:    String,
     default: _EDIT
   },
   value: {
-    type:    Boolean,
-    default: false
+    type:    String,
+    default: DEFAULT
   },
   globalSetting: {
     type:     Boolean,
     required: true,
-  }
+  },
+  oldValue: {
+    type:    String,
+    default: DEFAULT
+  },
 });
 
-const emit = defineEmits(['update:value']);
+defineEmits(['update:value']);
 const store = useStore();
 const t = store.getters['i18n/t'];
 
 const globalConfigurationText = computed(() => {
   return !props.globalSetting ? t('imported.basics.dayTwoOpsEnabled.globallyDisabled', {}, true) : t('imported.basics.dayTwoOpsEnabled.globallyEnabled', {}, true);
 });
+const isEdit = computed(() => props.mode === _EDIT);
+const dayTwoOptions = computed(() => {
+  const defaultLabel = props.globalSetting ? t('imported.basics.dayTwoOpsEnabled.globalEnabledDefault') : t('imported.basics.dayTwoOpsEnabled.globalDisabledDefault');
+
+  return [
+    { value: DEFAULT, label: defaultLabel },
+    { value: 'true', label: t('imported.basics.dayTwoOpsEnabled.enabled') },
+    { value: 'false', label: t('imported.basics.dayTwoOpsEnabled.disabled') },
+  ];
+});
+const clusterConfigurationText = computed(() => {
+  if (props.value === 'true') {
+    return t('imported.basics.dayTwoOpsEnabled.summary.willEnable', {}, true);
+  }
+  if (props.value === 'false') {
+    return t('imported.basics.dayTwoOpsEnabled.summary.willDisable', {}, true);
+  }
+
+  return !props.globalSetting ? t('imported.basics.dayTwoOpsEnabled.summary.canEnable', {}, true) : '';
+});
+const dayTwoOpsInfo = computed(() => {
+  if (!isEdit.value) {
+    return '';
+  }
+  if (props.oldValue === DEFAULT && props.value !== DEFAULT) {
+    return t('imported.basics.dayTwoOpsEnabled.banner.edit.defaultToNonDefault', {}, true);
+  } else if (props.oldValue !== DEFAULT && props.value === DEFAULT) {
+    return t('imported.basics.dayTwoOpsEnabled.banner.edit.nonDefaultToDefault', {}, true);
+  }
+
+  return '';
+});
+const showBanner = computed(() => {
+  const changedInvolvingDefault = (props.oldValue === DEFAULT && props.value !== DEFAULT) || (props.oldValue !== DEFAULT && props.value === DEFAULT);
+
+  return isEdit.value && changedInvolvingDefault;
+});
 </script>
 
 <template>
   <div class="mt-10">
     <h3>{{ t('imported.basics.dayTwoOpsEnabled.title') }}</h3>
-    <div class="col">
-      <Checkbox
-        :value="value"
-        :mode="mode"
-        :label="t('imported.basics.dayTwoOpsEnabled.label')"
-        :tooltip="globalConfigurationText"
-        @update:value="emit('update:value', $event)"
+    <Banner
+      v-if="showBanner"
+      color="info"
+      data-testid="day-two-ops-banner"
+    >
+      {{ dayTwoOpsInfo }}
+    </Banner>
+    <RadioGroup
+      :value="value"
+      :mode="mode"
+      :options="dayTwoOptions"
+      name="dayTwoOps"
+      data-testid="imported-day-two-ops-radio"
+      @update:value="$emit('update:value', $event)"
+    />
+    <div class="col mt-10">
+      <label
+        v-clean-html="globalConfigurationText"
+        class="summary"
+      /><br>
+      <label
+        v-clean-html="clusterConfigurationText"
+        class="summary mb-10"
       />
     </div>
   </div>

--- a/pkg/imported/components/__tests__/CruImported.test.ts
+++ b/pkg/imported/components/__tests__/CruImported.test.ts
@@ -3,6 +3,9 @@ import CruImported from '@pkg/imported/components/CruImported.vue';
 import { _CREATE, _EDIT } from '@shell/config/query-params';
 import { IMPORTED_CLUSTER_VERSION_MANAGEMENT, OPERATION_ANNOTATIONS } from '@shell/config/labels-annotations';
 import { MANAGEMENT } from '@shell/config/types';
+import { DAY_2_OPS_DEFAULT } from '@pkg/imported/util/shared.ts';
+import { SETTING } from '@shell/config/settings';
+import { IMPORTED_DAY_2_OPS } from '@shell/config/features';
 
 describe('cruImported component', () => {
   const defaultSetup = {
@@ -228,24 +231,57 @@ describe('cruImported component', () => {
     });
   });
 
-  describe('day 2 operations', () => {
-    const mountDayTwoOpsWrapper = ({
-      mode = _EDIT,
-      value = {
-        id:                'cluster-id',
-        isLocal:           false,
-        isRke1:            false,
-        findNormanCluster: jest.fn().mockResolvedValue({})
-      },
-      annotations = { [IMPORTED_CLUSTER_VERSION_MANAGEMENT]: 'system-default' },
-      dayTwoOpsGlobalSetting = false,
-      managementById = jest.fn(),
-      dispatch = jest.fn().mockResolvedValue({})
-    } = {}) => {
-      return shallowMount(CruImported, {
+  describe('day two ops', () => {
+    it('should return default day two ops value when annotation is not set', () => {
+      const wrapper = shallowMount(CruImported, {
         propsData: {
-          mode,
-          value
+          mode:  _EDIT,
+          value: { isRke1: false, isLocal: false }
+        },
+        ...defaultSetup
+      });
+
+      delete wrapper.vm.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED];
+
+      expect(wrapper.vm.dayTwoOps).toBe(DAY_2_OPS_DEFAULT);
+    });
+
+    it('should return annotation value when day two ops annotation is set', () => {
+      const wrapper = shallowMount(CruImported, {
+        propsData: {
+          mode:  _EDIT,
+          value: { isRke1: false, isLocal: false }
+        },
+        ...defaultSetup
+      });
+
+      wrapper.vm.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED] = 'true';
+
+      expect(wrapper.vm.dayTwoOps).toBe('true');
+    });
+
+    it('should set day two ops annotation', () => {
+      const wrapper = shallowMount(CruImported, {
+        propsData: {
+          mode:  _EDIT,
+          value: { isRke1: false, isLocal: false }
+        },
+        ...defaultSetup
+      });
+
+      wrapper.vm.dayTwoOps = 'false';
+
+      expect(wrapper.vm.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED]).toBe('false');
+    });
+
+    it('should initialize day two ops settings from feature and global setting', async() => {
+      const dispatch = jest.fn().mockResolvedValue({ enabled: true });
+      const byId = jest.fn().mockReturnValue({ value: 'true' });
+      const wrapper = shallowMount(CruImported, {
+        ...defaultSetup,
+        propsData: {
+          mode:  _EDIT,
+          value: { isRke1: false, isLocal: false }
         },
         global: {
           ...defaultSetup.global,
@@ -253,76 +289,59 @@ describe('cruImported component', () => {
             ...defaultSetup.global.mocks,
             $store: {
               ...defaultSetup.global.mocks.$store,
+              dispatch,
               getters: {
                 ...defaultSetup.global.mocks.$store.getters,
-                'management/byId': managementById,
-              },
-              dispatch,
+                'management/byId': byId,
+              }
             }
           }
         },
-        data: () => ({
-          normanCluster: {
-            name:                     '',
-            annotations,
-            importedConfig:           {},
-            localClusterAuthEndpoint: {}
-          },
-          dayTwoOpsGlobalSetting,
-        })
-      });
-    };
-
-    it('should prefer the annotation value over the global day two ops setting', () => {
-      const wrapper = mountDayTwoOpsWrapper({
-        annotations: {
-          [IMPORTED_CLUSTER_VERSION_MANAGEMENT]: 'system-default',
-          [OPERATION_ANNOTATIONS.ENABLED]:       'false'
-        },
-        dayTwoOpsGlobalSetting: true,
       });
 
-      expect(wrapper.vm.dayTwoOpsEnabled).toBe(false);
-    });
-
-    it('should fall back to the global day two ops setting when no annotation is present', () => {
-      const wrapper = mountDayTwoOpsWrapper({ dayTwoOpsGlobalSetting: true });
-
-      expect(wrapper.vm.dayTwoOpsEnabled).toBe(true);
-    });
-
-    it('should persist the day two ops selection as a string annotation', () => {
-      const wrapper = mountDayTwoOpsWrapper();
-
-      wrapper.vm.dayTwoOpsEnabled = true;
-      expect(wrapper.vm.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED]).toBe('true');
-
-      wrapper.vm.dayTwoOpsEnabled = false;
-      expect(wrapper.vm.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED]).toBe('false');
-    });
-
-    it('should initialize day two ops from feature and global settings in create mode', async() => {
-      const managementById = jest.fn().mockReturnValue({ value: 'true' });
-      const dispatch = jest.fn().mockResolvedValue({ enabled: true });
-      const wrapper = mountDayTwoOpsWrapper({
-        mode:  _CREATE,
-        value: {
-          isLocal: false,
-          isRke1:  false,
-        },
-        managementById,
-        dispatch,
-      });
+      wrapper.vm.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED] = 'true';
 
       await wrapper.vm.initDayTwoOps();
 
       expect(dispatch).toHaveBeenCalledWith('management/find', {
         type: MANAGEMENT.FEATURE,
-        id:   'imported-day-2-ops'
+        id:   IMPORTED_DAY_2_OPS
       });
+      expect(byId).toHaveBeenCalledWith(MANAGEMENT.SETTING, SETTING.IMPORTED_CLUSTER_DAY2_OPS_DEFAULT);
       expect(wrapper.vm.dayTwoOpsFlagEnabled).toBe(true);
       expect(wrapper.vm.dayTwoOpsGlobalSetting).toBe(true);
-      expect(wrapper.vm.normanCluster.annotations[OPERATION_ANNOTATIONS.ENABLED]).toBe('true');
+      expect(wrapper.vm.dayTwoOpsOld).toBe('true');
+    });
+
+    it('should set day two ops feature flag to false when feature lookup fails', async() => {
+      const dispatch = jest.fn().mockRejectedValue(new Error('not found'));
+      const wrapper = shallowMount(CruImported, {
+        ...defaultSetup,
+        propsData: {
+          mode:  _EDIT,
+          value: { isRke1: false, isLocal: false }
+        },
+        global: {
+          ...defaultSetup.global,
+          mocks: {
+            ...defaultSetup.global.mocks,
+            $store: {
+              ...defaultSetup.global.mocks.$store,
+              dispatch,
+              getters: {
+                ...defaultSetup.global.mocks.$store.getters,
+                'management/byId': () => ({ value: 'false' }),
+              }
+            }
+          }
+        },
+      });
+
+      await wrapper.vm.initDayTwoOps();
+
+      expect(wrapper.vm.dayTwoOpsFlagEnabled).toBe(false);
+      expect(wrapper.vm.dayTwoOpsGlobalSetting).toBe(false);
+      expect(wrapper.vm.dayTwoOpsOld).toBe(DAY_2_OPS_DEFAULT);
     });
   });
 });

--- a/pkg/imported/components/__tests__/DayTwoOps.test.ts
+++ b/pkg/imported/components/__tests__/DayTwoOps.test.ts
@@ -9,7 +9,12 @@ describe('component: DayTwoOps', () => {
   const defaultSetup = () => {
     const store = createStore({ getters: { 'i18n/t': () => (key: string) => key } });
 
-    return { global: { plugins: [store] } };
+    return {
+      global: {
+        plugins: [store],
+        stubs:   { Banner: { template: '<div v-bind="$attrs"><slot /></div>' } }
+      }
+    };
   };
 
   it('should render the title and radio group with default props', () => {
@@ -141,7 +146,7 @@ describe('component: DayTwoOps', () => {
     const banner = wrapper.find('[data-testid="day-two-ops-banner"]');
 
     expect(banner.exists()).toBe(true);
-    expect(banner.text()).toContain(expectedText);
+    expect(wrapper.text()).toContain(expectedText);
   });
 
   it.each([

--- a/pkg/imported/components/__tests__/DayTwoOps.test.ts
+++ b/pkg/imported/components/__tests__/DayTwoOps.test.ts
@@ -3,7 +3,7 @@ import { shallowMount } from '@vue/test-utils';
 import { createStore } from 'vuex';
 import DayTwoOps from '../DayTwoOps.vue';
 import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
-import { DEFAULT } from '@pkg/imported/util/shared.ts';
+import { DAY_2_OPS_DEFAULT as DEFAULT } from '@pkg/imported/util/shared.ts';
 
 describe('component: DayTwoOps', () => {
   const defaultSetup = () => {

--- a/pkg/imported/components/__tests__/DayTwoOps.test.ts
+++ b/pkg/imported/components/__tests__/DayTwoOps.test.ts
@@ -2,7 +2,8 @@ import { nextTick } from 'vue';
 import { shallowMount } from '@vue/test-utils';
 import { createStore } from 'vuex';
 import DayTwoOps from '../DayTwoOps.vue';
-import { _EDIT, _VIEW } from '@shell/config/query-params';
+import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
+import { DEFAULT } from '@pkg/imported/util/shared.ts';
 
 describe('component: DayTwoOps', () => {
   const defaultSetup = () => {
@@ -11,49 +12,69 @@ describe('component: DayTwoOps', () => {
     return { global: { plugins: [store] } };
   };
 
-  it('should render with default props', () => {
+  it('should render the title and radio group with default props', () => {
     const wrapper = shallowMount(DayTwoOps, {
       props: { globalSetting: true },
       ...defaultSetup()
     });
 
+    const radioGroup = wrapper.findComponent({ name: 'RadioGroup' });
+
     expect(wrapper.find('h3').exists()).toBe(true);
-    expect(wrapper.findComponent({ name: 'Checkbox' }).exists()).toBe(true);
+    expect(radioGroup.exists()).toBe(true);
+    expect(radioGroup.props('value')).toBe(DEFAULT);
+    expect(radioGroup.props('mode')).toBe(_EDIT);
   });
 
-  it('should pass value prop to checkbox', () => {
+  it('should pass the correct options to the radio group when the global setting is enabled', () => {
+    const wrapper = shallowMount(DayTwoOps, {
+      props: { globalSetting: true },
+      ...defaultSetup()
+    });
+
+    const radioGroup = wrapper.findComponent({ name: 'RadioGroup' });
+
+    expect(radioGroup.props('options')).toStrictEqual([
+      { value: DEFAULT, label: 'imported.basics.dayTwoOpsEnabled.globalEnabledDefault' },
+      { value: 'true', label: 'imported.basics.dayTwoOpsEnabled.enabled' },
+      { value: 'false', label: 'imported.basics.dayTwoOpsEnabled.disabled' },
+    ]);
+  });
+
+  it('should pass the correct options to the radio group when the global setting is disabled', () => {
+    const wrapper = shallowMount(DayTwoOps, {
+      props: { globalSetting: false },
+      ...defaultSetup()
+    });
+
+    const radioGroup = wrapper.findComponent({ name: 'RadioGroup' });
+
+    expect(radioGroup.props('options')).toStrictEqual([
+      { value: DEFAULT, label: 'imported.basics.dayTwoOpsEnabled.globalDisabledDefault' },
+      { value: 'true', label: 'imported.basics.dayTwoOpsEnabled.enabled' },
+      { value: 'false', label: 'imported.basics.dayTwoOpsEnabled.disabled' },
+    ]);
+  });
+
+  it('should emit update:value when the radio group is updated', async() => {
     const wrapper = shallowMount(DayTwoOps, {
       props: {
-        value:         true,
+        value:         DEFAULT,
         globalSetting: true,
       },
       ...defaultSetup()
     });
 
-    const checkbox = wrapper.findComponent({ name: 'Checkbox' });
+    const radioGroup = wrapper.findComponent({ name: 'RadioGroup' });
 
-    expect(checkbox.props('value')).toBe(true);
-  });
-
-  it('should emit update:value when checkbox is updated', async() => {
-    const wrapper = shallowMount(DayTwoOps, {
-      props: {
-        value:         false,
-        globalSetting: true,
-      },
-      ...defaultSetup()
-    });
-
-    const checkbox = wrapper.findComponent({ name: 'Checkbox' });
-
-    await checkbox.vm.$emit('update:value', true);
+    await radioGroup.vm.$emit('update:value', 'true');
     await nextTick();
 
     expect(wrapper.emitted('update:value')).toBeTruthy();
-    expect(wrapper.emitted('update:value')?.[0]).toEqual([true]);
+    expect(wrapper.emitted('update:value')?.[0]).toStrictEqual(['true']);
   });
 
-  it('should pass mode prop to checkbox', () => {
+  it('should pass the mode prop to the radio group', () => {
     const wrapper = shallowMount(DayTwoOps, {
       props: {
         mode:          _VIEW,
@@ -62,118 +83,108 @@ describe('component: DayTwoOps', () => {
       ...defaultSetup()
     });
 
-    const checkbox = wrapper.findComponent({ name: 'Checkbox' });
+    const radioGroup = wrapper.findComponent({ name: 'RadioGroup' });
 
-    expect(checkbox.props('mode')).toBe(_VIEW);
+    expect(radioGroup.props('mode')).toBe(_VIEW);
   });
 
-  it('should use default _EDIT mode when not provided', () => {
+  it('should render the global summary text for enabled global setting', () => {
     const wrapper = shallowMount(DayTwoOps, {
       props: { globalSetting: true },
       ...defaultSetup()
     });
 
-    const checkbox = wrapper.findComponent({ name: 'Checkbox' });
-
-    expect(checkbox.props('mode')).toBe(_EDIT);
+    expect(wrapper.text()).toContain('imported.basics.dayTwoOpsEnabled.globallyEnabled');
   });
 
-  it('should show globally enabled tooltip when globalSetting is true', () => {
-    const wrapper = shallowMount(DayTwoOps, {
-      props: { globalSetting: true },
-      ...defaultSetup()
-    });
-
-    const checkbox = wrapper.findComponent({ name: 'Checkbox' });
-    const tooltip = checkbox.props('tooltip');
-
-    // Tooltip should exist and contain relevant text
-    expect(tooltip).toBeTruthy();
-    expect(typeof tooltip).toBe('string');
-  });
-
-  it('should show globally disabled tooltip when globalSetting is false', () => {
+  it('should render the global summary text for disabled global setting', () => {
     const wrapper = shallowMount(DayTwoOps, {
       props: { globalSetting: false },
       ...defaultSetup()
     });
 
-    const checkbox = wrapper.findComponent({ name: 'Checkbox' });
-    const tooltip = checkbox.props('tooltip');
-
-    // Tooltip should exist and contain relevant text
-    expect(tooltip).toBeTruthy();
-    expect(typeof tooltip).toBe('string');
+    expect(wrapper.text()).toContain('imported.basics.dayTwoOpsEnabled.globallyDisabled');
   });
 
-  it('should update tooltip when globalSetting prop changes', async() => {
+  it.each([
+    [{ globalSetting: false, value: DEFAULT }, 'imported.basics.dayTwoOpsEnabled.summary.canEnable'],
+    [{ globalSetting: true, value: 'true' }, 'imported.basics.dayTwoOpsEnabled.summary.willEnable'],
+    [{ globalSetting: true, value: 'false' }, 'imported.basics.dayTwoOpsEnabled.summary.willDisable'],
+  ])('should render the expected cluster summary text', (props, expectedText) => {
     const wrapper = shallowMount(DayTwoOps, {
-      props: { globalSetting: true },
+      props: {
+        oldValue: DEFAULT,
+        ...props,
+      },
       ...defaultSetup()
     });
 
-    let checkbox = wrapper.findComponent({ name: 'Checkbox' });
-    const initialTooltip = checkbox.props('tooltip');
-
-    expect(initialTooltip).toBeTruthy();
-    expect(typeof initialTooltip).toBe('string');
-
-    await wrapper.setProps({ globalSetting: false });
-    await nextTick();
-
-    checkbox = wrapper.findComponent({ name: 'Checkbox' });
-    const updatedTooltip = checkbox.props('tooltip');
-
-    // Tooltip should update when prop changes
-    expect(updatedTooltip).toBeTruthy();
-    expect(typeof updatedTooltip).toBe('string');
+    expect(wrapper.text()).toContain(expectedText);
   });
 
-  it('should pass label prop to checkbox', () => {
+  it.each([
+    [{
+      oldValue: DEFAULT, value: 'true', mode: _EDIT
+    }, 'imported.basics.dayTwoOpsEnabled.banner.edit.defaultToNonDefault'],
+    [{
+      oldValue: 'true', value: DEFAULT, mode: _EDIT
+    }, 'imported.basics.dayTwoOpsEnabled.banner.edit.nonDefaultToDefault'],
+  ])('should show the edit banner when switching to or from the default value', (props, expectedText) => {
     const wrapper = shallowMount(DayTwoOps, {
-      props: { globalSetting: true },
+      props: {
+        globalSetting: true,
+        ...props,
+      },
       ...defaultSetup()
     });
 
-    const checkbox = wrapper.findComponent({ name: 'Checkbox' });
-    const label = checkbox.props('label');
+    const banner = wrapper.find('[data-testid="day-two-ops-banner"]');
 
-    // Label should exist and be a string
-    expect(label).toBeTruthy();
-    expect(typeof label).toBe('string');
+    expect(banner.exists()).toBe(true);
+    expect(wrapper.vm.dayTwoOpsInfo).toBe(expectedText);
   });
 
-  it('should render title from i18n', () => {
+  it.each([
+    {
+      oldValue: DEFAULT, value: DEFAULT, mode: _EDIT
+    },
+    {
+      oldValue: 'true', value: 'false', mode: _EDIT
+    },
+    {
+      oldValue: DEFAULT, value: 'true', mode: _CREATE
+    },
+  ])('should not show the banner when the change does not involve the default state in edit mode', (props) => {
     const wrapper = shallowMount(DayTwoOps, {
-      props: { globalSetting: true },
+      props: {
+        globalSetting: true,
+        ...props,
+      },
       ...defaultSetup()
     });
 
-    const h3 = wrapper.find('h3');
-
-    // Title should be rendered in an h3 element
-    expect(h3.exists()).toBe(true);
+    expect(wrapper.find('[data-testid="day-two-ops-banner"]').exists()).toBe(false);
   });
 
   it('should handle multiple emit events', async() => {
     const wrapper = shallowMount(DayTwoOps, {
       props: {
-        value:         false,
+        value:         DEFAULT,
         globalSetting: true,
       },
       ...defaultSetup()
     });
 
-    const checkbox = wrapper.findComponent({ name: 'Checkbox' });
+    const radioGroup = wrapper.findComponent({ name: 'RadioGroup' });
 
-    await checkbox.vm.$emit('update:value', true);
+    await radioGroup.vm.$emit('update:value', 'true');
     await nextTick();
 
-    await checkbox.vm.$emit('update:value', false);
+    await radioGroup.vm.$emit('update:value', DEFAULT);
     await nextTick();
 
     expect(wrapper.emitted('update:value')).toHaveLength(2);
-    expect(wrapper.emitted('update:value')?.[0]).toEqual([true]);
-    expect(wrapper.emitted('update:value')?.[1]).toEqual([false]);
+    expect(wrapper.emitted('update:value')?.[0]).toStrictEqual(['true']);
+    expect(wrapper.emitted('update:value')?.[1]).toStrictEqual([DEFAULT]);
   });
 });

--- a/pkg/imported/components/__tests__/DayTwoOps.test.ts
+++ b/pkg/imported/components/__tests__/DayTwoOps.test.ts
@@ -3,7 +3,7 @@ import { shallowMount } from '@vue/test-utils';
 import { createStore } from 'vuex';
 import DayTwoOps from '../DayTwoOps.vue';
 import { _CREATE, _EDIT, _VIEW } from '@shell/config/query-params';
-import { DAY_2_OPS_DEFAULT as DEFAULT } from '@pkg/imported/util/shared.ts';
+import { DAY_2_OPS_DEFAULT as DEFAULT } from '../../util/shared';
 
 describe('component: DayTwoOps', () => {
   const defaultSetup = () => {
@@ -141,7 +141,7 @@ describe('component: DayTwoOps', () => {
     const banner = wrapper.find('[data-testid="day-two-ops-banner"]');
 
     expect(banner.exists()).toBe(true);
-    expect(wrapper.vm.dayTwoOpsInfo).toBe(expectedText);
+    expect(banner.text()).toContain(expectedText);
   });
 
   it.each([

--- a/pkg/imported/l10n/en-us.yaml
+++ b/pkg/imported/l10n/en-us.yaml
@@ -45,7 +45,7 @@ imported:
       summary:
         canEnable: You can enable it at a cluster level.
         willEnable: It will be manually <b>ENABLED</b> for this cluster.
-        willDisable: it will be manually <b>DISABLED</b> for this cluster.
+        willDisable: It will be manually <b>DISABLED</b> for this cluster.
   drainWorkerNodes:
     label: Drain Worker Nodes
   drainControlPlaneNodes:

--- a/pkg/imported/l10n/en-us.yaml
+++ b/pkg/imported/l10n/en-us.yaml
@@ -31,8 +31,20 @@ imported:
     dayTwoOpsEnabled:
       title: Day 2 Operations
       label: Enable snapshot creation, snapshot restoration, and encryption key rotation
-      globallyEnabled: 'Day 2 Operations for imported clusters are globally <b>enabled</b>.'
-      globallyDisabled: Day 2 Operations for imported clusters are globally <b>disabled</b>.
+      globallyEnabled: 'Day 2 Operations (snapshot creation, snapshot restoration, and encryption key rotation) for imported clusters are globally <b>enabled</b>.'
+      globallyDisabled: 'Day 2 Operations (snapshot creation, snapshot restoration, and encryption key rotation) for imported clusters are globally <b>disabled</b>.'
+      enabled: Enabled
+      disabled: Disabled
+      globalEnabledDefault: Global default (enabled)
+      globalDisabledDefault: Global default (disabled)
+      banner:
+        edit:
+          defaultToNonDefault: Future changes to the global setting will not affect the cluster.
+          nonDefaultToDefault: Future changes to the global setting will affect the cluster.
+      summary:
+        canEnable: You can enable it at a cluster level.
+        willEnable: It will be manually <b>ENABLED</b> for this cluster.
+        willDisable: it will be manually <b>DISABLED</b> for this cluster.
   drainWorkerNodes:
     label: Drain Worker Nodes
   drainControlPlaneNodes:

--- a/pkg/imported/l10n/en-us.yaml
+++ b/pkg/imported/l10n/en-us.yaml
@@ -30,9 +30,10 @@ imported:
         willDisable: it will be manually <b>DISABLED</b> for this cluster.
     dayTwoOpsEnabled:
       title: Day 2 Operations
+      description: Snapshot creation, snapshot restoration, and encryption key rotation.
       label: Enable snapshot creation, snapshot restoration, and encryption key rotation
-      globallyEnabled: 'Day 2 Operations (snapshot creation, snapshot restoration, and encryption key rotation) for imported clusters are globally <b>enabled</b>.'
-      globallyDisabled: 'Day 2 Operations (snapshot creation, snapshot restoration, and encryption key rotation) for imported clusters are globally <b>disabled</b>.'
+      globallyEnabled: 'Day 2 Operations for imported clusters are globally <b>enabled</b>.'
+      globallyDisabled: 'Day 2 Operations for imported clusters are globally <b>disabled</b>.'
       enabled: Enabled
       disabled: Disabled
       globalEnabledDefault: Global default (enabled)

--- a/pkg/imported/util/shared.ts
+++ b/pkg/imported/util/shared.ts
@@ -1,1 +1,2 @@
 export const VERSION_MANAGEMENT_DEFAULT = 'system-default';
+export const DEFAULT = 'default';

--- a/pkg/imported/util/shared.ts
+++ b/pkg/imported/util/shared.ts
@@ -1,2 +1,2 @@
 export const VERSION_MANAGEMENT_DEFAULT = 'system-default';
-export const DEFAULT = 'default';
+export const DAY_2_OPS_DEFAULT = 'system-default';

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -9023,7 +9023,7 @@ advancedSettings:
     'k3s-based-upgrader-uninstall-concurrency': Defines the maximum number of clusters in which Rancher can concurrently uninstall the legacy `rancher-k3s-upgrader` or `rancher-rke2-upgrader` app from imported or node-driver K3s or RKE2 clusters.
     'system-agent-upgrader-install-concurrency': Defines the maximum number of clusters in which Rancher can concurrently install the resources required for upgrading system-agent.
     'imported-cluster-version-management': Enables version management for imported RKE2/K3s clusters, and the local cluster if it is an RKE2/K3s cluster. The per-cluster version management setting overrides this global setting at the cluster level. For existing clusters where the cluster-level version management is set to 'system-default', changing this flag will trigger a redeployment of the cluster agent during the next reconciliation (by default every 5 minutes, or as soon as the cluster is edited, whichever comes first).
-    'imported-cluster-day2-ops-enabled': Controls whether newly imported RKE2/K3s clusters will have day 2 operations (etcd snapshots, restores, encryption key rotations) enabled by default. This does not affect previously imported clusters.
+    'imported-cluster-day2-ops-enabled': Controls whether imported RKE2/K3s clusters will have day 2 operations (etcd snapshots, restores, encryption key rotations) enabled by default. This will affect all clusters using the default configuration, and can be overridden at the cluster level.
   warnings:
     'agent-tls-mode': 'Changing this setting will cause all agents to be redeployed.'
   editHelp:

--- a/shell/components/PromptRestore.vue
+++ b/shell/components/PromptRestore.vue
@@ -202,7 +202,7 @@ export default {
               kind:       'Cluster',
               name:       mgmtCluster?.id,
             },
-            args: { name: this.snapshot?.snapshotFile?.name },
+            args: { name: this.snapshot?.metadata?.name },
           };
 
           createOperationCR(this.$store.dispatch, OPERATION.ETCD_SNAPSHOT_RESTORE, spec, namespace, safePrefix);

--- a/shell/components/__tests__/PromptRestore.test.ts
+++ b/shell/components/__tests__/PromptRestore.test.ts
@@ -2,8 +2,6 @@ import { nextTick } from 'vue';
 import { shallowMount } from '@vue/test-utils';
 import PromptRestore from '@shell/components/PromptRestore.vue';
 import { createStore } from 'vuex';
-import { ExtendedVue, Vue } from 'vue/types/vue';
-import { DefaultProps } from 'vue/types/options';
 import { CAPI, MANAGEMENT, OPERATION, SNAPSHOT } from '@shell/config/types';
 import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 import { createOperationCR } from '@shell/utils/operation-cr';
@@ -39,12 +37,14 @@ const RKE2_FAILED_SNAPSHOT = {
   name:           'rke2_name_3'
 };
 
+type Rke2Snapshot = typeof RKE2_SUCCESSFUL_SNAPSHOT_1;
+
 describe('component: PromptRestore', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  const rke2TestCases = [
+  const rke2TestCases: Array<[Rke2Snapshot[], number]> = [
     [[], 0],
     [[RKE2_FAILED_SNAPSHOT], 0],
     [[RKE2_SUCCESSFUL_SNAPSHOT_1], 1],
@@ -52,7 +52,7 @@ describe('component: PromptRestore', () => {
     [[RKE2_FAILED_SNAPSHOT, RKE2_SUCCESSFUL_SNAPSHOT_1, RKE2_SUCCESSFUL_SNAPSHOT_2], 2]
   ];
 
-  it.each(rke2TestCases)('should list RKE2 snapshots properly', async(snapShots, expected) => {
+  it.each(rke2TestCases)('should list RKE2 snapshots properly', async(snapShots: Rke2Snapshot[], expected: number) => {
     const store = createStore({
       modules: {
         'action-menu': {
@@ -72,10 +72,7 @@ describe('component: PromptRestore', () => {
       actions: { 'management/findAll': jest.fn().mockResolvedValue(snapShots), 'rancher/findAll': jest.fn().mockResolvedValue([]) }
     });
 
-    const wrapper = shallowMount(
-      PromptRestore as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>,
-      { global: { mocks: { $store: store } } }
-    );
+    const wrapper = shallowMount(PromptRestore, { global: { mocks: { $store: store } } });
 
     await wrapper.vm.fetchSnapshots();
     await nextTick();
@@ -119,18 +116,15 @@ describe('component: PromptRestore', () => {
       }
     });
 
-    const wrapper = shallowMount(
-      PromptRestore as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>,
-      { global: { mocks: { $store: store } } }
-    );
+    const wrapper = shallowMount(PromptRestore, { global: { mocks: { $store: store } } });
 
     wrapper.vm.allSnapshots = {
       'snapshot-1': {
-        name:         'snapshot-1',
-        snapshotFile: { name: 'snapshot-file-1' }
+        name:     'snapshot-1',
+        metadata: { name: 'snapshot-1' }
       }
     };
-    wrapper.vm.selectedSnapshot = 'snapshot-1';
+    (wrapper.vm as any).selectedSnapshot = 'snapshot-1';
 
     await wrapper.vm.apply(buttonDone);
 
@@ -142,7 +136,7 @@ describe('component: PromptRestore', () => {
         kind:       'Cluster',
         name:       'c-m-imported',
       },
-      args: { name: 'snapshot-file-1' },
+      args: { name: 'snapshot-1' },
     });
     expect((createOperationCR as jest.Mock).mock.calls[0][3]).toBe('c-m-imported');
     expect((createOperationCR as jest.Mock).mock.calls[0][4]).toBe('c-m-imported');
@@ -187,7 +181,7 @@ describe('component: PromptRestore', () => {
             showPromptRestore: true,
             toRestore:         [{
               type:         SNAPSHOT,
-              metadata:     { namespace: 'fleet-default' },
+              metadata:     { namespace: 'fleet-default', name: 'snapshot-file-2' },
               spec:         { clusterName: 'imported-cluster', clusterRef: { name: 'c-m-imported' } },
               snapshotFile: { name: 'snapshot-file-2' },
               nameDisplay:  'snapshot-2',
@@ -200,10 +194,7 @@ describe('component: PromptRestore', () => {
       actions: { 'growl/success': jest.fn() }
     });
 
-    const wrapper = shallowMount(
-      PromptRestore as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>,
-      { global: { mocks: { $store: store } } }
-    );
+    const wrapper = shallowMount(PromptRestore, { global: { mocks: { $store: store } } });
 
     await wrapper.vm.apply(buttonDone);
 

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -325,7 +325,7 @@ export default class ProvCluster extends SteveModel {
    * Whether this is an imported RKE2/K3s cluster with day 2 operations enabled.
    */
   get isImportedWithDayTwoOps() {
-    const annotationExists = typeof this.metadata?.annotations?.[OPERATION_ANNOTATIONS.ENABLED] !== 'undefined';
+    const annotationExists = typeof this.mgmt?.metadata?.annotations?.[OPERATION_ANNOTATIONS.ENABLED] !== 'undefined';
     const annotationEnabled = this.mgmt?.metadata?.annotations?.[OPERATION_ANNOTATIONS.ENABLED] === 'true';
     const globalDefaultIsTrue = this.$rootGetters['management/byId'](MANAGEMENT.SETTING, SETTING.IMPORTED_CLUSTER_DAY2_OPS_DEFAULT)?.value === 'true';
     const annotationOrGlobalEnabled = annotationEnabled || (!annotationExists && globalDefaultIsTrue);

--- a/shell/models/rke.cattle.io.etcdsnapshot.js
+++ b/shell/models/rke.cattle.io.etcdsnapshot.js
@@ -46,7 +46,7 @@ export default class EtcdBackup extends NormanModel {
   }
 
   get nameDisplay() {
-    return this.snapshotFile?.name || this.name;
+    return this.snapshotFile?.name || this.name || this.metadata?.name;
   }
 
   get restoreEnabled() {

--- a/shell/utils/__tests__/operation-cr.test.ts
+++ b/shell/utils/__tests__/operation-cr.test.ts
@@ -20,7 +20,10 @@ describe('util: operation-cr', () => {
         namespace:    'c-m-1',
         generateName: 'cluster-name-'
       },
-      spec,
+      spec: {
+        ...spec,
+        ttl: 60,
+      },
     }, { root: true });
     expect(save).toHaveBeenCalledWith();
     expect(out).toStrictEqual({ id: 'op-1' });

--- a/shell/utils/operation-cr.js
+++ b/shell/utils/operation-cr.js
@@ -12,7 +12,7 @@ export async function createOperationCR(dispatch, type, spec, namespace, namePre
   const resource = await dispatch('management/create', {
     type,
     metadata: { namespace, generateName: `${ namePrefix }-` },
-    spec:     { ...spec, ...{ ttl: 60 } },
+    spec:     { ...{ ttl: 60 }, ...spec },
   }, { root: true });
 
   return resource.save();

--- a/shell/utils/operation-cr.js
+++ b/shell/utils/operation-cr.js
@@ -12,7 +12,7 @@ export async function createOperationCR(dispatch, type, spec, namespace, namePre
   const resource = await dispatch('management/create', {
     type,
     metadata: { namespace, generateName: `${ namePrefix }-` },
-    spec,
+    spec:     { ...spec, ...{ ttl: 60 } },
   }, { root: true });
 
   return resource.save();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17263
<!-- Define findings related to the feature or bug issue. -->
1. Switched Day 2 Ops control to Radio group to allow users to select to keep the global default as an option.
New options:
Enabled for this cluster, disabled for this cluster, default(the global setting will be used)
2. Added ttl to allow operations resource to stay visible for longer to allow users to troubleshoot failing operations
3. Changed how snapshot restore is done to match backend changes
4. Fixed OPS being enabled for clusters where it should have been disabled

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
NOTE: Editing doesn't work. This is currently expected

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Test that for clusters with explicitly enabled/disabled mode, the global setting doesn't affect the behavior
Test that for clusters with default mode, the global setting affects the behavior
Test that backup restore works

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Previous day 2 ops changes could be affected

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
