### PR TITLE
Set kubectl.kubernetes.io/restartedAt annotation on workload redeploy

### DIFF
--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -2,6 +2,7 @@ export const NORMAN_NAME = 'field.cattle.io/name';
 export const DESCRIPTION = 'field.cattle.io/description';
 export const HOSTNAME = 'kubernetes.io/hostname';
 export const TIMESTAMP = 'cattle.io/timestamp';
+export const KUBECTL_RESTARTED_AT = 'kubectl.kubernetes.io/restartedAt';
 export const SYSTEM_NAMESPACE = 'management.cattle.io/system-namespace';
 export const PROJECT = 'field.cattle.io/projectId';
 export const DEFAULT_PROJECT = 'authz.management.cattle.io/default-project';

--- a/shell/dialog/RedeployWorkloadDialog.vue
+++ b/shell/dialog/RedeployWorkloadDialog.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { TIMESTAMP } from '@shell/config/labels-annotations';
+import { TIMESTAMP, KUBECTL_RESTARTED_AT } from '@shell/config/labels-annotations';
 import AsyncButton from '@shell/components/AsyncButton';
 import { Card } from '@components/Card';
 import { Banner } from '@components/Banner';
@@ -83,6 +83,7 @@ export default {
           const annotations = metadata.annotations ??= {};
 
           annotations[TIMESTAMP] = now;
+          annotations[KUBECTL_RESTARTED_AT] = now;
 
           await workload.save();
         }

