### PR TITLE
Automation: Update hosted cluster provisioning specs for provider page titles

### DIFF
--- a/cypress/e2e/tests/pages/manager/aks-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/aks-cluster-provisioning.spec.ts
@@ -72,7 +72,7 @@ describe('Create AKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     clusterList.createCluster();
     createAKSClusterPage.selectKubeProvider(1);
     loadingPo.checkNotExists();
-    createAKSClusterPage.rke2PageTitle().should('include', 'Create Azure AKS');
+    createAKSClusterPage.rke2PageTitle().should('include', 'Create AKS');
     createAKSClusterPage.waitForPage('type=aks&rkeType=rke2');
 
     // create azure cloud credential
@@ -129,7 +129,7 @@ describe('Create AKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     clusterList.createCluster();
     createAKSClusterPage.selectKubeProvider(1);
     loadingPo.checkNotExists();
-    createAKSClusterPage.rke2PageTitle().should('include', 'Create Azure AKS');
+    createAKSClusterPage.rke2PageTitle().should('include', 'Create AKS');
     cy.intercept('GET', '**/meta/aksVersions*').as('getAksVersions');
     createAKSClusterPage.waitForPage('type=aks&rkeType=rke2');
 

--- a/cypress/e2e/tests/pages/manager/eks-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/eks-cluster-provisioning.spec.ts
@@ -60,7 +60,7 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     clusterList.createCluster();
     createEKSClusterPage.selectKubeProvider(0);
     loadingPo.checkNotExists();
-    createEKSClusterPage.rke2PageTitle().should('include', 'Create Amazon EKS');
+    createEKSClusterPage.rke2PageTitle().should('include', 'Create EKS');
     createEKSClusterPage.waitForPage('type=eks&rkeType=rke2');
 
     // create amazon cloud credential
@@ -115,7 +115,7 @@ describe('Create EKS cluster', { testIsolation: 'off', tags: ['@manager', '@admi
     clusterList.createCluster();
     createEKSClusterPage.selectKubeProvider(0);
     loadingPo.checkNotExists();
-    createEKSClusterPage.rke2PageTitle().should('include', 'Create Amazon EKS');
+    createEKSClusterPage.rke2PageTitle().should('include', 'Create EKS');
     createEKSClusterPage.waitForPage('type=eks&rkeType=rke2');
 
     // Verify that eks-zone-select dropdown is set to the default zone

--- a/cypress/e2e/tests/pages/manager/gke-cluster-provisioning.spec.ts
+++ b/cypress/e2e/tests/pages/manager/gke-cluster-provisioning.spec.ts
@@ -82,7 +82,7 @@ describe('Deploy GKE cluster with default settings', { tags: ['@manager', '@admi
     clusterList.createCluster();
     createGKEClusterPage.selectKubeProvider(2);
     loadingPo.checkNotExists();
-    createGKEClusterPage.rke2PageTitle().should('include', 'Create Google GKE');
+    createGKEClusterPage.rke2PageTitle().should('include', 'Create GKE');
     createGKEClusterPage.waitForPage('type=gke&rkeType=rke2');
     // Wait for the inline cloud credential form's async fetch to complete before interacting with it.
     loadingPo.checkNotExists();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2442

Updates the AKS, EKS, and GKE provisioning specs to assert against the new create-page titles introduced by #18159.

- "Create Azure AKS" → "Create AKS"
- "Create Amazon EKS" → "Create EKS"
- "Create Google GKE" → "Create GKE"

<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
