### PR TITLE
[FlakyTest] Test run

### DIFF
--- a/cypress/e2e/po/components/pagination.po.ts
+++ b/cypress/e2e/po/components/pagination.po.ts
@@ -27,6 +27,20 @@ export default class PaginationPo extends ComponentPo {
   }
 
   /**
+   * Retry-able assertion on the "x - y of z" pagination summary text.
+   * The summary updates asynchronously after a page-navigation click (next/prev/first/last),
+   * so reading it once through a non-retry-able `.then()` + `expect` races the re-render and
+   * flakes. `.should()` with a callback retries the whole `find('span').invoke('text')` chain
+   * until the trimmed text settles on the expected value.
+   * @param expected The exact expected summary text (compared after trimming)
+   */
+  checkPaginationTextEquals(expected: string): Cypress.Chainable {
+    return this.self().find('span').invoke('text').should((text) => {
+      expect(text.trim()).to.eq(expected);
+    });
+  }
+
+  /**
    * Check the x of y pagination text against the side nav count
    */
   checkPaginationText(productNav: ProductNavPo, options: {

--- a/cypress/e2e/po/components/password.po.ts
+++ b/cypress/e2e/po/components/password.po.ts
@@ -13,6 +13,17 @@ export default class PasswordPo extends ComponentPo {
   }
 
   /**
+   * Retry-able assertion that the input holds the expected value.
+   * `cy.type()` can occasionally drop keystrokes under CI load; asserting the settled
+   * value before acting (e.g. before submitting a login form) guards against a truncated
+   * value being sent. Retries until the reactive model settles.
+   * @param value Expected value
+   */
+  shouldHaveValue(value: string): Cypress.Chainable {
+    return this.input().should('have.value', value);
+  }
+
+  /**
    * Return the input HTML element from given container
    * @returns HTML Element
    */

--- a/cypress/e2e/po/pages/rancher-setup-configure.po.ts
+++ b/cypress/e2e/po/pages/rancher-setup-configure.po.ts
@@ -48,6 +48,24 @@ export class RancherSetupConfigurePage extends PagePo {
     return this.submitButton().isDisabled().then((isDisabled) => !isDisabled);
   }
 
+  /**
+   * Retry-able assertion that the submit button is enabled.
+   * Prefer this over `canSubmit().should('eq', true)`: `canSubmit()` reads the
+   * `disabled` attribute once through a non-retry-able `.then()`, so it races the
+   * reactive tick that toggles the button state. `.should('not.have.attr', ...)`
+   * retries until Vue settles.
+   */
+  submitShouldBeEnabled(): Cypress.Chainable {
+    return this.submitButton().expectToBeEnabled();
+  }
+
+  /**
+   * Retry-able assertion that the submit button is disabled (see `submitShouldBeEnabled`).
+   */
+  submitShouldBeDisabled(): Cypress.Chainable {
+    return this.submitButton().expectToBeDisabled();
+  }
+
   submit(): Cypress.Chainable {
     return this.submitButton().click();
   }

--- a/cypress/e2e/po/pages/rancher-setup-login.po.ts
+++ b/cypress/e2e/po/pages/rancher-setup-login.po.ts
@@ -18,9 +18,14 @@ export class RancherSetupLoginPagePo extends PagePo {
   }
 
   bootstrapLogin() {
-    this.canSubmit().should('eq', true);
+    // Use the retry-able `expectToBeEnabled()` assertion rather than
+    // `canSubmit().should('eq', true)`: `canSubmit()` reads the `disabled` attribute
+    // once through a non-retry-able `.then()`, so it races the reactive tick that
+    // toggles the submit button while the login form hydrates / validates the password.
+    // `.should('not.have.attr', 'disabled')` retries until the button settles enabled.
+    this.submitButton().expectToBeEnabled();
     this.password().set(Cypress.env('bootstrapPassword'));
-    this.canSubmit().should('eq', true);
+    this.submitButton().expectToBeEnabled();
     this.submit();
   }
 

--- a/cypress/e2e/po/pages/rancher-setup-login.po.ts
+++ b/cypress/e2e/po/pages/rancher-setup-login.po.ts
@@ -23,8 +23,15 @@ export class RancherSetupLoginPagePo extends PagePo {
     // once through a non-retry-able `.then()`, so it races the reactive tick that
     // toggles the submit button while the login form hydrates / validates the password.
     // `.should('not.have.attr', 'disabled')` retries until the button settles enabled.
+    const bootstrapPassword = Cypress.env('bootstrapPassword');
+
     this.submitButton().expectToBeEnabled();
-    this.password().set(Cypress.env('bootstrapPassword'));
+    this.password().set(bootstrapPassword);
+    // Guard against dropped keystrokes: `cy.type()` can lose characters under CI load,
+    // which would submit a truncated password, fail login (401), and leave the configure
+    // page (and every downstream setup assertion for this tag run) to time out. Assert the
+    // field holds the full value before clicking — this retries until the input settles.
+    this.password().shouldHaveValue(bootstrapPassword);
     this.submitButton().expectToBeEnabled();
     this.submit();
   }

--- a/cypress/e2e/tests/components/yaml-editor.spec.ts
+++ b/cypress/e2e/tests/components/yaml-editor.spec.ts
@@ -33,9 +33,14 @@ describe('Yaml Editor', { tags: ['@components', '@adminUser', '@standardUser'] }
 
       const resourceYaml = new ResourceYamlPo();
 
-      resourceYaml.body().should('be.visible').then(() => {
-        resourceYaml.footer().isVisible();
-      });
+      // `footer().isVisible()` is a one-shot viewport-position check (reads getBoundingClientRect()
+      // synchronously, no retry). Gate it behind a retry-able `.should('be.visible')` on both the
+      // body and the footer so the codemirror editor has finished laying out before we measure —
+      // firing the measurement from inside a `.then()` the moment the body appears races the layout
+      // and flakes. (Only the footer is viewport-measured; the body can legitimately be taller than
+      // the viewport, so it just needs to be rendered/visible.)
+      resourceYaml.body().should('be.visible');
+      resourceYaml.footer().should('be.visible').isVisible();
     }));
   });
 

