### PR TITLE
Bump svgo from 2.8.2 to 2.8.3 in /

### DIFF
--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -9075,9 +9075,9 @@ svg-parser@^2.0.4:
   integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
 
 svgo@^3.0.2, svgo@^3.2.0:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-3.3.3.tgz#8246aee0b08791fde3b0ed22b5661b471fadf58e"
-  integrity sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-3.3.4.tgz#fd2aa10ff585b3bd2b83ce3602f5582bc0718bb5"
+  integrity sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==
   dependencies:
     commander "^7.2.0"
     css-select "^5.1.0"

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -11578,9 +11578,9 @@ svg-tags@^1.0.0:
   integrity sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==
 
 svgo@^2.7.0:
-  version "2.8.2"
-  resolved "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz#8e99b7ba5ac9ed7e3a446063865f61e03223fe6b"
-  integrity sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==
+  version "2.8.3"
+  resolved "https://registry.npmjs.org/svgo/-/svgo-2.8.3.tgz#8de2fa579f3f7429dec3fb86471005cf46fb483a"
+  integrity sha512-5EZD0pafXX6PphdwOGCiVLDSaV1xyuQao2blHajHLsPxr07q4mmEjdtXEWgG07ae2mIz8Ex2CDXNCTiXhy3Khw==
   dependencies:
     commander "^7.2.0"
     css-select "^4.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13872,9 +13872,9 @@ svg-tags@^1.0.0:
   integrity sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==
 
 svgo@^2.7.0:
-  version "2.8.2"
-  resolved "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz#8e99b7ba5ac9ed7e3a446063865f61e03223fe6b"
-  integrity sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==
+  version "2.8.3"
+  resolved "https://registry.npmjs.org/svgo/-/svgo-2.8.3.tgz#8de2fa579f3f7429dec3fb86471005cf46fb483a"
+  integrity sha512-5EZD0pafXX6PphdwOGCiVLDSaV1xyuQao2blHajHLsPxr07q4mmEjdtXEWgG07ae2mIz8Ex2CDXNCTiXhy3Khw==
   dependencies:
     commander "^7.2.0"
     css-select "^4.1.3"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #

Bumps the `svgo` dependency to a patched version to address the advisory **"SVGO removeScripts plugin leaves some executable scripts intact"**, where the `removeScripts` plugin could leave some executable script content in place after processing untrusted SVG input.

### Occurred changes and/or fixed issues
- Bump `svgo` from `2.8.2` to `2.8.3` in `/` and `/shell`.
- Bump `svgo` from `3.3.3` to `3.3.4` in `/docusaurus`.
- Lockfiles (`yarn.lock`, `shell/yarn.lock`, `docusaurus/yarn.lock`) updated accordingly.

### Technical notes summary
This is a Dependabot-style dependency bump with no application source changes. Only the `svgo` transitive dependency is advanced to the first patched release on each major line so the `removeScripts` plugin correctly strips executable script content.

### Areas or cases that should be tested
- SVG asset processing / icon handling in the dashboard and shell packages.
- Docusaurus documentation build.
- Standard build and unit test suites.

### Areas which could experience regressions
- SVG optimization output (icons, embedded SVGs) produced via `svgo`.

### Screenshot/Video

Verification recording (Playwright):

https://github.com/user-attachments/assets/81b7e0f7-fcfc-44e5-ba18-f681efd1c0cd

**Playwright checks performed** (video recorded, 1280×800):

1. **Login page renders with SVG branding** — navigated to `/dashboard/auth/login`; the SVG `<img>` branding
   painted (`naturalWidth > 0`) with 0 broken SVG images and the login form was present. ✅ **PASS** (2/2 SVG images painted)
2. **Home page after login** — logged in with real credentials against the live `local` cluster; `/dashboard/home`
   loaded (not bounced to login) with all SVG nav/graphic images painted and inline `<svg>` icons rendered. ✅ **PASS** (3/3 SVG `<img>` painted, 3 inline `<svg>`)
3. **Create-cluster provider-logo grid** — opened Cluster Management → Create; the grid of **svgo-optimized
   provider-logo SVG assets** (amazonec2, azure, aliyun, … from `dashboard/img/*.svg`) all rendered with
   non-zero natural dimensions and zero breakage — the strongest direct evidence the SVG optimization output
   is intact. ✅ **PASS** (11/11 provider-logo SVGs painted, 0 broken)
4. **Live local-cluster Explorer (real API data)** — navigated to `/dashboard/c/local/explorer`; the view
   rendered real cluster content (events/capacity/nav) proxied from the live cluster, with all SVG type icons
   intact. ✅ **PASS** (real cluster content present, 1/1 SVG `<img>` painted, 4 inline `<svg>`)

**Verdict:** **4/4 checks passed.** The svgo bump (2.8.3 / 3.3.4) builds cleanly and leaves every SVG-backed visual —
optimized SVG assets, provider logos, and inline icons — rendering correctly across the login, home,
create-cluster, and live-cluster views. No regression from the fix; net lockfile change adds zero new
vulnerable entries.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Locks Dependabot alerts: #1039, #1030, #1023

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.

