### PR TITLE
bugfix(#13786): Registry Secrets content not visible (created from json file)  

### DIFF
--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/auth-types.test.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/auth-types.test.ts
@@ -47,16 +47,66 @@ describe('composables: SecretDataTab/auth-types', () => {
     });
   });
 
+  describe('decodeDockerAuthEntry', () => {
+    it('should return the username and password when they are set explicitly', () => {
+      const entry = { username: 'USERNAME', password: 'PASSWORD' };
+
+      expect(authTypes.decodeDockerAuthEntry(entry)).toStrictEqual({ username: 'USERNAME', password: 'PASSWORD' });
+      expect(base64DecodeSpy).not.toHaveBeenCalled();
+    });
+
+    it('should decode the base64 `auth` field (username:password) when username/password are not set', () => {
+      base64DecodeSpy.mockReturnValue('USERNAME:PASSWORD');
+
+      expect(authTypes.decodeDockerAuthEntry({ auth: 'base64Auth' })).toStrictEqual({ username: 'USERNAME', password: 'PASSWORD' });
+      expect(base64DecodeSpy).toHaveBeenCalledWith('base64Auth');
+    });
+
+    it('should only split on the first colon so passwords may contain colons', () => {
+      base64DecodeSpy.mockReturnValue('USERNAME:PASS:WORD');
+
+      expect(authTypes.decodeDockerAuthEntry({ auth: 'base64Auth' })).toStrictEqual({ username: 'USERNAME', password: 'PASS:WORD' });
+    });
+
+    it.each([
+      ['undefined entry', undefined],
+      ['empty entry', {}],
+      ['auth without a colon', { auth: 'base64Auth' }],
+    ])('should return empty strings for %s', (_label, entry) => {
+      base64DecodeSpy.mockReturnValue('nocolon');
+
+      expect(authTypes.decodeDockerAuthEntry(entry as any)).toStrictEqual({ username: '', password: '' });
+    });
+  });
+
   describe('useDockerAuths', () => {
     it('should return the auths field from a base64decoded json object in the `.dockerconfigjson` data field', () => {
       const data = { '.dockerconfigjson': 'base64Json' };
-      const json = { auths: 'AUTHS' };
+      const json = { auths: { 'registry-url.com': { username: 'u' } } };
 
       base64DecodeSpy.mockReturnValue(JSON.stringify(json));
       const dockerAuths = authTypes.useDockerAuths({ data });
 
       expect(dockerAuths.value).toStrictEqual(json.auths);
       expect(base64DecodeSpy).toHaveBeenCalledWith(data['.dockerconfigjson']);
+    });
+
+    it('should return an empty object when the json is invalid', () => {
+      const data = { '.dockerconfigjson': 'base64Json' };
+
+      base64DecodeSpy.mockReturnValue('not-valid-json');
+      const dockerAuths = authTypes.useDockerAuths({ data });
+
+      expect(dockerAuths.value).toStrictEqual({});
+    });
+
+    it('should return an empty object when there is no auths key', () => {
+      const data = { '.dockerconfigjson': 'base64Json' };
+
+      base64DecodeSpy.mockReturnValue(JSON.stringify({ someOtherKey: true }));
+      const dockerAuths = authTypes.useDockerAuths({ data });
+
+      expect(dockerAuths.value).toStrictEqual({});
     });
   });
 
@@ -71,6 +121,15 @@ describe('composables: SecretDataTab/auth-types', () => {
 
       expect(registry.value.registryUrl).toStrictEqual(registryUrl);
       expect(base64DecodeSpy).toHaveBeenCalledWith(data['.dockerconfigjson']);
+    });
+
+    it('should return an undefined registryUrl without throwing when there are no auths', () => {
+      const data = { '.dockerconfigjson': 'base64Json' };
+
+      base64DecodeSpy.mockReturnValue('not-valid-json');
+      const registry = authTypes.useDockerRegistry({ data });
+
+      expect(registry.value.registryUrl).toBeUndefined();
     });
   });
 
