### PR TITLE
Bump joi from 17.13.3 to 17.13.4

### DIFF
--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -8664,9 +8664,9 @@ jexl@2.3.0:
     "@babel/runtime" "^7.10.2"
 
 joi@^17.4.0:
-  version "17.13.3"
-  resolved "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz#0f5cc1169c999b30d344366d384b12d92558bcec"
-  integrity sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==
+  version "17.13.4"
+  resolved "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz#ad6153d97ce558eb3a3b593e0d43eab51df1c474"
+  integrity sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==
   dependencies:
     "@hapi/hoek" "^9.3.0"
     "@hapi/topo" "^5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10212,9 +10212,9 @@ jexl@2.3.0:
     "@babel/runtime" "^7.10.2"
 
 joi@^17.13.3, joi@^17.4.0:
-  version "17.13.3"
-  resolved "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz#0f5cc1169c999b30d344366d384b12d92558bcec"
-  integrity sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==
+  version "17.13.4"
+  resolved "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz#ad6153d97ce558eb3a3b593e0d43eab51df1c474"
+  integrity sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==
   dependencies:
     "@hapi/hoek" "^9.3.0"
     "@hapi/topo" "^5.1.0"


### PR DESCRIPTION
### Summary
Fixes a security advisory in the `joi` dependency by bumping it from `17.13.3` to `17.13.4`. joi had an uncaught `RangeError` on deeply nested input through recursive `link()` schemas.

### Occurred changes and/or fixed issues
Bumps `joi` from `17.13.3` to `17.13.4` in `/` and `/shell` (transitive/lockfile update). This resolves the Dependabot security advisory covering the uncaught `RangeError` triggered by deeply nested input through recursive `link()` schemas.

### Technical notes summary
Lockfile-only change (`yarn.lock`, `shell/yarn.lock`) — no source or API changes. Resolved `joi` version updated to the first patched release.

### Areas or cases that should be tested
Smoke test that the dashboard builds and loads. `joi` is used for schema validation; no behavioral changes are expected from a patch bump.

### Areas which could experience regressions
None expected — patch-level dependency bump with no direct source changes.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/018d6c6b-1b5d-4ada-8812-4fcbe8fb1def

**Playwright checks performed** (video recorded, 1280×800):
1. **Login page renders** — navigated to `/dashboard/auth/login`; the login form (username + password) rendered from the bundle produced by the joi-17.13.4 build. ✅ **PASS**
2. **Authentication** — logged in with console credentials; landed on `/dashboard/home` with the cluster nav available. ✅ **PASS**
3. **Live cluster resource list (proxied API)** — opened `c/local/explorer/configmap`; the ConfigMaps list rendered **99 rows** from the live `local` cluster through the Steve `/v1` proxy — no error masthead. ✅ **PASS**
4. **ConfigMap YAML create round-trip** — used **Create → Edit as YAML**, authored a ConfigMap manifest, clicked **Create**, then reopened the saved resource's YAML view: the resource loaded back with its name/data intact (parse → store → dump round-trip on the bumped build). Test resource cleaned up afterward. ✅ **PASS**

**Verdict:** **4/4 checks passed.** joi bumped 17.13.3 → 17.13.4 across root + `shell/` lockfiles; the dashboard builds and boots (proving the build-time consumer of joi is unaffected), authenticates, lists live cluster resources, and completes a YAML create/edit round-trip. No regression from the bump — ready to open the PR.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Locks Dependabot alerts: #860

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.

