### PR TITLE
Bump js-cookie from 3.0.5 to 3.0.7 in /shell

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -139,6 +139,7 @@
     "follow-redirects": "1.15.2",
     "glob": "7.2.3",
     "glob-parent": "6.0.2",
+    "js-cookie": "3.0.7",
     "json5": "2.2.3",
     "merge": "2.1.1",
     "node-forge": "1.3.1",

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -8370,10 +8370,10 @@ js-beautify@^1.14.9, js-beautify@^1.6.12:
     js-cookie "^3.0.5"
     nopt "^7.2.1"
 
-js-cookie@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
-  integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
+js-cookie@3.0.7, js-cookie@^3.0.5:
+  version "3.0.7"
+  resolved "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz#0a53abfc459c8e89c85d7a38eb6cb68714965b8c"
+  integrity sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==
 
 js-message@1.0.7:
   version "1.0.7"


### PR DESCRIPTION
### Summary
Fixes #

Resolves a **high**-severity Dependabot advisory: **JavaScript Cookie: Per-instance prototype hijack in `assign()` enables cookie-attribute injection** (`GHSA-qjx8-664m-686j` / `CVE-2026-46625`). `js-cookie` `<= 3.0.5` is vulnerable; the first patched version is `3.0.7`.

`js-cookie` is a **transitive** dependency in `/shell` — it is pulled in only via `js-beautify` (`@vue/test-utils` and `jest-serializer-vue` → `pretty` → `js-beautify` → `js-cookie`), i.e. the test/snapshot-serialization toolchain. It is **not** part of the shipped browser bundle (the dashboard's own cookie handling uses `cookie-universal`), so this is a devtool-chain hardening with no runtime UI surface.

Resolves Dependabot alert:
- https://github.com/rancher/dashboard/security/dependabot/823

### Occurred changes and/or fixed issues
- Pinned `js-cookie` to `3.0.7` via a `resolutions` entry in `shell/package.json` (transitive dep — `package.json` `dependencies` were not otherwise touched).
- Regenerated `shell/yarn.lock` so `js-cookie@^3.0.5` now resolves to `3.0.7`. No vulnerable version (`<= 3.0.5`) remains in the lockfile.
- Manifests touched: `shell/package.json`, `shell/yarn.lock` (old → new: `js-cookie` `3.0.5` → `3.0.7`).

### Technical notes summary
- Because `js-cookie` is transitive, the fix is a Yarn `resolutions` override in the `shell` project rather than a direct `dependencies` bump, matching the existing style of the other pinned resolutions in that file (`follow-redirects`, `glob`, `node-forge`, …). `js-beautify` requires `^3.0.5`, which `3.0.7` satisfies, so no consumer constraint is broken.

### Areas or cases that should be tested
- Jest snapshot serialization (the actual consumer of `js-cookie` via `jest-serializer-vue` → `js-beautify`). Verified locally — see below.
- General smoke: login, session-cookie handling, home/cluster-list rendering. Verified on a full preview build — see below.
- Browser used for local verification: Chromium (Playwright). Reviewer should verify with a different browser.

### Areas which could experience regressions
- None expected in the shipped app — `js-cookie` is not in the production bundle. The only consumer is the Jest snapshot toolchain; snapshot tests were run and behave identically to `master`.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/2a540a58-58b8-4077-ac41-4a5949bd7162

**Playwright checks performed** (video recorded, 1280×800):
1. Login succeeds and a session cookie is set — logged in as local user; `R_SESS`, `CSRF`, `R_PCS`, `R_LOCALE` cookies present, landed on `/dashboard/home` (cookie handling intact after the js-cookie bump). ✅ PASS
2. Authenticated Home dashboard renders the main app shell. ✅ PASS
3. Cluster explorer loads with side navigation — SPA stays authenticated across routes (`/c/local/explorer`). ✅ PASS
4. Nodes resource list renders substantive content without an application error. ✅ PASS

**Verdict:** Bumping js-cookie 3.0.5 → 3.0.7 keeps cookie-backed authentication and core cluster-explorer navigation fully functional; no regressions observed. ✅

**Verification results**
- `yarn install --frozen-lockfile` in `/shell`: passes (lockfile consistent, no changes).
- `yarn lint` (repo root, eslint): passes (exit 0, 0 warnings).
- `yarn test` (Jest): the `js-cookie`-backed snapshot-serialization chain passes; the full run has 2 **pre-existing** snapshot failures (`auditpolicy General` and `fleet HelmOpTargetOptionsSection`) that reproduce identically on clean `master` and are unrelated to this dependency bump.
- Full webpack production build of the dashboard from this branch: succeeds.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

