### PR TITLE
Remove duplicate resolutions key from storybook

### DIFF
--- a/storybook/package.json
+++ b/storybook/package.json
@@ -11,9 +11,6 @@
     "remark-gfm": "^4.0.0",
     "vue": "^3.5.10"
   },
-  "resolutions": {
-    "braces": "^3.0.3"
-  },
   "devDependencies": {
     "@storybook/addon-actions": "^8.4.2",
     "@storybook/addon-essentials": "^8.4.2",


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

This silences the esbuild duplicate-object-key warning emitted on every `yarn storybook` run.

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Remove duplicate resolutions key from storybook

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

`storybook/package.json` declared "resolutions" twice: once after "dependencies" and again after "devDependencies". This appears to have been introduced during a series of security bump PRs.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Running `yarn storybook` no longer emits:

```
▲ [WARNING] Duplicate key "resolutions" in object literal [duplicate-object-key]

    package.json:38:2:
      38 │   "resolutions": {
         ╵   ~~~~~~~~~~~~~

  The original key "resolutions" is here:

    package.json:14:2:
      14 │   "resolutions": {
         ╵   ~~~~~~~~~~~~~
```

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

NA

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
