### PR TITLE
Added a daily sweep and automatically added on PR creation

### DIFF
--- a/.github/workflows/dependabot-milestone.yaml
+++ b/.github/workflows/dependabot-milestone.yaml
@@ -1,0 +1,66 @@
+name: Dependabot Milestone
+
+# Automatically assigns the branch-derived milestone (see branches-metadata.json,
+# resolved via scripts/get-branch-metadata.sh) to Dependabot pull requests so they
+# satisfy the milestone validation performed by valid-pr.yaml / pr-check-milestone.sh.
+#
+# - pull_request_target: assigns the milestone as soon as a Dependabot PR opens.
+#   This trigger is used (instead of pull_request) because Dependabot's
+#   pull_request token is read-only and cannot set a milestone. No PR code is
+#   checked out or executed, only the trusted script from the base branch runs.
+# - schedule / workflow_dispatch: sweeps every open Dependabot PR as a safety net.
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  schedule:
+    # Daily at 06:00 UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+# Restrictive baseline permissions for all jobs
+permissions:
+  contents: read
+
+jobs:
+  assign-on-open:
+    name: Assign milestone on Dependabot PR open
+    if: >-
+      github.repository_owner == 'rancher' &&
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Assign milestone
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODE: event
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          # Read the checked-out branches-metadata.json (no network dependency)
+          METADATA_LOCAL: 'true'
+        run: ./.github/workflows/scripts/dependabot-milestone.sh
+
+  sweep-open-prs:
+    name: Sweep open Dependabot PRs
+    if: >-
+      github.repository_owner == 'rancher' &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Sweep and assign milestones
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODE: sweep
+          # Read the checked-out branches-metadata.json (no network dependency)
+          METADATA_LOCAL: 'true'
+        run: ./.github/workflows/scripts/dependabot-milestone.sh

--- a/.github/workflows/dependabot-milestone.yaml
+++ b/.github/workflows/dependabot-milestone.yaml
@@ -41,8 +41,6 @@ jobs:
           MODE: event
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-          # Read the checked-out branches-metadata.json (no network dependency)
-          METADATA_LOCAL: 'true'
         run: ./.github/workflows/scripts/dependabot-milestone.sh
 
   sweep-open-prs:
@@ -61,6 +59,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MODE: sweep
-          # Read the checked-out branches-metadata.json (no network dependency)
-          METADATA_LOCAL: 'true'
         run: ./.github/workflows/scripts/dependabot-milestone.sh

--- a/.github/workflows/scripts/dependabot-milestone.sh
+++ b/.github/workflows/scripts/dependabot-milestone.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-# Assigns the branch-derived milestone to Dependabot pull requests.
+# Sets up Dependabot pull requests: assigns the branch-derived milestone and
+# adds the auto-retry label so flaky test runs get retried automatically.
 #
 # The milestone for a PR is derived from its base branch using the canonical
 # helper `scripts/get-branch-metadata.sh` (which reads branches-metadata.json).
@@ -9,11 +10,12 @@ set -eo pipefail
 # the milestone here lets Dependabot PRs pass that check automatically.
 #
 # Modes (via the MODE environment variable):
-#   event (default) - assign the milestone to the single PR given by PR_NUMBER
-#                     (base branch BASE_REF), read from the workflow event.
-#   sweep           - assign the milestone to every open Dependabot PR.
+#   event (default) - process the single PR given by PR_NUMBER (base BASE_REF),
+#                     read from the workflow event.
+#   sweep           - process every open Dependabot PR.
 #
-# The branch-derived milestone is always (re)applied to the target open PR(s).
+# The branch-derived milestone and the retry label are always (re)applied to the
+# target open PR(s).
 #
 # Environment:
 #   GH_TOKEN            - token with pull-requests:write (required, used by gh)
@@ -22,12 +24,15 @@ set -eo pipefail
 #   PR_NUMBER, BASE_REF - required in event mode
 #   METADATA_LOCAL      - when 'true', read the checked-out branches-metadata.json
 #                         instead of fetching it from the master branch
