### PR TITLE
Bump node-forge from 1.3.1 to 1.4.0 in /shell

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -141,7 +141,7 @@
     "glob-parent": "6.0.2",
     "json5": "2.2.3",
     "merge": "2.1.1",
-    "node-forge": "1.3.1",
+    "node-forge": "1.4.0",
     "nth-check": "2.1.1",
     "qs": "6.15.2",
     "roarr": "7.0.4",

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -9070,10 +9070,10 @@ node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@1.3.1, node-forge@^1:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
-  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+node-forge@1.4.0, node-forge@^1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.4.0.tgz#1c7b7d8bdc2d078739f58287d589d903a11b2fc2"
+  integrity sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
### Summary
Fixes #

Bumps the transitive dependency **`node-forge` from 1.3.1 to 1.4.0** in `shell/` to resolve **7 open Dependabot advisories** (6 High, 1 Medium). `node-forge` is pulled in through `@vue/cli-service → webpack-dev-server → selfsigned → node-forge`. It was being held at the vulnerable `1.3.1` by a `resolutions` pin in `shell/package.json`; this PR raises that pin to `1.4.0` and regenerates the lockfile. The bump covers the ASN.1 parsing DoS/desync issues, the RSA-PKCS and Ed25519 signature-forgery flaws, the `basicConstraints` certificate-chain bypass, the `modInverse` DoS, and the ASN.1 OID integer-truncation issue.

### Occurred changes and/or fixed issues
- `shell/package.json`: `resolutions.node-forge` `1.3.1` → `1.4.0`.
- `shell/yarn.lock`: regenerated — `node-forge` now resolves to `1.4.0`; no vulnerable `1.3.x` runtime entry remains.
- Dependabot alerts / advisories closed by this change:
  - [#613](https://github.com/rancher/dashboard/security/dependabot/613) — GHSA-2328-f5f3-gj25 (basicConstraints bypass, CVE-2026-33896)
  - [#612](https://github.com/rancher/dashboard/security/dependabot/612) — GHSA-q67f-28xg-22rw (Ed25519 signature forgery, CVE-2026-33895)
  - [#611](https://github.com/rancher/dashboard/security/dependabot/611) — GHSA-ppp5-5v6c-4jwp (RSA-PKCS signature forgery, CVE-2026-33894)
  - [#610](https://github.com/rancher/dashboard/security/dependabot/610) — GHSA-5m6q-g25r-mvwx (modInverse infinite-loop DoS, CVE-2026-33891)
  - [#423](https://github.com/rancher/dashboard/security/dependabot/423) — GHSA-554w-wpv2-vw27 (ASN.1 unbounded recursion, CVE-2025-66031)
  - [#419](https://github.com/rancher/dashboard/security/dependabot/419) — GHSA-5gfm-wpxj-wjgq (ASN.1 validator desynchronization, CVE-2025-12816)
  - [#421](https://github.com/rancher/dashboard/security/dependabot/421) — GHSA-65ch-62r8-g69g (ASN.1 OID integer truncation, CVE-2025-66030)

### Technical notes summary
`node-forge` is a **transitive** dependency, so no application `package.json` `dependencies` entry changes. The version was forced to the vulnerable `1.3.1` by a `resolutions` override in `shell/package.json`; the fix raises that override to `1.4.0` and regenerates `shell/yarn.lock` so the whole `selfsigned` chain resolves to the patched build. Lockfile was regenerated with `yarn install` (not hand-edited).

### Areas or cases that should be tested
`node-forge` here backs `selfsigned`, used by `webpack-dev-server` to generate the local HTTPS dev-server certificate — i.e. dev tooling, not shipped browser code. Suggested checks:
- `vue-cli-service serve --https` (or `yarn dev` with HTTPS) starts and serves a valid self-signed cert.
- The production dashboard still builds cleanly (`yarn build`) — verified here via a green preview build.
- Smoke-test the built dashboard (login, navigate the local cluster explorer) — verified here via Playwright (4/4).
- Browser used for local testing: Chromium (Playwright). Reviewer: please retest in a different browser.

### Areas which could experience regressions
Minimal — the change is confined to the dev-server HTTPS certificate generation path (`selfsigned`/`node-forge`). No production/browser bundle code imports `node-forge`. Watch for any local HTTPS dev-server startup issues.

### Screenshot/Video

Verification recording (Playwright):

https://github.com/user-attachments/assets/ffbbb97a-5a1c-4e7e-a82d-dd59c088c309

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests, or tests are not needed (dependency-only bump; lint passes, cert generation and app smoke-test verified)
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes (no UX changes)
- [x] The PR has been reviewed in terms of Accessibility (no UI changes)
- [x] The PR has considered the three Global Roles, or it is not applicable (dependency bump, not applicable)


