### PR TITLE
Bump fast-uri from 3.1.2 to 3.1.4

### DIFF
--- a/cypress/yarn.lock
+++ b/cypress/yarn.lock
@@ -2370,9 +2370,9 @@ fast-printf@^1.6.9:
   integrity sha512-GwTgG9O4FVIdShhbVF3JxOgSBY2+ePGsu2V/UONgoCPzF9VY6ZdBMKsHKCYQHZwNk3qNouUolRDsgVxcVA5G1w==
 
 fast-uri@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
+  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
 
 fastq@^1.6.0:
   version "1.19.1"

--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -4594,9 +4594,9 @@ fast-json-stable-stringify@^2.0.0:
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-uri@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
+  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
 
 fastq@^1.6.0:
   version "1.20.1"

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -6613,9 +6613,9 @@ fast-printf@^1.6.9:
   integrity sha512-GwTgG9O4FVIdShhbVF3JxOgSBY2+ePGsu2V/UONgoCPzF9VY6ZdBMKsHKCYQHZwNk3qNouUolRDsgVxcVA5G1w==
 
 fast-uri@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
+  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
 
 fast-xml-builder@^1.1.5:
   version "1.2.0"

--- a/storybook/yarn.lock
+++ b/storybook/yarn.lock
@@ -2356,9 +2356,9 @@ fast-json-stable-stringify@^2.0.0:
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-uri@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
+  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
 
 fill-range@^7.1.1:
   version "7.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8103,9 +8103,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
+  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
 
 fast-xml-builder@^1.1.5:
   version "1.2.0"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes 2 security advisories in `fast-uri` by bumping it from `3.1.2` to `3.1.4` across all workspaces.

### Occurred changes and/or fixed issues
Updated the resolved `fast-uri` version in the yarn lockfiles (root, `shell`, `cypress`, `docusaurus`, `storybook`) from `3.1.2` to `3.1.4`, resolving the open Dependabot advisories for this package.

### Technical notes summary
Lockfile-only change — the `fast-uri@^3.0.1` range is unchanged; only the resolved version, integrity hash, and tarball URL are updated to `3.1.4`. No source changes.

### Areas or cases that should be tested
Smoke-test the dashboard build and boot; `fast-uri` is a transitive dependency, so general navigation and page loads exercise it.

### Areas which could experience regressions
No functional regressions expected — this is a patch-level bump of a transitive dependency confined to the lockfiles.

### Screenshot/Video

Verification recording (Playwright):

https://github.com/user-attachments/assets/ecc8942d-d85e-4f83-92e1-e4ff48a5f187

**Playwright checks performed** (video recorded, 1280×800):

1. **Login → authenticated home.** Logged in with local credentials; the SPA (built with fast-uri 3.1.4 in the ajv/schema-utils toolchain) bootstrapped and landed on `/dashboard/home`. ✅ PASS
2. **Live cluster resource list.** Opened `c/local/explorer/configmap`; the list rendered **23 real ConfigMap rows** served from the `/v1` Steve API proxied to the live `local` cluster. ✅ PASS
3. **Create via Edit-as-YAML (parse → submit).** Used the ConfigMap **Create → Edit as YAML** editor to author and submit a new ConfigMap (`fast-uri-verify-*` in `default`, with a `url` and `verified-by` key); the resource detail view then loaded the persisted object from the live API, showing both data keys. ✅ PASS
4. **YAML round-trip (load → store → dump).** Reopened the saved ConfigMap's YAML view; the server-materialized YAML preserved the name, namespace and both data values and included server fields (`uid`, `resourceVersion`, `creationTimestamp`) — a genuine round-trip through the proxied API. ✅ PASS

**Verdict:** **4/4 checks passed.** The dashboard builds cleanly with fast-uri 3.1.4 in the ajv/schema-utils build toolchain (its only consumer), and the resulting app authenticates, lists live cluster resources, and performs a full ConfigMap YAML create + round-trip against the proxied `local` cluster. No vulnerable fast-uri version remains in any of the 5 lockfiles, and the diff adds zero new packages. The bump is safe.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Locks Dependabot alerts: #1019, #1020, #1021, #1024, #1027, #1031, #1032, #1033, #1036, #1040

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.
