### PR TITLE
Adjust Banner component and it's usages so that it's announced by screen readers when applicable

### DIFF
--- a/cypress/e2e/tests/pages/explorer/service-discovery/services.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/service-discovery/services.spec.ts
@@ -133,7 +133,7 @@ describe('Services', { testIsolation: false, tags: ['@explorer', '@adminUser'] }
     it('validation errors should not be shown when form is just opened', () => {
       servicesPagePo.goTo();
       servicesPagePo.clickCreate();
-      servicesPagePo.createServicesForm().errorBanner().should('not.exist');
+      servicesPagePo.createServicesForm().errorBanner().should('be.empty');
     });
 
     after(() => {

--- a/cypress/e2e/tests/pages/explorer/service-discovery/services.spec.ts
+++ b/cypress/e2e/tests/pages/explorer/service-discovery/services.spec.ts
@@ -133,7 +133,7 @@ describe('Services', { testIsolation: false, tags: ['@explorer', '@adminUser'] }
     it('validation errors should not be shown when form is just opened', () => {
       servicesPagePo.goTo();
       servicesPagePo.clickCreate();
-      servicesPagePo.createServicesForm().errorBanner().should('be.empty');
+      servicesPagePo.createServicesForm().errorBanner().should('not.exist');
     });
 
     after(() => {

--- a/pkg/rancher-components/src/components/Banner/Banner.test.ts
+++ b/pkg/rancher-components/src/components/Banner/Banner.test.ts
@@ -104,4 +104,39 @@ describe('component: Banner', () => {
     expect(bannerCloseBtnRole).toBe('button');
     expect(bannerCloseBtnAriaLabel).toBeDefined();
   });
+
+  describe('a11y: role prop (live region)', () => {
+    it('should default to role="region" when no role prop is provided', () => {
+      const wrapper = mount(Banner, { propsData: { label: 'test' } });
+      const mainContainer = wrapper.find('.banner');
+
+      expect(mainContainer.attributes('role')).toBe('region');
+    });
+
+    it('should render role="alert" for dynamically-injected error messages', () => {
+      const wrapper = mount(Banner, { propsData: { label: 'Something went wrong', role: 'alert' } });
+      const mainContainer = wrapper.find('.banner');
+
+      expect(mainContainer.attributes('role')).toBe('alert');
+    });
+
+    it('should render role="status" for polite notifications and state changes', () => {
+      const wrapper = mount(Banner, { propsData: { label: 'Cluster is provisioning', role: 'status' } });
+      const mainContainer = wrapper.find('.banner');
+
+      expect(mainContainer.attributes('role')).toBe('status');
+    });
+
+    it('should preserve aria-labelledby regardless of the role prop value', () => {
+      const cases = ['region', 'alert', 'status'] as const;
+
+      cases.forEach((role) => {
+        const wrapper = mount(Banner, { propsData: { label: 'test', role } });
+        const mainContainer = wrapper.find('.banner');
+        const bannerContent = wrapper.find('.banner__content');
+
+        expect(mainContainer.attributes('aria-labelledby')).toBe(bannerContent.attributes('id'));
+      });
+    });
+  });
 });

--- a/pkg/rancher-components/src/components/Banner/Banner.test.ts
+++ b/pkg/rancher-components/src/components/Banner/Banner.test.ts
@@ -81,24 +81,18 @@ describe('component: Banner', () => {
 
     const mainContainer = wrapper.find('.banner');
     const bannerIcon = wrapper.find('.banner__icon i');
-    const bannerContent = wrapper.find('.banner__content');
     const bannerCloseBtn = wrapper.find('.banner__content__closer');
     const bannerCloseIcon = wrapper.find('.icon-close.closer-icon');
 
-    const mainContainerRole = mainContainer.attributes('role');
-    const mainContainerAriaLabelledBy = mainContainer.attributes('aria-labelledby');
-
     const bannerIconAlt = bannerIcon.attributes('alt');
-
-    const bannerContentId = bannerContent.attributes('id');
 
     const bannerCloseBtnRole = bannerCloseBtn.attributes('role');
     const bannerCloseBtnAriaLabel = bannerCloseBtn.attributes('aria-label');
 
     const bannerCloseIconAlt = bannerCloseIcon.attributes('alt');
 
-    expect(mainContainerRole).toBe('region');
-    expect(mainContainerAriaLabelledBy).toBe(bannerContentId);
+    expect(mainContainer.attributes('role')).toBeUndefined();
+    expect(mainContainer.attributes('aria-labelledby')).toBeUndefined();
     expect(bannerIconAlt).toBeDefined();
     expect(bannerCloseIconAlt).toBeDefined();
     expect(bannerCloseBtnRole).toBe('button');
@@ -106,37 +100,46 @@ describe('component: Banner', () => {
   });
 
   describe('a11y: role prop (live region)', () => {
-    it('should default to role="region" when no role prop is provided', () => {
+    it('should have no role attribute by default', () => {
       const wrapper = mount(Banner, { propsData: { label: 'test' } });
       const mainContainer = wrapper.find('.banner');
 
-      expect(mainContainer.attributes('role')).toBe('region');
+      expect(mainContainer.attributes('role')).toBeUndefined();
     });
 
-    it('should render role="alert" for dynamically-injected error messages', () => {
+    it('should render role="alert" for persistent live-region containers announcing errors', () => {
       const wrapper = mount(Banner, { propsData: { label: 'Something went wrong', role: 'alert' } });
       const mainContainer = wrapper.find('.banner');
 
       expect(mainContainer.attributes('role')).toBe('alert');
     });
 
-    it('should render role="status" for polite notifications and state changes', () => {
+    it('should render role="status" for persistent live-region containers announcing polite notifications', () => {
       const wrapper = mount(Banner, { propsData: { label: 'Cluster is provisioning', role: 'status' } });
       const mainContainer = wrapper.find('.banner');
 
       expect(mainContainer.attributes('role')).toBe('status');
     });
 
-    it('should preserve aria-labelledby regardless of the role prop value', () => {
-      const cases = ['region', 'alert', 'status'] as const;
+    it('should apply aria-labelledby only when role="region"', () => {
+      const regionWrapper = mount(Banner, { propsData: { label: 'test', role: 'region' } });
+      const bannerContent = regionWrapper.find('.banner__content');
 
-      cases.forEach((role) => {
-        const wrapper = mount(Banner, { propsData: { label: 'test', role } });
-        const mainContainer = wrapper.find('.banner');
-        const bannerContent = wrapper.find('.banner__content');
+      expect(regionWrapper.find('.banner').attributes('aria-labelledby')).toBe(bannerContent.attributes('id'));
+    });
 
-        expect(mainContainer.attributes('aria-labelledby')).toBe(bannerContent.attributes('id'));
-      });
+    it('should not apply aria-labelledby when role is alert or status', () => {
+      const alertWrapper = mount(Banner, { propsData: { label: 'test', role: 'alert' } });
+      const statusWrapper = mount(Banner, { propsData: { label: 'test', role: 'status' } });
+
+      expect(alertWrapper.find('.banner').attributes('aria-labelledby')).toBeUndefined();
+      expect(statusWrapper.find('.banner').attributes('aria-labelledby')).toBeUndefined();
+    });
+
+    it('should not apply aria-labelledby when no role is set', () => {
+      const wrapper = mount(Banner, { propsData: { label: 'test' } });
+
+      expect(wrapper.find('.banner').attributes('aria-labelledby')).toBeUndefined();
     });
   });
 });

--- a/pkg/rancher-components/src/components/Banner/Banner.test.ts
+++ b/pkg/rancher-components/src/components/Banner/Banner.test.ts
@@ -121,25 +121,12 @@ describe('component: Banner', () => {
       expect(mainContainer.attributes('role')).toBe('status');
     });
 
-    it('should apply aria-labelledby only when role="region"', () => {
-      const regionWrapper = mount(Banner, { propsData: { label: 'test', role: 'region' } });
-      const bannerContent = regionWrapper.find('.banner__content');
-
-      expect(regionWrapper.find('.banner').attributes('aria-labelledby')).toBe(bannerContent.attributes('id'));
-    });
-
-    it('should not apply aria-labelledby when role is alert or status', () => {
+    it('should accept only "alert" and "status" as valid role values', () => {
       const alertWrapper = mount(Banner, { propsData: { label: 'test', role: 'alert' } });
       const statusWrapper = mount(Banner, { propsData: { label: 'test', role: 'status' } });
 
-      expect(alertWrapper.find('.banner').attributes('aria-labelledby')).toBeUndefined();
-      expect(statusWrapper.find('.banner').attributes('aria-labelledby')).toBeUndefined();
-    });
-
-    it('should not apply aria-labelledby when no role is set', () => {
-      const wrapper = mount(Banner, { propsData: { label: 'test' } });
-
-      expect(wrapper.find('.banner').attributes('aria-labelledby')).toBeUndefined();
+      expect(alertWrapper.find('.banner').attributes('role')).toBe('alert');
+      expect(statusWrapper.find('.banner').attributes('role')).toBe('status');
     });
   });
 });

--- a/pkg/rancher-components/src/components/Banner/Banner.vue
+++ b/pkg/rancher-components/src/components/Banner/Banner.vue
@@ -70,9 +70,10 @@ export default defineComponent({
       default: false
     },
     /**
-     * ARIA live region role for persistent banners whose live-region responsibility is not
-     * handled by a wrapper element. Use 'alert' for error announcements (assertive) and
-     * 'status' for polite notifications. Omit when the wrapper div owns the live region.
+     * ARIA live region role. Assistive technology announces the banner when it is
+     * inserted into the page. Use 'alert' for errors, which interrupts the current
+     * announcement, and 'status' for informational messages, which waits for a pause.
+     * Omit for decorative or purely visual banners.
      * @values alert, status
      */
     role: {

--- a/pkg/rancher-components/src/components/Banner/Banner.vue
+++ b/pkg/rancher-components/src/components/Banner/Banner.vue
@@ -76,8 +76,9 @@ export default defineComponent({
      * @values alert, status
      */
     role: {
-      type:    String,
-      default: null
+      type:      String,
+      default:   null,
+      validator: (value: string | null) => ['alert', 'status', null].includes(value),
     },
   },
   emits:    ['close'],

--- a/pkg/rancher-components/src/components/Banner/Banner.vue
+++ b/pkg/rancher-components/src/components/Banner/Banner.vue
@@ -14,6 +14,7 @@ export interface Props {
   closable?: boolean;
   stacked?: boolean;
   disabled?: boolean;
+  role?: 'region' | 'alert' | 'status';
 }
 
 export default defineComponent({
@@ -68,6 +69,16 @@ export default defineComponent({
       type:    Boolean,
       default: false
     },
+    /**
+     * ARIA live region role. Use 'alert' for error messages that appear dynamically (e.g. form
+     * validation failures), 'status' for polite notifications (e.g. state changes, warnings), and
+     * 'region' (default) for static informational banners.
+     * @values region, alert, status
+     */
+    role: {
+      type:    String,
+      default: 'region'
+    },
   },
   emits: ['close'],
   data() {
@@ -91,7 +102,7 @@ export default defineComponent({
       [color]: true,
       'banner-disabled': disabled
     }"
-    role="region"
+    :role="role"
     :aria-labelledby="labelledbyId"
     tabindex="0"
   >

--- a/pkg/rancher-components/src/components/Banner/Banner.vue
+++ b/pkg/rancher-components/src/components/Banner/Banner.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { nlToBr, generateRandomAlphaString } from '@shell/utils/string';
+import { nlToBr } from '@shell/utils/string';
 import { stringify } from '@shell/utils/error';
 
 /**
@@ -14,7 +14,7 @@ export interface Props {
   closable?: boolean;
   stacked?: boolean;
   disabled?: boolean;
-  role?: 'region' | 'alert' | 'status';
+  role?: 'alert' | 'status' | null;
 }
 
 export default defineComponent({
@@ -70,20 +70,17 @@ export default defineComponent({
       default: false
     },
     /**
-     * ARIA live region role. Use 'alert' for error messages that appear dynamically (e.g. form
-     * validation failures), 'status' for polite notifications (e.g. state changes, warnings), and
-     * 'region' (default) for static informational banners.
-     * @values region, alert, status
+     * ARIA live region role for persistent banners whose live-region responsibility is not
+     * handled by a wrapper element. Use 'alert' for error announcements (assertive) and
+     * 'status' for polite notifications. Omit when the wrapper div owns the live region.
+     * @values alert, status
      */
     role: {
       type:    String,
-      default: 'region'
+      default: null
     },
   },
-  emits: ['close'],
-  data() {
-    return { labelledbyId: `banner-labelledby-${ generateRandomAlphaString(12) }` };
-  },
+  emits:    ['close'],
   computed: {
     /**
      * Return message text as label.
@@ -102,8 +99,7 @@ export default defineComponent({
       [color]: true,
       'banner-disabled': disabled
     }"
-    :role="role"
-    :aria-labelledby="labelledbyId"
+    :role="role || undefined"
     tabindex="0"
   >
     <div
@@ -118,7 +114,6 @@ export default defineComponent({
       />
     </div>
     <div
-      :id="labelledbyId"
       class="banner__content"
       data-testid="banner-content"
       :class="{

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -290,6 +290,13 @@ export default {
     ...mapActions('cru-resource', ['setCreateNamespace']),
 
     /**
+     * Prevent issues for malformed types injection
+     */
+    hasErrors() {
+      return this.errors?.length && Array.isArray(this.errors);
+    },
+
+    /**
      * Replace returned string with new picked value and icon
      */
     mappedErrors() {
@@ -676,7 +683,13 @@ export default {
       @submit.prevent
       @keydown.enter="onPressEnter($event)"
     >
+      <!-- `role="alert"` sits on the container that already exists rather than on a
+           persistent wrapper: this element is a grid cell under `.show-toc` and a
+           flex item otherwise, so an extra box would change the layout. Assistive
+           tech announces an alert when it is inserted, which is exactly when an
+           error appears. -->
       <div
+        v-if="hasErrors"
         id="cru-errors"
         class="cru__errors"
         role="alert"

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -290,13 +290,6 @@ export default {
     ...mapActions('cru-resource', ['setCreateNamespace']),
 
     /**
-     * Prevent issues for malformed types injection
-     */
-    hasErrors() {
-      return this.errors?.length && Array.isArray(this.errors);
-    },
-
-    /**
      * Replace returned string with new picked value and icon
      */
     mappedErrors() {

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -696,6 +696,7 @@ export default {
           :label="stringify(mappedErrors[err].message)"
           :icon="mappedErrors[err].icon"
           :closable="true"
+          role="alert"
           @close="closeError(i)"
         />
       </div>

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -683,11 +683,6 @@ export default {
       @submit.prevent
       @keydown.enter="onPressEnter($event)"
     >
-      <!-- `role="alert"` sits on the container that already exists rather than on a
-           persistent wrapper: this element is a grid cell under `.show-toc` and a
-           flex item otherwise, so an extra box would change the layout. Assistive
-           tech announces an alert when it is inserted, which is exactly when an
-           error appears. -->
       <div
         v-if="hasErrors"
         id="cru-errors"

--- a/shell/components/CruResource.vue
+++ b/shell/components/CruResource.vue
@@ -684,9 +684,10 @@ export default {
       @keydown.enter="onPressEnter($event)"
     >
       <div
-        v-if="hasErrors"
         id="cru-errors"
         class="cru__errors"
+        role="alert"
+        aria-live="assertive"
       >
         <Banner
           v-for="(err, i) in errors"
@@ -696,7 +697,6 @@ export default {
           :label="stringify(mappedErrors[err].message)"
           :icon="mappedErrors[err].icon"
           :closable="true"
-          role="alert"
           @close="closeError(i)"
         />
       </div>

--- a/shell/components/ResourceDetail/Masthead/latest.vue
+++ b/shell/components/ResourceDetail/Masthead/latest.vue
@@ -46,28 +46,25 @@ const store = useStore();
 <template>
   <div>
     <TitleBar v-bind="titleBarProps" />
-    <div
+    <!-- `role="status"` sits on the banner rather than on a wrapper element, so the
+         layout is unchanged. Assistive tech announces it when it is inserted. -->
+    <Banner
+      v-if="bannerProps"
+      v-ui-context="{
+        store: store,
+        icon: 'icon-info',
+        hookable: true,
+        value: {
+          bannerProps,
+          resource: uiCtxResource
+        },
+        tag: '__details-state-banner',
+        description: 'Status Message'
+      }"
+      class="new state-banner"
+      v-bind="bannerProps"
       role="status"
-      aria-atomic="true"
-      style="display: contents"
-    >
-      <Banner
-        v-if="bannerProps"
-        v-ui-context="{
-          store: store,
-          icon: 'icon-info',
-          hookable: true,
-          value: {
-            bannerProps,
-            resource: uiCtxResource
-          },
-          tag: '__details-state-banner',
-          description: 'Status Message'
-        }"
-        class="new state-banner"
-        v-bind="bannerProps"
-      />
-    </div>
+    />
     <Metadata
       v-bind="metadataProps"
       class="metadata-section"

--- a/shell/components/ResourceDetail/Masthead/latest.vue
+++ b/shell/components/ResourceDetail/Masthead/latest.vue
@@ -46,8 +46,6 @@ const store = useStore();
 <template>
   <div>
     <TitleBar v-bind="titleBarProps" />
-    <!-- `role="status"` sits on the banner rather than on a wrapper element, so the
-         layout is unchanged. Assistive tech announces it when it is inserted. -->
     <Banner
       v-if="bannerProps"
       v-ui-context="{

--- a/shell/components/ResourceDetail/Masthead/latest.vue
+++ b/shell/components/ResourceDetail/Masthead/latest.vue
@@ -60,6 +60,7 @@ const store = useStore();
         description: 'Status Message'
       }"
       class="new state-banner"
+      role="status"
       v-bind="bannerProps"
     />
     <Metadata

--- a/shell/components/ResourceDetail/Masthead/latest.vue
+++ b/shell/components/ResourceDetail/Masthead/latest.vue
@@ -46,23 +46,28 @@ const store = useStore();
 <template>
   <div>
     <TitleBar v-bind="titleBarProps" />
-    <Banner
-      v-if="bannerProps"
-      v-ui-context="{
-        store: store,
-        icon: 'icon-info',
-        hookable: true,
-        value: {
-          bannerProps,
-          resource: uiCtxResource
-        },
-        tag: '__details-state-banner',
-        description: 'Status Message'
-      }"
-      class="new state-banner"
+    <div
       role="status"
-      v-bind="bannerProps"
-    />
+      aria-atomic="true"
+      style="display: contents"
+    >
+      <Banner
+        v-if="bannerProps"
+        v-ui-context="{
+          store: store,
+          icon: 'icon-info',
+          hookable: true,
+          value: {
+            bannerProps,
+            resource: uiCtxResource
+          },
+          tag: '__details-state-banner',
+          description: 'Status Message'
+        }"
+        class="new state-banner"
+        v-bind="bannerProps"
+      />
+    </div>
     <Metadata
       v-bind="metadataProps"
       class="metadata-section"

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -410,6 +410,24 @@ export default {
 </script>
 
 <template>
+  <div
+    id="cru-errors"
+    class="cru__errors"
+    role="alert"
+    aria-live="assertive"
+    aria-atomic="true"
+  >
+    <Banner
+      v-for="(err, i) in errors"
+      :key="i"
+      color="error"
+      :data-testid="`error-banner${i}`"
+      :label="stringify(mappedErrors[err].message)"
+      :icon="mappedErrors[err].icon"
+      :closable="true"
+      @close="closeError(i)"
+    />
+  </div>
   <Loading v-if="$fetchState.pending || notFound" />
   <component
     :is="showComponent"
@@ -449,23 +467,6 @@ export default {
         :value="liveModel"
       />
     </Masthead>
-    <div
-      v-if="hasErrors"
-      id="cru-errors"
-      class="cru__errors"
-    >
-      <Banner
-        v-for="(err, i) in errors"
-        :key="i"
-        color="error"
-        :data-testid="`error-banner${i}`"
-        :label="stringify(mappedErrors[err].message)"
-        :icon="mappedErrors[err].icon"
-        :closable="true"
-        role="alert"
-        @close="closeError(i)"
-      />
-    </div>
 
     <ResourceYaml
       v-if="isYaml"

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -39,14 +39,6 @@ async function getYaml(store, model) {
   return model.cleanForDownload(yaml);
 }
 
-/**
- * NOTE: the template must keep a single root node - the `v-if` / `v-else-if` / `v-else`
- * chain counts as one. Adding an unconditional sibling (or a root-level comment) turns
- * this into a fragment component, and Vue then drops the `outlet` class that
- * `shell/components/templates/default.vue` passes down from `<router-view class="outlet" />`
- * as a fallthrough attribute. That class supplies the padding, flex layout and min-height
- * for every resource detail / create / edit page.
- */
 export default {
   emits: ['input'],
 
@@ -458,9 +450,6 @@ export default {
       />
     </Masthead>
 
-    <!-- `role="alert"` sits on the container that already exists rather than on a
-         persistent wrapper, so the layout is unchanged. Assistive tech announces an
-         alert when it is inserted, which is exactly when an error appears. -->
     <div
       v-if="hasErrors"
       id="cru-errors"

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -462,6 +462,7 @@ export default {
         :label="stringify(mappedErrors[err].message)"
         :icon="mappedErrors[err].icon"
         :closable="true"
+        role="alert"
         @close="closeError(i)"
       />
     </div>

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -39,6 +39,14 @@ async function getYaml(store, model) {
   return model.cleanForDownload(yaml);
 }
 
+/**
+ * NOTE: the template must keep a single root node - the `v-if` / `v-else-if` / `v-else`
+ * chain counts as one. Adding an unconditional sibling (or a root-level comment) turns
+ * this into a fragment component, and Vue then drops the `outlet` class that
+ * `shell/components/templates/default.vue` passes down from `<router-view class="outlet" />`
+ * as a fallthrough attribute. That class supplies the padding, flex layout and min-height
+ * for every resource detail / create / edit page.
+ */
 export default {
   emits: ['input'],
 
@@ -300,6 +308,9 @@ export default {
 
       return null;
     },
+    hasErrors() {
+      return this.errors?.length && Array.isArray(this.errors);
+    },
     mappedErrors() {
       return !this.errors ? {} : this.errorsMap || this.errors.reduce((acc, error) => ({
         ...acc,
@@ -407,24 +418,6 @@ export default {
 </script>
 
 <template>
-  <div
-    id="resource-detail-errors"
-    class="cru__errors"
-    role="alert"
-    aria-live="assertive"
-    aria-atomic="true"
-  >
-    <Banner
-      v-for="(err, i) in errors"
-      :key="i"
-      color="error"
-      :data-testid="`error-banner${i}`"
-      :label="stringify(mappedErrors[err].message)"
-      :icon="mappedErrors[err].icon"
-      :closable="true"
-      @close="closeError(i)"
-    />
-  </div>
   <Loading v-if="$fetchState.pending || notFound" />
   <component
     :is="showComponent"
@@ -464,6 +457,29 @@ export default {
         :value="liveModel"
       />
     </Masthead>
+
+    <!-- `role="alert"` sits on the container that already exists rather than on a
+         persistent wrapper, so the layout is unchanged. Assistive tech announces an
+         alert when it is inserted, which is exactly when an error appears. -->
+    <div
+      v-if="hasErrors"
+      id="cru-errors"
+      class="cru__errors"
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+    >
+      <Banner
+        v-for="(err, i) in errors"
+        :key="i"
+        color="error"
+        :data-testid="`error-banner${i}`"
+        :label="stringify(mappedErrors[err].message)"
+        :icon="mappedErrors[err].icon"
+        :closable="true"
+        @close="closeError(i)"
+      />
+    </div>
 
     <ResourceYaml
       v-if="isYaml"

--- a/shell/components/ResourceDetail/index.vue
+++ b/shell/components/ResourceDetail/index.vue
@@ -300,9 +300,6 @@ export default {
 
       return null;
     },
-    hasErrors() {
-      return this.errors?.length && Array.isArray(this.errors);
-    },
     mappedErrors() {
       return !this.errors ? {} : this.errorsMap || this.errors.reduce((acc, error) => ({
         ...acc,
@@ -411,7 +408,7 @@ export default {
 
 <template>
   <div
-    id="cru-errors"
+    id="resource-detail-errors"
     class="cru__errors"
     role="alert"
     aria-live="assertive"

--- a/shell/components/Wizard.vue
+++ b/shell/components/Wizard.vue
@@ -441,17 +441,22 @@ export default {
         :activeStep="activeStep"
       >
         <div
-          v-for="(err,idx) in errorStrings"
-          :key="idx"
+          role="alert"
+          aria-live="assertive"
+          style="display: contents"
         >
-          <Banner
-            color="error"
-            :label="err"
-            :closable="true"
-            class="footer-error"
-            role="alert"
-            @close="errors.splice(idx, 1)"
-          />
+          <div
+            v-for="(err,idx) in errorStrings"
+            :key="idx"
+          >
+            <Banner
+              color="error"
+              :label="err"
+              :closable="true"
+              class="footer-error"
+              @close="errors.splice(idx, 1)"
+            />
+          </div>
         </div>
         <div
           id="wizard-footer-controls"

--- a/shell/components/Wizard.vue
+++ b/shell/components/Wizard.vue
@@ -440,11 +440,6 @@ export default {
         :cancel="cancel"
         :activeStep="activeStep"
       >
-        <!-- No wrapping live region here: the parent is a flex column with
-             `justify-content: space-between`, so an always-present wrapper
-             would become a third item and redistribute the spacing.
-             `role="alert"` sits on each banner instead - assistive tech
-             announces an alert when it is inserted. -->
         <div
           v-for="(err,idx) in errorStrings"
           :key="idx"

--- a/shell/components/Wizard.vue
+++ b/shell/components/Wizard.vue
@@ -440,23 +440,23 @@ export default {
         :cancel="cancel"
         :activeStep="activeStep"
       >
+        <!-- No wrapping live region here: the parent is a flex column with
+             `justify-content: space-between`, so an always-present wrapper
+             would become a third item and redistribute the spacing.
+             `role="alert"` sits on each banner instead - assistive tech
+             announces an alert when it is inserted. -->
         <div
-          role="alert"
-          aria-live="assertive"
-          style="display: contents"
+          v-for="(err,idx) in errorStrings"
+          :key="idx"
         >
-          <div
-            v-for="(err,idx) in errorStrings"
-            :key="idx"
-          >
-            <Banner
-              color="error"
-              :label="err"
-              :closable="true"
-              class="footer-error"
-              @close="errors.splice(idx, 1)"
-            />
-          </div>
+          <Banner
+            color="error"
+            role="alert"
+            :label="err"
+            :closable="true"
+            class="footer-error"
+            @close="errors.splice(idx, 1)"
+          />
         </div>
         <div
           id="wizard-footer-controls"

--- a/shell/components/Wizard.vue
+++ b/shell/components/Wizard.vue
@@ -449,6 +449,7 @@ export default {
             :label="err"
             :closable="true"
             class="footer-error"
+            role="alert"
             @close="errors.splice(idx, 1)"
           />
         </div>

--- a/shell/components/__tests__/CruResource.test.ts
+++ b/shell/components/__tests__/CruResource.test.ts
@@ -68,6 +68,75 @@ describe('component: CruResource', () => {
     expect(node.text()).toContain(errors[1]);
   });
 
+  it('should announce the errors container as an assertive live region', () => {
+    const wrapper = mount(CruResource, {
+      props: {
+        canYaml:  false,
+        mode:     _EDIT,
+        resource: {},
+        errors:   ['mistake!']
+      },
+      global: {
+        mocks: {
+          $store: {
+            getters: {
+              currentStore:              () => 'current_store',
+              'current_store/schemaFor': jest.fn(),
+              'current_store/all':       jest.fn(),
+              'i18n/t':                  jest.fn(),
+              'i18n/exists':             jest.fn(),
+            },
+            dispatch: jest.fn(),
+          },
+          $route:  { query: { AS: _YAML } },
+          $router: { applyQuery: jest.fn() },
+        },
+      }
+    });
+
+    const node = wrapper.find('#cru-errors');
+
+    // The role lives on the existing container rather than on a persistent wrapper -
+    // an extra element would claim a grid cell under `.show-toc`. Assistive tech
+    // announces an alert when it is inserted, which is when an error appears.
+    expect(node.attributes('role')).toStrictEqual('alert');
+    expect(node.attributes('aria-live')).toStrictEqual('assertive');
+  });
+
+  it.each([
+    ['no errors prop', undefined],
+    ['an empty errors array', []],
+  ])('should not render the errors container given %s', (_label, errors) => {
+    const wrapper = mount(CruResource, {
+      props: {
+        canYaml:  false,
+        mode:     _EDIT,
+        resource: {},
+        errors
+      },
+      global: {
+        mocks: {
+          $store: {
+            getters: {
+              currentStore:              () => 'current_store',
+              'current_store/schemaFor': jest.fn(),
+              'current_store/all':       jest.fn(),
+              'i18n/t':                  jest.fn(),
+              'i18n/exists':             jest.fn(),
+            },
+            dispatch: jest.fn(),
+          },
+          $route:  { query: { AS: _YAML } },
+          $router: { applyQuery: jest.fn() },
+        },
+      }
+    });
+
+    // The container must not render when there is nothing to show, otherwise consumers
+    // cannot tell "no errors" from "errors" and it occupies a grid cell for nothing.
+    expect(wrapper.find('#cru-errors').exists()).toStrictEqual(false);
+  });
+
   it.each([
     ['error', 'error'],
     [{

--- a/shell/components/__tests__/CruResource.test.ts
+++ b/shell/components/__tests__/CruResource.test.ts
@@ -96,9 +96,6 @@ describe('component: CruResource', () => {
 
     const node = wrapper.find('#cru-errors');
 
-    // The role lives on the existing container rather than on a persistent wrapper -
-    // an extra element would claim a grid cell under `.show-toc`. Assistive tech
-    // announces an alert when it is inserted, which is when an error appears.
     expect(node.attributes('role')).toStrictEqual('alert');
     expect(node.attributes('aria-live')).toStrictEqual('assertive');
   });
@@ -132,8 +129,6 @@ describe('component: CruResource', () => {
       }
     });
 
-    // The container must not render when there is nothing to show, otherwise consumers
-    // cannot tell "no errors" from "errors" and it occupies a grid cell for nothing.
     expect(wrapper.find('#cru-errors').exists()).toStrictEqual(false);
   });
 

--- a/shell/components/auth/AuthBanner.vue
+++ b/shell/components/auth/AuthBanner.vue
@@ -59,6 +59,7 @@ export default {
     <Banner
       color="success clearfix"
       class="banner"
+      role="status"
     >
       <div class="text">
         {{ t('authConfig.stateBanner.enabled', tArgs) }}

--- a/shell/components/form/Error.vue
+++ b/shell/components/form/Error.vue
@@ -57,6 +57,7 @@ export default defineComponent({
     color="error"
     :label="validationMessage"
     :icon="icon"
+    role="alert"
   />
   <span
     v-else-if="!!validationMessage"

--- a/shell/components/form/Error.vue
+++ b/shell/components/form/Error.vue
@@ -52,16 +52,21 @@ export default defineComponent({
 });
 </script>
 <template>
-  <Banner
-    v-if="!!asBanner && !!validationMessage"
-    color="error"
-    :label="validationMessage"
-    :icon="icon"
+  <div
     role="alert"
-  />
-  <span
-    v-else-if="!!validationMessage"
-    class="text-error"
-    data-testid="error-span"
-  >{{ validationMessage }}</span>
+    aria-atomic="true"
+    style="display: contents"
+  >
+    <Banner
+      v-if="!!asBanner && !!validationMessage"
+      color="error"
+      :label="validationMessage"
+      :icon="icon"
+    />
+    <span
+      v-else-if="!!validationMessage"
+      class="text-error"
+      data-testid="error-span"
+    >{{ validationMessage }}</span>
+  </div>
 </template>

--- a/shell/components/form/Error.vue
+++ b/shell/components/form/Error.vue
@@ -52,11 +52,6 @@ export default defineComponent({
 });
 </script>
 <template>
-  <!-- No wrapping live region here: consumers such as ServicePorts render this
-       straight into a `display: grid` row with explicit columns, so an
-       always-present wrapper would claim a grid cell. `role="alert"` sits on the
-       message itself instead - assistive tech announces an alert when it is
-       inserted, which is exactly when a validation message appears. -->
   <Banner
     v-if="!!asBanner && !!validationMessage"
     color="error"

--- a/shell/components/form/Error.vue
+++ b/shell/components/form/Error.vue
@@ -52,21 +52,24 @@ export default defineComponent({
 });
 </script>
 <template>
-  <div
+  <!-- No wrapping live region here: consumers such as ServicePorts render this
+       straight into a `display: grid` row with explicit columns, so an
+       always-present wrapper would claim a grid cell. `role="alert"` sits on the
+       message itself instead - assistive tech announces an alert when it is
+       inserted, which is exactly when a validation message appears. -->
+  <Banner
+    v-if="!!asBanner && !!validationMessage"
+    color="error"
     role="alert"
     aria-atomic="true"
-    style="display: contents"
-  >
-    <Banner
-      v-if="!!asBanner && !!validationMessage"
-      color="error"
-      :label="validationMessage"
-      :icon="icon"
-    />
-    <span
-      v-else-if="!!validationMessage"
-      class="text-error"
-      data-testid="error-span"
-    >{{ validationMessage }}</span>
-  </div>
+    :label="validationMessage"
+    :icon="icon"
+  />
+  <span
+    v-else-if="!!validationMessage"
+    class="text-error"
+    role="alert"
+    aria-atomic="true"
+    data-testid="error-span"
+  >{{ validationMessage }}</span>
 </template>

--- a/shell/components/form/Footer.vue
+++ b/shell/components/form/Footer.vue
@@ -63,6 +63,7 @@ export default defineComponent({
         color="error"
         :label="err"
         :closable="true"
+        role="alert"
         @close="closeError(idx)"
       />
     </div>

--- a/shell/components/form/Footer.vue
+++ b/shell/components/form/Footer.vue
@@ -55,9 +55,6 @@ export default defineComponent({
   <div v-if="!isView">
     <div class="spacer-small" />
 
-    <!-- `role="alert"` sits on each banner rather than on a wrapper element, so the
-         layout is unchanged. Assistive tech announces an alert when it is inserted,
-         which is exactly when an error appears. -->
     <div
       v-for="(err,idx) in errors"
       :key="idx"

--- a/shell/components/form/Footer.vue
+++ b/shell/components/form/Footer.vue
@@ -55,22 +55,20 @@ export default defineComponent({
   <div v-if="!isView">
     <div class="spacer-small" />
 
+    <!-- `role="alert"` sits on each banner rather than on a wrapper element, so the
+         layout is unchanged. Assistive tech announces an alert when it is inserted,
+         which is exactly when an error appears. -->
     <div
-      role="alert"
-      aria-live="assertive"
-      style="display: contents"
+      v-for="(err,idx) in errors"
+      :key="idx"
     >
-      <div
-        v-for="(err,idx) in errors"
-        :key="idx"
-      >
-        <Banner
-          color="error"
-          :label="err"
-          :closable="true"
-          @close="closeError(idx)"
-        />
-      </div>
+      <Banner
+        color="error"
+        role="alert"
+        :label="err"
+        :closable="true"
+        @close="closeError(idx)"
+      />
     </div>
     <div class="buttons">
       <div class="left">

--- a/shell/components/form/Footer.vue
+++ b/shell/components/form/Footer.vue
@@ -56,16 +56,21 @@ export default defineComponent({
     <div class="spacer-small" />
 
     <div
-      v-for="(err,idx) in errors"
-      :key="idx"
+      role="alert"
+      aria-live="assertive"
+      style="display: contents"
     >
-      <Banner
-        color="error"
-        :label="err"
-        :closable="true"
-        role="alert"
-        @close="closeError(idx)"
-      />
+      <div
+        v-for="(err,idx) in errors"
+        :key="idx"
+      >
+        <Banner
+          color="error"
+          :label="err"
+          :closable="true"
+          @close="closeError(idx)"
+        />
+      </div>
     </div>
     <div class="buttons">
       <div class="left">

--- a/shell/dialog/GenericPrompt.vue
+++ b/shell/dialog/GenericPrompt.vue
@@ -112,6 +112,7 @@ export default {
           :key="i"
           color="error"
           :label="err"
+          role="alert"
         />
         <div class="buttons">
           <button

--- a/shell/dialog/GenericPrompt.vue
+++ b/shell/dialog/GenericPrompt.vue
@@ -107,13 +107,18 @@ export default {
 
     <template #actions>
       <div class="bottom">
-        <Banner
-          v-for="(err, i) in allErrors"
-          :key="i"
-          color="error"
-          :label="err"
+        <div
           role="alert"
-        />
+          aria-live="assertive"
+          style="display: contents"
+        >
+          <Banner
+            v-for="(err, i) in allErrors"
+            :key="i"
+            color="error"
+            :label="err"
+          />
+        </div>
         <div class="buttons">
           <button
             class="btn role-secondary mr-10"

--- a/shell/dialog/GenericPrompt.vue
+++ b/shell/dialog/GenericPrompt.vue
@@ -107,18 +107,16 @@ export default {
 
     <template #actions>
       <div class="bottom">
-        <div
+        <!-- `role="alert"` sits on each banner rather than on a wrapper element: the
+             parent is a flex column, so an extra box would become a flex item.
+             Assistive tech announces an alert when it is inserted. -->
+        <Banner
+          v-for="(err, i) in allErrors"
+          :key="i"
+          color="error"
           role="alert"
-          aria-live="assertive"
-          style="display: contents"
-        >
-          <Banner
-            v-for="(err, i) in allErrors"
-            :key="i"
-            color="error"
-            :label="err"
-          />
-        </div>
+          :label="err"
+        />
         <div class="buttons">
           <button
             class="btn role-secondary mr-10"

--- a/shell/dialog/GenericPrompt.vue
+++ b/shell/dialog/GenericPrompt.vue
@@ -107,9 +107,6 @@ export default {
 
     <template #actions>
       <div class="bottom">
-        <!-- `role="alert"` sits on each banner rather than on a wrapper element: the
-             parent is a flex column, so an extra box would become a flex item.
-             Assistive tech announces an alert when it is inserted. -->
         <Banner
           v-for="(err, i) in allErrors"
           :key="i"

--- a/shell/dialog/ImportDialog.vue
+++ b/shell/dialog/ImportDialog.vue
@@ -185,9 +185,6 @@ export default {
         class="yaml-editor"
         @onReady="onReadyYamlEditor"
       />
-      <!-- `role="alert"` sits on each banner rather than on a wrapper element: the
-           parent is a flex column that sizes the YAML editor, so an extra box would
-           become a flex item. Assistive tech announces an alert when it is inserted. -->
       <Banner
         v-for="(err, i) in errors"
         :key="i"

--- a/shell/dialog/ImportDialog.vue
+++ b/shell/dialog/ImportDialog.vue
@@ -185,18 +185,16 @@ export default {
         class="yaml-editor"
         @onReady="onReadyYamlEditor"
       />
-      <div
+      <!-- `role="alert"` sits on each banner rather than on a wrapper element: the
+           parent is a flex column that sizes the YAML editor, so an extra box would
+           become a flex item. Assistive tech announces an alert when it is inserted. -->
+      <Banner
+        v-for="(err, i) in errors"
+        :key="i"
+        color="error"
         role="alert"
-        aria-live="assertive"
-        style="display: contents"
-      >
-        <Banner
-          v-for="(err, i) in errors"
-          :key="i"
-          color="error"
-          :label="err"
-        />
-      </div>
+        :label="err"
+      />
     </template>
     <template #actions>
       <div

--- a/shell/dialog/ImportDialog.vue
+++ b/shell/dialog/ImportDialog.vue
@@ -185,13 +185,18 @@ export default {
         class="yaml-editor"
         @onReady="onReadyYamlEditor"
       />
-      <Banner
-        v-for="(err, i) in errors"
-        :key="i"
-        color="error"
-        :label="err"
+      <div
         role="alert"
-      />
+        aria-live="assertive"
+        style="display: contents"
+      >
+        <Banner
+          v-for="(err, i) in errors"
+          :key="i"
+          color="error"
+          :label="err"
+        />
+      </div>
     </template>
     <template #actions>
       <div

--- a/shell/dialog/ImportDialog.vue
+++ b/shell/dialog/ImportDialog.vue
@@ -190,6 +190,7 @@ export default {
         :key="i"
         color="error"
         :label="err"
+        role="alert"
       />
     </template>
     <template #actions>

--- a/shell/dialog/InstallExtensionDialog.vue
+++ b/shell/dialog/InstallExtensionDialog.vue
@@ -327,9 +327,6 @@ export default {
         <p>
           {{ t(`plugins.${ buttonMode }.prompt`) }}
         </p>
-        <!-- `role="status"` sits on each banner rather than on a wrapper element, so
-             the layout is unchanged. Assistive tech announces the notification when it
-             is inserted. -->
         <Banner
           v-if="chartVersionLoadsWithoutAuth"
           color="warning"

--- a/shell/dialog/InstallExtensionDialog.vue
+++ b/shell/dialog/InstallExtensionDialog.vue
@@ -327,22 +327,21 @@ export default {
         <p>
           {{ t(`plugins.${ buttonMode }.prompt`) }}
         </p>
-        <div
+        <!-- `role="status"` sits on each banner rather than on a wrapper element, so
+             the layout is unchanged. Assistive tech announces the notification when it
+             is inserted. -->
+        <Banner
+          v-if="chartVersionLoadsWithoutAuth"
+          color="warning"
           role="status"
-          aria-atomic="true"
-          style="display: contents"
-        >
-          <Banner
-            v-if="chartVersionLoadsWithoutAuth"
-            color="warning"
-            :label="t('plugins.warnNoAuth')"
-          />
-          <Banner
-            v-if="!plugin?.certified"
-            color="warning"
-            :label="t('plugins.install.warnNotCertified')"
-          />
-        </div>
+          :label="t('plugins.warnNoAuth')"
+        />
+        <Banner
+          v-if="!plugin?.certified"
+          color="warning"
+          role="status"
+          :label="t('plugins.install.warnNotCertified')"
+        />
         <LabeledSelect
           v-if="showVersionSelector"
           v-model:value="version"

--- a/shell/dialog/InstallExtensionDialog.vue
+++ b/shell/dialog/InstallExtensionDialog.vue
@@ -327,18 +327,28 @@ export default {
         <p>
           {{ t(`plugins.${ buttonMode }.prompt`) }}
         </p>
-        <Banner
-          v-if="chartVersionLoadsWithoutAuth"
-          color="warning"
-          :label="t('plugins.warnNoAuth')"
+        <div
           role="status"
-        />
-        <Banner
-          v-if="!plugin?.certified"
-          color="warning"
-          :label="t('plugins.install.warnNotCertified')"
+          aria-atomic="true"
+          style="display: contents"
+        >
+          <Banner
+            v-if="chartVersionLoadsWithoutAuth"
+            color="warning"
+            :label="t('plugins.warnNoAuth')"
+          />
+        </div>
+        <div
           role="status"
-        />
+          aria-atomic="true"
+          style="display: contents"
+        >
+          <Banner
+            v-if="!plugin?.certified"
+            color="warning"
+            :label="t('plugins.install.warnNotCertified')"
+          />
+        </div>
         <LabeledSelect
           v-if="showVersionSelector"
           v-model:value="version"

--- a/shell/dialog/InstallExtensionDialog.vue
+++ b/shell/dialog/InstallExtensionDialog.vue
@@ -331,11 +331,13 @@ export default {
           v-if="chartVersionLoadsWithoutAuth"
           color="warning"
           :label="t('plugins.warnNoAuth')"
+          role="status"
         />
         <Banner
           v-if="!plugin?.certified"
           color="warning"
           :label="t('plugins.install.warnNotCertified')"
+          role="status"
         />
         <LabeledSelect
           v-if="showVersionSelector"

--- a/shell/dialog/InstallExtensionDialog.vue
+++ b/shell/dialog/InstallExtensionDialog.vue
@@ -337,12 +337,6 @@ export default {
             color="warning"
             :label="t('plugins.warnNoAuth')"
           />
-        </div>
-        <div
-          role="status"
-          aria-atomic="true"
-          style="display: contents"
-        >
           <Banner
             v-if="!plugin?.certified"
             color="warning"

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -377,10 +377,6 @@ export default {
         <h1 class="text-center login-welcome">
           {{ t(customizations.welcomeLabelKey, {vendor}) }}
         </h1>
-        <!-- `.login-messages` is always rendered and exists solely to hold these
-             messages, so it is the live region itself. An inner wrapper would
-             re-parent the banner and break `.login-messages .banner { max-width: 80% }`,
-             which resolves against the flex item. -->
         <div
           class="login-messages"
           data-testid="login__messages"

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -382,20 +382,25 @@ export default {
           data-testid="login__messages"
           :class="{'login-messages--hasContent': hasLoginMessage}"
         >
-          <Banner
-            v-if="errorToDisplay"
-            :label="errorToDisplay"
-            color="error"
+          <div
             role="alert"
-          />
+            aria-atomic="true"
+            style="display: contents"
+          >
+            <Banner
+              v-if="errorToDisplay"
+              :label="errorToDisplay"
+              color="error"
+            />
+          </div>
           <h4
-            v-else-if="loggedOut"
+            v-if="!errorToDisplay && loggedOut"
             class="text-success text-center"
           >
             {{ loggedOutSuccessMsg }}
           </h4>
           <h4
-            v-else-if="timedOut"
+            v-if="!errorToDisplay && !loggedOut && timedOut"
             class="text-error text-center"
           >
             {{ t('login.loginAgain') }}

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -377,30 +377,31 @@ export default {
         <h1 class="text-center login-welcome">
           {{ t(customizations.welcomeLabelKey, {vendor}) }}
         </h1>
+        <!-- `.login-messages` is always rendered and exists solely to hold these
+             messages, so it is the live region itself. An inner wrapper would
+             re-parent the banner and break `.login-messages .banner { max-width: 80% }`,
+             which resolves against the flex item. -->
         <div
           class="login-messages"
           data-testid="login__messages"
           :class="{'login-messages--hasContent': hasLoginMessage}"
+          role="alert"
+          aria-live="assertive"
+          aria-atomic="true"
         >
-          <div
-            role="alert"
-            aria-atomic="true"
-            style="display: contents"
-          >
-            <Banner
-              v-if="errorToDisplay"
-              :label="errorToDisplay"
-              color="error"
-            />
-          </div>
+          <Banner
+            v-if="errorToDisplay"
+            :label="errorToDisplay"
+            color="error"
+          />
           <h4
-            v-if="!errorToDisplay && loggedOut"
+            v-else-if="loggedOut"
             class="text-success text-center"
           >
             {{ loggedOutSuccessMsg }}
           </h4>
           <h4
-            v-if="!errorToDisplay && !loggedOut && timedOut"
+            v-else-if="timedOut"
             class="text-error text-center"
           >
             {{ t('login.loginAgain') }}

--- a/shell/pages/auth/login.vue
+++ b/shell/pages/auth/login.vue
@@ -386,6 +386,7 @@ export default {
             v-if="errorToDisplay"
             :label="errorToDisplay"
             color="error"
+            role="alert"
           />
           <h4
             v-else-if="loggedOut"

--- a/shell/pages/auth/setup.vue
+++ b/shell/pages/auth/setup.vue
@@ -404,21 +404,31 @@ export default {
                 />
               </p>
               <div class="mt-20">
-                <Banner
-                  v-if="showLocalhostWarning"
-                  color="warning"
-                  :label="t('validation.setting.serverUrl.localhost')"
-                  data-testid="setup-serverurl-localhost-warning"
+                <div
                   role="status"
-                />
-                <Banner
-                  v-for="(err, i) in fvGetPathErrors(['serverUrl'])"
-                  :key="i"
-                  color="error"
-                  :label="err"
-                  data-testid="setup-error-banner"
+                  aria-atomic="true"
+                  style="display: contents"
+                >
+                  <Banner
+                    v-if="showLocalhostWarning"
+                    color="warning"
+                    :label="t('validation.setting.serverUrl.localhost')"
+                    data-testid="setup-serverurl-localhost-warning"
+                  />
+                </div>
+                <div
                   role="alert"
-                />
+                  aria-live="assertive"
+                  style="display: contents"
+                >
+                  <Banner
+                    v-for="(err, i) in fvGetPathErrors(['serverUrl'])"
+                    :key="i"
+                    color="error"
+                    :label="err"
+                    data-testid="setup-error-banner"
+                  />
+                </div>
                 <LabeledInput
                   v-model:value="serverUrl"
                   :label="t('setup.serverUrl.label')"

--- a/shell/pages/auth/setup.vue
+++ b/shell/pages/auth/setup.vue
@@ -404,9 +404,6 @@ export default {
                 />
               </p>
               <div class="mt-20">
-                <!-- The live-region roles sit on the banners rather than on wrapper
-                     elements, so the layout is unchanged. Assistive tech announces them
-                     when they are inserted. -->
                 <Banner
                   v-if="showLocalhostWarning"
                   color="warning"

--- a/shell/pages/auth/setup.vue
+++ b/shell/pages/auth/setup.vue
@@ -409,6 +409,7 @@ export default {
                   color="warning"
                   :label="t('validation.setting.serverUrl.localhost')"
                   data-testid="setup-serverurl-localhost-warning"
+                  role="status"
                 />
                 <Banner
                   v-for="(err, i) in fvGetPathErrors(['serverUrl'])"
@@ -416,6 +417,7 @@ export default {
                   color="error"
                   :label="err"
                   data-testid="setup-error-banner"
+                  role="alert"
                 />
                 <LabeledInput
                   v-model:value="serverUrl"

--- a/shell/pages/auth/setup.vue
+++ b/shell/pages/auth/setup.vue
@@ -404,31 +404,24 @@ export default {
                 />
               </p>
               <div class="mt-20">
-                <div
+                <!-- The live-region roles sit on the banners rather than on wrapper
+                     elements, so the layout is unchanged. Assistive tech announces them
+                     when they are inserted. -->
+                <Banner
+                  v-if="showLocalhostWarning"
+                  color="warning"
                   role="status"
-                  aria-atomic="true"
-                  style="display: contents"
-                >
-                  <Banner
-                    v-if="showLocalhostWarning"
-                    color="warning"
-                    :label="t('validation.setting.serverUrl.localhost')"
-                    data-testid="setup-serverurl-localhost-warning"
-                  />
-                </div>
-                <div
+                  :label="t('validation.setting.serverUrl.localhost')"
+                  data-testid="setup-serverurl-localhost-warning"
+                />
+                <Banner
+                  v-for="(err, i) in fvGetPathErrors(['serverUrl'])"
+                  :key="i"
+                  color="error"
                   role="alert"
-                  aria-live="assertive"
-                  style="display: contents"
-                >
-                  <Banner
-                    v-for="(err, i) in fvGetPathErrors(['serverUrl'])"
-                    :key="i"
-                    color="error"
-                    :label="err"
-                    data-testid="setup-error-banner"
-                  />
-                </div>
+                  :label="err"
+                  data-testid="setup-error-banner"
+                />
                 <LabeledInput
                   v-model:value="serverUrl"
                   :label="t('setup.serverUrl.label')"

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -1117,8 +1117,6 @@ export default {
       />
     </div>
     <div v-else>
-      <!-- `role="status"` sits on the banner rather than on a wrapper element, so the
-           layout is unchanged. Assistive tech announces it when it is inserted. -->
       <Banner
         v-if="!loading && showAddReposBanner"
         color="warning"

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -1117,24 +1117,29 @@ export default {
       />
     </div>
     <div v-else>
-      <Banner
-        v-if="!loading && showAddReposBanner"
-        color="warning"
-        class="add-repos-banner mb-20"
-        data-testid="extensions-new-repos-banner"
+      <div
         role="status"
+        aria-atomic="true"
+        style="display: contents"
       >
-        <span>{{ t('plugins.addRepos.banner', {}, true) }}</span>
-        <button
-          class="ml-10 btn btn-sm role-primary"
-          data-testid="extensions-new-repos-banner-action-btn"
-          role="button"
-          :aria-label="t('plugins.addRepos.bannerBtn')"
-          @click="showAddExtensionReposDialog()"
+        <Banner
+          v-if="!loading && showAddReposBanner"
+          color="warning"
+          class="add-repos-banner mb-20"
+          data-testid="extensions-new-repos-banner"
         >
-          {{ t('plugins.addRepos.bannerBtn') }}
-        </button>
-      </Banner>
+          <span>{{ t('plugins.addRepos.banner', {}, true) }}</span>
+          <button
+            class="ml-10 btn btn-sm role-primary"
+            data-testid="extensions-new-repos-banner-action-btn"
+            role="button"
+            :aria-label="t('plugins.addRepos.bannerBtn')"
+            @click="showAddExtensionReposDialog()"
+          >
+            {{ t('plugins.addRepos.bannerBtn') }}
+          </button>
+        </Banner>
+      </div>
 
       <Tabbed
         v-if="!loading"

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -1117,29 +1117,26 @@ export default {
       />
     </div>
     <div v-else>
-      <div
+      <!-- `role="status"` sits on the banner rather than on a wrapper element, so the
+           layout is unchanged. Assistive tech announces it when it is inserted. -->
+      <Banner
+        v-if="!loading && showAddReposBanner"
+        color="warning"
         role="status"
-        aria-atomic="true"
-        style="display: contents"
+        class="add-repos-banner mb-20"
+        data-testid="extensions-new-repos-banner"
       >
-        <Banner
-          v-if="!loading && showAddReposBanner"
-          color="warning"
-          class="add-repos-banner mb-20"
-          data-testid="extensions-new-repos-banner"
+        <span>{{ t('plugins.addRepos.banner', {}, true) }}</span>
+        <button
+          class="ml-10 btn btn-sm role-primary"
+          data-testid="extensions-new-repos-banner-action-btn"
+          role="button"
+          :aria-label="t('plugins.addRepos.bannerBtn')"
+          @click="showAddExtensionReposDialog()"
         >
-          <span>{{ t('plugins.addRepos.banner', {}, true) }}</span>
-          <button
-            class="ml-10 btn btn-sm role-primary"
-            data-testid="extensions-new-repos-banner-action-btn"
-            role="button"
-            :aria-label="t('plugins.addRepos.bannerBtn')"
-            @click="showAddExtensionReposDialog()"
-          >
-            {{ t('plugins.addRepos.bannerBtn') }}
-          </button>
-        </Banner>
-      </div>
+          {{ t('plugins.addRepos.bannerBtn') }}
+        </button>
+      </Banner>
 
       <Tabbed
         v-if="!loading"

--- a/shell/pages/c/_cluster/uiplugins/index.vue
+++ b/shell/pages/c/_cluster/uiplugins/index.vue
@@ -1122,6 +1122,7 @@ export default {
         color="warning"
         class="add-repos-banner mb-20"
         data-testid="extensions-new-repos-banner"
+        role="status"
       >
         <span>{{ t('plugins.addRepos.banner', {}, true) }}</span>
         <button

--- a/storybook/src/stories/Components/Banner.mdx
+++ b/storybook/src/stories/Components/Banner.mdx
@@ -64,6 +64,25 @@ Danger banners should be used when the system has failed to perform an action, o
 
 <Canvas of={BannerStories.Error} />
 
+#### Live regions
+
+By default a Banner has no ARIA role and is not announced by assistive technology. Set the `role` prop when the banner is a *status message* — something that appears in response to what the user just did, rather than content that was on the page all along.
+
+- `role="alert"` for errors and anything needing immediate attention. Equivalent to `aria-live="assertive"`; it interrupts whatever the screen reader is currently saying.
+- `role="status"` for informational and warning messages. Equivalent to `aria-live="polite"`; it waits for a pause before announcing.
+- Omit the prop for decorative or purely visual banners, and for banners that are part of the page on load — announcing those is disruptive and adds nothing.
+
+<Canvas of={BannerStories.LiveRegionAlert} />
+<Canvas of={BannerStories.LiveRegionStatus} />
+
+#### Where to put the role
+
+Assistive technology announces a live region in two situations: when the region is inserted into the page, and when the contents of an already-present region change. Banners in the dashboard are nearly always behind a `v-if` or `v-for`, so the insertion case is the one that applies.
+
+Put the role on an element that **already exists** — either the Banner itself, or the container that already groups several banners (`#cru-errors` on create/edit forms, for example). Don't add a wrapper element just to hold the live region: these banners sit inside grid and flex layouts, so a new box becomes a grid cell or a flex item and shifts the surrounding layout.
+
+If a container that only ever holds banners is already rendered unconditionally — the login page's `.login-messages` is one — put the role on that container rather than on the individual banners. The region is then present before the message arrives, which is the more reliable of the two patterns.
+
 ### Accessibility
 
 Make sure that the information presented in an alert is important enough to justify taking away the user’s attention from what they are doing (ie. errors, warnings, validations, etc.).

--- a/storybook/src/stories/Components/Banner.stories.ts
+++ b/storybook/src/stories/Components/Banner.stories.ts
@@ -10,7 +10,7 @@ const meta: Meta<typeof Banner> = {
     role:     {
       control:     'select',
       options:     [null, 'alert', 'status'],
-      description: 'ARIA live-region role. Use "alert" for assertive error announcements and "status" for polite notifications. Omit when a wrapper element owns the live region.',
+      description: 'ARIA live-region role. Assistive technology announces the banner when it is inserted into the page. Use "alert" for errors (assertive) and "status" for informational messages (polite). Omit for decorative or purely visual banners.',
     },
   },
 };

--- a/storybook/src/stories/Components/Banner.stories.ts
+++ b/storybook/src/stories/Components/Banner.stories.ts
@@ -7,6 +7,11 @@ const meta: Meta<typeof Banner> = {
     label:    { control: 'text' },
     closable: { control: 'boolean' },
     color:    { control: 'text' },
+    role:     {
+      control:     'select',
+      options:     [null, 'alert', 'status'],
+      description: 'ARIA live-region role. Use "alert" for assertive error announcements and "status" for polite notifications. Omit when a wrapper element owns the live region.',
+    },
   },
 };
 
@@ -93,5 +98,23 @@ export const Error: Story = {
   args: {
     label: 'The connection has been lost. Check your connection and refresh this page.',
     color: 'error',
+  },
+};
+
+export const LiveRegionAlert: Story = {
+  ...Default,
+  args: {
+    label: 'An error has occurred. The resource could not be saved.',
+    color: 'error',
+    role:  'alert',
+  },
+};
+
+export const LiveRegionStatus: Story = {
+  ...Default,
+  args: {
+    label: 'Cluster is provisioning, this may take a few minutes.',
+    color: 'info',
+    role:  'status',
   },
 };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14441
Fixes #15884

<!-- Define findings related to the feature or bug issue. -->

The `Banner` component hardcoded `role="region"` on every instance. `region` is a **landmark** role — it carries no live-region semantics, so when Vue injects an error banner into the page, no accessibility event fires and screen reader users are never told an error occurred. This PR replaces that with the correct live-region roles at the places where a banner is genuinely a status message.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Removed the hardcoded `role="region"` and the associated `aria-labelledby` / `labelledbyId` / `generateRandomAlphaString` wiring from the `Banner` component
- Added an optional `role` prop to `Banner` (`'alert' | 'status'`, default `null`) so each usage declares its own live-region semantics — banners with no role render as plain styled containers, as before
- Applied `role="alert"` to error banners that appear dynamically: form validation and save errors (`CruResource`, `ResourceDetail`, `Wizard`, `form/Footer`, `form/Error`), login failures, setup server-URL validation, YAML import errors and generic prompt errors
- Applied `role="status"` to conditional informational and warning banners: resource state on the detail masthead, localhost server-URL warning, extension install warnings, missing extension repos, and the auth-provider banner
- **No DOM structure and no CSS was changed.** Every change in `shell/` is attribute-only — the diff for those 13 files is pure addition, zero deleted lines
- Added unit tests for the `Banner` `role` prop and for the `CruResource` error container, plus two Storybook stories (`LiveRegionAlert`, `LiveRegionStatus`)

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

`role="alert"` and `role="status"` are the two ARIA roles that make a container a live region — `alert` interrupts the screen reader immediately (for errors), `status` waits politely for a pause (for informational messages). Both are listed by the W3C as sufficient techniques for WCAG 2.1 SC 4.1.3 "Status Messages"; `region` is not, which is why the previous markup announced nothing.

The role is placed on an element that **already exists** in each case — either the `Banner` itself, or the container that already groups several banners (for example `#cru-errors`, which holds all the validation errors on a create/edit form). Nothing new is inserted into the DOM.

This matters because these banners live inside carefully tuned layouts: `#cru-errors` occupies a named grid row on forms with a table of contents and is a flex item everywhere else, and the login messages container sizes its banner with a percentage width. Adding even an invisible wrapper element around a banner re-parents it and changes how those rules resolve. Putting the attribute on the existing element gets the same announcement with no possibility of a visual regression.

A note on coverage: screen readers announce a `role="alert"` element when it is **inserted** into the page, which is exactly when these banners appear. Some AT/browser combinations are more reliable when the live region is already present and only its contents change; that pattern needs a permanently rendered container, which is not possible here without changing the layout. The insertion behaviour is well supported and is a clear improvement over the current state, where nothing is announced at all.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

Tested locally in **Chrome**. There are two things to check in each case: the banner is **announced without moving keyboard focus**, and the page **looks exactly as it does on master**.

Screen reader checks (NVDA + Firefox, JAWS + Chrome, VoiceOver + Safari):

- Create a Deployment with a duplicate name → error banner(s) announced immediately
- Edit any resource as YAML (e.g. a ConfigMap → ⋮ → Edit YAML), change `metadata.name`, save → the API rejects it and the save error is announced
- Log in with invalid credentials → login error announced
- Initial Rancher setup with a `localhost` server URL → localhost warning announced politely; an invalid server URL announces its validation errors immediately
- Import invalid YAML via the Import dialog → error announced
- Extensions page without the required Helm repos → add-repos warning announced politely
- Install Extension dialog for an uncertified or auth-less chart → warnings announced politely
- Open a cluster or workload in an error/transitioning state → masthead state banner announced politely

Visual regression checks (light **and** dark mode) — the areas where these banners sit in a grid or flex layout:

- Create/edit form with validation errors, **with and without** a table of contents in the left column (`.show-toc`) — banner width, alignment and page padding unchanged
- Login page with a long error message — the banner must not wrap early or shrink
- Service create form with a port error (`form/Error` renders inside a 6-column grid row)
- Wizard with a banner on a step
- Generic prompt, Import and Install Extension dialogs

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

- **Every** `Banner` in the product loses `role="region"`, including the many not otherwise touched here. Landmark navigation ("jump to region") will no longer stop on banners. This was incorrect usage of a landmark role, but it is a behaviour change for anyone who had learned to navigate that way.
- Banners not covered by this PR now render with no role at all. Neutral for sighted users, and no worse than before for AT users, but it does mean the roles are now opt-in per usage rather than global — new banners will need to declare a role if they are status messages.
- Layout risk is low by construction — no element was added, moved or removed, and no CSS was changed — but the create/edit form grid and the login page are the two places to look first if anything does shift.
- `aria-labelledby` was removed from the banner root. Banners are no longer named by their own content when reached by other means; the content is still read.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