@@ -88,6 +147,31 @@ describe('composables: SecretDataTab/auth-types', () => {
       expect(dockerBasic.value.username).toStrictEqual(username);
       expect(dockerBasic.value.password).toStrictEqual(password);
       expect(base64DecodeSpy).toHaveBeenCalledWith(data['.dockerconfigjson']);
+    });
+
+    it('should decode the base64 `auth` field when username/password are not present', () => {
+      const data = { '.dockerconfigjson': 'base64Json' };
+      const registryUrl = 'registry-url.com';
+      const json = { auths: { [registryUrl]: { auth: 'base64Auth' } } };
+
+      base64DecodeSpy
+        .mockReturnValueOnce(JSON.stringify(json)) // dockerAuths.value
+        .mockReturnValueOnce(JSON.stringify(json)) // dockerRegistry -> dockerAuths.value
+        .mockReturnValueOnce('USERNAME:PASSWORD'); // decodeDockerAuthEntry(auth)
+
+      const dockerBasic = authTypes.useDockerBasic({ data });
+
+      expect(dockerBasic.value.username).toStrictEqual('USERNAME');
+      expect(dockerBasic.value.password).toStrictEqual('PASSWORD');
+    });
+
+    it('should return empty strings without throwing when there are no auths', () => {
+      const data = { '.dockerconfigjson': 'base64Json' };
+
+      base64DecodeSpy.mockReturnValue('not-valid-json');
+      const dockerBasic = authTypes.useDockerBasic({ data });
+
+      expect(dockerBasic.value).toStrictEqual({ username: '', password: '' });
     });
   });
 

--- a/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/auth-types.ts
+++ b/shell/components/Resource/Detail/ResourceTabs/SecretDataTab/auth-types.ts
@@ -32,13 +32,42 @@ export const useSecretRows = (resource: any) => {
   });
 };
 
+/**
+ * Extract username/password from a single docker `auths` entry.
+ *
+ * Rancher writes entries as separate `username`/`password` fields, but secrets created from a
+ * `docker login` config (`~/.docker/config.json`) store credentials in a single base64-encoded
+ * `auth` field (`username:password`). Prefer the explicit fields, fall back to decoding `auth`.
+ */
+export const decodeDockerAuthEntry = (entry: any = {}): { username: string; password: string } => {
+  if (entry.username || entry.password) {
+    return { username: entry.username || '', password: entry.password || '' };
+  }
+
+  if (entry.auth) {
+    const decoded = base64Decode(entry.auth) || '';
+    // The password may itself contain a colon, so only split on the first one.
+    const idx = decoded.indexOf(':');
+
+    if (idx !== -1) {
+      return { username: decoded.slice(0, idx), password: decoded.slice(idx + 1) };
+    }
+  }
+
+  return { username: '', password: '' };
+};
+
 export const useDockerAuths = (resource: any) => {
   const secretInfo = useSecretInfo(resource);
 
   return computed(() => {
     const json = base64Decode(secretInfo.value.secretData['.dockerconfigjson']);
 
-    return JSON.parse(json).auths;
+    try {
+      return JSON.parse(json)?.auths || {};
+    } catch {
+      return {};
+    }
   });
 };
 
@@ -55,10 +84,9 @@ export const useDockerBasic = (resource: any) => {
   const dockerRegistry = useDockerRegistry(resource);
 
   return computed(() => {
-    return {
-      username: dockerAuths.value[dockerRegistry.value.registryUrl].username,
-      password: dockerAuths.value[dockerRegistry.value.registryUrl].password,
-    };
+    const entry = dockerAuths.value[dockerRegistry.value.registryUrl] || {};
+
+    return decodeDockerAuthEntry(entry);
   });
 };
 

--- a/shell/edit/secret/registry.vue
+++ b/shell/edit/secret/registry.vue
@@ -4,6 +4,7 @@ import { LabeledInput } from '@components/Form/LabeledInput';
 import { RadioGroup } from '@components/Form/Radio';
 import { useFormRules } from '@shell/composables/useFormValidation';
 import { useI18n } from '@shell/composables/useI18n';
