### PR TITLE
Fix issue with side nav losing highlight for some routes

### DIFF
--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -1,6 +1,6 @@
 <script>
 import Type from '@shell/components/nav/Type';
-import { filterLocationValidParams } from '@shell/utils/router';
+import { filterLocationValidParams, isNavItemActive } from '@shell/utils/router';
 import { RcSeparator } from '@components/RcSeparator';
 
 export default {
@@ -207,14 +207,19 @@ export default {
         } else if (item.route) {
           const navLevels = ['cluster', 'product', 'resource'];
           const matchesNavLevel = navLevels.filter((param) => !this.$route.params[param] || this.$route.params[param] !== item.route.params[param]).length === 0;
+
+          // Keep the group open wherever the child itself is highlighted, otherwise pages nested under a
+          // child's route (its create/detail pages) would collapse the group out from under it
+          if (matchesNavLevel || isNavItemActive(this.$router, this.$route, item)) {
+            return true;
+          }
+
           const validItemRoute = filterLocationValidParams(this.$router, item.route);
 
           // Use .path instead of .fullPath to ignore query parameters and hashes when comparing routes
           const itemPath = this.$router.resolve(validItemRoute).path;
 
-          if (matchesNavLevel || itemPath === this.$route.path) {
-            return true;
-          } else if (parentPath && itemPath === parentPath) {
+          if (parentPath && itemPath === parentPath) {
             return true;
           }
         }

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -214,12 +214,16 @@ export default {
             return true;
           }
 
+          if (!parentPath) {
+            continue;
+          }
+
           const validItemRoute = filterLocationValidParams(this.$router, item.route);
 
           // Use .path instead of .fullPath to ignore query parameters and hashes when comparing routes
           const itemPath = this.$router.resolve(validItemRoute).path;
 
-          if (parentPath && itemPath === parentPath) {
+          if (itemPath === parentPath) {
             return true;
           }
         }

--- a/shell/components/nav/Type.vue
+++ b/shell/components/nav/Type.vue
@@ -3,7 +3,7 @@ import Favorite from '@shell/components/nav/Favorite';
 import { TYPE_MODES } from '@shell/store/type-map';
 
 import TabTitle from '@shell/components/TabTitle';
-import { filterLocationValidParams } from '@shell/utils/router';
+import { filterLocationValidParams, isNavItemActive } from '@shell/utils/router';
 
 const showFavoritesFor = [TYPE_MODES.FAVORITE, TYPE_MODES.USED];
 
@@ -68,38 +68,7 @@ export default {
     },
 
     isActive() {
-      // Use .path instead of .fullPath to ignore query parameters and hashes when comparing routes
-      const typePath = this.$router.resolve(this.typeRoute)?.path.toLowerCase();
-      const pagePath = this.$route.path?.toLowerCase();
-      const routeMetaNav = this.$route.meta?.nav;
-
-      // If the route explicitly declares the nav path that should be highlighted, then use that
-      if (routeMetaNav) {
-        const cluster = this.$route.params?.cluster;
-        const product = this.$route.params?.product;
-        const navPath = routeMetaNav
-          .replace(':cluster', cluster)
-          .replace(':product', product);
-
-        if (navPath === typePath) {
-          return true;
-        }
-      }
-
-      if ( !this.type.exact) {
-        const typeSplit = typePath.split('/');
-        const pageSplit = pagePath.split('/');
-
-        for (let index = 0; index < typeSplit.length; ++index) {
-          if ( index >= pageSplit.length || typeSplit[index] !== pageSplit[index] ) {
-            return false;
-          }
-        }
-
-        return true;
-      }
-
-      return typePath === pagePath;
+      return isNavItemActive(this.$router, this.$route, this.type);
     },
 
     typeRoute() {

--- a/shell/components/nav/__tests__/Group.test.ts
+++ b/shell/components/nav/__tests__/Group.test.ts
@@ -66,6 +66,118 @@ describe('component: Group', () => {
     expect((wrapper.vm as any).hasActiveRoute()).toBe(true);
   });
 
+  it('hasActiveRoute stays true on a route for a resource a child claims via navResources', () => {
+    const group = {
+      name:     'cluster',
+      children: [
+        {
+          name:         'projects-namespaces',
+          route:        { name: 'c-cluster-product-projectsnamespaces', params: { cluster: 'local', product: 'explorer' } },
+          navResources: ['management.cattle.io.project']
+        }
+      ]
+    };
+
+    const wrapper = shallowMount(Group as any, {
+      props: {
+        group, canCollapse: true, idPrefix: ''
+      },
+      global: {
+        mocks: {
+          // Creating a project uses the generic resource create route, which no nav item links to
+          $route: {
+            params: {
+              cluster: 'local', product: 'explorer', resource: 'management.cattle.io.project'
+            },
+            path:     '/c/local/explorer/management.cattle.io.project/create',
+            fullPath: '/c/local/explorer/management.cattle.io.project/create',
+            matched:  []
+          },
+          $router: {
+            resolve:   jest.fn().mockReturnValue({ path: '/c/local/explorer/projectsnamespaces' }),
+            getRoutes: jest.fn().mockReturnValue([])
+          },
+          t: (key: string) => key
+        }
+      }
+    });
+
+    expect((wrapper.vm as any).hasActiveRoute()).toBe(true);
+  });
+
+  it('hasActiveRoute is false on a route for a resource no child claims', () => {
+    const group = {
+      name:     'cluster',
+      children: [
+        {
+          name:         'projects-namespaces',
+          route:        { name: 'c-cluster-product-projectsnamespaces', params: { cluster: 'local', product: 'explorer' } },
+          navResources: ['management.cattle.io.project']
+        }
+      ]
+    };
+
+    const wrapper = shallowMount(Group as any, {
+      props: {
+        group, canCollapse: true, idPrefix: ''
+      },
+      global: {
+        mocks: {
+          $route: {
+            params: {
+              cluster: 'local', product: 'explorer', resource: 'apps.deployment'
+            },
+            path:     '/c/local/explorer/apps.deployment/create',
+            fullPath: '/c/local/explorer/apps.deployment/create',
+            matched:  []
+          },
+          $router: {
+            resolve:   jest.fn().mockReturnValue({ path: '/c/local/explorer/projectsnamespaces' }),
+            getRoutes: jest.fn().mockReturnValue([])
+          },
+          t: (key: string) => key
+        }
+      }
+    });
+
+    expect((wrapper.vm as any).hasActiveRoute()).toBe(false);
+  });
+
+  it('hasActiveRoute stays true on a page nested under a child route', () => {
+    // The Providers group in Cluster Management. There is no current cluster under /c/_, so nav items
+    // resolve without a cluster param and the nav level check can't match on its own
+    const group = {
+      name:     'providers',
+      children: [
+        { name: 'rke-kontainer-providers', route: { name: 'c-cluster-manager-driver-kontainerdriver', params: {} } },
+        { name: 'rke-node-providers', route: { name: 'c-cluster-manager-driver-nodedriver', params: {} } }
+      ]
+    };
+
+    const mountOnPath = (path: string) => shallowMount(Group as any, {
+      props: {
+        group, canCollapse: true, idPrefix: ''
+      },
+      global: {
+        mocks: {
+          $route: {
+            params: { cluster: '_' }, path, matched: []
+          },
+          $router: {
+            resolve:   jest.fn((route: any) => ({ path: route.name === 'c-cluster-manager-driver-kontainerdriver' ? '/c/_/manager/kontainerDriver' : '/c/_/manager/nodeDriver' })),
+            getRoutes: jest.fn().mockReturnValue([])
+          },
+          t: (key: string) => key
+        }
+      }
+    });
+
+    expect((mountOnPath('/c/_/manager/kontainerDriver').vm as any).hasActiveRoute()).toBe(true);
+    // Clicking Create must not collapse the group out from under the highlighted child
+    expect((mountOnPath('/c/_/manager/kontainerDriver/create').vm as any).hasActiveRoute()).toBe(true);
+    expect((mountOnPath('/c/_/manager/hostedprovider').vm as any).hasActiveRoute()).toBe(false);
+  });
+
   describe('group header label', () => {
     const mountGroup = (group: any) => shallowMount(Group as any, {
       props: {

--- a/shell/components/nav/__tests__/Type.test.ts
+++ b/shell/components/nav/__tests__/Type.test.ts
@@ -171,6 +171,97 @@ describe('component: Type', () => {
       });
     });
 
+    describe('nested routes', () => {
+      const mountOnPath = (type: any, path: string) => shallowMount(Type as any, {
+        props: { type },
+
+        global: {
+          directives: { cleanHtml: (identity) => identity },
+
+          mocks: {
+            $store:  storeMock,
+            $router: routerMock,
+            $route:  {
+              params: { cluster: '_' }, path, fullPath: path
+            }
+          },
+          stubs: { routerLink: createChildRenderingRouterLinkStub() },
+        },
+      });
+
+      // Pages such as /c/_/manager/kontainerDriver/create are nested under the nav item's own route,
+      // so a non-exact item has to stay highlighted on them
+      const kontainerDrivers = {
+        name:  'rke-kontainer-providers',
+        route: '/c/_/manager/kontainerDriver',
+        exact: false
+      };
+
+      it('should use active class on a route nested under a non-exact type', () => {
+        const wrapper = mountOnPath(kontainerDrivers, '/c/_/manager/kontainerDriver/create');
+
+        expect(wrapper.find(`.${ activeClass }`).exists()).toBe(true);
+      });
+
+      it('should not use active class on a sibling route of a non-exact type', () => {
+        const wrapper = mountOnPath(kontainerDrivers, '/c/_/manager/nodeDriver/create');
+
+        expect(wrapper.find(`.${ activeClass }`).exists()).toBe(false);
+      });
+
+      it('should not use active class on a nested route when the type is exact', () => {
+        const wrapper = mountOnPath({ ...kontainerDrivers, exact: true }, '/c/_/manager/kontainerDriver/create');
+
+        expect(wrapper.find(`.${ activeClass }`).exists()).toBe(false);
+      });
+    });
+
+    describe('navResources', () => {
+      const projectsNamespaces = {
+        name:         'projects-namespaces',
+        route:        'projectsnamespaces',
+        navResources: ['management.cattle.io.project', 'namespace']
+      };
+
+      const mountOnResource = (type: any, resource: string) => shallowMount(Type as any, {
+        props: { type },
+
+        global: {
+          directives: { cleanHtml: (identity) => identity },
+
+          mocks: {
+            $store:  storeMock,
+            $router: routerMock,
+            // Creating a project uses the generic resource create route, which no nav item links to
+            $route:  {
+              params:   { resource },
+              path:     `${ resource }/create`,
+              fullPath: `${ resource }/create`
+            }
+          },
+          stubs: { routerLink: createChildRenderingRouterLinkStub() },
+        },
+      });
+
+      it('should use active class on a route for a claimed resource', () => {
+        const wrapper = mountOnResource(projectsNamespaces, 'management.cattle.io.project');
+
+        expect(wrapper.find(`.${ activeClass }`).exists()).toBe(true);
+      });
+
+      it('should not use active class on a route for an unclaimed resource', () => {
+        const wrapper = mountOnResource(projectsNamespaces, 'apps.deployment');
+
+        expect(wrapper.find(`.${ activeClass }`).exists()).toBe(false);
+      });
+
+      it('should not use active class when the type claims no resources', () => {
+        const wrapper = mountOnResource({ name: 'namespaces', route: 'namespaces' }, 'namespace');
+
+        expect(wrapper.find(`.${ activeClass }`).exists()).toBe(false);
+      });
+    });
+
     describe('should use classes if preconditions are met', () => {
       it('should use active class if the link is active', () => {
         const wrapper = shallowMount(Type as any, {

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -600,6 +600,7 @@ export function init(store) {
     route:        { name: 'c-cluster-product-members' },
     exact:        false,
     'exact-path': true,
+    navResources: [MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING, MANAGEMENT.PROJECT_ROLE_TEMPLATE_BINDING],
     ifHaveType:   {
       type:  MANAGEMENT.CLUSTER_ROLE_TEMPLATE_BINDING,
       store: 'management'
@@ -616,6 +617,7 @@ export function init(store) {
     weight:           98,
     route:            { name: 'c-cluster-product-projectsnamespaces' },
     exact:            true,
+    navResources:     [MANAGEMENT.PROJECT, NAMESPACE],
   });
 
   virtualType({
@@ -640,6 +642,7 @@ export function init(store) {
     weight:           98,
     route:            { name: 'c-cluster-product-namespaces' },
     exact:            true,
+    navResources:     [NAMESPACE],
   });
 
   virtualType({

--- a/shell/config/product/manager.js
+++ b/shell/config/product/manager.js
@@ -111,7 +111,7 @@ export function init(store) {
     namespaced: false,
     icon:       'globe',
     route:      { name: 'c-cluster-manager-driver-kontainerdriver' },
-    exact:      true
+    exact:      false
   });
   virtualType({
     labelKey:   'drivers.node.title',
@@ -120,7 +120,7 @@ export function init(store) {
     namespaced: false,
     icon:       'globe',
     route:      { name: 'c-cluster-manager-driver-nodedriver' },
-    exact:      true
+    exact:      false
   });
 
   virtualType({

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -385,6 +385,12 @@ export interface ConfigureVirtualTypeOptions extends ConfigureTypeOptions {
   name: string;
 
   /**
+   * Resource types that this nav item owns but does not link to directly. For
+   * example, the create page of a resource that has no nav entry of its own.
+   */
+  navResources?: string[];
+
+  /**
    * The route that this type should correspond to {@link PluginRouteRecordRaw} {@link RouteRecordRaw} {@link RouteRecordRawWithParams}
    */
   route: PluginRouteRecordRaw | RouteRecordRaw | RouteRecordRawWithParams | Object;

--- a/shell/store/type-map.js
+++ b/shell/store/type-map.js
@@ -53,6 +53,9 @@
 //                            --  obj can contain anything in the objects getTree returns.
 //                            --  obj must have a `name` that is unique among all virtual types.
 //                            -- `cluster` is automatically added to route.params if it exists.
+//                            -- `navResources` is an optional array of resource types. The nav item stays
+//                               highlighted while on a route for one of those resources. For example, some
+//                               create/edit pages of a type have no nav entry of their own.
 //
 // spoofedType(obj)           Create a fake type that can be treated like a normal type
 //
@@ -783,6 +786,7 @@ export const getters = {
           name:         typeObj.name,
           weight:       typeObj.weight || getters.typeWeightFor(typeObj.schema?.id || label, isBasic),
           overview:     !!typeObj.overview,
+          navResources: typeObj.navResources,
         });
       }
 

--- a/shell/types/store/type-map.ts
+++ b/shell/types/store/type-map.ts
@@ -258,6 +258,12 @@ export interface TypeMapVirtualType {
   overview?: boolean;
   /** Whether this custom page has an exact path match */
   'exact-path'?: boolean;
+  /**
+   * `navResources` is an optional array of resource types. The nav item stays
+   * highlighted while on a route for one of those resources. For example, some
+   * create/edit pages of a type have no nav entry of their own.
+   */
+  navResources?: string[];
 }
 
 /**

--- a/shell/utils/__tests__/router.test.js
+++ b/shell/utils/__tests__/router.test.js
@@ -9,6 +9,8 @@ import {
   routeMatched,
   routeRequiresAuthentication,
   routeRequiresInstallRedirect,
+  navItemClaimsRoute,
+  isNavItemActive,
 } from '@shell/utils/router';
 
 describe('findRouteDefinitionByName', () => {
@@ -487,5 +489,138 @@ describe('routeRequiresInstallRedirect', () => {
     },
   ])('$desc', ({ to, expected }) => {
     expect(routeRequiresInstallRedirect(to)).toStrictEqual(expected);
+  });
+});
+
+describe('navItemClaimsRoute', () => {
+  const navItem = { name: 'projects-namespaces', navResources: ['management.cattle.io.project', 'namespace'] };
+
+  it.each([
+    {
+      desc:     'returns true when the route resource param is claimed by the nav item',
+      navItem,
+      to:       { params: { resource: 'management.cattle.io.project' } },
+      expected: true,
+    },
+    {
+      desc:     'returns true when the claimed resource comes from route meta rather than params',
+      navItem,
+      to:       { params: {}, meta: { resource: 'namespace' } },
+      expected: true,
+    },
+    {
+      desc:     'returns false when the route resource is not claimed by the nav item',
+      navItem,
+      to:       { params: { resource: 'apps.deployment' } },
+      expected: false,
+    },
+    {
+      desc:     'returns false when the route has no resource',
+      navItem,
+      to:       { params: {} },
+      expected: false,
+    },
+    {
+      desc:     'returns false when the nav item claims no resources',
+      navItem:  { name: 'namespaces' },
+      to:       { params: { resource: 'namespace' } },
+      expected: false,
+    },
+    {
+      desc:     'returns false when there is no nav item',
+      navItem:  undefined,
+      to:       { params: { resource: 'namespace' } },
+      expected: false,
+    },
+    {
+      desc:     'returns false when there is no route',
+      navItem,
+      to:       undefined,
+      expected: false,
+    },
+  ])('$desc', ({ navItem, to, expected }) => {
+    expect(navItemClaimsRoute(navItem, to)).toStrictEqual(expected);
+  });
+});
+
+describe('isNavItemActive', () => {
+  // Nav items resolve to their own path, mirroring how the type-map builds them
+  const router = {
+    getRoutes: () => [],
+    resolve:   (route) => ({ path: route?.path || route })
+  };
+
+  const clusterDrivers = { name: 'rke-kontainer-providers', route: { path: '/c/_/manager/kontainerDriver' } };
+  const clusterDashboard = {
+    name: 'cluster-dashboard', route: { path: '/c/local/explorer' }, exact: true
+  };
+
+  it.each([
+    {
+      desc:     'is active on its own route',
+      navItem:  clusterDrivers,
+      to:       { path: '/c/_/manager/kontainerDriver' },
+      expected: true,
+    },
+    {
+      desc:     'stays active on a page nested under its route',
+      navItem:  clusterDrivers,
+      to:       { path: '/c/_/manager/kontainerDriver/create' },
+      expected: true,
+    },
+    {
+      desc:     'stays active on a detail page nested under its route',
+      navItem:  clusterDrivers,
+      to:       { path: '/c/_/manager/kontainerDriver/linode-lke' },
+      expected: true,
+    },
+    {
+      desc:     'is not active on a sibling route',
+      navItem:  clusterDrivers,
+      to:       { path: '/c/_/manager/nodeDriver/create' },
+      expected: false,
+    },
+    {
+      desc:     'is not active on a route that only shares a partial path segment',
+      navItem:  clusterDrivers,
+      to:       { path: '/c/_/manager/kontainerDriverExtra' },
+      expected: false,
+    },
+    {
+      desc:     'an exact item is active on its own route',
+      navItem:  clusterDashboard,
+      to:       { path: '/c/local/explorer' },
+      expected: true,
+    },
+    {
+      desc:     'an exact item is not active on a nested route',
+      navItem:  clusterDashboard,
+      to:       { path: '/c/local/explorer/apps.deployment' },
+      expected: false,
+    },
+    {
+      desc:    'is active when the route claims it through meta.nav, ignoring case',
+      navItem: clusterDrivers,
+      to:      {
+        path: '/c/_/manager/somewhere-else', params: { cluster: '_' }, meta: { nav: '/c/:cluster/manager/kontainerDriver' }
+      },
+      expected: true,
+    },
+    {
+      desc:    'is active when it claims the route resource through navResources',
+      navItem: {
+        name: 'projects-namespaces', route: { path: '/c/local/explorer/projectsnamespaces' }, exact: true, navResources: ['management.cattle.io.project']
+      },
+      to:       { path: '/c/local/explorer/management.cattle.io.project/create', params: { resource: 'management.cattle.io.project' } },
+      expected: true,
+    },
+    {
+      desc:     'is not active when the item has no route',
+      navItem:  { name: 'no-route' },
+      to:       { path: '/c/_/manager/kontainerDriver' },
+      expected: false,
+    },
+  ])('$desc', ({ navItem, to, expected }) => {
+    expect(isNavItemActive(router, to, navItem)).toStrictEqual(expected);
   });
 });

--- a/shell/utils/router.js
+++ b/shell/utils/router.js
@@ -78,6 +78,80 @@ export const getResourceFromRoute = (to) => {
 };
 
 /**
+ * Some pages have no side nav entry of their own. For example, creating a
+ * Project uses the generic `management.cattle.io.project` route, while the
+ * associated list route is 'projectsnamespaces'. Nav entries can use
+ * `navResources` to claim disparate routes and keep nav entries highlighted
+ * while they are active.
+ *
+ * @param {*} navItem a side nav entry, as built by the type-map `getTree` getter
+ * @param {*} to a VueRouter Route object
+ * @returns true if the nav item claims the route's resource, false otherwise
+ */
+export const navItemClaimsRoute = (navItem, to) => {
+  const resource = to ? getResourceFromRoute(to) : undefined;
+
+  return !!resource && !!navItem?.navResources?.includes(resource);
+};
+
+/**
+ * Whether a side nav entry should be highlighted for the given route. Both the
+ * nav item and the group containing it use this to determine what is active.
+ *
+ * An item is active when any of these hold true:
+ * - it claims the route's resource via `navResources`
+ * - the route names the nav path it belongs to via `meta.nav`
+ * - its own path matches the route. Unless the item is `exact`, pages nested
+ *   under that path count too, so `/c/_/manager/kontainerDriver` stays active
+ *   on `/c/_/manager/kontainerDriver/create`
+ *
+ * @param {*} router VueRouter instance
+ * @param {*} to a VueRouter Route object
+ * @param {*} navItem a side nav entry, as built by the type-map `getTree` getter
+ * @returns true if the nav item should be highlighted, false otherwise
+ */
+export const isNavItemActive = (router, to, navItem) => {
+  if (!navItem?.route) {
+    return false;
+  }
+
+  if (navItemClaimsRoute(navItem, to)) {
+    return true;
+  }
+
+  // Use .path instead of .fullPath to ignore query parameters and hashes when comparing routes
+  const itemPath = router.resolve(filterLocationValidParams(router, navItem.route))?.path?.toLowerCase();
+  const routePath = to?.path?.toLowerCase();
+
+  if (!itemPath || !routePath) {
+    return false;
+  }
+
+  // If the route explicitly declares the nav path that should be highlighted, then use that
+  const routeMetaNav = findMeta(to, 'nav');
+
+  if (routeMetaNav) {
+    const navPath = Object.entries(to.params || {})
+      .reduce((path, [param, value]) => path.replace(`:${ param }`, value), routeMetaNav)
+      .toLowerCase();
+
+    if (navPath === itemPath) {
+      return true;
+    }
+  }
+
+  if (navItem.exact) {
+    return itemPath === routePath;
+  }
+
+  // Compare whole path segments, so `/foo/bar` is not treated as a parent of `/foo/barbaz`
+  const itemSegments = itemPath.split('/');
+  const routeSegments = routePath.split('/');
+
+  return itemSegments.every((segment, index) => segment === routeSegments[index]);
+};
+
+/**
  * Given a route it will look through the matching parent routes to see if any match the fn (predicate) criteria
  *
  * @param {*} to a VueRouter Route object


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This resolves an issue where some routes would lose their highlight and would collapse the containing group when active.

Fixes #18495 

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Add `navResources` option to `type-map`
- Move `isActive()` logic into router utils

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Two issues were identified during triage:

1. Certain generic routes are expected to behave as children for resources. For example, listing Projects/Namespace has an active route of `/c/local/explorer/projectsnamespaces`, but creating a Project has an active route of `/c/local/explorer/management.cattle.io.project/create#members`. The create pages will never match a nav entry in this event.
2. Some routes like creating cluster drivers have `exact: true` specified. In these cases, the list route is `/c/_/manager/kontainerDriver` and the create route is `/c/_/manager/kontainerDriver/create`. The create page is a direct child of, but will never match the nav item because it requires an exact route match to be marked as active.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

The affected areas were identified during triage:

- Cluster explorer
   - Projects/Namespace
      - Create Namespace
      - Create Project
   - Cluster and Project Members
      - Add
- Cluster Management
   -  Providers
      - Create Cluster Drivers
      - Create Node Drivers

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

Changing exact to false for existing types could impact some behavior elsewhere. I wasn't able to identify where this could be problematic, but I think that we should be cautious of the change. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

#### Create Namespace

##### Before
<img width="1371" height="795" alt="image" src="https://github.com/user-attachments/assets/37c1402d-3e30-4ff0-9fdc-9b95646429bc" />

##### After
<img width="1371" height="795" alt="image" src="https://github.com/user-attachments/assets/e99f4524-072b-43d7-bb59-c9bdd276f199" />

#### Create Cluster Driver

##### Before

<img width="1371" height="795" alt="image" src="https://github.com/user-attachments/assets/0636a0fb-6a16-4ef0-9f85-a00aff8ac183" />

##### After

<img width="1371" height="795" alt="image" src="https://github.com/user-attachments/assets/5e1cce1f-f06e-409d-9a70-dac9a0688e79" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