--- a/shell/dialog/__tests__/RedeployWorkloadDialog.test.ts
+++ b/shell/dialog/__tests__/RedeployWorkloadDialog.test.ts
@@ -1,0 +1,124 @@
+import { shallowMount } from '@vue/test-utils';
+import RedeployWorkloadDialog from '@shell/dialog/RedeployWorkloadDialog.vue';
+import { TIMESTAMP, KUBECTL_RESTARTED_AT } from '@shell/config/labels-annotations';
+
+const defaultStubs = {
+  Card:        true,
+  AsyncButton: true,
+  Banner:      true,
+};
+
+const defaultMocks = {
+  $store: {
+    getters: {
+      'i18n/t':            jest.fn((key: string) => key),
+      'type-map/labelFor': jest.fn(() => 'Deployment'),
+    },
+  },
+  t: jest.fn((key: string) => key),
+};
+
+function createWorkload(overrides = {}) {
+  return {
+    nameDisplay: 'my-workload',
+    type:        'apps.deployment',
+    schema:      { id: 'apps.deployment' },
+    spec:        { template: { metadata: { annotations: {} } } },
+    save:        jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('component: RedeployWorkloadDialog', () => {
+  const createWrapper = (propsData = {}, mocks = {}) => {
+    return shallowMount(RedeployWorkloadDialog, {
+      propsData: {
+        workloads: [createWorkload()],
+        ...propsData,
+      },
+      global: {
+        mocks: {
+          ...defaultMocks,
+          ...mocks,
+        },
+        stubs:      defaultStubs,
+        directives: { 'clean-html': true },
+      },
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render correctly', () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  describe('apply', () => {
+    it('should set both TIMESTAMP and kubectl restartedAt annotations', async() => {
+      const workload = createWorkload();
+      const wrapper = createWrapper({ workloads: [workload] });
+      const buttonDone = jest.fn();
+
+      await (wrapper.vm as any).apply(buttonDone);
+
+      const annotations = workload.spec.template.metadata.annotations;
+
+      expect(annotations[TIMESTAMP]).toBeDefined();
+      expect(annotations[KUBECTL_RESTARTED_AT]).toBeDefined();
+      expect(annotations[TIMESTAMP]).toStrictEqual(annotations[KUBECTL_RESTARTED_AT]);
+      expect(workload.save).toHaveBeenCalledWith();
+      expect(buttonDone).toHaveBeenCalledWith(true);
+    });
+
+    it('should set annotations as ISO timestamps without milliseconds', async() => {
+      const workload = createWorkload();
+      const wrapper = createWrapper({ workloads: [workload] });
+
+      await (wrapper.vm as any).apply();
+
+      const ts = workload.spec.template.metadata.annotations[KUBECTL_RESTARTED_AT];
+
+      expect(ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    });
+
+    it('should initialize metadata and annotations when missing', async() => {
+      const workload = createWorkload({ spec: { template: {} } });
+      const wrapper = createWrapper({ workloads: [workload] });
+
+      await (wrapper.vm as any).apply();
+
+      const annotations = workload.spec.template.metadata.annotations;
+
+      expect(annotations[TIMESTAMP]).toBeDefined();
+      expect(annotations[KUBECTL_RESTARTED_AT]).toBeDefined();
+    });
+
+    it('should redeploy all workloads', async() => {
+      const workloads = [createWorkload(), createWorkload(), createWorkload()];
+      const wrapper = createWrapper({ workloads });
+
+      await (wrapper.vm as any).apply();
+
+      for (const w of workloads) {
+        expect(w.save).toHaveBeenCalledWith();
+        expect(w.spec.template.metadata.annotations[TIMESTAMP]).toBeDefined();
+        expect(w.spec.template.metadata.annotations[KUBECTL_RESTARTED_AT]).toBeDefined();
+      }
+    });
+
+    it('should report errors and call buttonDone(false) on failure', async() => {
+      const workload = createWorkload({ save: jest.fn().mockRejectedValue(new Error('save failed')) });
+      const wrapper = createWrapper({ workloads: [workload] });
+      const buttonDone = jest.fn();
+
+      await (wrapper.vm as any).apply(buttonDone);
+
+      expect(buttonDone).toHaveBeenCalledWith(false);
+      expect((wrapper.vm as any).errors.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
### Summary
Fixes #16445

### Occurred changes and/or fixed issues
When redeploying a Prometheus-managed StatefulSet, only some pods were restarted.
The dashboard set only the `cattle.io/timestamp` annotation to trigger a rolling
update, but the Prometheus operator does not recognize this annotation and reverts
it before the rollout completes.

This PR additionally sets the standard `kubectl.kubernetes.io/restartedAt` annotation
on the pod template during redeploy. The Prometheus operator recognizes and preserves
this annotation, so the rolling update completes successfully for all pods.

### Technical notes summary
- Added `KUBECTL_RESTARTED_AT` constant (`kubectl.kubernetes.io/restartedAt`) to
  [`shell/config/labels-annotations.js`](https://github.com/rancher/dashboard/blob/c1484305863daa8736e8fd7c9f0f0b5068c2e95d/shell/config/labels-annotations.js#L5).
- Updated `RedeployWorkloadDialog.vue` to set both `cattle.io/timestamp` and
  `kubectl.kubernetes.io/restartedAt` in the pod template annotations when
  redeploying. See
  [`shell/dialog/RedeployWorkloadDialog.vue`](https://github.com/rancher/dashboard/blob/c1484305863daa8736e8fd7c9f0f0b5068c2e95d/shell/dialog/RedeployWorkloadDialog.vue#L86).
- Added unit tests covering the dual-annotation behavior, timestamp format, missing
  metadata initialization, multi-workload redeploy, and error handling.

### Areas or cases that should be tested
- Redeploy a Prometheus-managed StatefulSet and verify all pods restart.
- Redeploy a standard Deployment and verify it still works as before.
- Redeploy multiple workloads at once from the list view.

### Areas which could experience regressions
- Workload redeploy for any resource type (Deployment, DaemonSet, StatefulSet).
- Controllers or operators that watch pod template annotations for changes.

### Screenshot/Video

**Before** (Ready 1/2, only one pod restarted):

![before](https://github.com/marcelofukumoto/dashboard/releases/download/issue-16445-artifacts/before-fix.png)

**After** (Ready 2/2, both pods restarted successfully):

![after](https://github.com/marcelofukumoto/dashboard/releases/download/issue-16445-artifacts/after-fix.png)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
