### PR TITLE
fix(rancher-prime): clearer offline registration download timeout message

### DIFF
--- a/pkg/rancher-prime/l10n/en-us.yaml
+++ b/pkg/rancher-prime/l10n/en-us.yaml
@@ -60,6 +60,7 @@ registration:
     mismatch-code: Registration active but does not match Secret registration code. Please verify the <a href="${ url }">registration</a>
     generic-registration: No registration found for existing registration code (Secret).
     timeout-registration: Timeout reached while waiting for resource.
+    timeout-offline-request: Timed out waiting for the offline registration request. The SCC operator may still be preparing resources. Wait a moment and try Download again, or export the request with kubectl from the cattle-scc-system namespace (secret labeled scc.cattle.io/secret-role=offline-request).
 
 prime:
   installed: This is a SUSE Rancher Prime installation

--- a/pkg/rancher-prime/pages/registration.composable.test.ts
+++ b/pkg/rancher-prime/pages/registration.composable.test.ts
@@ -13,6 +13,46 @@ const namespaceRequest = {
 jest.mock('vuex', () => ({ useStore: () => ({ dispatch: dispatchSpy }) }));
 jest.mock('@shell/utils/download', () => ({ downloadFile: (...args: any) => downloadSpy(...args) }));
 
+/**
+ * Fake clock helper for pollResource (250ms interval, 60s timeout).
+ * Install before starting the polled flow, then advance past the timeout,
+ * then restore. Keeps timer-driving logic out of the individual test bodies.
+ *
+ * jest 27 has no async timer advance, so we drive the sync clock and flush the
+ * async setInterval callback chain with microtasks. An initial flush lets the
+ * flow reach pollResource (so startTime is captured at the base `now`), then
+ * each tick advances the clock past the 60s timeout.
+ */
+const flushMicrotasks = async(rounds = 20) => {
+  for (let i = 0; i < rounds; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+};
+
+const useFakePollClock = () => {
+  jest.useFakeTimers();
+  let now = Date.now();
+  const spy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+
+  return {
+    advance: async() => {
+      // Let the flow progress to pollResource so startTime is captured at `now`
+      await flushMicrotasks();
+      // 245 ticks * 250ms = 61.25s, past the 60s poll timeout
+      for (let i = 0; i < 245; i++) {
+        now += 250;
+        jest.advanceTimersByTime(250);
+        await flushMicrotasks();
+      }
+    },
+    restore: () => {
+      jest.useRealTimers();
+      spy.mockRestore();
+    }
+  };
+};
+
 describe('registration composable', () => {
   beforeEach(() => {
     dispatchSpy = jest.fn().mockReturnValue(Promise.resolve([]));
@@ -108,6 +148,16 @@ describe('registration composable', () => {
     it('should retrieve and start download process', async() => {
       const expectation = 'whatever';
       const hash = 'anything';
+      const createdSecret = {
+        metadata: {
+          namespace: REGISTRATION_NAMESPACE,
+          name:      REGISTRATION_SECRET,
+          labels:    { [REGISTRATION_LABEL]: hash }
+        },
+        data: { registrationType: btoa('offline') },
+        save:   () => Promise.resolve(),
+        remove: () => Promise.resolve(),
+      };
       const secrets = [
         {
           metadata: {
@@ -120,19 +170,20 @@ describe('registration composable', () => {
         },
       ];
       const registrations = [{
-        spec:     { mode: 'online' },
+        spec:     { mode: 'offline' },
         metadata: { labels: { [REGISTRATION_LABEL]: hash } },
         links:    { view: '123' },
         status:   {
-          activationStatus: { activated: true },
-          currentCondition: { type: 'Done' }
+          activationStatus: { activated: false },
+          currentCondition: { type: 'OfflineRequestReady' }
         },
       }];
 
       dispatchSpy = jest.fn()
         .mockReturnValueOnce(Promise.resolve(/** Ensure namespace */))
-        .mockReturnValueOnce(Promise.resolve(/** Create secret */))
-        .mockReturnValueOnce(Promise.resolve(secrets))
+        .mockReturnValueOnce(Promise.resolve([])) // deleteSecret → getSecret (none)
+        .mockReturnValueOnce(Promise.resolve(createdSecret)) // createSecret
+        .mockReturnValueOnce(Promise.resolve(secrets)) // poll findOfflineRequest
         .mockReturnValue(Promise.resolve(registrations));
       const store = { state: {}, dispatch: dispatchSpy } as any;
       const { downloadOfflineRequest } = usePrimeRegistration(store);
@@ -142,6 +193,41 @@ describe('registration composable', () => {
 
       expect(downloadSpy).toHaveBeenCalledWith(REGISTRATION_REQUEST_FILENAME, expectation, 'application/json');
     });
+
+    it('should show an offline timeout message when the request secret is not ready', async() => {
+      const expectation = 'registration.errors.timeout-offline-request';
+      const createdSecret = {
+        metadata: {
+          namespace: REGISTRATION_NAMESPACE,
+          name:      REGISTRATION_SECRET,
+          labels:    {}
+        },
+        data: { registrationType: btoa('offline') },
+        save:   () => Promise.resolve(),
+        remove: () => Promise.resolve(),
+      };
+
+      dispatchSpy = jest.fn()
+        .mockReturnValueOnce(Promise.resolve(/** Ensure namespace */))
+        .mockReturnValueOnce(Promise.resolve([])) // deleteSecret → getSecret
+        .mockReturnValueOnce(Promise.resolve(createdSecret)) // createSecret
+        .mockReturnValue(Promise.resolve([])); // poll never finds offline-request
+      const store = { state: {}, dispatch: dispatchSpy } as any;
+      const { downloadOfflineRequest, errors } = usePrimeRegistration(store);
+      let resolved: boolean | undefined;
+
+      const clock = useFakePollClock();
+      const downloadPromise = downloadOfflineRequest((val: boolean) => {
+        resolved = val;
+      });
+
+      await clock.advance();
+      await downloadPromise;
+      clock.restore();
+
+      expect(resolved).toBe(false);
+      expect(errors.value[0]).toStrictEqual(expectation);
+    }, 15000);
   });
 
   describe('changing registration type', () => {
@@ -161,8 +247,11 @@ describe('registration composable', () => {
 
       await registerOnline((val: boolean) => true);
 
-      expect(dispatchSpy).toHaveBeenCalledTimes(2);
       expect(dispatchSpy).toHaveBeenCalledWith('management/find', namespaceRequest);
+      expect(dispatchSpy).toHaveBeenCalledWith('management/create', {
+        type:     'namespace',
+        metadata: { name: REGISTRATION_NAMESPACE }
+      });
     });
 
     it('should delete any existing secret', async() => {
@@ -231,8 +320,8 @@ describe('registration composable', () => {
 
       dispatchSpy = jest.fn()
         .mockReturnValueOnce(Promise.resolve(/** Ensure namespace */))
-        // .mockReturnValueOnce(Promise.resolve(/** Create secret */))
-        .mockReturnValueOnce(Promise.resolve(secrets))
+        .mockReturnValueOnce(Promise.resolve([])) // deleteSecret → getSecret
+        .mockReturnValueOnce(Promise.resolve(secrets)) // createSecret
         .mockReturnValueOnce(Promise.resolve(registrations));
       const {
         registrationCode,
@@ -244,7 +333,7 @@ describe('registration composable', () => {
 
       await registerOnline((val: boolean) => true);
 
-      expect(dispatchSpy).toHaveBeenCalledTimes(4);
+      expect(dispatchSpy).toHaveBeenCalledTimes(5);
       expect(dispatchSpy).toHaveBeenCalledWith('management/find', namespaceRequest);
       expect(dispatchSpy).toHaveBeenCalledWith('management/create', secretRequest);
       expect(dispatchSpy).toHaveBeenCalledWith('management/findAll', { type: 'scc.cattle.io.registration' });

--- a/pkg/rancher-prime/pages/registration.composable.test.ts
+++ b/pkg/rancher-prime/pages/registration.composable.test.ts
@@ -154,7 +154,7 @@ describe('registration composable', () => {
           name:      REGISTRATION_SECRET,
           labels:    { [REGISTRATION_LABEL]: hash }
         },
-        data: { registrationType: btoa('offline') },
+        data:   { registrationType: btoa('offline') },
         save:   () => Promise.resolve(),
         remove: () => Promise.resolve(),
       };
@@ -202,7 +202,7 @@ describe('registration composable', () => {
           name:      REGISTRATION_SECRET,
           labels:    {}
         },
-        data: { registrationType: btoa('offline') },
+        data:   { registrationType: btoa('offline') },
         save:   () => Promise.resolve(),
         remove: () => Promise.resolve(),
       };

--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -286,24 +286,47 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
   };
 
   /**
-   * Download is also on its own a form of registration as it uses the same secret
-   * @param asyncButtonResolution Async button callback
+   * Generate the offline registration request by creating the entrypoint secret
+   * and polling for the operator-produced offline-request secret.
+   * Returns null when the entrypoint secret could not be created; throws on poll timeout/failure
+   * so the caller can resolve the async button and surface errors.
    */
-  const downloadOfflineRequest = async(asyncButtonResolution: (status: boolean) => void) => {
-    registrationStatus.value = 'registration-request';
+  const generateOfflineRequest = async(): Promise<string | null> => {
     await preRegistration();
     const originalHash = secretHash.value;
 
     secret.value = await createSecret('offline'); // Generate secret to trigger offline registration request
-    registrationCode.value = null;
-    const data = await pollResource(originalHash, findOfflineRequest, getRegistrationRequest);
+    if (!secret.value) {
+      return null;
+    }
 
-    await downloadFile(REGISTRATION_REQUEST_FILENAME, data ? btoa(data) : data, 'application/json')
-      .catch(() => {
+    registrationCode.value = null;
+    // Offline request generation can take longer while the SCC operator prepares resources
+    return await pollResource(originalHash, findOfflineRequest, getRegistrationRequest, undefined, 250, 60000);
+  };
+
+  /**
+   * Download is also on its own a form of registration as it uses the same secret
+   * @param asyncButtonResolution AsyncButton callback
+   */
+  const downloadOfflineRequest = async(asyncButtonResolution: (status: boolean) => void) => {
+    registrationStatus.value = 'registration-request';
+
+    try {
+      const data = await generateOfflineRequest();
+
+      if (data === null) {
         asyncButtonResolution(false);
-        onError(new Error('Registration request download not found'));
-      });
-    asyncButtonResolution(true);
+
+        return;
+      }
+
+      await downloadFile(REGISTRATION_REQUEST_FILENAME, data ? btoa(data) : data, 'application/json');
+      asyncButtonResolution(true);
+    } catch (error) {
+      asyncButtonResolution(false);
+      onError(error);
+    }
   };
 
   /**
@@ -426,21 +449,68 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
    * Get unique secret code with hardcoded namespace and name
    */
   const getSecret = async(): Promise<PartialSecret | null> => {
-    const secrets: PartialSecret[] = await store.dispatch('management/findAll', { type: SECRET, opt: { namespaced: REGISTRATION_NAMESPACE } }).catch(() => []) || [];
+    const result = await store.dispatch('management/findAll', { type: SECRET, opt: { namespaced: REGISTRATION_NAMESPACE } }).catch(() => []) || [];
+    const secrets: PartialSecret[] = Array.isArray(result) ? result : [];
 
     return secrets.find((secret) => secret.metadata?.namespace === REGISTRATION_NAMESPACE &&
       secret.metadata?.name === REGISTRATION_SECRET) ?? null;
   };
 
   /**
-   * Delete any secret before creating a new one
+   * Tracked timer used by waitForSecretDeleted so the pending wait can be cleared
+   * when it completes (avoids leaking a setTimeout after the composable is done).
+   */
+  let deleteWaitTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Wait until the cluster entrypoint secret is gone so a follow-up create does not
+   * hit AlreadyExists/409 while finalizers run. Only invoked after an actual remove.
+   * The backing setTimeout is tracked and cleared on completion.
+   */
+  const waitForSecretDeleted = async(timeoutMs = 30000): Promise<void> => {
+    const start = Date.now();
+
+    return new Promise<void>((resolve) => {
+      const check = async() => {
+        const stillThere = await getSecret();
+
+        if (!stillThere || Date.now() - start >= timeoutMs) {
+          if (deleteWaitTimer) {
+            clearTimeout(deleteWaitTimer);
+            deleteWaitTimer = null;
+          }
+          resolve();
+
+          return;
+        }
+
+        deleteWaitTimer = setTimeout(check, 250);
+      };
+
+      check();
+    });
+  };
+
+  /**
+   * Delete any secret before creating a new one.
+   * Resolve the cluster secret by name (not only the in-memory ref) so a stale cluster
+   * secret is removed even after a page reload, then wait for it to be gone when we did
+   * remove something so a follow-up create does not hit AlreadyExists/409.
    */
   const deleteSecret = async() => {
-    if (secret.value) {
-      try {
-        await secret.value.remove();
-      } catch (error) {}
+    const existing = secret.value || await getSecret();
+
+    secret.value = null;
+
+    if (!existing?.remove) {
+      return;
     }
+
+    try {
+      await existing.remove();
+    } catch (error) {}
+
+    await waitForSecretDeleted();
   };
 
   /**
@@ -489,11 +559,38 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
   };
 
   /**
+   * Whether the current entrypoint secret (or UI flow) is offline registration.
+   * Offline secrets intentionally omit regCode; only registrationType is set.
+   */
+  const isOfflineRegistrationSecret = (): boolean => {
+    if (registrationStatus.value === 'registration-request' || registrationStatus.value === 'registering-offline') {
+      return true;
+    }
+
+    const registrationType = secret.value?.data?.registrationType;
+
+    if (!registrationType) {
+      return registration.value?.mode === 'offline';
+    }
+
+    try {
+      return atob(registrationType) === 'offline';
+    } catch (error) {
+      return registrationType === 'offline';
+    }
+  };
+
+  /**
    * Generic fallback in case of unhandled errors based on existing resources
    * @param polling
    * @returns
    */
   const getError = (polling?: boolean): string => {
+    // Offline registration never has a regCode; a poll timeout must not claim the code secret is missing
+    if (polling && isOfflineRegistrationSecret()) {
+      return t('registration.errors.timeout-offline-request');
+    }
+
     if (polling && !secret.value?.data?.regCode) {
       return t('registration.errors.missing-code');
     }

--- a/pkg/rancher-prime/pages/registration.composable.ts
+++ b/pkg/rancher-prime/pages/registration.composable.ts
@@ -301,6 +301,7 @@ export const usePrimeRegistration = (storeArg?: Store<any>) => {
     }
 
     registrationCode.value = null;
+
     // Offline request generation can take longer while the SCC operator prepares resources
     return await pollResource(originalHash, findOfflineRequest, getRegistrationRequest, undefined, 250, 60000);
   };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18420

Offline SCC registration **Download registration request** can fail with the misleading error **"Registration code as Secret is missing"**. Offline secrets intentionally omit `regCode` (they only set `registrationType: offline`), so a poll timeout was misclassified as a missing registration-code secret.

### Occurred changes and/or fixed issues
- Correct offline poll timeout messaging (`registration.errors.timeout-offline-request`) instead of `missing-code`
- Increase offline request poll timeout from 10s to 60s
- Wait for `cattle-scc-system/scc-registration` deletion to complete before recreate (reduces 409 AlreadyExists when finalizers are slow)
- Wrap offline download in try/catch so failures surface in the UI error banner, not only the browser console
- Unit coverage for successful download and offline timeout message

### Technical notes summary
- Root cause in `getError(true)`: `polling && !secret.value?.data?.regCode` always matched offline secrets
- `downloadOfflineRequest` previously always called `asyncButtonResolution(true)` after a failed `downloadFile` catch path; poll rejections were uncaught
- `deleteSecret` previously only removed the in-memory Vue ref; it now resolves the secret by fixed name and waits until it is gone before create
- Error copy adjusted per review: avoid slow/air-gapped wording; mention SCC operator preparing resources

### Areas or cases that should be tested
- Global Settings → Registration → Offline → **Download registration request**
  - Happy path with healthy `rancher-scc-operator`: request file downloads
  - Slow / blocked operator (scale operator to 0 or delay): UI shows the new offline timeout message, **not** "Registration code as Secret is missing"
  - Click Download twice in succession: should wait for secret deletion rather than immediately failing with 409 / missing-code
- Upload certificate / register offline still works after a successful download
- Online registration path still works (regCode / missing-code behavior unchanged for online)
- Local testing browser: Chromium/Edge; please retest with another browser (e.g. Firefox)

### Areas which could experience regressions
- Online registration (`registerOnline`) — shares `preRegistration` / `deleteSecret` / `getError`
- Offline certificate upload (`registerOffline`)
- Deregister flow (also uses `preRegistration` → `deleteSecret`)
- Any automation that depends on the previous 10s poll timeout or the old error string

### Screenshot/Video
N/A (error copy / timing behavior; no layout change). New user-facing string:

> Timed out waiting for the offline registration request. The SCC operator may still be preparing resources. Wait a moment and try Download again, or export the request with kubectl from the cattle-scc-system namespace (secret labeled scc.cattle.io/secret-role=offline-request).

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`