### PR TITLE
Cluster Detail: Show the mgmt cluster status instead of provisioning cluster state

### DIFF
--- a/shell/detail/__tests__/provisioning.cattle.io.cluster.test.ts
+++ b/shell/detail/__tests__/provisioning.cattle.io.cluster.test.ts
@@ -1,20 +1,24 @@
 import { shallowMount } from '@vue/test-utils';
 import ProvisioningCattleIoCluster from '@shell/detail/provisioning.cattle.io.cluster.vue';
-import * as MastheadComposable from '@shell/components/Resource/Detail/Masthead/composable';
+import * as TitleBarComposables from '@shell/components/Resource/Detail/TitleBar/composables';
+import * as MetadataComposables from '@shell/components/Resource/Detail/Metadata/composables';
 
 jest.mock('@shell/utils/clipboard', () => {
   return { copyTextToClipboard: jest.fn(() => Promise.resolve({})) };
 });
 
-jest.mock('@shell/components/Resource/Detail/Masthead/composable');
+jest.mock('@shell/components/Resource/Detail/TitleBar/composables');
+jest.mock('@shell/components/Resource/Detail/Metadata/composables');
 
 describe('view: provisioning.cattle.io.cluster', () => {
-  const useDefaultMastheadPropsSpy = jest.spyOn(MastheadComposable, 'useDefaultMastheadProps');
+  const useDefaultTitleBarPropsSpy = jest.spyOn(TitleBarComposables, 'useDefaultTitleBarProps');
+  const useDefaultMetadataForLegacyPagesPropsSpy = jest.spyOn(MetadataComposables, 'useDefaultMetadataForLegacyPagesProps');
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    useDefaultMastheadPropsSpy.mockReturnValue({} as any);
+    useDefaultTitleBarPropsSpy.mockReturnValue({ value: {} } as any);
+    useDefaultMetadataForLegacyPagesPropsSpy.mockReturnValue({ value: {} } as any);
   });
 
   const mockStore = {
@@ -291,6 +295,73 @@ describe('view: provisioning.cattle.io.cluster', () => {
       });
 
       expect(wrapper.vm.showLog).toBeFalsy();
+    });
+  });
+
+  describe('setup: customMastheadProps', () => {
+    const titleBarProps = {
+      resourceTypeLabel: 'Cluster',
+      resourceName:      'my-cluster',
+      badge:             { color: 'bg-info', label: 'Provisioning State' },
+    };
+    const metadataProps = { resource: { some: 'resource' } };
+
+    beforeEach(() => {
+      useDefaultTitleBarPropsSpy.mockReturnValue({ value: titleBarProps } as any);
+      useDefaultMetadataForLegacyPagesPropsSpy.mockReturnValue({ value: metadataProps } as any);
+    });
+
+    it('uses the mgmt cluster state for the header badge when mgmt exists', () => {
+      const value = {
+        stateBackground: 'bg-error',
+        stateDisplay:    'Prov Error',
+        mgmt:            {
+          stateBackground: 'bg-success',
+          stateDisplay:    'Active',
+        },
+      };
+
+      const wrapper = shallowMount(ProvisioningCattleIoCluster, {
+        props:  { value },
+        global: { mocks },
+      });
+
+      expect(wrapper.vm.customMastheadProps.titleBarProps.badge).toStrictEqual({
+        color: 'bg-success',
+        label: 'Active',
+      });
+    });
+
+    it('falls back to the provisioning cluster state for the header badge when mgmt is undefined', () => {
+      const value = {
+        stateBackground: 'bg-error',
+        stateDisplay:    'Prov Error',
+      };
+
+      const wrapper = shallowMount(ProvisioningCattleIoCluster, {
+        props:  { value },
+        global: { mocks },
+      });
+
+      expect(wrapper.vm.customMastheadProps.titleBarProps.badge).toStrictEqual({
+        color: 'bg-error',
+        label: 'Prov Error',
+      });
+    });
+
+    it('preserves the other default title bar props and passes through the metadata props', () => {
+      const value = { mgmt: { stateBackground: 'bg-success', stateDisplay: 'Active' } };
+
+      const wrapper = shallowMount(ProvisioningCattleIoCluster, {
+        props:  { value },
+        global: { mocks },
+      });
+
+      const result = wrapper.vm.customMastheadProps;
+
+      expect(result.titleBarProps.resourceTypeLabel).toStrictEqual('Cluster');
+      expect(result.titleBarProps.resourceName).toStrictEqual('my-cluster');
+      expect(result.metadataProps).toStrictEqual(metadataProps);
     });
   });
 });

--- a/shell/detail/provisioning.cattle.io.cluster.vue
+++ b/shell/detail/provisioning.cattle.io.cluster.vue
@@ -34,9 +34,11 @@ import CapiMachineDeployment from '@shell/models/cluster.x-k8s.io.machinedeploym
 import { isAlternate } from '@shell/utils/platform';
 import DetailPage from '@shell/components/Resource/Detail/Page.vue';
 import Masthead from '@shell/components/Resource/Detail/Masthead/index.vue';
-import { useDefaultMastheadProps } from '@shell/components/Resource/Detail/Masthead/composable';
 import AutoscalerTab from '@shell/components/AutoscalerTab.vue';
 import { isAutoscalerFeatureFlagEnabled } from '@shell/utils/autoscaler-utils';
+import { useDefaultTitleBarProps } from '@shell/components/Resource/Detail/TitleBar/composables';
+import { useDefaultMetadataForLegacyPagesProps } from '@shell/components/Resource/Detail/Metadata/composables';
+import { computed } from 'vue';
 
 let lastId = 1;
 const ansiup = new AnsiUp();
@@ -90,7 +92,29 @@ export default {
   },
 
   setup(props) {
-    return { defaultMastheadProps: useDefaultMastheadProps(props.value) };
+    const titleBarProps = useDefaultTitleBarProps(props.value);
+    const metadataProps = useDefaultMetadataForLegacyPagesProps(props.value);
+
+    const customMastheadProps = computed(() => {
+      const resource = props.value.mgmt || props.value;
+
+      return {
+        titleBarProps: {
+          ...titleBarProps.value,
+          // Show the mgmt cluster state instead of provisioning state
+          // This now matches the prov list where we show mgmt cluster state
+          // (mgmt cluster is the single-source of truth)
+          // `badge` is of type @Badge
+          badge: {
+            color: resource?.stateBackground,
+            label: resource?.stateDisplay,
+          },
+        },
+        metadataProps: metadataProps.value,
+      };
+    });
+
+    return { customMastheadProps };
   },
 
   async fetch() {
@@ -858,7 +882,7 @@ export default {
 <template>
   <DetailPage :loading="$fetchState.pending">
     <template #top-area>
-      <Masthead v-bind="defaultMastheadProps">
+      <Masthead v-bind="customMastheadProps">
         <template #additional-actions>
           <button
             data-testid="detail-explore-button"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/17960
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- in 2.15 the single-source of truth changes from provisioning.cattle.io cluster (PCIC) to management.cattle.io cluster (MCIC)
- the PCIC list page was kept but we now show MCIC instead
- the detail page is the same though - PCIC
- this meant we were showing incorrect and lagging cluster status
- we now use MCIC status in PCIC detail page

### Areas or cases that should be tested
- cluster detail page should show a status matching the cluster list
- the status should update automatically as cluster state changes

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
