### PR TITLE
Bump yaml from 1.10.2 to 1.10.3 and 2.8.2 to 2.8.3 to fix GHSA-48c2-rrv3-qjmp

### DIFF
--- a/cypress/yarn.lock
+++ b/cypress/yarn.lock
@@ -6256,14 +6256,14 @@ yallist@^3.0.2:
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yaml@^1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
+  integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==
 
 yaml@^2.0.0, yaml@^2.4.1:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.2.tgz#5694f25eca0ce9c3e7a9d9e00ce0ddabbd9e35c5"
-  integrity sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.3.tgz#a0d6bd2efb3dd03c59370223701834e60409bd7d"
+  integrity sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==
 
 yargs-parser@^18.1.2:
   version "18.1.3"

--- a/storybook/yarn.lock
+++ b/storybook/yarn.lock
@@ -5080,9 +5080,9 @@ yallist@^3.0.2:
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yaml@^1.10.0:
-  version "1.10.2"
-  resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+  version "1.10.3"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
+  integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==
 
 yocto-queue@^1.0.0:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15142,9 +15142,9 @@ yaml@2.8.3, yaml@^2.0.0, yaml@^2.4.1:
   integrity sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==
 
 yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
-  version "1.10.2"
-  resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+  version "1.10.3"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
+  integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==
 
 yargs-parser@20.2.4:
   version "20.2.4"


### PR DESCRIPTION
### Summary
Bumps [`yaml`](https://github.com/eemeli/yaml) to a non-vulnerable version to resolve **GHSA-48c2-rrv3-qjmp** (CVE-2026-33532): *yaml is vulnerable to Stack Overflow via deeply nested YAML collections*.

Fixes the open Dependabot alerts for the `yaml` package (no separate issue needed).

### Occurred changes and/or fixed issues
- Bump `yaml` from `1.10.2` to `1.10.3` (1.x line) and from `2.8.2` to `2.8.3` (2.x line).
- Applied across the root, `cypress/`, and `storybook/` workspaces (`yarn.lock`, `cypress/yarn.lock`, `storybook/yarn.lock`).
- Lockfile-only change; no application source code is modified.

### Technical notes summary
`yaml` 1.10.3 and 2.8.3 are the first patched releases for GHSA-48c2-rrv3-qjmp, which addresses uncontrolled recursion causing a stack overflow when parsing deeply nested YAML collections. Both major lines exist in the dependency tree, so each is updated to its respective patched version.

### Areas or cases that should be tested
- YAML editing/viewing across the UI (resource YAML editor, import/export) to confirm no parsing regressions.
- Cypress and Storybook builds, which pull `yaml` transitively.

### Areas which could experience regressions
- Anywhere the app parses or serialises YAML. These are semver-compatible patch bumps, so regression risk is low.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/2b24200c-c6cd-4328-8879-d143ee97b724

**Playwright checks performed** (video recorded, 1280×800):
1. **Login + Home dashboard.** Logged into the preview with real credentials; `/dashboard/home` rendered the
   live cluster list (7 clusters) — the app bundle built with the bumped `yaml` serves and boots. ✅ PASS
2. **Fleet → Settings (direct `yaml` 2.8.3 consumer).** Navigated to `/c/local/fleet/settings`, whose
   `ConfigMapSettings` component imports `yaml` and calls `YAML.parse`; the settings UI rendered with no
   yaml/stack-overflow JS error — the bumped module loads and parses in the running app. ✅ PASS
3. **ConfigMap Create → Edit as YAML (store→dump).** On the ConfigMap create form set a name, toggled
   **Edit as YAML**, and the editor serialized the resource showing `kind: ConfigMap` and the chosen name —
   the store→dump path works. ✅ PASS
4. **Saved ConfigMap YAML round-trip (load→dump).** Clicked **Create** against the live Steve API, then
   reopened the persisted resource's YAML view; it re-serialized from live-cluster data with the correct
   name, `resourceVersion`, and `uid` — full load→store→dump round-trip. (Test ConfigMap deleted afterward.) ✅ PASS
5. **(Extra) CVE-2026-33532 fix assertion.** Fed a 50,000-deep nested collection (`[[[…]]]`) through the
   exact bundled `yaml@2.8.3` module: the patched parser raised a controlled `YAMLParseError` and the process
   survived — no native stack-overflow crash (the DoS is fixed). ✅ PASS

**Verdict:** **5/5 checks passed.** The `yaml` bump to 1.10.3/2.8.3 compiles, the preview builds and serves, the `yaml`-package-backed Fleet Settings view and the YAML editor round-trip against live cluster data all work unchanged, and the deeply-nested-collection stack-overflow (CVE-2026-33532) is fixed. Safe to open the PR.


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Locks Dependabot alerts: #593, #591

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.

