### PR TITLE
[backport 2.15.1] Automation: Fix getHostStats task breaking Jenkins runs

### DIFF
--- a/cypress/base-config.ts
+++ b/cypress/base-config.ts
@@ -182,6 +182,12 @@ const baseConfig = defineConfig({
           };
         },
       });
+      // Signals to the shared `afterEach` in `support/e2e.ts` that the `getHostStats`
+      // task has been registered by this config. Consumers of `@rancher/cypress` that
+      // supply their own `setupNodeEvents` (e.g. Jenkins runners) won't set this
+      // flag, so the `afterEach` will skip calling the task and avoid failing the
+      // hook (which would skip all remaining tests in the spec).
+      config.env.hasHostStats = true;
       websocketTasks(on, config);
 
       require('cypress-terminal-report/src/installLogsPrinter')(on, {

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -34,7 +34,7 @@ require('cypress-terminal-report/src/installLogsCollector')({
  */
 afterEach(function() {
   // We use a regular function to have access to `this.currentTest`.
-  if (this.currentTest.state === 'failed') {
+  if (this.currentTest?.state === 'failed' && Cypress.env('hasHostStats')) {
     cy.task<{ processCpu: string; memory: string }>('getHostStats').then((stats) => {
       cy.log('**Host Stats on Failure**');
       cy.log(`Process CPU: ${ stats.processCpu }`);


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2443

Backport of https://github.com/rancher/dashboard/pull/18438
<!-- Define findings related to the feature or bug issue. -->

### Verification

Confirmed the host-stats diagnostic still reports on failures with this change — see the browser logs of the failing test in this PR's CI run: 
### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
