### PR TITLE
address <hr> a11y issue where separators that are just for cosmetical purposes should not be captured by screen readers

### DIFF
--- a/.eslintrc.default.js
+++ b/.eslintrc.default.js
@@ -197,6 +197,10 @@ module.exports = {
   },
   overrides: [
     {
+      files: ['**/RcDropdownSeparator.vue', '**/RcSeparator.vue'],
+      rules: { 'local-rules/no-hr-element': 'off' }
+    },
+    {
       files: [
         '**/*.{js,ts,vue}'
       ],

--- a/.eslintrc.default.js
+++ b/.eslintrc.default.js
@@ -197,7 +197,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['**/RcDropdownSeparator.vue', '**/RcSeparator.vue'],
+      files: ['**/RcSeparator.vue'],
       rules: { 'local-rules/no-hr-element': 'off' }
     },
     {

--- a/eslint-plugin-local-rules/index.js
+++ b/eslint-plugin-local-rules/index.js
@@ -10,8 +10,19 @@
  */
 
 const vCleanTooltip = require('./v-clean-tooltip');
+const noHrElement = require('./no-hr-element');
 
 module.exports = {
-  configs: { all: { rules: { 'local-rules/v-clean-tooltip': 'error' } } },
-  rules:   { 'v-clean-tooltip': vCleanTooltip }
+  configs: {
+    all: {
+      rules: {
+        'local-rules/v-clean-tooltip': 'error',
+        'local-rules/no-hr-element':   'error',
+      }
+    }
+  },
+  rules: {
+    'v-clean-tooltip': vCleanTooltip,
+    'no-hr-element':   noHrElement,
+  }
 };

--- a/eslint-plugin-local-rules/no-hr-element.js
+++ b/eslint-plugin-local-rules/no-hr-element.js
@@ -1,0 +1,22 @@
+const vueUtils = require('eslint-plugin-vue/lib/utils');
+
+module.exports = {
+  meta: {
+    type:   'problem',
+    docs:   { description: 'Use <RcSeparator> instead of bare <hr> elements. For menu separators, use <RcDropdownSeparator>.' },
+    schema: [],
+  },
+  create(context) {
+    return vueUtils.defineTemplateBodyVisitor(context, {
+      VElement(node) {
+        if (node.rawName === 'hr') {
+          context.report({
+            node,
+            loc:     node.loc,
+            message: 'Use <RcSeparator> instead of <hr>. For menu/listbox separators use <RcDropdownSeparator>.'
+          });
+        }
+      }
+    });
+  }
+};

--- a/eslint-plugin-local-rules/no-hr-element.js
+++ b/eslint-plugin-local-rules/no-hr-element.js
@@ -13,7 +13,7 @@ module.exports = {
           context.report({
             node,
             loc:     node.loc,
-            message: 'Use <RcSeparator> instead of <hr>. For menu/listbox separators use <RcDropdownSeparator>.'
+            message: 'Use <RcSeparator> (import { RcSeparator } from \'@components/RcSeparator\') instead of <hr>. For menu/listbox separators use <RcDropdownSeparator>.'
           });
         }
       }

--- a/pkg/eks/components/NodeGroup.vue
+++ b/pkg/eks/components/NodeGroup.vue
@@ -19,6 +19,7 @@ import FileSelector from '@shell/components/form/FileSelector.vue';
 import { MANAGED_TEMPLATE_PREFIX, parseTags } from '../util/aws';
 import * as AWS from '@shell/types/aws-sdk';
 import { DEFAULT_NODE_GROUP_CONFIG } from './CruEKS.vue';
+import RcSeparator from '@shell/components/RcSeparator';
 
 // map between fields in rancher eksConfig and amazon launch templates
 const launchTemplateFieldMapping: {[key: string]: string} = {
@@ -55,7 +56,8 @@ export default defineComponent({
     Checkbox,
     UnitInput,
     FileSelector,
-    RadioGroup
+    RadioGroup,
+    RcSeparator,
   },
 
   props: {
@@ -798,10 +800,7 @@ export default defineComponent({
         </KeyValue>
       </div>
     </div>
-    <hr
-      class="mb-20"
-      role="none"
-    >
+    <RcSeparator class="mb-20" />
     <h3>{{ t('eks.nodeGroups.templateDetails') }}</h3>
     <Banner
       v-if="clusterWillUpgrade && !poolIsUnprovisioned"

--- a/pkg/eks/components/NodeGroup.vue
+++ b/pkg/eks/components/NodeGroup.vue
@@ -19,7 +19,7 @@ import FileSelector from '@shell/components/form/FileSelector.vue';
 import { MANAGED_TEMPLATE_PREFIX, parseTags } from '../util/aws';
 import * as AWS from '@shell/types/aws-sdk';
 import { DEFAULT_NODE_GROUP_CONFIG } from './CruEKS.vue';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 // map between fields in rancher eksConfig and amazon launch templates
 const launchTemplateFieldMapping: {[key: string]: string} = {

--- a/pkg/gke/components/GKENodePool.vue
+++ b/pkg/gke/components/GKENodePool.vue
@@ -14,6 +14,7 @@ import KeyValue from '@shell/components/form/KeyValue.vue';
 import AuthScopes from './AuthScopes.vue';
 import { GKEImageTypes } from '@shell/components/google/util/gcp';
 import type { GKEMachineTypeOption } from '@shell/components/google/types/index.d.ts';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export default defineComponent({
   name: 'GKENodePool',
@@ -28,7 +29,8 @@ export default defineComponent({
     Taints,
     ArrayList,
     KeyValue,
-    AuthScopes
+    AuthScopes,
+    RcSeparator,
   },
 
   props: {
@@ -292,7 +294,7 @@ export default defineComponent({
 <template>
   <div>
     <h3>{{ t('gke.groupDetails') }}</h3>
-    <hr role="none">
+    <RcSeparator />
     <div class="row mb-10">
       <div class="col span-4">
         <LabeledInput
@@ -372,7 +374,7 @@ export default defineComponent({
     <h3 class="mt-20">
       {{ t('gke.nodeDetails') }}
     </h3>
-    <hr role="none">
+    <RcSeparator />
     <div class="row mb-10">
       <div class="col span-6">
         <Checkbox

--- a/pkg/gke/components/GKENodePool.vue
+++ b/pkg/gke/components/GKENodePool.vue
@@ -14,7 +14,7 @@ import KeyValue from '@shell/components/form/KeyValue.vue';
 import AuthScopes from './AuthScopes.vue';
 import { GKEImageTypes } from '@shell/components/google/util/gcp';
 import type { GKEMachineTypeOption } from '@shell/components/google/types/index.d.ts';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default defineComponent({
   name: 'GKENodePool',

--- a/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
@@ -28,6 +28,7 @@ import {
 } from '@shell/utils/uiplugins';
 import { isRancherPrime, getVersionData } from '@shell/config/version';
 import { RcButton } from '@components/RcButton';
+import RcSeparator from '@shell/components/RcSeparator';
 
 const HARVESTER_REPO = isRancherPrime() ? HARVESTER_RANCHER_REPO : HARVESTER_COMMUNITY_REPO;
 
@@ -40,6 +41,7 @@ export default {
     TypeDescription,
     Loading,
     RcButton,
+    RcSeparator,
   },
 
   props: {
@@ -447,10 +449,7 @@ export default {
         <div class="no-clusters">
           {{ t('harvesterManager.cluster.none') }}
         </div>
-        <hr
-          class="info-section"
-          role="none"
-        >
+        <RcSeparator class="info-section" />
       </div>
     </div>
     <template v-if="harvester.toInstall || harvester.toUpdate || !rows || !rows.length">

--- a/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
+++ b/pkg/harvester-manager/list/harvesterhci.io.management.cluster.vue
@@ -28,7 +28,7 @@ import {
 } from '@shell/utils/uiplugins';
 import { isRancherPrime, getVersionData } from '@shell/config/version';
 import { RcButton } from '@components/RcButton';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const HARVESTER_REPO = isRancherPrime() ? HARVESTER_RANCHER_REPO : HARVESTER_COMMUNITY_REPO;
 

--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -39,6 +39,7 @@ import { isValidMac } from '@shell/utils/validators/cidr';
 import { HCI as HCI_ANNOTATIONS, STORAGE } from '@shell/config/labels-annotations';
 import { isEqual } from 'lodash';
 import { FilterArgs, PaginationFilterField, PaginationParamFilter } from '@shell/types/store/pagination.types';
+import RcSeparator from '@shell/components/RcSeparator';
 
 const STORAGE_NETWORK = 'storage-network.settings.harvesterhci.io';
 const HARVESTER_CPU_MODEL = 'harvester-system/node-cpu-model-configuration';
@@ -86,7 +87,7 @@ export default {
   name: 'ConfigComponentHarvester',
 
   components: {
-    ArrayListSelect, Checkbox, draggable, Loading, LabeledSelect, LabeledInput, UnitInput, Banner, YamlEditor, NodeAffinity, PodAffinity, InfoBox
+    ArrayListSelect, Checkbox, draggable, Loading, LabeledSelect, LabeledInput, UnitInput, Banner, YamlEditor, NodeAffinity, PodAffinity, InfoBox, RcSeparator
   },
 
   mixins: [CreateEditView],
@@ -1478,10 +1479,7 @@ export default {
         </button>
       </div>
 
-      <hr
-        class="mt-10 mb-10"
-        role="none"
-      >
+      <RcSeparator class="mt-10 mb-10" />
 
       <h2>{{ t('cluster.credential.harvester.network.title') }}</h2>
       <div
@@ -1667,10 +1665,7 @@ export default {
           />
         </div>
 
-        <hr
-          class="divider mt-20"
-          role="none"
-        >
+        <RcSeparator class="divider mt-20" />
 
         <h3 class="mt-20">
           {{ t("workload.container.titles.nodeScheduling") }}
@@ -1694,10 +1689,7 @@ export default {
           @update="updateScheduling"
         />
 
-        <hr
-          class="divider mt-20"
-          role="none"
-        >
+        <RcSeparator class="divider mt-20" />
       </portal>
     </div>
     <div v-if="errors.length">

--- a/pkg/harvester-manager/machine-config/harvester.vue
+++ b/pkg/harvester-manager/machine-config/harvester.vue
@@ -39,7 +39,7 @@ import { isValidMac } from '@shell/utils/validators/cidr';
 import { HCI as HCI_ANNOTATIONS, STORAGE } from '@shell/config/labels-annotations';
 import { isEqual } from 'lodash';
 import { FilterArgs, PaginationFilterField, PaginationParamFilter } from '@shell/types/store/pagination.types';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const STORAGE_NETWORK = 'storage-network.settings.harvesterhci.io';
 const HARVESTER_CPU_MODEL = 'harvester-system/node-cpu-model-configuration';

--- a/pkg/rancher-components/src/components/Card/Card.vue
+++ b/pkg/rancher-components/src/components/Card/Card.vue
@@ -1,10 +1,12 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default defineComponent({
 
-  name:  'Card',
-  props: {
+  name:       'Card',
+  components: { RcSeparator },
+  props:      {
     /**
      * The card's title.
      */
@@ -71,7 +73,7 @@ export default defineComponent({
           {{ title }}
         </slot>
       </div>
-      <hr role="none">
+      <RcSeparator />
       <div
         class="card-body"
         data-testid="card-body-slot"

--- a/pkg/rancher-components/src/components/Card/Card.vue
+++ b/pkg/rancher-components/src/components/Card/Card.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
-import { RcSeparator } from '@components/RcSeparator';
+import RcSeparator from '@shell/components/RcSeparator.vue';
 
 export default defineComponent({
 

--- a/pkg/rancher-components/src/components/Card/Card.vue
+++ b/pkg/rancher-components/src/components/Card/Card.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
-import RcSeparator from '@shell/components/RcSeparator.vue';
+import RcSeparator from '@components/RcSeparator/RcSeparator.vue';
 
 export default defineComponent({
 

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownSeparator.test.ts
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownSeparator.test.ts
@@ -1,0 +1,18 @@
+import { mount } from '@vue/test-utils';
+import { RcDropdownSeparator } from '@components/RcDropdown';
+
+describe('component: RcDropdownSeparator', () => {
+  it('renders a meaningful horizontal separator for menu and listbox contexts', () => {
+    const wrapper = mount(RcDropdownSeparator);
+
+    expect(wrapper.element.tagName).toBe('HR');
+    expect(wrapper.attributes('role')).toBe('separator');
+    expect(wrapper.attributes('aria-orientation')).toBe('horizontal');
+  });
+
+  it('passes attributes through to the underlying separator', () => {
+    const wrapper = mount(RcDropdownSeparator, { attrs: { class: 'ns-divider' } });
+
+    expect(wrapper.classes()).toContain('ns-divider');
+  });
+});

--- a/pkg/rancher-components/src/components/RcDropdown/RcDropdownSeparator.vue
+++ b/pkg/rancher-components/src/components/RcDropdown/RcDropdownSeparator.vue
@@ -1,6 +1,7 @@
+<script setup lang="ts">
+import RcSeparator from '@components/RcSeparator/RcSeparator.vue';
+</script>
+
 <template>
-  <hr
-    role="separator"
-    aria-orientation="horizontal"
-  >
+  <RcSeparator :decorative="false" />
 </template>

--- a/pkg/rancher-components/src/components/RcSeparator/RcSeparator.test.ts
+++ b/pkg/rancher-components/src/components/RcSeparator/RcSeparator.test.ts
@@ -1,0 +1,54 @@
+import { shallowMount } from '@vue/test-utils';
+import RcSeparator from './RcSeparator.vue';
+
+describe('component: RcSeparator', () => {
+  it('renders an hr element', () => {
+    const wrapper = shallowMount(RcSeparator);
+
+    expect(wrapper.element.tagName).toBe('HR');
+  });
+
+  it('hides the separator from the accessibility tree by default', () => {
+    const wrapper = shallowMount(RcSeparator);
+
+    expect(wrapper.attributes('role')).toBe('none');
+    expect(wrapper.attributes('aria-orientation')).toBeUndefined();
+  });
+
+  it('exposes a horizontal separator role when it is not decorative', () => {
+    const wrapper = shallowMount(RcSeparator, { props: { decorative: false } });
+
+    expect(wrapper.attributes('role')).toBe('separator');
+    expect(wrapper.attributes('aria-orientation')).toBe('horizontal');
+  });
+
+  it('exposes the orientation of a vertical separator when it is not decorative', () => {
+    const wrapper = shallowMount(RcSeparator, { props: { decorative: false, orientation: 'vertical' } });
+
+    expect(wrapper.attributes('role')).toBe('separator');
+    expect(wrapper.attributes('aria-orientation')).toBe('vertical');
+  });
+
+  it('does not expose an orientation for a decorative vertical separator', () => {
+    const wrapper = shallowMount(RcSeparator, { props: { orientation: 'vertical' } });
+
+    expect(wrapper.attributes('role')).toBe('none');
+    expect(wrapper.attributes('aria-orientation')).toBeUndefined();
+  });
+
+  it.each([
+    ['horizontal' as const, false],
+    ['vertical' as const, true],
+  ])('applies the vertical class only for a vertical orientation: %s', (orientation, expected) => {
+    const wrapper = shallowMount(RcSeparator, { props: { orientation } });
+
+    expect(wrapper.classes().includes('vertical')).toBe(expected);
+  });
+
+  it('passes attributes through to the root element', () => {
+    const wrapper = shallowMount(RcSeparator, { attrs: { class: 'ns-divider', 'data-testid': 'separator' } });
+
+    expect(wrapper.classes()).toContain('ns-divider');
+    expect(wrapper.attributes('data-testid')).toBe('separator');
+  });
+});

--- a/pkg/rancher-components/src/components/RcSeparator/RcSeparator.vue
+++ b/pkg/rancher-components/src/components/RcSeparator/RcSeparator.vue
@@ -1,0 +1,9 @@
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({ name: 'RcSeparator' });
+</script>
+
+<template>
+  <hr role="none">
+</template>

--- a/pkg/rancher-components/src/components/RcSeparator/RcSeparator.vue
+++ b/pkg/rancher-components/src/components/RcSeparator/RcSeparator.vue
@@ -1,9 +1,0 @@
-<script lang="ts">
-import { defineComponent } from 'vue';
-
-export default defineComponent({ name: 'RcSeparator' });
-</script>
-
-<template>
-  <hr role="none">
-</template>

--- a/pkg/rancher-components/src/components/RcSeparator/RcSeparator.vue
+++ b/pkg/rancher-components/src/components/RcSeparator/RcSeparator.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { RcSeparatorProps } from './types';
+
+const props = withDefaults(defineProps<RcSeparatorProps>(), {
+  decorative:  true,
+  orientation: 'horizontal',
+});
+
+/**
+ * Decorative separators are removed from the accessibility tree so that screen
+ * readers skip over them. Meaningful separators keep the `separator` role and
+ * expose their orientation.
+ */
+const role = computed(() => (props.decorative ? 'none' : 'separator'));
+
+const ariaOrientation = computed(() => (props.decorative ? undefined : props.orientation));
+</script>
+
+<template>
+  <hr
+    :role="role"
+    :aria-orientation="ariaOrientation"
+    :class="{ vertical: props.orientation === 'vertical' }"
+  >
+</template>
+
+<style lang="scss" scoped>
+hr.vertical {
+  align-self: stretch;
+  height: auto;
+  margin: 0;
+  border-top: none;
+  border-left: 1px solid var(--border);
+}
+</style>

--- a/pkg/rancher-components/src/components/RcSeparator/index.ts
+++ b/pkg/rancher-components/src/components/RcSeparator/index.ts
@@ -1,0 +1,1 @@
+export { default as RcSeparator } from './RcSeparator.vue';

--- a/pkg/rancher-components/src/components/RcSeparator/index.ts
+++ b/pkg/rancher-components/src/components/RcSeparator/index.ts
@@ -1,1 +1,0 @@
-export { default as RcSeparator } from './RcSeparator.vue';

--- a/pkg/rancher-components/src/components/RcSeparator/index.ts
+++ b/pkg/rancher-components/src/components/RcSeparator/index.ts
@@ -1,0 +1,2 @@
+export { default as RcSeparator } from './RcSeparator.vue';
+export type { RcSeparatorProps, RcSeparatorOrientation } from './types';

--- a/pkg/rancher-components/src/components/RcSeparator/types.ts
+++ b/pkg/rancher-components/src/components/RcSeparator/types.ts
@@ -1,0 +1,17 @@
+export type RcSeparatorOrientation = 'horizontal' | 'vertical';
+
+export interface RcSeparatorProps {
+  /**
+   * Purely cosmetic separator that is hidden from the accessibility tree.
+   *
+   * Set to `false` when the separator conveys meaning, for example when
+   * grouping tems within a menu or a listbox.
+   */
+  decorative?: boolean;
+
+  /**
+   * Orientation of the separator. Drives `aria-orientation` when the
+   * separator is not decorative.
+   */
+  orientation?: RcSeparatorOrientation;
+}

--- a/pkg/rancher-components/src/index.ts
+++ b/pkg/rancher-components/src/index.ts
@@ -11,6 +11,7 @@ export {
   RcDropdownTrigger,
   RcDropdownMenu
 } from './components/RcDropdown';
+export { RcSeparator } from './components/RcSeparator';
 export { RcIcon } from './components/RcIcon';
 export { RcSection } from './components/RcSection';
 export { RcItemCard, RcItemCardAction } from './components/RcItemCard';

--- a/pkg/rancher-components/src/index.ts
+++ b/pkg/rancher-components/src/index.ts
@@ -11,7 +11,6 @@ export {
   RcDropdownTrigger,
   RcDropdownMenu
 } from './components/RcDropdown';
-export { RcSeparator } from './components/RcSeparator';
 export { RcIcon } from './components/RcIcon';
 export { RcSection } from './components/RcSection';
 export { RcItemCard, RcItemCardAction } from './components/RcItemCard';

--- a/pkg/rancher-components/src/index.ts
+++ b/pkg/rancher-components/src/index.ts
@@ -13,6 +13,7 @@ export {
 } from './components/RcDropdown';
 export { RcIcon } from './components/RcIcon';
 export { RcSection } from './components/RcSection';
+export { RcSeparator } from './components/RcSeparator';
 export { RcItemCard, RcItemCardAction } from './components/RcItemCard';
 export { default as RcCounterBadge } from './components/Pill/RcCounterBadge';
 export { default as RcStatusBadge } from './components/Pill/RcStatusBadge';

--- a/pkg/rancher-components/types/index.d.ts
+++ b/pkg/rancher-components/types/index.d.ts
@@ -17,6 +17,7 @@ export const RcDropdownItem: DefineComponent;
 export const RcDropdownSeparator: DefineComponent;
 export const RcDropdownTrigger: DefineComponent;
 export const RcItemCard: DefineComponent;
+export const RcSeparator: DefineComponent;
 
 type ArrayListRow = {
     value: string;

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -22,6 +22,7 @@ import {
 
 import { BEFORE_SAVE_HOOKS } from '@shell/mixins/child-hook';
 import Wizard from '@shell/components/Wizard';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export const CONTEXT_HOOK_EDIT_YAML = 'show-preview-yaml';
 
@@ -37,7 +38,8 @@ export default {
     CruResourceFooter,
     ResourceYaml,
     Wizard,
-    TableOfContents
+    TableOfContents,
+    RcSeparator,
   },
 
   props: {
@@ -765,10 +767,7 @@ export default {
                       class="flex-right"
                     >{{ t('generic.moreInfo') }} <i class="icon icon-external-link" /></a>
                   </div>
-                  <hr
-                    v-if="subtype.description"
-                    role="none"
-                  >
+                  <RcSeparator v-if="subtype.description" />
                   <div
                     v-if="subtype.description"
                     class="description"

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -22,7 +22,7 @@ import {
 
 import { BEFORE_SAVE_HOOKS } from '@shell/mixins/child-hook';
 import Wizard from '@shell/components/Wizard';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export const CONTEXT_HOOK_EDIT_YAML = 'show-preview-yaml';
 

--- a/shell/components/RcSeparator.vue
+++ b/shell/components/RcSeparator.vue
@@ -1,0 +1,9 @@
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({ name: 'RcSeparator' });
+</script>
+
+<template>
+  <hr role="none">
+</template>

--- a/shell/components/RcSeparator.vue
+++ b/shell/components/RcSeparator.vue
@@ -1,9 +1,0 @@
-<script lang="ts">
-import { defineComponent } from 'vue';
-
-export default defineComponent({ name: 'RcSeparator' });
-</script>
-
-<template>
-  <hr role="none">
-</template>

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -14,13 +14,14 @@ import { useLabeledFormElement, labeledFormElementProps } from '@shell/composabl
 import { useLabeledSelect } from '@shell/composables/useLabeledSelect';
 import { ref, toRef } from 'vue';
 import { useVeeValidateField } from '@shell/composables/useVeeValidateField';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export default {
   name: 'LabeledSelect',
 
   inheritAttrs: false,
 
-  components: { LabeledTooltip },
+  components: { LabeledTooltip, RcSeparator },
   mixins:     [
     CompactInput,
     VueSelectOverrides,
@@ -507,7 +508,7 @@ export default {
           </div>
         </template>
         <template v-else-if="option.kind === 'divider'">
-          <hr role="none">
+          <RcSeparator />
         </template>
         <template v-else-if="option.kind === 'highlighted'">
           <div class="option-kind-highlighted">

--- a/shell/components/form/LabeledSelect.vue
+++ b/shell/components/form/LabeledSelect.vue
@@ -14,7 +14,7 @@ import { useLabeledFormElement, labeledFormElementProps } from '@shell/composabl
 import { useLabeledSelect } from '@shell/composables/useLabeledSelect';
 import { ref, toRef } from 'vue';
 import { useVeeValidateField } from '@shell/composables/useVeeValidateField';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   name: 'LabeledSelect',

--- a/shell/components/form/Probe.vue
+++ b/shell/components/form/Probe.vue
@@ -7,6 +7,7 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import ShellInput from '@shell/components/form/ShellInput';
 import KeyValue from '@shell/components/form/KeyValue';
 import { computed, ref, watch } from 'vue';
+import RcSeparator from '@shell/components/RcSeparator';
 
 const KINDS = [
   'none',
@@ -20,7 +21,7 @@ export default {
   emits: ['update:value'],
 
   components: {
-    LabeledInput, LabeledSelect, UnitInput, ShellInput, KeyValue,
+    LabeledInput, LabeledSelect, UnitInput, ShellInput, KeyValue, RcSeparator,
   },
 
   props: {
@@ -241,12 +242,11 @@ export default {
       </div>
 
       <div class="col span-1-of-13">
-        <hr
+        <RcSeparator
           v-if="kind && kind!=='none'"
           :style="{'position':'relative', 'margin':'0px'}"
           class="vertical"
-          role="none"
-        >
+        />
       </div>
 
       <!-- none -->

--- a/shell/components/form/Probe.vue
+++ b/shell/components/form/Probe.vue
@@ -7,7 +7,7 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import ShellInput from '@shell/components/form/ShellInput';
 import KeyValue from '@shell/components/form/KeyValue';
 import { computed, ref, watch } from 'vue';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const KINDS = [
   'none',

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -1,10 +1,12 @@
 <script>
 import Type from '@shell/components/nav/Type';
 import { filterLocationValidParams } from '@shell/utils/router';
+import RcSeparator from '@shell/components/RcSeparator';
+
 export default {
   name: 'Group',
 
-  components: { Type },
+  components: { Type, RcSeparator },
 
   emits: ['expand', 'close'],
 
@@ -333,7 +335,7 @@ export default {
           v-if="child.divider"
           :key="idx"
         >
-          <hr role="none">
+          <RcSeparator />
         </li>
         <!-- <div v-else-if="child[childrenKey] && hideGroup(child[childrenKey])" :key="child.name">
           HIDDEN

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -1,7 +1,7 @@
 <script>
 import Type from '@shell/components/nav/Type';
 import { filterLocationValidParams } from '@shell/utils/router';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   name: 'Group',

--- a/shell/components/nav/NamespaceFilter.vue
+++ b/shell/components/nav/NamespaceFilter.vue
@@ -22,12 +22,13 @@ import { SETTING } from '@shell/config/settings';
 import paginationUtils from '@shell/utils/pagination-utils';
 import { randomStr } from '@shell/utils/string';
 import { RcButton } from '@components/RcButton';
+import { RcDropdownSeparator } from '@components/RcDropdown';
 
 const forcedNamespaceValidTypes = [NAMESPACE_FILTER_KINDS.DIVIDER, NAMESPACE_FILTER_KINDS.PROJECT, NAMESPACE_FILTER_KINDS.NAMESPACE];
 
 export default {
 
-  components: { RcButton },
+  components: { RcButton, RcDropdownSeparator },
 
   data() {
     return {
@@ -898,12 +899,10 @@ export default {
           v-for="(opt, i) in cachedFiltered"
           :key="opt.id"
         >
-          <hr
+          <RcDropdownSeparator
             v-if="opt.kind === NAMESPACE_FILTER_KINDS.DIVIDER"
-            role="separator"
-            aria-orientation="horizontal"
             class="ns-divider"
-          >
+          />
           <div
             v-else
             :id="opt.elementId"

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -18,13 +18,15 @@ import Pinned from '@shell/components/nav/Pinned';
 import sideNavService from '@shell/components/nav/TopLevelMenu.helper';
 import { debounce } from 'lodash';
 import { sameContents } from '@shell/utils/array';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export default {
   components: {
     BrandImage,
     ClusterIconMenu,
     IconOrSvg,
-    Pinned
+    Pinned,
+    RcSeparator,
   },
 
   data() {
@@ -774,7 +776,7 @@ export default {
                   v-if="clustersFiltered.length > 0"
                   class="category-title"
                 >
-                  <hr role="none">
+                  <RcSeparator />
                 </div>
               </div>
 
@@ -888,7 +890,7 @@ export default {
               <div
                 class="category-title"
               >
-                <hr role="none">
+                <RcSeparator />
                 <span>
                   {{ t('nav.categories.multiCluster') }}
                 </span>
@@ -921,7 +923,7 @@ export default {
               <div
                 class="category-title"
               >
-                <hr role="none">
+                <RcSeparator />
                 <span>
                   {{ t('nav.categories.configuration') }}
                 </span>

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -18,7 +18,7 @@ import Pinned from '@shell/components/nav/Pinned';
 import sideNavService from '@shell/components/nav/TopLevelMenu.helper';
 import { debounce } from 'lodash';
 import { sameContents } from '@shell/utils/array';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -19,6 +19,7 @@ import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBann
 import formRulesGenerator from '@shell/utils/validators/formRules/index';
 import { useFormValidation } from '@shell/composables/useFormValidation';
 import { useI18n } from '@shell/composables/useI18n';
+import RcSeparator from '@shell/components/RcSeparator';
 
 const TENANT_ID_TOKEN = '__[[TENANT_ID]]__';
 
@@ -68,7 +69,8 @@ export default {
     CopyToClipboardText,
     AllowedPrincipals,
     AuthBanner,
-    AuthProviderWarningBanners
+    AuthProviderWarningBanners,
+    RcSeparator,
   },
 
   mixins: [CreateEditView, AuthConfig],
@@ -455,7 +457,7 @@ export default {
           </template>
         </AuthBanner>
 
-        <hr role="none">
+        <RcSeparator />
 
         <AllowedPrincipals
           provider="azuread"

--- a/shell/edit/auth/azuread.vue
+++ b/shell/edit/auth/azuread.vue
@@ -19,7 +19,7 @@ import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBann
 import formRulesGenerator from '@shell/utils/validators/formRules/index';
 import { useFormValidation } from '@shell/composables/useFormValidation';
 import { useI18n } from '@shell/composables/useI18n';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const TENANT_ID_TOKEN = '__[[TENANT_ID]]__';
 

--- a/shell/edit/auth/github.vue
+++ b/shell/edit/auth/github.vue
@@ -19,6 +19,7 @@ import FileSelector from '@shell/components/form/FileSelector';
 import GithubSteps from '@shell/edit/auth/github-steps.vue';
 import GithubAppSteps from '@shell/edit/auth/github-app-steps.vue';
 import { useI18n } from '@shell/composables/useI18n';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export default {
   components: {
@@ -32,6 +33,7 @@ export default {
     FileSelector,
     GithubSteps,
     GithubAppSteps,
+    RcSeparator,
   },
 
   mixins: [CreateEditView, AuthConfig],
@@ -226,7 +228,7 @@ export default {
           </template>
         </AuthBanner>
 
-        <hr role="none">
+        <RcSeparator />
 
         <AllowedPrincipals
           provider="github"

--- a/shell/edit/auth/github.vue
+++ b/shell/edit/auth/github.vue
@@ -19,7 +19,7 @@ import FileSelector from '@shell/components/form/FileSelector';
 import GithubSteps from '@shell/edit/auth/github-steps.vue';
 import GithubAppSteps from '@shell/edit/auth/github-app-steps.vue';
 import { useI18n } from '@shell/composables/useI18n';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/shell/edit/auth/googleoauth.vue
+++ b/shell/edit/auth/googleoauth.vue
@@ -12,6 +12,7 @@ import FileSelector from '@shell/components/form/FileSelector';
 import AuthBanner from '@shell/components/auth/AuthBanner';
 import CopyToClipboardText from '@shell/components/CopyToClipboardText';
 import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBanners';
+import RcSeparator from '@shell/components/RcSeparator';
 
 const NAME = 'googleoauth';
 
@@ -26,7 +27,8 @@ export default {
     FileSelector,
     AuthBanner,
     CopyToClipboardText,
-    AuthProviderWarningBanners
+    AuthProviderWarningBanners,
+    RcSeparator,
   },
 
   mixins: [CreateEditView, AuthConfig],
@@ -90,7 +92,7 @@ export default {
           </template>
         </AuthBanner>
 
-        <hr role="none">
+        <RcSeparator />
 
         <AllowedPrincipals
           provider="googleoauth"

--- a/shell/edit/auth/googleoauth.vue
+++ b/shell/edit/auth/googleoauth.vue
@@ -12,7 +12,7 @@ import FileSelector from '@shell/components/form/FileSelector';
 import AuthBanner from '@shell/components/auth/AuthBanner';
 import CopyToClipboardText from '@shell/components/CopyToClipboardText';
 import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBanners';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const NAME = 'googleoauth';
 

--- a/shell/edit/auth/ldap/index.vue
+++ b/shell/edit/auth/ldap/index.vue
@@ -15,6 +15,7 @@ import AuthBanner from '@shell/components/auth/AuthBanner';
 import Password from '@shell/components/form/Password';
 import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBanners';
 import { useI18n } from '@shell/composables/useI18n';
+import RcSeparator from '@shell/components/RcSeparator';
 
 const AUTH_TYPE = 'ldap';
 
@@ -27,7 +28,8 @@ export default {
     config,
     AuthBanner,
     Password,
-    AuthProviderWarningBanners
+    AuthProviderWarningBanners,
+    RcSeparator,
   },
 
   mixins: [CreateEditView, AuthConfig],
@@ -171,7 +173,7 @@ export default {
           </template>
         </AuthBanner>
 
-        <hr role="none">
+        <RcSeparator />
 
         <AllowedPrincipals
           :provider="NAME"

--- a/shell/edit/auth/ldap/index.vue
+++ b/shell/edit/auth/ldap/index.vue
@@ -15,7 +15,7 @@ import AuthBanner from '@shell/components/auth/AuthBanner';
 import Password from '@shell/components/form/Password';
 import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBanners';
 import { useI18n } from '@shell/composables/useI18n';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const AUTH_TYPE = 'ldap';
 

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -21,6 +21,7 @@ import { Checkbox } from '@components/Form/Checkbox';
 import { BASE_SCOPES } from '@shell/store/auth';
 import CopyToClipboardText from '@shell/components/CopyToClipboardText.vue';
 import { useI18n } from '@shell/composables/useI18n';
+import RcSeparator from '@shell/components/RcSeparator';
 
 const PKCE_S256 = 'S256';
 
@@ -39,6 +40,7 @@ export default {
     RadioGroup,
     Checkbox,
     CopyToClipboardText,
+    RcSeparator,
   },
 
   emits: ['validationChanged'],
@@ -373,7 +375,7 @@ export default {
           </template>
         </AuthBanner>
 
-        <hr role="none">
+        <RcSeparator />
 
         <AllowedPrincipals
           :provider="NAME"

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -21,7 +21,7 @@ import { Checkbox } from '@components/Form/Checkbox';
 import { BASE_SCOPES } from '@shell/store/auth';
 import CopyToClipboardText from '@shell/components/CopyToClipboardText.vue';
 import { useI18n } from '@shell/composables/useI18n';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const PKCE_S256 = 'S256';
 

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -19,6 +19,7 @@ import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBann
 import RadioGroup from '@components/Form/Radio/RadioGroup.vue';
 import { RcButton } from '@components/RcButton';
 import { useI18n } from '@shell/composables/useI18n';
+import RcSeparator from '@shell/components/RcSeparator';
 
 // Standard LDAP defaults
 const LDAP_DEFAULTS = {
@@ -56,6 +57,7 @@ export default {
     AuthBanner,
     AuthProviderWarningBanners,
     RcButton,
+    RcSeparator,
   },
 
   mixins: [CreateEditView, AuthConfig],
@@ -284,7 +286,7 @@ export default {
           </template>
         </AuthBanner>
 
-        <hr role="none">
+        <RcSeparator />
 
         <AllowedPrincipals
           :provider="NAME"

--- a/shell/edit/auth/saml.vue
+++ b/shell/edit/auth/saml.vue
@@ -19,7 +19,7 @@ import AuthProviderWarningBanners from '@shell/edit/auth/AuthProviderWarningBann
 import RadioGroup from '@components/Form/Radio/RadioGroup.vue';
 import { RcButton } from '@components/RcButton';
 import { useI18n } from '@shell/composables/useI18n';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 // Standard LDAP defaults
 const LDAP_DEFAULTS = {

--- a/shell/edit/fleet.cattle.io.cluster.vue
+++ b/shell/edit/fleet.cattle.io.cluster.vue
@@ -7,6 +7,7 @@ import NameNsDescription from '@shell/components/form/NameNsDescription';
 import { _VIEW } from '@shell/config/query-params';
 import { NORMAN } from '@shell/config/types';
 import { FLEET } from '@shell/config/labels-annotations';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export default {
   name: 'CruFleetCluster',
@@ -18,6 +19,7 @@ export default {
     Labels,
     Loading,
     NameNsDescription,
+    RcSeparator,
   },
 
   inheritAttrs: false,
@@ -111,7 +113,7 @@ export default {
       @update:value="$emit('input', $event)"
     />
 
-    <hr class="mt-20 mb-20">
+    <RcSeparator class="mt-20 mb-20" />
 
     <Labels
       default-section-class="mt-20"

--- a/shell/edit/fleet.cattle.io.cluster.vue
+++ b/shell/edit/fleet.cattle.io.cluster.vue
@@ -7,7 +7,7 @@ import NameNsDescription from '@shell/components/form/NameNsDescription';
 import { _VIEW } from '@shell/config/query-params';
 import { NORMAN } from '@shell/config/types';
 import { FLEET } from '@shell/config/labels-annotations';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   name: 'CruFleetCluster',

--- a/shell/edit/monitoring.coreos.com.route.vue
+++ b/shell/edit/monitoring.coreos.com.route.vue
@@ -19,6 +19,7 @@ import { MONITORING } from '@shell/config/types';
 import { Banner } from '@components/Banner';
 import { createDefaultRouteName } from '@shell/utils/alertmanagerconfig';
 import Loading from '@shell/components/Loading';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export default {
   components: {
@@ -30,7 +31,8 @@ export default {
     LabeledSelect,
     Loading,
     Tab,
-    Tabbed
+    Tabbed,
+    RcSeparator,
   },
 
   mixins: [CreateEditView],
@@ -143,7 +145,7 @@ export default {
             </div>
           </div>
         </div>
-        <hr class="divider">
+        <RcSeparator class="divider" />
         <div class="row mb-10">
           <div class="col span-6">
             <LabeledInput

--- a/shell/edit/monitoring.coreos.com.route.vue
+++ b/shell/edit/monitoring.coreos.com.route.vue
@@ -19,7 +19,7 @@ import { MONITORING } from '@shell/config/types';
 import { Banner } from '@components/Banner';
 import { createDefaultRouteName } from '@shell/utils/alertmanagerconfig';
 import Loading from '@shell/components/Loading';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -10,12 +10,13 @@ import { MANAGEMENT } from '@shell/config/types';
 import { STACK_PREFS } from './tabs/networking/index.vue';
 
 import { sanitizeKey, sanitizeIP, sanitizeValue } from '@shell/utils/string';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export default {
   emits: ['copied-windows'],
 
   components: {
-    Banner, Checkbox, CopyCode, InfoBox, KeyValue, LabeledInput, Taints
+    Banner, Checkbox, CopyCode, InfoBox, KeyValue, LabeledInput, Taints, RcSeparator
   },
 
   props: {
@@ -287,10 +288,7 @@ export default {
       />
 
       <template v-if="cluster.supportsWindows">
-        <hr
-          class="mt-20 mb-20"
-          role="none"
-        >
+        <RcSeparator class="mt-20 mb-20" />
         <h4 v-t="'cluster.custom.registrationCommand.windowsDetail'" />
         <Banner
           v-if="readyForWindows"

--- a/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/CustomCommand.vue
@@ -10,7 +10,7 @@ import { MANAGEMENT } from '@shell/config/types';
 import { STACK_PREFS } from './tabs/networking/index.vue';
 
 import { sanitizeKey, sanitizeIP, sanitizeValue } from '@shell/utils/string';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   emits: ['copied-windows'],

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
@@ -11,6 +11,7 @@ import { randomStr } from '@shell/utils/string';
 import FormValidation from '@shell/mixins/form-validation';
 import { MACHINE_POOL_VALIDATION } from '@shell/utils/validators/machine-pool';
 import { isAutoscalerFeatureFlagEnabled } from '@shell/utils/autoscaler-utils';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export default {
 
@@ -25,7 +26,8 @@ export default {
     KeyValue,
     AdvancedSection,
     Banner,
-    UnitInput
+    UnitInput,
+    RcSeparator,
   },
 
   mixins: [FormValidation],
@@ -366,10 +368,7 @@ export default {
         />
       </div>
     </div>
-    <hr
-      class="mt-10"
-      role="none"
-    >
+    <RcSeparator class="mt-10" />
     <component
       :is="configComponent"
       v-if="value.config && configComponent"

--- a/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/tabs/MachinePool.vue
@@ -11,7 +11,7 @@ import { randomStr } from '@shell/utils/string';
 import FormValidation from '@shell/mixins/form-validation';
 import { MACHINE_POOL_VALIDATION } from '@shell/utils/validators/machine-pool';
 import { isAutoscalerFeatureFlagEnabled } from '@shell/utils/autoscaler-utils';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
 

--- a/shell/list/harvesterhci.io.management.cluster.vue
+++ b/shell/list/harvesterhci.io.management.cluster.vue
@@ -9,6 +9,7 @@ import { CAPI, HCI, MANAGEMENT } from '@shell/config/types';
 import { isHarvesterCluster } from '@shell/utils/cluster';
 import { allHash } from '@shell/utils/promise';
 import { RcButton } from '@components/RcButton';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export default {
   components: {
@@ -18,6 +19,7 @@ export default {
     TypeDescription,
     Loading,
     RcButton,
+    RcSeparator,
   },
 
   props: {
@@ -177,10 +179,7 @@ export default {
       <div class="no-clusters">
         {{ t('harvesterManager.cluster.none') }}
       </div>
-      <hr
-        class="info-section"
-        role="none"
-      >
+      <RcSeparator class="info-section" />
       <div class="logo">
         <BrandImage
           file-name="harvester.png"

--- a/shell/list/harvesterhci.io.management.cluster.vue
+++ b/shell/list/harvesterhci.io.management.cluster.vue
@@ -9,7 +9,7 @@ import { CAPI, HCI, MANAGEMENT } from '@shell/config/types';
 import { isHarvesterCluster } from '@shell/utils/cluster';
 import { allHash } from '@shell/utils/promise';
 import { RcButton } from '@components/RcButton';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -17,6 +17,7 @@ import { findBy } from '@shell/utils/array';
 import KeyValue from '@shell/components/form/KeyValue';
 import { RadioGroup } from '@components/Form/Radio';
 import { _CREATE, _EDIT } from '@shell/config/query-params';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export const azureEnvironments = [
   { value: 'AzurePublicCloud' },
@@ -106,7 +107,8 @@ export default {
     LabeledInput,
     LabeledSelect,
     Loading,
-    RadioGroup
+    RadioGroup,
+    RcSeparator,
   },
 
   mixins: [CreateEditView, FormValidation],
@@ -611,10 +613,7 @@ export default {
         />
       </div>
     </div>
-    <hr
-      class="mt-20"
-      role="none"
-    >
+    <RcSeparator class="mt-20" />
     <div class="row mt-20">
       <div class="col span-6">
         <LabeledInput
@@ -680,10 +679,7 @@ export default {
           </div>
         </div>
       </div>
-      <hr
-        class="mt-20 mb-20"
-        role="none"
-      >
+      <RcSeparator class="mt-20 mb-20" />
       <h2>{{ t('cluster.machineConfig.azure.sections.purchasePlan') }}</h2>
       <div class="row mt-20">
         <div class="col span-6">
@@ -696,10 +692,7 @@ export default {
           />
         </div>
       </div>
-      <hr
-        class="mt-20"
-        role="none"
-      >
+      <RcSeparator class="mt-20" />
       <h2>{{ t('cluster.machineConfig.azure.sections.network') }}</h2>
       <div class="row mt-20 mb-20">
         <div class="col span-6">
@@ -821,10 +814,7 @@ export default {
           />
         </div>
       </div>
-      <hr
-        class="mt-20 mb-20"
-        role="none"
-      >
+      <RcSeparator class="mt-20 mb-20" />
       <h2>{{ t('cluster.machineConfig.azure.sections.disks') }}</h2>
       <div class="row mt-20 mb-20">
         <div class="col span-6">

--- a/shell/machine-config/azure.vue
+++ b/shell/machine-config/azure.vue
@@ -17,7 +17,7 @@ import { findBy } from '@shell/utils/array';
 import KeyValue from '@shell/components/form/KeyValue';
 import { RadioGroup } from '@components/Form/Radio';
 import { _CREATE, _EDIT } from '@shell/config/query-params';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export const azureEnvironments = [
   { value: 'AzurePublicCloud' },

--- a/shell/pages/account/index.vue
+++ b/shell/pages/account/index.vue
@@ -11,12 +11,13 @@ import { Banner } from '@components/Banner';
 import ResourceTable from '@shell/components/ResourceTable';
 import CopyToClipboardText from '@shell/components/CopyToClipboardText';
 import TabTitle from '@shell/components/TabTitle';
+import RcSeparator from '@shell/components/RcSeparator';
 
 const API_ENDPOINT = '/v3';
 
 export default {
   components: {
-    CopyToClipboardText, BackLink, Banner, Loading, ResourceTable, Principal, TabTitle
+    CopyToClipboardText, BackLink, Banner, Loading, ResourceTable, Principal, TabTitle, RcSeparator
   },
   mixins: [BackRoute],
   async fetch() {
@@ -187,7 +188,7 @@ export default {
       </div>
     </div>
 
-    <hr role="none">
+    <RcSeparator />
     <div class="keys-header">
       <div>
         <h2 v-t="'accountAndKeys.apiKeys.title'" />

--- a/shell/pages/account/index.vue
+++ b/shell/pages/account/index.vue
@@ -11,7 +11,7 @@ import { Banner } from '@components/Banner';
 import ResourceTable from '@shell/components/ResourceTable';
 import CopyToClipboardText from '@shell/components/CopyToClipboardText';
 import TabTitle from '@shell/components/TabTitle';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const API_ENDPOINT = '/v3';
 

--- a/shell/pages/auth/setup.vue
+++ b/shell/pages/auth/setup.vue
@@ -21,6 +21,7 @@ import { isLocalhost, isValidUrl } from '@shell/utils/validators/setting';
 import Loading from '@shell/components/Loading';
 import { getBrandMeta } from '@shell/utils/brand';
 import { findMe } from '@shell/utils/auth';
+import RcSeparator from '@shell/components/RcSeparator';
 
 const calcIsFirstLogin = (store) => {
   const firstLoginSetting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.FIRST_LOGIN);
@@ -104,7 +105,7 @@ export default {
   },
 
   components: {
-    AsyncButton, LabeledInput, CopyToClipboard, Checkbox, RadioGroup, Password, BrandImage, Banner, Loading
+    AsyncButton, LabeledInput, CopyToClipboard, Checkbox, RadioGroup, Password, BrandImage, Banner, Loading, RcSeparator
   },
 
   async fetch() {
@@ -392,11 +393,10 @@ export default {
 
           <template v-if="isFirstLogin">
             <template v-if="mcmEnabled">
-              <hr
+              <RcSeparator
                 v-if="mustChangePassword"
                 class="mt-20 mb-20"
-                role="none"
-              >
+              />
               <p>
                 <t
                   k="setup.serverUrl.tip"

--- a/shell/pages/auth/setup.vue
+++ b/shell/pages/auth/setup.vue
@@ -21,7 +21,7 @@ import { isLocalhost, isValidUrl } from '@shell/utils/validators/setting';
 import Loading from '@shell/components/Loading';
 import { getBrandMeta } from '@shell/utils/brand';
 import { findMe } from '@shell/utils/auth';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const calcIsFirstLogin = (store) => {
   const firstLoginSetting = store.getters['management/byId'](MANAGEMENT.SETTING, SETTING.FIRST_LOGIN);

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -47,6 +47,7 @@ import SelectOrCreateAuthSecret from '@shell/components/form/SelectOrCreateAuthS
 import PrivateRegistry from '@shell/components/form/PrivateRegistry.vue';
 import { PRIVATE_REGISTRY_CONTEXT } from '@shell/components/form/PrivateRegistry.constants';
 import { generateRandomAlphaString } from '@shell/utils/string';
+import RcSeparator from '@shell/components/RcSeparator';
 
 const VALUES_STATE = {
   FORM: 'FORM',
@@ -99,7 +100,8 @@ export default {
     YamlEditor,
     Wizard,
     SelectOrCreateAuthSecret,
-    PrivateRegistry
+    PrivateRegistry,
+    RcSeparator,
   },
 
   mixins: [
@@ -1776,7 +1778,7 @@ export default {
               >
                 <template v-slot:option="opt">
                   <template v-if="opt.kind === 'divider'">
-                    <hr role="none">
+                    <RcSeparator />
                   </template>
                   <template v-else-if="opt.kind === 'label'">
                     <b style="position: relative; left: -2.5px;">{{ opt.label }}</b>

--- a/shell/pages/c/_cluster/apps/charts/install.vue
+++ b/shell/pages/c/_cluster/apps/charts/install.vue
@@ -47,7 +47,7 @@ import SelectOrCreateAuthSecret from '@shell/components/form/SelectOrCreateAuthS
 import PrivateRegistry from '@shell/components/form/PrivateRegistry.vue';
 import { PRIVATE_REGISTRY_CONTEXT } from '@shell/components/form/PrivateRegistry.constants';
 import { generateRandomAlphaString } from '@shell/utils/string';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const VALUES_STATE = {
   FORM: 'FORM',

--- a/shell/pages/c/_cluster/fleet/application/create.vue
+++ b/shell/pages/c/_cluster/fleet/application/create.vue
@@ -10,6 +10,7 @@ import FleetUtils from '@shell/utils/fleet';
 import Masthead from '@shell/components/ResourceDetail/Masthead';
 import suseLogo from '@shell/assets/images/content/suse.svg';
 import suseLogoDark from '@shell/assets/images/content/dark/suse.svg';
+import RcSeparator from '@shell/components/RcSeparator';
 
 interface Subtype {
   id: string;
@@ -219,7 +220,7 @@ const cancel = () => {
                 class="flex-right"
               >{{ t('generic.moreInfo') }} <i class="icon icon-external-link" /></a>
             </div>
-            <hr v-if="subtype.description">
+            <RcSeparator v-if="subtype.description" />
             <div
               v-if="subtype.description"
               class="description"

--- a/shell/pages/c/_cluster/fleet/application/create.vue
+++ b/shell/pages/c/_cluster/fleet/application/create.vue
@@ -10,7 +10,7 @@ import FleetUtils from '@shell/utils/fleet';
 import Masthead from '@shell/components/ResourceDetail/Masthead';
 import suseLogo from '@shell/assets/images/content/suse.svg';
 import suseLogoDark from '@shell/assets/images/content/dark/suse.svg';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 interface Subtype {
   id: string;

--- a/shell/pages/c/_cluster/fleet/application/suse-app-collection/credentials.vue
+++ b/shell/pages/c/_cluster/fleet/application/suse-app-collection/credentials.vue
@@ -17,6 +17,7 @@ import Banner from '@components/Banner/Banner.vue';
 import Loading from '@shell/components/Loading';
 import { RcButton } from '@components/RcButton';
 import AppCoPageHeader from '@shell/components/fleet/AppCoPageHeader.vue';
+import RcSeparator from '@shell/components/RcSeparator';
 
 const ADD_NEW_TOKEN = '__add_new__';
 
@@ -249,7 +250,7 @@ onMounted(async() => {
     </div>
 
     <div class="appco-credentials-page-footer">
-      <hr class="footer-divider">
+      <RcSeparator class="footer-divider" />
       <div class="footer">
         <RcButton
           variant="secondary"

--- a/shell/pages/c/_cluster/fleet/application/suse-app-collection/credentials.vue
+++ b/shell/pages/c/_cluster/fleet/application/suse-app-collection/credentials.vue
@@ -17,7 +17,7 @@ import Banner from '@components/Banner/Banner.vue';
 import Loading from '@shell/components/Loading';
 import { RcButton } from '@components/RcButton';
 import AppCoPageHeader from '@shell/components/fleet/AppCoPageHeader.vue';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 const ADD_NEW_TOKEN = '__add_new__';
 

--- a/shell/pages/c/_cluster/istio/index.vue
+++ b/shell/pages/c/_cluster/istio/index.vue
@@ -4,8 +4,10 @@ import { SERVICE } from '@shell/config/types';
 import Loading from '@shell/components/Loading';
 import kialiSvg from '~shell/assets/images/vendor/kiali.svg';
 import jaegerSvg from '~shell/assets/images/vendor/jaeger.svg';
+import RcSeparator from '@shell/components/RcSeparator';
+
 export default {
-  components: { Loading },
+  components: { Loading, RcSeparator },
 
   async fetch() {
     if (this.$store.getters['cluster/schemaFor'](SERVICE)) {
@@ -112,7 +114,7 @@ export default {
               <t k="istio.links.kiali.label" />
               <i class="icon icon-external-link pull-right" />
             </a>
-            <hr role="none">
+            <RcSeparator />
             <div class="description">
               <span v-clean-html="t('istio.links.kiali.description', {link: monitoringUrl}, true)" />
             </div>
@@ -148,7 +150,7 @@ export default {
               <t k="istio.links.jaeger.label" />
               <i class="icon icon-external-link pull-right" />
             </a>
-            <hr role="none">
+            <RcSeparator />
             <div class="description">
               <span v-clean-html="t('istio.links.jaeger.description', true)" />
             </div>

--- a/shell/pages/c/_cluster/istio/index.vue
+++ b/shell/pages/c/_cluster/istio/index.vue
@@ -4,7 +4,7 @@ import { SERVICE } from '@shell/config/types';
 import Loading from '@shell/components/Loading';
 import kialiSvg from '~shell/assets/images/vendor/kiali.svg';
 import jaegerSvg from '~shell/assets/images/vendor/jaeger.svg';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: { Loading, RcSeparator },

--- a/shell/pages/c/_cluster/longhorn/index.vue
+++ b/shell/pages/c/_cluster/longhorn/index.vue
@@ -5,10 +5,11 @@ import IconMessage from '@shell/components/IconMessage';
 import LazyImage from '@shell/components/LazyImage';
 import longhornSvg from '~shell/assets/images/vendor/longhorn.svg';
 import Loading from '@shell/components/Loading';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export default {
   components: {
-    IconMessage, LazyImage, Loading
+    IconMessage, LazyImage, Loading, RcSeparator
   },
 
   async fetch() {
@@ -88,7 +89,7 @@ export default {
           <div class="link-content">
             <t :k="fel.label" />
             <i class="icon icon-external-link pull-right" />
-            <hr role="none">
+            <RcSeparator />
             <div class="description"><t :k="fel.description" /></div>
           </div>
         </a>

--- a/shell/pages/c/_cluster/longhorn/index.vue
+++ b/shell/pages/c/_cluster/longhorn/index.vue
@@ -5,7 +5,7 @@ import IconMessage from '@shell/components/IconMessage';
 import LazyImage from '@shell/components/LazyImage';
 import longhornSvg from '~shell/assets/images/vendor/longhorn.svg';
 import Loading from '@shell/components/Loading';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/shell/pages/c/_cluster/monitoring/index.vue
+++ b/shell/pages/c/_cluster/monitoring/index.vue
@@ -11,13 +11,15 @@ import { canViewAlertManagerLink, canViewGrafanaLink, canViewPrometheusLink } fr
 import Loading from '@shell/components/Loading';
 import grafanaSrc from '~shell/assets/images/vendor/grafana.svg';
 import prometheusSrc from '~shell/assets/images/vendor/prometheus.svg';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export default {
   components: {
     LazyImage,
     SimpleBox,
     AlertTable,
-    Loading
+    Loading,
+    RcSeparator,
   },
 
   async fetch() {
@@ -177,7 +179,7 @@ export default {
                   <i class="icon icon-external-link" />
                 </div>
               </div>
-              <hr role="none">
+              <RcSeparator />
               <div class="description">
                 <span>
                   <t :k="fel.description" />

--- a/shell/pages/c/_cluster/monitoring/index.vue
+++ b/shell/pages/c/_cluster/monitoring/index.vue
@@ -11,7 +11,7 @@ import { canViewAlertManagerLink, canViewGrafanaLink, canViewPrometheusLink } fr
 import Loading from '@shell/components/Loading';
 import grafanaSrc from '~shell/assets/images/vendor/grafana.svg';
 import prometheusSrc from '~shell/assets/images/vendor/prometheus.svg';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/shell/pages/c/_cluster/neuvector/index.vue
+++ b/shell/pages/c/_cluster/neuvector/index.vue
@@ -5,9 +5,14 @@ import { NEU_VECTOR_NAMESPACE } from '@shell/config/product/neuvector';
 import LazyImage from '@shell/components/LazyImage';
 import Loading from '@shell/components/Loading';
 import neuvectorSvg from '~shell/assets/images/vendor/neuvector.svg';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export default {
-  components: { LazyImage, Loading },
+  components: {
+    LazyImage,
+    Loading,
+    RcSeparator,
+  },
 
   data() {
     return {
@@ -66,7 +71,7 @@ export default {
           <div class="link-content">
             <t :k="fel.label" />
             <i class="icon icon-external-link pull-right" />
-            <hr role="none">
+            <RcSeparator />
             <div class="description"><t :k="fel.description" /></div>
           </div>
         </a>

--- a/shell/pages/c/_cluster/neuvector/index.vue
+++ b/shell/pages/c/_cluster/neuvector/index.vue
@@ -5,7 +5,7 @@ import { NEU_VECTOR_NAMESPACE } from '@shell/config/product/neuvector';
 import LazyImage from '@shell/components/LazyImage';
 import Loading from '@shell/components/Loading';
 import neuvectorSvg from '~shell/assets/images/vendor/neuvector.svg';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/shell/pages/fail-whale.vue
+++ b/shell/pages/fail-whale.vue
@@ -9,11 +9,12 @@ import GrowlManager from '@shell/components/GrowlManager';
 import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
 import PromptModal from '@shell/components/PromptModal';
 import { RcButton } from '@components/RcButton';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export default {
 
   components: {
-    BrandImage, FixedBanner, GrowlManager, Header, PromptModal, RcButton
+    BrandImage, FixedBanner, GrowlManager, Header, PromptModal, RcButton, RcSeparator
   },
   mixins: [Brand, BrowserTabVisibility],
 
@@ -117,11 +118,10 @@ export default {
                   {{ t('nav.home') }}
                 </rc-button>
               </p>
-              <hr
+              <RcSeparator
                 class="custom-content"
                 :style="styles"
-                role="none"
-              >
+              />
               <p class="mt-20">
                 <rc-button
                   size="large"

--- a/shell/pages/fail-whale.vue
+++ b/shell/pages/fail-whale.vue
@@ -9,7 +9,7 @@ import GrowlManager from '@shell/components/GrowlManager';
 import BrowserTabVisibility from '@shell/mixins/browser-tab-visibility';
 import PromptModal from '@shell/components/PromptModal';
 import { RcButton } from '@components/RcButton';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
 

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -17,10 +17,11 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { addObject } from '@shell/utils/array';
 import LocaleSelector from '@shell/components/LocaleSelector';
 import TabTitle from '@shell/components/TabTitle';
+import RcSeparator from '@shell/components/RcSeparator';
 
 export default {
   components: {
-    BackLink, ButtonGroup, LabeledSelect, Checkbox, LandingPagePreference, LocaleSelector, TabTitle
+    BackLink, ButtonGroup, LabeledSelect, Checkbox, LandingPagePreference, LocaleSelector, TabTitle, RcSeparator
   },
   mixins: [BackRoute],
   data() {
@@ -225,7 +226,7 @@ export default {
       v-if="!isSingleProduct"
       class="mt-10 mb-10"
     >
-      <hr role="none">
+      <RcSeparator />
       <h4 v-t="'prefs.landing.label'" />
       <LandingPagePreference
         data-testid="prefs__landingPagePreference"
@@ -233,7 +234,7 @@ export default {
     </div>
     <!-- Display Settings -->
     <div class="mt-10 mb-10">
-      <hr role="none">
+      <RcSeparator />
       <h4 v-t="'prefs.displaySettings.title'" />
       <p class="set-landing-leadin">
         {{ t('prefs.displaySettings.detail', {}, raw=true) }}
@@ -277,7 +278,7 @@ export default {
       v-if="!isSingleProduct"
       class="col adv-features mt-10 mb-10"
     >
-      <hr role="none">
+      <RcSeparator />
       <h4 v-t="'prefs.confirmationSetting.title'" />
       <Checkbox
         v-model:value="scalingDownPrompt"
@@ -288,7 +289,7 @@ export default {
     </div>
     <!-- Advanced Features -->
     <div class="col adv-features mt-10 mb-10">
-      <hr role="none">
+      <RcSeparator />
       <h4 v-t="'prefs.advFeatures.title'" />
       <Checkbox
         v-model:value="viewInApi"
@@ -332,7 +333,7 @@ export default {
     </div>
     <!-- YAML editor key mapping -->
     <div class="col mt-10 mb-10">
-      <hr role="none">
+      <RcSeparator />
       <h4 v-t="'prefs.keymap.label'" />
       <ButtonGroup
         v-model:value="keymap"
@@ -345,7 +346,7 @@ export default {
       v-if="!isSingleProduct"
       class="col mt-10 mb-40"
     >
-      <hr role="none">
+      <RcSeparator />
       <h4 v-t="'prefs.helm.label'" />
       <ButtonGroup
         v-model:value="showPreRelease"

--- a/shell/pages/prefs.vue
+++ b/shell/pages/prefs.vue
@@ -17,7 +17,7 @@ import LabeledSelect from '@shell/components/form/LabeledSelect';
 import { addObject } from '@shell/utils/array';
 import LocaleSelector from '@shell/components/LocaleSelector';
 import TabTitle from '@shell/components/TabTitle';
-import RcSeparator from '@shell/components/RcSeparator';
+import { RcSeparator } from '@components/RcSeparator';
 
 export default {
   components: {

--- a/storybook/src/stories/Components/RcSeparator.stories.ts
+++ b/storybook/src/stories/Components/RcSeparator.stories.ts
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import { RcSeparator } from '@components/RcSeparator';
+import type { RcSeparatorOrientation } from '@components/RcSeparator/types';
+
+const meta: Meta<typeof RcSeparator> = {
+  component:  RcSeparator,
+  parameters: {
+    docs: {
+      description: {
+        component: `A thin wrapper around \`<hr>\` that gets its accessibility semantics from props.
+
+By default the separator is decorative: it renders \`role="none"\` so that screen readers skip over it, which is the correct treatment for separators that exist purely to break up content visually.
+
+Set \`decorative\` to \`false\` when the separator conveys meaning (e.g. groups items within a menu or a listbox). When \`decorative\` is \`false\`, RcSeparator renders \`role="separator"\` along with an \`aria-orientation\`.
+
+The component ships no visual styling for horizontal separators; consumers style them, typically with \`border-top: 1px solid var(--border)\`.`,
+      },
+    },
+  },
+  argTypes: {
+    decorative: {
+      control:     { type: 'boolean' },
+      description: 'Purely cosmetic separator that is hidden from the accessibility tree. Defaults to `true`.',
+    },
+    orientation: {
+      options:     ['horizontal', 'vertical'] as RcSeparatorOrientation[],
+      control:     { type: 'select' },
+      description: 'Orientation of the separator. Drives `aria-orientation` when the separator is not decorative.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RcSeparator>;
+
+const decorativeTemplate = `<div style="display: flex; flex-direction: column; gap: 20px; width: 300px;">
+  <p style="margin: 0;">Content above the separator</p>
+  <RcSeparator v-bind="args" style="border-top: 1px solid var(--border);" />
+  <p style="margin: 0;">Content below the separator</p>
+</div>`;
+
+export const Decorative: Story = {
+  render: (args: any) => ({
+    components: { RcSeparator },
+    setup() {
+      return { args };
+    },
+    template: decorativeTemplate,
+  }),
+  args:       { decorative: true, orientation: 'horizontal' },
+  parameters: {
+    docs: {
+      description: { story: 'The default. Renders `role="none"` so the separator is not announced by screen readers.' },
+      canvas:      { sourceState: 'shown' },
+      source:      { code: decorativeTemplate },
+    },
+  },
+};
+
+const semanticTemplate = `<ul role="menu" style="list-style: none; margin: 0; padding: 0; width: 300px;">
+  <li role="menuitem" style="padding: 8px 0;">First group item</li>
+  <RcSeparator :decorative="false" style="border-top: 1px solid var(--border);" />
+  <li role="menuitem" style="padding: 8px 0;">Second group item</li>
+</ul>`;
+
+export const Semantic: Story = {
+  render: () => ({
+    components: { RcSeparator },
+    template:   semanticTemplate,
+  }),
+  parameters: {
+    docs: {
+      description: { story: 'A meaningful separator inside a menu. Renders `role="separator"` and `aria-orientation="horizontal"` so that the grouping is announced.' },
+      canvas:      { sourceState: 'shown' },
+      source:      { code: semanticTemplate },
+    },
+  },
+};
+
+const verticalTemplate = `<div style="display: flex; align-items: center; gap: 20px; height: 40px;">
+  <span>Left</span>
+  <RcSeparator :decorative="false" orientation="vertical" />
+  <span>Right</span>
+</div>`;
+
+export const Vertical: Story = {
+  render: () => ({
+    components: { RcSeparator },
+    template:   verticalTemplate,
+  }),
+  parameters: {
+    docs: {
+      description: { story: 'A vertical separator. The component supplies the geometry for this case, so no additional styling is required.' },
+      canvas:      { sourceState: 'shown' },
+      source:      { code: verticalTemplate },
+    },
+  },
+};


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14140

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Introduce `RcSeparator` component (`shell/components/RcSeparator.vue`) that wraps `<hr role="none">`, hiding decorative separators from the accessibility tree (avoids overhead for screen readers)
- Replace all bare `<hr>` elements across `shell/` and `pkg/` with `<RcSeparator />` — the one exception being `NamespaceFilter.vue` where the separator lives inside a listbox context and correctly uses `<RcDropdownSeparator>` (which keeps `role="separator"`)
- Add a `local-rules/no-hr-element` ESLint rule that prevents bare `<hr>` from being reintroduced; `RcSeparator.vue` and `RcDropdownSeparator.vue` are exempted via ESLint overrides

### Technical notes summary
`RcSeparator` is a thin wrapper around `<hr role="none">`. The `role="none"` attribute removes the element from the accessibility tree so screen readers skip it, which is the correct treatment for purely decorative separators. For separators inside menus or listboxes — where the role is meaningful — `RcDropdownSeparator` (already existing) should be used instead. The ESLint rule uses `eslint-plugin-vue`'s template AST visitor so it catches both single-line and multi-line `<hr>` tags at the linting stage.

### Areas or cases that should be tested
- Visually verify separators still render correctly (same appearance as `<hr>`) across the affected pages listed below
- Verify with a screen reader (VoiceOver / NVDA) that decorative separators are **not** announced
- Verify the namespace filter dropdown separator in the top nav is still announced correctly as a separator by a screen reader
- Auth configuration pages: Azure AD, GitHub, Google OAuth, LDAP, OIDC, SAML
- User preferences page (`/prefs`) and account page
- Cluster pages: Istio, Longhorn, Monitoring, NeuVector, Apps > Charts install flow
- Nav sidebar (top-level menu, group separators, pin section divider)
- Machine config forms: Azure, Harvester
- Fleet application creation and SUSE App Collection credentials pages
- EKS node group form, GKE node pool form
- Harvester manager cluster list page
- `Card` component in rancher-components (storybook)
- Fail-whale error page
- Run `yarn lint` — should exit with zero errors/warnings

### Areas which could experience regressions
- Any page that relied on browser-default `<hr>` styling being applied through element selectors (e.g. `hr { ... }` in global SCSS) — visual styling should be unaffected since `<hr role="none">` still renders as an `<hr>` element
- Components that use `<hr>` inside a menu/listbox context — these were handled case by case, but a missed instance could silently lose the correct `role="separator"` semantic; the new ESLint rule prevents new ones from being added
- Rancher extensions that import `RcSeparator` from the `rancher-components` package

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
