### PR TITLE
update Group component to prevent occurences of nested-interactive violations with a11y

### DIFF
--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -260,19 +260,6 @@ export default {
         v-if="showHeader"
         class="header"
         :class="{'active': highlightRoute && isOverview, 'noHover': !canCollapse || fixedOpen}"
-        role="button"
-        :tabindex="fixedOpen ? -1 : 0"
-        :aria-label="group.labelDisplay || group.label || ''"
-        :aria-expanded="!canCollapse || isExpanded"
-        :aria-controls="!canCollapse ? null : `group-${id}`"
-        @click="groupSelected()"
-        @keyup.enter="groupSelected()"
-        @keyup.space="groupSelected()"
-      >
-        <!-- <div
-        v-if="showHeader"
-        class="header"
-        :class="{'active': highlightRoute && isOverview, 'noHover': !canCollapse || fixedOpen}"
         :role="hasChildren ? 'button' : undefined"
         :tabindex="hasChildren ? (fixedOpen ? -1 : 0) : undefined"
         :aria-label="hasChildren ? (group.labelDisplay || group.label || '') : undefined"
@@ -281,7 +268,7 @@ export default {
         @click="groupSelected()"
         @keyup.enter="groupSelected()"
         @keyup.space="groupSelected()"
-      > -->
+      >
         <slot name="header">
           <!-- Group overview with link -->
           <router-link

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -269,6 +269,19 @@ export default {
         @keyup.enter="groupSelected()"
         @keyup.space="groupSelected()"
       >
+        <!-- <div
+        v-if="showHeader"
+        class="header"
+        :class="{'active': highlightRoute && isOverview, 'noHover': !canCollapse || fixedOpen}"
+        :role="hasChildren ? 'button' : undefined"
+        :tabindex="hasChildren ? (fixedOpen ? -1 : 0) : undefined"
+        :aria-label="hasChildren ? (group.labelDisplay || group.label || '') : undefined"
+        :aria-expanded="hasChildren ? (!canCollapse || isExpanded) : undefined"
+        :aria-controls="hasChildren ? (!canCollapse ? null : `group-${id}`) : undefined"
+        @click="groupSelected()"
+        @keyup.enter="groupSelected()"
+        @keyup.space="groupSelected()"
+      > -->
         <slot name="header">
           <!-- Group overview with link -->
           <router-link

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -260,11 +260,11 @@ export default {
         v-if="showHeader"
         class="header"
         :class="{'active': highlightRoute && isOverview, 'noHover': !canCollapse || fixedOpen}"
-        :role="hasChildren ? 'button' : undefined"
-        :tabindex="hasChildren ? (fixedOpen ? -1 : 0) : undefined"
-        :aria-label="hasChildren ? (group.labelDisplay || group.label || '') : undefined"
-        :aria-expanded="hasChildren ? (!canCollapse || isExpanded) : undefined"
-        :aria-controls="hasChildren ? (!canCollapse ? null : `group-${id}`) : undefined"
+        :role="hasChildren && !hasOverview ? 'button' : undefined"
+        :tabindex="hasChildren && !hasOverview ? (fixedOpen ? -1 : 0) : undefined"
+        :aria-label="hasChildren && !hasOverview ? (group.labelDisplay || group.label || '') : undefined"
+        :aria-expanded="hasChildren && !hasOverview ? (!canCollapse || isExpanded) : undefined"
+        :aria-controls="hasChildren && !hasOverview ? (!canCollapse ? null : `group-${id}`) : undefined"
         @click="groupSelected()"
         @keyup.enter="groupSelected()"
         @keyup.space="groupSelected()"
@@ -275,7 +275,6 @@ export default {
             v-if="hasOverview && hasChildren"
             :to="headerRoute"
             :exact="group.children[0].exact"
-            :tabindex="-1"
           >
             <h6>
               <span v-clean-html="group.labelDisplay || group.label" />
@@ -400,6 +399,11 @@ export default {
       }
       &:focus{
         outline:none;
+
+        h6 span {
+          @include focus-outline;
+          // outline-offset: -6px;
+        }
       }
     }
   }

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -402,7 +402,6 @@ export default {
 
         h6 span {
           @include focus-outline;
-          // outline-offset: -6px;
         }
       }
     }

--- a/shell/components/nav/__tests__/Group.test.ts
+++ b/shell/components/nav/__tests__/Group.test.ts
@@ -1,5 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import Group from '@shell/components/nav/Group.vue';
+import Type from '@shell/components/nav/Type.vue';
 
 describe('component: Group', () => {
   it('isOverview ignores query parameters and hash strings when checking active state', () => {
@@ -123,6 +124,127 @@ describe('component: Group', () => {
       expect(link.exists()).toBe(true);
       expect(h6.exists()).toBe(true);
       expect(h6.find('span').html()).toContain('My Group');
+    });
+  });
+
+  /**
+   * Regression guard for the nested-interactive a11y fix (issue #17260).
+   *
+   * PR #16352 introduced a pattern where root-group children are promoted to
+   * top-level nav items with `children: []`. Group.vue must NOT render those
+   * items as `role="button"`, because they already contain an <a> link via the
+   * Type component — nesting an interactive element inside another interactive
+   * element violates the nested-interactive WCAG rule.
+   */
+  describe('header role and ARIA attributes (nested-interactive a11y fix)', () => {
+    const routerMocks = {
+      $route: {
+        params:   {},
+        path:     '/test/route',
+        fullPath: '/test/route',
+        matched:  [],
+      },
+      $router: {
+        resolve:   jest.fn().mockReturnValue({ path: '/test/route', fullPath: '/test/route' }),
+        getRoutes: jest.fn().mockReturnValue([]),
+      },
+      t: (key: string) => key,
+    };
+
+    const mountGroupWithMocks = (group: any, extraProps: Record<string, unknown> = {}) => shallowMount(Group as any, {
+      props: {
+        group,
+        canCollapse: true,
+        idPrefix:    '',
+        ...extraProps,
+      },
+      global: { mocks: routerMocks },
+    });
+
+    describe('when group has children (standard collapsible group)', () => {
+      const group = {
+        name:     'test',
+        label:    'My Group',
+        children: [{ route: { name: 'child-route', params: {} } }],
+      };
+
+      it('renders header with role="button"', () => {
+        const wrapper = mountGroupWithMocks(group);
+
+        expect(wrapper.find('.header').attributes('role')).toBe('button');
+      });
+
+      it('renders header with tabindex="0" when not fixedOpen', () => {
+        const wrapper = mountGroupWithMocks(group);
+
+        expect(wrapper.find('.header').attributes('tabindex')).toBe('0');
+      });
+
+      it('renders header with tabindex="-1" when fixedOpen is true', () => {
+        const wrapper = mountGroupWithMocks(group, { fixedOpen: true });
+
+        expect(wrapper.find('.header').attributes('tabindex')).toBe('-1');
+      });
+
+      it('renders header with aria-label from group label', () => {
+        const wrapper = mountGroupWithMocks(group);
+
+        expect(wrapper.find('.header').attributes('aria-label')).toBe('My Group');
+      });
+
+      it('renders header with aria-expanded attribute', () => {
+        const wrapper = mountGroupWithMocks(group);
+
+        expect(wrapper.find('.header').attributes('aria-expanded')).toBeDefined();
+      });
+
+      it('renders header with aria-controls pointing to group body', () => {
+        const wrapper = mountGroupWithMocks(group);
+
+        // id = idPrefix + group.name = '' + 'test' = 'test'
+        expect(wrapper.find('.header').attributes('aria-controls')).toBe('group-test');
+      });
+
+      it('omits aria-controls when canCollapse is false', () => {
+        const wrapper = mountGroupWithMocks(group, { canCollapse: false });
+
+        expect(wrapper.find('.header').attributes('aria-controls')).toBeUndefined();
+      });
+    });
+
+    describe('when group has no children (simple nav item, root group promotion from PR #16352)', () => {
+      // Mirrors the data shape produced by SideNav.vue's root-group unpacking:
+      //   rootGroup.children.forEach(child => addObject(out, { ...child, children: [] }))
+      const group = {
+        name:     'cluster-dashboard',
+        label:    'Cluster',
+        route:    { name: 'c-cluster-explorer', params: {} },
+        children: [],
+      };
+
+      it.each([
+        ['role'],
+        ['tabindex'],
+        ['aria-label'],
+        ['aria-expanded'],
+        ['aria-controls'],
+      ])('does not set %s on the header div (avoids nested-interactive violation)', (attr) => {
+        const wrapper = mountGroupWithMocks(group);
+
+        expect(wrapper.find('.header').attributes(attr)).toBeUndefined();
+      });
+
+      it('still renders the Type component as the nav link', () => {
+        const wrapper = mountGroupWithMocks(group);
+
+        expect(wrapper.findComponent(Type).exists()).toBe(true);
+      });
+
+      it('passes the group object as the type prop to the Type component', () => {
+        const wrapper = mountGroupWithMocks(group);
+
+        expect(wrapper.findComponent(Type).props('type')).toStrictEqual(group);
+      });
     });
   });
 });

--- a/shell/components/nav/__tests__/Group.test.ts
+++ b/shell/components/nav/__tests__/Group.test.ts
@@ -252,7 +252,9 @@ describe('component: Group', () => {
         name:     'cluster',
         label:    'Cluster',
         children: [
-          { route: { name: 'c-cluster-explorer', params: {} }, overview: true, exact: true },
+          {
+            route: { name: 'c-cluster-explorer', params: {} }, overview: true, exact: true
+          },
           { route: { name: 'c-cluster-workloads', params: {} } },
         ],
       };

--- a/shell/components/nav/__tests__/Group.test.ts
+++ b/shell/components/nav/__tests__/Group.test.ts
@@ -151,14 +151,14 @@ describe('component: Group', () => {
       t: (key: string) => key,
     };
 
-    const mountGroupWithMocks = (group: any, extraProps: Record<string, unknown> = {}) => shallowMount(Group as any, {
+    const mountGroupWithMocks = (group: any, extraProps: Record<string, unknown> = {}, stubs: Record<string, unknown> = {}) => shallowMount(Group as any, {
       props: {
         group,
         canCollapse: true,
         idPrefix:    '',
         ...extraProps,
       },
-      global: { mocks: routerMocks },
+      global: { mocks: routerMocks, stubs },
     });
 
     describe('when group has children (standard collapsible group)', () => {
@@ -244,6 +244,37 @@ describe('component: Group', () => {
         const wrapper = mountGroupWithMocks(group);
 
         expect(wrapper.findComponent(Type).props('type')).toStrictEqual(group);
+      });
+    });
+
+    describe('when group has children AND an overview link (nested-interactive regression guard)', () => {
+      const group = {
+        name:     'cluster',
+        label:    'Cluster',
+        children: [
+          { route: { name: 'c-cluster-explorer', params: {} }, overview: true, exact: true },
+          { route: { name: 'c-cluster-workloads', params: {} } },
+        ],
+      };
+
+      it.each([
+        ['role'],
+        ['tabindex'],
+        ['aria-label'],
+        ['aria-expanded'],
+        ['aria-controls'],
+      ])('does not set %s on the header div when group has an overview link', (attr) => {
+        const wrapper = mountGroupWithMocks(group);
+
+        expect(wrapper.find('.header').attributes(attr)).toBeUndefined();
+      });
+
+      it('renders the overview router-link without tabindex', () => {
+        const wrapper = mountGroupWithMocks(group, {}, { 'router-link': { template: '<a><slot /></a>' } });
+        const link = wrapper.find('.header a');
+
+        expect(link.exists()).toBe(true);
+        expect(link.attributes('tabindex')).toBeUndefined();
       });
     });
   });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #17260
Fixes #15953 

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Fix `nested-interactive` a11y violation in `Group.vue` introduced by PR #16352
- ARIA interactive attributes (`role`, `tabindex`, `aria-label`, `aria-expanded`, `aria-controls`) on the group header `div` are now only set when the group actually has children — preventing a `role="button"` element from wrapping an `<a>` link (the `Type` component), which is a WCAG nested-interactive violation
- Add unit tests in `Group.test.ts` to guard against future regressions on this violation

### Technical notes summary
PR #16352 introduced root-group promotion in `SideNav.vue`: top-level nav items (registered via `basicType` without an explicit group) are unpacked from the root group and passed to `Group.vue` with `children: []`. For those items, `Group.vue` renders a `<Type>` component (which produces an `<a>` link) inside the `div.header` — but that `div` was always assigned `role="button"`, regardless of whether it had children. That created a nested interactive element. The fix makes all five interactive ARIA attributes conditional on `hasChildren`, so the `div.header` stays in the DOM (CSS is unchanged) but carries no interactive semantics when it's just a wrapper for a nav link.

### Areas or cases that should be tested

> **Priority: new product registration with nested children**
>
> This is the scenario most likely to surface regressions from this fix — it exercises the exact code path changed.

1. Register a product with a group that has children using the new `addProduct` API, e.g.:
   ```ts
   plugin.addProduct({ name: 'my-product', label: 'My Product' }, [
     {
       name:      'page1',
       label:     'My Group',
       component: () => import('./pages/Overview.vue'),
       sideMenu:  {
         children: [
           { name: 'child1', label: 'Child One', component: () => import('./pages/ChildOne.vue') },
           { name: 'child2', label: 'Child Two', component: () => import('./pages/ChildTwo.vue') },
         ],
       },
     },
   ]);
   ```
   - Group header should be collapsible/expandable ✓
   - Children appear as nav links inside the group ✓
   - No a11y `nested-interactive` violation in the browser dev tools (axe / Accessibility panel) ✓

2. Register a product with flat (no-children) top-level items (root group promotion path):
   ```ts
   plugin.addProduct({ name: 'my-product', label: 'My Product' }, [
     { name: 'page1', label: 'Page One', component: () => import('./pages/PageOne.vue') },
   ]);
   ```
   - Item renders as a direct nav link, no collapsible behavior ✓
   - No `role="button"` on the header `div` ✓
   - No a11y `nested-interactive` violation ✓

3. Visual regression checks (standard SideNav behavior — these should be unchanged):
   - Cluster Explorer side-menu: groups expand/collapse correctly, active item highlights, overview links work
   - Cluster Manager side-menu: same as above
   - Settings side-menu: same as above
   - Hover background on group headers (depth-0 and depth-1)
   - Focus-visible outline on group headers (keyboard navigation, Tab key)
   - Chevron icon (`toggle-accordion`) still collapses/expands groups independently of the header click

### Areas which could experience regressions
- `Group.vue` header interactions (click to expand, keyboard Enter/Space, focus styles) — only affects groups with children, should be unchanged
- Root-group promoted items (products registered via old-style `basicType` without an explicit group, such as the main Cluster Dashboard entry) — the `div.header` no longer carries `role="button"` for these, which is intentional and correct

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