+#   RETRY_LABEL         - label added to trigger auto-retry (default bot/auto-retry/10)
 
 # Configuration (all overridable via the environment; defaults suit local runs)
 GITHUB_REPOSITORY=${GITHUB_REPOSITORY:-rancher/dashboard}
 MODE=${MODE:-event}
 # GitHub search/author handle for the Dependabot app (used to filter PRs)
 DEPENDABOT_AUTHOR="app/dependabot"
+# Label that tells the auto-retry workflow how many times to retry failed tests
+RETRY_LABEL=${RETRY_LABEL:-bot/auto-retry/10}
 
 # By default get-branch-metadata.sh fetches the metadata from the master branch;
 # '--local' makes it read the checked-out branches-metadata.json instead.
@@ -72,6 +77,16 @@ assign_milestone() {
   gh pr edit "$number" --repo "$GITHUB_REPOSITORY" --milestone "$version"
 }
 
+# Add the auto-retry label to a PR so failed test runs get retried automatically.
+# Non-fatal: a missing label (e.g. on a fork) warns but does not fail the run.
+add_retry_label() {
+  local number="$1"
+
+  echo "  PR #${number}: adding label '${RETRY_LABEL}'"
+  gh pr edit "$number" --repo "$GITHUB_REPOSITORY" --add-label "$RETRY_LABEL" ||
+    echo "  ⚠️  PR #${number}: could not add label '${RETRY_LABEL}' (does it exist in the repo?), continuing"
+}
+
 if [ "$MODE" = "sweep" ]; then
   # Safety-net path: find every open Dependabot PR and (re)apply its milestone.
   echo "Sweeping all open Dependabot pull requests in ${GITHUB_REPOSITORY}..."
@@ -91,6 +106,7 @@ if [ "$MODE" = "sweep" ]; then
       echo "  ⚠️  PR #${number}: failed to set milestone, continuing"
       failed=1
     }
+    add_retry_label "$number"
   done <<< "$pr_list"
 
   if [ "$failed" != "0" ]; then
@@ -106,4 +122,5 @@ else
 
   echo "Processing Dependabot PR #${PR_NUMBER} (base branch '${BASE_REF}')"
   assign_milestone "$PR_NUMBER" "$BASE_REF"
+  add_retry_label "$PR_NUMBER"
 fi

