### PR TITLE
feat(#17664): Add "Copy KubeConfig" bulk action to the Cluster Management page

### DIFF
--- a/shell/models/__tests__/management.cattle.io.cluster.test.ts
+++ b/shell/models/__tests__/management.cattle.io.cluster.test.ts
@@ -1,4 +1,5 @@
 import MgmtCluster from '@shell/models/management.cattle.io.cluster';
+import { copyTextToClipboard } from '@shell/utils/clipboard';
 
 jest.mock('@shell/utils/clipboard', () => {
   return { copyTextToClipboard: jest.fn(() => Promise.resolve({})) };
@@ -19,5 +20,150 @@ describe('class MgmtCluster', () => {
       expect(cluster.provisioner).toBe(expected);
     }
     );
+  });
+
+  describe('copyKubeConfig', () => {
+    let cluster: any;
+    const mockGenerateKubeConfig = jest.fn();
+    const mockConfig = 'apiVersion: v1\nkind: Config\nclusters:\n- name: test-cluster';
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      cluster = new MgmtCluster({
+        id:       'test-cluster-1',
+        metadata: { name: 'test-cluster-1' }
+      });
+      cluster.generateKubeConfig = mockGenerateKubeConfig;
+    });
+
+    it('should copy single cluster kubeconfig to clipboard', async() => {
+      mockGenerateKubeConfig.mockResolvedValue(mockConfig);
+
+      await cluster.copyKubeConfig();
+
+      expect(mockGenerateKubeConfig).toHaveBeenCalledWith();
+      expect(copyTextToClipboard).toHaveBeenCalledWith(mockConfig);
+    });
+
+    it('should not copy to clipboard if config generation returns null', async() => {
+      mockGenerateKubeConfig.mockResolvedValue(null);
+
+      await cluster.copyKubeConfig();
+
+      expect(mockGenerateKubeConfig).toHaveBeenCalledWith();
+      expect(copyTextToClipboard).not.toHaveBeenCalled();
+    });
+
+    it('should handle errors gracefully', async() => {
+      mockGenerateKubeConfig.mockRejectedValue(new Error('Generation failed'));
+
+      await expect(cluster.copyKubeConfig()).resolves.not.toThrow();
+      expect(copyTextToClipboard).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('copyKubeConfigBulk', () => {
+    let cluster: any;
+    const mockGenerateKubeConfig = jest.fn();
+    const mockConfig = 'apiVersion: v1\nkind: Config\nclusters:\n- name: cluster-1\n- name: cluster-2';
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      cluster = new MgmtCluster({
+        id:       'cluster-1',
+        metadata: { name: 'cluster-1' }
+      });
+      cluster.generateKubeConfig = mockGenerateKubeConfig;
+    });
+
+    it('should copy multiple cluster kubeconfigs to clipboard', async() => {
+      const items = [
+        { id: 'cluster-1', mgmt: { id: 'mgmt-cluster-1' } },
+        { id: 'cluster-2', mgmt: { id: 'mgmt-cluster-2' } },
+        { id: 'cluster-3', mgmt: { id: 'mgmt-cluster-3' } }
+      ];
+
+      mockGenerateKubeConfig.mockResolvedValue(mockConfig);
+
+      await cluster.copyKubeConfigBulk(items);
+
+      expect(mockGenerateKubeConfig).toHaveBeenCalledWith(['mgmt-cluster-1', 'mgmt-cluster-2', 'mgmt-cluster-3']);
+      expect(copyTextToClipboard).toHaveBeenCalledWith(mockConfig);
+    });
+
+    it('should use item.id when mgmt.id is not available', async() => {
+      const items = [
+        { id: 'cluster-1' },
+        { id: 'cluster-2' },
+        { id: 'cluster-3', mgmt: { id: 'mgmt-cluster-3' } }
+      ];
+
+      mockGenerateKubeConfig.mockResolvedValue(mockConfig);
+
+      await cluster.copyKubeConfigBulk(items);
+
+      expect(mockGenerateKubeConfig).toHaveBeenCalledWith(['cluster-1', 'cluster-2', 'mgmt-cluster-3']);
+      expect(copyTextToClipboard).toHaveBeenCalledWith(mockConfig);
+    });
+
+    it('should handle single cluster in bulk action', async() => {
+      const items = [{ id: 'cluster-1', mgmt: { id: 'mgmt-cluster-1' } }];
+
+      mockGenerateKubeConfig.mockResolvedValue(mockConfig);
+
+      await cluster.copyKubeConfigBulk(items);
+
+      expect(mockGenerateKubeConfig).toHaveBeenCalledWith(['mgmt-cluster-1']);
+      expect(copyTextToClipboard).toHaveBeenCalledWith(mockConfig);
+    });
+
+    it('should not copy to clipboard if config generation returns null', async() => {
+      const items = [
+        { id: 'cluster-1', mgmt: { id: 'mgmt-cluster-1' } },
+        { id: 'cluster-2', mgmt: { id: 'mgmt-cluster-2' } }
+      ];
+
+      mockGenerateKubeConfig.mockResolvedValue(null);
+
+      await cluster.copyKubeConfigBulk(items);
+
+      expect(mockGenerateKubeConfig).toHaveBeenCalledWith(['mgmt-cluster-1', 'mgmt-cluster-2']);
+      expect(copyTextToClipboard).not.toHaveBeenCalled();
+    });
+
+    it('should not copy to clipboard if config is empty string', async() => {
+      const items = [
+        { id: 'cluster-1', mgmt: { id: 'mgmt-cluster-1' } }
+      ];
+
+      mockGenerateKubeConfig.mockResolvedValue('');
+
+      await cluster.copyKubeConfigBulk(items);
+
+      expect(mockGenerateKubeConfig).toHaveBeenCalledWith(['mgmt-cluster-1']);
+      expect(copyTextToClipboard).not.toHaveBeenCalled();
+    });
+
+    it('should handle errors gracefully', async() => {
+      const items = [
+        { id: 'cluster-1', mgmt: { id: 'mgmt-cluster-1' } }
+      ];
+
+      mockGenerateKubeConfig.mockRejectedValue(new Error('Generation failed'));
+
+      await expect(cluster.copyKubeConfigBulk(items)).resolves.not.toThrow();
+      expect(copyTextToClipboard).not.toHaveBeenCalled();
+    });
+
+    it('should handle empty items array', async() => {
+      const items: any[] = [];
+
+      mockGenerateKubeConfig.mockResolvedValue(mockConfig);
+
+      await cluster.copyKubeConfigBulk(items);
+
+      expect(mockGenerateKubeConfig).toHaveBeenCalledWith([]);
+      expect(copyTextToClipboard).toHaveBeenCalledWith(mockConfig);
+    });
   });
 });

