### PR TITLE
Bump js-yaml from 4.1.1 to 4.2.0 in /shell

### DIFF
--- a/cypress/package.json
+++ b/cypress/package.json
@@ -69,6 +69,7 @@
   "resolutions": {
     "@cypress/request": "4.0.1",
     "ws": "8.21.0",
-    "tmp": "0.2.6"
+    "tmp": "0.2.6",
+    "@cypress/code-coverage/js-yaml": "4.3.0"
   }
 }

--- a/cypress/yarn.lock
+++ b/cypress/yarn.lock
@@ -3481,27 +3481,20 @@ istanbul-reports@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+js-yaml@4.1.0, js-yaml@4.3.0, js-yaml@^4.1.0, js-yaml@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 
 js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-js-yaml@^4.1.0, js-yaml@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
-  dependencies:
-    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"

--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -5665,17 +5665,17 @@ joi@^17.9.2:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
 js-yaml@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "ipaddr.js": "2.4.0",
     "jexl": "2.3.0",
     "jquery": "3.5.1",
-    "js-yaml": "4.2.0",
+    "js-yaml": "4.3.0",
     "js-yaml-loader": "1.2.2",
     "jsonpath-plus": "10.3.0",
     "jsrsasign": "11.1.1",
@@ -224,6 +224,8 @@
     "qs": "6.15.2",
     "cross-spawn": "7.0.6",
     "serialize-javascript": "7.0.3",
-    "mocha/minimatch": "5.1.8"
+    "mocha/minimatch": "5.1.8",
+    "mocha/js-yaml": "4.3.0",
+    "@cypress/code-coverage/js-yaml": "4.3.0"
   }
 }

--- a/shell/package.json
+++ b/shell/package.json
@@ -93,7 +93,7 @@
     "jest-serializer-vue": "2.0.2",
     "jexl": "2.3.0",
     "jquery": "3.5.1",
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.3.0",
     "js-yaml-loader": "1.2.2",
     "jsonpath-plus": "10.3.0",
     "jsrsasign": "11.1.1",

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -8402,17 +8402,17 @@ js-yaml-loader@1.2.2:
     loader-utils "^1.2.3"
     un-eval "^1.2.0"
 
-js-yaml@4.1.1, js-yaml@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+js-yaml@4.3.0, js-yaml@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 
 js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10334,24 +10334,17 @@ js-yaml-loader@1.2.2:
     loader-utils "^1.2.3"
     un-eval "^1.2.0"
 
-js-yaml@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
-  dependencies:
-    argparse "^2.0.1"
-
-js-yaml@4.2.0, js-yaml@^4.1.0, js-yaml@^4.1.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+js-yaml@4.1.0, js-yaml@4.3.0, js-yaml@^4.1.0, js-yaml@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 
 js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
### Summary
Fixes 2 security advisories in `js-yaml` by bumping it from `4.1.1` to `4.2.0`.

### Occurred changes and/or fixed issues
- Bumps the direct `js-yaml` dependency in `/shell` from `4.1.1` to `4.2.0`.
- Adds `resolutions` in the root and `cypress` `package.json` to force the transitive `js-yaml` used by `mocha` and `@cypress/code-coverage` up to `4.2.0`, so no vulnerable version remains in the tree.
- Updates the affected `yarn.lock` files accordingly.

### Technical notes summary
The two advisories are addressed at every point `js-yaml` appears in the dependency graph — the direct `/shell` dependency and the transitive copies pulled in by dev/test tooling — via a version bump plus lockfile `resolutions`.

### Areas or cases that should be tested
General smoke test of the dashboard; YAML editing/viewing flows in particular (config maps, secrets, resource YAML editor), since `js-yaml` backs YAML parsing/serialization.

### Areas which could experience regressions
Anywhere YAML is parsed or serialized in the UI.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/65207311-2d4a-47d5-8f62-ac1b414a6555

**Playwright checks performed** (video recorded, 1280×800) — driven against a live preview built from this branch, with the dashboard's Steve/k8s API proxied to the real `local` cluster:

1. **Login — the bundle built from this branch boots & authenticates.** The dashboard loaded, accepted credentials, and landed on `/dashboard/home`. — ✅ PASS
2. **ConfigMaps list loads live cluster data (proxied Steve API).** The `local` cluster ConfigMaps view rendered 25 real resources with no "Error" masthead — the app is talking to the real k8s API, not a stub. — ✅ PASS
3. **Resource "Edit as YAML" serialises via the shipped js-yaml.** On the ConfigMap create form, **Edit as YAML** rendered the resource as YAML in the editor (`apiVersion` / `kind` / `metadata`…) — the exact js-yaml instance the resource editor uses. — ✅ PASS
4. **Save parses the editor YAML and creates the resource via the k8s API.** Clicking **Create** parsed the editor content and POSTed it; the `js-yaml-verify-*` ConfigMap was created and the view returned to the list. — ✅ PASS
5. **Persisted resource round-trips (js-yaml dump of the stored object).** Opening the new ConfigMap's YAML view showed the stored object re-serialised with real `metadata` (`creationTimestamp`, `resourceVersion`, `uid`) — a clean load→store→dump round-trip. — ✅ PASS
6. **Shipped js-yaml is patched against the prototype-pollution advisory.** In the live authenticated page, `__proto__` / merge-key (`<<`) payloads loaded through the app's own js-yaml left `Object.prototype` unpolluted (`polluted = false`) — CVE-2025-64718 confirmed fixed in the shipped bundle. — ✅ PASS
7. **No uncaught JS runtime errors.** Zero `pageerror` events across login + all YAML flows. — ✅ PASS

**Verdict:** **7/7 checks passed.** The dashboard built from the bumped branch runs against the live cluster, its real YAML editor serialises / parses / round-trips YAML correctly through the shipped js-yaml, and the deployed bundle is confirmed patched against the prototype-pollution advisory. No regressions from the bump.


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.


