### PR TITLE
Bump braces from 2.3.2 to 3.0.3 in /storybook

### DIFF
--- a/storybook/package.json
+++ b/storybook/package.json
@@ -11,6 +11,9 @@
     "remark-gfm": "^4.0.0",
     "vue": "^3.5.10"
   },
+  "resolutions": {
+    "braces": "^3.0.3"
+  },
   "devDependencies": {
     "@storybook/addon-actions": "^8.4.2",
     "@storybook/addon-essentials": "^8.4.2",

--- a/storybook/yarn.lock
+++ b/storybook/yarn.lock
@@ -1615,21 +1615,6 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^2.3.1:
-  version "2.3.2"
-  resolved "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
-  integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
-  dependencies:
-    arr-flatten "^1.1.0"
-    array-unique "^0.3.2"
-    extend-shallow "^2.0.1"
-    fill-range "^4.0.0"
-    isobject "^3.0.1"
-    repeat-element "^1.1.2"
-    snapdragon "^0.8.1"
-    snapdragon-node "^2.0.1"
-    split-string "^3.0.2"
-    to-regex "^3.0.1"
 
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"


### PR DESCRIPTION
### Summary
Bumps [braces](https://github.com/micromatch/braces) from 2.3.2 to 3.0.3 in `/storybook` to address a security advisory (uncontrolled resource consumption). Applied via a `resolutions` entry in `storybook/package.json`.

Fixes the transitive `braces@2.3.2` advisory (GHSA-grv7-fg5c-xmjg) — braces could allocate excessive memory when parsing crafted input, enabling a denial of service.

### Occurred changes and/or fixed issues
- `storybook/package.json`: added `resolutions` pinning `braces` to `^3.0.3`.
- `storybook/yarn.lock`: removed the vulnerable `braces@2.3.2` tree; all consumers now resolve to `braces@3.0.3`.

### Technical notes summary
`braces` was only present as a transitive dependency under the storybook workspace. A yarn `resolutions` override forces the fixed patch line without touching direct dependencies. No application source changes.

### Areas or cases that should be tested
- Storybook builds and runs.
- Dashboard smoke test — no regression in the running UI (verified below via Playwright).

### Areas which could experience regressions
- Only the storybook workspace's dependency graph is affected; `braces` is a build/glob utility with a compatible 2.x→3.x API for the usage here. Low regression risk to the shipped dashboard.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/b7163537-825a-4901-aa27-2b8647c8669d


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher vulnerability console by marceloyfukumoto@gmail.com.

