### PR TITLE
Added LabeledSelectWithCreate and NamespaceSelect components

### DIFF
--- a/cypress/e2e/po/components/labeled-select-with-create.po.ts
+++ b/cypress/e2e/po/components/labeled-select-with-create.po.ts
@@ -4,9 +4,8 @@ import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 
 /**
  * PO for the LabeledSelectWithCreate component - a LabeledSelect that swaps
- * to a LabeledInput (with confirm/cancel buttons) when the user picks the
- * "Create new" option
- */
+ * to a LabeledInput (with a cancel button) when the user picks the "Create
+ * new" option.
 export default class LabeledSelectWithCreatePo extends ComponentPo {
   /**
    * The underlying select, shown when not creating a new value
@@ -19,11 +18,11 @@ export default class LabeledSelectWithCreatePo extends ComponentPo {
    * The new-value input, shown while creating a new value
    */
   createInput(): LabeledInputPo {
-    return new LabeledInputPo(this.self().find('.create-input-row input'));
+    return new LabeledInputPo(this.self().find('.create-input input'));
   }
 
   isCreating(): Cypress.Chainable<boolean> {
-    return this.self().then(($el) => $el.find('.create-input-row').length > 0);
+    return this.self().then(($el) => $el.find('.create-input').length > 0);
   }
 
   /**
@@ -34,11 +33,7 @@ export default class LabeledSelectWithCreatePo extends ComponentPo {
     this.select().clickOptionWithLabel(createLabel);
   }
 
-  confirmCreate() {
-    return this.self().find('.confirm-create').click();
-  }
-
   cancelCreate() {
-    return this.self().find('.cancel-create').click();
+    return this.self().find('.create-input button').click();
   }
 }

--- a/cypress/e2e/po/components/labeled-select-with-create.po.ts
+++ b/cypress/e2e/po/components/labeled-select-with-create.po.ts
@@ -1,0 +1,44 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
+
+/**
+ * PO for the LabeledSelectWithCreate component - a LabeledSelect that swaps
+ * to a LabeledInput (with confirm/cancel buttons) when the user picks the
+ * "Create new" option
+ */
+export default class LabeledSelectWithCreatePo extends ComponentPo {
+  /**
+   * The underlying select, shown when not creating a new value
+   */
+  select(): LabeledSelectPo {
+    return new LabeledSelectPo(this.self());
+  }
+
+  /**
+   * The new-value input, shown while creating a new value
+   */
+  createInput(): LabeledInputPo {
+    return new LabeledInputPo(this.self().find('.create-input-row input'));
+  }
+
+  isCreating(): Cypress.Chainable<boolean> {
+    return this.self().then(($el) => $el.find('.create-input-row').length > 0);
+  }
+
+  /**
+   * Open the dropdown and click the "Create new" option, matched by its visible label
+   */
+  selectCreateNew(createLabel: string) {
+    this.select().toggle();
+    this.select().clickOptionWithLabel(createLabel);
+  }
+
+  confirmCreate() {
+    return this.self().find('.confirm-create').click();
+  }
+
+  cancelCreate() {
+    return this.self().find('.cancel-create').click();
+  }
+}

--- a/cypress/e2e/po/components/labeled-select-with-create.po.ts
+++ b/cypress/e2e/po/components/labeled-select-with-create.po.ts
@@ -6,6 +6,7 @@ import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
  * PO for the LabeledSelectWithCreate component - a LabeledSelect that swaps
  * to a LabeledInput (with a cancel button) when the user picks the "Create
  * new" option.
+ */
 export default class LabeledSelectWithCreatePo extends ComponentPo {
   /**
    * The underlying select, shown when not creating a new value

--- a/cypress/e2e/po/components/name-ns-description.po.ts
+++ b/cypress/e2e/po/components/name-ns-description.po.ts
@@ -1,6 +1,6 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
-import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
+import LabeledSelectWithCreatePo from '@/cypress/e2e/po/components/labeled-select-with-create.po';
 
 export default class NameNsDescription extends ComponentPo {
   name() {
@@ -11,13 +11,13 @@ export default class NameNsDescription extends ComponentPo {
     return new LabeledInputPo(this.self().find('[data-testid="name-ns-description-description"] input'));
   }
 
-  namespace() {
-    return new LabeledSelectPo(`[data-testid="name-ns-description-namespace"]`, this.self());
+  namespace(): LabeledSelectWithCreatePo {
+    return new LabeledSelectWithCreatePo(`[data-testid="name-ns-description-namespace"]`, this.self());
   }
 
   selectNamespace(label: string) {
-    this.namespace().toggle();
-    this.namespace().clickLabel(label);
+    this.namespace().select().toggle();
+    this.namespace().select().clickLabel(label);
   }
 
   project() {

--- a/cypress/e2e/po/pages/explorer/workloads-jobs.po.ts
+++ b/cypress/e2e/po/pages/explorer/workloads-jobs.po.ts
@@ -1,7 +1,6 @@
 import { BaseListPagePo } from '@/cypress/e2e/po/pages/base/base-list-page.po';
 import { BaseDetailPagePo } from '~/cypress/e2e/po/pages/base/base-detail-page.po';
 import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
-import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import ProductNavPo from '@/cypress/e2e/po/side-bars/product-side-nav.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 
@@ -51,17 +50,6 @@ export class WorkLoadsJobDetailsPagePo extends BaseDetailPagePo {
     super(WorkLoadsJobDetailsPagePo.createPath(jobId, clusterId, namespaceId, queryParams));
 
     WorkLoadsJobDetailsPagePo.url = WorkLoadsJobDetailsPagePo.createPath(jobId, clusterId, namespaceId, queryParams);
-  }
-
-  selectNamespaceOption(index: number) {
-    const selectVerb = new LabeledSelectPo(`[data-testid="name-ns-description-namespace"]`, this.self());
-
-    selectVerb.toggle();
-    selectVerb.clickOption(index);
-  }
-
-  namespace(): LabeledInputPo {
-    return LabeledInputPo.byLabel(this.self(), 'Namespace');
   }
 
   containerImage(): LabeledInputPo {

--- a/cypress/e2e/tests/pages/explorer/service-discovery/ingress.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/service-discovery/ingress.spec.ts
@@ -96,8 +96,10 @@ describe('Ingresses', { testIsolation: false, tags: ['@explorer', '@adminUser'] 
       ingressCreatePagePo.resourceDetail().createEditView().nameNsDescription().name()
         .set(ingressName);
       ingressCreatePagePo.resourceDetail().createEditView().nameNsDescription().namespace()
+        .select()
         .toggle();
       ingressCreatePagePo.resourceDetail().createEditView().nameNsDescription().namespace()
+        .select()
         .clickOptionWithLabel(namespace);
       ingressCreatePagePo.resourceDetail().createEditView().nameNsDescription().description()
         .set(`${ ingressName } description`);
@@ -246,8 +248,10 @@ describe('Ingresses', { testIsolation: false, tags: ['@explorer', '@adminUser'] 
       ingressCreatePagePo.resourceDetail().createEditView().nameNsDescription().name()
         .set(ingressHeadlessName);
       ingressCreatePagePo.resourceDetail().createEditView().nameNsDescription().namespace()
+        .select()
         .toggle();
       ingressCreatePagePo.resourceDetail().createEditView().nameNsDescription().namespace()
+        .select()
         .clickOptionWithLabel(namespace);
 
       ingressCreatePagePo.setRuleRequestHostValue(0, 'example-headless.com');

--- a/cypress/e2e/tests/pages/explorer2/workloads/jobs.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/jobs.spec.ts
@@ -38,8 +38,10 @@ describe('Jobs', { testIsolation: false, tags: ['@explorer2', '@adminUser'] }, (
         // create view jobs
         const workloadsJobDetailsPage = new WorkLoadsJobDetailsPagePo(localCluster);
 
-        workloadsJobDetailsPage.selectNamespaceOption(1);
-        workloadsJobDetailsPage.namespace().set(namespaceName);
+        const namespaceField = workloadsJobDetailsPage.resourceDetail().createEditView().nameNsDescription().namespace();
+
+        namespaceField.selectCreateNew('Create a new Namespace');
+        namespaceField.createInput().set(namespaceName);
         workloadsJobDetailsPage.resourceDetail().createEditView().nameNsDescription().name()
           .set(jobName);
         workloadsJobDetailsPage.containerImage().set(containerImageName);
@@ -79,8 +81,10 @@ describe('Jobs', { testIsolation: false, tags: ['@explorer2', '@adminUser'] }, (
         // create view jobs
         const workloadsJobDetailsPage = new WorkLoadsJobDetailsPagePo('local');
 
-        workloadsJobDetailsPage.selectNamespaceOption(1);
-        workloadsJobDetailsPage.namespace().set(namespaceName);
+        const namespaceField = workloadsJobDetailsPage.resourceDetail().createEditView().nameNsDescription().namespace();
+
+        namespaceField.selectCreateNew('Create a new Namespace');
+        namespaceField.createInput().set(namespaceName);
         workloadsJobDetailsPage.resourceDetail().createEditView().nameNsDescription().name()
           .set(jobName2);
         workloadsJobDetailsPage.containerImage().set(containerImageName);

--- a/shell/apis/shell/__tests__/proxy.test.ts
+++ b/shell/apis/shell/__tests__/proxy.test.ts
@@ -182,7 +182,7 @@ describe('proxyApiImpl', () => {
       const processed = { items: ['a', 'b'] };
 
       mockDispatch.mockResolvedValue(raw);
-      const postProcess = jest.fn().mockResolvedValue(processed) as jest.Mock;
+      const postProcess = jest.fn().mockResolvedValue(processed);
 
       const result = await proxyApi.request({ url: new URL('https://api.example.com/items'), postProcess });
 

--- a/shell/apis/shell/__tests__/slide-in.test.ts
+++ b/shell/apis/shell/__tests__/slide-in.test.ts
@@ -130,7 +130,7 @@ describe('slideInApiImpl', () => {
 
   describe('deprecation warnings', () => {
     const originalEnv = process.env.dev;
-    let warnSpy: jest.SpyInstance;
+    let warnSpy: ReturnType<typeof jest.spyOn>;
 
     beforeEach(() => {
       process.env.dev = 'true';

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -33,6 +33,7 @@ generic:
   copyValueToClipboard: 'Copy {value} to Clipboard'
   copiedToClipboard: Text copied to Clipboard
   create: Create
+  createNew: Create new…
   created: Created
   customize: Customize
   dashboard: Dashboard

--- a/shell/components/form/LabeledSelectWithCreate.vue
+++ b/shell/components/form/LabeledSelectWithCreate.vue
@@ -1,0 +1,207 @@
+<script setup>
+import { ref, computed, nextTick } from 'vue';
+import { useStore } from 'vuex';
+import { LabeledInput } from '@components/Form/LabeledInput';
+import LabeledSelect from '@shell/components/form/LabeledSelect';
+import { useI18n } from '@shell/composables/useI18n';
+
+/**
+ * A LabeledSelect that prepends a "Create new" highlighted option.
+ * When the user picks "Create new", the select is replaced by a LabeledInput
+ */
+defineOptions({ name: 'LabeledSelectWithCreate' });
+
+const props = defineProps({
+  value: {
+    type:    String,
+    default: null,
+  },
+  options: {
+    type:    Array,
+    default: () => [],
+  },
+
+  label: {
+    type:    String,
+    default: '',
+  },
+  /** takes precedence over label if set */
+  labelKey: {
+    type:    String,
+    default: null,
+  },
+  /** Text shown on the "Create new" option in the dropdown */
+  createLabel: {
+    type:    String,
+    default: 'Create new…',
+  },
+  /** Placeholder shown in the new-value input */
+  createPlaceholder: {
+    type:    String,
+    default: '',
+  },
+  /** Placeholder shown in the select when not creating */
+  placeholder: {
+    type:    String,
+    default: '',
+  },
+  mode: {
+    type:    String,
+    default: 'create',
+  },
+  loading: {
+    type:    Boolean,
+    default: false,
+  },
+  disabled: {
+    type:    Boolean,
+    default: false,
+  },
+  clearable: {
+    type:    Boolean,
+    default: false,
+  },
+  rules: {
+    type:    Array,
+    default: () => [],
+  },
+  appendToBody: {
+    type:    Boolean,
+    default: false,
+  },
+  /**
+   * When false, the "Create new" option is not shown.
+   * Use this to gate creation on RBAC permissions.
+   */
+  createAllowed: {
+    type:    Boolean,
+    default: true,
+  },
+  requireDirty: {
+    type:    Boolean,
+    default: true,
+  },
+  required: {
+    type:    Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['update:value', 'creating', 'cancel']);
+
+const store = useStore();
+const { t } = useI18n(store);
+
+const creating = ref(false);
+const newValue = ref('');
+const inputRef = ref(null);
+
+const selectOptions = computed(() => {
+  if (!props.createAllowed) {
+    return props.options;
+  }
+
+  const createEntry = {
+    label: props.createLabel,
+    value: '__create__',
+    kind:  'highlighted',
+  };
+  const divider = {
+    label:    'divider',
+    disabled: true,
+    kind:     'divider',
+  };
+
+  return [createEntry, divider, ...props.options];
+});
+
+function onSelecting(opt) {
+  if (!opt || opt.value === '__create__') {
+    creating.value = true;
+    newValue.value = '';
+    emit('creating');
+    nextTick(() => inputRef.value?.focus());
+  }
+}
+
+function cancelCreate() {
+  creating.value = false;
+  newValue.value = '';
+  emit('cancel');
+}
+
+function onCreateInput(val) {
+  newValue.value = val;
+  emit('update:value', val);
+}
+
+function onSelectChange(val) {
+  if (val !== '__create__') {
+    emit('update:value', val);
+  }
+}
+</script>
+
+<template>
+  <div class="labeled-select-with-create">
+    <!-- New-value input mode -->
+    <LabeledInput
+      v-if="creating"
+      ref="inputRef"
+      :value="newValue"
+      :label="labelKey ? t(labelKey) : label"
+      :placeholder="createPlaceholder"
+      :mode="mode"
+      :rules="rules"
+      class="create-input"
+      @update:value="onCreateInput"
+      @keyup.escape="cancelCreate"
+    >
+      <template #suffix>
+        <button
+          :aria-label="t('namespace.cancelCreateAriaLabel')"
+          @click="cancelCreate"
+        >
+          <i
+            v-clean-tooltip="t('generic.cancel')"
+            class="icon icon-close align-value"
+          />
+        </button>
+      </template>
+    </LabeledInput>
+
+    <!-- Select mode -->
+    <LabeledSelect
+      v-else
+      :value="value"
+      :label="labelKey ? t(labelKey) : label"
+      :placeholder="placeholder"
+      :options="selectOptions"
+      :mode="mode"
+      :loading="loading"
+      :disabled="disabled"
+      :clearable="clearable"
+      :rules="rules"
+      :append-to-body="appendToBody"
+      :require-dirty="requireDirty"
+      :required="required"
+      :searchable="true"
+      @selecting="onSelecting"
+      @update:value="onSelectChange"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+button {
+  all: unset;
+  display: flex;
+  align-items: center;
+  align-self: flex-end;
+  cursor: pointer;
+}
+
+.labeled-select-with-create {
+  width: 100%;
+}
+</style>

--- a/shell/components/form/LabeledSelectWithCreate.vue
+++ b/shell/components/form/LabeledSelectWithCreate.vue
@@ -1,9 +1,12 @@
-<script setup>
+<script setup lang="ts">
 import { ref, computed, nextTick } from 'vue';
 import { useStore } from 'vuex';
 import { LabeledInput } from '@components/Form/LabeledInput';
-import LabeledSelect from '@shell/components/form/LabeledSelect';
+import LabeledSelect from '@shell/components/form/LabeledSelect.vue';
+import { _CREATE } from '@shell/config/query-params';
 import { useI18n } from '@shell/composables/useI18n';
+import type { SelectOption } from '@shell/types/components/labeledSelect';
+import type { Validator } from '@shell/utils/validators/formRules/index';
 
 /**
  * A LabeledSelect that prepends a "Create new" highlighted option.
@@ -11,102 +14,78 @@ import { useI18n } from '@shell/composables/useI18n';
  */
 defineOptions({ name: 'LabeledSelectWithCreate' });
 
-const props = defineProps({
-  value: {
-    type:    String,
-    default: null,
-  },
-  options: {
-    type:    Array,
-    default: () => [],
-  },
+type FocusableInput = { focus: () => void };
 
-  label: {
-    type:    String,
-    default: '',
-  },
+interface Props {
+  value?: string | null;
+  options?: SelectOption[];
+  name?: string;
+  label?: string;
   /** takes precedence over label if set */
-  labelKey: {
-    type:    String,
-    default: null,
-  },
+  labelKey?: string | null;
   /** Text shown on the "Create new" option in the dropdown */
-  createLabel: {
-    type:    String,
-    default: 'Create new…',
-  },
+  createLabel?: string;
   /** Placeholder shown in the new-value input */
-  createPlaceholder: {
-    type:    String,
-    default: '',
-  },
+  createPlaceholder?: string;
   /** Placeholder shown in the select when not creating */
-  placeholder: {
-    type:    String,
-    default: '',
-  },
-  mode: {
-    type:    String,
-    default: 'create',
-  },
-  loading: {
-    type:    Boolean,
-    default: false,
-  },
-  disabled: {
-    type:    Boolean,
-    default: false,
-  },
-  clearable: {
-    type:    Boolean,
-    default: false,
-  },
-  rules: {
-    type:    Array,
-    default: () => [],
-  },
-  appendToBody: {
-    type:    Boolean,
-    default: false,
-  },
+  placeholder?: string;
+  mode?: string;
+  loading?: boolean;
+  disabled?: boolean;
+  clearable?: boolean;
+  rules?: Validator[];
+  appendToBody?: boolean;
   /**
    * When false, the "Create new" option is not shown.
    * Use this to gate creation on RBAC permissions.
    */
-  createAllowed: {
-    type:    Boolean,
-    default: true,
-  },
-  requireDirty: {
-    type:    Boolean,
-    default: true,
-  },
-  required: {
-    type:    Boolean,
-    default: false,
-  },
+  createAllowed?: boolean;
+  requireDirty?: boolean;
+  required?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  value:             null,
+  options:           () => [],
+  name:              undefined,
+  label:             '',
+  labelKey:          null,
+  createLabel:       undefined,
+  createPlaceholder: '',
+  placeholder:       '',
+  mode:              _CREATE,
+  loading:           false,
+  disabled:          false,
+  clearable:         false,
+  rules:             () => [],
+  appendToBody:      false,
+  createAllowed:     true,
+  requireDirty:      true,
+  required:          false,
 });
 
-const emit = defineEmits(['update:value', 'creating', 'cancel']);
+const emit = defineEmits<{(e: 'update:value', value: string): void, (e: 'creating'): void, (e: 'cancel'): void}>();
 
 const store = useStore();
 const { t } = useI18n(store);
 
 const creating = ref(false);
 const newValue = ref('');
-const inputRef = ref(null);
+const inputRef = ref<FocusableInput | null>(null);
 
-const selectOptions = computed(() => {
+const createLabelText = computed(() => props.createLabel || t('generic.createNew'));
+
+const selectOptions = computed<SelectOption[]>(() => {
   if (!props.createAllowed) {
     return props.options;
   }
 
-  const createEntry = {
-    label: props.createLabel,
+  const createEntry: SelectOption = {
+    label: createLabelText.value,
     value: '__create__',
     kind:  'highlighted',
   };
-  const divider = {
+  const divider: SelectOption = {
     label:    'divider',
     disabled: true,
     kind:     'divider',
@@ -115,11 +94,12 @@ const selectOptions = computed(() => {
   return [createEntry, divider, ...props.options];
 });
 
-function onSelecting(opt) {
+function onSelecting(opt: SelectOption | null) {
   if (!opt || opt.value === '__create__') {
     creating.value = true;
     newValue.value = '';
     emit('creating');
+    emit('update:value', '');
     nextTick(() => inputRef.value?.focus());
   }
 }
@@ -130,12 +110,12 @@ function cancelCreate() {
   emit('cancel');
 }
 
-function onCreateInput(val) {
+function onCreateInput(val: string) {
   newValue.value = val;
   emit('update:value', val);
 }
 
-function onSelectChange(val) {
+function onSelectChange(val: string) {
   if (val !== '__create__') {
     emit('update:value', val);
   }
@@ -148,11 +128,13 @@ function onSelectChange(val) {
     <LabeledInput
       v-if="creating"
       ref="inputRef"
+      :name="name"
       :value="newValue"
       :label="labelKey ? t(labelKey) : label"
       :placeholder="createPlaceholder"
       :mode="mode"
       :rules="rules"
+      :required="required"
       class="create-input"
       @update:value="onCreateInput"
       @keyup.escape="cancelCreate"
@@ -173,7 +155,8 @@ function onSelectChange(val) {
     <!-- Select mode -->
     <LabeledSelect
       v-else
-      :value="value"
+      :name="name"
+      :value="value ?? undefined"
       :label="labelKey ? t(labelKey) : label"
       :placeholder="placeholder"
       :options="selectOptions"

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -85,7 +85,11 @@ export default {
     },
     namespacePlaceholder: {
       type:    String,
-      default: 'nameNsDescription.namespace.placeholder',
+      default: 'namespace.selectOrCreate',
+    },
+    namespaceCreatePlaceholder: {
+      type:    String,
+      default: 'namespace.createNamespace',
     },
     namespaceDisabled: {
       type:    Boolean,
@@ -221,9 +225,19 @@ export default {
 
     const store = useStore();
 
+    function persistNamespace(val) {
+      if (props.namespaceKey) {
+        set(props.value, props.namespaceKey, val);
+      } else {
+        props.value.metadata.namespace = val;
+      }
+      emit('update:value', props.value);
+    }
+
     if (props.namespaced) {
       if (props.forceNamespace) {
         namespace.value = props.forceNamespace;
+        persistNamespace(namespace.value);
       } else if (props.namespaceKey) {
         namespace.value = get(v.value, props.namespaceKey);
       } else {
@@ -249,6 +263,7 @@ export default {
       name,
       description,
       isCreate,
+      persistNamespace,
     };
   },
 
@@ -288,12 +303,7 @@ export default {
 
   watch: {
     namespace(val) {
-      if (this.namespaceKey) {
-        set(this.value, this.namespaceKey, val);
-      } else {
-        this.value.metadata.namespace = val;
-      }
-      this.$emit('update:value', this.value);
+      this.persistNamespace(val);
     },
 
     description(val) {
@@ -347,10 +357,10 @@ export default {
         :mapper="namespaceMapper"
         :create-namespace-override="createNamespaceOverride"
         :placeholder="namespacePlaceholder"
+        :create-placeholder="namespaceCreatePlaceholder"
         :rules="rules.namespace"
-        :field-name="namespaceFieldName"
         :label-key="namespaceLabel"
-        :append-to-body="false"
+        :append-to-body="true"
         :required="true"
         @update:value="onNamespaceChange"
         @is-namespace-new="$emit('isNamespaceNew', $event)"

--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -3,14 +3,12 @@ import { computed, ref, toRef, watch } from 'vue';
 import { mapActions, useStore } from 'vuex';
 
 import { get, set } from '@shell/utils/object';
-import { sortBy } from '@shell/utils/sort';
 import { NAMESPACE } from '@shell/config/types';
 import { DESCRIPTION } from '@shell/config/labels-annotations';
 import { _VIEW, _EDIT, _CREATE } from '@shell/config/query-params';
 import { LabeledInput } from '@components/Form/LabeledInput';
-import LabeledSelect from '@shell/components/form/LabeledSelect';
+import NamespaceSelect from '@shell/components/form/NamespaceSelect';
 import { normalizeName } from '@shell/utils/kube';
-import { useI18n } from '@shell/composables/useI18n';
 
 export default {
   name: 'NameNsDescription',
@@ -19,7 +17,7 @@ export default {
 
   components: {
     LabeledInput,
-    LabeledSelect,
+    NamespaceSelect,
   },
 
   props: {
@@ -191,13 +189,9 @@ export default {
     }
   },
 
-  data() {
-    return { createNamespace: false };
-  },
-
   setup(props, { emit }) {
     const v = toRef(props.value);
-    const metadata = v.value.metadata;
+    const metadata = v.value?.metadata;
     const namespace = ref(null);
     const name = ref(null);
     const description = ref(null);
@@ -226,100 +220,10 @@ export default {
     });
 
     const store = useStore();
-    const { t } = useI18n(store);
-    const allowedNamespaces = computed(() => store.getters.allowedNamespaces());
-    const storeNamespaces = computed(() => store.getters.namespaces());
-    const currentCluster = computed(() => store.getters.currentCluster);
-
-    const inStore = computed(() => {
-      return store.getters['currentStore']();
-    });
-
-    const nsSchema = computed(() => {
-      return store.getters[`${ inStore.value }/schemaFor`](NAMESPACE);
-    });
-
-    const canCreateNamespace = computed(() => {
-      // Check if user can push to namespaces... and as the ns is outside of a project restrict to admins and cluster owners
-      return (nsSchema.value?.collectionMethods || []).includes('POST') && currentCluster.value?.canUpdate;
-    });
-
-    /**
-     * Map namespaces from the store to options, adding divider and create button
-     */
-    const options = computed(() => {
-      let namespaces;
-
-      if (props.namespacesOverride) {
-        // Use the resources provided
-        namespaces = props.namespacesOverride;
-      } else {
-        if (props.namespaceOptions) {
-          // Use the namespaces provided
-          namespaces = (props.namespaceOptions.map((ns) => ns.name) || []).sort();
-        } else {
-          // Determine the namespaces
-          const namespaceObjs = isCreate.value ? allowedNamespaces.value : storeNamespaces.value;
-
-          namespaces = Object.keys(namespaceObjs);
-        }
-      }
-
-      const options = namespaces
-        .map((namespace) => ({ nameDisplay: namespace, id: namespace }))
-        .map(props.namespaceMapper || ((obj) => ({
-          label: obj.nameDisplay,
-          value: obj.id,
-        })));
-
-      const sortedByLabel = sortBy(options, 'label');
-
-      if (props.forceNamespace) {
-        sortedByLabel.unshift({
-          label: props.forceNamespace,
-          value: props.forceNamespace,
-        });
-      }
-
-      const createButton = {
-        label: t('namespace.createNamespace'),
-        value: '',
-        kind:  'highlighted'
-      };
-      const divider = {
-        label:    'divider',
-        disabled: true,
-        kind:     'divider'
-      };
-
-      const createOverhead = canCreateNamespace.value || props.createNamespaceOverride ? [createButton, divider] : [];
-
-      return [
-        ...createOverhead,
-        ...sortedByLabel
-      ];
-    });
-
-    const updateNamespace = (val) => {
-      if (props.forceNamespace) {
-        val = props.forceNamespace;
-      }
-
-      if (props.namespaced) {
-        emit('isNamespaceNew', !val || (options.value && !options.value.find((n) => n.value === val)));
-      }
-
-      if (props.namespaceKey) {
-        set(props.value, props.namespaceKey, val);
-      } else {
-        props.value.metadata.namespace = val;
-      }
-    };
 
     if (props.namespaced) {
       if (props.forceNamespace) {
         namespace.value = props.forceNamespace;
-        updateNamespace(namespace.value);
       } else if (props.namespaceKey) {
         namespace.value = get(v.value, props.namespaceKey);
       } else {
@@ -345,8 +249,6 @@ export default {
       name,
       description,
       isCreate,
-      options,
-      updateNamespace,
     };
   },
 
@@ -386,7 +288,11 @@ export default {
 
   watch: {
     namespace(val) {
-      this.updateNamespace(val);
+      if (this.namespaceKey) {
+        set(this.value, this.namespaceKey, val);
+      } else {
+        this.value.metadata.namespace = val;
+      }
       this.$emit('update:value', this.value);
     },
 
@@ -414,30 +320,8 @@ export default {
       this.namespace = e.selected;
     },
 
-    cancelCreateNamespace(e) {
-      this.createNamespace = false;
-      this.$parent.$emit('createNamespace', false);
-      // In practice we should always have a defaultNamespace... unless we're in non-kube extension world,  so fall back on options
-      this.namespace = this.$store.getters['defaultNamespace'] || this.options.find((o) => !!o.value)?.value;
-    },
-
-    selectNamespace(e) {
-      if (!e || e.value === '') { // The blank value in the dropdown is labeled "Create a New Namespace"
-        this.createNamespace = true;
-        this.$store.dispatch(
-          'cru-resource/setCreateNamespace',
-          true,
-        );
-        this.$emit('isNamespaceNew', true);
-        this.$nextTick(() => this.$refs.namespaceInput.focus());
-      } else {
-        this.createNamespace = false;
-        this.$store.dispatch(
-          'cru-resource/setCreateNamespace',
-          false,
-        );
-        this.$emit('isNamespaceNew', false);
-      }
+    onNamespaceChange(val) {
+      this.namespace = val;
     },
   },
 };
@@ -447,52 +331,29 @@ export default {
   <div :class="['row', { 'mb-20': !noBottomMargin }]">
     <slot name="project-selector" />
     <div
-      v-if="namespaced && !nameNsHidden && createNamespace"
-      :data-testid="componentTestid + '-namespace-create'"
-      class="col span-3"
-    >
-      <LabeledInput
-        ref="namespaceInput"
-        v-model:value="namespace"
-        :name="namespaceFieldName"
-        :label="t('namespace.label')"
-        :placeholder="t('namespace.createNamespace')"
-        :disabled="namespaceReallyDisabled"
-        :mode="mode"
-        :min-height="30"
-        :required="nameRequired"
-        :rules="rules.namespace"
-      />
-      <button
-        :aria-label="t('namespace.cancelCreateAriaLabel')"
-        @click="cancelCreateNamespace"
-      >
-        <i
-          v-clean-tooltip="t('generic.cancel')"
-          class="icon icon-close align-value"
-        />
-      </button>
-    </div>
-    <div
-      v-if="namespaced && !nameNsHidden && !createNamespace"
+      v-if="namespaced && !nameNsHidden"
       :data-testid="componentTestid + '-namespace'"
       class="col span-3"
     >
-      <LabeledSelect
-        v-show="!createNamespace"
-        v-model:value="namespace"
+      <NamespaceSelect
+        :value="namespace"
         :name="namespaceFieldName"
-        :clearable="true"
-        :options="options"
-        :disabled="namespaceReallyDisabled"
-        :searchable="true"
         :mode="mode"
-        :multiple="false"
-        :label="t('namespace.label')"
-        :placeholder="t('namespace.selectOrCreate')"
+        :disabled="namespaceDisabled"
+        :force-namespace="forceNamespace"
+        :no-default-namespace="noDefaultNamespace"
+        :override="namespacesOverride"
+        :options="namespaceOptions"
+        :mapper="namespaceMapper"
+        :create-namespace-override="createNamespaceOverride"
+        :placeholder="namespacePlaceholder"
         :rules="rules.namespace"
-        required
-        @selecting="selectNamespace"
+        :field-name="namespaceFieldName"
+        :label-key="namespaceLabel"
+        :append-to-body="false"
+        :required="true"
+        @update:value="onNamespaceChange"
+        @is-namespace-new="$emit('isNamespaceNew', $event)"
       />
     </div>
 

--- a/shell/components/form/NamespaceSelect.vue
+++ b/shell/components/form/NamespaceSelect.vue
@@ -1,12 +1,14 @@
-<script setup>
+<script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import { useStore } from 'vuex';
 
 import { sortBy } from '@shell/utils/sort';
 import { NAMESPACE } from '@shell/config/types';
 import { _CREATE, _EDIT } from '@shell/config/query-params';
-import LabeledSelectWithCreate from '@shell/components/form/LabeledSelectWithCreate';
+import LabeledSelectWithCreate from '@shell/components/form/LabeledSelectWithCreate.vue';
 import { useI18n } from '@shell/composables/useI18n';
+import type { SelectOption } from '@shell/types/components/labeledSelect';
+import type { Validator } from '@shell/utils/validators/formRules/index';
 
 /**
  * A self-contained namespace selector that:
@@ -17,79 +19,64 @@ import { useI18n } from '@shell/composables/useI18n';
  */
 defineOptions({ name: 'NamespaceSelect' });
 
-const props = defineProps({
-  value: {
-    type:    String,
-    default: null,
-  },
-  mode: {
-    type:    String,
-    default: _CREATE,
-  },
-  label: {
-    type:    String,
-    default: null,
-  },
+interface RawNamespace {
+  id?: string;
+  name?: string;
+  nameDisplay?: string;
+  [key: string]: any;
+}
+
+interface NormalizedNamespace extends RawNamespace {
+  id: string;
+  nameDisplay: string;
+}
+
+type Mapper = (ns: NormalizedNamespace) => SelectOption;
+
+interface Props {
+  value?: string | null;
+  mode?: string;
+  label?: string;
   /** takes precedence over label if set */
-  labelKey: {
-    type:    String,
-    default: 'nameNsDescription.namespace.label',
-  },
-  placeholder: {
-    type:    String,
-    default: 'namespace.selectOrCreate',
-  },
-  disabled: {
-    type:    Boolean,
-    default: false,
-  },
-  forceNamespace: {
-    type:    String,
-    default: null,
-  },
-  noDefaultNamespace: {
-    type:    Boolean,
-    default: false,
-  },
-  override: {
-    type:    Array,
-    default: null,
-  },
-  options: {
-    type:    Array,
-    default: null,
-  },
-  mapper: {
-    type:    Function,
-    default: null,
-  },
-  createNamespaceOverride: {
-    type:    Boolean,
-    default: false,
-  },
-  rules: {
-    type:    Array,
-    default: () => [],
-  },
-  fieldName: {
-    type:    String,
-    default: null,
-  },
-  appendToBody: {
-    type:    Boolean,
-    default: false,
-  },
-  requireDirty: {
-    type:    Boolean,
-    default: true,
-  },
-  required: {
-    type:    Boolean,
-    default: false,
-  },
+  labelKey?: string | null;
+  placeholder?: string;
+  createPlaceholder?: string;
+  disabled?: boolean;
+  forceNamespace?: string | null;
+  noDefaultNamespace?: boolean;
+  override?: (string | RawNamespace)[] | null;
+  options?: (string | RawNamespace)[] | null;
+  mapper?: Mapper | null;
+  createNamespaceOverride?: boolean;
+  rules?: Validator[];
+  name?: string;
+  appendToBody?: boolean;
+  requireDirty?: boolean;
+  required?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  value:                   null,
+  mode:                    _CREATE,
+  label:                   undefined,
+  labelKey:                'nameNsDescription.namespace.label',
+  placeholder:             'namespace.selectOrCreate',
+  createPlaceholder:       'namespace.createNamespace',
+  disabled:                false,
+  forceNamespace:          null,
+  noDefaultNamespace:      false,
+  override:                null,
+  options:                 null,
+  mapper:                  null,
+  createNamespaceOverride: false,
+  rules:                   () => [],
+  name:                    undefined,
+  appendToBody:            false,
+  requireDirty:            true,
+  required:                false,
 });
 
-const emit = defineEmits(['update:value', 'isNamespaceNew']);
+const emit = defineEmits<{(e: 'update:value', value: string): void, (e: 'isNamespaceNew', value: boolean): void}>();
 
 const store = useStore();
 const { t } = useI18n(store);
@@ -106,26 +93,26 @@ const canCreateNamespace = computed(() => {
   return (nsSchema.value?.collectionMethods || []).includes('POST') && currentCluster.value?.canUpdate;
 });
 
-const namespace = ref(
+const namespace = ref<string | null>(
   props.forceNamespace ??
     props.value ??
     (!props.noDefaultNamespace ? store.getters['defaultNamespace'] : null)
 );
 
-const realNamespaceOptions = computed(() => {
-  let namespaces;
+const realNamespaceOptions = computed<SelectOption[]>(() => {
+  let namespaces: (string | RawNamespace)[];
 
   if (props.override) {
     namespaces = props.override;
   } else if (props.options) {
-    namespaces = props.options.map((ns) => (typeof ns === 'string' ? ns : (ns.name || ns.id))).filter(Boolean).sort();
+    namespaces = props.options.map((ns) => (typeof ns === 'string' ? ns : (ns.name || ns.id))).filter(Boolean).sort() as string[];
   } else {
     const namespaceObjs = isCreate.value ? allowedNamespaces.value : storeNamespaces.value;
 
     namespaces = Object.keys(namespaceObjs);
   }
 
-  const normalized = namespaces
+  const normalized: NormalizedNamespace[] = namespaces
     .map((ns) => {
       if (typeof ns === 'string') {
         return { nameDisplay: ns, id: ns };
@@ -140,10 +127,10 @@ const realNamespaceOptions = computed(() => {
         id,
       };
     })
-    .filter((ns) => !!ns.id);
+    .filter((ns): ns is NormalizedNamespace => !!ns.id);
 
   const mapped = normalized
-    .map(props.mapper || ((obj) => ({
+    .map(props.mapper || ((obj: NormalizedNamespace) => ({
       label: obj.nameDisplay,
       value: obj.id,
     })));
@@ -157,7 +144,7 @@ const realNamespaceOptions = computed(() => {
   return sorted;
 });
 
-const namespaceSelectOptions = computed(() => {
+const namespaceSelectOptions = computed<SelectOption[]>(() => {
   const sorted = [...realNamespaceOptions.value];
 
   // A namespace the user just created via the "create new" flow doesn't
@@ -171,34 +158,34 @@ const namespaceSelectOptions = computed(() => {
   return sorted;
 });
 
-const lastIsNamespaceNew = ref(null);
+const lastIsNamespaceNew = ref<boolean | null>(null);
 
 // Keep in sync when the parent changes value externally
 watch(() => props.value, (val) => {
-  if (val !== namespace.value) namespace.value = val;
+  if (val !== namespace.value) namespace.value = val ?? null;
 });
 
-const isNew = (val) => !val || !realNamespaceOptions.value.find((o) => o.value === val);
+const isNew = (val: string) => !val || !realNamespaceOptions.value.find((o) => o.value === val);
 
-function emitNamespaceNewIfChanged(nextIsNew) {
+function emitNamespaceNewIfChanged(nextIsNew: boolean) {
   if (lastIsNamespaceNew.value !== nextIsNew) {
     lastIsNamespaceNew.value = nextIsNew;
     emit('isNamespaceNew', nextIsNew);
   }
 }
 
-function emitChange(val) {
+function emitChange(val: string) {
   namespace.value = val;
   emit('update:value', val);
   emitNamespaceNewIfChanged(isNew(val));
 }
 
-function dispatchCreateNamespace(creating) {
+function dispatchCreateNamespace(creating: boolean) {
   store.dispatch('cru-resource/setCreateNamespace', creating);
 }
 const isCreatingNamespace = ref(false);
 
-function onUpdate(val) {
+function onUpdate(val: string) {
   if (!isCreatingNamespace.value) {
     dispatchCreateNamespace(false);
   }
@@ -224,9 +211,8 @@ const isReallyDisabled = computed(() => !!props.forceNamespace || props.disabled
 
 <template>
   <LabeledSelectWithCreate
-    v-if="!forceNamespace"
     :value="namespace"
-    :name="fieldName"
+    :name="name"
     :clearable="true"
     :options="namespaceSelectOptions"
     :disabled="isReallyDisabled"
@@ -235,7 +221,7 @@ const isReallyDisabled = computed(() => !!props.forceNamespace || props.disabled
     :label-key="labelKey"
     :placeholder="t(placeholder)"
     :create-label="t('namespace.createNamespace')"
-    :create-placeholder="t('namespace.createNamespace')"
+    :create-placeholder="t(createPlaceholder)"
     :create-allowed="canCreateNamespace || createNamespaceOverride"
     :rules="rules"
     :append-to-body="appendToBody"

--- a/shell/components/form/NamespaceSelect.vue
+++ b/shell/components/form/NamespaceSelect.vue
@@ -1,0 +1,248 @@
+<script setup>
+import { computed, ref, watch } from 'vue';
+import { useStore } from 'vuex';
+
+import { sortBy } from '@shell/utils/sort';
+import { NAMESPACE } from '@shell/config/types';
+import { _CREATE, _EDIT } from '@shell/config/query-params';
+import LabeledSelectWithCreate from '@shell/components/form/LabeledSelectWithCreate';
+import { useI18n } from '@shell/composables/useI18n';
+
+/**
+ * A self-contained namespace selector that:
+ *  - Reads namespaces from the Vuex store (or accepts overrides)
+ *  - Prepends a "Create new namespace" option when the user has permission
+ *  - Delegates the create/select UI to LabeledSelectWithCreate
+ *  - Emits `update:value` (the namespace string) and `isNamespaceNew`
+ */
+defineOptions({ name: 'NamespaceSelect' });
+
+const props = defineProps({
+  value: {
+    type:    String,
+    default: null,
+  },
+  mode: {
+    type:    String,
+    default: _CREATE,
+  },
+  label: {
+    type:    String,
+    default: null,
+  },
+  /** takes precedence over label if set */
+  labelKey: {
+    type:    String,
+    default: 'nameNsDescription.namespace.label',
+  },
+  placeholder: {
+    type:    String,
+    default: 'namespace.selectOrCreate',
+  },
+  disabled: {
+    type:    Boolean,
+    default: false,
+  },
+  forceNamespace: {
+    type:    String,
+    default: null,
+  },
+  noDefaultNamespace: {
+    type:    Boolean,
+    default: false,
+  },
+  override: {
+    type:    Array,
+    default: null,
+  },
+  options: {
+    type:    Array,
+    default: null,
+  },
+  mapper: {
+    type:    Function,
+    default: null,
+  },
+  createNamespaceOverride: {
+    type:    Boolean,
+    default: false,
+  },
+  rules: {
+    type:    Array,
+    default: () => [],
+  },
+  fieldName: {
+    type:    String,
+    default: null,
+  },
+  appendToBody: {
+    type:    Boolean,
+    default: false,
+  },
+  requireDirty: {
+    type:    Boolean,
+    default: true,
+  },
+  required: {
+    type:    Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['update:value', 'isNamespaceNew']);
+
+const store = useStore();
+const { t } = useI18n(store);
+
+const isCreate = computed(() => props.mode === _CREATE);
+
+const allowedNamespaces = computed(() => store.getters.allowedNamespaces());
+const storeNamespaces = computed(() => store.getters.namespaces());
+const currentCluster = computed(() => store.getters.currentCluster);
+const inStore = computed(() => store.getters['currentStore']());
+const nsSchema = computed(() => store.getters[`${ inStore.value }/schemaFor`](NAMESPACE));
+
+const canCreateNamespace = computed(() => {
+  return (nsSchema.value?.collectionMethods || []).includes('POST') && currentCluster.value?.canUpdate;
+});
+
+const namespace = ref(
+  props.forceNamespace ??
+    props.value ??
+    (!props.noDefaultNamespace ? store.getters['defaultNamespace'] : null)
+);
+
+const realNamespaceOptions = computed(() => {
+  let namespaces;
+
+  if (props.override) {
+    namespaces = props.override;
+  } else if (props.options) {
+    namespaces = props.options.map((ns) => (typeof ns === 'string' ? ns : (ns.name || ns.id))).filter(Boolean).sort();
+  } else {
+    const namespaceObjs = isCreate.value ? allowedNamespaces.value : storeNamespaces.value;
+
+    namespaces = Object.keys(namespaceObjs);
+  }
+
+  const normalized = namespaces
+    .map((ns) => {
+      if (typeof ns === 'string') {
+        return { nameDisplay: ns, id: ns };
+      }
+
+      const id = ns?.id || ns?.name;
+      const nameDisplay = ns?.nameDisplay || ns?.name || id;
+
+      return {
+        ...ns,
+        nameDisplay,
+        id,
+      };
+    })
+    .filter((ns) => !!ns.id);
+
+  const mapped = normalized
+    .map(props.mapper || ((obj) => ({
+      label: obj.nameDisplay,
+      value: obj.id,
+    })));
+
+  const sorted = sortBy(mapped, 'label');
+
+  if (props.forceNamespace) {
+    sorted.unshift({ label: props.forceNamespace, value: props.forceNamespace });
+  }
+
+  return sorted;
+});
+
+const namespaceSelectOptions = computed(() => {
+  const sorted = [...realNamespaceOptions.value];
+
+  // A namespace the user just created via the "create new" flow doesn't
+  // exist in the store's namespace list yet - it isn't actually created
+  // until save. Without a matching option, the underlying select has
+  // nothing to display for the current value and falls back to blank.
+  if (namespace.value && !sorted.some((o) => o.value === namespace.value)) {
+    sorted.unshift({ label: namespace.value, value: namespace.value });
+  }
+
+  return sorted;
+});
+
+const lastIsNamespaceNew = ref(null);
+
+// Keep in sync when the parent changes value externally
+watch(() => props.value, (val) => {
+  if (val !== namespace.value) namespace.value = val;
+});
+
+const isNew = (val) => !val || !realNamespaceOptions.value.find((o) => o.value === val);
+
+function emitNamespaceNewIfChanged(nextIsNew) {
+  if (lastIsNamespaceNew.value !== nextIsNew) {
+    lastIsNamespaceNew.value = nextIsNew;
+    emit('isNamespaceNew', nextIsNew);
+  }
+}
+
+function emitChange(val) {
+  namespace.value = val;
+  emit('update:value', val);
+  emitNamespaceNewIfChanged(isNew(val));
+}
+
+function dispatchCreateNamespace(creating) {
+  store.dispatch('cru-resource/setCreateNamespace', creating);
+}
+const isCreatingNamespace = ref(false);
+
+function onUpdate(val) {
+  if (!isCreatingNamespace.value) {
+    dispatchCreateNamespace(false);
+  }
+  emitChange(val);
+}
+
+function onCreating() {
+  isCreatingNamespace.value = true;
+  dispatchCreateNamespace(true);
+  emitNamespaceNewIfChanged(true);
+}
+
+function onCancel() {
+  isCreatingNamespace.value = false;
+  dispatchCreateNamespace(false);
+  const defaultNs = store.getters['defaultNamespace'] || realNamespaceOptions.value.find((o) => !!o.value)?.value;
+
+  emitChange(defaultNs);
+}
+
+const isReallyDisabled = computed(() => !!props.forceNamespace || props.disabled || props.mode === _EDIT);
+</script>
+
+<template>
+  <LabeledSelectWithCreate
+    v-if="!forceNamespace"
+    :value="namespace"
+    :name="fieldName"
+    :clearable="true"
+    :options="namespaceSelectOptions"
+    :disabled="isReallyDisabled"
+    :mode="mode"
+    :label="label"
+    :label-key="labelKey"
+    :placeholder="t(placeholder)"
+    :create-label="t('namespace.createNamespace')"
+    :create-placeholder="t('namespace.createNamespace')"
+    :create-allowed="canCreateNamespace || createNamespaceOverride"
+    :rules="rules"
+    :append-to-body="appendToBody"
+    :require-dirty="requireDirty"
+    :required="required"
+    @update:value="onUpdate"
+    @creating="onCreating"
+    @cancel="onCancel"
+  />
+</template>

--- a/shell/components/form/__tests__/LabeledSelectWithCreate.test.ts
+++ b/shell/components/form/__tests__/LabeledSelectWithCreate.test.ts
@@ -1,0 +1,275 @@
+import { mount } from '@vue/test-utils';
+import LabeledSelectWithCreate from '@shell/components/form/LabeledSelectWithCreate.vue';
+
+const LabeledSelectStub = {
+  name:  'LabeledSelect',
+  props: [
+    'value', 'label', 'placeholder', 'options', 'mode', 'loading',
+    'disabled', 'clearable', 'rules', 'appendToBody', 'requireDirty',
+    'required', 'searchable',
+  ],
+  emits:    ['selecting', 'update:value'],
+  template: '<div class="labeled-select-stub" />',
+};
+
+jest.mock('@components/Form/LabeledInput', () => ({
+  LabeledInput: {
+    name:  'LabeledInput',
+    props: ['value', 'label', 'placeholder', 'mode', 'rules'],
+    emits: ['update:value'],
+
+    template: `
+      <div class="labeled-input-stub">
+        <input :value="value" @input="$emit('update:value', $event.target.value)" />
+        <slot name="suffix" />
+      </div>
+    `,
+    methods: { focus() {} }, // the real component exposes this for the parent's nextTick(() => inputRef.value?.focus())
+  },
+}));
+
+jest.mock('@shell/composables/useI18n', () => ({ useI18n: () => ({ t: (key) => key }) }));
+
+const CREATE_OPTIONS = [
+  { label: 'Option A', value: 'a' },
+  { label: 'Option B', value: 'b' },
+];
+
+function mountComponent(props = {}) {
+  return mount(LabeledSelectWithCreate, {
+    props: {
+      value:   null,
+      options: CREATE_OPTIONS,
+      label:   'Test Label',
+      ...props,
+    },
+    global: {
+      stubs: { LabeledSelect: LabeledSelectStub },
+      mocks: { t: (key: string) => key },
+    },
+  });
+}
+
+function findSelect(wrapper) {
+  return wrapper.findComponent(LabeledSelectStub);
+}
+
+function findInput(wrapper) {
+  return wrapper.findComponent({ name: 'LabeledInput' });
+}
+
+describe('component: LabeledSelectWithCreate', () => {
+  describe('select mode (default)', () => {
+    it('renders the LabeledSelect and not the create input', () => {
+      const wrapper = mountComponent();
+
+      expect(findSelect(wrapper).exists()).toBe(true);
+      expect(findInput(wrapper).exists()).toBe(false);
+    });
+
+    it('prepends a highlighted "create" entry and a divider before the passed-in options by default', () => {
+      const wrapper = mountComponent();
+
+      expect(findSelect(wrapper).props('options')).toEqual([
+        {
+          label: 'Create new…', value: '__create__', kind: 'highlighted',
+        },
+        {
+          label: 'divider', disabled: true, kind: 'divider',
+        },
+        ...CREATE_OPTIONS,
+      ]);
+    });
+
+    it('uses the custom createLabel prop for the create entry label', () => {
+      const wrapper = mountComponent({ createLabel: 'Add a new thing' });
+
+      expect(findSelect(wrapper).props('options')[0].label).toBe('Add a new thing');
+    });
+
+    it('does not add the create entry or divider when createAllowed is false', () => {
+      const wrapper = mountComponent({ createAllowed: false });
+
+      expect(findSelect(wrapper).props('options')).toEqual(CREATE_OPTIONS);
+    });
+
+    it('prefers labelKey (translated) over label when both are provided', () => {
+      const wrapper = mountComponent({ labelKey: 'some.translation.key', label: 'Raw Label' });
+
+      expect(findSelect(wrapper).props('label')).toBe('some.translation.key');
+    });
+
+    it('falls back to the raw label when labelKey is not set', () => {
+      const wrapper = mountComponent({ label: 'Raw Label' });
+
+      expect(findSelect(wrapper).props('label')).toBe('Raw Label');
+    });
+
+    it('passes through the remaining select props unchanged', () => {
+      const wrapper = mountComponent({
+        placeholder:  'Pick one',
+        mode:         'edit',
+        loading:      true,
+        disabled:     true,
+        clearable:    true,
+        appendToBody: true,
+        requireDirty: false,
+        required:     true,
+      });
+
+      expect(findSelect(wrapper).props()).toMatchObject({
+        value:        null,
+        placeholder:  'Pick one',
+        mode:         'edit',
+        loading:      true,
+        disabled:     true,
+        clearable:    true,
+        appendToBody: true,
+        requireDirty: false,
+        required:     true,
+        searchable:   true,
+      });
+    });
+
+    it('emits update:value when the select emits update:value with a normal option', async() => {
+      const wrapper = mountComponent();
+
+      await findSelect(wrapper).vm.$emit('update:value', 'a');
+
+      expect(wrapper.emitted('update:value')).toEqual([['a']]);
+    });
+
+    it('does not emit update:value when the select reports the create sentinel value', async() => {
+      const wrapper = mountComponent();
+
+      await findSelect(wrapper).vm.$emit('update:value', '__create__');
+
+      expect(wrapper.emitted('update:value')).toBeFalsy();
+    });
+
+    it('switches to create mode and emits "creating" when the create option is selected', async() => {
+      const wrapper = mountComponent();
+
+      await findSelect(wrapper).vm.$emit('selecting', { label: 'Create new…', value: '__create__' });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted('creating')).toBeTruthy();
+      expect(findSelect(wrapper).exists()).toBe(false);
+      expect(findInput(wrapper).exists()).toBe(true);
+    });
+
+    it('switches to create mode when "selecting" fires with no option (e.g. clearing)', async() => {
+      const wrapper = mountComponent();
+
+      await findSelect(wrapper).vm.$emit('selecting', null);
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted('creating')).toBeTruthy();
+      expect(findInput(wrapper).exists()).toBe(true);
+    });
+
+    it('does not switch to create mode when a regular option is selected', async() => {
+      const wrapper = mountComponent();
+
+      await findSelect(wrapper).vm.$emit('selecting', { label: 'Option A', value: 'a' });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted('creating')).toBeFalsy();
+      expect(findInput(wrapper).exists()).toBe(false);
+    });
+  });
+
+  describe('create mode', () => {
+    async function mountInCreateMode(props = {}) {
+      const wrapper = mountComponent(props);
+
+      await findSelect(wrapper).vm.$emit('selecting', { value: '__create__' });
+      await wrapper.vm.$nextTick();
+
+      return wrapper;
+    }
+
+    it('renders a LabeledInput with the createPlaceholder and label, and hides the select', async() => {
+      const wrapper = await mountInCreateMode({
+        createPlaceholder: 'Type a new value',
+        label:             'Test Label',
+      });
+      const input = findInput(wrapper);
+
+      expect(input.exists()).toBe(true);
+      expect(input.props('placeholder')).toBe('Type a new value');
+      expect(input.props('label')).toBe('Test Label');
+      expect(findSelect(wrapper).exists()).toBe(false);
+    });
+
+    it('starts with an empty new-value input', async() => {
+      const wrapper = await mountInCreateMode();
+
+      expect(findInput(wrapper).props('value')).toBe('');
+    });
+
+    it('emits update:value immediately on every keystroke, with no separate confirm step', async() => {
+      const wrapper = await mountInCreateMode();
+
+      await findInput(wrapper).vm.$emit('update:value', 'N');
+      await findInput(wrapper).vm.$emit('update:value', 'Ne');
+      await findInput(wrapper).vm.$emit('update:value', 'New');
+
+      expect(wrapper.emitted('update:value')).toEqual([['N'], ['Ne'], ['New']]);
+      // typing never auto-confirms/returns to select mode - only cancel does
+      expect(findInput(wrapper).exists()).toBe(true);
+      expect(findSelect(wrapper).exists()).toBe(false);
+    });
+
+    it('reflects the last emitted value back into the input value prop', async() => {
+      const wrapper = await mountInCreateMode();
+
+      await findInput(wrapper).vm.$emit('update:value', 'New Item');
+      await wrapper.vm.$nextTick();
+
+      expect(findInput(wrapper).props('value')).toBe('New Item');
+    });
+
+    it('does not render a confirm/add button', async() => {
+      const wrapper = await mountInCreateMode();
+
+      expect(wrapper.find('.confirm-create').exists()).toBe(false);
+    });
+
+    it('cancels creation, clears the new value, emits "cancel", and returns to select mode when the cancel button is clicked', async() => {
+      const wrapper = await mountInCreateMode();
+
+      await findInput(wrapper).vm.$emit('update:value', 'Abandoned');
+      await wrapper.vm.$nextTick();
+      await wrapper.find('button').trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted('cancel')).toBeTruthy();
+      expect(findInput(wrapper).exists()).toBe(false);
+      expect(findSelect(wrapper).exists()).toBe(true);
+
+      // Re-entering create mode should start from a cleared value.
+      await findSelect(wrapper).vm.$emit('selecting', { value: '__create__' });
+      await wrapper.vm.$nextTick();
+      expect(findInput(wrapper).props('value')).toBe('');
+    });
+
+    it('cancels creation when Escape is pressed in the input', async() => {
+      const wrapper = await mountInCreateMode();
+
+      await findInput(wrapper).trigger('keyup.escape');
+
+      expect(wrapper.emitted('cancel')).toBeTruthy();
+      expect(findInput(wrapper).exists()).toBe(false);
+    });
+
+    it('passes mode and rules through to the create-mode LabeledInput', async() => {
+      const rules = [(val) => (!val ? 'Required' : undefined)];
+      const wrapper = await mountInCreateMode({ mode: 'edit', rules });
+      const input = findInput(wrapper);
+
+      expect(input.props('mode')).toBe('edit');
+      expect(input.props('rules')).toStrictEqual(rules);
+    });
+  });
+});

--- a/shell/components/form/__tests__/LabeledSelectWithCreate.test.ts
+++ b/shell/components/form/__tests__/LabeledSelectWithCreate.test.ts
@@ -4,7 +4,7 @@ import LabeledSelectWithCreate from '@shell/components/form/LabeledSelectWithCre
 const LabeledSelectStub = {
   name:  'LabeledSelect',
   props: [
-    'value', 'label', 'placeholder', 'options', 'mode', 'loading',
+    'name', 'value', 'label', 'placeholder', 'options', 'mode', 'loading',
     'disabled', 'clearable', 'rules', 'appendToBody', 'requireDirty',
     'required', 'searchable',
   ],
@@ -15,7 +15,7 @@ const LabeledSelectStub = {
 jest.mock('@components/Form/LabeledInput', () => ({
   LabeledInput: {
     name:  'LabeledInput',
-    props: ['value', 'label', 'placeholder', 'mode', 'rules'],
+    props: ['name', 'value', 'label', 'placeholder', 'mode', 'rules'],
     emits: ['update:value'],
 
     template: `
@@ -72,7 +72,7 @@ describe('component: LabeledSelectWithCreate', () => {
 
       expect(findSelect(wrapper).props('options')).toEqual([
         {
-          label: 'Create new…', value: '__create__', kind: 'highlighted',
+          label: 'generic.createNew', value: '__create__', kind: 'highlighted',
         },
         {
           label: 'divider', disabled: true, kind: 'divider',
@@ -105,6 +105,12 @@ describe('component: LabeledSelectWithCreate', () => {
       expect(findSelect(wrapper).props('label')).toBe('Raw Label');
     });
 
+    it('forwards the name prop to the select', () => {
+      const wrapper = mountComponent({ name: 'my-field' });
+
+      expect(findSelect(wrapper).props('name')).toBe('my-field');
+    });
+
     it('passes through the remaining select props unchanged', () => {
       const wrapper = mountComponent({
         placeholder:  'Pick one',
@@ -117,8 +123,10 @@ describe('component: LabeledSelectWithCreate', () => {
         required:     true,
       });
 
+      // a null value is forwarded as undefined so it matches LabeledSelect's own prop type;
+      // LabeledSelect's real default (null) then applies, same as passing null directly
       expect(findSelect(wrapper).props()).toMatchObject({
-        value:        null,
+        value:        undefined,
         placeholder:  'Pick one',
         mode:         'edit',
         loading:      true,
@@ -156,6 +164,15 @@ describe('component: LabeledSelectWithCreate', () => {
       expect(wrapper.emitted('creating')).toBeTruthy();
       expect(findSelect(wrapper).exists()).toBe(false);
       expect(findInput(wrapper).exists()).toBe(true);
+    });
+
+    it('emits an empty update:value when entering create mode, so the parent value is not stale', async() => {
+      const wrapper = mountComponent();
+
+      await findSelect(wrapper).vm.$emit('selecting', { label: 'Create new…', value: '__create__' });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted('update:value')).toEqual([['']]);
     });
 
     it('switches to create mode when "selecting" fires with no option (e.g. clearing)', async() => {
@@ -215,7 +232,9 @@ describe('component: LabeledSelectWithCreate', () => {
       await findInput(wrapper).vm.$emit('update:value', 'Ne');
       await findInput(wrapper).vm.$emit('update:value', 'New');
 
-      expect(wrapper.emitted('update:value')).toEqual([['N'], ['Ne'], ['New']]);
+      // entering create mode itself emits an empty value first, so the parent's tracked
+      // value doesn't lag behind the now-blank input until the first keystroke
+      expect(wrapper.emitted('update:value')).toEqual([[''], ['N'], ['Ne'], ['New']]);
       // typing never auto-confirms/returns to select mode - only cancel does
       expect(findInput(wrapper).exists()).toBe(true);
       expect(findSelect(wrapper).exists()).toBe(false);
@@ -270,6 +289,12 @@ describe('component: LabeledSelectWithCreate', () => {
 
       expect(input.props('mode')).toBe('edit');
       expect(input.props('rules')).toStrictEqual(rules);
+    });
+
+    it('forwards the name prop to the create-mode LabeledInput', async() => {
+      const wrapper = await mountInCreateMode({ name: 'my-field' });
+
+      expect(findInput(wrapper).props('name')).toBe('my-field');
     });
   });
 });

--- a/shell/components/form/__tests__/LabeledSelectWithCreate.test.ts
+++ b/shell/components/form/__tests__/LabeledSelectWithCreate.test.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount, VueWrapper } from '@vue/test-utils';
 import LabeledSelectWithCreate from '@shell/components/form/LabeledSelectWithCreate.vue';
 
 const LabeledSelectStub = {
@@ -28,7 +28,7 @@ jest.mock('@components/Form/LabeledInput', () => ({
   },
 }));
 
-jest.mock('@shell/composables/useI18n', () => ({ useI18n: () => ({ t: (key) => key }) }));
+jest.mock('@shell/composables/useI18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }));
 
 const CREATE_OPTIONS = [
   { label: 'Option A', value: 'a' },
@@ -50,11 +50,11 @@ function mountComponent(props = {}) {
   });
 }
 
-function findSelect(wrapper) {
+function findSelect(wrapper: VueWrapper) {
   return wrapper.findComponent(LabeledSelectStub);
 }
 
-function findInput(wrapper) {
+function findInput(wrapper: VueWrapper) {
   return wrapper.findComponent({ name: 'LabeledInput' });
 }
 
@@ -283,7 +283,7 @@ describe('component: LabeledSelectWithCreate', () => {
     });
 
     it('passes mode and rules through to the create-mode LabeledInput', async() => {
-      const rules = [(val) => (!val ? 'Required' : undefined)];
+      const rules = [(val: string) => (!val ? 'Required' : undefined)];
       const wrapper = await mountInCreateMode({ mode: 'edit', rules });
       const input = findInput(wrapper);
 

--- a/shell/components/form/__tests__/NameNsDescription.test.ts
+++ b/shell/components/form/__tests__/NameNsDescription.test.ts
@@ -222,4 +222,35 @@ describe('nameNsDescription', () => {
 
     expect(lastEmittedValue.spec.myNs).toStrictEqual('new-ns');
   });
+
+  it('persists forceNamespace into value.metadata.namespace immediately on mount', () => {
+    const value = { metadata: { name: 'test-name', namespace: '' } };
+    const wrapper = shallowMount(NameNsDescription, {
+      ...requiredSetup(),
+      props: {
+        value,
+        mode:           _CREATE,
+        forceNamespace: 'forced-ns',
+      },
+    });
+
+    expect(value.metadata.namespace).toStrictEqual('forced-ns');
+    expect(wrapper.emitted('update:value')).toBeTruthy();
+  });
+
+  it('persists forceNamespace via namespaceKey immediately on mount, when provided', () => {
+    const value = { metadata: {}, spec: { myNs: '' } };
+    const wrapper = shallowMount(NameNsDescription, {
+      ...requiredSetup(),
+      props: {
+        value,
+        mode:           _CREATE,
+        namespaceKey:   'spec.myNs',
+        forceNamespace: 'forced-ns',
+      },
+    });
+
+    expect(value.spec.myNs).toStrictEqual('forced-ns');
+    expect(wrapper.emitted('update:value')).toBeTruthy();
+  });
 });

--- a/shell/components/form/__tests__/NameNsDescription.test.ts
+++ b/shell/components/form/__tests__/NameNsDescription.test.ts
@@ -1,290 +1,225 @@
-import { mount } from '@vue/test-utils';
-import NameNsDescription from '@shell/components/form/NameNsDescription.vue';
+import { shallowMount } from '@vue/test-utils';
 import { createStore } from 'vuex';
+import NameNsDescription from '../NameNsDescription.vue';
+import { _CREATE, _EDIT } from '@shell/config/query-params';
 
-describe('component: NameNsDescription', () => {
-  // Accessing to computed value due code complexity
-  it('should map namespaces to options', () => {
-    const namespaceName = 'test';
-    const store = createStore({
-      getters: {
-        allowedNamespaces:   () => () => ({ [namespaceName]: true }),
-        currentStore:        () => () => 'cluster',
-        'cluster/schemaFor': () => jest.fn()
+const requiredSetup = () => {
+  const store = createStore({
+    getters: { defaultNamespace: () => 'default' },
+    modules: {
+      'cru-resource': {
+        namespaced: true,
+        actions:    { setCreateNamespace: jest.fn() }
       }
-    });
-    const result = [
-      {
-        label: namespaceName,
-        value: namespaceName,
-      },
-    ];
-    const wrapper = mount(NameNsDescription, {
-      props: {
-        value: {
-          setAnnotation: jest.fn(),
-          metadata:      {}
-        },
-        mode:    'create',
-        cluster: {},
-      },
-      global: {
-        provide: { store },
-        mocks:   {
-          $store: {
-            dispatch: jest.fn(),
-            getters:  {
-              namespaces: jest.fn(),
-              'i18n/t':   jest.fn(),
-            },
-          },
-        },
-      },
-    });
-
-    expect((wrapper.vm as any).options).toStrictEqual(result);
+    }
   });
 
-  it('should emit in case of new namespace', () => {
-    const namespaceName = 'test';
-    const store = createStore({
-      getters: {
-        allowedNamespaces:   () => () => ({ [namespaceName]: true }),
-        currentStore:        () => () => 'cluster',
-        'cluster/schemaFor': () => jest.fn()
+  return {
+    global: {
+      plugins: [store],
+      mocks:   { t: (text: string) => text },
+      stubs:   {
+        LabeledInput: {
+          name:     'LabeledInput',
+          template: '<input />',
+          methods:  { focus: jest.fn() },
+        },
+        NamespaceSelect: {
+          name:     'NamespaceSelect',
+          template: '<div class="namespace-select" />',
+        },
       }
-    });
-    const newNamespaceName = 'bananas';
-    const wrapper = mount(NameNsDescription, {
+    }
+  };
+};
+
+describe('nameNsDescription', () => {
+  it('mounts and renders correctly with default props', () => {
+    const wrapper = shallowMount(NameNsDescription, {
+      ...requiredSetup(),
       props: {
-        value: {
-          setAnnotation: jest.fn(),
-          metadata:      {}
-        },
-        mode: 'create',
-      },
-      global: {
-        provide: { store },
-        mocks:   {
-          $store: {
-            dispatch: jest.fn(),
-            getters:  {
-              namespaces:                         jest.fn(),
-              'customizations/getPreviewCluster': {
-                ready:   true,
-                isLocal: false,
-                badge:   {},
-              },
-              'i18n/t': jest.fn(),
-            },
-          },
-        },
+        value: { metadata: { name: 'test-name', namespace: 'test-ns' } },
+        mode:  _CREATE,
       },
     });
 
-    (wrapper.vm as any).updateNamespace(newNamespaceName);
-
-    expect(wrapper.emitted().isNamespaceNew?.[0][0]).toBe(true);
+    expect(wrapper.exists()).toStrictEqual(true);
   });
 
-  it('should set the namespace using the namespaceKey prop', () => {
-    const namespaceName = 'custom-namespace';
-    const store = createStore({
-      getters: {
-        allowedNamespaces:   () => () => ({ [namespaceName]: true }),
-        currentStore:        () => () => 'cluster',
-        'cluster/schemaFor': () => jest.fn()
-      }
-    });
-
-    const wrapper = mount(NameNsDescription, {
+  it.each([
+    {
+      desc:     'create mode, not disabled',
+      props:    { mode: _CREATE },
+      expected: false,
+    },
+    {
+      desc:     'edit mode, name not editable',
+      props:    { mode: _EDIT },
+      expected: true,
+    },
+    {
+      desc:     'edit mode, name editable',
+      props:    { mode: _EDIT, nameEditable: true },
+      expected: false,
+    },
+    {
+      desc:     'disabled prop is true',
+      props:    { mode: _CREATE, nameDisabled: true },
+      expected: true,
+    },
+  ])('calculates nameReallyDisabled correctly when $desc', ({ props, expected }) => {
+    const wrapper = shallowMount(NameNsDescription, {
+      ...requiredSetup(),
       props: {
-        value: {
-          setAnnotation: jest.fn(),
-          metadata:      {},
-          value:         { metadata: { namespace: namespaceName } }
-        },
-        mode:         'create',
-        namespaceKey: 'value.metadata.namespace',
-      },
-      global: {
-        provide: { store },
-        mocks:   {
-          $store: {
-            dispatch: jest.fn(),
-            getters:  {
-              namespaces:                         jest.fn(),
-              'customizations/getPreviewCluster': {
-                ready:   true,
-                isLocal: false,
-                badge:   {},
-              },
-              'i18n/t': jest.fn(),
-            },
-          },
-        },
+        value: { metadata: {} },
+        ...props,
       },
     });
 
-    expect((wrapper.vm as any).namespace).toBe(namespaceName);
+    const nameReallyDisabled = (wrapper.vm as any).nameReallyDisabled;
+
+    expect(nameReallyDisabled).toStrictEqual(expected);
   });
 
-  it('renders the name input with the expected value', () => {
-    const namespaceName = 'test';
-    const store = createStore({
-      getters: {
-        allowedNamespaces:   () => () => ({ [namespaceName]: true }),
-        currentStore:        () => () => 'cluster',
-        'cluster/schemaFor': () => jest.fn()
-      }
-    });
-    const wrapper = mount(NameNsDescription, {
+  it.each([
+    {
+      desc:     'create mode, not disabled',
+      props:    { mode: _CREATE },
+      expected: false,
+    },
+    {
+      desc:     'edit mode',
+      props:    { mode: _EDIT },
+      expected: true,
+    },
+    {
+      desc:     'disabled prop is true',
+      props:    { mode: _CREATE, namespaceDisabled: true },
+      expected: true,
+    },
+    {
+      desc:     'forceNamespace is set',
+      props:    { mode: _CREATE, forceNamespace: 'custom' },
+      expected: true,
+    },
+  ])('calculates namespaceReallyDisabled correctly when $desc', ({ props, expected }) => {
+    const wrapper = shallowMount(NameNsDescription, {
+      ...requiredSetup(),
       props: {
-        value: {
-          setAnnotation: jest.fn(),
-          metadata:      { name: 'Default' }
-        },
-        mode: 'create',
-      },
-      global: {
-        provide: { store },
-        mocks:   {
-          $store: {
-            dispatch: jest.fn(),
-            getters:  {
-              namespaces:                         jest.fn(),
-              'customizations/getPreviewCluster': {
-                ready:   true,
-                isLocal: false,
-                badge:   {},
-              },
-              'i18n/t': jest.fn(),
-            },
-          },
-        },
+        value: { metadata: {} },
+        ...props,
       },
     });
 
-    const nameInput = wrapper.find('[data-testid="NameNsDescriptionNameInput"]');
+    const namespaceReallyDisabled = (wrapper.vm as any).namespaceReallyDisabled;
 
-    expect(nameInput.element.value).toBe('Default');
+    expect(namespaceReallyDisabled).toStrictEqual(expected);
   });
 
-  it('should set namespace to a plain string when forceNamespace prop is provided', () => {
-    const forcedNs = 'cert-manager';
-    const store = createStore({
-      getters: {
-        allowedNamespaces:   () => () => ({}),
-        currentStore:        () => () => 'cluster',
-        'cluster/schemaFor': () => jest.fn()
-      }
-    });
-
-    const wrapper = mount(NameNsDescription, {
+  it.each([
+    {
+      desc:       'nameHidden is true',
+      props:      { nameHidden: true },
+      nameExists: false,
+      nsExists:   true,
+      descExists: true,
+    },
+    {
+      desc:       'descriptionHidden is true',
+      props:      { descriptionHidden: true },
+      nameExists: true,
+      nsExists:   true,
+      descExists: false,
+    },
+    {
+      desc:       'nameNsHidden is true',
+      props:      { nameNsHidden: true },
+      nameExists: false,
+      nsExists:   false,
+      descExists: true,
+    },
+  ])('hides sections appropriately when $desc', ({
+    props, nameExists, nsExists, descExists
+  }) => {
+    const wrapper = shallowMount(NameNsDescription, {
+      ...requiredSetup(),
       props: {
-        value: {
-          setAnnotation: jest.fn(),
-          metadata:      { namespace: '' }
-        },
-        mode:           'create',
-        forceNamespace: forcedNs,
-      },
-      global: {
-        provide: { store },
-        mocks:   {
-          $store: {
-            dispatch: jest.fn(),
-            getters:  {
-              namespaces: jest.fn(),
-              'i18n/t':   jest.fn(),
-            },
-          },
-        },
+        value: { metadata: {} },
+        mode:  _CREATE,
+        ...props,
       },
     });
 
-    expect(typeof (wrapper.vm as any).namespace).toBe('string');
-    expect((wrapper.vm as any).namespace).toBe(forcedNs);
+    expect(wrapper.find('[data-testid="name-ns-description-name"]').exists()).toStrictEqual(nameExists);
+    expect(wrapper.find('[data-testid="name-ns-description-namespace"]').exists()).toStrictEqual(nsExists);
+    expect(wrapper.find('[data-testid="name-ns-description-description"]').isVisible()).toStrictEqual(descExists);
   });
 
-  it('should set metadata.namespace to a plain string when falling back to defaultNamespace', () => {
-    const defaultNs = 'default';
-    const metadata: Record<string, unknown> = {};
-    const store = createStore({
-      getters: {
-        allowedNamespaces:   () => () => ({}),
-        currentStore:        () => () => 'cluster',
-        'cluster/schemaFor': () => jest.fn(),
-        defaultNamespace:    () => defaultNs,
-      }
-    });
-
-    mount(NameNsDescription, {
+  it('applies custom componentTestid to wrappers', () => {
+    const wrapper = shallowMount(NameNsDescription, {
+      ...requiredSetup(),
       props: {
-        value: {
-          setAnnotation: jest.fn(),
-          metadata,
-        },
-        mode: 'create',
-      },
-      global: {
-        provide: { store },
-        mocks:   {
-          $store: {
-            dispatch: jest.fn(),
-            getters:  {
-              namespaces: jest.fn(),
-              'i18n/t':   jest.fn(),
-            },
-          },
-        },
+        value:           { metadata: {} },
+        mode:            _CREATE,
+        componentTestid: 'custom-prefix',
       },
     });
 
-    expect(typeof metadata.namespace).toBe('string');
-    expect(metadata.namespace).toBe(defaultNs);
+    expect(wrapper.find('[data-testid="custom-prefix-name"]').exists()).toStrictEqual(true);
+    expect(wrapper.find('[data-testid="custom-prefix-namespace"]').exists()).toStrictEqual(true);
+    expect(wrapper.find('[data-testid="custom-prefix-description"]').exists()).toStrictEqual(true);
   });
 
-  it('sets the name using the nameKey prop', () => {
-    const namespaceName = 'test';
-    const store = createStore({
-      getters: {
-        allowedNamespaces:   () => () => ({ [namespaceName]: true }),
-        currentStore:        () => () => 'cluster',
-        'cluster/schemaFor': () => jest.fn()
-      }
-    });
-    const wrapper = mount(NameNsDescription, {
+  it('emits update:value when name is updated', async() => {
+    const value = { metadata: { name: 'old', namespace: 'default' } };
+    const wrapper = shallowMount(NameNsDescription, {
+      ...requiredSetup(),
       props: {
-        value: {
-          setAnnotation: jest.fn(),
-          metadata:      {},
-          spec:          { displayName: 'Default' }
-        },
-        mode:    'create',
-        nameKey: 'spec.displayName'
-      },
-      global: {
-        provide: { store },
-        mocks:   {
-          $store: {
-            dispatch: jest.fn(),
-            getters:  {
-              namespaces:                         jest.fn(),
-              'customizations/getPreviewCluster': {
-                ready:   true,
-                isLocal: false,
-                badge:   {},
-              },
-              'i18n/t': jest.fn(),
-            },
-          },
-        },
+        value,
+        mode: _CREATE,
       },
     });
 
-    const nameInput = wrapper.find('[data-testid="NameNsDescriptionNameInput"]');
+    const nameInput = wrapper.findComponent({ name: 'LabeledInput' });
 
-    expect(nameInput.element.value).toBe('Default');
+    nameInput.vm.$emit('update:value', 'new-name');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('update:value')).toBeTruthy();
+
+    const emittedEvents = wrapper.emitted('update:value') || [];
+    const lastEmittedValue = emittedEvents[emittedEvents.length - 1][0] as any;
+
+    expect(lastEmittedValue.metadata.name).toStrictEqual('new-name');
+  });
+
+  it('updates using custom keys when provided', async() => {
+    const value = {
+      spec: {
+        myName: '', myNs: '', myDesc: ''
+      }
+    };
+    const wrapper = shallowMount(NameNsDescription, {
+      ...requiredSetup(),
+      props: {
+        value,
+        mode:           _CREATE,
+        nameKey:        'spec.myName',
+        namespaceKey:   'spec.myNs',
+        descriptionKey: 'spec.myDesc',
+      },
+    });
+
+    const namespaceSelect = wrapper.findComponent({ name: 'NamespaceSelect' });
+
+    namespaceSelect.vm.$emit('update:value', 'new-ns');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('update:value')).toBeTruthy();
+
+    const emittedEvents = wrapper.emitted('update:value') || [];
+    const lastEmittedValue = emittedEvents[emittedEvents.length - 1][0] as any;
+
+    expect(lastEmittedValue.spec.myNs).toStrictEqual('new-ns');
   });
 });

--- a/shell/components/form/__tests__/NamespaceSelect.test.ts
+++ b/shell/components/form/__tests__/NamespaceSelect.test.ts
@@ -42,13 +42,17 @@ describe('namespaceSelect', () => {
     expect(wrapper.findComponent(LabeledSelectWithCreate).exists()).toStrictEqual(true);
   });
 
-  it('does not render LabeledSelectWithCreate when forceNamespace is provided', () => {
+  it('renders LabeledSelectWithCreate disabled, showing the forced namespace, when forceNamespace is provided', () => {
     const wrapper = shallowMount(NamespaceSelect, {
       ...requiredSetup(),
       props: { forceNamespace: 'forced-ns' },
     });
 
-    expect(wrapper.findComponent(LabeledSelectWithCreate).exists()).toStrictEqual(false);
+    const labeledSelect = wrapper.findComponent(LabeledSelectWithCreate);
+
+    expect(labeledSelect.exists()).toStrictEqual(true);
+    expect(labeledSelect.props('disabled')).toStrictEqual(true);
+    expect(labeledSelect.props('value')).toStrictEqual('forced-ns');
   });
 
   it.each([

--- a/shell/components/form/__tests__/NamespaceSelect.test.ts
+++ b/shell/components/form/__tests__/NamespaceSelect.test.ts
@@ -1,0 +1,209 @@
+import { shallowMount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import NamespaceSelect from '../NamespaceSelect.vue';
+import LabeledSelectWithCreate from '@shell/components/form/LabeledSelectWithCreate.vue';
+import { _CREATE, _EDIT } from '@shell/config/query-params';
+
+const mockSetCreateNamespace = jest.fn();
+
+const requiredSetup = (customGetters = {}) => {
+  const store = createStore({
+    getters: {
+      'i18n/t':            () => (text: string) => text,
+      t:                   () => (text: string) => text,
+      allowedNamespaces:   () => () => ({ 'ns-1': { id: 'ns-1' } }),
+      namespaces:          () => () => ({ 'ns-1': { id: 'ns-1' }, 'ns-2': { id: 'ns-2' } }),
+      currentCluster:      () => ({ canUpdate: true }),
+      currentStore:        () => () => 'cluster',
+      'cluster/schemaFor': () => () => ({ collectionMethods: ['POST'] }),
+      defaultNamespace:    () => 'default',
+      ...customGetters,
+    },
+    actions: { 'cru-resource/setCreateNamespace': mockSetCreateNamespace }
+  });
+
+  return {
+    global: {
+      provide:    { store },
+      components: { LabeledSelectWithCreate },
+    }
+  };
+};
+
+describe('namespaceSelect', () => {
+  beforeEach(() => {
+    mockSetCreateNamespace.mockClear();
+  });
+
+  it('mounts properly with default props', () => {
+    const wrapper = shallowMount(NamespaceSelect, { ...requiredSetup() });
+
+    expect(wrapper.exists()).toStrictEqual(true);
+    expect(wrapper.findComponent(LabeledSelectWithCreate).exists()).toStrictEqual(true);
+  });
+
+  it('does not render LabeledSelectWithCreate when forceNamespace is provided', () => {
+    const wrapper = shallowMount(NamespaceSelect, {
+      ...requiredSetup(),
+      props: { forceNamespace: 'forced-ns' },
+    });
+
+    expect(wrapper.findComponent(LabeledSelectWithCreate).exists()).toStrictEqual(false);
+  });
+
+  it.each([
+    {
+      desc:     'is in edit mode',
+      props:    { mode: _EDIT },
+      expected: true,
+    },
+    {
+      desc:     'disabled prop is passed as true',
+      props:    { disabled: true },
+      expected: true,
+    },
+    {
+      desc:     'forceNamespace is provided',
+      props:    { forceNamespace: 'test-ns' },
+      expected: true,
+    },
+    {
+      desc:     'is in create mode and not disabled',
+      props:    { mode: _CREATE, disabled: false },
+      expected: false,
+    },
+  ])('calculates isReallyDisabled correctly when $desc', ({ props, expected }) => {
+    const wrapper = shallowMount(NamespaceSelect, {
+      ...requiredSetup(),
+      props,
+    });
+
+    // We check the vm to access the computed property directly or through component binding
+    const isReallyDisabled = (wrapper.vm as any).isReallyDisabled;
+
+    expect(isReallyDisabled).toStrictEqual(expected);
+  });
+
+  it('uses overridden options if override prop is provided', () => {
+    const wrapper = shallowMount(NamespaceSelect, {
+      ...requiredSetup(),
+      props: { override: ['override-ns-1', 'override-ns-2'] },
+    });
+
+    const selectOptions = (wrapper.vm as any).realNamespaceOptions;
+
+    expect(selectOptions).toHaveLength(2);
+    expect(selectOptions[0].value).toStrictEqual('override-ns-1');
+  });
+
+  it('uses options prop if provided instead of store', () => {
+    const wrapper = shallowMount(NamespaceSelect, {
+      ...requiredSetup(),
+      props: { options: ['prop-ns-1', 'prop-ns-2'] },
+    });
+
+    const selectOptions = (wrapper.vm as any).realNamespaceOptions;
+
+    expect(selectOptions).toHaveLength(2);
+    expect(selectOptions[0].value).toStrictEqual('prop-ns-1');
+  });
+
+  it('pads namespaceSelectOptions with the current value when creating a namespace that does not exist yet', () => {
+    const wrapper = shallowMount(NamespaceSelect, {
+      ...requiredSetup(),
+      props: { override: ['override-ns-1'], value: 'brand-new-ns' },
+    });
+
+    const selectOptions = (wrapper.vm as any).namespaceSelectOptions;
+
+    expect(selectOptions).toContainEqual({ label: 'brand-new-ns', value: 'brand-new-ns' });
+  });
+
+  it('updates selected namespace externally when value prop changes', async() => {
+    const wrapper = shallowMount(NamespaceSelect, {
+      ...requiredSetup(),
+      props: { value: 'initial-ns' },
+    });
+
+    expect((wrapper.vm as any).namespace).toStrictEqual('initial-ns');
+
+    await wrapper.setProps({ value: 'updated-ns' });
+
+    expect((wrapper.vm as any).namespace).toStrictEqual('updated-ns');
+  });
+
+  describe('labeledSelectWithCreate event delegations', () => {
+    it('dispatches creation state correctly and emits on update', () => {
+      const wrapper = shallowMount(NamespaceSelect, { ...requiredSetup() });
+
+      const labeledSelect = wrapper.findComponent(LabeledSelectWithCreate);
+
+      labeledSelect.vm.$emit('update:value', 'existing-ns');
+
+      expect(mockSetCreateNamespace).toHaveBeenCalledWith(expect.anything(), false);
+      expect(wrapper.emitted('update:value')).toBeTruthy();
+      const emittedUpdate = wrapper.emitted('update:value') || [];
+
+      expect(emittedUpdate[emittedUpdate.length - 1]).toStrictEqual(['existing-ns']);
+    });
+
+    it('dispatches creation true and emits isNamespaceNew on creating', () => {
+      const wrapper = shallowMount(NamespaceSelect, { ...requiredSetup() });
+
+      const labeledSelect = wrapper.findComponent(LabeledSelectWithCreate);
+
+      labeledSelect.vm.$emit('creating');
+
+      expect(mockSetCreateNamespace).toHaveBeenCalledWith(expect.anything(), true);
+      expect(wrapper.emitted('isNamespaceNew')).toBeTruthy();
+      const emittedNew = wrapper.emitted('isNamespaceNew') || [];
+
+      expect(emittedNew[emittedNew.length - 1]).toStrictEqual([true]);
+    });
+
+    it('keeps the create-namespace flag true through live typing, with no separate confirm step', () => {
+      const wrapper = shallowMount(NamespaceSelect, { ...requiredSetup() });
+
+      const labeledSelect = wrapper.findComponent(LabeledSelectWithCreate);
+
+      labeledSelect.vm.$emit('creating');
+      mockSetCreateNamespace.mockClear();
+
+      labeledSelect.vm.$emit('update:value', 'n');
+      labeledSelect.vm.$emit('update:value', 'ne');
+      labeledSelect.vm.$emit('update:value', 'new-ns');
+
+      expect(mockSetCreateNamespace).not.toHaveBeenCalledWith(expect.anything(), false);
+      expect(wrapper.emitted('update:value')).toStrictEqual([['n'], ['ne'], ['new-ns']]);
+    });
+
+    it('dispatches creation false again once cancelled and an existing namespace is subsequently picked', () => {
+      const wrapper = shallowMount(NamespaceSelect, { ...requiredSetup() });
+
+      const labeledSelect = wrapper.findComponent(LabeledSelectWithCreate);
+
+      labeledSelect.vm.$emit('creating');
+      labeledSelect.vm.$emit('update:value', 'partial-typed-name');
+      labeledSelect.vm.$emit('cancel');
+      mockSetCreateNamespace.mockClear();
+
+      labeledSelect.vm.$emit('update:value', 'ns-1');
+
+      expect(mockSetCreateNamespace).toHaveBeenCalledWith(expect.anything(), false);
+    });
+
+    it('resets to default namespace and dispatches creation false on cancel', () => {
+      const wrapper = shallowMount(NamespaceSelect, { ...requiredSetup() });
+
+      const labeledSelect = wrapper.findComponent(LabeledSelectWithCreate);
+
+      labeledSelect.vm.$emit('cancel');
+
+      expect(mockSetCreateNamespace).toHaveBeenCalledWith(expect.anything(), false);
+      expect(wrapper.emitted('update:value')).toBeTruthy();
+      const emittedUpdate = wrapper.emitted('update:value') || [];
+
+      expect(emittedUpdate[emittedUpdate.length - 1]).toStrictEqual(['default']);
+    });
+  });
+});

--- a/shell/components/form/__tests__/NamespaceSelect.test.ts
+++ b/shell/components/form/__tests__/NamespaceSelect.test.ts
@@ -55,7 +55,7 @@ describe('namespaceSelect', () => {
     expect(labeledSelect.props('value')).toStrictEqual('forced-ns');
   });
 
-  it.each([
+  it.each<{ desc: string, props: { mode?: string, disabled?: boolean, forceNamespace?: string }, expected: boolean }>([
     {
       desc:     'is in edit mode',
       props:    { mode: _EDIT },

--- a/shell/types/components/labeledSelect.ts
+++ b/shell/types/components/labeledSelect.ts
@@ -1,3 +1,10 @@
+export interface SelectOption {
+  label: string;
+  value?: string;
+  kind?: string;
+  disabled?: boolean;
+}
+
 export const LABEL_SELECT_KINDS = {
   GROUP:   'group',
   DIVIDER: 'divider',


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18510
<!-- Define findings related to the feature or bug issue. -->
Needed for https://github.com/rancher/virtual-clusters-ui/issues/76

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added new LabeledSelectWithCreate and NamespaceSelect components to standardize a namespace control that creates a new namespace in addition to allowing selecting existing ones.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
There are more components that are doing similar logic (SelectOrCreateAuthSecret, persistentVolumeClaim/index.vue, credentials.vue) but they are different enough to not migrate at this time.
The point of this PR is to isolate this logic instead of re-inventing the wheel every time we need it, as we often run into the need to create namespaces while offering user to select one.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
Mostly regression testing is required. There shouldn't be any noticeable change in behavior for the users when selecting existing or creating a new namespace.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
Any pages that use nameNsDescription component could be affected, but we don't need to test all of them.
make sure that the behavior is the same for core pages, like workload creation, chart installation, etc

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
