### PR TITLE
add extension route guard to prevent access to routes that are bound to `VirtualType` registrations with IF conditions

### DIFF
--- a/shell/config/router/navigation-guards/__tests__/extension-route-guard.test.ts
+++ b/shell/config/router/navigation-guards/__tests__/extension-route-guard.test.ts
@@ -1,0 +1,173 @@
+import { guardExtensionRoute } from '@shell/config/router/navigation-guards/extension-route-guard';
+
+const PRODUCT = 'my-product';
+const GATED_ROUTE = 'c-cluster-my-product-gated';
+const OPEN_ROUTE = 'c-cluster-my-product-open';
+const UNKNOWN_ROUTE = 'c-cluster-my-product-unknown';
+
+const gatedVirtualType = {
+  name:      'my-gated-type',
+  route:     { name: GATED_ROUTE },
+  ifFeature: 'some-feature',
+};
+
+const openVirtualType = {
+  name:  'my-open-type',
+  route: { name: OPEN_ROUTE },
+};
+
+function makeStore({ allTypesResult = {} }: { allTypesResult?: Record<string, any> } = {}) {
+  return {
+    state: {
+      'type-map': {
+        products:     [{ name: PRODUCT, inStore: 'cluster' }],
+        virtualTypes: { [PRODUCT]: [gatedVirtualType, openVirtualType] },
+      },
+    },
+    getters: { 'type-map/allTypes': jest.fn(() => allTypesResult) },
+  };
+}
+
+function makeRoute(name: string, meta: Record<string, any> = {}) {
+  return { name, meta };
+}
+
+describe('navigation-guards/extension-route-guard', () => {
+  describe('non-extension routes', () => {
+    it('allows routes without _extensionRoute meta', async() => {
+      const next = jest.fn();
+      const store = makeStore();
+
+      await guardExtensionRoute(makeRoute(GATED_ROUTE), {}, next, { store } as any);
+
+      expect(next).toHaveBeenCalledWith();
+      expect(next).not.toHaveBeenCalledWith(expect.objectContaining({ name: '404' }));
+    });
+  });
+
+  describe('timing bail-out', () => {
+    it('allows when products are not yet loaded', async() => {
+      const next = jest.fn();
+      const store = {
+        state:   { 'type-map': { products: [] } },
+        getters: {},
+      };
+
+      await guardExtensionRoute(makeRoute(GATED_ROUTE, { _extensionRoute: true }), {}, next, { store } as any);
+
+      expect(next).toHaveBeenCalledWith();
+    });
+
+    it('allows when type-map state is absent', async() => {
+      const next = jest.fn();
+      const store = {
+        state:   {},
+        getters: {},
+      };
+
+      await guardExtensionRoute(makeRoute(GATED_ROUTE, { _extensionRoute: true }), {}, next, { store } as any);
+
+      expect(next).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('extension routes with no matching virtualType', () => {
+    it('allows pure extension routes that have no virtualType registration', async() => {
+      const next = jest.fn();
+      const store = makeStore();
+
+      await guardExtensionRoute(makeRoute(UNKNOWN_ROUTE, { _extensionRoute: true }), {}, next, { store } as any);
+
+      expect(next).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('extension routes with a matching virtualType but no conditions', () => {
+    it('allows unconditional virtualType routes', async() => {
+      const next = jest.fn();
+      const store = makeStore();
+
+      await guardExtensionRoute(makeRoute(OPEN_ROUTE, { _extensionRoute: true }), {}, next, { store } as any);
+
+      expect(next).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('extension routes with a gated virtualType', () => {
+    it('allows when virtualType appears in allTypes (conditions met)', async() => {
+      const next = jest.fn();
+      const store = makeStore({ allTypesResult: { all: { 'my-gated-type': gatedVirtualType } } });
+
+      await guardExtensionRoute(makeRoute(GATED_ROUTE, { _extensionRoute: true }), {}, next, { store } as any);
+
+      expect(next).toHaveBeenCalledWith();
+      expect(next).not.toHaveBeenCalledWith(expect.objectContaining({ name: '404' }));
+    });
+
+    it('redirects to 404 when virtualType is absent from allTypes (conditions not met)', async() => {
+      const next = jest.fn();
+      const store = makeStore({ allTypesResult: {} });
+
+      await guardExtensionRoute(makeRoute(GATED_ROUTE, { _extensionRoute: true }), {}, next, { store } as any);
+
+      expect(next).toHaveBeenCalledWith({ name: '404' });
+    });
+
+    it('redirects to 404 when only unrelated types appear in allTypes', async() => {
+      const next = jest.fn();
+      const store = makeStore({ allTypesResult: { all: { 'some-other-type': { name: 'some-other-type' } } } });
+
+      await guardExtensionRoute(makeRoute(GATED_ROUTE, { _extensionRoute: true }), {}, next, { store } as any);
+
+      expect(next).toHaveBeenCalledWith({ name: '404' });
+    });
+  });
+
+  describe('multi-product setup', () => {
+    it('finds the correct virtualType across multiple products', async() => {
+      const next = jest.fn();
+      const OTHER_PRODUCT = 'other-product';
+      const store = {
+        state: {
+          'type-map': {
+            products:     [{ name: OTHER_PRODUCT, inStore: 'cluster' }, { name: PRODUCT, inStore: 'cluster' }],
+            virtualTypes: {
+              [OTHER_PRODUCT]: [],
+              [PRODUCT]:       [gatedVirtualType],
+            },
+          },
+        },
+        getters: { 'type-map/allTypes': jest.fn(() => ({})) },
+      };
+
+      await guardExtensionRoute(makeRoute(GATED_ROUTE, { _extensionRoute: true }), {}, next, { store } as any);
+
+      expect(next).toHaveBeenCalledWith({ name: '404' });
+      expect(store.getters['type-map/allTypes']).toHaveBeenCalledWith(PRODUCT);
+    });
+  });
+
+  describe('ifRancherCluster condition', () => {
+    it('treats ifRancherCluster: false as a condition and enforces the gate', async() => {
+      const next = jest.fn();
+      const rancherClusterVt = {
+        name:             'my-rancher-type',
+        route:            { name: 'c-cluster-my-product-rancher' },
+        ifRancherCluster: false,
+      };
+      const store = {
+        state: {
+          'type-map': {
+            products:     [{ name: PRODUCT, inStore: 'cluster' }],
+            virtualTypes: { [PRODUCT]: [rancherClusterVt] },
+          },
+        },
+        getters: { 'type-map/allTypes': jest.fn(() => ({})) },
+      };
+
+      await guardExtensionRoute(makeRoute('c-cluster-my-product-rancher', { _extensionRoute: true }), {}, next, { store } as any);
+
+      expect(next).toHaveBeenCalledWith({ name: '404' });
+    });
+  });
+});

--- a/shell/config/router/navigation-guards/__tests__/extension-route-guard.test.ts
+++ b/shell/config/router/navigation-guards/__tests__/extension-route-guard.test.ts
@@ -83,13 +83,15 @@ describe('navigation-guards/extension-route-guard', () => {
   });
 
   describe('extension routes with a matching virtualType but no conditions', () => {
-    it('allows unconditional virtualType routes', async() => {
+    it('allows unconditional virtualType routes because allTypes always includes them', async() => {
       const next = jest.fn();
-      const store = makeStore();
+      // allTypes always includes virtualTypes with no conditions — simulate that here
+      const store = makeStore({ allTypesResult: { all: { 'my-open-type': openVirtualType } } });
 
       await guardExtensionRoute(makeRoute(OPEN_ROUTE, { _extensionRoute: true }), {}, next, { store } as any);
 
       expect(next).toHaveBeenCalledWith();
+      expect(next).not.toHaveBeenCalledWith(expect.objectContaining({ name: '404' }));
     });
   });
 

--- a/shell/config/router/navigation-guards/extension-route-guard.js
+++ b/shell/config/router/navigation-guards/extension-route-guard.js
@@ -1,0 +1,73 @@
+export function install(router, context) {
+  router.beforeEach((to, from, next) => guardExtensionRoute(to, from, next, context));
+}
+
+/**
+ * Guard that prevents direct URL access to extension routes whose virtualType conditions
+ * (ifHave, ifFeature, ifHaveType, etc.) are not met.
+ *
+ * Only applies to routes registered via pluginRoutes.addRoutes(), which automatically
+ * stamps meta._extensionRoute = true on every route it registers. Routes that do not
+ * carry that flag are never touched by this guard.
+ *
+ * The guard relies on the allTypes getter, which already evaluates all virtualType
+ * conditions — if a virtualType is absent from the allTypes result it means its
+ * conditions failed, and the corresponding route should not be accessible.
+ */
+export function guardExtensionRoute(to, from, next, { store }) {
+  // Only applies to routes registered through the extension system
+  if (!to.meta?._extensionRoute) {
+    return next();
+  }
+
+  // Timing-safe bail-out: if products haven't been registered yet (applyProducts
+  // hasn't run), we can't evaluate conditions — allow and let the next navigation
+  // re-apply the check with full data.
+  const products = store.state['type-map']?.products;
+
+  if (!products?.length) {
+    return next();
+  }
+
+  // Find a virtualType whose route.name matches the navigated-to route name
+  let matchingVirtualType = null;
+  let owningProductName = null;
+
+  for (const product of products) {
+    const virtualTypes = store.state['type-map'].virtualTypes[product.name] || [];
+    const match = virtualTypes.find((vt) => vt.route?.name === to.name);
+
+    if (match) {
+      matchingVirtualType = match;
+      owningProductName = product.name;
+      break;
+    }
+  }
+
+  // No matching virtualType means this is a pure extension route with no gate — allow
+  if (!matchingVirtualType) {
+    return next();
+  }
+
+  // VirtualType is registered but has no conditions — allow
+  const hasConditions = !!(
+    matchingVirtualType.ifHave ||
+    matchingVirtualType.ifFeature ||
+    matchingVirtualType.ifHaveType ||
+    matchingVirtualType.ifHaveSubTypes ||
+    typeof matchingVirtualType.ifRancherCluster !== 'undefined'
+  );
+
+  if (!hasConditions) {
+    return next();
+  }
+
+  // allTypes already evaluates every condition; if the virtualType is absent from
+  // its output the conditions are not met and the route should not be accessible.
+  const allTypes = store.getters['type-map/allTypes'](owningProductName);
+  const conditionsPassed = Object.values(allTypes).some(
+    (modeTypes) => modeTypes?.[matchingVirtualType.name]
+  );
+
+  return conditionsPassed ? next() : next({ name: '404' });
+}

--- a/shell/config/router/navigation-guards/extension-route-guard.js
+++ b/shell/config/router/navigation-guards/extension-route-guard.js
@@ -49,19 +49,6 @@ export function guardExtensionRoute(to, from, next, { store }) {
     return next();
   }
 
-  // VirtualType is registered but has no conditions — allow
-  const hasConditions = !!(
-    matchingVirtualType.ifHave ||
-    matchingVirtualType.ifFeature ||
-    matchingVirtualType.ifHaveType ||
-    matchingVirtualType.ifHaveSubTypes ||
-    typeof matchingVirtualType.ifRancherCluster !== 'undefined'
-  );
-
-  if (!hasConditions) {
-    return next();
-  }
-
   // allTypes already evaluates every condition; if the virtualType is absent from
   // its output the conditions are not met and the route should not be accessible.
   const allTypes = store.getters['type-map/allTypes'](owningProductName);

--- a/shell/config/router/navigation-guards/index.js
+++ b/shell/config/router/navigation-guards/index.js
@@ -9,6 +9,7 @@ import { install as installClusters } from '@shell/config/router/navigation-guar
 import { install as installHandleInstallRedirect } from '@shell/config/router/navigation-guards/install-redirect';
 import { install as installPageTitle } from '@shell/config/router/navigation-guards/page-title';
 import { install as installServerUpgradeGrowl } from '@shell/config/router/navigation-guards/server-upgrade-growl';
+import { install as installExtensionRouteGuard } from '@shell/config/router/navigation-guards/extension-route-guard';
 
 /**
  * Install our router navigation guards. i.e. router.beforeEach(), router.afterEach()
@@ -17,7 +18,7 @@ export function installNavigationGuards(router, context) {
   // NOTE: the order of the installation matters.
   // Be intentional when adding, removing or modifying the guards that are installed.
 
-  const navigationGuardInstallers = [installLoadInitialSettings, installAttemptFirstLogin, installAuthentication, installProducts, installClusters, installRuntimeExtensionRoute, installI18N, installHandleInstallRedirect, installPageTitle, installRecordLastRoute, installServerUpgradeGrowl];
+  const navigationGuardInstallers = [installLoadInitialSettings, installAttemptFirstLogin, installAuthentication, installProducts, installClusters, installExtensionRouteGuard, installRuntimeExtensionRoute, installI18N, installHandleInstallRedirect, installPageTitle, installRecordLastRoute, installServerUpgradeGrowl];
 
   navigationGuardInstallers.forEach((installer) => installer(router, context));
 }

--- a/shell/core/plugin-routes.ts
+++ b/shell/core/plugin-routes.ts
@@ -22,8 +22,14 @@ export class PluginRoutes {
     });
   }
 
+  private tagRoute(route: RouteRecordRaw): void {
+    route.meta = { ...route.meta, _extensionRoute: true };
+    route.children?.forEach((child) => this.tagRoute(child));
+  }
+
   public addRoutes(newRouteInfos: RouteInfo[]) {
     newRouteInfos.forEach((routeInfo) => {
+      this.tagRoute(routeInfo.route);
       if (routeInfo.parent) {
         this.router.addRoute(routeInfo.parent, routeInfo.route);
       } else {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15645

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Extension routes registered via `addRoutes()` are now automatically gated: if the corresponding `virtualType` has conditions (`ifHave`, `ifFeature`, `ifHaveType`, etc.) that are not met, navigating directly to the route URL redirects to a `404` page
- No changes required from extension developers — the gating is automatic based on already-existing `virtualType` definitions
- Adds unit tests for the new navigation guard

### Technical notes summary
A new navigation guard is added to the router chain, positioned after the cluster/management data is loaded so all conditions can be evaluated correctly.

The guard only activates for routes registered through the extension system (automatically tagged with an internal meta flag by `PluginRoutes.addRoutes()`). For each such route it looks up whether a matching `virtualType` with conditions exists, and defers to the already-existing `allTypes` store getter — which already evaluates all `if*` conditions for the nav sidebar — to decide whether to allow or block the navigation.

Routes that have no matching `virtualType`, or whose `virtualType` has no conditions, are always allowed through. Framework and shell routes are never touched.

### Areas or cases that should be tested
- **SCC (rancher-prime builtin extension)** — navigate directly to `/c/local/settings/registration`:
  - As a non-admin user or with the SCC feature disabled → should be redirected to `404`
  - As an admin user with SCC feature enabled → page should load normally
- Any other builtin extension route that has `ifHave` / `ifFeature` conditions defined on its `virtualType` — same expectations as above
- External extensions (installed via UIPlugin resource) that register gated routes — same expectations
- Extension routes with **no conditions** on the `virtualType` → should always load normally
- Extension routes with **no virtualType at all** (pure custom routes) → should always load normally
- All standard shell/product routes → should be completely unaffected
- Test with all three global roles: `Admin`, `Standard User`, `User Base`

### Areas which could experience regressions
- Any extension (builtin or external) that registers routes via `addRoutes()` — verify routes that should be accessible still load correctly
- Navigation to extension pages after a cluster switch or re-login
- Extensions that register `virtualType` entries without a matching `addRoutes()` call (no impact expected, but worth a sanity check)

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
