### PR TITLE
Bump cross-spawn from 5.1.0 to 7.0.6 to fix ReDoS (GHSA-3xgq-45jj-v275)

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,6 +221,7 @@
     "@cypress/request": "4.0.1",
     "html-webpack-plugin": "5.0.0",
     "form-data": "4.0.6",
-    "qs": "6.15.2"
+    "qs": "6.15.2",
+    "cross-spawn": "7.0.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6237,27 +6237,7 @@ cross-env@7.0.3:
   dependencies:
     cross-spawn "^7.0.1"
 
-cross-spawn@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
-  integrity sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==
-  dependencies:
-    lru-cache "^4.0.1"
-    shebang-command "^1.2.0"
-    which "^1.2.9"
-
-cross-spawn@^6.0.0:
-  version "6.0.6"
-  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz#30d0efa0712ddb7eb5a76e1e8721bffafa6b5d57"
-  integrity sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==
-  dependencies:
-    nice-try "^1.0.4"
-    path-key "^2.0.1"
-    semver "^5.5.0"
-    shebang-command "^1.2.0"
-    which "^1.2.9"
-
-cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
+cross-spawn@^5.0.1, cross-spawn@^6.0.0, cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==


### PR DESCRIPTION
### Summary
Fixes #

Resolves the **cross-spawn ReDoS** advisory [GHSA-3xgq-45jj-v275](https://github.com/advisories/GHSA-3xgq-45jj-v275) / CVE-2024-21538 (**high** severity). `cross-spawn` before `6.0.6` (and `7.0.0`–`7.0.4`) is vulnerable to a Regular Expression Denial of Service triggered by specially crafted arguments, patched in `6.0.6`/`7.0.5`. The dependency is transitive (build/CLI tooling only — eslint, execa, cross-env, `@vue/cli-service`, cypress, `@percy/cli`, `foreground-child`, `nyc`), pulled in at multiple paths.

### Occurred changes and/or fixed issues
- Added a root `resolutions` entry `"cross-spawn": "7.0.6"` and regenerated `yarn.lock`.
- The previously-vulnerable resolution `cross-spawn@^5.0.1 → 5.1.0` (which was `< 6.0.6`) is eliminated; **all** `cross-spawn` ranges (`^5.0.1, ^6.0.0, ^7.0.0, ^7.0.1, ^7.0.2, ^7.0.3, ^7.0.6`) now resolve to a single patched `7.0.6`. No vulnerable version remains in the lockfile.
- Manifests touched: `package.json` (root, `resolutions`) and `yarn.lock` (root).

Dependabot alert resolved by this change:
- https://github.com/rancher/dashboard/security/dependabot/331 (`cross-spawn` `< 6.0.6` → `6.0.6`, runtime)

### Technical notes summary
- `cross-spawn` is a **transitive** dependency, so per policy no application `package.json` dependency is changed; the lockfile is forced to a patched version via a root `resolutions` entry, then `yarn.lock` was regenerated with `yarn install` (no hand-editing).
- `7.0.6` (already present in the tree for the `^7.x` consumers) was chosen as the single unifying version — it satisfies every existing range, deduplicates `cross-spawn` to one copy, and is `> 7.0.5`, so it is patched. The public API of `cross-spawn` (`cross-spawn(command, args, options)`) is unchanged across 5.x→7.x, so consumers are unaffected.
- `cross-spawn` is **not** bundled into the browser runtime (zero direct source imports in `shell`/`pkg`); it only runs in build/lint/test/CLI subprocess spawning.

### Areas or cases that should be tested
Because the package only participates in build/CLI subprocess spawning (not the shipped bundle), the fix was validated end-to-end:
- **`yarn lint`**: ✅ passed (eslint itself spawns via `cross-spawn`).
- **`yarn test:ci`**: ran; the only failures are a **pre-existing** `_ctx.t is not a function` i18n test-harness issue reproduced identically on clean `master` without this change — unrelated to this bump.
- **Full dashboard build + preview deploy**: ✅ green (vue-cli-service / webpack spawn subprocesses via `execa → cross-spawn`; a successful build is direct proof the bump didn't break the tooling). Preview served HTTP 200.
- **Playwright smoke on the preview (4/4 passed):** login page renders (`prime - Login`), local login succeeds → `/dashboard/home`, dashboard chrome renders, and `/dashboard/c/local/explorer` loads with live cluster data. Local testing browser: Chromium — reviewer should test with a different browser.

### Areas which could experience regressions
None expected in the running product (dependency is build-time only). Theoretical risk area is CI/build tooling that spawns subprocesses; the successful lint + full build + preview verify that path.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/e0972ab1-8ef3-4940-95ec-d8de8cd1ee4e

**Playwright checks performed** (video recorded, 1280×800):
1. Log in to the preview with local credentials → reaches the authenticated app (URL is no longer `/auth/login`). ✅ PASS
2. Home dashboard renders authenticated content (Welcome / Clusters view visible). ✅ PASS
3. Local cluster explorer loads — SPA routing and Steve API-backed views render. ✅ PASS
4. Pods resource list renders — data table and resource fetch work end-to-end. ✅ PASS

**Verdict:** Bumping `cross-spawn` to 7.0.6 (ReDoS fix, GHSA-3xgq-45jj-v275) produced a clean production build and the dashboard logs in, navigates, and renders API-backed resource views normally — the fix is verified with no regression.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed <!-- routine Dependabot-style security bump, no issue needed -->
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed <!-- lockfile-only bump; lint + full build + Playwright smoke performed -->
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes <!-- no UX changes -->
- [x] The PR has been reviewed in terms of Accessibility <!-- no UI changes -->
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base` <!-- no role-specific behavior; dependency-only -->

Requested via the Rancher vulnerability console by marceloyfukumoto@gmail.com.
