### PR TITLE
[Release 2.15] Step 1 - Add release-2.15 metadata & freeze all branches

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -3,7 +3,7 @@
     "master": {
       "milestone": {
         "version": "v2.15.0",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -29,10 +29,28 @@
         "ui-index": "https://releases.rancher.com/ui/latest2/index.html"
       }
     },
+    "release-2.15": {
+      "milestone": {
+        "version": "v2.15.0",
+        "codeFreeze": true
+      },
+      "e2e": {
+        "rancher-image": {
+          "namespace": "rancher",
+          "name": "rancher",
+          "tag": "v2.15-head"
+        }
+      },
+      "rancher-rancher-repo": {
+        "branch": "release/v2.15",
+        "ui-dashboard-index": "https://releases.rancher.com/dashboard/release-2.15/index.html",
+        "ui-index": "https://releases.rancher.com/ui/release-2.15/index.html"
+      }
+    },
     "release-2.14": {
       "milestone": {
         "version": "v2.14.4",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -50,7 +68,7 @@
     "release-2.13": {
       "milestone": {
         "version": "v2.13.8",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -69,7 +87,7 @@
     "release-2.12": {
       "milestone": {
         "version": "v2.12.12",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -88,7 +106,7 @@
     "release-2.11": {
       "milestone": {
         "version": "v2.11.16",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {


### PR DESCRIPTION
## Summary

Step 1 of the release-2.15 branching procedure.

Fixes #

## Occurred changes

Branching procedure for 2.15 - part 1 (`branches-metadata.json` only):

- Added a new `release-2.15` block (milestone `v2.15.0`, `codeFreeze: true`, e2e tag `v2.15-head`, rancher repo branch `release/v2.15`).
- Put **every** branch under code freeze — `master` and all existing release lines (`release-2.14`, `release-2.13`, `release-2.12`, `release-2.11`) now have `milestone.codeFreeze: true`.

No `milestone.version` values were changed. Builds pending.

## Checklist

- [x] PR template filled
- [x] Self-reviewed
- [x] No tests needed (metadata-only change)