--- a/shell/models/__tests__/provisioning.cattle.io.cluster.test.ts
+++ b/shell/models/__tests__/provisioning.cattle.io.cluster.test.ts
@@ -653,4 +653,58 @@ describe('class ProvCluster', () => {
       expect(cluster.namespaceLocation).toBeNull();
     });
   });
+
+  describe('copyKubeConfigBulk', () => {
+    it('should delegate to mgmt cluster copyKubeConfigBulk method', async() => {
+      const mockCopyKubeConfigBulk = jest.fn().mockResolvedValue(undefined);
+      const mgmtCluster = new MgmtCluster({});
+
+      mgmtCluster.copyKubeConfigBulk = mockCopyKubeConfigBulk;
+
+      const cluster = new ProvCluster({});
+
+      jest.spyOn(cluster, 'mgmt', 'get').mockReturnValue(mgmtCluster);
+
+      const items = [
+        { id: 'cluster-1', mgmt: { id: 'mgmt-cluster-1' } },
+        { id: 'cluster-2', mgmt: { id: 'mgmt-cluster-2' } }
+      ];
+
+      await cluster.copyKubeConfigBulk(items);
+
+      expect(mockCopyKubeConfigBulk).toHaveBeenCalledWith(items);
+    });
+
+    it('should handle when mgmt cluster is undefined', () => {
+      const cluster = new ProvCluster({});
+
+      jest.spyOn(cluster, 'mgmt', 'get').mockReturnValue(undefined);
+
+      const items = [{ id: 'cluster-1' }];
+
+      expect(cluster.copyKubeConfigBulk(items)).toBeUndefined();
+    });
+
+    it('should pass through all items to mgmt cluster', async() => {
+      const mockCopyKubeConfigBulk = jest.fn().mockResolvedValue(undefined);
+      const mgmtCluster = new MgmtCluster({});
+
+      mgmtCluster.copyKubeConfigBulk = mockCopyKubeConfigBulk;
+
+      const cluster = new ProvCluster({});
+
+      jest.spyOn(cluster, 'mgmt', 'get').mockReturnValue(mgmtCluster);
+
+      const items = [
+        { id: 'rke2-cluster', mgmt: { id: 'c-m-1' } },
+        { id: 'k3s-cluster', mgmt: { id: 'c-m-2' } },
+        { id: 'eks-cluster', mgmt: { id: 'c-m-3' } }
+      ];
+
+      await cluster.copyKubeConfigBulk(items);
+
+      expect(mockCopyKubeConfigBulk).toHaveBeenCalledWith(items);
+      expect(mockCopyKubeConfigBulk).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -104,11 +104,12 @@ export default class MgmtCluster extends SteveModel {
     });
 
     insertAt(out, 2, {
-      action:   'copyKubeConfig',
-      label:    this.t('cluster.copyConfig'),
-      bulkable: false,
-      enabled:  this.$rootGetters['isRancher'] && this.canCreateKubeconfig,
-      icon:     'icon icon-copy',
+      action:     'copyKubeConfig',
+      bulkAction: 'copyKubeConfigBulk',
+      label:      this.t('cluster.copyConfig'),
+      bulkable:   true,
+      enabled:    this.$rootGetters['isRancher'] && this.canCreateKubeconfig,
+      icon:       'icon icon-copy',
     });
 
     return out;
@@ -687,6 +688,17 @@ export default class MgmtCluster extends SteveModel {
   async copyKubeConfig() {
     try {
       const config = await this.generateKubeConfig();
+
+      if (config) {
+        await copyTextToClipboard(config);
+      }
+    } catch {}
+  }
+
+  async copyKubeConfigBulk(items) {
+    try {
+      const clusters = items.map((item) => item.mgmt?.id || item.id);
+      const config = await this.generateKubeConfig(clusters);
 
       if (config) {
         await copyTextToClipboard(config);

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -146,11 +146,12 @@ export default class ProvCluster extends SteveModel {
         bulkable:   true,
         enabled:    this.mgmt?.canCreateKubeconfig,
       }, {
-        action:   'copyKubeConfig',
-        label:    this.t('cluster.copyConfig'),
-        bulkable: false,
-        enabled:  this.mgmt?.canCreateKubeconfig,
-        icon:     'icon icon-copy',
+        action:     'copyKubeConfig',
+        bulkAction: 'copyKubeConfigBulk',
+        label:      this.t('cluster.copyConfig'),
+        bulkable:   true,
+        enabled:    this.mgmt?.canCreateKubeconfig,
+        icon:       'icon icon-copy',
       }, {
         action:     'snapshotAction',
         label:      this.$rootGetters['i18n/t']('nav.takeSnapshot'),
@@ -551,6 +552,10 @@ export default class ProvCluster extends SteveModel {
 
   downloadKubeConfigBulk(items) {
     return this.mgmt?.downloadKubeConfigBulk(items);
+  }
+
+  copyKubeConfigBulk(items) {
+    return this.mgmt?.copyKubeConfigBulk(items);
   }
 
   async snapshotAction() {


### PR DESCRIPTION
### Summary
Fixes #17664

This PR adds a "Copy KubeConfig" bulk action to the Cluster Management page, allowing users to copy KubeConfigs to the clipboard when one or more clusters are selected.

### Occurred changes and/or fixed issues
- Added `copyKubeConfigBulk` method to `management.cattle.io.cluster.js` that copies KubeConfigs for multiple selected clusters to the clipboard
- Updated the `copyKubeConfig` action to be bulkable in both `management.cattle.io.cluster.js` and `provisioning.cattle.io.cluster.js`
- Added delegation methods in `provisioning.cattle.io.cluster.js` to forward bulk copy operations to the management cluster model

### Technical notes summary
- The implementation follows the same pattern as the existing "Download KubeConfig" bulk action
- When multiple clusters are selected, `copyKubeConfigBulk()` extracts cluster IDs, generates a combined KubeConfig, and copies it to the clipboard using `copyTextToClipboard()`
- The provisioning cluster model delegates to the management cluster model through `this.mgmt?.copyKubeConfigBulk(items)`

### Areas or cases that should be tested
- Select a single cluster on the Cluster Management page and verify "Copy KubeConfig" action works
- Select multiple clusters (2+) on the Cluster Management page and verify "Copy KubeConfig" bulk action appears and works
- Verify the copied KubeConfig contains valid configuration for all selected clusters
- Test with different cluster types (RKE1, RKE2, K3s, imported, hosted providers like EKS/GKE/AKS)
- Verify the action is disabled when user doesn't have permission to create KubeConfig

### Areas which could experience regressions
- Cluster Management list page bulk actions menu
- Single cluster actions menu
- KubeConfig generation for multiple clusters
- Clipboard operations

### Screenshot/Video
https://github.com/user-attachments/assets/532b5d7a-61fa-4818-9812-755b8b80ef66

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
