### PR TITLE
Fix capi machine based e2e tests

### DIFF
--- a/cypress/e2e/blueprints/cluster_management/machine-deployments.yml
+++ b/cypress/e2e/blueprints/cluster_management/machine-deployments.yml
@@ -7,7 +7,8 @@ metadata:
 #  labels:  key: string
 spec:
   selector:
-    matchLabels:#  key: string
+    matchLabels:
+#  key: string
 #    matchExpressions:
 #      - key: string
 #        operator: string
@@ -15,7 +16,8 @@ spec:
 #          - string
   template:
     metadata:
-      labels:#  key: string
+      labels:
+#  key: string
 #      annotations:  key: string
 #      generateName: string
 #      name: string

--- a/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-deployments.spec.ts
@@ -167,14 +167,6 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
     cy.wait('@deleteMachineSet');
     machineDeploymentsPage.waitForPage();
 
-    cy.getRancherResource('v1', 'cluster.x-k8s.io.machinedeployments', `${ nsName }/${ cloneName }`, 200).then((resp) => {
-      // Resource gets updated post create (finalizer added). So refetch it to get the correct resourceVersion
-      const resource = resp.body;
-
-      delete resource.metadata.finalizers;
-      cy.setRancherResource('v1', 'cluster.x-k8s.io.machinedeployments', `${ nsName }/${ cloneName }`, resource);
-    });
-
     // check list details
     cy.contains(cloneName).should('not.exist');
   });
@@ -197,14 +189,6 @@ describe('MachineDeployments', { testIsolation: 'off', tags: ['@manager', '@admi
     promptRemove.remove();
     cy.wait('@deleteMachineSet');
     machineDeploymentsPage.waitForPage();
-
-    cy.getRancherResource('v1', 'cluster.x-k8s.io.machinedeployments', `${ machineName }`, 200).then((resp) => {
-      // Resource gets updated post create (finalizer added). So refetch it to get the correct resourceVersion
-      const resource = resp.body;
-
-      delete resource.metadata.finalizers;
-      cy.setRancherResource('v1', 'cluster.x-k8s.io.machinedeployments', `${ machineName }`, resource);
-    });
 
     // check list details
     cy.contains(this.machineDeploymentsName).should('not.exist');

--- a/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machine-sets.spec.ts
@@ -165,14 +165,6 @@ describe('MachineSets', { testIsolation: 'off', tags: ['@manager', '@adminUser']
     cy.wait('@deleteMachineSet');
     machineSetsPage.waitForPage();
 
-    cy.getRancherResource('v1', 'cluster.x-k8s.io.machinesets', `${ name }`, 200).then((resp) => {
-      // Resource gets updated post create (finalizer added). So refetch it to get the correct resourceVersion
-      const resource = resp.body;
-
-      delete resource.metadata.finalizers;
-      cy.setRancherResource('v1', 'cluster.x-k8s.io.machinesets', `${ name }`, resource);
-    });
-
     // check list details
     cy.contains(`${ this.machineSetName }-clone`).should('not.exist');
   });
@@ -195,14 +187,6 @@ describe('MachineSets', { testIsolation: 'off', tags: ['@manager', '@adminUser']
     promptRemove.remove();
     cy.wait('@deleteMachineSet');
     machineSetsPage.waitForPage();
-
-    cy.getRancherResource('v1', 'cluster.x-k8s.io.machinesets', `${ name }`, 200).then((resp) => {
-      // Resource gets updated post create (finalizer added). So refetch it to get the correct resourceVersion
-      const resource = resp.body;
-
-      delete resource.metadata.finalizers;
-      cy.setRancherResource('v1', 'cluster.x-k8s.io.machinesets', `${ name }`, resource);
-    });
 
     // check list details
     cy.contains(this.machineSetName).should('not.exist');

--- a/cypress/e2e/tests/pages/manager/machines.spec.ts
+++ b/cypress/e2e/tests/pages/manager/machines.spec.ts
@@ -119,14 +119,6 @@ describe('Machines', { testIsolation: 'off', tags: ['@manager', '@adminUser'] },
     cy.wait('@deleteCloudCred');
     machinesPage.waitForPage();
 
-    cy.getRancherResource('v1', 'cluster.x-k8s.io.machines', `${ machineName }`, 200).then((resp) => {
-      // Resource gets updated post create (finalizer added). So refetch it to get the correct resourceVersion
-      const resource = resp.body;
-
-      delete resource.metadata.finalizers;
-      cy.setRancherResource('v1', 'cluster.x-k8s.io.machines', `${ machineName }`, resource);
-    });
-
     // check list details
     cy.contains(this.machineName).should('not.exist');
   });


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- machines now delete on their own, no need to remove of the finalizer added as part of https://github.com/rancher/dashboard/pull/13492
- caused by turtles bump https://github.com/rancher/rancher/pull/55940, which bumps capi https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.13.3, which has a bug fix https://github.com/kubernetes-sigs/cluster-api/pull/13748 (props to @mantis-toboggan-md for finding)

### Occurred changes and/or fixed issues
- removed finalizer delete from 
- also fixed blueprint comments

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
