### PR TITLE
Bump serialize-javascript to 7.0.3 to fix RCE (GHSA-5c6j-r48x-rmvq)

### DIFF
--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -51,7 +51,8 @@
   "resolutions": {
     "cheerio": "1.0.0-rc.12",
     "webpack": "5.105.4",
-    "ws": "8.21.0"
+    "ws": "8.21.0",
+    "serialize-javascript": "7.0.3"
   },
   "engines": {
     "node": ">=18.0"

--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -7742,13 +7742,6 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-randombytes@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
-  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
-  dependencies:
-    safe-buffer "^5.1.0"
-
 range-parser@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
@@ -8196,7 +8189,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -8304,12 +8297,10 @@ send@~0.19.0, send@~0.19.1:
     range-parser "~1.2.1"
     statuses "~2.0.2"
 
-serialize-javascript@^6.0.0, serialize-javascript@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
+serialize-javascript@7.0.3, serialize-javascript@^6.0.0, serialize-javascript@^6.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.3.tgz#c92008d8a21bc7b2307c2e885a4bd0f03b2aee6c"
+  integrity sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==
 
 serve-handler@^6.1.6:
   version "6.1.7"

--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "html-webpack-plugin": "5.0.0",
     "form-data": "4.0.6",
     "qs": "6.15.2",
-    "cross-spawn": "7.0.6"
+    "cross-spawn": "7.0.6",
+    "serialize-javascript": "7.0.3"
   }
 }

--- a/shell/package.json
+++ b/shell/package.json
@@ -148,6 +148,7 @@
     "roarr": "7.0.4",
     "semver": "7.5.4",
     "ws": "8.21.0",
+    "serialize-javascript": "7.0.3",
     "@types/lodash": "4.17.5",
     "@types/node": "25.3.3",
     "@vue/cli-service/html-webpack-plugin": "^5.0.0"

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -10600,12 +10600,10 @@ send@~0.19.0, send@~0.19.1:
     range-parser "~1.2.1"
     statuses "~2.0.2"
 
-serialize-javascript@^6.0.0:
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
+serialize-javascript@7.0.3, serialize-javascript@^6.0.0:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.3.tgz#c92008d8a21bc7b2307c2e885a4bd0f03b2aee6c"
+  integrity sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==
 
 serve-index@^1.9.1:
   version "1.9.2"

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -34,5 +34,8 @@
     "storybook-vue3-router": "^5.0.0",
     "typescript": "^5.5.3",
     "vue-tsc": "^2.1.6"
+  },
+  "resolutions": {
+    "serialize-javascript": "7.0.3"
   }
 }

--- a/storybook/yarn.lock
+++ b/storybook/yarn.lock
@@ -4146,13 +4146,6 @@ querystring@^0.2.0:
   resolved "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz#40d77615bb09d16902a85c3e38aa8b5ed761c2dd"
   integrity sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==
 
-randombytes@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
-  integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
-  dependencies:
-    safe-buffer "^5.1.0"
-
 range-parser@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -4327,11 +4320,6 @@ rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
-safe-buffer@^5.1.0:
-  version "5.2.1"
-  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
@@ -4390,12 +4378,10 @@ semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.4, semver@^7.6.2:
   resolved "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
-serialize-javascript@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
+serialize-javascript@7.0.3, serialize-javascript@^6.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.3.tgz#c92008d8a21bc7b2307c2e885a4bd0f03b2aee6c"
+  integrity sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==
 
 set-function-length@^1.2.1:
   version "1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13283,19 +13283,10 @@ send@~0.19.0, send@~0.19.1:
     range-parser "~1.2.1"
     statuses "~2.0.2"
 
-serialize-javascript@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
-  integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
-  dependencies:
-    randombytes "^2.1.0"
-
-serialize-javascript@^6.0.0:
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
+serialize-javascript@6.0.0, serialize-javascript@7.0.3, serialize-javascript@^6.0.0:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.3.tgz#c92008d8a21bc7b2307c2e885a4bd0f03b2aee6c"
+  integrity sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==
 
 serve-index@^1.9.1:
   version "1.9.2"


### PR DESCRIPTION
### Summary
Fixes #