--- a/cypress/e2e/tests/pages/charts/chart-install-wizard.spec.ts
+++ b/cypress/e2e/tests/pages/charts/chart-install-wizard.spec.ts
@@ -141,6 +141,10 @@ describe('Charts Wizard', { testIsolation: 'off', tags: ['@charts', '@adminUser'
 
         // Change chart version
         installChartPage.chartVersionSelector().toggle();
+        // Ensure the version list has fully populated before selecting by index — clicking
+        // `nth-child(2)` can otherwise land while the async version fetch is still rendering
+        // rows, selecting a transient/placeholder option (or missing the click entirely).
+        installChartPage.chartVersionSelector().getOptions().should('have.length.greaterThan', 2);
         installChartPage.chartVersionSelector().clickOption(2);
 
         // Verify custom registry is still there

--- a/cypress/e2e/tests/pages/charts/chart-install-wizard.spec.ts
+++ b/cypress/e2e/tests/pages/charts/chart-install-wizard.spec.ts
@@ -69,6 +69,9 @@ describe('Charts Wizard', { testIsolation: 'off', tags: ['@charts', '@adminUser'
 
       labeledSelect.self().scrollIntoView();
       labeledSelect.toggle();
+      // Ensure the dropdown menu is actually open (options rendered) before selecting;
+      // avoids a race where the click lands before vue-select finishes populating configmaps.
+      labeledSelect.isOpened();
       labeledSelect.clickLabel(`${ configMapPayload.metadata.name }`);
     });
 

--- a/cypress/e2e/tests/pages/charts/chart-install-wizard.spec.ts
+++ b/cypress/e2e/tests/pages/charts/chart-install-wizard.spec.ts
@@ -69,9 +69,9 @@ describe('Charts Wizard', { testIsolation: 'off', tags: ['@charts', '@adminUser'
 
       labeledSelect.self().scrollIntoView();
       labeledSelect.toggle();
-      // Ensure the dropdown menu is actually open (options rendered) before selecting;
-      // avoids a race where the click lands before vue-select finishes populating configmaps.
-      labeledSelect.isOpened();
+      // Wait for the *specific* ConfigMap option to render before selecting; avoids a race
+      // where the click lands before vue-select finishes populating configmaps.
+      labeledSelect.getOptions().contains(`${ configMapPayload.metadata.name }`).should('be.visible');
       labeledSelect.clickLabel(`${ configMapPayload.metadata.name }`);
     });
 

--- a/cypress/e2e/tests/pages/charts/compliance.spec.ts
+++ b/cypress/e2e/tests/pages/charts/compliance.spec.ts
@@ -30,7 +30,9 @@ describe('Charts', { testIsolation: 'off', tags: ['@charts', '@adminUser'] }, ()
 
             installChartPage.footerControls().should('be.visible');
 
-            installChartPage.footerControls().then(($el) => {
+            // Use a retry-able `.should()` (not a one-shot `.then()`) so the sticky-footer
+            // position assertion re-evaluates until layout settles after the YAML editor renders.
+            installChartPage.footerControls().should(($el) => {
               const elementRect = $el[0].getBoundingClientRect();
               const viewportHeight = Cypress.config('viewportHeight');
               const pageHeight = Cypress.$(cy.state('window')).height();

--- a/cypress/e2e/tests/pages/charts/logging.spec.ts
+++ b/cypress/e2e/tests/pages/charts/logging.spec.ts
@@ -86,6 +86,9 @@ describe('Logging Chart', { testIsolation: 'off', tags: ['@charts', '@adminUser'
       loggingFlowCreate.resourceDetail().tabs().clickTabWithSelector('[data-testid="btn-outputs"]');
       loggingFlowCreate.waitForPage(undefined, 'outputs');
       loggingFlowCreate.outputSelector().toggle();
+      // Wait for the dropdown options to render before selecting, so the click doesn't
+      // race the async load of the cluster outputs list.
+      loggingFlowCreate.outputSelector().isOpened();
       loggingFlowCreate.outputSelector().clickOptionWithLabel(outputName);
 
       // Configure namespaces during creation

--- a/cypress/e2e/tests/pages/charts/logging.spec.ts
+++ b/cypress/e2e/tests/pages/charts/logging.spec.ts
@@ -86,9 +86,11 @@ describe('Logging Chart', { testIsolation: 'off', tags: ['@charts', '@adminUser'
       loggingFlowCreate.resourceDetail().tabs().clickTabWithSelector('[data-testid="btn-outputs"]');
       loggingFlowCreate.waitForPage(undefined, 'outputs');
       loggingFlowCreate.outputSelector().toggle();
-      // Wait for the dropdown options to render before selecting, so the click doesn't
-      // race the async load of the cluster outputs list.
-      loggingFlowCreate.outputSelector().isOpened();
+      // Wait for the *specific* output option to render (not just any option) before
+      // selecting, so the click doesn't race the async load of the cluster outputs list
+      // and clickOptionWithLabel doesn't read an option index while the list is still
+      // mutating.
+      loggingFlowCreate.outputSelector().getOptions().contains('li', outputName).should('be.visible');
       loggingFlowCreate.outputSelector().clickOptionWithLabel(outputName);
 
       // Configure namespaces during creation

--- a/cypress/e2e/tests/pages/explorer/dashboard/events.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/dashboard/events.spec.ts
@@ -12,6 +12,29 @@ const pageSize = 10;
 // Should be enough to create at least 3 pages of events
 const podCount = 15;
 
+// Events are generated asynchronously by the backend after the pods are created. The
+// pagination tests need at least 3 pages of events, so poll the events endpoint until the
+// count clears that threshold rather than blindly waiting a fixed time. Bounded so a genuinely
+// event-starved backend still fails fast instead of hanging the whole run.
+const MIN_EVENTS_TO_SETTLE = 3 * pageSize;
+const SETTLE_MAX_ATTEMPTS = 30;
+const SETTLE_INTERVAL_MS = 2000;
+
+const waitForEventsToSettle = (attempt = 0) => {
+  return cy.getRancherResource('v1', 'events').then((resp: Cypress.Response<any>) => {
+    const count = resp.body?.count || 0;
+
+    if (count > MIN_EVENTS_TO_SETTLE || attempt >= SETTLE_MAX_ATTEMPTS) {
+      return;
+    }
+
+    // eslint-disable-next-line cypress/no-unnecessary-waiting -- short backoff between event-count polls, not a fixed settle
+    cy.wait(SETTLE_INTERVAL_MS);
+
+    return waitForEventsToSettle(attempt + 1);
+  });
+};
+
 const countHelper = {
   setupCount: (vaiCacheEnabled: boolean, initialCount: number) => {
     if (vaiCacheEnabled) {
@@ -74,8 +97,11 @@ describe('Events', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, 
           nsName2 = ns;
         });
 
-      // I'm loathed to do this, but the events created from the pods need to settle before we start
-      cy.wait(20000); // eslint-disable-line cypress/no-unnecessary-waiting
+      // The events created from the pods need to settle before we start. A fixed wait is
+      // flaky: too short on a slow/loaded CI runner (events not yet emitted, so the
+      // `greaterThan(3 * pageSize)` count assertion below fails) and wasteful on a fast one.
+      // Poll the events endpoint until enough events exist to fill the >3 pages the test needs.
+      waitForEventsToSettle();
     });
 
     it('pagination is visible and user is able to navigate through events data', () => {
@@ -131,10 +157,7 @@ describe('Events', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, 
             .self()
             .scrollIntoView();
           events.list().resourceTable().sortableTable().pagination()
-            .paginationText()
-            .then((el) => {
-              expect(el.trim()).to.eq(`1 - ${ pageSize } of ${ initialCount } Events`);
-            });
+            .checkPaginationTextEquals(`1 - ${ pageSize } of ${ initialCount } Events`);
 
           // navigate to next page - right button
           countHelper.setupCount(vaiCacheEnabled, initialCount);
@@ -149,10 +172,7 @@ describe('Events', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, 
             .scrollIntoView();
           countHelper.getCount().then((count) => {
             return events.list().resourceTable().sortableTable().pagination()
-              .paginationText()
-              .then((el) => {
-                expect(el.trim()).to.eq(`${ pageSize + 1 } - ${ 2 * pageSize } of ${ count } Events`);
-              });
+              .checkPaginationTextEquals(`${ pageSize + 1 } - ${ 2 * pageSize } of ${ count } Events`);
           });
           events.list().resourceTable().sortableTable().pagination()
             .beginningButton()
@@ -174,10 +194,7 @@ describe('Events', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, 
             .scrollIntoView();
           countHelper.getCount().then((count) => {
             return events.list().resourceTable().sortableTable().pagination()
-              .paginationText()
-              .then((el) => {
-                expect(el.trim()).to.eq(`1 - ${ pageSize } of ${ count } Events`);
-              });
+              .checkPaginationTextEquals(`1 - ${ pageSize } of ${ count } Events`);
           });
 
           events.list().resourceTable().sortableTable().pagination()
@@ -200,19 +217,16 @@ describe('Events', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, 
             .self()
             .scrollIntoView();
           countHelper.getCount().then((count) => {
+            let pages = Math.floor(count / pageSize);
+
+            if (count % pageSize === 0) {
+              pages--;
+            }
+            const from = (pages * pageSize) + 1;
+            const to = count;
+
             return events.list().resourceTable().sortableTable().pagination()
-              .paginationText()
-              .then((el) => {
-                let pages = Math.floor(count / pageSize);
-
-                if (count % pageSize === 0) {
-                  pages--;
-                }
-                const from = (pages * pageSize) + 1;
-                const to = count;
-
-                expect(el.trim()).to.eq(`${ from } - ${ to } of ${ to } Events`);
-              });
+              .checkPaginationTextEquals(`${ from } - ${ to } of ${ to } Events`);
           });
 
           // navigate to first page - beginning button
@@ -228,10 +242,7 @@ describe('Events', { testIsolation: 'off', tags: ['@explorer', '@adminUser'] }, 
             .scrollIntoView();
           countHelper.getCount().then((count) => {
             events.list().resourceTable().sortableTable().pagination()
-              .paginationText()
-              .then((el) => {
-                expect(el.trim()).to.eq(`1 - ${ pageSize } of ${ count } Events`);
-              });
+              .checkPaginationTextEquals(`1 - ${ pageSize } of ${ count } Events`);
           });
 
           events.list().resourceTable().sortableTable().pagination()

--- a/cypress/e2e/tests/pages/explorer/policy/network-policy.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/policy/network-policy.spec.ts
@@ -135,6 +135,13 @@ describe('NetworkPolicies', { testIsolation: 'off', tags: ['@explorer', '@adminU
   it('can delete a network policy', () => {
     NetworkPolicyListPagePo.navTo();
     networkPolicyPage.waitForPage();
+    // Scope to the target row and wait for the list to finish loading so the action
+    // menu opens on a settled table row rather than a row still being rendered/re-fetched
+    networkPolicyPage.baseResourceList().resourceTable().sortableTable().filter(customNetworkPolicyName);
+    networkPolicyPage.waitForPage(`q=${ customNetworkPolicyName }`);
+    networkPolicyPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+    networkPolicyPage.list().resourceTable().sortableTable().rowElementWithName(customNetworkPolicyName)
+      .should('be.visible');
     networkPolicyPage.list().actionMenu(customNetworkPolicyName).getMenuItem('Delete').click();
     const promptRemove = new PromptRemove();
 
@@ -142,7 +149,9 @@ describe('NetworkPolicies', { testIsolation: 'off', tags: ['@explorer', '@adminU
     promptRemove.remove();
     cy.wait('@deleteNetworkPolicy');
     networkPolicyPage.waitForPage();
-    cy.contains(customNetworkPolicyName).should('not.exist');
+    // Assert against the table row (not a page-wide text match, which can catch the filter input / toasts)
+    networkPolicyPage.list().resourceTable().sortableTable().rowElementWithName(customNetworkPolicyName)
+      .should('not.exist');
   });
 
   after(() => {

--- a/cypress/e2e/tests/pages/explorer2/workloads/cronjobs.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/cronjobs.spec.ts
@@ -304,6 +304,10 @@ describe('CronJobs', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] 
     it('sorting changes the order of paginated cronjobs data', () => {
       WorkloadsCronJobsListPagePo.navTo();
       cronJobListPage.waitForPage();
+      // Wait for the table to finish loading before filtering/sorting: filtering a table that
+      // is still fetching rows races the sort-order and row-visibility assertions below.
+      cronJobListPage.list().resourceTable().sortableTable().checkVisible();
+      cronJobListPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
       // use filter to only show test data
       cronJobListPage.list().resourceTable().sortableTable().filter(rootResourceName);
 

--- a/cypress/e2e/tests/pages/explorer2/workloads/cronjobs.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/cronjobs.spec.ts
@@ -235,10 +235,7 @@ describe('CronJobs', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] 
 
         // check text before navigation
         cronJobListPage.list().resourceTable().sortableTable().pagination()
-          .paginationText()
-          .then((el) => {
-            expect(el.trim()).to.eq(`1 - 10 of ${ count } CronJobs`);
-          });
+          .checkPaginationTextEquals(`1 - 10 of ${ count } CronJobs`);
 
         // navigate to next page - right button
         cronJobListPage.list().resourceTable().sortableTable().pagination()
@@ -247,10 +244,7 @@ describe('CronJobs', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] 
 
         // check text and buttons after navigation
         cronJobListPage.list().resourceTable().sortableTable().pagination()
-          .paginationText()
-          .then((el) => {
-            expect(el.trim()).to.eq(`11 - 20 of ${ count } CronJobs`);
-          });
+          .checkPaginationTextEquals(`11 - 20 of ${ count } CronJobs`);
         cronJobListPage.list().resourceTable().sortableTable().pagination()
           .beginningButton()
           .isEnabled();
@@ -265,10 +259,7 @@ describe('CronJobs', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] 
 
         // check text and buttons after navigation
         cronJobListPage.list().resourceTable().sortableTable().pagination()
-          .paginationText()
-          .then((el) => {
-            expect(el.trim()).to.eq(`1 - 10 of ${ count } CronJobs`);
-          });
+          .checkPaginationTextEquals(`1 - 10 of ${ count } CronJobs`);
         cronJobListPage.list().resourceTable().sortableTable().pagination()
           .beginningButton()
           .isDisabled();
@@ -291,10 +282,7 @@ describe('CronJobs', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] 
 
         // check text after navigation
         cronJobListPage.list().resourceTable().sortableTable().pagination()
-          .paginationText()
-          .then((el) => {
-            expect(el.trim()).to.eq(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } CronJobs`);
-          });
+          .checkPaginationTextEquals(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } CronJobs`);
 
         // navigate to first page - beginning button
         cronJobListPage.list().resourceTable().sortableTable().pagination()
@@ -303,10 +291,7 @@ describe('CronJobs', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] 
 
         // check text and buttons after navigation
         cronJobListPage.list().resourceTable().sortableTable().pagination()
-          .paginationText()
-          .then((el) => {
-            expect(el.trim()).to.eq(`1 - 10 of ${ count } CronJobs`);
-          });
+          .checkPaginationTextEquals(`1 - 10 of ${ count } CronJobs`);
         cronJobListPage.list().resourceTable().sortableTable().pagination()
           .beginningButton()
           .isDisabled();

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -405,17 +405,13 @@ describe('Deployments', { testIsolation: 'off', tags: ['@explorer2', '@adminUser
         deploymentsListPage.sortableTable().pagination().endButton().isEnabled();
 
         // check text before navigation
-        deploymentsListPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`1 - 10 of ${ count } Deployments`);
-        });
+        deploymentsListPage.sortableTable().pagination().checkPaginationTextEquals(`1 - 10 of ${ count } Deployments`);
 
         // navigate to next page - right button
         deploymentsListPage.sortableTable().pagination().rightButton().click();
 
         // check text and buttons after navigation
-        deploymentsListPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`11 - 20 of ${ count } Deployments`);
-        });
+        deploymentsListPage.sortableTable().pagination().checkPaginationTextEquals(`11 - 20 of ${ count } Deployments`);
         deploymentsListPage.sortableTable().pagination().beginningButton().isEnabled();
         deploymentsListPage.sortableTable().pagination().leftButton().isEnabled();
 
@@ -423,9 +419,7 @@ describe('Deployments', { testIsolation: 'off', tags: ['@explorer2', '@adminUser
         deploymentsListPage.sortableTable().pagination().leftButton().click();
 
         // check text and buttons after navigation
-        deploymentsListPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`1 - 10 of ${ count } Deployments`);
-        });
+        deploymentsListPage.sortableTable().pagination().checkPaginationTextEquals(`1 - 10 of ${ count } Deployments`);
         deploymentsListPage.sortableTable().pagination().beginningButton().isDisabled();
         deploymentsListPage.sortableTable().pagination().leftButton().isDisabled();
 
@@ -441,17 +435,13 @@ describe('Deployments', { testIsolation: 'off', tags: ['@explorer2', '@adminUser
         }
 
         // check text after navigation
-        deploymentsListPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } Deployments`);
-        });
+        deploymentsListPage.sortableTable().pagination().checkPaginationTextEquals(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } Deployments`);
 
         // navigate to first page - beginning button
         deploymentsListPage.sortableTable().pagination().beginningButton().click();
 
         // check text and buttons after navigation
-        deploymentsListPage.sortableTable().pagination().paginationText().then((el) => {
-          expect(el.trim()).to.eq(`1 - 10 of ${ count } Deployments`);
-        });
+        deploymentsListPage.sortableTable().pagination().checkPaginationTextEquals(`1 - 10 of ${ count } Deployments`);
         deploymentsListPage.sortableTable().pagination().beginningButton().isDisabled();
         deploymentsListPage.sortableTable().pagination().leftButton().isDisabled();
       });

--- a/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/deployments.spec.ts
@@ -450,6 +450,10 @@ describe('Deployments', { testIsolation: 'off', tags: ['@explorer2', '@adminUser
     it('sorting changes the order of paginated deployments data', () => {
       WorkloadsDeploymentsListPagePo.navTo();
       deploymentsListPage.waitForPage();
+      // Wait for the table to finish loading before filtering/sorting: filtering a table that
+      // is still fetching rows races the sort-order and row-visibility assertions below.
+      deploymentsListPage.sortableTable().checkVisible();
+      deploymentsListPage.sortableTable().checkLoadingIndicatorNotVisible();
       // use filter to only show test data
       deploymentsListPage.sortableTable().filter(rootResourceName);
 

--- a/cypress/e2e/tests/pages/explorer2/workloads/jobs.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/jobs.spec.ts
@@ -255,6 +255,10 @@ describe('Jobs', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, (
     it('sorting changes the order of paginated jobs data', () => {
       WorkloadsJobsListPagePo.navTo();
       jobsListPage.waitForPage();
+      // Wait for the table to finish loading before filtering/sorting: filtering a table that
+      // is still fetching rows races the sort-order and row-visibility assertions below.
+      jobsListPage.list().resourceTable().sortableTable().checkVisible();
+      jobsListPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
       // use filter to only show test data
       jobsListPage.list().resourceTable().sortableTable().filter(rootResourceName);
 

--- a/cypress/e2e/tests/pages/explorer2/workloads/jobs.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/jobs.spec.ts
@@ -186,10 +186,7 @@ describe('Jobs', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, (
 
         // check text before navigation
         jobsListPage.list().resourceTable().sortableTable().pagination()
-          .paginationText()
-          .then((el) => {
-            expect(el.trim()).to.eq(`1 - 10 of ${ count } Jobs`);
-          });
+          .checkPaginationTextEquals(`1 - 10 of ${ count } Jobs`);
 
         // navigate to next page - right button
         jobsListPage.list().resourceTable().sortableTable().pagination()
@@ -198,10 +195,7 @@ describe('Jobs', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, (
 
         // check text and buttons after navigation
         jobsListPage.list().resourceTable().sortableTable().pagination()
-          .paginationText()
-          .then((el) => {
-            expect(el.trim()).to.eq(`11 - 20 of ${ count } Jobs`);
-          });
+          .checkPaginationTextEquals(`11 - 20 of ${ count } Jobs`);
         jobsListPage.list().resourceTable().sortableTable().pagination()
           .beginningButton()
           .isEnabled();
@@ -216,10 +210,7 @@ describe('Jobs', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, (
 
         // check text and buttons after navigation
         jobsListPage.list().resourceTable().sortableTable().pagination()
-          .paginationText()
-          .then((el) => {
-            expect(el.trim()).to.eq(`1 - 10 of ${ count } Jobs`);
-          });
+          .checkPaginationTextEquals(`1 - 10 of ${ count } Jobs`);
         jobsListPage.list().resourceTable().sortableTable().pagination()
           .beginningButton()
           .isDisabled();
@@ -242,10 +233,7 @@ describe('Jobs', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, (
 
         // check text after navigation
         jobsListPage.list().resourceTable().sortableTable().pagination()
-          .paginationText()
-          .then((el) => {
-            expect(el.trim()).to.eq(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } Jobs`);
-          });
+          .checkPaginationTextEquals(`${ count - (lastPageCount) + 1 } - ${ count } of ${ count } Jobs`);
 
         // navigate to first page - beginning button
         jobsListPage.list().resourceTable().sortableTable().pagination()
@@ -254,10 +242,7 @@ describe('Jobs', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, (
 
         // check text and buttons after navigation
         jobsListPage.list().resourceTable().sortableTable().pagination()
-          .paginationText()
-          .then((el) => {
-            expect(el.trim()).to.eq(`1 - 10 of ${ count } Jobs`);
-          });
+          .checkPaginationTextEquals(`1 - 10 of ${ count } Jobs`);
         jobsListPage.list().resourceTable().sortableTable().pagination()
           .beginningButton()
           .isDisabled();

--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -380,6 +380,10 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
 
     // click on update button on card
     extensionsPo.extensionCardUpgradeClick(EXTENSION_NAME);
+    // Wait for the install dialog to finish rendering before clicking the async install
+    // button — clicking it while the modal is still animating open races the render and
+    // can miss or hit a detached element. Mirrors the install/large-extension tests.
+    extensionsPo.installModal().checkVisible();
     extensionsPo.installModal().installButton().click();
     cy.wait('@upgradeExtension').its('response.statusCode').should('eq', 201);
 
@@ -406,6 +410,9 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     // click on the downgrade button on card
     // this will downgrade to the immediate previous version
     extensionsPo.extensionCardDowngradeClick(EXTENSION_NAME);
+    // Guard against the modal-open race before clicking the async install button, as in
+    // the upgrade/install tests above.
+    extensionsPo.installModal().checkVisible();
     extensionsPo.installModal().installButton().click();
 
     // let's check the extension reload banner and reload the page

--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -200,8 +200,15 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     extensionsPo.extensionMenuToggle();
     extensionsPo.addRepositoriesClick();
 
+    // Intercept the cluster-repo creation POST that the "Add" button fires so we can wait
+    // for the repo to be persisted before navigating. Without this, the repos list can be
+    // fetched before the new repo exists on the backend, and `.should('exist')` then retries
+    // against a stale, non-refetching table until it times out — the flake.
+    cy.intercept('POST', CLUSTER_REPOS_BASE_URL).as('createPartnerRepo');
+
     // add the partners repo
     extensionsPo.addReposModalAddClick();
+    cy.wait('@createPartnerRepo').its('response.statusCode').should('be.oneOf', [200, 201]);
     extensionsPo.addReposModal().should('not.exist');
 
     // go to repos list page

--- a/cypress/e2e/tests/pages/extensions/extensions.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/extensions.spec.ts
@@ -288,6 +288,11 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     // we should be on the extensions page
     extensionsPo.waitForTitle();
 
+    // Wait for the specific card to render before clicking it — the available-tab card
+    // list can still be populating right after the title appears, and clicking a
+    // not-yet-rendered card flakes.
+    extensionsPo.extensionCard(EXTENSION_NAME, { timeout: 30000 }).self().should('be.visible');
+
     // show extension details
     extensionsPo.extensionCardClick(EXTENSION_NAME);
 
@@ -317,6 +322,13 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
 
     extensionsPo.extensionTabAvailableClick();
     extensionsPo.waitForPage(undefined, 'available');
+
+    // The extension cards come from the repo added in the earlier "add repository" test.
+    // After that repo becomes Active its charts are indexed asynchronously, so the card
+    // (and its action menu) can render a beat after the available tab is shown. Wait for
+    // the specific card to be visible before opening its action menu — otherwise the
+    // install click races the card render and flakes. Mirrors the large-extension test.
+    extensionsPo.extensionCard(EXTENSION_NAME, { timeout: 30000 }).self().should('be.visible');
 
     // click on install button on card
     extensionsPo.extensionCardInstallClick(EXTENSION_NAME);
@@ -468,6 +480,10 @@ describe('Extensions page', { tags: ['@extensions', '@adminUser'] }, () => {
     extensionsPo.extensionTabAvailableClick();
     extensionsPo.waitForPage(undefined, 'available');
     extensionsPo.loading().should('not.exist');
+
+    // Wait for the specific card to render before opening its action menu, so the install
+    // click doesn't race the available-tab card list still populating after load.
+    extensionsPo.extensionCard(UNAUTHENTICATED_EXTENSION_NAME, { timeout: 30000 }).self().should('be.visible');
 
     // Install unauthenticated extension
     extensionsPo.extensionCardInstallClick(UNAUTHENTICATED_EXTENSION_NAME);

--- a/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
+++ b/cypress/e2e/tests/pages/extensions/kubewarden.spec.ts
@@ -90,10 +90,11 @@ describe('Kubewarden Extension', { tags: ['@extensions', '@adminUser'] }, () => 
     kubewardenPo.goTo();
     kubewardenPo.waitForPage();
 
-    const kubewardenNavItem = productMenu.groups().contains('Admission Policy Management');
-
-    kubewardenNavItem.should('exist');
-    kubewardenNavItem.click();
+    // Re-query the nav item for each command instead of reusing a stored chainable: the
+    // side-nav re-renders as the extension's menu registers, so a snapshot captured for the
+    // `.should('exist')` assertion can be detached by the time we `.click()` it.
+    productMenu.groups().contains('Admission Policy Management').should('exist');
+    productMenu.groups().contains('Admission Policy Management').click();
   }));
 
   qase(1432, it('Kubewarden dashboard view should exist', () => {

--- a/cypress/e2e/tests/pages/fleet/cluster-groups.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/cluster-groups.spec.ts
@@ -162,6 +162,12 @@ describe('Cluster Groups', { testIsolation: 'off', tags: ['@fleet', '@adminUser'
     // check table headers
     const expectedHeadersDetailsView = ['State', 'Name', 'Git Repos Ready', 'Helm Ops Ready', 'Bundles Ready', 'Resources', 'Last Seen', 'Age'];
 
+    // Settle the cluster list before snapshotting its header row: the `.each()` below is a
+    // non-retryable assertion, so if it runs while the details table is still loading the
+    // header cells can be empty/partial and the equality check flakes.
+    fleetClusterGroupDetailsPage.clusterList().sortableTable().checkVisible();
+    fleetClusterGroupDetailsPage.clusterList().sortableTable().checkLoadingIndicatorNotVisible();
+
     fleetClusterGroupDetailsPage.clusterList().sortableTable()
       .tableHeaderRow()
       .within('.table-header-container .content')

--- a/cypress/e2e/tests/pages/global-settings/feature-flags.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/feature-flags.spec.ts
@@ -197,15 +197,20 @@ describe('Feature Flags', { testIsolation: 'off' }, () => {
       // check table headers are visible
       const expectedHeaders = ['State', 'Name', 'Description', 'Restart Rancher'];
 
+      // Let the table settle before snapshotting the header row. The `.each()` below is a
+      // non-retryable, single-snapshot assertion — if it runs while the table is still
+      // loading, the header cells can be empty or partially rendered and the text equality
+      // check fails intermittently. Assert the table is visible with the loading indicator
+      // gone first so the headers are guaranteed to be their final values.
+      featureFlagsPage.list().resourceTable().sortableTable().checkVisible();
+      featureFlagsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+      featureFlagsPage.list().resourceTable().sortableTable().noRowsShouldNotExist();
+
       featureFlagsPage.list().resourceTable().sortableTable().tableHeaderRow()
         .get('.table-header-container .content')
         .each((el, i) => {
           expect(el.text().trim()).to.eq(expectedHeaders[i]);
         });
-
-      featureFlagsPage.list().resourceTable().sortableTable().checkVisible();
-      featureFlagsPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
-      featureFlagsPage.list().resourceTable().sortableTable().noRowsShouldNotExist();
       cy.getRancherResource('v1', 'management.cattle.io.features').then((resp: Cypress.Response<any>) => {
         // We filter out fleet and ui-sql-cache feature flags
         const featureCount = resp.body.count - 2;

--- a/cypress/e2e/tests/pages/manager/repositories.spec.ts
+++ b/cypress/e2e/tests/pages/manager/repositories.spec.ts
@@ -189,7 +189,7 @@ describe('Cluster Management Helm Repositories', { testIsolation: 'off', tags: [
 
     // check list details
     repositoriesPage.list().details(`${ this.repoName }ssh`, 2).should('be.visible');
-    repositoriesPage.list().details(`${ this.repoName }ssh`, 1).contains('Active').should('be.visible');
+    repositoriesPage.list().details(`${ this.repoName }ssh`, 1).contains('Active', LONG_TIMEOUT_OPT).should('be.visible');
   });
 
   it('can delete repositories via bulk actions', function() {

--- a/cypress/e2e/tests/pages/user-menu/preferences.spec.ts
+++ b/cypress/e2e/tests/pages/user-menu/preferences.spec.ts
@@ -76,6 +76,10 @@ describe('User can update their preferences', () => {
     header.showKubectlExplainTooltip();
     header.getKubectlExplainTooltipContent().contains('Describe Resource');
     cy.reload();
+    // After reload the app re-hydrates asynchronously; driving the header tooltip before
+    // the page has re-rendered acts on a not-yet-mounted element and flakes. Wait for the
+    // events list to be back on screen (same settle point used above) before interacting.
+    cy.contains('.title > h1', '事件').should('be.visible');
     header.showKubectlExplainTooltip();
     header.getKubectlExplainTooltipContent().contains('Describe Resource');
     // EO test https://github.com/rancher/dashboard/issues/10153

--- a/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
+++ b/cypress/e2e/tests/pages/users-and-auth/roles.spec.ts
@@ -602,6 +602,10 @@ describe('Roles Templates', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
       usersPo.goTo();
       usersPo.list().create();
 
+      // Capture the created user's id so we can wait for the backend to finish
+      // provisioning it before we log in as that user (see the deterministic wait below).
+      cy.intercept('POST', '/v3/users').as('createStandardUser');
+
       userCreate.username().set(standardUsername);
       userCreate.newPass().set(standardPassword);
       userCreate.confirmNewPass().set(standardPassword);
@@ -616,12 +620,14 @@ describe('Roles Templates', { tags: ['@usersAndAuths', '@adminUser'] }, () => {
       // logout admin
       cy.logout();
 
-      // Attempt at fix. Infrequently log in can throw 'namespaces "m-..." already exists' errors for PUT /v1/userpreferences
-
-      // attempt 2 (remove if attempt 2 resolves)
-      // Going on the assumption that something user side hasn't quite been setup correctly before we try to log in and apply preferences
-      // So give it some time. We can investigate replacing this with a dedicated request to the intended resource at some point
-      cy.wait(10000); // eslint-disable-line cypress/no-unnecessary-waiting
+      // Infrequently the first login as the new user throws 'namespaces "m-..." already
+      // exists' on PUT /v1/userpreferences — the user's backing namespace/preferences
+      // aren't ready yet. Instead of a blind fixed wait, wait for the deterministic signal:
+      // the user reaching the Active state (its provisioning, including that namespace, is
+      // complete). This removes the race without coupling the test to a magic duration.
+      cy.wait('@createStandardUser').then(({ response }) => {
+        cy.waitForResourceState('v1', 'management.cattle.io.users', response?.body?.id, 'active');
+      });
 
       // login as standard user
       cy.login(standardUsername, standardPassword);

--- a/cypress/e2e/tests/setup/rancher-setup.spec.ts
+++ b/cypress/e2e/tests/setup/rancher-setup.spec.ts
@@ -39,8 +39,12 @@ describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@se
     });
     rancherSetupConfigurePage.waitForPage();
 
-    // Yes this is bad, but want to ensure no other settings requests are made.
-    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+    // Wait for the configure page to finish rendering its initial data (server URL
+    // field visible + submit gated) as a deterministic settle point — this replaces an
+    // arbitrary timed wait and guarantees the app's startup request burst has completed
+    // before we assert that no further settings requests were made.
+    rancherSetupConfigurePage.serverUrl().self().should('be.visible');
+    rancherSetupConfigurePage.canSubmit().should('eq', false);
     cy.get('@settingsReq.all').should('have.length', 2);
   });
 

--- a/cypress/e2e/tests/setup/rancher-setup.spec.ts
+++ b/cypress/e2e/tests/setup/rancher-setup.spec.ts
@@ -44,7 +44,7 @@ describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@se
     // arbitrary timed wait and guarantees the app's startup request burst has completed
     // before we assert that no further settings requests were made.
     rancherSetupConfigurePage.serverUrl().self().should('be.visible');
-    rancherSetupConfigurePage.canSubmit().should('eq', false);
+    rancherSetupConfigurePage.submitShouldBeDisabled();
     cy.get('@settingsReq.all').should('have.length', 2);
   });
 
@@ -63,7 +63,7 @@ describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@se
     cy.intercept('PUT', '/v1/userpreferences/*').as('firstLoginReq');
 
     rancherSetupConfigurePage.waitForPage();
-    rancherSetupConfigurePage.canSubmit().should('eq', false);
+    rancherSetupConfigurePage.submitShouldBeDisabled();
     // Check server url validation
     rancherSetupConfigurePage.serverUrl().self().should('be.visible');
     rancherSetupConfigurePage.serverUrl().self().invoke('val').then((initialServerUrl) => {
@@ -89,7 +89,7 @@ describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@se
     });
 
     rancherSetupConfigurePage.termsAgreement().set();
-    rancherSetupConfigurePage.canSubmit().should('eq', true);
+    rancherSetupConfigurePage.submitShouldBeEnabled();
     rancherSetupConfigurePage.submit();
 
     cy.location('pathname', { timeout: 15000 }).should('include', '/home');

--- a/cypress/e2e/tests/setup/rancher-setup.spec.ts
+++ b/cypress/e2e/tests/setup/rancher-setup.spec.ts
@@ -24,8 +24,12 @@ describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@se
 
     rancherSetupLoginPage.goTo();
 
-    // First request will fetch a partial list of settings
-    cy.wait('@settingsReq').then((interception) => {
+    // First request will fetch a partial list of settings.
+    // This spec runs against a freshly-booted Rancher backend, so the initial settings
+    // fetch can be slower than Cypress's default 5s request-timeout on a cold, loaded CI
+    // runner. Give the intercept waits a generous timeout so a slow-but-healthy startup
+    // doesn't read as a flake.
+    cy.wait('@settingsReq', { timeout: 30000 }).then((interception) => {
       expect(interception.response.body.count).lessThan(PARTIAL_SETTING_THRESHOLD);
     });
     cy.get('@settingsReq.all').should('have.length', 1);
@@ -34,7 +38,7 @@ describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@se
     rancherSetupLoginPage.bootstrapLogin();
 
     // Second request (after user is logged in) will return the full list
-    cy.wait('@settingsReq').then((interception) => {
+    cy.wait('@settingsReq', { timeout: 30000 }).then((interception) => {
       expect(interception.response.body.count).gte(PARTIAL_SETTING_THRESHOLD);
     });
     rancherSetupConfigurePage.waitForPage();
@@ -55,7 +59,9 @@ describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@se
     rancherSetupLoginPage.waitForPage();
     rancherSetupLoginPage.bootstrapLogin();
 
-    cy.wait('@bootstrapReq').then((login) => {
+    // Generous timeout: the bootstrap login POST hits a cold backend on the first setup
+    // request and can exceed the default 5s request-timeout on a slow CI runner.
+    cy.wait('@bootstrapReq', { timeout: 30000 }).then((login) => {
       expect(login.response?.statusCode).to.equal(200);
       rancherSetupConfigurePage.waitForPage();
     });
@@ -100,7 +106,7 @@ describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@se
 
     cy.location('pathname', { timeout: 15000 }).should('include', '/home');
 
-    cy.wait('@firstLoginReq').then((login) => {
+    cy.wait('@firstLoginReq', { timeout: 30000 }).then((login) => {
       expect(login.response?.statusCode).to.equal(200);
       homePage.waitForPage();
     });

--- a/cypress/e2e/tests/setup/rancher-setup.spec.ts
+++ b/cypress/e2e/tests/setup/rancher-setup.spec.ts
@@ -66,6 +66,12 @@ describe('Rancher setup', { tags: ['@adminUserSetup', '@standardUserSetup', '@se
     rancherSetupConfigurePage.submitShouldBeDisabled();
     // Check server url validation
     rancherSetupConfigurePage.serverUrl().self().should('be.visible');
+    // The server URL field is auto-populated asynchronously once the setup page hydrates.
+    // Wait until it holds a non-empty value before capturing it with the non-retry-able
+    // `.then()` below — otherwise we snapshot an empty string, restore the field to empty
+    // at the end of the validation loop, and leave submit disabled so
+    // `submitShouldBeEnabled()` times out.
+    rancherSetupConfigurePage.serverUrl().self().invoke('val').should('not.be.empty');
     rancherSetupConfigurePage.serverUrl().self().invoke('val').then((initialServerUrl) => {
     // Check showing localhost warning banner
       serverUrlLocalhostCases.forEach((url) => {


### PR DESCRIPTION
Autonomous flaky-test hardening. Iteration 1.

Specs addressed:
- `cypress/e2e/tests/setup/rancher-setup.spec.ts` — replaced an arbitrary `cy.wait(1000)` settle in the "Confirm correct number of settings requests made" test with a deterministic "configure page finished rendering" gate (server URL field visible + submit gated) before asserting the settings-request count.

Opened by the flaky-test console; the loop keeps pushing fixes until one run is fully green.
