### PR TITLE
Fix local user creation storing unhashed password secret

### DIFF
--- a/shell/components/form/ChangePassword.vue
+++ b/shell/components/form/ChangePassword.vue
@@ -234,18 +234,23 @@ export default {
       });
     },
 
-    async save() {
+    async save(user) {
+      // The password change request targets a user by id. On create the user
+      // doesn't exist until createUser() has run, so the caller passes the
+      // freshly created user in; on change/edit we fall back to the prop.
+      const userId = user?.id || this.userId;
+
       if (this.isChange) {
-        await this.changePassword('change');
+        await this.changePassword('change', userId);
         if (this.form.deleteKeys) {
           await this.deleteKeys();
         }
-      } else if (this.isEdit) {
-        return this.changePassword('set');
+      } else if (this.isCreate || this.isEdit) {
+        return this.changePassword('set', userId);
       }
     },
 
-    async changePassword(mode) {
+    async changePassword(mode, userId = this.userId) {
       if (!this.canChangePassword) {
         this.errorMessages = [this.t('changePassword.errors.cannotChange')];
         throw new Error(this.t('changePassword.errors.cannotChange'));
@@ -253,7 +258,7 @@ export default {
 
       const spec = {
         newPassword: this.isRandomGenerated ? this.form.genP : this.form.newP,
-        userID:      this.userId
+        userID:      userId
       };
 
       if (mode === 'change') {

--- a/shell/edit/management.cattle.io.user.vue
+++ b/shell/edit/management.cattle.io.user.vue
@@ -1,5 +1,5 @@
 <script>
-import { MANAGEMENT, SECRET } from '@shell/config/types';
+import { MANAGEMENT } from '@shell/config/types';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import GlobalRoleBindings from '@shell/components/GlobalRoleBindings.vue';
 import ChangePassword from '@shell/components/form/ChangePassword';
@@ -9,7 +9,6 @@ import { exceptionToErrorsArray } from '@shell/utils/error';
 import { _CREATE, _EDIT } from '@shell/config/query-params';
 import Loading from '@shell/components/Loading';
 import { wait } from '@shell/utils/async';
-import { base64Encode } from '@shell/utils/crypto';
 
 export default {
   components: {
@@ -107,7 +106,7 @@ export default {
         if (this.isCreate) {
           const user = await this.createUser();
 
-          await this.createSecret(user);
+          await this.setPassword(user);
           await this.updateRoles(user);
 
           // Show success notification only after ALL operations complete
@@ -137,13 +136,15 @@ export default {
 
     async createUser() {
       // never use "password" as it's deprecated!
+      // Don't set mustChangePassword here: the password is set afterwards via
+      // the passwordChangeRequest API, which clears mustChangePassword. It's
+      // re-applied in setPassword() once the password is stored.
       const user = await this.$store.dispatch('management/create', {
-        type:               MANAGEMENT.USER,
-        description:        this.form.description,
-        enabled:            true,
-        mustChangePassword: this.form.password.userChangeOnLogin,
-        displayName:        this.form.displayName,
-        username:           this.form.username
+        type:        MANAGEMENT.USER,
+        description: this.form.description,
+        enabled:     true,
+        displayName: this.form.displayName,
+        username:    this.form.username
       });
 
       const userSaved = await user.save({
@@ -179,33 +180,35 @@ export default {
       return user;
     },
 
-    async createSecret(user) {
-      if (this.form.password.password) {
-        try {
-        // create secret to hold user password
-          const secret = await this.$store.dispatch('management/create', {
-            type:     SECRET,
-            metadata: {
-              namespace: 'cattle-local-user-passwords',
-              name:      user.id
-            },
-            data: { password: base64Encode(this.form.password.password) }
-          });
+    async setPassword(user) {
+      if (!this.form.password.password) {
+        return;
+      }
 
-          await secret.save();
-        } catch (err) {
-          if (this.isCreate) {
-            try {
-              // If secret creation fails, attempt to clean up the user to maintain consistency
-              await user.remove();
-            } catch (cleanupErr) {
-              // Log cleanup error but prioritize original error for user feedback
-              console.error('Failed to clean up user after secret creation failure:', cleanupErr); // eslint-disable-line no-console
-            }
-          }
+      try {
+        // Set the password via the passwordChangeRequest API so the backend
+        // hashes it and stores the secret with the required
+        // `cattle.io/password-hash` annotation and salt. Writing the secret
+        // directly from the UI would omit the hash and break login/password
+        // changes (rancher/rancher#55378).
+        await this.$refs.changePassword.save(user);
 
-          throw err;
+        // The passwordChangeRequest clears mustChangePassword, so re-apply it
+        // afterwards when requested (mirrors the edit flow).
+        if (this.form.password.userChangeOnLogin) {
+          user.mustChangePassword = true;
+          await user.save();
         }
+      } catch (err) {
+        try {
+          // If setting the password fails, clean up the user to maintain consistency
+          await user.remove();
+        } catch (cleanupErr) {
+          // Log cleanup error but prioritize original error for user feedback
+          console.error('Failed to clean up user after password creation failure:', cleanupErr); // eslint-disable-line no-console
+        }
+
+        throw err;
       }
     },
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/19038

Newly created local users cannot log in, and password changes for them fail with `unsupported hashing algorithm ""`.

Since rancher/rancher#16526 the user create flow stopped POSTing to the Norman `/v3/users` endpoint and instead writes the password secret directly to the `cattle-local-user-passwords` namespace with only a base64-encoded **plaintext** password:

```js
data: { password: base64Encode(this.form.password.password) }
```

That secret has no `cattle.io/password-hash` annotation and no salt. The backend (`pkg/auth/providers/local/pbkdf2`) keys every password verify/update off that annotation and accepts only `pbkdf2sha3512` (password + salt) or `bcrypt`; an empty annotation produces the exact `unsupported hashing algorithm ""` error reported. The edit flow was unaffected because it already sets passwords through the `passwordChangeRequest` API.

### Occurred changes and/or fixed issues
- Local user **creation** now sets the password through the `passwordChangeRequest` API (the same path the edit flow uses), so the backend hashes the password and stores the secret with the required annotation and salt.
- Removed the direct secret write to `cattle-local-user-passwords` (and the now-dead `SECRET` / `base64Encode` imports).
- `mustChangePassword` is applied after the password is set, since the `passwordChangeRequest` clears it — mirroring the existing edit flow.
- Existing behavior preserved: if setting the password fails, the just-created user is cleaned up.

### Technical notes summary
- `shell/components/form/ChangePassword.vue`: `save(user)` and `changePassword(mode, userId = this.userId)` now accept a user id, so the request can target the freshly created user (whose id does not exist until `createUser()` returns). `save()` now handles `isCreate` in addition to `isEdit`.
- `shell/edit/management.cattle.io.user.vue`: `createSecret()` → `setPassword()`, delegating to the `ChangePassword` ref. `createUser()` no longer sets `mustChangePassword` at create time (it would be cleared by the subsequent password set); it is re-applied in `setPassword()` afterwards.

### Areas or cases that should be tested
- Create a new local user with a password, then log in as that user — login should succeed.
- Inspect the created secret in `cattle-local-user-passwords`: it should have the `cattle.io/password-hash` annotation and a `salt` key (matching secrets created by older Rancher versions), not a base64 plaintext password.
- Create a user with **"User must change password on next login"** checked — the flag should be honored (user is prompted on first login).
- Create a user with a **randomly generated** password (the generate-password checkbox) — login should work.
- Change the password of a newly created user (as admin) — should succeed.
- Existing edit flow (change/set password on an existing user) should be unchanged.
- Browser used for local testing: _pending_ — reviewer should test in a different browser.

### Areas which could experience regressions
- Password **edit** flow for existing users (shares the modified `ChangePassword.save`/`changePassword` signatures).
- Self-service password **change** flow (account settings), which also uses `ChangePassword`.
- User creation error/cleanup path (user removal when password or role binding fails).
- `mustChangePassword` handling on both create and edit.

### Screenshot/Video
_Pending manual verification against a running Rancher._

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
