### PR TITLE
Bump ejs from 3.1.9 to 3.1.10 in /shell

### DIFF
--- a/shell/package.json
+++ b/shell/package.json
@@ -137,7 +137,7 @@
     "@babel/core": "7.29.7",
     "uuid": "11.1.1",
     "d3-color": "3.1.0",
-    "ejs": "3.1.9",
+    "ejs": "3.1.10",
     "follow-redirects": "1.16.0",
     "glob": "7.2.3",
     "glob-parent": "6.0.2",

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -6338,10 +6338,10 @@ ee-first@1.1.1:
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-ejs@3.1.9:
-  version "3.1.9"
-  resolved "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz#03c9e8777fe12686a9effcef22303ca3d8eeb361"
-  integrity sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==
+ejs@3.1.10:
+  version "3.1.10"
+  resolved "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
+  integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
   dependencies:
     jake "^10.8.5"
 


### PR DESCRIPTION
### Summary
Bumps [ejs](https://github.com/mde/ejs) from 3.1.9 to 3.1.10 to remediate GHSA-ghr5-ch3p-vcr6 / CVE-2024-33883 — "ejs lacks certain pollution protection".

### Occurred changes and/or fixed issues
- `ejs` bumped `3.1.9` → `3.1.10` in `shell/package.json` (direct, exact pin), with the corresponding `shell/yarn.lock` update.
- Addresses the "ejs lacks certain pollution protection" advisory (option-object pollination hardening).

### Technical notes summary
Direct dependency patch bump only; no source changes. `ejs` is a build-time template engine consumed by the webpack/`@vue/cli-service` build (no runtime import and no `.ejs` templates in the shipped bundle). The patch release has an identical public API and dependency tree (`jake ^10.8.5` unchanged) and only hardens option-object pollution, so render output is unchanged. Lockfile re-resolved to pull `ejs@3.1.10`.

### Areas or cases that should be tested
General smoke test of the dashboard — since `ejs` is build-time only, the meaningful checks are that the app builds cleanly with the bumped version and the built app runs correctly end-to-end against the live proxied cluster API. Verified locally in a preview deploy (see recording below).

### Areas which could experience regressions
The build-time HTML app-shell generation and, by extension, the built dashboard bundle. No runtime code paths import `ejs`.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/09cbb9a1-664a-49de-b464-f285861d39ef

**Playwright checks performed** (video recorded, 1280×800):
1. **Login page renders from the built app shell** — navigated to `/dashboard/auth/login`; the login form
   rendered and `document.title` was `prime - Login`, confirming the build-time-templated HTML shell loads. ✅ PASS
2. **Authenticates and loads the dashboard home UI** — logged in with real credentials; reached
   `/dashboard/home` with the side-nav/header rendered, proving the app bootstraps from the built bundles. ✅ PASS
3. **Local-cluster ConfigMaps list loads real proxied API data** — opened
   `/dashboard/c/local/explorer/configmap`; the list rendered **100 real ConfigMap rows** served through the
   preview's proxied `/k8s` Steve API against the live `local` cluster (no Error masthead). ✅ PASS
4. **Resource detail view renders in the built UI** — opened the Nodes list and drilled into a node detail
   view; the masthead rendered live cluster data (`Node: ip-10-0-0-253 — Active`), confirming resource
   views work with real API data on the bumped build. ✅ PASS

**Verdict:** **4/4 checks passed.** ejs 3.1.9 → 3.1.10 is a build-time-only patch bump; the dashboard builds cleanly and the built app runs correctly end-to-end against the live proxied cluster API — the fix is safe.


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Locks Dependabot alerts: #259

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.

