### PR TITLE
Bump cookie from 0.4.2 to 0.7.2 to fix GHSA-pxg6-pf52-xh8x (CVE-2024-47764)

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,6 +235,7 @@
     "@cypress/code-coverage/js-yaml": "4.3.0",
     "webpack-dev-server": "5.2.6",
     "postcss": "8.5.18",
-    "@tootallnate/once": "^2.0.1"
+    "@tootallnate/once": "^2.0.1",
+    "cookie": "0.7.2"
   }
 }

--- a/shell/package.json
+++ b/shell/package.json
@@ -159,7 +159,8 @@
     "@vue/cli-service/html-webpack-plugin": "^5.0.0",
     "webpack-dev-server": "5.2.6",
     "postcss": "8.5.18",
-    "@tootallnate/once": "^2.0.1"
+    "@tootallnate/once": "^2.0.1",
+    "cookie": "0.7.2"
   },
   "nyc": {
     "extension": [

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -5385,12 +5385,7 @@ cookie-universal@2.2.2:
     "@types/cookie" "^0.3.3"
     cookie "^0.4.0"
 
-cookie@^0.4.0:
-  version "0.4.2"
-  resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
-  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
-
-cookie@~0.7.1:
+cookie@0.7.2, cookie@^0.4.0, cookie@~0.7.1:
   version "0.7.2"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6182,12 +6182,7 @@ cookie-universal@2.2.2:
     "@types/cookie" "^0.3.3"
     cookie "^0.4.0"
 
-cookie@^0.4.0:
-  version "0.4.2"
-  resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
-  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
-
-cookie@~0.7.1:
+cookie@0.7.2, cookie@^0.4.0, cookie@~0.7.1:
   version "0.7.2"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==


### PR DESCRIPTION
Out-of-bounds character handling in `cookie` name/path/domain parsing & serialization (low). Transitive bump forced via `resolutions` to the patched **0.7.2** in the root and `shell/` workspaces; `yarn.lock` regenerated in each.

### Summary
Fixes #
https://github.com/rancher/dashboard/security/dependabot/308
https://github.com/rancher/dashboard/security/dependabot/309

Resolves the `cookie` advisory **GHSA-pxg6-pf52-xh8x** (CVE-2024-47764) — *cookie accepts cookie name, path, and domain with out of bounds characters*. Vulnerable range is `< 0.7.0`; first patched in `0.7.0`. This PR moves every copy of `cookie` in the tree to **0.7.2**.

### Occurred changes and/or fixed issues
- Added a `cookie: 0.7.2` entry to the `resolutions` block of the root `package.json` and `shell/package.json` to force the **transitive** copies of `cookie` to the patched version. `cookie` is pulled in transitively via `cookie-universal@2.2.2`, whose `cookie@^0.4.0` range could not admit the patch.
- Regenerated `yarn.lock` and `shell/yarn.lock`. After the change, no `cookie` entry in either lockfile resolves inside the vulnerable range (`< 0.7.0`).
- `cypress/yarn.lock` and `docusaurus/yarn.lock` already resolved to the safe `0.7.2` and had no open alert — left untouched.

### Technical notes summary
- `cookie` (HTTP cookie name/path/domain **parse** + **serialize**) reaches the dashboard through `cookie-universal`, wrapped by `shell/store/cookies.ts` (Vuex `cookies` store with `get`/`set`/`remove`). Its user-facing consumer is the **local login page** (`shell/pages/auth/login.vue`): the `fetch()` hook calls `cookies/get` (→ `cookie.parse`) to restore a remembered username, and a successful login with **"Remember username"** checked calls `cookies/set` (→ `cookie.serialize` with `name=R_USERNAME`, `path='/'`, `secure`, `sameSite`).
- Yarn (classic v1) `resolutions` keys cannot be scoped by semver range, so a single `cookie: 0.7.2` resolution per workspace forces the whole tree to the patched version. `0.7.0` tightened name/path/domain validation, exactly the surface exercised by the login remember-me round-trip.
- Lockfiles were regenerated with `yarn install` (no hand-editing of integrity hashes); the bump adds zero net-new vulnerable packages.

### Areas or cases that should be tested
- The **local login page**: cookie parse-on-load (remembered username pre-fill) and cookie serialize on login with "Remember username" checked.
- Reviewer should verify with a different browser than the author.

### Areas which could experience regressions
- Anything that reads/writes cookies via `shell/store/cookies.ts` — principally the login remember-username flow. `0.7.2` is a patch within the `0.7.x` line and only tightens character validation on names/paths/domains, so existing valid cookies (e.g. `R_USERNAME`, `path='/'`) round-trip unchanged. Verified below.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/c8187bf2-71f0-4eb7-9feb-ed0e85521b5a

**Playwright checks performed** (video recorded, 1280×800):
1. **Login page renders / cookie parse-on-load** — navigated to the preview; the login `fetch()` hook ran `cookies/get` (`cookie.parse`) and the local login form rendered and was interactive with no error. **✅ PASS** — form present, no parse error.
2. **Login with "Remember username" → cookie serialize** — logged in as the local admin with Remember checked; landed on `/dashboard/home`, and `cookies/set` (`cookie.serialize` with `name=R_USERNAME path='/' secure sameSite`) wrote the cookie `R_USERNAME=admin`. **✅ PASS** — authenticated and cookie correctly serialized under cookie@0.7.2's stricter name/path validation.
3. **Serialize→parse round-trip** — reopened the login page; the `fetch()` hook read the persisted `R_USERNAME` cookie back (`cookie.parse`) and pre-filled the username field with `admin`. **✅ PASS** — round-trip intact, no data loss/rejection from the bump.
4. **App end-to-end on the bumped dep (real cluster data)** — navigated authenticated to the local cluster Deployments list (`/dashboard/c/local/explorer/apps.deployment`); the view loaded real data through the proxied Steve API with no error masthead. **✅ PASS** — dashboard runs end-to-end on cookie@0.7.2.

**Verdict:** **4/4 checks passed.** Bumping `cookie` to `0.7.2` fixes CVE-2024-47764 with no behavioral regression — the login remember-username serialize/parse round-trip works and the dashboard runs end-to-end against live cluster data. Preview built cleanly and lockfiles add zero net-new vulnerable packages.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.

