### PR TITLE
Show units on both used and total in ConsumptionGauge

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -5153,7 +5153,7 @@ node:
     glance:
       consumptionGauge:
         used: Used
-        amount: "{used} of {total} {unit}"
+        amount: "{used}{unit} of {total}{unit}"
         cpu: CPU
         memory: MEMORY
         pods: PODS

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -3614,7 +3614,7 @@ node:
     glance:
       consumptionGauge:
         used: 已使用
-        amount: "已使用 {total} {unit} 中的 {used}"
+        amount: "已使用 {total}{unit} 中的 {used}{unit}"
         cpu: CPU
         memory: 内存
         pods: Pod

--- a/shell/components/__tests__/ConsumptionGauge.test.ts
+++ b/shell/components/__tests__/ConsumptionGauge.test.ts
@@ -3,6 +3,74 @@ import ConsumptionGauge from '@shell/components/ConsumptionGauge.vue';
 import PercentageBar from '@shell/components/PercentageBar.vue';
 
 describe('component: ConsumptionGauge', () => {
+  it('amountTemplateValues should include unit for both used and total', () => {
+    const wrapper = mount(ConsumptionGauge, {
+      props: {
+        resourceName: 'MEMORY',
+        capacity:     16000,
+        used:         4000,
+        units:        'GiB',
+      },
+    });
+
+    const values = (wrapper.vm as any).amountTemplateValues;
+
+    expect(values).toStrictEqual({
+      used:  4000,
+      total: 16000,
+      unit:  ' GiB',
+    });
+  });
+
+  it('amountTemplateValues should have empty unit when units prop is not provided', () => {
+    const wrapper = mount(ConsumptionGauge, {
+      props: {
+        resourceName: 'CPU',
+        capacity:     4,
+        used:         2,
+      },
+    });
+
+    const values = (wrapper.vm as any).amountTemplateValues;
+
+    expect(values).toStrictEqual({
+      used:  2,
+      total: 4,
+      unit:  '',
+    });
+  });
+
+  it('should render the amount string with units on both used and total values', () => {
+    const amountTemplate = '{used}{unit} of {total}{unit}';
+
+    const wrapper = mount(ConsumptionGauge, {
+      props: {
+        resourceName: 'MEMORY',
+        capacity:     16000,
+        used:         4000,
+        units:        'GiB',
+      },
+      global: {
+        mocks: {
+          t: (key: string, opts?: Record<string, string>) => {
+            if (key === 'node.detail.glance.consumptionGauge.amount' && opts) {
+              return amountTemplate
+                .replace('{used}', opts.used)
+                .replace('{total}', opts.total)
+                .replace(/\{unit\}/g, opts.unit);
+            }
+
+            return `%${ key }%`;
+          }
+        }
+      }
+    });
+
+    const statsText = wrapper.find('.numbers-stats').text();
+
+    expect(statsText).toContain('4000 GiB of 16000 GiB');
+  });
+
   it('should render component with the correct data applied', () => {
     const colorStops = {
       0: '--success', 30: '--warning', 70: '--error'


### PR DESCRIPTION
### Summary
Fixes #16645

### Occurred changes and/or fixed issues

The ConsumptionGauge memory card on the node detail page displayed values like "3.55 of 15 GiB" where only the total had a unit. The i18n template `"{used} of {total} {unit}"` placed the unit only after `{total}`.

Changed the template to `"{used}{unit} of {total}{unit}"` so both values display their unit (e.g. "3.55 GiB of 15 GiB"). Applied the same fix to the `zh-hans` translation.

### Technical notes summary

- [`shell/assets/translations/en-us.yaml`](https://github.com/rancher/dashboard/blob/d612949637e3b3495b02898ebc17aa31588b5ca4/shell/assets/translations/en-us.yaml#L5156): changed `consumptionGauge.amount` template from `"{used} of {total} {unit}"` to `"{used}{unit} of {total}{unit}"`
- [`shell/assets/translations/zh-hans.yaml`](https://github.com/rancher/dashboard/blob/d612949637e3b3495b02898ebc17aa31588b5ca4/shell/assets/translations/zh-hans.yaml#L3617): same pattern applied to the Chinese translation
- [`shell/components/__tests__/ConsumptionGauge.test.ts`](https://github.com/rancher/dashboard/blob/d612949637e3b3495b02898ebc17aa31588b5ca4/shell/components/__tests__/ConsumptionGauge.test.ts): added three tests verifying `amountTemplateValues` includes the unit for both used and total, handles missing units, and renders the formatted string correctly

### Areas or cases that should be tested

- Node detail page memory card: verify both used and total display units (e.g. "0 GiB of 62 GiB")
- Node detail page CPU and pods cards: verify they still render correctly (they pass no unit, so they should show no unit suffix)
- Verify the Chinese locale also renders units on both values

### Areas which could experience regressions

- Any dashboard component using the `consumptionGauge.amount` i18n key with the `{unit}` placeholder
- Other locales that override this key (only `en-us` and `zh-hans` are patched here)

### Screenshot/Video

**Before** (unit missing from used value):

![before](https://github.com/codyrancher/dashboard/releases/download/issue-16645-artifacts/before-fix.png)

**After** (unit shown on both used and total):

![after](https://github.com/codyrancher/dashboard/releases/download/issue-16645-artifacts/after-fix.png)

### Checklist
- [] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [] The PR has a Milestone
- [] The PR template has been filled out
- [] The PR has been self reviewed
- [] The PR has a reviewer assigned
- [] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [] The PR has been reviewed in terms of Accessibility
- [] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
- [] New item
