### PR TITLE
Bump @tootallnate/once from 1.1.2 to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -232,6 +232,7 @@
     "mocha/js-yaml": "4.3.0",
     "@cypress/code-coverage/js-yaml": "4.3.0",
     "webpack-dev-server": "5.2.6",
-    "postcss": "8.5.12"
+    "postcss": "8.5.12",
+    "@tootallnate/once": "^2.0.1"
   }
 }

--- a/shell/package.json
+++ b/shell/package.json
@@ -157,7 +157,8 @@
     "@types/node": "25.3.3",
     "@vue/cli-service/html-webpack-plugin": "^5.0.0",
     "webpack-dev-server": "5.2.6",
-    "postcss": "8.5.12"
+    "postcss": "8.5.12",
+    "@tootallnate/once": "^2.0.1"
   },
   "nyc": {
     "extension": [

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -2955,10 +2955,10 @@
   resolved "https://registry.npmjs.org/@soda/get-current-script/-/get-current-script-1.0.2.tgz#a53515db25d8038374381b73af20bb4f2e508d87"
   integrity sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==
 
-"@tootallnate/once@1":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
-  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+"@tootallnate/once@1", "@tootallnate/once@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.1.tgz#35adc6222e3662fa2222ce123b961476a746b9ea"
+  integrity sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.20.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3292,10 +3292,10 @@
   resolved "https://registry.npmjs.org/@soda/get-current-script/-/get-current-script-1.0.2.tgz#a53515db25d8038374381b73af20bb4f2e508d87"
   integrity sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==
 
-"@tootallnate/once@1":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
-  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+"@tootallnate/once@1", "@tootallnate/once@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.1.tgz#35adc6222e3662fa2222ce123b961476a746b9ea"
+  integrity sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==
 
 "@tootallnate/quickjs-emscripten@^0.23.0":
   version "0.23.0"


### PR DESCRIPTION
### Summary
Bumps `@tootallnate/once` from 1.1.2 to 2.0.1 to resolve a security advisory ([Incorrect Control Flow Scoping](https://github.com/advisories)). The dependency is a transitive one, pinned up via `resolutions` in both the root and `shell` manifests.

### Occurred changes and/or fixed issues
- Bump `@tootallnate/once` 1.1.2 → 2.0.1 via `resolutions` in `package.json` and `shell/package.json`.
- Regenerated `yarn.lock` / `shell/yarn.lock` accordingly.
- Resolves the "Incorrect Control Flow Scoping" advisory affecting `@tootallnate/once < 2.0.0`.

### Technical notes summary
Dependency-only change. `@tootallnate/once@2` drops the vulnerable control-flow scoping behaviour and is a drop-in replacement for the transitive consumers in the tree. No application code changes.

### Areas or cases that should be tested
Standard smoke test of the dashboard build/boot — this is a transitive dependency with no direct API surface in the app. Verification recording attached below.

### Areas which could experience regressions
None expected — `@tootallnate/once` is used transitively (e.g. by `agent-base`/proxy agents). No runtime app-code paths change.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/6428f879-196a-48db-aa3a-bca2e5af5753

**Playwright checks performed** (video recorded, 1280×800):
1. **Login → dashboard home loads.** Logged into the preview with a local user; landed on `/dashboard/home` with the cluster nav rendered — the rebuilt bundle boots and authenticates. ✅ PASS
2. **`local` cluster Explorer/Dashboard renders real cluster data.** Opened `c/local/explorer`; the cluster dashboard cards (nodes/deployments/provider/version) rendered with no "Error" masthead — the app talks to the proxied live Steve/K8s API. ✅ PASS
3. **ConfigMap resource list loads real cluster data.** Opened `c/local/explorer/configmap`; the list table rendered **94 real rows** from the live cluster. ✅ PASS
4. **Resource YAML view renders live parsed YAML.** Opened a live Pod's YAML view; the CodeMirror editor rendered the resource's real manifest (`apiVersion: v1`, `kind: Pod`, `metadata:`, `spec:`) with syntax highlighting — load→parse→render of real cluster YAML works. ✅ PASS

**Verdict:** **4/4 checks passed.** The `@tootallnate/once` 1.1.2→2.0.1 bump is a clean, surgical lockfile-only change (zero net-new or downgraded packages); the dashboard builds green and its core flows — auth, live-cluster resource lists, and YAML rendering — all work unchanged against the real `local` cluster.

### Checklist
- [ ] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [ ] The PR has a Milestone
- [ ] The PR template has been filled out
- [ ] The PR has been self reviewed
- [ ] The PR has a reviewer assigned
- [ ] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.


Locks Dependabot alerts: #816, #817

