### PR TITLE
[Automation] - Update masthead create selector for repositories spec

### DIFF
--- a/cypress/e2e/po/components/ResourceList/resource-list-masthead.po.ts
+++ b/cypress/e2e/po/components/ResourceList/resource-list-masthead.po.ts
@@ -14,6 +14,6 @@ export default class ResourceListMastheadPo extends ComponentPo {
   }
 
   create() {
-    return this.self().find('[data-testid="masthead-create"]').click();
+    return cy.get('[data-testid="masthead-create"]').click();
   }
 }

--- a/cypress/e2e/po/pages/chart-repositories.po.ts
+++ b/cypress/e2e/po/pages/chart-repositories.po.ts
@@ -56,8 +56,7 @@ export default class ChartRepositoriesPagePo extends PagePo {
   }
 
   create() {
-    return this.list().masthead().actions().contains('Add Repository')
-      .click();
+    return this.list().masthead().create();
   }
 
   waitForGoTo(endpoint: string) {


### PR DESCRIPTION
### Summary
Fixes: rancher/qa-tasks#2465

Update `ChartRepositoriesPagePo.create()` to delegate to ResourceListMastheadPo.create(), and update `ResourceListMastheadPo.create()` to use page-unique `data-testid="masthead-create"`.

On Rancher head (v2.15/master), the create button on the chart repositories page uses `data-testid="masthead-create"` rather than text "Add Repository". Using `cy.get('[data-testid="masthead-create"]')` ensures reliable page object encapsulation without scoped parent lookup issues.


### Screenshot/Video
<img width="1008" height="1183" alt="Screenshot 2026-07-28 12-10-22" src="https://github.com/user-attachments/assets/6094c4e2-96db-4296-8d10-cdd94b957c43" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
