### PR TITLE
Add keyboard navigation to the resource search dialog

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -292,7 +292,7 @@ nav:
     prompt: Search for a Kubernetes Resource/Custom Resource type
     toolTip: Resource Type Search {key}
     placeholder: Type to search for a resource type...
-    filteringDescription: Using this input will immediately filter the results in the list below
+    filteringDescription: Using this input will immediately filter the results in the list below. Use the Up and Down arrow keys to move through the results and Enter to open the selected result
   header:
     setLoginPage: Set as login page
     showHideBanner: Show/Hide Banner

--- a/shell/dialog/SearchDialog.vue
+++ b/shell/dialog/SearchDialog.vue
@@ -79,7 +79,20 @@ export default {
       return Array.from(this.$refs.results?.querySelectorAll('li.child.nav-type a.type-link') || []);
     },
 
-    focusLink(direction) {
+    /**
+     * Filtering the results is debounced, so what is rendered can lag behind what has been typed. Apply any pending
+     * filter before acting on the results, otherwise a key pressed within the debounce window would use the results
+     * of the previous filter
+     */
+    async settleResults() {
+      this.queueUpdate?.flush();
+
+      await this.$nextTick();
+    },
+
+    async focusLink(direction) {
+      await this.settleResults();
+
       const links = this.visibleLinks();
 
       if (!links.length) {
@@ -106,9 +119,15 @@ export default {
         break;
       case KEY.CR:
         e.preventDefault();
-        this.visibleLinks()[0]?.click();
+        this.openFirstResult();
         break;
       }
+    },
+
+    async openFirstResult() {
+      await this.settleResults();
+
+      this.visibleLinks()[0]?.click();
     },
 
     resultsKeyHandler(e) {

--- a/shell/dialog/SearchDialog.vue
+++ b/shell/dialog/SearchDialog.vue
@@ -1,7 +1,7 @@
 <script>
 import debounce from 'lodash/debounce';
 import Group from '@shell/components/nav/Group';
-import { isMac } from '@shell/utils/platform';
+import { isMac, KEY } from '@shell/utils/platform';
 import { BOTH, TYPE_MODES } from '@shell/store/type-map';
 import { COUNT } from '@shell/config/types';
 
@@ -72,7 +72,65 @@ export default {
 
         g.hidden = !!hidden;
       });
-    }
+    },
+
+    // Keyboard support
+    visibleLinks() {
+      return Array.from(this.$refs.results?.querySelectorAll('li.child.nav-type a.type-link') || []);
+    },
+
+    focusLink(direction) {
+      const links = this.visibleLinks();
+
+      if (!links.length) {
+        return;
+      }
+
+      const index = links.indexOf(document.activeElement);
+      // Down from the input (or past either end of the list) wraps around
+      const next = index === -1 ? (direction > 0 ? 0 : links.length - 1) : (index + direction + links.length) % links.length;
+
+      links[next].focus();
+      links[next].scrollIntoView?.({ block: 'nearest' });
+    },
+
+    inputKeyHandler(e) {
+      switch (e.keyCode) {
+      case KEY.DOWN:
+        e.preventDefault();
+        this.focusLink(1);
+        break;
+      case KEY.UP:
+        e.preventDefault();
+        this.focusLink(-1);
+        break;
+      case KEY.CR:
+        e.preventDefault();
+        this.visibleLinks()[0]?.click();
+        break;
+      }
+    },
+
+    resultsKeyHandler(e) {
+      switch (e.keyCode) {
+      case KEY.DOWN:
+        e.preventDefault();
+        this.focusLink(1);
+        break;
+      case KEY.UP:
+        e.preventDefault();
+        this.focusLink(-1);
+        break;
+      case KEY.ESCAPE:
+        this.$emit('close');
+        break;
+      default:
+        // Typing returns focus to the input so the user can keep refining the filter
+        if (e.key === 'Backspace' || (e.key?.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey)) {
+          this.$refs.input.focus();
+        }
+      }
+    },
   },
 };
 </script>
