### PR TITLE
Generate single token when downloading kubeconfigs

### DIFF
--- a/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/dashboard/cluster-dashboard.spec.ts
@@ -8,6 +8,7 @@ import { WorkloadsDeploymentsListPagePo } from '@/cypress/e2e/po/pages/explorer/
 import { NodesPagePo } from '@/cypress/e2e/po/pages/explorer/nodes.po';
 import { EventsPageListPo } from '@/cypress/e2e/po/pages/explorer/events.po';
 import * as path from 'path';
+import * as jsyaml from 'js-yaml';
 import { eventsNoDataset } from '@/cypress/e2e/blueprints/explorer/cluster/events';
 import HomePagePo from '@/cypress/e2e/po/pages/home.po';
 
@@ -99,8 +100,23 @@ describe('Cluster Dashboard', { testIsolation: false, tags: ['@explorer', '@admi
 
     ClusterDashboardPagePo.navTo();
 
+    cy.intercept('POST', '/v1/ext.cattle.io.kubeconfigs').as('generateKubeConfig');
     header.downloadKubeconfig().click();
-    cy.readFile(downloadedFilename).should('contain', 'kind: Config');
+    cy.wait('@generateKubeConfig');
+
+    // A single click must only ever generate one kubeconfig, as each request mints at least one token.
+    // See https://github.com/rancher/rancher/issues/55672
+    cy.get('@generateKubeConfig.all').should('have.length', 1);
+
+    cy.readFile(downloadedFilename).then((buffer) => {
+      const obj: any = jsyaml.load(buffer);
+
+      expect(obj.kind).to.equal('Config');
+
+      // The legacy `rancher` entry pointing at the Rancher server root is excluded
+      expect(obj.clusters.map((cluster: { name: string }) => cluster.name)).to.not.include('rancher');
+      expect(obj.contexts.map((context: { name: string }) => context.name)).to.not.include('rancher');
+    });
   });
 
   it('can copy the kubeconfig to clipboard', () => {

--- a/cypress/e2e/tests/pages/global-settings/settings.spec.ts
+++ b/cypress/e2e/tests/pages/global-settings/settings.spec.ts
@@ -565,7 +565,8 @@ describe('Settings', { testIsolation: false }, () => {
 
       // checks on the downloaded YAML
       expect(obj.clusters.length).to.be.gte(1);
-      expect(obj.clusters[1].name).to.equal('local');
+      // Only the selected cluster is present. The legacy `rancher` entry used to occupy index 0
+      expect(obj.clusters[0].name).to.equal('local');
       expect(obj.users[0].user.token).to.have.length.gt(0);
       expect(obj.apiVersion).to.equal('v1');
       expect(obj.kind).to.equal('Config');

--- a/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
+++ b/cypress/e2e/tests/pages/manager/cluster-manager.spec.ts
@@ -314,6 +314,10 @@ describe('Cluster Manager', { testIsolation: false, tags: ['@manager', '@adminUs
         clusterList.list().actionMenu(rke2CustomName).getMenuItem('Download KubeConfig').click();
         cy.wait('@generateKubeconfig').its('response.statusCode').should('be.oneOf', [200, 201]);
 
+        // A single click must only ever generate one kubeconfig. Each request mints at least one token, and for ACE
+        // clusters the legacy default entry used to mint a second. See https://github.com/rancher/rancher/issues/55672
+        cy.get('@generateKubeconfig.all').should('have.length', 1);
+
         const downloadedFilename = path.join(downloadsFolder, `${ rke2CustomName }.yaml`);
 
         cy.readFile(downloadedFilename).then((buffer) => {
@@ -324,6 +328,10 @@ describe('Cluster Manager', { testIsolation: false, tags: ['@manager', '@adminUs
           expect(obj.clusters.some((cluster: { name: string }) => cluster.name === rke2CustomName)).to.equal(true);
           expect(obj.apiVersion).to.equal('v1');
           expect(obj.kind).to.equal('Config');
+
+          // The legacy `rancher` entry pointing at the Rancher server root is excluded
+          expect(obj.clusters.map((cluster: { name: string }) => cluster.name)).to.not.include('rancher');
+          expect(obj.contexts.map((context: { name: string }) => context.name)).to.not.include('rancher');
         });
       }));
 
@@ -763,6 +771,10 @@ describe('Cluster Manager', { testIsolation: false, tags: ['@manager', '@adminUs
     cy.intercept('POST', '/v1/ext.cattle.io.kubeconfigs').as('generateKubeConfig');
     clusterList.list().downloadKubeConfig().click();
     cy.wait('@generateKubeConfig').its('response.statusCode').should('eq', 201);
+
+    // A single bulk action must only ever generate one kubeconfig, no matter how many clusters are selected
+    cy.get('@generateKubeConfig.all').should('have.length', 1);
+
     const downloadedFilename = path.join(downloadsFolder, 'local.yaml');
 
     cy.readFile(downloadedFilename).then((buffer) => {
@@ -770,8 +782,12 @@ describe('Cluster Manager', { testIsolation: false, tags: ['@manager', '@adminUs
 
       // Basic checks on the downloaded YAML
       expect(obj.apiVersion).to.equal('v1');
-      expect(obj.clusters[1].name).to.equal('local');
       expect(obj.kind).to.equal('Config');
+
+      // Only the selected cluster is present. The legacy `rancher` entry used to occupy index 0
+      expect(obj.clusters).to.have.length(1);
+      expect(obj.clusters[0].name).to.equal('local');
+      expect(obj.contexts.map((context: { name: string }) => context.name)).to.not.include('rancher');
     });
   }));
 

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -1880,6 +1880,10 @@ cluster:
   explore: Explore
   importAction: Import Existing
   manageAction: Manage
+  kubeConfig:
+    error:
+      title: Unable to generate KubeConfig
+      noClusters: No clusters could be resolved from the current selection. Refresh the page and try again.
   kubernetesVersion:
     label: Kubernetes Version
     current: (current)

--- a/shell/models/__tests__/management.cattle.io.cluster.test.ts
+++ b/shell/models/__tests__/management.cattle.io.cluster.test.ts
@@ -179,7 +179,12 @@ describe('class MgmtCluster', () => {
     let mockDispatch: jest.Mock;
 
     const makeCluster = (id = 'cluster-1') => {
-      return new MgmtCluster({ id, metadata: { name: id } }, { dispatch: mockDispatch }) as any;
+      const ctx = {
+        dispatch:    mockDispatch,
+        rootGetters: { 'i18n/t': (key: string) => key }
+      };
+
+      return new MgmtCluster({ id, metadata: { name: id } }, ctx) as any;
     };
 
     beforeEach(() => {
@@ -217,8 +222,19 @@ describe('class MgmtCluster', () => {
 
       const res = await cluster.generateKubeConfig([]);
 
-      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalledWith('management/create', expect.anything(), expect.anything());
       expect(res).toBeUndefined();
+    });
+
+    it('should growl an error when there are no clusters', async() => {
+      const cluster = makeCluster();
+
+      await cluster.generateKubeConfig([]);
+
+      expect(mockDispatch).toHaveBeenCalledWith('growl/error', {
+        title:   'cluster.kubeConfig.error.title',
+        message: 'cluster.kubeConfig.error.noClusters',
+      }, { root: true });
     });
 
     it('should return undefined when the response has no value', async() => {

--- a/shell/models/__tests__/management.cattle.io.cluster.test.ts
+++ b/shell/models/__tests__/management.cattle.io.cluster.test.ts
@@ -1,8 +1,14 @@
 import MgmtCluster from '@shell/models/management.cattle.io.cluster';
+import { EXT } from '@shell/config/types';
 import { copyTextToClipboard } from '@shell/utils/clipboard';
+import { downloadFile } from '@shell/utils/download';
 
 jest.mock('@shell/utils/clipboard', () => {
   return { copyTextToClipboard: jest.fn(() => Promise.resolve({})) };
+});
+
+jest.mock('@shell/utils/download', () => {
+  return { downloadFile: jest.fn(() => Promise.resolve({})) };
 });
 
 describe('class MgmtCluster', () => {
@@ -164,6 +170,129 @@ describe('class MgmtCluster', () => {
 
       expect(mockGenerateKubeConfig).toHaveBeenCalledWith([]);
       expect(copyTextToClipboard).toHaveBeenCalledWith(mockConfig);
+    });
+  });
+
+  describe('generateKubeConfig', () => {
+    const mockConfig = 'apiVersion: v1\nkind: Config';
+    let mockSave: jest.Mock;
+    let mockDispatch: jest.Mock;
+
+    const makeCluster = (id = 'cluster-1') => {
+      return new MgmtCluster({ id, metadata: { name: id } }, { dispatch: mockDispatch }) as any;
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockSave = jest.fn().mockResolvedValue({ status: { value: mockConfig } });
+      mockDispatch = jest.fn().mockResolvedValue({ save: mockSave });
+    });
+
+    it('should request a kubeconfig for this cluster without the default `rancher` entry', async() => {
+      const cluster = makeCluster();
+
+      const res = await cluster.generateKubeConfig();
+
+      expect(mockDispatch).toHaveBeenCalledWith('management/create', {
+        type: EXT.KUBECONFIG,
+        spec: { clusters: ['cluster-1'], includeDefaultEntry: false }
+      }, { root: true });
+      expect(mockSave).toHaveBeenCalledWith();
+      expect(res).toBe(mockConfig);
+    });
+
+    it('should pass an explicit list of clusters through, still excluding the default entry', async() => {
+      const cluster = makeCluster();
+
+      await cluster.generateKubeConfig(['cluster-1', 'cluster-2']);
+
+      expect(mockDispatch).toHaveBeenCalledWith('management/create', {
+        type: EXT.KUBECONFIG,
+        spec: { clusters: ['cluster-1', 'cluster-2'], includeDefaultEntry: false }
+      }, { root: true });
+    });
+
+    it('should not make a request when there are no clusters', async() => {
+      const cluster = makeCluster();
+
+      const res = await cluster.generateKubeConfig([]);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(res).toBeUndefined();
+    });
+
+    it('should return undefined when the response has no value', async() => {
+      mockSave.mockResolvedValue({});
+      const cluster = makeCluster();
+
+      const res = await cluster.generateKubeConfig();
+
+      expect(res).toBeUndefined();
+    });
+  });
+
+  describe('kubeConfigClusterIds', () => {
+    const cluster = () => new MgmtCluster({ id: 'cluster-1' }) as any;
+
+    it('should prefer the management cluster id over the row id', () => {
+      const items = [{ id: 'prov-1', mgmt: { id: 'mgmt-1' } }, { id: 'prov-2' }];
+
+      expect(cluster().kubeConfigClusterIds(items)).toStrictEqual(['mgmt-1', 'prov-2']);
+    });
+
+    it('should de-duplicate ids that resolve to the same management cluster', () => {
+      const items = [
+        { id: 'prov-1', mgmt: { id: 'mgmt-1' } },
+        { id: 'mgmt-1' },
+        { id: 'prov-2', mgmt: { id: 'mgmt-2' } }
+      ];
+
+      expect(cluster().kubeConfigClusterIds(items)).toStrictEqual(['mgmt-1', 'mgmt-2']);
+    });
+
+    it('should drop rows without an id', () => {
+      const items = [{ id: 'mgmt-1' }, {}, { id: '' }];
+
+      expect(cluster().kubeConfigClusterIds(items)).toStrictEqual(['mgmt-1']);
+    });
+
+    it('should handle no items', () => {
+      expect(cluster().kubeConfigClusterIds()).toStrictEqual([]);
+      expect(cluster().kubeConfigClusterIds([])).toStrictEqual([]);
+    });
+  });
+
+  describe('downloadKubeConfigBulk', () => {
+    let cluster: any;
+    const mockGenerateKubeConfig = jest.fn();
+    const mockConfig = 'apiVersion: v1\nkind: Config';
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      cluster = new MgmtCluster({ id: 'cluster-1' });
+      cluster.generateKubeConfig = mockGenerateKubeConfig;
+    });
+
+    it('should download a kubeconfig for the de-duplicated set of clusters', async() => {
+      const items = [
+        { id: 'prov-1', mgmt: { id: 'mgmt-1' } },
+        { id: 'mgmt-1' }
+      ];
+
+      mockGenerateKubeConfig.mockResolvedValue(mockConfig);
+
+      await cluster.downloadKubeConfigBulk(items);
+
+      expect(mockGenerateKubeConfig).toHaveBeenCalledWith(['mgmt-1']);
+      expect(downloadFile).toHaveBeenCalledWith('kubeconfig.yaml', mockConfig, 'application/yaml');
+    });
+
+    it('should not download a file when no config was generated', async() => {
+      mockGenerateKubeConfig.mockResolvedValue(undefined);
+
+      await cluster.downloadKubeConfigBulk([]);
+
+      expect(downloadFile).not.toHaveBeenCalled();
     });
   });
 });

--- a/shell/models/ext.cattle.io.kubeconfig.ts
+++ b/shell/models/ext.cattle.io.kubeconfig.ts
@@ -11,6 +11,11 @@ export default class Kubeconfig extends SteveModel {
   declare spec: {
     clusters?: string[];
     ttl?: number;
+    /**
+     * Whether to include the legacy `rancher` cluster/user/context entry pointing at the Rancher server root.
+     * Defaults to `true` in the backend when omitted.
+     */
+    includeDefaultEntry?: boolean;
   };
 
   declare metadata: {

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -683,6 +683,11 @@ export default class MgmtCluster extends SteveModel {
   async generateKubeConfig(clusters = [this.id]) {
     // The backend rejects a request with no clusters when the default entry is excluded
     if (!clusters.length) {
+      this.$dispatch('growl/error', {
+        title:   this.t('cluster.kubeConfig.error.title'),
+        message: this.t('cluster.kubeConfig.error.noClusters'),
+      }, { root: true });
+
       return;
     }
 

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -4,7 +4,7 @@ import {
   NORMAN,
   HCI
 } from '@shell/config/types';
-import { insertAt, addObject, removeObject } from '@shell/utils/array';
+import { insertAt, addObject, removeObject, uniq } from '@shell/utils/array';
 import { downloadFile } from '@shell/utils/download';
 import { parseSi } from '@shell/utils/units';
 import { parseColor, textColor } from '@shell/utils/color';
@@ -661,10 +661,34 @@ export default class MgmtCluster extends SteveModel {
     }, { root: true });
   }
 
+  /**
+   * Collect the unique management cluster ids for a set of selected rows
+   *
+   * Both management and provisioning cluster rows can be selected, and both can resolve to the same management
+   * cluster, so the ids need to be de-duplicated (spec.clusters is a set)
+   */
+  kubeConfigClusterIds(items = []) {
+    return uniq(items.map((item) => item.mgmt?.id || item.id).filter((id) => !!id));
+  }
+
+  /**
+   * Generate a kubeconfig covering the given clusters
+   *
+   * `includeDefaultEntry: false` omits the legacy `rancher` cluster/user/context entry pointing at the Rancher
+   * server root. As well as being noise in every downloaded file, asking for it makes the backend mint an extra
+   * unscoped 'shared' token on top of the per-cluster token used by ACE clusters.
+   *
+   * See https://github.com/rancher/rancher/issues/55672 and https://github.com/rancher/rancher/issues/55031
+   */
   async generateKubeConfig(clusters = [this.id]) {
+    // The backend rejects a request with no clusters when the default entry is excluded
+    if (!clusters.length) {
+      return;
+    }
+
     const memoryResource = await this.$dispatch('management/create', {
       type: EXT.KUBECONFIG,
-      spec: { clusters }
+      spec: { clusters, includeDefaultEntry: false }
     }, { root: true });
 
     const res = await memoryResource.save();
@@ -679,10 +703,12 @@ export default class MgmtCluster extends SteveModel {
   }
 
   async downloadKubeConfigBulk(items) {
-    const clusters = items.map((item) => item.mgmt?.id || item.id);
+    const clusters = this.kubeConfigClusterIds(items);
     const config = await this.generateKubeConfig(clusters);
 
-    downloadFile('kubeconfig.yaml', config, 'application/yaml');
+    if (config) {
+      downloadFile('kubeconfig.yaml', config, 'application/yaml');
+    }
   }
 
   async copyKubeConfig() {
@@ -697,7 +723,7 @@ export default class MgmtCluster extends SteveModel {
 
   async copyKubeConfigBulk(items) {
     try {
-      const clusters = items.map((item) => item.mgmt?.id || item.id);
+      const clusters = this.kubeConfigClusterIds(items);
       const config = await this.generateKubeConfig(clusters);
 
       if (config) {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This appends `includeDefaultEntry: false` when downloading kubeconfigs so that only a single token will be generated on the request.

Fixes rancher/rancher#55672
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

- Exclude the default rancher entry from generated kubeconfigs
- Cover kubeconfig generation excluding the default rancher entry

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

Dashboard sends a single POST to `/v1/ext.cattle.io.kubeconfigs`, but never set `spec.includeDefaultEntry`, which the backend defaults to true. That adds the legacy Rancher `cluster/user/context` entry pointing at the Rancher server root, and forces an unscoped shared token to be minted for it. An ACE cluster already gets its own cluster-scoped token, which covers both the Rancher proxy and the direct ACE endpoint, resulting in two tokens being generated.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

- Provision a downstream cluster
- Ensure that Authorized Endpoint is enabled in the downstream cluster (Cluster Management => Edit Config => Networking => Authorized Endpoint)
- Check the token count (`kubectl get tokens.ext.cattle.io -n cattle-system --no-headers | wc -l)
- Download KubeConfig for the downstream cluster
- Check the token count again (`kubectl get tokens.ext.cattle.io -n cattle-system --no-headers | wc -l`)

In master, we should see the count increment by 2. With this patch in place, we should see the count increment by 1.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->



### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA - This is a change that is demonstrated via shell access. See the steps above for details on how to confirm.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
