### PR TITLE
Bump linkify-it from 3.0.3 to 5.0.2

### DIFF
--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -53,7 +53,8 @@
     "webpack": "5.105.4",
     "ws": "8.21.0",
     "serialize-javascript": "7.0.3",
-    "webpack-dev-server": "5.2.6"
+    "webpack-dev-server": "5.2.6",
+    "linkify-it": "5.0.2"
   },
   "engines": {
     "node": ">=18.0"

--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -6095,10 +6095,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linkify-it@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.0.tgz#9ef238bfa6dc70bd8e7f9572b52d369af569b421"
-  integrity sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==
+linkify-it@5.0.2, linkify-it@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.2.tgz#d3be0a693af3da9df3883f1e346a0e97461a8c19"
+  integrity sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==
   dependencies:
     uc.micro "^2.0.0"
 

--- a/package.json
+++ b/package.json
@@ -224,6 +224,7 @@
     "qs": "6.15.2",
     "cross-spawn": "7.0.6",
     "serialize-javascript": "7.0.3",
+    "linkify-it": "5.0.2",
     "mocha/minimatch": "5.1.8",
     "mocha/js-yaml": "4.3.0",
     "@cypress/code-coverage/js-yaml": "4.3.0",

--- a/shell/package.json
+++ b/shell/package.json
@@ -149,6 +149,7 @@
     "semver": "7.5.4",
     "ws": "8.21.0",
     "serialize-javascript": "7.0.3",
+    "linkify-it": "5.0.2",
     "@types/lodash": "4.17.5",
     "@types/node": "25.3.3",
     "@vue/cli-service/html-webpack-plugin": "^5.0.0",

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -8927,12 +8927,12 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linkify-it@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
-  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+linkify-it@5.0.2, linkify-it@^3.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.2.tgz#d3be0a693af3da9df3883f1e346a0e97461a8c19"
+  integrity sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==
   dependencies:
-    uc.micro "^1.0.1"
+    uc.micro "^2.0.0"
 
 loader-runner@^4.1.0, loader-runner@^4.3.1:
   version "4.3.1"
@@ -11940,10 +11940,15 @@ typescript@5.6.3:
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
   integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
 
-uc.micro@^1.0.1, uc.micro@^1.0.5:
+uc.micro@^1.0.5:
   version "1.0.6"
   resolved "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
+uc.micro@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
+  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
 ufo@0.7.11:
   version "0.7.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10520,12 +10520,12 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-linkify-it@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
-  integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
+linkify-it@5.0.2, linkify-it@^3.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.2.tgz#d3be0a693af3da9df3883f1e346a0e97461a8c19"
+  integrity sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==
   dependencies:
-    uc.micro "^1.0.1"
+    uc.micro "^2.0.0"
 
 listr2@^3.8.3:
   version "3.14.0"
@@ -14344,10 +14344,15 @@ typescript@5.6.3:
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
   integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
 
-uc.micro@^1.0.1, uc.micro@^1.0.5:
+uc.micro@^1.0.5:
   version "1.0.6"
   resolved "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
+
+uc.micro@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-2.1.0.tgz#f8d3f7d0ec4c3dea35a7e3c8efa4cb8b45c9e7ee"
+  integrity sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==
 
 ufo@0.7.11:
   version "0.7.11"


### PR DESCRIPTION
### Summary
Fixes the `linkify-it` quadratic-complexity vulnerability (GHSA-22p9-wv53-3rq4, CVE-2026-48801). `LinkifyIt#match`'s scan loop exhibits quadratic algorithmic complexity, so a crafted input can force excessive CPU work (ReDoS-style resource exhaustion).

### Occurred changes and/or fixed issues
Force-patched `linkify-it` across the affected manifests:
- `linkify-it` `3.0.3` → `5.0.2` (pinned via `resolutions` so the transitive markdown-it consumer picks up the patched version) across **root**, `shell/`, and `docusaurus/`

No application source was changed — this is a dependency-only bump.

### Technical notes summary
The pin is applied via `resolutions` in the **root**, `shell/`, and `docusaurus/` `package.json` files so every transitive consumer (including the root `markdown-it@12.3.2 → linkify-it@^3.0.1` build-time chain) resolves to the patched `linkify-it` 5.0.2, and the lockfiles were regenerated accordingly. `LinkifyIt#match` is only reached through markdown rendering; the bump keeps the public API compatible.

### Areas or cases that should be tested
Smoke-test the Dashboard UI (build + boot) to confirm the resolution change doesn't break the bundle. The Playwright verification recording below drives the running preview.

### Areas which could experience regressions
Anything that renders markdown/auto-links content. No runtime behaviour change is expected from a patched `linkify-it` — the fix removes the quadratic scan path while keeping the matching API compatible.

### Screenshot/Video
> 🔄 Recording + checks updated 2026-07-21 based on review feedback: added the missing root `resolutions` pin so the root `yarn.lock` no longer resolves the vulnerable `linkify-it@3.0.3`, and re-verified the markdown/link-matching surface.

Verification recording (Playwright):

https://github.com/user-attachments/assets/92838b59-6247-43c6-8385-9c617ce42269

**Playwright checks performed** (video recorded, 1280×800):
1. **Login — the linkify-it-5.0.2-integrated bundle boots & authenticates.** Logged in with local credentials and landed on `/dashboard/home`. ✅ PASS — the rebuilt shell bundle (webpack → markdown-it → linkify-it 5.0.2) executes without boot errors.
2. **Authenticated app shell renders.** Side nav / header visible; `document.title = "prime - Homepage"`. ✅ PASS — no post-bump runtime crash.
3. **Apps → Charts marketplace list renders.** Navigated to `c/local/apps/charts`; 133 chart cards rendered with marketplace content. ✅ PASS — the charts UI (markdown-backed descriptions) loads.
4. **Chart README markdown + link-matching intact.** Opened the Longhorn chart detail page; the README rendered through the dashboard markdown pipeline (`.markdown.md-desc`, ~3500 chars) with 10 resolved hyperlinks. ✅ PASS — the markdown-it → linkify-it 5.0.2 pipeline (the exact `LinkifyIt#match` surface the advisory concerns) renders and matches links correctly after the bump.
5. **No uncaught JS runtime errors.** A global `pageerror` listener captured **zero** uncaught exceptions across the full login + navigation session. ✅ PASS — the markdown-it/linkify-it integration is clean at runtime.

**Verdict:** 5/5 checks passed. `linkify-it` is now pinned to 5.0.2 across **root**, `shell`, and `docusaurus` (resolving GHSA-22p9-wv53-3rq4 / CVE-2026-48801); the added root `resolutions` entry closes the `markdown-it@12.3.2 → linkify-it@^3.0.1 → 3.0.3` chain the review flagged. The preview builds, boots, and renders markdown/link surfaces with no runtime errors.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.