@@ -99,9 +157,14 @@ export default {
         :aria-label="t('nav.resourceSearch.label')"
         aria-describedby="describe-filter-resource-search"
         @keyup.esc="$emit('close')"
+        @keydown="inputKeyHandler($event)"
       >
     </div>
-    <div class="results">
+    <div
+      ref="results"
+      class="results"
+      @keydown="resultsKeyHandler($event)"
+    >
       <div
         v-for="g in groups"
         :key="g.name"
@@ -160,5 +223,10 @@ export default {
     background-color: var(--dropdown-bg);
     border-top: 1px solid var(--dropdown-border);
     height: 75vh;
+
+    // Match the row hover style when a result is focused via the keyboard
+    :deep() li.child a.type-link:focus {
+      background-color: var(--nav-hover);
+    }
   }
 </style>

--- a/shell/dialog/__tests__/SearchDialog.test.ts
+++ b/shell/dialog/__tests__/SearchDialog.test.ts
@@ -1,0 +1,236 @@
+import { shallowMount, VueWrapper } from '@vue/test-utils';
+import SearchDialog from '@shell/dialog/SearchDialog.vue';
+import { KEY } from '@shell/utils/platform';
+
+const t = (key: string): string => key;
+
+// Renders each group child the same way nav/Type.vue does, so the dialog's
+// keyboard navigation can be exercised against a realistic DOM
+const GroupStub = {
+  props:    ['group'],
+  emits:    ['close'],
+  template: `
+    <ul>
+      <li
+        v-for="c in group.children"
+        :key="c.name"
+        class="child nav-type"
+      >
+        <a
+          class="type-link"
+          href="#"
+          @click.prevent="$emit('close')"
+        >{{ c.label }}</a>
+      </li>
+    </ul>
+  `,
+};
+
+describe('component: SearchDialog', () => {
+  let wrapper: VueWrapper<any>;
+
+  const createMockGroups = () => [
+    {
+      name:     'workload',
+      label:    'Workload',
+      children: [
+        {
+          name: 'apps.deployment', label: 'Deployments', route: { name: 'c-cluster-product-resource' }
+        },
+        {
+          name: 'pod', label: 'Pods', route: { name: 'c-cluster-product-resource' }
+        },
+      ],
+    },
+    {
+      name:     'storage',
+      label:    'Storage',
+      children: [
+        {
+          name: 'persistentvolume', label: 'PersistentVolumes', route: { name: 'c-cluster-product-resource' }
+        },
+      ],
+    },
+  ];
+
+  const mountComponent = async(groups = createMockGroups()) => {
+    const store = {
+      getters: {
+        clusterId:           'local',
+        productId:           'explorer',
+        currentProduct:      { inStore: 'cluster' },
+        'type-map/allTypes': jest.fn().mockReturnValue({}),
+        'type-map/getTree':  jest.fn().mockReturnValue(groups),
+        'cluster/all':       jest.fn().mockReturnValue([]),
+        'cluster/canList':   jest.fn().mockReturnValue(true),
+      },
+    };
+
+    const mounted = shallowMount(SearchDialog, {
+      attachTo: document.body,
+      global:   {
+        mocks: {
+          $store: store,
+          t,
+        },
+        stubs: { Group: GroupStub },
+      },
+    });
+
+    // The results list renders after the initial updateMatches() from mounted()
+    await mounted.vm.$nextTick();
+
+    return mounted;
+  };
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+  });
+
+  it('should focus the input on mount', async() => {
+    wrapper = await mountComponent();
+
+    expect(document.activeElement).toBe(wrapper.find('input').element);
+  });
+
+  it('should close on Escape in the input', async() => {
+    wrapper = await mountComponent();
+
+    await wrapper.find('input').trigger('keyup.esc');
+
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+
+  describe('arrow key navigation', () => {
+    it('should focus the first result on Down from the input', async() => {
+      wrapper = await mountComponent();
+
+      await wrapper.find('input').trigger('keydown', { keyCode: KEY.DOWN });
+
+      const links = wrapper.findAll('a.type-link');
+
+      expect(document.activeElement).toBe(links[0].element);
+    });
+
+    it('should focus the last result on Up from the input', async() => {
+      wrapper = await mountComponent();
+
+      await wrapper.find('input').trigger('keydown', { keyCode: KEY.UP });
+
+      const links = wrapper.findAll('a.type-link');
+
+      expect(document.activeElement).toBe(links[links.length - 1].element);
+    });
+
+    it('should move focus to the next result on Down, across groups', async() => {
+      wrapper = await mountComponent();
+
+      const links = wrapper.findAll('a.type-link');
+
+      await wrapper.find('input').trigger('keydown', { keyCode: KEY.DOWN });
+      await links[0].trigger('keydown', { keyCode: KEY.DOWN });
+
+      expect(document.activeElement).toBe(links[1].element);
+
+      // Third result lives in the second group
+      await links[1].trigger('keydown', { keyCode: KEY.DOWN });
+
+      expect(document.activeElement).toBe(links[2].element);
+    });
+
+    it('should wrap to the first result on Down from the last result', async() => {
+      wrapper = await mountComponent();
+
+      const links = wrapper.findAll('a.type-link');
+
+      links[links.length - 1].element.focus();
+      await links[links.length - 1].trigger('keydown', { keyCode: KEY.DOWN });
+
+      expect(document.activeElement).toBe(links[0].element);
+    });
+
+    it('should wrap to the last result on Up from the first result', async() => {
+      wrapper = await mountComponent();
+
+      const links = wrapper.findAll('a.type-link');
+
+      links[0].element.focus();
+      await links[0].trigger('keydown', { keyCode: KEY.UP });
+
+      expect(document.activeElement).toBe(links[links.length - 1].element);
+    });
+
+    it('should do nothing on Down when there are no results', async() => {
+      wrapper = await mountComponent([]);
+
+      const input = wrapper.find('input');
+
+      await input.trigger('keydown', { keyCode: KEY.DOWN });
+
+      expect(document.activeElement).toBe(input.element);
+    });
+  });
+
+  describe('opening a result', () => {
+    it('should open the first result on Enter in the input', async() => {
+      wrapper = await mountComponent();
+
+      const firstLink = wrapper.find('a.type-link');
+      const click = jest.spyOn(firstLink.element, 'click');
+
+      await wrapper.find('input').trigger('keydown', { keyCode: KEY.CR });
+
+      expect(click).toHaveBeenCalledWith();
+    });
+
+    it('should do nothing on Enter in the input when there are no results', async() => {
+      wrapper = await mountComponent([]);
+
+      await wrapper.find('input').trigger('keydown', { keyCode: KEY.CR });
+
+      expect(wrapper.emitted('close')).toBeUndefined();
+    });
+  });
+
+  describe('keyboard interaction within the results', () => {
+    it('should close on Escape when a result is focused', async() => {
+      wrapper = await mountComponent();
+
+      const firstLink = wrapper.find('a.type-link');
+
+      firstLink.element.focus();
+      await firstLink.trigger('keydown', { keyCode: KEY.ESCAPE });
+
+      expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+
+    it.each([
+      ['a', 65],
+      ['Backspace', 8],
+    ])('should return focus to the input when "%s" is pressed on a result', async(key, keyCode) => {
+      wrapper = await mountComponent();
+
+      const firstLink = wrapper.find('a.type-link');
+
+      firstLink.element.focus();
+      await firstLink.trigger('keydown', { key, keyCode });
+
+      expect(document.activeElement).toBe(wrapper.find('input').element);
+    });
+
+    it('should not steal focus from a result when a modifier combination is pressed', async() => {
+      wrapper = await mountComponent();
+
+      const firstLink = wrapper.find('a.type-link');
+
+      firstLink.element.focus();
+      await firstLink.trigger('keydown', {
+        key: 'c', keyCode: 67, ctrlKey: true,
+      });
+
+      expect(document.activeElement).toBe(firstLink.element);
+    });
+  });
+});

--- a/shell/dialog/__tests__/SearchDialog.test.ts
+++ b/shell/dialog/__tests__/SearchDialog.test.ts
@@ -4,11 +4,19 @@ import { KEY } from '@shell/utils/platform';
 
 const t = (key: string): string => key;
 
+// Labels of the results that have been opened, in order
+let clicked: string[] = [];
+
 // Renders each group child the same way nav/Type.vue does, so the dialog's
 // keyboard navigation can be exercised against a realistic DOM
 const GroupStub = {
-  props:    ['group'],
-  emits:    ['close'],
+  props:   ['group'],
+  emits:   ['close'],
+  methods: {
+    open(label: string) {
+      clicked.push(label);
+    },
+  },
   template: `
     <ul>
       <li
@@ -19,7 +27,7 @@ const GroupStub = {
         <a
           class="type-link"
           href="#"
-          @click.prevent="$emit('close')"
+          @click.prevent="open(c.label); $emit('close')"
         >{{ c.label }}</a>
       </li>
     </ul>
@@ -28,6 +36,8 @@ const GroupStub = {
 
 describe('component: SearchDialog', () => {
   let wrapper: VueWrapper<any>;
+  // Lets a test change the results the store returns after the component has mounted
+  let getTree: jest.Mock;
 
   const createMockGroups = () => [
     {
@@ -54,13 +64,15 @@ describe('component: SearchDialog', () => {
   ];
 
   const mountComponent = async(groups = createMockGroups()) => {
+    getTree = jest.fn().mockReturnValue(groups);
+
     const store = {
       getters: {
         clusterId:           'local',
         productId:           'explorer',
         currentProduct:      { inStore: 'cluster' },
         'type-map/allTypes': jest.fn().mockReturnValue({}),
-        'type-map/getTree':  jest.fn().mockReturnValue(groups),
+        'type-map/getTree':  getTree,
         'cluster/all':       jest.fn().mockReturnValue([]),
         'cluster/canList':   jest.fn().mockReturnValue(true),
       },
@@ -82,6 +94,10 @@ describe('component: SearchDialog', () => {
 
     return mounted;
   };
+
+  beforeEach(() => {
+    clicked = [];
+  });
 
   afterEach(() => {
     if (wrapper) {
@@ -162,6 +178,31 @@ describe('component: SearchDialog', () => {
       expect(document.activeElement).toBe(links[links.length - 1].element);
     });
 
+    it('should focus a result of the current filter when Down is pressed before the debounce fires', async() => {
+      wrapper = await mountComponent();
+
+      getTree.mockReturnValue([{
+        name:     'workload',
+        label:    'Workload',
+        children: [
+          {
+            name: 'apps.replicaset', label: 'ReplicaSets', route: { name: 'c-cluster-product-resource' }
+          },
+        ],
+      }]);
+
+      wrapper.vm.value = 'repli';
+      await wrapper.vm.$nextTick();
+
+      await wrapper.find('input').trigger('keydown', { keyCode: KEY.DOWN });
+      await wrapper.vm.$nextTick();
+
+      const links = wrapper.findAll('a.type-link');
+
+      expect(links).toHaveLength(1);
+      expect(document.activeElement).toBe(links[0].element);
+    });
+
     it('should do nothing on Down when there are no results', async() => {
       wrapper = await mountComponent([]);
 
@@ -191,6 +232,29 @@ describe('component: SearchDialog', () => {
       await wrapper.find('input').trigger('keydown', { keyCode: KEY.CR });
 
       expect(wrapper.emitted('close')).toBeUndefined();
+    });
+
+    // Filtering is debounced, so pressing Enter straight after typing must not open a result of the previous filter
+    it('should open a result of the current filter when Enter is pressed before the debounce fires', async() => {
+      wrapper = await mountComponent();
+
+      getTree.mockReturnValue([{
+        name:     'workload',
+        label:    'Workload',
+        children: [
+          {
+            name: 'apps.replicaset', label: 'ReplicaSets', route: { name: 'c-cluster-product-resource' }
+          },
+        ],
+      }]);
+
+      wrapper.vm.value = 'repli';
+      await wrapper.vm.$nextTick();
+
+      await wrapper.find('input').trigger('keydown', { keyCode: KEY.CR });
+      await wrapper.vm.$nextTick();
+
+      expect(clicked).toStrictEqual(['ReplicaSets']);
     });
   });
 


### PR DESCRIPTION
### Summary
Fixes #18522

The resource type search (Ctrl+K / Cmd+K) filtered results as you type, but arrow keys and Enter did nothing, so results could only be opened with the mouse. This PR adds command-palette style keyboard navigation to the dialog.

### Occurred changes and/or fixed issues

- Down/Up in the search input moves focus through the visible results, wrapping at either end
- Enter in the search input opens the first result
- Enter on a focused result opens it (native link activation through the existing click path in `nav/Type.vue`)
- Escape closes the dialog while a result is focused (previously only worked from the input)
- Typing (or Backspace) while a result is focused returns focus to the input so the filter can keep being refined
- The focused result row reuses the existing `--nav-hover` row style so it is visually identical to hovering
- The hidden description announced by screen readers (`nav.resourceSearch.filteringDescription`) now mentions the arrow keys

### Technical notes summary

- Follows the same roving-focus keyboard pattern (and the `KEY` codes from `@shell/utils/platform`) already used by `shell/components/nav/NamespaceFilter.vue`, rather than introducing a new highlight/`aria-activedescendant` mechanism
- The change is deliberately confined to `shell/dialog/SearchDialog.vue`: results are rendered by the shared sidebar `Group`/`Type` components, and the dialog navigates between the rendered `a.type-link` elements instead of threading new props through those shared components. Happy to move to a prop-based approach in `Group`/`Type` if that's preferred
- Enter on a focused result is intentionally not handled by the new key handlers — native anchor activation triggers the existing `selectType()`/`navigate()` click path, so navigation and dialog close behave exactly like a mouse click

### Areas or cases that should be tested

1. Open the resource search with Ctrl+K (Cmd+K on Mac)
2. Type a filter (e.g. `depl`) and press Enter → the first match opens and the dialog closes
3. Type a filter, press Down/Up to move through results (check wrap-around at both ends, and moving across group boundaries), press Enter on a focused result → it opens
4. Press Escape with a result focused → dialog closes
5. With a result focused, type a letter → focus returns to the input and the character is appended to the filter
6. Mouse interaction with results is unchanged

Tested locally with Chrome against a Rancher v2.12.3 Docker backend — the full keyboard flow was verified end to end (see GIF). Unit tests cover the new keyboard behavior (`shell/dialog/__tests__/SearchDialog.test.ts`).

### Areas which could experience regressions

- The resource search dialog itself (input handling, closing behavior)
- The shared sidebar `Group`/`Type` components are untouched, so the side nav should be unaffected; the only addition is a scoped `:focus` style applied within the dialog's results container
### Screenshot/Video
<img width="1568" height="709" alt="rancher-search-keyboard-nav" src="https://github.com/user-attachments/assets/0b5a36c6-5e87-40da-b744-3c0b1254b151" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
