### PR TITLE
Bump follow-redirects from 1.15.2 to 1.16.0 in /shell

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -137,7 +137,7 @@
     "uuid": "11.1.1",
     "d3-color": "3.1.0",
     "ejs": "3.1.9",
-    "follow-redirects": "1.15.2",
+    "follow-redirects": "1.16.0",
     "glob": "7.2.3",
     "glob-parent": "6.0.2",
     "js-cookie": "3.0.7",

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -7043,10 +7043,10 @@ focus-trap@7.6.5:
   dependencies:
     tabbable "^6.2.0"
 
-follow-redirects@1.15.2, follow-redirects@^1.0.0, follow-redirects@^1.16.0:
-  version "1.15.2"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
-  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+follow-redirects@1.16.0, follow-redirects@^1.0.0, follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"


### PR DESCRIPTION
### Summary
Bumps [follow-redirects](https://github.com/follow-redirects/follow-redirects) from `1.15.2` to `1.16.0` to resolve 3 security advisories.

### Occurred changes and/or fixed issues
Updates the `follow-redirects` `resolutions` pin in `shell/package.json` from `1.15.2` to `1.16.0` (plus the corresponding `yarn.lock`). `follow-redirects` is pulled in transitively via `axios`; the previous `1.15.2` pin was both vulnerable and in violation of axios's own `^1.16.0` requirement.

Resolves:
- GHSA-r4q5-vmmm-2653
- GHSA-jchw-25xp-jwwc (CVE-2023-26159)
- GHSA-cxjh-pqwp-8mfp (CVE-2024-28849)

### Technical notes summary
`follow-redirects` is a transitive dependency of `axios@1.18.0`. The `shell` workspace pinned it to `1.15.2` via `resolutions`; bumping the pin to `1.16.0` clears all three advisories and brings the tree back into compliance with axios's `^1.16.0` requirement. No source changes — dependency resolution only.

### Areas or cases that should be tested
The axios/HTTP request pipeline: authentication, live cluster resource `GET`s, and resource create round-trips. Verified via Playwright against a live cluster (see Screenshot/Video).

### Areas which could experience regressions
Any feature routed through `axios` (Steve/Norman stores, the auth handshake, and all backend API calls).

### Screenshot/Video

Verification recording (Playwright):

https://github.com/user-attachments/assets/b70f7168-b684-4e23-b309-10f4737a4c1f

**Playwright checks performed** (video recorded, 1280×800):
1. **Login / auth request pipeline** — logged in with the Local User provider; reached `/dashboard/home` with the global nav ("Cluster Management" present). The auth handshake runs through the axios/HTTP pipeline. ✅ PASS — landed on the home dashboard, fully authenticated.
2. **Live cluster resource list (HTTP GET)** — opened ConfigMaps in the `local` cluster explorer. The proxied Steve API returned real data and the table rendered 100 live rows with no error masthead. ✅ PASS — 100 real ConfigMaps listed from the live cluster.
3. **Create round-trip (HTTP POST)** — created a ConfigMap (`fr-verify-…`, namespace `default`) with a description via the form; the POST succeeded and a fresh reload of the resource's edit view returned the persisted name and description. ✅ PASS — resource POSTed and re-fetched intact (test object deleted afterward).
4. **Detail / YAML view (HTTP GET round-trip)** — opened the newly created ConfigMap's detail view; the GET round-trip rendered its name and stored content (not a not-found page). ✅ PASS — load-after-store round-trip rendered correctly.

**Verdict:** **4/4 checks passed.** The `follow-redirects` 1.15.2 → 1.16.0 bump compiles cleanly (full dashboard preview built green) and the axios-backed HTTP pipeline — auth, live resource GETs, and a create round-trip — works unchanged against the live cluster. Fix is safe; ready to open the PR.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Locks Dependabot alerts: #707, #256, #253

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.