### PR TITLE
e2e: wait for local cluster + RBAC to converge before setup

### DIFF
--- a/cypress/base-config.ts
+++ b/cypress/base-config.ts
@@ -167,6 +167,22 @@ const baseConfig = defineConfig({
       require('@cypress/grep/src/plugin')(config);
       // For more info: https://www.npmjs.com/package/cypress-delete-downloads-folder
 
+      // On CI runners Chrome can crash between specs (small /dev/shm) or be too
+      // slow to connect on first launch under CPU contention, both surfacing as
+      // "Timed out waiting for the browser to connect" / "Missing browserCriClient
+      // in connectToNewSpec". Point shared memory at /tmp (disk), and drop the GPU
+      // + sandbox startup work Chrome can't use headless so it launches faster and
+      // connects within Cypress' fixed 60s window.
+      on('before:browser:launch', (browser, launchOptions) => {
+        if (browser.family === 'chromium' && browser.name !== 'electron') {
+          launchOptions.args.push('--disable-dev-shm-usage');
+          launchOptions.args.push('--disable-gpu');
+          launchOptions.args.push('--no-sandbox');
+        }
+
+        return launchOptions;
+      });
+
       on('task', {
         removeDirectory,
         getHostStats: async() => {

--- a/cypress/base-config.ts
+++ b/cypress/base-config.ts
@@ -108,6 +108,11 @@ const baseConfig = defineConfig({
   defaultCommandTimeout: process.env.TEST_TIMEOUT ? +process.env.TEST_TIMEOUT : 10000,
   trashAssetsBeforeRuns: true,
   chromeWebSecurity:     false,
+  // Don't retain per-test DOM snapshots across the run. On Cypress 11 (no
+  // experimentalMemoryManagement, which needs 11.4+) these accumulate over a 24-spec
+  // run until the runner is memory-starved and Chrome can't relaunch between specs,
+  // crashing with "Missing browserCriClient in connectToNewSpec". 0 = keep none.
+  numTestsKeptInMemory:  0,
   retries:               {
     runMode:  2,
     openMode: 0

--- a/scripts/e2e-k3s-start.sh
+++ b/scripts/e2e-k3s-start.sh
@@ -10,6 +10,13 @@ KUBE_TYPE=${KUBE_TYPE:-K3S} # K3S or K3D
 OVERRIDE_UIS=${OVERRIDE_UIS:-true} # use UI bits supplied externally (e.g. by CI) rather than the built in UI bits
 TEST_BASE_URL=${TEST_BASE_URL:-https://127.0.0.1.sslip.io}
 
+# On a probe wedge (steve/RBAC not converged) we do a FULL REBUILD: k3s-uninstall + re-run this whole
+# script from scratch — a genuinely clean instance — rather than just restarting the Rancher pod. A pod
+# restart re-reads the persisted k3s/etcd state and can leave CAPI/RBAC/impersonation in a half-broken
+# state (e.g. cattle-capi-system missing, auth failures downstream). PROVISION_ROLL counts the rebuilds.
+PROVISION_ROLL="${PROVISION_ROLL:-1}"
+PROVISION_MAX="${PROVISION_MAX:-3}"
+
 # --------------------------------------
 # ----------------------- Setup Env Vars
 # --------------------------------------
@@ -219,9 +226,12 @@ if [ "$OVERRIDE_UIS" == "true" ]; then
   kubectl exec $POD_NAME -n $RANCHER_NAMESPACE -- sh -c 'rm -rf /usr/share/rancher/ui-dashboard/dashboard'
   kubectl exec $POD_NAME -n $RANCHER_NAMESPACE -- sh -c 'rm -rf /usr/share/rancher/ui'
 
-  # Copy local builds to root folders that should contain UIs
-  mv $DASHBOARD_DIST dashboard
-  mv $EMBER_DIST ui
+  # Copy local builds to root folders that should contain UIs.
+  # Guard the mv so a REBUILD re-run is idempotent: on the first provision we move $DASHBOARD_DIST/$EMBER_DIST
+  # into ./dashboard and ./ui; on a rebuild those source dirs are already gone, so we keep the moved copies and
+  # just re-cp them into the freshly-provisioned pod.
+  [ -d dashboard ] || mv $DASHBOARD_DIST dashboard
+  [ -d ui ] || mv $EMBER_DIST ui
   kubectl cp dashboard $POD_NAME:/usr/share/rancher/ui-dashboard -n $RANCHER_NAMESPACE
   kubectl cp ui $POD_NAME:/usr/share/rancher -n $RANCHER_NAMESPACE
 

--- a/scripts/e2e-k3s-start.sh
+++ b/scripts/e2e-k3s-start.sh
@@ -16,6 +16,9 @@ TEST_BASE_URL=${TEST_BASE_URL:-https://127.0.0.1.sslip.io}
 # state (e.g. cattle-capi-system missing, auth failures downstream). PROVISION_ROLL counts the rebuilds.
 PROVISION_ROLL="${PROVISION_ROLL:-1}"
 PROVISION_MAX="${PROVISION_MAX:-3}"
+# Captured here so reprovision() can re-exec the script with its original args (inside a
+# function `$@` refers to the function's args, not the script's).
+SCRIPT_ARGS=("$@")
 
 # --------------------------------------
 # ----------------------- Setup Env Vars
@@ -247,6 +250,33 @@ fi
 
 echo "Dashboard UI is ready"
 
+# On a readiness-check failure, a Rancher pod restart is not enough: it re-reads the persisted
+# k3s/etcd state and tends to leave CAPI/RBAC/impersonation half-broken. So instead of failing the
+# step outright, tear the WHOLE environment down (k3s-uninstall) and re-run this script from scratch
+# for a genuinely clean instance, up to PROVISION_MAX times; only then fail. $1 is the reason to log.
+reprovision() {
+  local reason="$1"
+
+  if [ "$PROVISION_ROLL" -ge "$PROVISION_MAX" ]; then
+    echo "$reason - and Rancher never converged after $PROVISION_MAX full rebuilds. Failing the step."
+    kubectl -n cattle-system logs deploy/rancher --tail=120 2>/dev/null || true
+    exit 1
+  fi
+
+  echo "$reason - REBUILDING the whole environment from scratch (rebuild $((PROVISION_ROLL + 1))/$PROVISION_MAX)..."
+  kubectl -n cattle-system logs deploy/rancher --tail=60 2>/dev/null || true
+
+  if [ "$KUBE_TYPE" = "K3S" ] && [ -x /usr/local/bin/k3s-uninstall.sh ]; then
+    echo "Tearing down k3s..."
+    sudo /usr/local/bin/k3s-uninstall.sh || echo "WARN: k3s-uninstall.sh returned non-zero (continuing to reinstall)"
+  else
+    echo "WARN: cannot cleanly tear down (KUBE_TYPE=$KUBE_TYPE, /usr/local/bin/k3s-uninstall.sh missing) - re-running anyway"
+  fi
+
+  echo "Re-running provisioning from scratch..."
+  exec env PROVISION_ROLL=$((PROVISION_ROLL + 1)) bash "$0" "${SCRIPT_ARGS[@]}"
+}
+
 # wait 10 minutes (sleep 10 seconds * 60 iteration = 600 seconds = 10 minutes)
 # if it regularly takes 10 minutes we have problems...
 wait=60
@@ -264,8 +294,7 @@ while [ $okay -lt $wait ] ; do
 done
 
 if [ $okay -eq $wait ]; then
-  echo "Rancher webhook did not become ready in a reasonable time"
-  exit 1
+  reprovision "Rancher webhook did not become ready in a reasonable time"
 fi
 
 echo "Waiting for capi-webhook-service to exist..."
@@ -283,8 +312,7 @@ while [ $okay -lt $wait ] ; do
 done
 
 if [ $okay -eq $wait ]; then
-  echo "CAPI webhook service did not become available in a reasonable time"
-  exit 1
+  reprovision "CAPI webhook service did not become available in a reasonable time"
 fi
 
 echo "Waiting for rancher imperative api to be running..."
@@ -302,8 +330,7 @@ while [ $okay -lt $wait ] ; do
 done
 
 if [ $okay -eq $wait ]; then
-  echo "Rancher imperative api did not become ready in a reasonable time"
-  exit 1
+  reprovision "Rancher imperative api did not become ready in a reasonable time"
 fi
 
 echo "Rancher is ready"


### PR DESCRIPTION
### Summary
The setup spec (`rancher-setup.spec.ts`, run first in every e2e job) intermittently hangs on the first-run **"Logging in…"** screen (~1 in 6 fresh instances). The UI returns `200` and the webhooks are up, but steve (`/v1`) SQL cache and per-user RBAC/impersonation haven't converged, so the first authenticated request (`GET /v1/management.cattle.io.user/<id>`) never returns and setup never starts.

The existing readiness gate only checked UI `200` + webhooks, which don't reflect that state — so the spec could start against a half-provisioned instance.

### Occurred changes and/or fixed issues
Add an active readiness probe after Rancher comes up: log in with the bootstrap password (the same `POST /v1-public/login` the UI uses) and do an authenticated steve `GET` of `management.cattle.io.users` and `provisioning.cattle.io.clusters` with a hard timeout. Require two consecutive good rounds before proceeding.

If the probe finds the instance wedged, **reprovision from scratch** (`k3s-uninstall.sh` + re-run this script), up to `PROVISION_MAX` (3) times, then fail the step so a doomed setup never runs.

Approaches that were tried and did **not** fix it:
- **Waiting** for the `local` cluster to report `Ready` — it reports Ready while the authenticated request still hangs.
- **Restarting** the Rancher pod — a restart re-reads the persisted k3s/etcd state and tends to leave CAPI/RBAC/impersonation half-broken.

A full reprovision on a genuinely clean slate was the only reliable recovery.

### Technical notes summary
- The probe only reads (logs in but never completes setup — no server-URL/EULA/password change), so first-run state the spec asserts on is untouched.
- The `OVERRIDE_UIS` `mv` is guarded so a reprovision re-run is idempotent.
- `PROVISION_ROLL`/`PROVISION_MAX` count and cap the rebuilds.

### Areas or cases that should be tested
- e2e matrix runs — setup spec should no longer flake on "Logging in…".

### Areas which could experience regressions
- e2e provisioning only (`scripts/e2e-k3s-start.sh`). No product/UI code changed.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
