### PR TITLE
Bump ws to 8.21.0 (and 7.5.11 for the 7.x line) to fix GHSA-96hv-2xvq-fx4p

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
     "webpack-bundle-analyzer": "4.10.2",
     "webpack-virtual-modules": "0.6.2",
     "worker-loader": "3.0.8",
-    "ws": "8.18.0",
+    "ws": "8.21.0",
     "yaml-lint": "1.7.0",
     "yarn": "1.22.22"
   },

--- a/storybook/yarn.lock
+++ b/storybook/yarn.lock
@@ -5070,9 +5070,9 @@ write-file-atomic@^2.3.0:
     signal-exit "^3.0.2"
 
 ws@^8.2.3:
-  version "8.18.0"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+  version "8.21.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 yallist@^3.0.2:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15057,25 +15057,15 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@8.18.0:
-  version "8.18.0"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+ws@8.21.0, ws@^8.17.1, ws@^8.18.0:
+  version "8.21.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 ws@^7.3.1, ws@^7.4.6:
-  version "7.5.10"
-  resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
-  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
-
-ws@^8.17.1:
-  version "8.19.0"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz#ddc2bdfa5b9ad860204f5a72a4863a8895fd8c8b"
-  integrity sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==
-
-ws@^8.18.0:
-  version "8.20.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
-  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==
+  version "7.5.11"
+  resolved "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz#9460daf1812bb81a423c5b9eac746941a86310fa"
+  integrity sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==
 
 wsl-utils@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
### Summary
Resolves the high-severity `ws` advisory GHSA-96hv-2xvq-fx4p (CVE-2026-48779) — a memory-exhaustion DoS: a remote peer can exhaust process memory by sending many tiny WebSocket fragments/data chunks. Fixed in `ws` **7.5.11** (7.x line) and **8.21.0** (8.x line); this PR moves every still-vulnerable copy of `ws` to its line's own first-patched version.

Follow-up to #18283 (which moved the 8.x copies to 8.21.0): this covers the still-open root `yarn.lock` 7.x line (→ 7.5.11) and the remaining root/`storybook` 8.x transitives (→ 8.21.0) that Dependabot re-flagged (alerts #894, #893, #891).

### Occurred changes and/or fixed issues
Force-patched every remaining vulnerable copy of `ws`, each line to its own first-patched version:
- **root `yarn.lock`** — direct `ws@8.18.0` and transitive `^8.13.0 / ^8.17.1 / ^8.18.0` → **8.21.0**; `^7.3.1 / ^7.4.6` → **7.5.11**
- **`storybook/yarn.lock`** — `ws@^8.2.3` → **8.21.0**
- `shell/`, `cypress/`, `docusaurus/` lockfiles already resolved `ws` to 8.21.0 (from #18283) — no change needed

No application source was changed — this is a dependency-only bump (lockfiles plus one `package.json` line).

### Technical notes summary
`ws` is **not imported by any app/runtime source** — a repo grep for `require('ws')` / `from 'ws'` across `shell/`, `pkg/`, and `storybook/` returns only dev/test tooling (`webpack-dev-server`, `webpack-bundle-analyzer`, `storybook`, `cypress`, and jsdom's test-time WebSocket); it never enters the production browser bundle. The dashboard's own runtime websockets (live resource updates, log/shell streaming) use the browser-native `WebSocket` in `shell/utils/socket.js`, not the `ws` npm package. Each affected manifest was bumped to its line's own first-patched version and the lockfiles regenerated; the whole diff touches only `ws` version/resolved/integrity lines plus one `package.json` line, so no new package (and no net-new vulnerable transitive) was introduced. `yarn install --frozen-lockfile` confirmed the lockfiles satisfy the manifests unchanged.

### Areas or cases that should be tested
Anything that opens a WebSocket in the dev/build tooling: the webpack dev-server HMR socket, `webpack-bundle-analyzer`, and Cypress' internal websocket — smoke-test a build + boot and a Cypress run. jsdom-based unit tests (`shell`) now resolve `ws@8.21.0` instead of `ws@7.x`. The Playwright verification recording below drives the running preview.

### Areas which could experience regressions
Transitive `ws` consumers that assumed 7.x behaviour (jsdom, `webpack-bundle-analyzer`) — the forced 7.x → 8.x bump for those paths is the main risk. `ws` 8.x is API-compatible for these consumers, and since `ws` never enters the production bundle no runtime behaviour change is expected (see testing above).

### Screenshot/Video
Verification recording (Playwright — the WebSocket-backed live-update layer, shared with #18283):

https://github.com/user-attachments/assets/2c1dc375-c86b-48d1-b5ce-a8c80f0e4e8c

**Playwright checks performed** (video recorded, 1280×800):
1. **Production build compiles & login works** — full dashboard built from the bumped branch, served 200; logged in and landed on `/dashboard/home`. A green build is the first proof the `ws` bump didn't break compilation (webpack-dev-server / bundle-analyzer depend on `ws`). ✅ PASS
2. **Local cluster Explorer — Nodes list loads live data** — `c/local/explorer/node` rendered 2 rows of real cluster data fetched over the Steve subscription. ✅ PASS
3. **Pods list + native websocket live-update layer** — `c/local/explorer/pod` rendered 18 rows; the app opened 7 native `wss://…/v1/subscribe` and `/v3/subscribe` sockets, confirming the websocket-backed live-update path works end-to-end through the preview's proxy (the real-world analog of what `ws` covers). ✅ PASS
4. **Resource YAML view round-trips** — opened a Node's YAML view; the editor rendered valid parsed YAML (`apiVersion` / `kind` / `metadata` present). ✅ PASS

**Verdict:** 4/4 checks passed. The production build compiles with `ws` 8.21.0 / 7.5.11, and the dashboard's websocket-backed live features (nodes/pods live lists, 7 active native sockets) plus YAML rendering all work on the preview — the bump is safe; `ws` is confined to build/test tooling and no vulnerable version remains in any lockfile.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.
