### PR TITLE
Changes to allow extensions to do actions on events

### DIFF
--- a/shell/core/types-provisioning.ts
+++ b/shell/core/types-provisioning.ts
@@ -352,6 +352,22 @@ export interface IClusterProvisioner {
    * @returns Array of errors. If there are no errors the array will be empty
    */
   provision?(cluster: any, pools: any[]): Promise<any[]>;
+
+  /**
+   * Generic event hook called by the cluster form on specific user actions.
+   *
+   * Use this to react to any form event without needing a dedicated hook per action.
+   * The `cluster` argument is the live `provisioning.cattle.io.cluster` object and can be mutated directly.
+   *
+   * Supported events:
+   * - `'kubernetesVersionChange'` — payload: `{ newVersion: string, oldVersion: string | undefined, infrastructureCluster: any | null }`
+   * - `'credentialChange'`        — payload: `{ credentialId: string, infrastructureCluster: any | null }`
+   *
+   * @param event  Name of the event
+   * @param payload Event-specific data
+   * @param cluster The provisioning cluster (`provisioning.cattle.io.cluster`)
+   */
+  onEvent?(event: string, payload: Record<string, any>, cluster: any): void | Promise<void>;
 }
 
 /**

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -937,16 +937,25 @@ describe('component: rke2', () => {
   });
 
   describe('extensionProvider.onEvent error handling', () => {
-    const makeVm = (onEvent: jest.Mock) => ({
-      extensionProvider:        { onEvent },
-      errors:                   [] as unknown[],
-      infrastructureCluster:    null,
-      value:                    { spec: {} },
-      togglePsaDefault:         jest.fn(),
-      updateNginxConfiguration: jest.fn(),
-      isHarvesterDriver:        false,
-      serverConfig:             {},
-    });
+    const makeVm = (onEvent: jest.Mock) => {
+      const vm: Record<string, any> = {
+        extensionProvider:        { onEvent },
+        errors:                   [] as unknown[],
+        infrastructureCluster:    null,
+        value:                    { spec: {} },
+        togglePsaDefault:         jest.fn(),
+        updateNginxConfiguration: jest.fn(),
+        isHarvesterDriver:        false,
+        serverConfig:             {},
+      };
+
+      // Bind the real _scheduleOnEvent so handleKubernetesChange can call it
+      vm._scheduleOnEvent = (fn: () => unknown) => (rke2.methods as any)._scheduleOnEvent.call(vm, fn);
+
+      return vm;
+    };
+
+    const flushPromises = () => new Promise(process.nextTick);
 
     describe('method: handleKubernetesChange', () => {
       it('pushes error to this.errors when onEvent rejects', async() => {
@@ -955,7 +964,7 @@ describe('component: rke2', () => {
         const vm = makeVm(onEvent) as any;
 
         (rke2.methods as any).handleKubernetesChange.call(vm, 'v1.30.0+rke2r1', 'v1.29.0+rke2r1');
-        await new Promise(process.nextTick);
+        await flushPromises();
 
         expect(vm.errors).toContain(err);
       });
@@ -965,7 +974,7 @@ describe('component: rke2', () => {
         const vm = makeVm(onEvent) as any;
 
         (rke2.methods as any).handleKubernetesChange.call(vm, 'v1.30.0+rke2r1', 'v1.29.0+rke2r1');
-        await new Promise(process.nextTick);
+        await flushPromises();
 
         expect(vm.errors).toHaveLength(0);
       });
@@ -975,9 +984,45 @@ describe('component: rke2', () => {
         const vm = makeVm(onEvent) as any;
 
         (rke2.methods as any).handleKubernetesChange.call(vm, 'v1.30.0+rke2r1', 'v1.29.0+rke2r1');
-        await new Promise(process.nextTick);
+        await flushPromises();
 
         expect(vm.errors).toHaveLength(0);
+      });
+
+      it('serializes rapid calls: runs first, then only the latest pending', async() => {
+        let resolveFirst!: () => void;
+        const firstSettled = new Promise<void>((res) => {
+          resolveFirst = res;
+        });
+
+        const onEvent = jest.fn()
+          .mockImplementationOnce(() => new Promise<void>((res) => {
+            firstSettled.then(res);
+          }))
+          .mockImplementation(() => Promise.resolve());
+
+        const vm = makeVm(onEvent) as any;
+        const call = (v: string) => (rke2.methods as any).handleKubernetesChange.call(vm, v, '');
+
+        // Fire three rapid changes while the first is still in-flight
+        call('v1.28.0+rke2r1');
+        call('v1.29.0+rke2r1'); // replaced by the next
+        call('v1.30.0+rke2r1'); // becomes the single pending call
+
+        // First in-flight is running; onEvent called once so far
+        expect(onEvent).toHaveBeenCalledTimes(1);
+
+        // Settle the first call — the latest pending (v1.30) should now run
+        resolveFirst();
+        await flushPromises();
+
+        // Intermediate call (v1.29) was dropped; only v1.28 and v1.30 ran
+        expect(onEvent).toHaveBeenCalledTimes(2);
+        expect(onEvent).not.toHaveBeenCalledWith(
+          'kubernetesVersionChange',
+          expect.objectContaining({ newVersion: 'v1.29.0+rke2r1' }),
+          expect.anything()
+        );
       });
     });
 
@@ -993,7 +1038,7 @@ describe('component: rke2', () => {
         } as any;
 
         credentialIdWatcher.call(vm, 'cred-123');
-        await new Promise(process.nextTick);
+        await flushPromises();
 
         expect(vm.errors).toContain(err);
       });
@@ -1006,7 +1051,7 @@ describe('component: rke2', () => {
         } as any;
 
         credentialIdWatcher.call(vm, 'cred-123');
-        await new Promise(process.nextTick);
+        await flushPromises();
 
         expect(vm.errors).toHaveLength(0);
       });
@@ -1019,7 +1064,7 @@ describe('component: rke2', () => {
         } as any;
 
         credentialIdWatcher.call(vm, 'cred-123');
-        await new Promise(process.nextTick);
+        await flushPromises();
 
         expect(vm.errors).toHaveLength(0);
       });

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -937,57 +937,34 @@ describe('component: rke2', () => {
   });
 
   describe('extensionProvider.onEvent error handling', () => {
-    const makeWrapper = (onEvent: jest.Mock) => {
-      const mockExtClass = jest.fn().mockImplementation(() => ({ onEvent }));
-
-      return shallowMount(rke2, {
-        props: {
-          mode:  _CREATE,
-          value: {
-            spec: {
-              ...defaultSpec,
-              cloudCredentialSecretName: '',
-            },
-            agentConfig: {},
-          },
-          provider: 'awsmachinetemplate',
-        },
-        global: {
-          mocks: {
-            ...defaultMocks,
-            $store: {
-              dispatch: jest.fn(),
-              getters:  {
-                ...defaultGetters,
-                'rancher/byId': jest.fn(),
-              },
-            },
-            $extension: { getDynamic: jest.fn(() => mockExtClass) },
-          },
-          stubs: defaultStubs,
-        },
-      });
-    };
+    const makeVm = (onEvent: jest.Mock) => ({
+      extensionProvider:        { onEvent },
+      errors:                   [] as unknown[],
+      infrastructureCluster:    null,
+      value:                    { spec: {} },
+      togglePsaDefault:         jest.fn(),
+      updateNginxConfiguration: jest.fn(),
+      isHarvesterDriver:        false,
+      serverConfig:             {},
+    });
 
     describe('method: handleKubernetesChange', () => {
       it('pushes error to this.errors when onEvent rejects', async() => {
         const err = new Error('prepareProvCluster failed');
-        const onEvent = jest.fn().mockReturnValue(Promise.reject(err));
-        const wrapper = makeWrapper(onEvent);
-        const vm = wrapper.vm as any;
+        const onEvent = jest.fn().mockImplementation(() => Promise.reject(err));
+        const vm = makeVm(onEvent) as any;
 
-        vm.handleKubernetesChange('v1.30.0+rke2r1', 'v1.29.0+rke2r1');
+        (rke2.methods as any).handleKubernetesChange.call(vm, 'v1.30.0+rke2r1', 'v1.29.0+rke2r1');
         await new Promise(process.nextTick);
 
         expect(vm.errors).toContain(err);
       });
 
       it('does not push to this.errors when onEvent resolves', async() => {
-        const onEvent = jest.fn().mockReturnValue(Promise.resolve());
-        const wrapper = makeWrapper(onEvent);
-        const vm = wrapper.vm as any;
+        const onEvent = jest.fn().mockImplementation(() => Promise.resolve());
+        const vm = makeVm(onEvent) as any;
 
-        vm.handleKubernetesChange('v1.30.0+rke2r1', 'v1.29.0+rke2r1');
+        (rke2.methods as any).handleKubernetesChange.call(vm, 'v1.30.0+rke2r1', 'v1.29.0+rke2r1');
         await new Promise(process.nextTick);
 
         expect(vm.errors).toHaveLength(0);
@@ -995,10 +972,9 @@ describe('component: rke2', () => {
 
       it('does not push to this.errors when onEvent is synchronous', async() => {
         const onEvent = jest.fn().mockReturnValue(undefined);
-        const wrapper = makeWrapper(onEvent);
-        const vm = wrapper.vm as any;
+        const vm = makeVm(onEvent) as any;
 
-        vm.handleKubernetesChange('v1.30.0+rke2r1', 'v1.29.0+rke2r1');
+        (rke2.methods as any).handleKubernetesChange.call(vm, 'v1.30.0+rke2r1', 'v1.29.0+rke2r1');
         await new Promise(process.nextTick);
 
         expect(vm.errors).toHaveLength(0);
@@ -1006,36 +982,46 @@ describe('component: rke2', () => {
     });
 
     describe('watcher: credentialId', () => {
+      const credentialIdWatcher = (rke2.watch as any).credentialId as (val: string) => void;
+
       it('pushes error to this.errors when onEvent rejects on credential change', async() => {
         const err = new Error('credential onEvent failed');
-        const onEvent = jest.fn().mockReturnValue(Promise.reject(err));
-        const wrapper = makeWrapper(onEvent);
-        const vm = wrapper.vm as any;
+        const onEvent = jest.fn().mockImplementation(() => Promise.reject(err));
+        const vm = {
+          ...makeVm(onEvent),
+          $store: { getters: { 'rancher/byId': jest.fn() } },
+        } as any;
 
-        await wrapper.setData({ credentialId: 'cred-123' });
+        credentialIdWatcher.call(vm, 'cred-123');
         await new Promise(process.nextTick);
 
         expect(vm.errors).toContain(err);
       });
 
       it('does not push to this.errors when onEvent resolves on credential change', async() => {
-        const onEvent = jest.fn().mockReturnValue(Promise.resolve());
-        const wrapper = makeWrapper(onEvent);
+        const onEvent = jest.fn().mockImplementation(() => Promise.resolve());
+        const vm = {
+          ...makeVm(onEvent),
+          $store: { getters: { 'rancher/byId': jest.fn() } },
+        } as any;
 
-        await wrapper.setData({ credentialId: 'cred-123' });
+        credentialIdWatcher.call(vm, 'cred-123');
         await new Promise(process.nextTick);
 
-        expect((wrapper.vm as any).errors).toHaveLength(0);
+        expect(vm.errors).toHaveLength(0);
       });
 
       it('does not push to this.errors when onEvent is synchronous on credential change', async() => {
         const onEvent = jest.fn().mockReturnValue(undefined);
-        const wrapper = makeWrapper(onEvent);
+        const vm = {
+          ...makeVm(onEvent),
+          $store: { getters: { 'rancher/byId': jest.fn() } },
+        } as any;
 
-        await wrapper.setData({ credentialId: 'cred-123' });
+        credentialIdWatcher.call(vm, 'cred-123');
         await new Promise(process.nextTick);
 
-        expect((wrapper.vm as any).errors).toHaveLength(0);
+        expect(vm.errors).toHaveLength(0);
       });
     });
   });

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -991,13 +991,13 @@ describe('component: rke2', () => {
 
       it('serializes rapid calls: runs first, then only the latest pending', async() => {
         let resolveFirst!: () => void;
-        const firstSettled = new Promise<void>((res) => {
-          resolveFirst = res;
+        const firstSettled = new Promise<void>((resolve) => {
+          resolveFirst = resolve;
         });
 
         const onEvent = jest.fn()
-          .mockImplementationOnce(() => new Promise<void>((res) => {
-            firstSettled.then(res);
+          .mockImplementationOnce(() => new Promise<void>((resolve) => {
+            firstSettled.then(resolve);
           }))
           .mockImplementation(() => Promise.resolve());
 

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -935,4 +935,108 @@ describe('component: rke2', () => {
       expect(canEditAsYaml).toBe(true);
     });
   });
+
+  describe('extensionProvider.onEvent error handling', () => {
+    const makeWrapper = (onEvent: jest.Mock) => {
+      const mockExtClass = jest.fn().mockImplementation(() => ({ onEvent }));
+
+      return shallowMount(rke2, {
+        props: {
+          mode:  _CREATE,
+          value: {
+            spec: {
+              ...defaultSpec,
+              cloudCredentialSecretName: '',
+            },
+            agentConfig: {},
+          },
+          provider: 'awsmachinetemplate',
+        },
+        global: {
+          mocks: {
+            ...defaultMocks,
+            $store: {
+              dispatch: jest.fn(),
+              getters:  {
+                ...defaultGetters,
+                'rancher/byId': jest.fn(),
+              },
+            },
+            $extension: { getDynamic: jest.fn(() => mockExtClass) },
+          },
+          stubs: defaultStubs,
+        },
+      });
+    };
+
+    describe('method: handleKubernetesChange', () => {
+      it('pushes error to this.errors when onEvent rejects', async() => {
+        const err = new Error('prepareProvCluster failed');
+        const onEvent = jest.fn().mockReturnValue(Promise.reject(err));
+        const wrapper = makeWrapper(onEvent);
+        const vm = wrapper.vm as any;
+
+        vm.handleKubernetesChange('v1.30.0+rke2r1', 'v1.29.0+rke2r1');
+        await new Promise(process.nextTick);
+
+        expect(vm.errors).toContain(err);
+      });
+
+      it('does not push to this.errors when onEvent resolves', async() => {
+        const onEvent = jest.fn().mockReturnValue(Promise.resolve());
+        const wrapper = makeWrapper(onEvent);
+        const vm = wrapper.vm as any;
+
+        vm.handleKubernetesChange('v1.30.0+rke2r1', 'v1.29.0+rke2r1');
+        await new Promise(process.nextTick);
+
+        expect(vm.errors).toHaveLength(0);
+      });
+
+      it('does not push to this.errors when onEvent is synchronous', async() => {
+        const onEvent = jest.fn().mockReturnValue(undefined);
+        const wrapper = makeWrapper(onEvent);
+        const vm = wrapper.vm as any;
+
+        vm.handleKubernetesChange('v1.30.0+rke2r1', 'v1.29.0+rke2r1');
+        await new Promise(process.nextTick);
+
+        expect(vm.errors).toHaveLength(0);
+      });
+    });
+
+    describe('watcher: credentialId', () => {
+      it('pushes error to this.errors when onEvent rejects on credential change', async() => {
+        const err = new Error('credential onEvent failed');
+        const onEvent = jest.fn().mockReturnValue(Promise.reject(err));
+        const wrapper = makeWrapper(onEvent);
+        const vm = wrapper.vm as any;
+
+        await wrapper.setData({ credentialId: 'cred-123' });
+        await new Promise(process.nextTick);
+
+        expect(vm.errors).toContain(err);
+      });
+
+      it('does not push to this.errors when onEvent resolves on credential change', async() => {
+        const onEvent = jest.fn().mockReturnValue(Promise.resolve());
+        const wrapper = makeWrapper(onEvent);
+
+        await wrapper.setData({ credentialId: 'cred-123' });
+        await new Promise(process.nextTick);
+
+        expect((wrapper.vm as any).errors).toHaveLength(0);
+      });
+
+      it('does not push to this.errors when onEvent is synchronous on credential change', async() => {
+        const onEvent = jest.fn().mockReturnValue(undefined);
+        const wrapper = makeWrapper(onEvent);
+
+        await wrapper.setData({ credentialId: 'cred-123' });
+        await new Promise(process.nextTick);
+
+        expect((wrapper.vm as any).errors).toHaveLength(0);
+      });
+    });
+  });
 });

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -860,7 +860,13 @@ export default {
         extensionContext.isEdit = this.isEdit;
         extensionContext.isView = this.isView;
 
-        const out = extensionProps(extensionContext);
+        let out;
+
+        try {
+          out = extensionProps(extensionContext);
+        } catch {
+          return defaultProps;
+        }
 
         if (out && typeof out === 'object') {
           return { ...defaultProps, ...out };
@@ -1008,13 +1014,9 @@ export default {
       this.value.spec.cloudCredentialSecretName = val;
 
       if (this.extensionProvider?.onEvent) {
-        try {
-          const p = this.extensionProvider.onEvent('credentialChange', { credentialId: val, infrastructureCluster: this.infrastructureCluster }, this.value);
+        const payload = { credentialId: val, infrastructureCluster: this.infrastructureCluster };
 
-          Promise.resolve(p).catch((err) => this.errors.push(err));
-        } catch (err) {
-          this.errors.push(err);
-        }
+        this._scheduleOnEvent(() => this.extensionProvider.onEvent('credentialChange', payload, this.value));
       }
     },
 
@@ -2324,19 +2326,48 @@ export default {
           k8sChangePayload.newVersion = value;
           k8sChangePayload.oldVersion = old;
           k8sChangePayload.infrastructureCluster = this.infrastructureCluster;
-          try {
-            const p = this.extensionProvider.onEvent('kubernetesVersionChange', k8sChangePayload, this.value);
 
-            Promise.resolve(p).catch((err) => this.errors.push(err));
-          } catch (err) {
-            this.errors.push(err);
-          }
+          // Use latest-only scheduling: if a previous onEvent is still in-flight, the
+          // intermediate call is replaced so only the most-recent version change runs next.
+          this._scheduleOnEvent(() => this.extensionProvider.onEvent('kubernetesVersionChange', k8sChangePayload, this.value));
         }
       }
     },
 
     handleShowDeprecatedPatchVersionsChanged(value) {
       this.showDeprecatedPatchVersions = value;
+    },
+
+    /**
+     * Schedules an onEvent call using a latest-only queue: one call runs at a time, and
+     * any new call while one is in-flight replaces the pending slot, so only the most
+     * recent call runs after the current in-flight one settles.
+     *
+     * This prevents out-of-order mutations when extension providers perform async work
+     * (e.g. rapid Kubernetes version changes).
+     */
+    _scheduleOnEvent(fn) {
+      this._onEventPending = fn;
+      if (this._onEventInFlight) {
+        return;
+      }
+
+      const run = () => {
+        const next = this._onEventPending;
+
+        if (!next) {
+          this._onEventInFlight = false;
+
+          return;
+        }
+        this._onEventPending = null;
+        this._onEventInFlight = true;
+        new Promise((resolve) => resolve(fn()))
+          .catch((err) => this.errors.push(err))
+          .finally(run);
+      };
+
+      run();
     },
     /**
      * Track Machine Pool validation status

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -1008,10 +1008,12 @@ export default {
       this.value.spec.cloudCredentialSecretName = val;
 
       if (this.extensionProvider?.onEvent) {
-        const p = this.extensionProvider.onEvent('credentialChange', { credentialId: val, infrastructureCluster: this.infrastructureCluster }, this.value);
+        try {
+          const p = this.extensionProvider.onEvent('credentialChange', { credentialId: val, infrastructureCluster: this.infrastructureCluster }, this.value);
 
-        if (p) {
-          p.catch((err) => this.errors.push(err));
+          Promise.resolve(p).catch((err) => this.errors.push(err));
+        } catch (err) {
+          this.errors.push(err);
         }
       }
     },
@@ -2322,10 +2324,12 @@ export default {
           k8sChangePayload.newVersion = value;
           k8sChangePayload.oldVersion = old;
           k8sChangePayload.infrastructureCluster = this.infrastructureCluster;
-          const p = this.extensionProvider.onEvent('kubernetesVersionChange', k8sChangePayload, this.value);
+          try {
+            const p = this.extensionProvider.onEvent('kubernetesVersionChange', k8sChangePayload, this.value);
 
-          if (p) {
-            p.catch((err) => this.errors.push(err));
+            Promise.resolve(p).catch((err) => this.errors.push(err));
+          } catch (err) {
+            this.errors.push(err);
           }
         }
       }

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -840,6 +840,38 @@ export default {
       return this.extensionProvider?.extensionInfrastructureSection || null;
     },
 
+    extensionInfrastructureSectionProps() {
+      const defaultProps = {
+        value:               this.infrastructureCluster,
+        mode:                this.mode,
+        provider:            this.provider,
+        credentialId:        this.credentialId,
+        provisioningCluster: this.value,
+      };
+
+      const extensionProps = this.extensionProvider?.extensionInfrastructureSectionProps;
+
+      if (typeof extensionProps === 'function') {
+        const extensionContext = { ...defaultProps };
+
+        extensionContext.infrastructureCluster = this.infrastructureCluster;
+        extensionContext.cluster = this.value;
+        extensionContext.isCreate = this.isCreate;
+        extensionContext.isEdit = this.isEdit;
+        extensionContext.isView = this.isView;
+
+        const out = extensionProps(extensionContext);
+
+        if (out && typeof out === 'object') {
+          return { ...defaultProps, ...out };
+        }
+      } else if (extensionProps && typeof extensionProps === 'object') {
+        return { ...defaultProps, ...extensionProps };
+      }
+
+      return defaultProps;
+    },
+
     showForm() {
       return !!this.credentialId || !this.needCredential;
     },
@@ -974,6 +1006,14 @@ export default {
       }
 
       this.value.spec.cloudCredentialSecretName = val;
+
+      if (this.extensionProvider?.onEvent) {
+        const p = this.extensionProvider.onEvent('credentialChange', { credentialId: val, infrastructureCluster: this.infrastructureCluster }, this.value);
+
+        if (p) {
+          p.catch((err) => this.errors.push(err));
+        }
+      }
     },
 
     addonNames(neu, old) {
@@ -2274,6 +2314,20 @@ export default {
         if (this.isHarvesterDriver && this.mode === _CREATE && this.isHarvesterIncompatible) {
           this.setHarvesterDefaultCloudProvider();
         }
+
+        // Allow extension providers to react to the version change
+        if (this.extensionProvider?.onEvent) {
+          const k8sChangePayload = {};
+
+          k8sChangePayload.newVersion = value;
+          k8sChangePayload.oldVersion = old;
+          k8sChangePayload.infrastructureCluster = this.infrastructureCluster;
+          const p = this.extensionProvider.onEvent('kubernetesVersionChange', k8sChangePayload, this.value);
+
+          if (p) {
+            p.catch((err) => this.errors.push(err));
+          }
+        }
       }
     },
 
@@ -2541,11 +2595,7 @@ export default {
           <component
             :is="extensionInfrastructureSection"
             v-if="extensionInfrastructureSection"
-            :value="infrastructureCluster"
-            :mode="mode"
-            :provider="provider"
-            :credential-id="credentialId"
-            :provisioning-cluster="value"
+            v-bind="extensionInfrastructureSectionProps"
             data-testid="extension-top-section"
             class="span-12"
             @update:value="updateExtensionInfrastructureSection"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18300 
<!-- Define findings related to the feature or bug issue. -->
Added a way to have extension perform actions onEvent. In this case, it applies to k8s version change and credential change
Corresponding extension change: https://github.com/rancher/prov-capi-ui-extensions/pull/21

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Changed infrastructure cluster section to bind to props provided from extesnion instead of hardcoding them on dashboard
- Added onEvent checks to k8 verion change handler and cloud credential watch
### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
1. Kubernetes version change with CAPA provider — change the Kubernetes version on a CAPA-provisioned cluster and verify CAPA-required fields (additionalManifest, machineSelectorConfig, cloud-provider-name are correctly reapplied.
2. Kubernetes version change failure — simulate a failure in prepareProvCluster (e.g. network error, missing schema) and verify the error is displayed in the UI error banner rather than silently failing.
3. Credential change with CAPA provider — change the cloud credential and verify dentityRef is cleared from the infrastructure cluster spec and no error is shown on success.
4. Credential change failure — simulate a rejection from onEvent during credential change and verify the error appears in the UI.
5. Non-CAPA providers — verify that clusters using providers without onEvent](e.g. custom, DigitalOcean) are unaffected.
6. Rapid version changes — change Kubernetes version multiple times in quick succession and verify no race condition leaves the cluster in a bad state.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- All extension provisioners implementing [IClusterProvisioner] — the interface change is additive, but any provisioner that had a synchronous [onEvent] returning undefined should be verified to still work correctly
- credentialId watcher behaviour — the watcher logic around credential loading is unchanged, but the surrounding async flow should be verified for Harvester and other drivers that also react to credential changes.
- handleKubernetesChange — PSA defaults, NGINX configuration, and Harvester cloud provider resets all happen before the onEvent call and are unaffected, but the full method should be regression-tested across provider types.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