--- a/.github/workflows/scripts/dependabot-milestone.sh
+++ b/.github/workflows/scripts/dependabot-milestone.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Assigns the branch-derived milestone to Dependabot pull requests.
+#
+# The milestone for a PR is derived from its base branch using the canonical
+# helper `scripts/get-branch-metadata.sh` (which reads branches-metadata.json).
+# This mirrors the validation performed by `pr-check-milestone.sh`, so assigning
+# the milestone here lets Dependabot PRs pass that check automatically.
+#
+# Modes (via the MODE environment variable):
+#   event (default) - assign the milestone to the single PR given by PR_NUMBER
+#                     (base branch BASE_REF), read from the workflow event.
+#   sweep           - assign the milestone to every open Dependabot PR.
+#
+# The branch-derived milestone is always (re)applied to the target open PR(s).
+#
+# Environment:
+#   GH_TOKEN            - token with pull-requests:write (required, used by gh)
+#   GITHUB_REPOSITORY   - 'owner/repo' (provided by the Actions runner)
+#   MODE                - 'event' or 'sweep' (default 'event')
+#   PR_NUMBER, BASE_REF - required in event mode
+#   METADATA_LOCAL      - when 'true', read the checked-out branches-metadata.json
+#                         instead of fetching it from the master branch
+
+# Configuration (all overridable via the environment; defaults suit local runs)
+GITHUB_REPOSITORY=${GITHUB_REPOSITORY:-rancher/dashboard}
+MODE=${MODE:-event}
+# GitHub search/author handle for the Dependabot app (used to filter PRs)
+DEPENDABOT_AUTHOR="app/dependabot"
+
+# By default get-branch-metadata.sh fetches the metadata from the master branch;
+# '--local' makes it read the checked-out branches-metadata.json instead.
+METADATA_FLAG=""
+if [ "$METADATA_LOCAL" = "true" ]; then
+  METADATA_FLAG="--local"
+fi
+
+# Resolve the milestone version for a branch via the canonical helper.
+# Echoes the version (empty if the branch has no milestone / is unknown).
+milestone_for_branch() {
+  local branch="$1"
+  local data version
+
+  # The helper exits non-zero for an unknown branch; treat that as "no milestone"
+  if data=$(./scripts/get-branch-metadata.sh $METADATA_FLAG "$branch" 2>/dev/null); then
+    # Metadata found - pull the milestone version out of the JSON
+    version=$(echo "$data" | jq -r '.milestone.version // ""')
+  else
+    version=""
+  fi
+
+  echo "$version"
+}
+
+# Assign the branch-derived milestone to a single PR
+assign_milestone() {
+  local number="$1"
+  local branch="$2"
+  local version
+
+  version=$(milestone_for_branch "$branch")
+
+  # A branch with no configured milestone (e.g. a feature branch) is skipped
+  if [ -z "$version" ]; then
+    echo "  PR #${number}: no milestone found for base branch '${branch}', skipping"
+    return 0
+  fi
+
+  # '--milestone' takes the milestone title; re-applying the same one is a no-op
+  echo "  PR #${number}: setting milestone to '${version}' (base branch '${branch}')"
+  gh pr edit "$number" --repo "$GITHUB_REPOSITORY" --milestone "$version"
+}
+
+if [ "$MODE" = "sweep" ]; then
+  # Safety-net path: find every open Dependabot PR and (re)apply its milestone.
+  echo "Sweeping all open Dependabot pull requests in ${GITHUB_REPOSITORY}..."
+
+  # Fetch the list up front. Under 'set -e' a failure here (auth / API error)
+  # aborts the job loudly instead of being silently swallowed by a pipeline.
+  pr_list=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --author "$DEPENDABOT_AUTHOR" \
+    --limit 200 --json number,baseRefName --jq '.[] | [.number, .baseRefName] | @tsv')
+
+  # Process each PR ("<number>\t<baseBranch>"). Keep going past a single PR's
+  # failure so one bad PR can't stop the rest of the sweep; report at the end.
+  failed=0
+  while IFS=$'\t' read -r number branch; do
+    [ -z "$number" ] && continue
+    echo "Processing Dependabot PR #${number}"
+    assign_milestone "$number" "$branch" || {
+      echo "  ⚠️  PR #${number}: failed to set milestone, continuing"
+      failed=1
+    }
+  done <<< "$pr_list"
+
+  if [ "$failed" != "0" ]; then
+    echo "❌ One or more Dependabot PRs could not be updated" >&2
+    exit 1
+  fi
+else
+  # Event path: assign the milestone to the one PR from the triggering event.
+  if [ -z "$PR_NUMBER" ] || [ -z "$BASE_REF" ]; then
+    echo "❌ PR_NUMBER and BASE_REF must be set in event mode" >&2
+    exit 1
+  fi
+
+  echo "Processing Dependabot PR #${PR_NUMBER} (base branch '${BASE_REF}')"
+  assign_milestone "$PR_NUMBER" "$BASE_REF"
+fi

--- a/.github/workflows/scripts/dependabot-milestone.sh
+++ b/.github/workflows/scripts/dependabot-milestone.sh
@@ -22,10 +22,6 @@ set -eo pipefail
 #   GITHUB_REPOSITORY   - 'owner/repo' (provided by the Actions runner)
 #   MODE                - 'event' or 'sweep' (default 'event')
 #   PR_NUMBER, BASE_REF - required in event mode
-#   METADATA_LOCAL      - when 'true', read the checked-out branches-metadata.json
-#                         instead of the canonical copy in master. Only for local
-#                         development of a change to branches-metadata.json itself;
-#                         the workflow deliberately leaves this unset.
 #   RETRY_LABEL         - label added to trigger auto-retry (default bot/auto-retry/10)
 
 # Configuration (all overridable via the environment; defaults suit local runs)
@@ -36,22 +32,15 @@ DEPENDABOT_AUTHOR="app/dependabot"
 # Label that tells the auto-retry workflow how many times to retry failed tests
 RETRY_LABEL=${RETRY_LABEL:-bot/auto-retry/10}
 
