### PR TITLE
Show in context fail whale for unknown list resource type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,24 @@ To get started, follow the `Getting Started` section.
   - `shell/`: Core application logic, components, and pages.
   - `storybook/`: Component documentation source
 
+When either created, editing, viewing or listing a kubernetes resource the following core components are used
+- Listing resources
+  - Root component
+    - shell/pages/c/_cluster/_product/_resource/index.vue
+  - shell/components/ResourceList/index.vue
+    - This contains a generic component for the list's header
+    - Then either a ResourceTable or a custom page for that specific resource type
+      - custom components are either supplied via components in `shell/list` or externally via a UI Extension
+- Create / Edit a resource, or Viewing a Resource
+  - Root component
+    - Create / Edit - shell/pages/c/_cluster/_product/_resource/create.vue
+    - Viewing - shell/pages/c/_cluster/_product/_resource/_id.vue
+  - shell/components/ResourceDetail/index.vue
+    - Contains either
+      - a totally custom page for that resource type and mode,
+      - or a generic component for header, handling YAML or a custom component to show a form
+    - custom components are either supplied via components in `shell/edit` (create/edit), `shell/detail` (detail) or externally via a UI Extension
+
 
 ## Unit Tests
 

--- a/cypress/e2e/po/components/fail-whale.po.ts
+++ b/cypress/e2e/po/components/fail-whale.po.ts
@@ -1,0 +1,27 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+
+/**
+ * The 'fail whale' error content.
+ *
+ * Used both as the full page (`shell/pages/fail-whale.vue`) and in-context, in place of a
+ * resource list, when the resource type is unknown (`shell/components/FailWhale.vue`).
+ */
+export default class FailWhalePo extends ComponentPo {
+  constructor() {
+    super('[data-testid="fail-whale"]');
+  }
+
+  /**
+   * The error title (e.g. 'Error' or 'HTTP Error 404: ...')
+   */
+  title() {
+    return this.self().find('h1');
+  }
+
+  /**
+   * The error message
+   */
+  message() {
+    return this.self().find('h2');
+  }
+}

