### PR TITLE
Bump postcss to 8.5.12 to fix GHSA-6g55-p6wh-862q (CVE-2026-45623)

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,6 +231,6 @@
     "mocha/js-yaml": "4.3.0",
     "@cypress/code-coverage/js-yaml": "4.3.0",
     "webpack-dev-server": "5.2.6",
-    "postcss": "8.5.10"
+    "postcss": "8.5.12"
   }
 }

--- a/shell/package.json
+++ b/shell/package.json
@@ -156,7 +156,7 @@
     "@types/node": "25.3.3",
     "@vue/cli-service/html-webpack-plugin": "^5.0.0",
     "webpack-dev-server": "5.2.6",
-    "postcss": "8.5.10"
+    "postcss": "8.5.12"
   },
   "nyc": {
     "extension": [

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -10284,10 +10284,10 @@ postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.5.10, postcss@^7.0.36, postcss@^8.2.6, postcss@^8.3.5, postcss@^8.4.19, postcss@^8.4.33, postcss@^8.5.6, postcss@^8.5.8:
-  version "8.5.10"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.10.tgz#8992d8c30acf3f12169e7c09514a12fed7e48356"
-  integrity sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
+postcss@8.5.12, postcss@^7.0.36, postcss@^8.2.6, postcss@^8.3.5, postcss@^8.4.19, postcss@^8.4.33, postcss@^8.5.6, postcss@^8.5.8:
+  version "8.5.12"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.12.tgz#cd0c0f667f7cb0521e2313234ea6e707a9ec1ddb"
+  integrity sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==
   dependencies:
     nanoid "^3.3.11"
     picocolors "^1.1.1"

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -38,7 +38,7 @@
   "resolutions": {
     "uuid": "11.1.1",
     "serialize-javascript": "7.0.5",
-    "postcss": "8.5.10",
+    "postcss": "8.5.12",
     "braces": "^3.0.3"
   }
 }

--- a/storybook/yarn.lock
+++ b/storybook/yarn.lock
@@ -3967,10 +3967,10 @@ postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.5.10, postcss@^8.4.33, postcss@^8.4.48:
-  version "8.5.10"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.10.tgz#8992d8c30acf3f12169e7c09514a12fed7e48356"
-  integrity sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
+postcss@8.5.12, postcss@^8.4.33, postcss@^8.4.48:
+  version "8.5.12"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.12.tgz#cd0c0f667f7cb0521e2313234ea6e707a9ec1ddb"
+  integrity sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==
   dependencies:
     nanoid "^3.3.11"
     picocolors "^1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12376,10 +12376,10 @@ postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.5.10, postcss@^7.0.36, postcss@^8.2.6, postcss@^8.3.5, postcss@^8.4.33, postcss@^8.5.6, postcss@^8.5.8:
-  version "8.5.10"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.10.tgz#8992d8c30acf3f12169e7c09514a12fed7e48356"
-  integrity sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==
+postcss@8.5.12, postcss@^7.0.36, postcss@^8.2.6, postcss@^8.3.5, postcss@^8.4.33, postcss@^8.5.6, postcss@^8.5.8:
+  version "8.5.12"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.12.tgz#cd0c0f667f7cb0521e2313234ea6e707a9ec1ddb"
+  integrity sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==
   dependencies:
     nanoid "^3.3.11"
     picocolors "^1.1.1"


### PR DESCRIPTION
Arbitrary file read / information disclosure in `postcss` (high). Transitive bump forced via `resolutions` to the patched **8.5.12** in the root, `shell/`, and `storybook/` workspaces; `yarn.lock` regenerated in each.

### Summary
Fixes #
https://github.com/rancher/dashboard/security/dependabot/1043
https://github.com/rancher/dashboard/security/dependabot/1042
https://github.com/rancher/dashboard/security/dependabot/1041

Resolves the high-severity `postcss` advisory **GHSA-6g55-p6wh-862q** (CVE-2026-45623) — *PostCSS: Arbitrary file read and information disclosure via attacker-controlled `sourceMappingURL` in CSS comments*. Vulnerable range is `<= 8.5.11`; first patched in `8.5.12`. This PR moves every copy of `postcss` in the tree to **8.5.12**.

### Occurred changes and/or fixed issues
- Added / bumped a `postcss: 8.5.12` entry in the `resolutions` block of the root `package.json`, `shell/package.json`, and `storybook/package.json` to force the **transitive** copies of `postcss` to the patched version.
- Regenerated `yarn.lock`, `shell/yarn.lock`, and `storybook/yarn.lock`. After the change, no `postcss` entry in any lockfile resolves inside the vulnerable range (`<= 8.5.11`).
- `docusaurus/yarn.lock` already resolved to `8.5.12` and had no open alert — left untouched.

### Technical notes summary
- `postcss` is a **build-time** CSS transform engine, not a runtime import. In this repo it is pulled in transitively by the CSS toolchain: `@vue/compiler-sfc` / `@vue/component-compiler-utils` (which run postcss to compile and scope every `.vue` component's `<style>` block), `css-loader`, `css-minimizer-webpack-plugin`, and `@vue/cli-service`. All open alerts (root, `shell/`, `storybook/`) were transitive.
- Yarn (classic v1) `resolutions` keys cannot be scoped by semver range, so a single `postcss: 8.5.12` resolution per workspace forces the whole tree — every consuming range (`^7.0.36`, `^8.2.6`, `^8.3.5`, `^8.4.33`, `^8.5.6`, `^8.5.8`, …) — to the single patched `8.5.12`.
- The dependency set (`nanoid`, `picocolors`, `source-map-js`) is identical between the prior and patched postcss, so the lockfile change adds **zero** new packages.
- Lockfiles were regenerated with `yarn install` (no hand-editing of integrity hashes).

### Areas or cases that should be tested
- Anything that renders styled UI, since postcss produces the shipped CSS: the login page, the global app shell / side-nav, Vue scoped `<style>` blocks, and component/table styling.
- Reviewer should verify with a different browser than the author.

### Areas which could experience regressions
- The CSS build pipeline (`@vue/compiler-sfc` scoped styles, `css-loader`, `css-minimizer-webpack-plugin`). Because postcss is pinned via an exact `resolutions` entry, any consumer expecting an older postcss now gets `8.5.12`; the patch is a minor within the `8.5.x` line, so API compatibility is expected. Verified below that global stylesheets, Vue scoped styles, and table styling all render correctly.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/35962964-becd-482d-b4c6-d34e97875770

**Playwright checks performed** (video recorded, 1280×800):
1. **Login page CSS applied** — the login submit button is styled by the postcss-built stylesheet (computed `background-color: rgb(0, 134, 87)`, white text, `border-radius: 4px`) — not an unstyled default. ✅ PASS
2. **postcss-8.5.12 bundle boots & authenticates** — logged in with real credentials and landed on `/dashboard/` (off `/auth/login`). ✅ PASS
3. **Global app-shell CSS loaded** — 426 stylesheets / **5582** CSS rules present; the side-nav renders with `display: flex` (layout applied, not inline default). ✅ PASS
4. **Vue scoped-style postcss transform shipped & applied** — found a compiled scoped rule `.empty-product-page[data-v-06415220]` and a rendered element carrying a matching `data-v-*` attribute, proving `@vue/compiler-sfc`'s postcss scoped-style pipeline produced working CSS. ✅ PASS
5. **Real cluster ConfigMaps list renders styled** — navigated the live UI to `c/local/explorer/configmap` against the proxied local cluster; the SortableTable rendered with correct postcss-compiled table CSS (header `display: table-cell`). (List returned 0 rows — an empty/filtered namespace — but the component and its styling rendered correctly.) ✅ PASS
6. **No uncaught JS runtime errors** — zero `pageerror` events captured across login, app-shell, and cluster-view navigation. ✅ PASS

**Verdict:** **6/6 checks passed.** postcss 8.5.12 builds cleanly and the shipped CSS (global stylesheets, Vue scoped styles, and component/table styling) renders and applies correctly across the login page, app shell, and a live cluster resource view — the bump is safe.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Locks Dependabot alerts: #1043, #1042, #1041

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.