-# get-branch-metadata.sh reads the canonical branches-metadata.json from master, which is
-# the only copy we maintain — a release branch's checked-out copy can be stale. '--local'
-# is an opt-in escape hatch for developing a change to that file itself.
-METADATA_FLAG=""
-if [ "$METADATA_LOCAL" = "true" ]; then
-  METADATA_FLAG="--local"
-fi
-
 # Resolve the milestone version for a branch via the canonical helper.
 # Echoes the version (empty if the branch has no milestone / is unknown).
 milestone_for_branch() {
   local branch="$1"
   local data version
 
-  # The helper exits non-zero for an unknown branch; treat that as "no milestone"
-  if data=$(./scripts/get-branch-metadata.sh $METADATA_FLAG "$branch" 2>/dev/null); then
+  # The helper reads the canonical branches-metadata.json from master (the only copy we
+  # maintain). It exits non-zero for an unknown branch; treat that as "no milestone".
+  if data=$(./scripts/get-branch-metadata.sh "$branch" 2>/dev/null); then
     # Metadata found - pull the milestone version out of the JSON
     version=$(echo "$data" | jq -r '.milestone.version // ""')
   else

--- a/.github/workflows/scripts/dependabot-milestone.sh
+++ b/.github/workflows/scripts/dependabot-milestone.sh
@@ -23,7 +23,9 @@ set -eo pipefail
 #   MODE                - 'event' or 'sweep' (default 'event')
 #   PR_NUMBER, BASE_REF - required in event mode
 #   METADATA_LOCAL      - when 'true', read the checked-out branches-metadata.json
-#                         instead of fetching it from the master branch
+#                         instead of the canonical copy in master. Only for local
+#                         development of a change to branches-metadata.json itself;
+#                         the workflow deliberately leaves this unset.
 #   RETRY_LABEL         - label added to trigger auto-retry (default bot/auto-retry/10)
 
 # Configuration (all overridable via the environment; defaults suit local runs)
@@ -34,8 +36,9 @@ DEPENDABOT_AUTHOR="app/dependabot"
 # Label that tells the auto-retry workflow how many times to retry failed tests
 RETRY_LABEL=${RETRY_LABEL:-bot/auto-retry/10}
 
-# By default get-branch-metadata.sh fetches the metadata from the master branch;
-# '--local' makes it read the checked-out branches-metadata.json instead.
+# get-branch-metadata.sh reads the canonical branches-metadata.json from master, which is
+# the only copy we maintain — a release branch's checked-out copy can be stale. '--local'
+# is an opt-in escape hatch for developing a change to that file itself.
 METADATA_FLAG=""
 if [ "$METADATA_LOCAL" = "true" ]; then
   METADATA_FLAG="--local"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18449

Adds a GitHub Action that automatically sets the correct milestone on Dependabot PRs (and adds the auto-retry label), so they don't sit around failing the milestone check.

### Occurred changes and/or fixed issues
- New workflow `dependabot-milestone.yaml` plus the `dependabot-milestone.sh` script it runs.
- It runs in two ways:
  - As soon as a Dependabot PR is opened/reopened.
  - A daily sweep (and a manual run) over all open Dependabot PRs, as a safety net for any that were missed.
- For each Dependabot PR it:
  - Sets the milestone from the PR's base branch using the existing `scripts/get-branch-metadata.sh` (e.g. `master` -> v2.16.0, `release-2.14` -> v2.14.4).
  - Adds the `bot/auto-retry/10` label so failed test runs get retried automatically.

### Technical notes summary
- The on-open job uses `pull_request_target` because Dependabot's own token is read-only and can't set a milestone.
- Sets the milestone with `gh pr edit --milestone`, so no manual milestone-number lookup.
- Reads the checked-out `branches-metadata.json` (`METADATA_LOCAL`) instead of fetching it over the network.
- The sweep keeps going if a single PR fails (and reports at the end), and fails loudly if the PR list can't be fetched.
- The milestone is always (re)applied, so if the branch metadata changes the daily sweep moves open PRs to the new version.
- Adding the label is non-fatal - if the label doesn't exist it just warns and carries on.

### Areas or cases that should be tested
- Open a Dependabot PR against `master` -> it gets `v2.16.0` and the `bot/auto-retry/10` label.
- Trigger the sweep manually (`workflow_dispatch`) -> open Dependabot PRs get their milestone and label.
- A PR against a branch not in `branches-metadata.json` -> milestone skipped, no error (label still added).

### Areas which could experience regressions
- None expected. Only adds new files under `.github/`, no app/shell code is touched.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