+import { decodeDockerAuthEntry } from '@shell/components/Resource/Detail/ResourceTabs/SecretDataTab/auth-types';
 
 export default {
   components: { LabeledInput, RadioGroup },
@@ -70,8 +71,8 @@ export default {
       registryProvider = 'Artifactory';
     }
 
-    const username = auths[registryUrl]?.username || '';
-    const password = auths[registryUrl]?.password || '';
+    // Supports both Rancher's username/password fields and the base64 `auth` field written by `docker login`.
+    const { username, password } = decodeDockerAuthEntry(auths[registryUrl]);
 
     return {
       registryProvider,


### PR DESCRIPTION
### Summary
Fixes #13786

Registry secrets (`kubernetes.io/dockerconfigjson`) created outside the UI — e.g. via `kubectl` from a `~/.docker/config.json` produced by `docker login` — crashed the secret **detail view**. Those secrets store credentials in a single base64-encoded `auth` field (`username:password`) rather than the separate `username`/`password` fields Rancher's UI assumed, and the detail-view parsers did no defensive handling, throwing a `TypeError` that broke the page.

### Occurred changes and/or fixed issues
- **Detail view no longer crashes** for docker config secrets that use the standard `auth` field, and now displays the registry URL, username and password correctly.
- **Edit view** now pre-populates the username/password fields when editing a secret that uses the `auth` field (previously blank).
- Parsing is now resilient to malformed `.dockerconfigjson` content and to a missing `auths` key (renders empty instead of throwing).

Changed files:
- `shell/components/Resource/Detail/ResourceTabs/SecretDataTab/auth-types.ts`
- `shell/edit/secret/registry.vue`
- `shell/components/Resource/Detail/ResourceTabs/SecretDataTab/__tests__/auth-types.test.ts`

### Technical notes summary
- Added an exported helper `decodeDockerAuthEntry(entry)` in `auth-types.ts` that returns `{ username, password }`. It prefers explicit `username`/`password` fields and falls back to base64-decoding the `auth` field, splitting on the **first** `:` only so passwords containing colons are preserved.
- `useDockerAuths` now wraps `JSON.parse` in a `try/catch` and defaults to `{}` (`JSON.parse(json)?.auths || {}`), so invalid JSON or a missing `auths` key no longer throws. As a result `useDockerRegistry` (`Object.keys({})[0]`) and `useDockerBasic` degrade gracefully to `undefined`/empty strings instead of crashing.
- `useDockerBasic` resolves the registry entry safely and delegates to `decodeDockerAuthEntry`.
- The edit component (`registry.vue`) imports and reuses the same `decodeDockerAuthEntry` helper to avoid divergence. On save it still re-serializes to the `username`/`password` form, matching existing behavior — only the read-in path changed.
- Reference for the standard Kubernetes docker-config secret format: https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets

### Areas or cases that should be tested
Local testing browser: **Chrome** (reviewer please verify in a different browser, e.g. Firefox).

Repro / verification steps:
1. Create a `kubernetes.io/dockerconfigjson` secret whose `.dockerconfigjson` uses the `auth` field only — e.g. apply via `kubectl` from a `docker login`-generated config:
   ```json
   { "auths": { "registry.example.com": { "auth": "<base64 of user:pass>" } } }
   ```
2. Open the secret's **detail** page → it must render without crashing and show Registry URL, Username and Password.
3. Open the secret in **edit** → Username and Password fields must be pre-populated; save and confirm the secret still works.
4. Regression: create/view/edit a normal registry secret **via the Rancher UI** (username/password form) → detail and edit views still behave as before.
5. Edge cases: a secret with malformed/empty `.dockerconfigjson` or no `auths` key → detail view renders empty fields, no crash.

### Areas which could experience regressions
- The registry secret **detail** view (`SecretDataTab` → `Registry` / `BasicAuth`) for all `kubernetes.io/dockerconfigjson` secrets.
- The registry secret **edit** view (`shell/edit/secret/registry.vue`) — initial population of username/password/registry URL and the DockerHub/Quay.io/Artifactory/Custom provider detection.
- Shared helper `decodeDockerAuthEntry` is exported from `auth-types.ts` and now consumed by both detail and edit paths.
- The secret **list** view (`dataPreview`) was already defensive and is unchanged.

### Screenshot/Video


https://github.com/user-attachments/assets/b477dc64-e6d1-4618-8051-6b6cd1d05304



### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
