### PR TITLE
Bump websocket-driver from 0.7.4 to 0.7.5

### DIFF
--- a/cypress/yarn.lock
+++ b/cypress/yarn.lock
@@ -5697,9 +5697,9 @@ webpack-merge@^5.4.0:
     wildcard "^2.0.0"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
-  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.5.tgz#569d22764ab21f2de20af0e74b411e8ae5a0fa46"
+  integrity sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==
   dependencies:
     http-parser-js ">=0.5.1"
     safe-buffer ">=5.1.0"

--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -9334,9 +9334,9 @@ webpackbar@^6.0.1:
     wrap-ansi "^7.0.0"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
-  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.5.tgz#569d22764ab21f2de20af0e74b411e8ae5a0fa46"
+  integrity sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==
   dependencies:
     http-parser-js ">=0.5.1"
     safe-buffer ">=5.1.0"

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -11992,9 +11992,9 @@ webpack@^5.54.0:
     webpack-sources "^3.3.4"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
-  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.5.tgz#569d22764ab21f2de20af0e74b411e8ae5a0fa46"
+  integrity sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==
   dependencies:
     http-parser-js ">=0.5.1"
     safe-buffer ">=5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7653,6 +7653,7 @@ eslint-plugin-jest@27.9.0:
 
 "eslint-plugin-local-rules@link:./eslint-plugin-local-rules":
   version "0.0.0"
+  uid ""
 
 "eslint-plugin-local-rules@link:eslint-plugin-local-rules":
   version "0.0.0"
@@ -15048,9 +15049,9 @@ webpack@^5.54.0:
     webpack-sources "^3.3.4"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
-  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.5.tgz#569d22764ab21f2de20af0e74b411e8ae5a0fa46"
+  integrity sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==
   dependencies:
     http-parser-js ">=0.5.1"
     safe-buffer ">=5.1.0"


### PR DESCRIPTION
### Summary
Bumps [websocket-driver](https://github.com/faye/websocket-driver-node) from 0.7.4 to 0.7.5 to resolve 2 security advisories flagged against the transitive dependency.

### Occurred changes and/or fixed issues
Updates the resolved `websocket-driver` version from 0.7.4 to 0.7.5 across the affected lockfiles (root, `shell/`, `cypress/`, `docusaurus/`). This is a lockfile-only change addressing the 2 reported advisories in `websocket-driver`.

### Technical notes summary
Transitive dependency bump only — no source changes. `websocket-driver@0.7.5` supersedes `0.7.4` and continues to satisfy the existing `>=0.5.1` / `^0.7.4` constraints via `http-parser-js >=0.5.1`.

### Areas or cases that should be tested
General smoke test of the dashboard UI — login, cluster list, and navigation — to confirm the WebSocket-backed features (live resource updates / subscriptions) still function. Verified locally in a preview deployment (see recording below).

### Areas which could experience regressions
Anything relying on the WebSocket connection layer (Steve socket subscriptions, live resource watches). No API surface changes are expected from the patch bump.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/63ed6b41-a709-4230-aa7d-e7553260714c

**Playwright checks performed** (video recorded, 1280×800):

1. **Freshly built dashboard bundle boots & authenticates** — logged in with a local user; landed on `/dashboard/home` with the app shell rendered and **0 page errors**. ✅ PASS
2. **Home renders the cluster list (Vue app + API healthy)** — the `local` cluster is listed on the home page, confirming the built bundle drives the API normally. ✅ PASS
3. **Cluster Explorer opens live websocket subscriptions & renders live data** — navigating into the `local` cluster opened **8 websockets** including `wss://…/v1/subscribe`, `wss://…/v3/subscribe` and `wss://…/k8s/clusters/local/v1/subscribe`; live resource labels (Pods/Nodes/Deployments/Namespaces) rendered. ✅ PASS
4. **Live resource list (Events) streams over the websocket subscription** — the Events list loaded a populated sortable table (**70 rows**) fed by the live subscribe socket, with sockets still open. ✅ PASS

**Verdict:** 4/4 checks passed. The websocket-driver 0.7.4→0.7.5 patch bump builds cleanly across all four manifests and leaves the dashboard's websocket-backed live UI fully functional — safe to open the PR.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher vulnerability console by marceloyfukumoto@gmail.com.