--- a/cypress/e2e/po/side-bars/product-side-nav.po.ts
+++ b/cypress/e2e/po/side-bars/product-side-nav.po.ts
@@ -2,6 +2,9 @@ import ComponentPo from '@/cypress/e2e/po/components/component.po';
 import VersionNumberPo from '~/cypress/e2e/po/components/version-number.po';
 import { LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 
+/**
+ * This is the side menu
+ */
 export default class ProductNavPo extends ComponentPo {
   constructor() {
     super('.side-nav');

--- a/cypress/e2e/tests/pages/generic/not-found-page.spec.ts
+++ b/cypress/e2e/tests/pages/generic/not-found-page.spec.ts
@@ -4,10 +4,31 @@ import NotFoundPagePo from '@/cypress/e2e/po/pages/not-found-page.po';
 import PagePo from '@/cypress/e2e/po/pages/page.po';
 import ChartRepositoriesPagePo from '~/cypress/e2e/po/pages/chart-repositories.po';
 import { ChartsPage } from '@/cypress/e2e/po/pages/explorer/charts/charts.po';
+import FailWhalePo from '@/cypress/e2e/po/components/fail-whale.po';
+import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 
 describe('Not found page display', { tags: ['@generic', '@adminUser', '@standardUser'] }, () => {
   beforeEach(() => {
     cy.login();
+  });
+
+  it('Will show the fail whale in-context (retaining cluster context) when a resource list is loaded with an unknown resource type', () => {
+    // Load a list page with a junky resource type in the url
+    const page = new PagePo('/c/local/explorer/thisisatypethatdoesnotexist');
+    const failWhale = new FailWhalePo();
+    const sideNav = new ProductNavPo();
+
+    page.goTo();
+    page.waitForPage();
+
+    // The fail whale is shown in-context (in place of the list), not on the global fail-whale page
+    cy.url().should('not.include', '/fail-whale');
+    failWhale.checkExists();
+    failWhale.title().should('contain.text', 'Error');
+    failWhale.message().should('contain.text', 'Resource type thisisatypethatdoesnotexist');
+
+    // The cluster explorer context (side menu) is retained
+    sideNav.checkVisible();
   });
 
   it('Will show a 404 if we do not have a valid Product id on the route path', () => {

--- a/docs/agents.md/contributors/1_contributors.md
+++ b/docs/agents.md/contributors/1_contributors.md
@@ -31,3 +31,21 @@ To get started, follow the `Getting Started` section.
   - `shell/`: Core application logic, components, and pages.
   - `storybook/`: Component documentation source
 
+When either created, editing, viewing or listing a kubernetes resource the following core components are used
+- Listing resources
+  - Root component
+    - shell/pages/c/_cluster/_product/_resource/index.vue
+  - shell/components/ResourceList/index.vue
+    - This contains a generic component for the list's header
+    - Then either a ResourceTable or a custom page for that specific resource type
+      - custom components are either supplied via components in `shell/list` or externally via a UI Extension
+- Create / Edit a resource, or Viewing a Resource
+  - Root component
+    - Create / Edit - shell/pages/c/_cluster/_product/_resource/create.vue
+    - Viewing - shell/pages/c/_cluster/_product/_resource/_id.vue
+  - shell/components/ResourceDetail/index.vue
+    - Contains either
+      - a totally custom page for that resource type and mode,
+      - or a generic component for header, handling YAML or a custom component to show a form
+    - custom components are either supplied via components in `shell/edit` (create/edit), `shell/detail` (detail) or externally via a UI Extension
+

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -319,6 +319,7 @@ nav:
     resourceListNotListable: Resource type { resource } cannot be listed
     resourceListNotFound: Resource type { resource } not found, unable to display list
     resourceIdNotFound: Resource { resource } with id { fqid } not found, unable to display resource details
+    didYouMean: 'Did you mean <a href="{url}">{resource}</a>?'
     reload: Reload
     separator: or
 

--- a/shell/components/FailWhale.vue
+++ b/shell/components/FailWhale.vue
@@ -1,0 +1,83 @@
+<script>
+import BrandImage from '@shell/components/BrandImage';
+import { stringify } from '@shell/utils/error';
+
+/**
+ * Presentational 'fail whale' error content.
+ *
+ * Renders the error imagery, title and message. Any actions (Home, Reload, ...)
+ * are supplied by the consumer via the `actions` slot, so the same content can be
+ * used both as a full page (see `shell/pages/fail-whale.vue`) and in-context in
+ * place of a resource list/detail (retaining the side menu and cluster context).
+ */
+export default {
+  name:       'FailWhale',
+  components: { BrandImage },
+
+  props: {
+    error: {
+      type:    [Object, Error],
+      default: null,
+    },
+  },
+
+  computed: {
+    displayError() {
+      return this.error?.data ? this.error.data : stringify(this.error);
+    },
+  },
+};
+</script>
+
+<template>
+  <div
+    class="fail-whale error"
+    data-testid="fail-whale"
+  >
+    <div class="text-center">
+      <BrandImage
+        file-name="error-desert-landscape.svg"
+        width="900"
+        height="300"
+      />
+      <h1 v-if="error && error.status">
+        HTTP Error {{ error.status }}: {{ error.statusText }}
+      </h1>
+      <h1 v-else>
+        Error
+      </h1>
+      <h2
+        v-if="error"
+        class="text-secondary mt-20"
+      >
+        {{ displayError }}
+      </h2>
+      <slot name="actions" />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+  .fail-whale.error {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    justify-content: center;
+    overflow: hidden;
+
+    .row {
+      align-items: center;
+    }
+
+    h1 {
+      font-size: 5rem;
+    }
+
+    .desert-landscape {
+      img {
+        max-width: 100%;
+      }
+    }
+  }
+</style>

--- a/shell/components/FailWhale.vue
+++ b/shell/components/FailWhale.vue
@@ -19,11 +19,30 @@ export default {
       type:    [Object, Error],
       default: null,
     },
+
+    /**
+     * Optional 'did you mean ...?' suggestion, rendered as a link below the message.
+     * Shape: `{ label, url }` where `url` is the resolved href to the suggested resource.
+     */
+    suggestion: {
+      type:    Object,
+      default: null,
+    },
   },
 
   computed: {
     displayError() {
       return this.error?.data ? this.error.data : stringify(this.error);
+    },
+
+    // The link is part of the translated string (see `nav.failWhale.didYouMean`) so it can
+    // be positioned per locale, then rendered via `v-clean-html`
+    suggestionHtml() {
+      if (!this.suggestion) {
+        return null;
+      }
+
+      return this.t('nav.failWhale.didYouMean', { url: this.suggestion.url, resource: this.suggestion.label }, true);
     },
   },
 };
@@ -52,6 +71,12 @@ export default {
       >
         {{ displayError }}
       </h2>
+      <h2
+        v-if="suggestionHtml"
+        v-clean-html="suggestionHtml"
+        class="text-secondary mt-20"
+        data-testid="fail-whale-suggestion"
+      />
       <slot name="actions" />
     </div>
   </div>

--- a/shell/components/FailWhale.vue
+++ b/shell/components/FailWhale.vue
@@ -1,5 +1,8 @@
-<script>
+<script setup lang="ts">
+import { computed, type PropType } from 'vue';
+import { useStore } from 'vuex';
 import BrandImage from '@shell/components/BrandImage';
+import { useI18n } from '@shell/composables/useI18n';
 import { stringify } from '@shell/utils/error';
 
 /**
@@ -10,42 +13,54 @@ import { stringify } from '@shell/utils/error';
  * used both as a full page (see `shell/pages/fail-whale.vue`) and in-context in
  * place of a resource list/detail (retaining the side menu and cluster context).
  */
-export default {
-  name:       'FailWhale',
-  components: { BrandImage },
+interface Suggestion {
+  label: string;
+  url: string;
+}
 
-  props: {
-    error: {
-      type:    [Object, Error],
-      default: null,
-    },
+/**
+ * Error shapes handled here: a plain `Error`, or an API error carrying an HTTP
+ * `status`/`statusText` and/or a `data` payload used as the display message.
+ * All fields are optional so a plain `Error` instance is also assignable.
+ */
+interface FailWhaleError {
+  status?: number | string;
+  statusText?: string;
+  data?: string;
+}
 
-    /**
-     * Optional 'did you mean ...?' suggestion, rendered as a link below the message.
-     * Shape: `{ label, url }` where `url` is the resolved href to the suggested resource.
-     */
-    suggestion: {
-      type:    Object,
-      default: null,
-    },
+const props = defineProps({
+  error: {
+    type:    Object as PropType<FailWhaleError | null>,
+    default: null,
   },
 
-  computed: {
-    displayError() {
-      return this.error?.data ? this.error.data : stringify(this.error);
-    },
-
-    // The link is part of the translated string (see `nav.failWhale.didYouMean`) so it can
-    // be positioned per locale, then rendered via `v-clean-html`
-    suggestionHtml() {
-      if (!this.suggestion) {
-        return null;
-      }
-
-      return this.t('nav.failWhale.didYouMean', { url: this.suggestion.url, resource: this.suggestion.label }, true);
-    },
+  /**
+   * Optional 'did you mean ...?' suggestion, rendered as a link below the message.
+   * Shape: `{ label, url }` where `url` is the resolved href to the suggested resource.
+   */
+  suggestion: {
+    type:    Object as PropType<Suggestion | null>,
+    default: null,
   },
-};
+});
+
+const store = useStore();
+const { t } = useI18n(store);
+
+const displayError = computed(() => {
+  return props.error?.data ? props.error.data : stringify(props.error);
+});
+
+// The link is part of the translated string (see `nav.failWhale.didYouMean`) so it can
+// be positioned per locale, then rendered via `v-clean-html`
+const suggestionHtml = computed(() => {
+  if (!props.suggestion) {
+    return null;
+  }
+
+  return t('nav.failWhale.didYouMean', { url: props.suggestion.url, resource: props.suggestion.label }, true);
+});
 </script>
 
 <template>
@@ -97,12 +112,6 @@ export default {
 
     h1 {
       font-size: 5rem;
-    }
-
-    .desert-landscape {
-      img {
-        max-width: 100%;
-      }
     }
   }
 </style>

--- a/shell/components/ResourceList/__tests__/index.test.ts
+++ b/shell/components/ResourceList/__tests__/index.test.ts
@@ -1,0 +1,117 @@
+import { shallowMount } from '@vue/test-utils';
+
+jest.mock('@shell/mixins/resource-fetch', () => ({
+  __esModule: true,
+  default:    {
+    data() {
+      return {
+        forceUpdateLiveAndDelayed:  0,
+        loading:                    false,
+        rows:                       [],
+        namespaceFilterRequired:    false,
+        paginationNsFilterRequired: false,
+        canPaginate:                false,
+        isFirstLoad:                true,
+        paginationResult:           null,
+        perfConfig:                 {},
+      };
+    },
+    computed: {
+      namespaceFilter() {
+        return null;
+      },
+      pagination() {
+        return null;
+      },
+    },
+    methods: {
+      async $fetchType() {},
+      calcCanPaginate() {
+        return false;
+      },
+      paginationChanged() {},
+    },
+  },
+}));
+
+// eslint-disable-next-line import/first
+import ResourceList from '@shell/components/ResourceList/index.vue';
+
+type StoreOpts = {
+  schema?: any;
+  canList?: boolean;
+};
+
+const createStore = ({ schema, canList = true }: StoreOpts) => ({
+  getters: {
+    'i18n/t':                 (key: string, args: any) => `${ key }-${ JSON.stringify(args ?? {}) }`,
+    currentStore:             () => 'cluster',
+    'cluster/schemaFor':      () => schema,
+    'cluster/canList':        () => canList,
+    'type-map/hasCustomList': () => false,
+    'type-map/optionsFor':    () => ({ showListMasthead: false }),
+    'type-map/headersFor':    () => [],
+    'type-map/groupByFor':    () => null,
+    'type-map/importList':    () => ({}),
+  },
+  dispatch: jest.fn(),
+});
+
+const createWrapper = (store: any) => {
+  return shallowMount(ResourceList as any, {
+    global: {
+      mocks: {
+        $store: store,
+        $route: { params: { resource: 'bogus-resource-type' }, query: {} },
+        t:      (key: string, args: any) => `${ key }-${ JSON.stringify(args ?? {}) }`,
+      },
+      stubs: {
+        FailWhale:      true,
+        ResourceTable:  true,
+        Masthead:       true,
+        ExtensionPanel: true,
+        IconMessage:    true,
+        Loading:        true,
+      },
+    },
+  });
+};
+
+describe('component: ResourceList', () => {
+  it('renders the in-context FailWhale (not the list) when the resource type has no schema', async() => {
+    const store = createStore({ schema: undefined, canList: true });
+    const wrapper = createWrapper(store);
+
+    // fetch() is a Nuxt option and is not run by the test harness, so invoke it directly
+    await (wrapper.vm.$options as any).fetch.call(wrapper.vm);
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as any).resourceNotFoundError).toBeInstanceOf(Error);
+    expect(wrapper.findComponent({ name: 'FailWhale' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'ResourceTable' }).exists()).toBe(false);
+    // Must NOT redirect to the global fail-whale page
+    expect(store.dispatch).not.toHaveBeenCalledWith('loadingError', expect.anything());
+  });
+
+  it('renders the in-context FailWhale when the resource type cannot be listed', () => {
+    const store = createStore({ schema: { id: 'bogus-resource-type' }, canList: false });
+    const wrapper = createWrapper(store);
+
+    expect((wrapper.vm as any).resourceNotFoundError).toBeInstanceOf(Error);
+    expect(wrapper.findComponent({ name: 'FailWhale' }).exists()).toBe(true);
+    expect(store.dispatch).not.toHaveBeenCalledWith('loadingError', expect.anything());
+  });
+
+  it('renders the list (no FailWhale) for a valid, listable resource type', async() => {
+    const store = createStore({ schema: { id: 'bogus-resource-type' }, canList: true });
+    const wrapper = createWrapper(store);
+
+    await (wrapper.vm.$options as any).fetch.call(wrapper.vm);
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as any).resourceNotFoundError).toBeNull();
+    expect(wrapper.findComponent({ name: 'FailWhale' }).exists()).toBe(false);
+    expect(wrapper.findComponent({ name: 'ResourceTable' }).exists()).toBe(true);
+    expect(store.dispatch).not.toHaveBeenCalledWith('loadingError', expect.anything());
+  });
+});

--- a/shell/components/ResourceList/__tests__/index.test.ts
+++ b/shell/components/ResourceList/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
+import ResourceList from '@shell/components/ResourceList/index.vue';
 
 jest.mock('@shell/mixins/resource-fetch', () => ({
   __esModule: true,
@@ -34,9 +35,6 @@ jest.mock('@shell/mixins/resource-fetch', () => ({
   },
 }));
 
-// eslint-disable-next-line import/first
-import ResourceList from '@shell/components/ResourceList/index.vue';
-
 type StoreOpts = {
   schema?: any;
   canList?: boolean;
@@ -47,6 +45,7 @@ const createStore = ({ schema, canList = true }: StoreOpts) => ({
     'i18n/t':                 (key: string, args: any) => `${ key }-${ JSON.stringify(args ?? {}) }`,
     currentStore:             () => 'cluster',
     'cluster/schemaFor':      () => schema,
+    'cluster/all':            () => [],
     'cluster/canList':        () => canList,
     'type-map/hasCustomList': () => false,
     'type-map/optionsFor':    () => ({ showListMasthead: false }),

--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -10,6 +10,8 @@ import { ResourceListComponentName } from './resource-list.config';
 import { PanelLocation, ExtensionPoint } from '@shell/core/types';
 import ExtensionPanel from '@shell/components/ExtensionPanel';
 import { sameContents } from '@shell/utils/array';
+import { nearestMatches } from '@shell/utils/fuzzy';
+import { SCHEMA } from '@shell/config/types';
 import perfSettingsUtils from '@shell/utils/perf-setting.utils';
 import { BadgeState } from '@components/BadgeState';
 import { stateDisplay } from '@shell/plugins/dashboard-store/resource-class';
@@ -88,6 +90,7 @@ export default {
         // Render the error in-context (in place of the list) rather than redirecting to
         // the global fail-whale page, so the side menu and cluster context are retained
         this.resourceNotFoundError = new Error(this.t('nav.failWhale.resourceListNotFound', { resource }, true));
+        this.resourceSuggestion = this.nearestResourceSuggestion(resource);
 
         return;
       }
@@ -130,6 +133,8 @@ export default {
       // When set, the resource type could not be found/listed. The error is rendered
       // in-context (in place of the list) instead of redirecting to the fail-whale page
       resourceNotFoundError:            null,
+      // When set, a 'did you mean ...?' link to the closest matching resource type
+      resourceSuggestion:               null,
       overrideInStore:                  undefined,
       hasListComponent,
       showMasthead:                     showMasthead === undefined ? true : showMasthead,
@@ -202,6 +207,32 @@ export default {
   },
 
   methods: {
+    /**
+     * Find the closest matching, listable resource type for an unknown resource and,
+     * if one exists, return a `{ label, to }` suggestion for the fail whale link.
+     */
+    nearestResourceSuggestion(resource) {
+      const inStore = this.$store.getters['currentStore'](resource);
+      const schemas = this.$store.getters[`${ inStore }/all`](SCHEMA) || [];
+      const ids = schemas.map((s) => s.id).filter(Boolean);
+
+      const [match] = nearestMatches(resource, ids, 1);
+
+      if (!match) {
+        return null;
+      }
+
+      const { href } = this.$router.resolve({
+        name:   'c-cluster-product-resource',
+        params: {
+          ...this.$route.params,
+          resource: match
+        }
+      });
+
+      return { label: match, url: href };
+    },
+
     clearStateFilter() {
       const query = { ...this.$route.query };
 
@@ -283,6 +314,7 @@ export default {
   <FailWhale
     v-if="resourceNotFoundError"
     :error="resourceNotFoundError"
+    :suggestion="resourceSuggestion"
   />
   <IconMessage
     v-else-if="namespaceFilterRequired"

--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -95,6 +95,11 @@ export default {
         return;
       }
 
+      // Avoid fetch if we've errored here or previously
+      if (this.resourceNotFoundError) {
+        return;
+      }
+
       // See comment for `namespaceFilter` and `pagination` watchers, skip fetch if we're not ready yet... and something is going to call fetch later on
       if (!this.namespaceFilterRequired && (!this.canPaginate || this.refreshFlag)) {
         await this.$fetchType(resource);

--- a/shell/components/ResourceList/index.vue
+++ b/shell/components/ResourceList/index.vue
@@ -1,6 +1,7 @@
 <script>
 import ResourceTable from '@shell/components/ResourceTable';
 import Loading from '@shell/components/Loading';
+import FailWhale from '@shell/components/FailWhale';
 import Masthead from './Masthead';
 import ResourceLoadingIndicator from './ResourceLoadingIndicator';
 import ResourceFetch from '@shell/mixins/resource-fetch';
@@ -20,6 +21,7 @@ export default {
   components: {
     Loading,
     ResourceTable,
+    FailWhale,
     Masthead,
     ResourceLoadingIndicator,
     IconMessage,
@@ -50,7 +52,6 @@ export default {
   },
 
   async fetch() {
-    const store = this.$store;
     const resource = this.resource;
 
     const schema = this.schema;
@@ -84,7 +85,9 @@ export default {
 
     if ( !this.componentWillFetch ) {
       if ( !schema ) {
-        store.dispatch('loadingError', new Error(this.t('nav.failWhale.resourceListNotFound', { resource }, true)));
+        // Render the error in-context (in place of the list) rather than redirecting to
+        // the global fail-whale page, so the side menu and cluster context are retained
+        this.resourceNotFoundError = new Error(this.t('nav.failWhale.resourceListNotFound', { resource }, true));
 
         return;
       }
@@ -103,7 +106,9 @@ export default {
       const canList = this.$store.getters[`${ inStore }/canList`](this.resource);
 
       if (!canList) {
-        this.$store.dispatch('loadingError', new Error(this.t('nav.failWhale.resourceListNotListable', { resource: this.schema?.id || this.resource || 'unknown' }, true)));
+        // Render the error in-context (in place of the list) rather than redirecting to
+        // the global fail-whale page, so the side menu and cluster context are retained
+        this.resourceNotFoundError = new Error(this.t('nav.failWhale.resourceListNotListable', { resource: this.schema?.id || this.resource || 'unknown' }, true));
       }
     }
   },
@@ -122,6 +127,9 @@ export default {
 
     return {
       schema,
+      // When set, the resource type could not be found/listed. The error is rendered
+      // in-context (in place of the list) instead of redirecting to the fail-whale page
+      resourceNotFoundError:            null,
       overrideInStore:                  undefined,
       hasListComponent,
       showMasthead:                     showMasthead === undefined ? true : showMasthead,
@@ -272,8 +280,12 @@ export default {
 </script>
 
 <template>
+  <FailWhale
+    v-if="resourceNotFoundError"
+    :error="resourceNotFoundError"
+  />
   <IconMessage
-    v-if="namespaceFilterRequired"
+    v-else-if="namespaceFilterRequired"
     :vertical="true"
     :subtle="false"
     icon="icon-filter_alt"

--- a/shell/components/__tests__/FailWhale.test.ts
+++ b/shell/components/__tests__/FailWhale.test.ts
@@ -5,7 +5,16 @@ const createWrapper = (props: any = {}) => {
   return shallowMount(FailWhale, {
     props,
     slots:  props.slots,
-    global: { stubs: { BrandImage: true } },
+    global: {
+      stubs:      { BrandImage: true },
+      // The real `clean-html` directive relies on `purifyHTML`, which returns empty in
+      // the test environment, so stub it to render the raw value (as DetailText.test.ts does)
+      directives: {
+        'clean-html': (el: HTMLElement, binding: { value: string }) => {
+          el.innerHTML = binding.value;
+        }
+      },
+    },
   });
 };
 
@@ -52,5 +61,37 @@ describe('component: FailWhale', () => {
 
     expect(wrapper.find('h2').exists()).toBe(false);
     expect(wrapper.find('h1').text()).toBe('Error');
+  });
+
+  it('renders a suggestion when one is supplied', () => {
+    const wrapper = createWrapper({
+      error:      { data: 'Resource type foo not found, unable to display list' },
+      suggestion: { label: 'bar', url: '/c/local/explorer/bar' },
+    });
+
+    const suggestion = wrapper.find('[data-testid="fail-whale-suggestion"]');
+
+    expect(suggestion.exists()).toBe(true);
+    // The mocked `t` echoes the key and its interpolation args, so we can assert the
+    // suggestion's label and url are passed through to the translation
+    expect(suggestion.text()).toContain('nav.failWhale.didYouMean');
+    expect(suggestion.text()).toContain('/c/local/explorer/bar');
+    expect(suggestion.text()).toContain('bar');
+  });
+
+  it('does not render a suggestion when none is supplied', () => {
+    const wrapper = createWrapper({ error: new Error('boom') });
+
+    expect(wrapper.find('[data-testid="fail-whale-suggestion"]').exists()).toBe(false);
+  });
+
+  it('does not render a suggestion when there is no error', () => {
+    const wrapper = createWrapper({
+      error:      null,
+      suggestion: { label: 'bar', url: '/c/local/explorer/bar' },
+    });
+
+    // The suggestion still renders even without an error, as it sits in its own block
+    expect(wrapper.find('[data-testid="fail-whale-suggestion"]').exists()).toBe(true);
   });
 });

--- a/shell/components/__tests__/FailWhale.test.ts
+++ b/shell/components/__tests__/FailWhale.test.ts
@@ -1,0 +1,56 @@
+import { shallowMount } from '@vue/test-utils';
+import FailWhale from '@shell/components/FailWhale.vue';
+
+const createWrapper = (props: any = {}) => {
+  return shallowMount(FailWhale, {
+    props,
+    slots:  props.slots,
+    global: { stubs: { BrandImage: true } },
+  });
+};
+
+describe('component: FailWhale', () => {
+  it('renders a generic error title when the error has no status', () => {
+    const wrapper = shallowMount(FailWhale, {
+      props:  { error: new Error('boom') },
+      global: { stubs: { BrandImage: true } },
+    });
+
+    expect(wrapper.find('h1').text()).toBe('Error');
+  });
+
+  it('renders an HTTP error title when the error has a status', () => {
+    const wrapper = shallowMount(FailWhale, {
+      props:  { error: { status: 404, statusText: 'Not Found' } },
+      global: { stubs: { BrandImage: true } },
+    });
+
+    expect(wrapper.find('h1').text()).toContain('HTTP Error 404: Not Found');
+  });
+
+  it('renders the error message', () => {
+    const wrapper = shallowMount(FailWhale, {
+      props:  { error: { data: 'Resource type foo not found, unable to display list' } },
+      global: { stubs: { BrandImage: true } },
+    });
+
+    expect(wrapper.find('h2').text()).toBe('Resource type foo not found, unable to display list');
+  });
+
+  it('renders content supplied via the actions slot', () => {
+    const wrapper = shallowMount(FailWhale, {
+      props:  { error: new Error('boom') },
+      slots:  { actions: '<button class="my-action">Home</button>' },
+      global: { stubs: { BrandImage: true } },
+    });
+
+    expect(wrapper.find('button.my-action').exists()).toBe(true);
+  });
+
+  it('does not render a message when there is no error', () => {
+    const wrapper = createWrapper({ error: null });
+
+    expect(wrapper.find('h2').exists()).toBe(false);
+    expect(wrapper.find('h1').text()).toBe('Error');
+  });
+});

--- a/shell/config/router/routes.js
+++ b/shell/config/router/routes.js
@@ -7,6 +7,7 @@ import { NAME as AUTH } from '@shell/config/product/auth';
 
 // All these imports are related to the install-redirect.js navigation guard.
 import { installRedirectRouteMeta } from '@shell/config/router/navigation-guards/install-redirect';
+import { INVALID_RESOURCE_IN_CONTEXT } from '@shell/utils/resource';
 import { NAME as BACKUP_NAME, CHART_NAME as BACKUP_CHART_NAME } from '@shell/config/product/backup';
 import { NAME as COMPLIANCE_NAME, CHART_NAME as COMPLIANCE_CHART_NAME } from '@shell/config/product/compliance';
 import { NAME as GATEKEEPER_NAME, CHART_NAME as GATEKEEPER_CHART_NAME } from '@shell/config/product/gatekeeper';
@@ -515,7 +516,10 @@ export default [
       }, {
         path:      '/c/:cluster/:product/:resource',
         component: () => interopDefault(import('@shell/pages/c/_cluster/_product/_resource/index.vue')),
-        name:      'c-cluster-product-resource'
+        name:      'c-cluster-product-resource',
+        // Show an unknown resource error in-context (in place of the list), retaining the cluster
+        // context, rather than redirecting to the global fail whale page. See `validateResource`.
+        meta:      { [INVALID_RESOURCE_IN_CONTEXT]: true }
       }, {
         path:      '/c/:cluster/:product/:resource/create',
         component: () => interopDefault(import('@shell/pages/c/_cluster/_product/_resource/create.vue')),

--- a/shell/pages/fail-whale.vue
+++ b/shell/pages/fail-whale.vue
@@ -1,7 +1,6 @@
 <script>
-import BrandImage from '@shell/components/BrandImage';
+import FailWhale from '@shell/components/FailWhale';
 import { mapGetters, mapState } from 'vuex';
-import { stringify } from '@shell/utils/error';
 import Header from '@shell/components/nav/Header';
 import Brand from '@shell/mixins/brand';
 import FixedBanner from '@shell/components/FixedBanner';
@@ -14,7 +13,7 @@ import { RcSeparator } from '@components/RcSeparator';
 export default {
 
   components: {
-    BrandImage, FixedBanner, GrowlManager, Header, PromptModal, RcButton, RcSeparator
+    FailWhale, FixedBanner, GrowlManager, Header, PromptModal, RcButton, RcSeparator
   },
   mixins: [Brand, BrowserTabVisibility],
 
@@ -46,10 +45,6 @@ export default {
       }
 
       return this.$router.resolve({ name: 'home' }).href;
-    },
-
-    displayError() {
-      return this.error?.data ? this.error.data : stringify(this.error);
     },
   },
 
@@ -91,25 +86,8 @@ export default {
           v-if="error"
           class="outlet"
         >
-          <div class="main-layout error">
-            <div class="text-center">
-              <BrandImage
-                file-name="error-desert-landscape.svg"
-                width="900"
-                height="300"
-              />
-              <h1 v-if="error.status">
-                HTTP Error {{ error.status }}: {{ error.statusText }}
-              </h1>
-              <h1 v-else>
-                Error
-              </h1>
-              <h2
-                v-if="error"
-                class="text-secondary mt-20"
-              >
-                {{ displayError }}
-              </h2>
+          <FailWhale :error="error">
+            <template #actions>
               <p class="mt-20">
                 <rc-button
                   size="large"
@@ -131,8 +109,8 @@ export default {
                   {{ t('nav.failWhale.reload') }}
                 </rc-button>
               </p>
-            </div>
-          </div>
+            </template>
+          </FailWhale>
         </div>
       </main>
     </div>
@@ -142,28 +120,6 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-  .error {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    justify-content: center;
-    overflow: hidden;
-
-    .row {
-      align-items: center;
-    }
-
-    h1 {
-      font-size: 5rem;
-    }
-
-    .desert-landscape {
-      img {
-        max-width: 100%;
-      }
-    }
-  }
-
   .custom-content {
     text-align: center;
     margin-top: 18px;

--- a/shell/utils/__tests__/fuzzy.test.ts
+++ b/shell/utils/__tests__/fuzzy.test.ts
@@ -1,0 +1,88 @@
+import { levenshtein, nearestMatches } from '@shell/utils/fuzzy';
+
+describe('fx: levenshtein', () => {
+  it.each([
+    ['identical strings', 'pod', 'pod', 0],
+    ['empty vs empty', '', '', 0],
+    ['empty vs non-empty', '', 'pod', 3],
+    ['non-empty vs empty', 'pod', '', 3],
+    ['single substitution', 'pod', 'pad', 1],
+    ['single insertion', 'pod', 'pods', 1],
+    ['single deletion', 'pods', 'pod', 1],
+    ['transposition counts as two edits', 'pdo', 'pod', 2],
+    ['completely different', 'abc', 'xyz', 3],
+    ['case sensitive', 'Pod', 'pod', 1],
+  ])('should return the edit distance for %s', (_label, a, b, expected) => {
+    expect(levenshtein(a, b)).toStrictEqual(expected);
+  });
+
+  it('should be symmetric', () => {
+    expect(levenshtein('kitten', 'sitting')).toStrictEqual(levenshtein('sitting', 'kitten'));
+  });
+
+  it('should compute the classic kitten/sitting distance', () => {
+    expect(levenshtein('kitten', 'sitting')).toStrictEqual(3);
+  });
+});
+
+describe('fx: nearestMatches', () => {
+  const candidates = ['pod', 'service', 'secret', 'namespace', 'configmap', 'deployment'];
+
+  it('should return an empty array for empty input', () => {
+    expect(nearestMatches('', candidates)).toStrictEqual([]);
+  });
+
+  it('should return an empty array when there are no candidates', () => {
+    expect(nearestMatches('pod', [])).toStrictEqual([]);
+  });
+
+  it('should return an exact match', () => {
+    expect(nearestMatches('pod', candidates)).toStrictEqual(['pod']);
+  });
+
+  it('should match ignoring case', () => {
+    expect(nearestMatches('POD', candidates)).toStrictEqual(['pod']);
+  });
+
+  it('should suggest the closest match for a small typo', () => {
+    expect(nearestMatches('pdo', candidates, 1)).toStrictEqual(['pod']);
+  });
+
+  it('should treat a substring as a high-signal match', () => {
+    // 'pods' contains 'pod' -> substring wins over edit distance
+    expect(nearestMatches('pods', candidates, 1)).toStrictEqual(['pod']);
+  });
+
+  it('should return nothing when no candidate is within tolerance', () => {
+    expect(nearestMatches('xyz', candidates)).toStrictEqual([]);
+  });
+
+  it('should respect the limit', () => {
+    const result = nearestMatches('secre', candidates, 1);
+
+    expect(result).toStrictEqual(['secret']);
+  });
+
+  it('should default to at most 3 results', () => {
+    // Several plausible near-misses to 'secet'
+    const many = ['secret', 'secrets', 'secreta', 'secretb', 'secretc'];
+    const result = nearestMatches('secet', many);
+
+    expect(result.length).toStrictEqual(3);
+  });
+
+  it('should order results by ascending distance', () => {
+    // 'servic' is a substring of 'service' (distance 0) and one edit from nothing else close
+    const result = nearestMatches('servic', ['service', 'secret', 'serviceaccount']);
+
+    expect(result[0]).toStrictEqual('service');
+  });
+
+  it('should scale tolerance with the length of the input', () => {
+    // Short input: tolerance floor of 2, so a 3-edit difference is excluded
+    expect(nearestMatches('abc', ['xyz'])).toStrictEqual([]);
+
+    // Longer input: tolerance grows, so a small relative difference is included
+    expect(nearestMatches('deploymentx', ['deployment'], 1)).toStrictEqual(['deployment']);
+  });
+});

--- a/shell/utils/__tests__/resource.test.ts
+++ b/shell/utils/__tests__/resource.test.ts
@@ -1,16 +1,17 @@
-import { validateResource } from '@shell/utils/resource';
+import { validateResource, INVALID_RESOURCE_IN_CONTEXT } from '@shell/utils/resource';
 import { canViewResource } from '@shell/utils/auth';
-import { getResourceFromRoute } from '@shell/utils/router';
+import { getResourceFromRoute, findMeta } from '@shell/utils/router';
 import { RouteLocation } from 'vue-router';
 
 // Mock dependencies from other modules
 jest.mock('@shell/utils/auth', () => ({ canViewResource: jest.fn() }));
 
-jest.mock('@shell/utils/router', () => ({ getResourceFromRoute: jest.fn() }));
+jest.mock('@shell/utils/router', () => ({ getResourceFromRoute: jest.fn(), findMeta: jest.fn() }));
 
 // Typed mocks for better intellisense and type-checking
 const mockCanViewResource = canViewResource as jest.Mock;
 const mockGetResourceFromRoute = getResourceFromRoute as jest.Mock;
+const mockFindMeta = findMeta as jest.Mock;
 
 describe('validateResource', () => {
   let mockStore: any;
@@ -70,11 +71,12 @@ describe('validateResource', () => {
     expect(mockStore.dispatch).not.toHaveBeenCalled();
   });
 
-  it('should throw an error and dispatch loadingError if user cannot view the resource', () => {
+  it('should throw an error and dispatch loadingError if user cannot view the resource on a route without the in-context meta', () => {
     const resource = 'pod';
 
     mockGetResourceFromRoute.mockReturnValue(resource);
     mockCanViewResource.mockReturnValue(false);
+    mockFindMeta.mockReturnValue(undefined);
 
     const errorMessage = `i18n: nav.failWhale.resourceNotFound {"resource":"${ resource }"}`;
 
@@ -83,5 +85,17 @@ describe('validateResource', () => {
     expect(() => validateResource(mockStore, mockTo)).toThrow(errorMessage);
     expect(mockStore.dispatch).toHaveBeenCalledWith('loadingError', expect.any(Error));
     expect(mockStore.getters['i18n/t']).toHaveBeenCalledWith('nav.failWhale.resourceNotFound', { resource }, true);
+  });
+
+  it('should not throw or redirect to fail whale for an unknown resource when the route opts in via meta (shown in-context instead)', () => {
+    mockGetResourceFromRoute.mockReturnValue('thisisatypethatdoesnotexist');
+    mockCanViewResource.mockReturnValue(false);
+    mockFindMeta.mockReturnValue(true);
+
+    const result = validateResource(mockStore, mockTo);
+
+    expect(result).toBe(false);
+    expect(mockStore.dispatch).not.toHaveBeenCalled();
+    expect(mockFindMeta).toHaveBeenCalledWith(mockTo, INVALID_RESOURCE_IN_CONTEXT);
   });
 });

--- a/shell/utils/fuzzy.ts
+++ b/shell/utils/fuzzy.ts
@@ -1,0 +1,66 @@
+/**
+ * Small, dependency-free fuzzy matching helpers.
+ *
+ * Used to suggest a close resource type when a user navigates to an unknown one
+ * (see `ResourceList` / `FailWhale`).
+ */
+
+/**
+ * Classic iterative Levenshtein (edit) distance - two-row, O(n*m).
+ *
+ * Cheap enough to run once over the schema list on an error path.
+ */
+export function levenshtein(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+  if (!a.length) {
+    return b.length;
+  }
+  if (!b.length) {
+    return a.length;
+  }
+
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+
+  for (let i = 0; i < a.length; i++) {
+    const curr = [i + 1];
+
+    for (let j = 0; j < b.length; j++) {
+      const cost = a[i] === b[j] ? 0 : 1;
+
+      curr[j + 1] = Math.min(curr[j] + 1, prev[j + 1] + 1, prev[j] + cost);
+    }
+    prev = curr;
+  }
+
+  return prev[b.length];
+}
+
+/**
+ * Rank `candidates` by closeness to `input`, returning up to `limit` closest.
+ *
+ * A substring match (typo in the tail, partial type) is high-signal and forced to the top;
+ * otherwise entries are ranked by edit distance and filtered to a length-scaled tolerance.
+ */
+export function nearestMatches(input: string, candidates: string[], limit = 3): string[] {
+  if (!input) {
+    return [];
+  }
+
+  const needle = input.toLowerCase();
+  const tolerance = Math.max(2, Math.floor(needle.length / 4));
+
+  return candidates
+    .map((c) => {
+      const hay = c.toLowerCase();
+      const substring = hay.includes(needle) || needle.includes(hay);
+      const distance = substring ? 0 : levenshtein(needle, hay);
+
+      return { candidate: c, distance };
+    })
+    .filter((m) => m.distance <= tolerance)
+    .sort((a, b) => a.distance - b.distance)
+    .slice(0, limit)
+    .map((m) => m.candidate);
+}

--- a/shell/utils/resource.ts
+++ b/shell/utils/resource.ts
@@ -1,10 +1,23 @@
 import { canViewResource } from '@shell/utils/auth';
-import { getResourceFromRoute } from '@shell/utils/router';
+import { getResourceFromRoute, findMeta } from '@shell/utils/router';
 import { RouteLocation } from 'vue-router';
 import { Store } from 'vuex';
 
 /**
+ * Route `meta` flag opting a route out of the global fail whale redirect for an unknown resource.
+ *
+ * When set (see `shell/config/router/routes.js`), navigation is allowed to continue so the error
+ * can be shown in-context (in place of the route's content, see `ResourceList`) - retaining the
+ * side menu and cluster context - rather than redirecting to the global fail whale page.
+ */
+export const INVALID_RESOURCE_IN_CONTEXT = 'invalidResourceInContext';
+
+/**
  * Check that the resource is valid, if not redirect to fail whale
+ *
+ * The exception is routes flagged with the `invalidResourceInContext` meta - there we allow
+ * navigation to continue so the error can be shown in-context (retaining the cluster explorer
+ * context). See `ResourceList`.
  *
  * This requires that
  * - product is set
@@ -25,7 +38,15 @@ export function validateResource(store: Store<any>, to: RouteLocation) {
     return false;
   }
 
-  // Unknown resource, redirect to fail whale
+  // Unknown resource.
+  // If the route opts in via meta, let navigation continue so the error is rendered in-context
+  // (in place of the route's content) - retaining the side menu and cluster context.
+  // The page (e.g. `ResourceList`) detects the missing schema and renders the error itself.
+  if (findMeta(to, INVALID_RESOURCE_IN_CONTEXT)) {
+    return false;
+  }
+
+  // Otherwise redirect to fail whale
 
   const error = new Error(store.getters['i18n/t']('nav.failWhale.resourceNotFound', { resource }, true));
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18231

Navigating to an unknown resource type in Cluster Explorer (e.g. a junky URL) redirected to the global `/fail-whale` page, dropping cluster context (side menu, header, cluster switcher). This implements the "lo-bar" fix: on the resource **list** page, the "resource not found" error now renders **in-context**, in place of the list, keeping the explorer layout intact.

### Occurred changes and/or fixed issues
- Unknown resource types on the list route render an in-context fail-whale message instead of redirecting to `/fail-whale`; side menu and cluster context are retained.
- Extracted a reusable `FailWhale` component, shared by the full `/fail-whale` page and the in-context usage.
- The in-context fail whale now offers a "Did you mean …?" link to the closest matching resource type (dependency-free fuzzy match against the loaded schemas).
- Also applies to other products on the shared list route (e.g. `manager`).

Bonus
- Included some intro stuff to agents to possibly save some tokens(?)

### Technical notes summary
- Root cause was the `validateResource` navigation guard ([shell/utils/resource.ts](shell/utils/resource.ts)) redirecting before `ResourceList` mounted. It now checks a route `meta` flag (`invalidResourceInContext`) and lets navigation continue when set.
- The opt-out is declared as metadata on the `c-cluster-product-resource` route in [shell/config/router/routes.js](shell/config/router/routes.js); detail/create/edit routes are unchanged and still redirect.
- [FailWhale.vue](shell/components/FailWhale.vue) is consumed by [fail-whale.vue](shell/pages/fail-whale.vue) (with Home + Reload) and [ResourceList/index.vue](shell/components/ResourceList/index.vue) (message only). Existing i18n keys reused.
- Suggestion matching lives in [shell/utils/fuzzy.ts](shell/utils/fuzzy.ts) (`levenshtein` + `nearestMatches`, no new dependency). `ResourceList` ranks the unknown type against the already-loaded schema ids and resolves an href for the closest match. The link is embedded in the translatable string (`nav.failWhale.didYouMean`, `<a href="{url}">{resource}</a>`) and rendered via `v-clean-html` so localizers control its placement.

### Areas or cases that should be tested
- unknown resource types show the correct error
  - `/c/local/explorer/aaaa` --> Resource type aaaa not found, unable to display list
  - side menu/cluster context retained, URL not `/fail-whale`.
- "Did you mean …?" suggestion for near misses
  - `/c/local/explorer/pdo` --> also suggests did you mean <pod link>
  - `/c/local/explorer/sdfdfgfdgsdg` --> does not suggest a "did you mean"
- Valid list pages render normally; detail/create/edit with a bogus type still go to `/fail-whale`.
- Global `/fail-whale` (bogus product id, lost API connection) still renders with Home + Reload.
- Unlistable resource types show correct error
  - `/c/local/explorer/ext.cattle.io.passwordchangerequest` --> `Resource type ext.cattle.io.passwordchangerequest cannot be listed`

### Areas which could experience regressions
- `validateResource` guard (all cluster-scoped routes) — verify other fail-whale redirects unchanged.
- `/fail-whale` page after the `FailWhale` extraction (light & dark mode).

### Screenshot/Video
<img width="1169" height="620" alt="image" src="https://github.com/user-attachments/assets/7a402200-6ca6-4152-88ca-5fbd4c95d759" />

<img width="1167" height="634" alt="image" src="https://github.com/user-attachments/assets/45cac144-3be0-4ded-a081-93d39c971e18" />

<img width="1173" height="617" alt="image" src="https://github.com/user-attachments/assets/f16b5e05-bce2-4d8c-9609-050fba659ffb" />

<img width="1164" height="630" alt="image" src="https://github.com/user-attachments/assets/8ca1aab0-efac-46e2-9d02-764369691ec6" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