Resolves the high-severity **serialize-javascript RCE via `RegExp.flags` and `Date.prototype.toISOString()`** advisory ([GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq), severity: **high**). `serialize-javascript` is pulled in transitively (via `terser-webpack-plugin`, `css-minimizer-webpack-plugin`, `copy-webpack-plugin`) at `6.0.0`/`6.0.2`, which fall inside the vulnerable range (`<= 7.0.2`). This bumps it to the first patched version, **7.0.3**, across every manifest it appears in.

Dependabot alerts closed by this change:
- https://github.com/rancher/dashboard/security/dependabot/556 (`shell/yarn.lock`, runtime)
- https://github.com/rancher/dashboard/security/dependabot/689 (`docusaurus/yarn.lock`, runtime)
- https://github.com/rancher/dashboard/security/dependabot/557 (root `yarn.lock`, development)
- https://github.com/rancher/dashboard/security/dependabot/555 (`storybook/yarn.lock`, development)

### Occurred changes and/or fixed issues
Bumped **serialize-javascript** `6.0.0` / `6.0.2` → **`7.0.3`** in every manifest the advisory touches:

| Manifest | Old | New |
| --- | --- | --- |
| `yarn.lock` (root) | 6.0.0, 6.0.2 | 7.0.3 |
| `shell/yarn.lock` | 6.0.2 | 7.0.3 |
| `docusaurus/yarn.lock` | 6.0.2 | 7.0.3 |
| `storybook/yarn.lock` | 6.0.2 | 7.0.3 |

Each affected `package.json` gained a `"serialize-javascript": "7.0.3"` **`resolutions`** entry and its `yarn.lock` was regenerated with `yarn install`. No vulnerable version (`<= 7.0.2`) remains in any lockfile. The only incidental change is that `serialize-javascript@7.0.3` no longer depends on `randombytes`, so that transitive edge (and its `safe-buffer` requestor) drops out of the lockfiles.

### Technical notes summary
`serialize-javascript` is a **transitive, build-time** dependency (webpack minifier/asset-copy plugins use it to serialize their cache/manifest data — it is not imported by any dashboard source code). Because it is transitive, the fix is applied via a yarn `resolutions` override rather than a direct `package.json` bump. `resolutions` was added in the root, `shell`, `docusaurus` and `storybook` projects (the four separate yarn installs where the advisory appears).

### Areas or cases that should be tested
Because the package is only exercised at build time (JS/CSS minification + asset copy), the key regression surface is that the **production build still succeeds and the minified bundles run correctly**. Verified by:
- Full production dashboard build from this branch — **succeeded** (webpack build ran terser / css-minimizer / copy-webpack with `serialize-javascript@7.0.3`).
- `yarn lint` — **passed**.
- Deployed the built bundles to a live preview and drove it with Playwright (Chromium):
  - login page renders from the minified assets — **pass**
  - authenticates and lands on `/dashboard/home` (Vue app boots from minified bundle) — **pass**
  - app shell / cluster list renders — **pass**
  - lazy-loaded route `/c/local/explorer` (webpack split-chunk manifest resolves) — **pass**
  - second lazy route `/prefs` — **pass**
  - **0 uncaught page errors / no JS SyntaxErrors** (corrupt minifier output would surface here) — **pass**

Browser used for local testing: Chromium (via Playwright). Reviewer should verify with a different browser.

### Areas which could experience regressions
Anything produced by the webpack minification/asset pipeline — i.e. all shipped JS/CSS bundles and copied assets. A bad minifier-cache serialization would manifest as broken/corrupted bundles that fail to parse or execute; the Playwright run above exercised app boot + lazy chunk loading and observed zero parse/runtime errors.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/ad4f9773-e55b-439c-951e-c5b39af0e011

**Playwright checks performed** (video recorded, 1280×800):
1. Login page (webpack-built bundle) renders with its auth form — auth controls present ✅ PASS
2. Login submits and the Rancher UI shell loads / SPA bootstraps (landed on `/dashboard/home`) ✅ PASS
3. Home / cluster-management view renders — async routes + built assets served ✅ PASS
4. Navigation chrome hydrated and interactive (9 nav links present) ✅ PASS

**Verdict:** Preview built from the bumped branch serves the dashboard and works end-to-end — the serialize-javascript 7.0.3 bump is safe to ship. ✅

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

<sub>This is a dependency-only security bump (no source or UX changes); the Accessibility / UX / Global-Roles items are ticked as not-applicable.</sub>

