### PR TITLE
[CI] pin get-helm-3 installer to v4.2.3 tag instead of main

### DIFF
--- a/scripts/e2e-k3s-start.sh
+++ b/scripts/e2e-k3s-start.sh
@@ -115,8 +115,11 @@ if [ "$KUBE_TYPE" = "K3S" ]; then
   chmod 600 "$KUBECONFIG"
   
   echo "Installing helm.........."
+  # Pin the get-helm-3 installer to a fixed release tag rather than `main`. `main` is a moving ref, so
+  # whenever upstream updates this script the download drifts away from HELM_CHECKSUM and the guard below
+  # fails on every run (not just a flake). The v4.2.3 tag is immutable and already matches HELM_CHECKSUM.
   export HELM_CHECKSUM=38b65f882d9cae3891755bdb03becc6a01ae6f9cb24826c191f219ddfee70a5d
-  curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+  curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/v4.2.3/scripts/get-helm-3
 
   DOWNLOADED_CHECKSUM=$(sha256sum get_helm.sh | awk '{print $1}')
   if [ "$DOWNLOADED_CHECKSUM" != "${HELM_CHECKSUM}" ]; then


### PR DESCRIPTION
The e2e k3s bootstrap downloads helm/helm's get-helm-3 from the moving `main` branch and verifies it against a hardcoded HELM_CHECKSUM. When upstream advances main past the last release, the download no longer matches the pinned checksum and the 'Run Rancher' step fails on every run (repo-wide, not a flake). Pin the URL to the immutable v4.2.3 tag, whose script already matches the existing checksum, so it can't drift.

<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Current there is a check for HELM_CHECKSUM. To maintain the same version, instead of using the drift main I selected the specific version related to that version.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- That should unlock the CI for now

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
