### PR TITLE
Run validate PR workflow on label/unlabel

### DIFF
--- a/.github/workflows/valid-pr.yaml
+++ b/.github/workflows/valid-pr.yaml
@@ -2,7 +2,7 @@ name: Validate Pull Request
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, milestoned, demilestoned]
+    types: [opened, edited, synchronize, milestoned, demilestoned, labeled, unlabeled]
 
 jobs:
   validate-description:


### PR DESCRIPTION
### Summary

Fix to the validate PR workflow so that it runs when we label/unlabel.

This way, if the workflow runs and then we add the label for skipping the workflow, it will now correctly pass.
 
### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
