### PR TITLE
Bump picomatch to 2.3.2/4.0.5 to fix ReDoS (GHSA-c2c7-rcm5-vvqj)

### DIFF
--- a/cypress/yarn.lock
+++ b/cypress/yarn.lock
@@ -4378,14 +4378,14 @@ picocolors@^1.1.1:
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 picomatch@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
+  integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
 
 pify@^2.2.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12151,14 +12151,14 @@ picocolors@^1.0.0, picocolors@^1.1.1:
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 picomatch@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
+  integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
 
 pify@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
### Summary
Fixes #

Resolves the **high-severity ReDoS in `picomatch`** — *"Picomatch has a ReDoS vulnerability via extglob quantifiers"* (**GHSA-c2c7-rcm5-vvqj**, **CVE-2026-33671**). A crafted glob using extglob quantifiers can cause catastrophic backtracking in `picomatch`'s regex, leading to denial of service. `picomatch` is a transitive dependency (glob matching used by the build/dev toolchain — `fast-glob`, `micromatch`, `chokidar`/`anymatch`, `tinyglobby`, `jest`).

### Occurred changes and/or fixed issues
Bumped `picomatch` past the vulnerable ranges (`< 2.3.2` and `>= 4.0.0, < 4.0.4`) by regenerating the lockfiles; no `package.json` dependency was direct so no manifest version pins were needed (existing semver ranges already permit the patched releases).

Manifests changed (old → new):

| Manifest | picomatch (2.x line) | picomatch (4.x line) |
| --- | --- | --- |
| `yarn.lock` (root) | 2.3.1 → **2.3.2** | 4.0.3 → **4.0.5** |
| `cypress/yarn.lock` | 2.3.1 → **2.3.2** | 4.0.3 → **4.0.5** |

Dependabot alerts closed by this change:
- https://github.com/rancher/dashboard/security/dependabot/606 (root `yarn.lock`, `>= 4.0.0, < 4.0.4`)
- https://github.com/rancher/dashboard/security/dependabot/595 (`cypress/yarn.lock`, `< 2.3.2`)
- https://github.com/rancher/dashboard/security/dependabot/594 (`cypress/yarn.lock`, `>= 4.0.0, < 4.0.4`)

No open Dependabot PR exists for this advisory (Dependabot cannot bump this transitive automatically).

### Technical notes summary
- `picomatch` is **transitive** in both manifests. The fix removes the stale `picomatch@…` lock entries and reinstalls so each requirement re-resolves to the highest matching published version: the `^2.x` requirements resolve to `2.3.2` (the patched 2.x release) and the `^4.0.3` requirement resolves to `4.0.5` (`> 4.0.4`, patched). No `resolutions` entry was required because the existing caret ranges already admit the patched versions.
- Both major lines are kept (v2 and v4) so no consumer is forced across a major boundary.
- Lockfiles were regenerated with `yarn install` (via the repo's no-lock helper for the root, which carries `--frozen-lockfile`); no hashes were hand-edited. Diff is lockfile-only, 12 lines total, `picomatch` entries exclusively.

### Areas or cases that should be tested
`picomatch` has **no direct import** in `shell`/`pkg` source — it is used only by the build/dev/test toolchain (webpack glob resolution, chokidar file-watching, jest test-path matching). The relevant regression surface is therefore *the build itself and correct code-splitting/module resolution in the shipped bundle*. Verified on a full preview build:

- **Preview build:** `yarn build` completed cleanly ("Build complete"), i.e. the picomatch-consuming glob tooling produced a correct bundle.
- **Preview URL:** https://rancherdependabot-npm-and-yarn-multi-picomatchr.13.48.147.135.sslip.io/dashboard/ (serves HTTP 200)
- **Playwright checks (all passed):**
  1. `login-page-renders` — `/dashboard/auth/login` renders (app served, Vue boots).
  2. `login-succeeds-appshell` — local-auth login succeeds, lands on `/dashboard/home` (entry + vendor chunks resolve).
  3. `cluster-mgmt-chunk-loads` — Cluster Management provisioning view renders (lazy route chunk resolves).
  4. `cluster-explorer-chunk-loads` — cluster explorer Deployments list renders with live data (second lazy chunk + deeper module graph).
  5. `no-failed-js-chunks` — no failed `.js` chunk requests and no page errors during the flow.
- **Lint:** `yarn lint` passed clean.
- **Unit tests:** the jest toolchain (which consumes `picomatch` via `jest-util`) is healthy — targeted suites pass (e.g. `shell/utils/__tests__/string.test.ts`, 47/47). A full-suite local run showed unrelated pre-existing failures (jest-worker OOM cascade and a duplicate `@vue/runtime-core` in the local checkout), not caused by this lockfile change.

Tested locally in Chromium; reviewer should test in a different browser.

### Areas which could experience regressions
Anything relying on build-time glob matching / file-watching: webpack asset & module resolution, dev-server file watching, and jest test discovery. All exercised above (build + running app) with no regressions observed. No runtime bundle code imports `picomatch` directly.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/2e724b44-9f68-4986-a845-74853f054a26

**Playwright checks performed** (video recorded, 1280×800):
1. `login-page-renders` — login page serves and the Vue app boots (login form present). ✅ PASS
2. `login-succeeds-appshell` — local-auth login → landed on `/dashboard/home`. ✅ PASS
3. `cluster-mgmt-chunk-loads` — Cluster Management view renders (lazy route chunk resolves). ✅ PASS
4. `cluster-explorer-chunk-loads` — Cluster Explorer Deployments list renders (second lazy chunk, live data). ✅ PASS
5. `no-failed-js-chunks` — no failed `.js` chunk requests and no page errors (failedJs=0, pageErrors=0). ✅ PASS

**Verdict:** Safe — the dashboard built with picomatch 2.3.2/4.0.5 boots and navigates with no chunk/module-resolution regressions.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

