### PR TITLE
address wrongful output of screen readers when interacting with `KeyValue` component

### DIFF
--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -617,7 +617,7 @@ export default {
       class="kv-container"
       role="grid"
       :aria-label="title || t('generic.ariaLabel.keyValue')"
-      :aria-rowcount="rows.length > 0 ? rows.length + 1 : isView ? 2 : 0"
+      :aria-rowcount="rows.length > 0 ? rows.length : isView ? 1 : 0"
       :aria-colcount="extraColumns.length + 2 + (canRemove ? 1 : 0)"
       :style="containerStyle"
     >
@@ -633,7 +633,6 @@ export default {
             <div
               class="text-label key-value-label"
               role="columnheader"
-              aria-rowindex="1"
               aria-colindex="1"
             >
               {{ _keyLabel }}
@@ -649,7 +648,6 @@ export default {
             <div
               class="text-label key-value-label"
               role="columnheader"
-              aria-rowindex="1"
               aria-colindex="2"
             >
               {{ _valueLabel }}
@@ -666,7 +664,6 @@ export default {
               v-for="(c, i) in extraColumns"
               :key="i"
               role="columnheader"
-              aria-rowindex="1"
               :aria-colindex="i+3"
             >
               <slot :name="'label:'+c">
@@ -676,9 +673,12 @@ export default {
             <div
               v-if="canRemove"
               role="columnheader"
-              aria-rowindex="1"
               :aria-colindex="extraColumns.length+3"
-            />
+            >
+              <slot name="remove">
+                <span />
+              </slot>
+            </div>
           </div>
         </div>
       </template>
@@ -694,7 +694,7 @@ export default {
             <div
               class="kv-item key text-muted"
               role="gridcell"
-              aria-rowindex="2"
+              aria-rowindex="1"
               aria-colindex="1"
             >
               &mdash;
@@ -702,7 +702,7 @@ export default {
             <div
               class="kv-item key text-muted"
               role="gridcell"
-              aria-rowindex="2"
+              aria-rowindex="1"
               aria-colindex="2"
             >
               &mdash;
@@ -727,7 +727,7 @@ export default {
             <div
               class="kv-item key"
               role="gridcell"
-              :aria-rowindex="i+2"
+              :aria-rowindex="i+1"
               :aria-colindex="1"
               :class="{
                 'labeled-input-key': keyErrors[row.key],
@@ -780,7 +780,7 @@ export default {
               :data-testid="`kv-item-value-${i}`"
               class="kv-item value"
               role="gridcell"
-              :aria-rowindex="i+2"
+              :aria-rowindex="i+1"
               :aria-colindex="2"
             >
               <slot
@@ -811,7 +811,7 @@ export default {
                     :as-text-area="true"
                     :mode="mode"
                     :options="{
-                      screenReaderLabel: t('generic.ariaLabel.value', { index: i })
+                      screenReaderLabel: t('generic.ariaLabel.value', { index: i+1 })
                     }"
                     @onInput="onInputMarkdownMultiline(i, $event)"
                     @onFocus="onFocusMarkdownMultiline(i, $event)"
@@ -864,7 +864,7 @@ export default {
               :key="`${i}-${j}`"
               class="kv-item extra"
               role="gridcell"
-              :aria-rowindex="i+2"
+              :aria-rowindex="i+1"
               :aria-colindex="j+3"
             >
               <slot
@@ -879,7 +879,7 @@ export default {
               :key="i"
               class="kv-item remove"
               role="gridcell"
-              :aria-rowindex="i+2"
+              :aria-rowindex="i+1"
               :aria-colindex="extraColumns.length+3"
               :data-testid="`remove-column-${i}`"
             >

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -617,16 +617,24 @@ export default {
       class="kv-container"
       role="grid"
       :aria-label="title || t('generic.ariaLabel.keyValue')"
-      :aria-rowcount="rows.length"
-      :aria-colcount="extraColumns.length + 2"
+      :aria-rowcount="rows.length > 0 ? rows.length + 1 : isView ? 2 : 0"
+      :aria-colcount="extraColumns.length + 2 + (canRemove ? 1 : 0)"
       :style="containerStyle"
     >
       <template v-if="rows.length || isView">
-        <div class="rowgroup">
-          <div class="row">
+        <div
+          class="rowgroup"
+          role="rowgroup"
+        >
+          <div
+            class="row"
+            role="row"
+          >
             <div
               class="text-label key-value-label"
               role="columnheader"
+              aria-rowindex="1"
+              aria-colindex="1"
             >
               {{ _keyLabel }}
               <i
@@ -641,6 +649,8 @@ export default {
             <div
               class="text-label key-value-label"
               role="columnheader"
+              aria-rowindex="1"
+              aria-colindex="2"
             >
               {{ _valueLabel }}
               <i
@@ -656,32 +666,44 @@ export default {
               v-for="(c, i) in extraColumns"
               :key="i"
               role="columnheader"
+              aria-rowindex="1"
+              :aria-colindex="i+3"
             >
               <slot :name="'label:'+c">
                 {{ c }}
               </slot>
             </div>
-            <slot
+            <div
               v-if="canRemove"
-              name="remove"
-            >
-              <span />
-            </slot>
+              role="columnheader"
+              aria-rowindex="1"
+              :aria-colindex="extraColumns.length+3"
+            />
           </div>
         </div>
       </template>
       <template v-if="!rows.length && isView">
-        <div class="rowgroup">
-          <div class="row">
+        <div
+          class="rowgroup"
+          role="rowgroup"
+        >
+          <div
+            class="row"
+            role="row"
+          >
             <div
               class="kv-item key text-muted"
               role="gridcell"
+              aria-rowindex="2"
+              aria-colindex="1"
             >
               &mdash;
             </div>
             <div
               class="kv-item key text-muted"
               role="gridcell"
+              aria-rowindex="2"
+              aria-colindex="2"
             >
               &mdash;
             </div>
@@ -693,13 +715,19 @@ export default {
         v-else
         :key="i"
       >
-        <div class="rowgroup">
-          <div class="row">
+        <div
+          class="rowgroup"
+          role="rowgroup"
+        >
+          <div
+            class="row"
+            role="row"
+          >
             <!-- Key -->
             <div
               class="kv-item key"
               role="gridcell"
-              :aria-rowindex="i+1"
+              :aria-rowindex="i+2"
               :aria-colindex="1"
               :class="{
                 'labeled-input-key': keyErrors[row.key],
@@ -752,7 +780,7 @@ export default {
               :data-testid="`kv-item-value-${i}`"
               class="kv-item value"
               role="gridcell"
-              :aria-rowindex="i+1"
+              :aria-rowindex="i+2"
               :aria-colindex="2"
             >
               <slot
@@ -836,7 +864,7 @@ export default {
               :key="`${i}-${j}`"
               class="kv-item extra"
               role="gridcell"
-              :aria-rowindex="i+1"
+              :aria-rowindex="i+2"
               :aria-colindex="j+3"
             >
               <slot
@@ -851,7 +879,7 @@ export default {
               :key="i"
               class="kv-item remove"
               role="gridcell"
-              :aria-rowindex="i+1"
+              :aria-rowindex="i+2"
               :aria-colindex="extraColumns.length+3"
               :data-testid="`remove-column-${i}`"
             >

--- a/shell/components/form/__tests__/KeyValue.test.ts
+++ b/shell/components/form/__tests__/KeyValue.test.ts
@@ -343,4 +343,131 @@ describe('component: KeyValue', () => {
       expect(textarea.attributes('disabled')).toBeDefined();
     });
   });
+
+  describe('a11y: grid ARIA structure', () => {
+    const mountKV = (props: Record<string, unknown> = {}) => mount(KeyValue, {
+      props: {
+        valueMultiline: false,
+        ...props,
+      } as any,
+      global: {
+        mocks: { $store: { getters: { 'i18n/t': jest.fn() } } },
+        stubs: { CodeMirror: true },
+      },
+    });
+
+    describe('aria-colcount', () => {
+      it.each([
+        ['no extraColumns, remove not allowed', { value: { k: 'v' }, removeAllowed: false }, 2],
+        ['no extraColumns, remove allowed', { value: { k: 'v' }, removeAllowed: true }, 3],
+        [
+          '1 extraColumn, remove allowed',
+          {
+            value: { k: 'v' }, removeAllowed: true, extraColumns: ['x']
+          },
+          4
+        ],
+        [
+          '2 extraColumns, remove not allowed',
+          {
+            value: { k: 'v' }, removeAllowed: false, extraColumns: ['a', 'b']
+          },
+          4
+        ],
+      ])('%s', (_: string, props: Record<string, unknown>, expected: number) => {
+        const wrapper = mountKV(props);
+
+        expect(wrapper.find('.kv-container').attributes('aria-colcount')).toStrictEqual(String(expected));
+      });
+    });
+
+    describe('aria-rowcount', () => {
+      it.each([
+        ['1 data row in edit mode', { value: { k: 'v' }, mode: 'edit' }, 2],
+        ['2 data rows in edit mode', { value: { k: 'v', k2: 'v2' }, mode: 'edit' }, 3],
+        ['no rows in view mode', { value: {}, mode: 'view' }, 2],
+        ['no rows in edit mode', { value: {}, mode: 'edit' }, 0],
+      ])('%s', (_: string, props: Record<string, unknown>, expected: number) => {
+        const wrapper = mountKV(props);
+
+        expect(wrapper.find('.kv-container').attributes('aria-rowcount')).toStrictEqual(String(expected));
+      });
+    });
+
+    describe('rowgroup and row roles', () => {
+      it('header section should wrap its row with role="rowgroup" > role="row"', () => {
+        const wrapper = mountKV({ value: { k: 'v' } });
+        const firstRowgroup = wrapper.find('[role="rowgroup"]');
+
+        expect(firstRowgroup.exists()).toBe(true);
+        expect(firstRowgroup.find('[role="row"]').exists()).toBe(true);
+      });
+
+      it('each data row should be wrapped in role="rowgroup" > role="row"', () => {
+        const wrapper = mountKV({ value: { k1: 'v1', k2: 'v2' } });
+        const rowgroups = wrapper.findAll('[role="rowgroup"]');
+
+        // 1 header rowgroup + 2 data rowgroups
+        expect(rowgroups).toHaveLength(3);
+        rowgroups.forEach((rg) => {
+          expect(rg.find('[role="row"]').exists()).toBe(true);
+        });
+      });
+    });
+
+    describe('header columnheader cells', () => {
+      it('key and value headers have role="columnheader" with aria-rowindex="1" and sequential aria-colindex', () => {
+        const wrapper = mountKV({ value: { k: 'v' }, removeAllowed: false });
+        const headers = wrapper.findAll('[role="columnheader"]');
+
+        expect(headers[0].attributes('aria-rowindex')).toStrictEqual('1');
+        expect(headers[0].attributes('aria-colindex')).toStrictEqual('1');
+        expect(headers[1].attributes('aria-rowindex')).toStrictEqual('1');
+        expect(headers[1].attributes('aria-colindex')).toStrictEqual('2');
+      });
+
+      it('remove column header has aria-colindex equal to extraColumns.length + 3', () => {
+        const wrapper = mountKV({ value: { k: 'v' }, removeAllowed: true });
+        const headers = wrapper.findAll('[role="columnheader"]');
+
+        expect(headers[2].attributes('aria-rowindex')).toStrictEqual('1');
+        expect(headers[2].attributes('aria-colindex')).toStrictEqual('3');
+      });
+    });
+
+    describe('data gridcell aria-rowindex and aria-colindex', () => {
+      it('first data row cells have aria-rowindex="2" to account for the header row', () => {
+        const wrapper = mountKV({ value: { k: 'v' }, removeAllowed: false });
+        const cells = wrapper.findAll('[role="gridcell"]');
+
+        expect(cells[0].attributes('aria-rowindex')).toStrictEqual('2');
+        expect(cells[0].attributes('aria-colindex')).toStrictEqual('1');
+        expect(cells[1].attributes('aria-rowindex')).toStrictEqual('2');
+        expect(cells[1].attributes('aria-colindex')).toStrictEqual('2');
+      });
+
+      it('second data row cells have aria-rowindex="3"', () => {
+        const wrapper = mountKV({ value: { k1: 'v1', k2: 'v2' }, removeAllowed: false });
+        const cells = wrapper.findAll('[role="gridcell"]');
+
+        // 2 rows × 2 cells (no remove), second row starts at cells[2]
+        expect(cells[2].attributes('aria-rowindex')).toStrictEqual('3');
+        expect(cells[2].attributes('aria-colindex')).toStrictEqual('1');
+        expect(cells[3].attributes('aria-rowindex')).toStrictEqual('3');
+        expect(cells[3].attributes('aria-colindex')).toStrictEqual('2');
+      });
+    });
+
+    describe('no-data placeholder in view mode', () => {
+      it('placeholder cells have aria-rowindex="2" and sequential aria-colindex', () => {
+        const wrapper = mountKV({ value: {}, mode: 'view' });
+        const cells = wrapper.findAll('[role="gridcell"]');
+
+        expect(cells[0].attributes('aria-rowindex')).toStrictEqual('2');
+        expect(cells[0].attributes('aria-colindex')).toStrictEqual('1');
+        expect(cells[1].attributes('aria-rowindex')).toStrictEqual('2');
+        expect(cells[1].attributes('aria-colindex')).toStrictEqual('2');
+      });
+    });
+  });
 });

--- a/shell/components/form/__tests__/KeyValue.test.ts
+++ b/shell/components/form/__tests__/KeyValue.test.ts
@@ -383,9 +383,9 @@ describe('component: KeyValue', () => {
 
     describe('aria-rowcount', () => {
       it.each([
-        ['1 data row in edit mode', { value: { k: 'v' }, mode: 'edit' }, 2],
-        ['2 data rows in edit mode', { value: { k: 'v', k2: 'v2' }, mode: 'edit' }, 3],
-        ['no rows in view mode', { value: {}, mode: 'view' }, 2],
+        ['1 data row in edit mode', { value: { k: 'v' }, mode: 'edit' }, 1],
+        ['2 data rows in edit mode', { value: { k: 'v', k2: 'v2' }, mode: 'edit' }, 2],
+        ['no rows in view mode', { value: {}, mode: 'view' }, 1],
         ['no rows in edit mode', { value: {}, mode: 'edit' }, 0],
       ])('%s', (_: string, props: Record<string, unknown>, expected: number) => {
         const wrapper = mountKV(props);
@@ -416,56 +416,56 @@ describe('component: KeyValue', () => {
     });
 
     describe('header columnheader cells', () => {
-      it('key and value headers have role="columnheader" with aria-rowindex="1" and sequential aria-colindex', () => {
+      it('key and value headers have role="columnheader" with sequential aria-colindex and no aria-rowindex', () => {
         const wrapper = mountKV({ value: { k: 'v' }, removeAllowed: false });
         const headers = wrapper.findAll('[role="columnheader"]');
 
-        expect(headers[0].attributes('aria-rowindex')).toStrictEqual('1');
+        expect(headers[0].attributes('aria-rowindex')).toBeUndefined();
         expect(headers[0].attributes('aria-colindex')).toStrictEqual('1');
-        expect(headers[1].attributes('aria-rowindex')).toStrictEqual('1');
+        expect(headers[1].attributes('aria-rowindex')).toBeUndefined();
         expect(headers[1].attributes('aria-colindex')).toStrictEqual('2');
       });
 
-      it('remove column header has aria-colindex equal to extraColumns.length + 3', () => {
+      it('remove column header has aria-colindex equal to extraColumns.length + 3 and no aria-rowindex', () => {
         const wrapper = mountKV({ value: { k: 'v' }, removeAllowed: true });
         const headers = wrapper.findAll('[role="columnheader"]');
 
-        expect(headers[2].attributes('aria-rowindex')).toStrictEqual('1');
+        expect(headers[2].attributes('aria-rowindex')).toBeUndefined();
         expect(headers[2].attributes('aria-colindex')).toStrictEqual('3');
       });
     });
 
     describe('data gridcell aria-rowindex and aria-colindex', () => {
-      it('first data row cells have aria-rowindex="2" to account for the header row', () => {
+      it('first data row cells have aria-rowindex="1" (header is not counted as a row)', () => {
         const wrapper = mountKV({ value: { k: 'v' }, removeAllowed: false });
         const cells = wrapper.findAll('[role="gridcell"]');
 
-        expect(cells[0].attributes('aria-rowindex')).toStrictEqual('2');
+        expect(cells[0].attributes('aria-rowindex')).toStrictEqual('1');
         expect(cells[0].attributes('aria-colindex')).toStrictEqual('1');
-        expect(cells[1].attributes('aria-rowindex')).toStrictEqual('2');
+        expect(cells[1].attributes('aria-rowindex')).toStrictEqual('1');
         expect(cells[1].attributes('aria-colindex')).toStrictEqual('2');
       });
 
-      it('second data row cells have aria-rowindex="3"', () => {
+      it('second data row cells have aria-rowindex="2"', () => {
         const wrapper = mountKV({ value: { k1: 'v1', k2: 'v2' }, removeAllowed: false });
         const cells = wrapper.findAll('[role="gridcell"]');
 
         // 2 rows × 2 cells (no remove), second row starts at cells[2]
-        expect(cells[2].attributes('aria-rowindex')).toStrictEqual('3');
+        expect(cells[2].attributes('aria-rowindex')).toStrictEqual('2');
         expect(cells[2].attributes('aria-colindex')).toStrictEqual('1');
-        expect(cells[3].attributes('aria-rowindex')).toStrictEqual('3');
+        expect(cells[3].attributes('aria-rowindex')).toStrictEqual('2');
         expect(cells[3].attributes('aria-colindex')).toStrictEqual('2');
       });
     });
 
     describe('no-data placeholder in view mode', () => {
-      it('placeholder cells have aria-rowindex="2" and sequential aria-colindex', () => {
+      it('placeholder cells have aria-rowindex="1" and sequential aria-colindex', () => {
         const wrapper = mountKV({ value: {}, mode: 'view' });
         const cells = wrapper.findAll('[role="gridcell"]');
 
-        expect(cells[0].attributes('aria-rowindex')).toStrictEqual('2');
+        expect(cells[0].attributes('aria-rowindex')).toStrictEqual('1');
         expect(cells[0].attributes('aria-colindex')).toStrictEqual('1');
-        expect(cells[1].attributes('aria-rowindex')).toStrictEqual('2');
+        expect(cells[1].attributes('aria-rowindex')).toStrictEqual('1');
         expect(cells[1].attributes('aria-colindex')).toStrictEqual('2');
       });
     });


### PR DESCRIPTION

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14439

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Fix `aria-colcount` on the `KeyValue` grid to include the remove column when it is present
- Fix `aria-rowcount` to include the header row in the total count
- Add missing `role="rowgroup"` and `role="row"` to the grouping divs so screen readers can build the correct grid ownership chain (`grid → rowgroup → row → columnheader/gridcell`)
- Add `aria-rowindex` and `aria-colindex` to all header `columnheader` cells
- Offset data-row `aria-rowindex` from `i+1` to `i+2` to account for the header row being row 1
- Fix the no-data placeholder cells in view mode to include `aria-rowindex` and `aria-colindex`

### Technical notes summary
The `KeyValue` component renders a CSS grid with `role="grid"` but was missing the required ARIA ownership chain. Without `role="rowgroup"` and `role="row"` on the intermediate wrapper divs, VoiceOver ignored the declared `aria-colcount` and computed the column count from all visible cells combined, producing incorrect announcements like "6 columns, 2 rows" for a 3-column grid. The fix adds the missing roles and corrects all row/column index attributes throughout the header, data, and empty-state rows.

### Areas or cases that should be tested
- Use VoiceOver (macOS) or NVDA (Windows) on a `KeyValue` component with one or more rows in edit mode — the screen reader should announce the correct column and row counts
- Verify with the **Selectors** tab on a Service edit page (local cluster)
- Verify with the **Labels & Annotations** section on any resource edit page
- Verify the empty/view-only state (no rows, view mode) announces "2 rows, 2 columns"
- Verify with `extraColumns` (e.g. environment variable editor) that the column count adjusts correctly
- Tested locally with VoiceOver on Chrome

### Areas which could experience regressions
- Any page that renders the `KeyValue` component: Labels & Annotations, Selectors, ConfigMaps, Secrets, environment variables
- Extensions or third-party plugins that rely on the `KeyValue` component slot `name="remove"` in the header (that slot was replaced with a plain `div` with `role="columnheader"`)

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
