### PR TITLE
Fix empty create token cluster scope selector

### DIFF
--- a/shell/components/form/ResourceLabeledSelect.vue
+++ b/shell/components/form/ResourceLabeledSelect.vue
@@ -32,6 +32,14 @@ export default defineComponent({
       required: true
     },
 
+    /**
+     * Used with @resourceType to determine if pagination is enabled
+     */
+    context: {
+      type:    String,
+      default: null,
+    },
+
     inStore: {
       type:    String,
       default: undefined,

--- a/shell/components/form/labeled-select-utils/useLabeledSelectPagination.ts
+++ b/shell/components/form/labeled-select-utils/useLabeledSelectPagination.ts
@@ -12,6 +12,7 @@ interface LabeledSelectPaginationProps {
   paginate?: LabelSelectPaginateFn | null;
   inStore?: string;
   resourceType?: string | null;
+  context?: string | null;
   options?: Array<any>;
 }
 
@@ -38,6 +39,11 @@ export const labeledSelectPaginationProps = {
     default: 'cluster',
   },
 
+  context: {
+    type:    String,
+    default: null,
+  },
+
   /**
    * Resource to show
   */
@@ -62,7 +68,7 @@ export const useLabeledSelectPagination = (props: LabeledSelectPaginationProps):
   const paginating = ref(false);
 
   const canPaginate = computed(() => {
-    return !!props.paginate && !!props.resourceType && store.getters[`${ props.inStore }/paginationEnabled`](props.resourceType);
+    return !!props.paginate && !!props.resourceType && store.getters[`${ props.inStore }/paginationEnabled`]({ id: props.resourceType, context: props.context });
   });
 
   const _options = computed(() => canPaginate.value ? page.value : (props.options || []));

--- a/shell/edit/__tests__/token.test.ts
+++ b/shell/edit/__tests__/token.test.ts
@@ -1,0 +1,216 @@
+import { shallowMount } from '@vue/test-utils';
+import Token from '@shell/edit/token.vue';
+import { SETTING } from '@shell/config/settings';
+import { PaginationParamFilter } from '@shell/types/store/pagination.types';
+import { CAPI } from '@shell/config/labels-annotations';
+import { VIRTUAL_HARVESTER_PROVIDER } from '@shell/config/types';
+import { LABEL_SELECT_KINDS } from '@shell/types/components/labeledSelect';
+
+// DetailText -> CopyToClipboard pulls in the ESM-only clipboard-polyfill, which jest can't transform
+jest.mock('@shell/utils/clipboard', () => {
+  return { copyTextToClipboard: jest.fn(() => Promise.resolve({})) };
+});
+
+interface StoreOptions {
+  hideLocal?: boolean;
+  maxTTL?: string;
+}
+
+const makeStore = ({ hideLocal = false, maxTTL = '0' }: StoreOptions = {}) => ({
+  getters: {
+    'i18n/t':          (k: string) => k,
+    currentStore:      () => 'management',
+    'features/get':    () => false, // Treat harvester container workloads as disabled
+    'management/byId': (_type: string, id: string) => {
+      if (id === SETTING.AUTH_TOKEN_MAX_TTL_MINUTES) {
+        return { value: maxTTL };
+      }
+      if (id === SETTING.HIDE_LOCAL_CLUSTER) {
+        return { value: `${ hideLocal }` };
+      }
+
+      return undefined;
+    },
+  },
+  dispatch: jest.fn(),
+});
+
+const mountToken = (value: any = {}, storeOptions?: StoreOptions) => shallowMount(Token, {
+  props:  { value: { type: 'management.cattle.io.token', ...value }, mode: 'create' },
+  global: {
+    mocks: {
+      $fetchState: { pending: false },
+      $route:      { name: 'account', query: {} },
+      $store:      makeStore(storeOptions),
+    },
+  },
+});
+
+describe('view: token.vue', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('noScopeOption', () => {
+    it('uses a truthy sentinel value so vue-select can render it as selected', () => {
+      const { noScopeOption } = mountToken().vm;
+
+      // vue-select treats '' as "nothing selected", so the sentinel must not be an empty string
+      expect(noScopeOption.value).not.toStrictEqual('');
+      expect(!!noScopeOption.value).toStrictEqual(true);
+      expect(noScopeOption.kind).toStrictEqual(LABEL_SELECT_KINDS.NONE);
+      expect(noScopeOption.label).toStrictEqual('accountAndKeys.apiKeys.add.noScope');
+    });
+  });
+
+  describe('clusterScope', () => {
+    it('reports "no scope" when clusterId is unset', () => {
+      const wrapper = mountToken();
+
+      expect(wrapper.vm.clusterScope).toStrictEqual(wrapper.vm.noScopeOption.value);
+    });
+
+    it('reports "no scope" when clusterId is an empty string', () => {
+      const wrapper = mountToken({ clusterId: '' });
+
+      expect(wrapper.vm.clusterScope).toStrictEqual(wrapper.vm.noScopeOption.value);
+    });
+
+    it('reports the cluster id when one is selected', () => {
+      const wrapper = mountToken({ clusterId: 'c-abc' });
+
+      expect(wrapper.vm.clusterScope).toStrictEqual('c-abc');
+    });
+
+    it('stores an empty string when "no scope" is selected', () => {
+      const wrapper = mountToken({ clusterId: 'c-abc' });
+
+      wrapper.vm.clusterScope = wrapper.vm.noScopeOption.value;
+
+      expect(wrapper.vm.value.clusterId).toStrictEqual('');
+    });
+
+    it('stores the cluster id when a cluster is selected', () => {
+      const wrapper = mountToken();
+
+      wrapper.vm.clusterScope = 'c-xyz';
+
+      expect(wrapper.vm.value.clusterId).toStrictEqual('c-xyz');
+    });
+  });
+
+  describe('scopeAllSettings (pagination off)', () => {
+    it('maps and sorts clusters by label, prepending "no scope"', () => {
+      const wrapper = mountToken();
+      const { updateResources } = wrapper.vm.scopeAllSettings;
+
+      const result = updateResources([
+        { id: 'c-b', nameDisplay: 'Beta' },
+        { id: 'c-a', nameDisplay: 'Alpha' },
+      ]);
+
+      expect(result[0]).toStrictEqual(wrapper.vm.noScopeOption);
+      expect(result.slice(1)).toStrictEqual([
+        { value: 'c-a', label: 'Alpha' },
+        { value: 'c-b', label: 'Beta' },
+      ]);
+    });
+
+    it('filters out harvester clusters', () => {
+      const wrapper = mountToken();
+      const { updateResources } = wrapper.vm.scopeAllSettings;
+
+      const result = updateResources([
+        { id: 'c-n', nameDisplay: 'Normal' },
+        {
+          id: 'c-h', nameDisplay: 'Harvester', metadata: { labels: { [CAPI.PROVIDER]: VIRTUAL_HARVESTER_PROVIDER } }
+        },
+      ]);
+
+      expect(result.map((o: any) => o.value)).not.toContain('c-h');
+      expect(result.map((o: any) => o.value)).toContain('c-n');
+    });
+
+    it('filters out the local cluster when hide-local is enabled', () => {
+      const wrapper = mountToken({}, { hideLocal: true });
+      const { updateResources } = wrapper.vm.scopeAllSettings;
+
+      const result = updateResources([
+        {
+          id: 'local', nameDisplay: 'local', isLocal: true
+        },
+        { id: 'c-1', nameDisplay: 'One' },
+      ]);
+
+      expect(result.map((o: any) => o.value)).not.toContain('local');
+      expect(result.map((o: any) => o.value)).toContain('c-1');
+    });
+  });
+
+  describe('scopePaginatedSettings (pagination on)', () => {
+    it('maps raw clusters via spec.displayName, prepending "no scope"', () => {
+      const wrapper = mountToken();
+      const { updateResources } = wrapper.vm.scopePaginatedSettings;
+
+      const result = updateResources([{ id: 'c-1', spec: { displayName: 'One' } }]);
+
+      expect(result[0]).toStrictEqual(wrapper.vm.noScopeOption);
+      expect(result[1]).toStrictEqual({ value: 'c-1', label: 'One' });
+    });
+
+    it('falls back to the cluster id when a display name is missing', () => {
+      const wrapper = mountToken();
+      const { updateResources } = wrapper.vm.scopePaginatedSettings;
+
+      const result = updateResources([
+        { id: 'c-2', spec: {} },
+        { id: 'c-3' },
+      ]);
+
+      expect(result).toContainEqual({ value: 'c-2', label: 'c-2' });
+      expect(result).toContainEqual({ value: 'c-3', label: 'c-3' });
+    });
+
+    it('is idempotent across accumulated pages (no duplicate "no scope", keeps already-mapped options)', () => {
+      const wrapper = mountToken();
+      const { noScopeOption } = wrapper.vm;
+      const { updateResources } = wrapper.vm.scopePaginatedSettings;
+
+      // Mimics a "load more": the previous (already transformed) page is passed back in, concatenated with new raw results
+      const result = updateResources([
+        noScopeOption,
+        { value: 'c-1', label: 'One' },
+        { id: 'c-2', spec: { displayName: 'Two' } },
+      ]);
+
+      expect(result.filter((o: any) => o.value === noScopeOption.value)).toHaveLength(1);
+      expect(result[0]).toStrictEqual(noScopeOption);
+      expect(result).toContainEqual({ value: 'c-1', label: 'One' });
+      expect(result).toContainEqual({ value: 'c-2', label: 'Two' });
+    });
+
+    it('applies the cluster scope filters, disables namespace grouping and sorts by display name', () => {
+      const wrapper = mountToken();
+      const { requestSettings } = wrapper.vm.scopePaginatedSettings;
+
+      const result = requestSettings({ opts: { filter: '' } });
+
+      expect(result.groupByNamespace).toStrictEqual(false);
+      expect(result.sort).toStrictEqual([{ asc: true, field: 'spec.displayName' }]);
+      // paginationFilterClusters contributes the two harvester-exclusion filters (hide-local is off)
+      expect(result.filters).toHaveLength(2);
+    });
+
+    it('adds a display-name search filter when the user types', () => {
+      const wrapper = mountToken();
+      const { requestSettings } = wrapper.vm.scopePaginatedSettings;
+      const createSingleField = jest.spyOn(PaginationParamFilter, 'createSingleField');
+
+      const result = requestSettings({ opts: { filter: 'prod' } });
+
+      expect(createSingleField).toHaveBeenCalledWith({
+        field: 'spec.displayName', value: 'prod', exact: false
+      });
+      // search filter + the two harvester-exclusion filters
+      expect(result.filters).toHaveLength(3);
+    });
+  });
+});

--- a/shell/edit/token.vue
+++ b/shell/edit/token.vue
@@ -7,13 +7,26 @@ import { Banner } from '@components/Banner';
 import DetailText from '@shell/components/DetailText';
 import Footer from '@shell/components/form/Footer';
 import { LabeledInput } from '@components/Form/LabeledInput';
-import LabeledSelect from '@shell/components/form/LabeledSelect';
+import ResourceLabeledSelect from '@shell/components/form/ResourceLabeledSelect.vue';
 import { RadioGroup } from '@components/Form/Radio';
 import Select from '@shell/components/form/Select';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import { diffFrom } from '@shell/utils/time';
-import { filterHiddenLocalCluster, filterOnlyKubernetesClusters } from '@shell/utils/cluster';
+import { PaginationParamFilter } from '@shell/types/store/pagination.types';
+import {
+  filterHiddenLocalCluster,
+  filterOnlyKubernetesClusters,
+  paginationFilterClusters
+} from '@shell/utils/cluster';
 import { SETTING } from '@shell/config/settings';
+import { STORE } from '@shell/store/store-types';
+import { LABEL_SELECT_KINDS } from '@shell/types/components/labeledSelect';
+
+// Sentinel value for the "no scope" option. vue-select treats an empty string as
+// "nothing selected" (see its `selectedValue` computed), so an option whose value is ''
+// can never be rendered as the selected one. We use a truthy sentinel in the dropdown and
+// map it back to '' when reading/writing value.clusterId (see the `clusterScope` computed).
+const NO_SCOPE = '__no_scope__';
 
 export default {
   components: {
@@ -21,7 +34,7 @@ export default {
     DetailText,
     Footer,
     LabeledInput,
-    LabeledSelect,
+    ResourceLabeledSelect,
     RadioGroup,
     Select,
   },
@@ -46,25 +59,89 @@ export default {
         customExpiry:      0,
         customExpiryUnits: 'minute',
       },
-      created:    null,
-      ttlLimited: false,
-      accessKey:  '',
-      secretKey:  '',
+      created:            null,
+      ttlLimited:         false,
+      accessKey:          '',
+      secretKey:          '',
       maxTTL,
+      MANAGEMENT_CLUSTER: MANAGEMENT.CLUSTER,
+      noScopeOption:      {
+        value: NO_SCOPE, label: this.$store.getters['i18n/t']('accountAndKeys.apiKeys.add.noScope'), kind: LABEL_SELECT_KINDS.NONE
+      },
+      MANAGEMENT_STORE: STORE.MANAGEMENT
     };
   },
 
   computed: {
     ...mapGetters({ t: 'i18n/t' }),
-    scopes() {
-      const all = this.$store.getters['management/all'](MANAGEMENT.CLUSTER);
-      const kubeClusters = filterHiddenLocalCluster(filterOnlyKubernetesClusters(all, this.$store), this.$store);
-      let out = kubeClusters.map((opt) => ({ value: opt.id, label: opt.nameDisplay }));
 
-      out = sortBy(out, ['label']);
-      out.unshift( { value: '', label: this.t('accountAndKeys.apiKeys.add.noScope') } );
+    /**
+     * Proxy between the scope dropdown and value.clusterId. The dropdown uses a truthy
+     * sentinel for "no scope" (see NO_SCOPE) but the token stores '' for that case.
+     */
+    clusterScope: {
+      get() {
+        return this.value.clusterId || NO_SCOPE;
+      },
+      set(neu) {
+        this.value.clusterId = neu === NO_SCOPE ? '' : neu;
+      },
+    },
 
-      return out;
+    /**
+     * ResourceLabeledSelect settings used when pagination is OFF: everything is fetched up front,
+     * so filter & map the clusters client-side (as before) and inject the "no scope" option.
+     */
+    scopeAllSettings() {
+      return {
+        updateResources: (clusters) => {
+          const filtered = filterHiddenLocalCluster(filterOnlyKubernetesClusters(clusters, this.$store), this.$store);
+          const mapped = sortBy(filtered.map((c) => ({ value: c.id, label: c.nameDisplay })), ['label']);
+
+          mapped.unshift(this.noScopeOption);
+
+          return mapped;
+        },
+      };
+    },
+
+    /**
+     * ResourceLabeledSelect settings used when pagination is ON: filter the clusters server-side
+     * and inject the "no scope" option into each page.
+     */
+    scopePaginatedSettings() {
+      const store = this.$store;
+
+      return {
+        updateResources: (clusters) => {
+          const mapped = clusters
+            // updateResources runs over the accumulated pages, so drop any previously injected "no scope"...
+            .filter((c) => c.value !== NO_SCOPE)
+            // Paginated results are transient raw JSON (not model instances), so read spec.displayName directly.
+            .map((c) => (c.value !== undefined ? c : { value: c.id, label: c.spec?.displayName || c.id }));
+
+          mapped.unshift(this.noScopeOption);
+
+          return mapped;
+        },
+        requestSettings: (opts) => {
+          const { filter } = opts.opts;
+
+          // User's search text - mgmt clusters display by spec.displayName, not metadata.name
+          const filters = filter ? [PaginationParamFilter.createSingleField({
+            field: 'spec.displayName', value: filter, exact: false
+          })] : [];
+
+          // Server-side equivalent of the old filterOnlyKubernetesClusters + filterHiddenLocalCluster
+          filters.push(...paginationFilterClusters(store));
+
+          opts.filters = filters;
+          opts.groupByNamespace = false;
+          opts.sort = [{ asc: true, field: 'spec.displayName' }];
+
+          return opts;
+        },
+      };
     },
 
     expiryOptions() {
@@ -185,11 +262,15 @@ export default {
         :min-height="30"
       />
 
-      <LabeledSelect
-        v-model:value="value.clusterId"
+      <ResourceLabeledSelect
+        v-model:value="clusterScope"
         class="mt-20 scope-select"
         label-key="accountAndKeys.apiKeys.add.scope"
-        :options="scopes"
+        :resource-type="MANAGEMENT_CLUSTER"
+        :in-store="MANAGEMENT_STORE"
+        context="token"
+        :all-resources-settings="scopeAllSettings"
+        :paginated-resource-settings="scopePaginatedSettings"
       />
 
       <h5 class="pt-20">

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -779,7 +779,7 @@ export const PAGINATION_SETTINGS_STORE_DEFAULTS: PaginationSettingsStores = {
       enableSome: {
         enabled: [
           { resource: CAPI.RANCHER_CLUSTER, context: ['side-bar', 'home', 'cluster-management'] },
-          { resource: MANAGEMENT.CLUSTER, context: ['side-bar', 'home', 'cluster-management'] },
+          { resource: MANAGEMENT.CLUSTER, context: ['side-bar', 'home', 'cluster-management', 'token'] },
           { resource: CATALOG.APP, context: ['branding'] },
           SECRET
         ],


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/16708
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- previously there were scenarios where not all clusters were shown (see issue)
- this also relied on fetching all clusters. given the 2.15 push to help scale these we now use a control that will paginate the options

### Technical notes summary
- had to introduce the `context` to the component which is used to selectively enable SSP for a resource type

### Areas or cases that should be tested
- user avatar --> Account and API Keys --> Create API Key
- default scope should be 'no scope'
- clicking on the scope should show first 10 clusters. if there are more than 10 a load more should show

### Screenshot/Video
<img width="969" height="564" alt="image" src="https://github.com/user-attachments/assets/634baaa6-eef0-4208-a9e6-46028cc317de" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
