### PR TITLE
Update disable local auth message link, and add to additional place

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -504,7 +504,8 @@ authConfig:
   allowedPrincipalIds:
     title: Authorized Users & Groups
   associatedWarning: 'The {provider} account that is used to enable the external provider will be granted permissions equal to the currently logged in Rancher user. See <a href="{docsBase}/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/authentication-config#external-authentication-configuration-and-principal-users" target="_blank" rel="noopener noreferrer nofollow">External Authentication Configuration and Principal Users</a> to understand why.'
-  bannerEnableAuthProvider: "The \"Disable Local Authentication\" setting is enabled. Enabling an Authentication Provider will prevent users from logging in with local credentials. In the event of a Provider failure no user will be able to log in. Ensure you have continued API or CLI access to Rancher to disable the feature and regain access. Please see {vendor} documentation for more information."
+  bannerEnableAuthProvider: 'The "Disable Local Authentication" feature flag is enabled. Enabling an Authentication Provider will prevent users from logging in with local credentials. In the event of a Provider failure no user will be able to log in. Ensure you have continued API or CLI access to Rancher to disable the feature to regain access. Please see the <a href="{docsBase}/getting-started/installation-and-upgrade/installation-references/feature-flags" target="_blank" rel="noopener noreferrer nofollow">documentation</a> for more information.'
+  bannerEnabledAuthProvider: 'The "Disable Local Authentication" feature flag is also enabled. Users cannot log in with local credentials. In the event of a failure with this provider no user will be able to log in. Ensure you have continued API or CLI access to Rancher to disable the feature to regain access. Please see the <a href="{docsBase}/getting-started/installation-and-upgrade/installation-references/feature-flags" target="_blank" rel="noopener noreferrer nofollow">documentation</a> for more information.'
   githubapp:
     clientId:
       label: Client ID
@@ -9053,7 +9054,7 @@ advancedSettings:
 
 featureFlags:
   description:
-    'hide-local-auth-provider': Activating this feature and enabling an Authentication Provider will prevent users from logging in with local credentials. In the event of a Provider failure no user will be able to log in. Ensure you have continued API or CLI access to Rancher to disable the feature and regain access. Please see {vendor} documentation for more information.
+    'hide-local-auth-provider': Activating this feature and enabling an Authentication Provider will prevent users from logging in with local credentials. In the event of a Provider failure no user will be able to log in. Ensure you have continued API or CLI access to Rancher to disable the feature to regain access. Please see {vendor} documentation on Feature Flags for more information.
   label: Feature Flags
   title: "Are you sure?"
   warning: |-

--- a/shell/components/auth/AuthBanner.vue
+++ b/shell/components/auth/AuthBanner.vue
@@ -1,9 +1,15 @@
 
 <script>
 import { Banner } from '@components/Banner';
+import { HIDE_LOCAL_AUTH_PROVIDER } from '@shell/store/features';
+import { RcButton } from '@components/RcButton';
 
 export default {
-  components: { Banner },
+  components: { Banner, RcButton },
+
+  data() {
+    return { disableLocalAuth: this.$store.getters['features/get'](HIDE_LOCAL_AUTH_PROVIDER) };
+  },
 
   props: {
     tArgs: {
@@ -56,22 +62,30 @@ export default {
     >
       <div class="text">
         {{ t('authConfig.stateBanner.enabled', tArgs) }}
+        <br><br>
+        <span
+          v-if="disableLocalAuth"
+          v-clean-html="t('authConfig.bannerEnabledAuthProvider', {}, true)"
+        />
       </div>
+
       <slot name="actions" />
-      <button
-        type="button"
-        class="btn btn-sm role-primary"
+
+      <rc-button
+        size="medium"
+        class="banner-action"
         @click="edit"
       >
         {{ t('action.edit') }}
-      </button>
-      <button
-        type="button"
-        class="ml-10 btn-sm role-primary bg-error"
+      </rc-button>
+
+      <rc-button
+        size="medium"
+        class="banner-action"
         @click="showDisableModal"
       >
         {{ t('generic.disable') }}
-      </button>
+      </rc-button>
     </Banner>
 
     <table
@@ -91,9 +105,17 @@ export default {
 <style lang="scss" scoped>
 .banner {
   display: flex;
-    align-items: center;
+  align-items: center;
+
   .text {
     flex: 1;
+  }
+
+  // The Banner's content is a flex row that defaults to align-items: stretch, so
+  // the buttons stretch to match the tall text block. Keep them at their natural
+  // height instead.
+  .banner-action {
+    align-self: center;
   }
 }
 

--- a/shell/pages/c/_cluster/auth/config/index.vue
+++ b/shell/pages/c/_cluster/auth/config/index.vue
@@ -103,9 +103,10 @@ export default {
           {{ t('authConfig.manageLocal') }}
         </router-link>
         <br><br>
-        <template v-if="disableLocalAuth">
-          {{ t('authConfig.bannerEnableAuthProvider', null, true) }}
-        </template>
+        <span
+          v-if="disableLocalAuth"
+          v-clean-html="t('authConfig.bannerEnableAuthProvider', {}, true)"
+        />
         <template v-else>
           {{ t('authConfig.noneEnabled') }}
         </template>


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18144
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- update messages for disabling local auth to include link to docs
  - in the end this is just the feature flag page
- add message to one more place
  - the landing auth config page, no auth configured yet
- so message is shown in three places
  - ff enabled, no auth config enabled, auth config home page  (Users and Authentication --> Auth Provider)
  - ff enabled, configure auth config (Users and Authentication --> Auth Provider --> select a provider)
  - ff enabled, auth config enabled, auth config detail page  (Users and Authentication --> Auth Provider)
- note the description for the feature flag (Global Settings --> Feature flags --> `hide-local-auth-provider` remains unchanged (minus tweak)

Docs will be updated once https://github.com/rancher/rancher-product-docs/pull/1286 is deployed

### Technical notes summary
- The text is included in banners with three different levels (blue, yellow, green). I thought about fixing this but they represent different things at their different places in the flow 
  - if you do this - info
  - you're doing this - warning
  - you've done this - green

### Areas or cases that should be tested
- Exercise the three places with the feature flag on and confirm message is shown and link works

### Areas which could experience regressions
- Three places with feature flag off

### Screenshot/Video

<img width="1333" height="305" alt="image" src="https://github.com/user-attachments/assets/2dc37473-d25d-41b4-aedc-8bbf554a8d0d" />

<img width="1323" height="325" alt="image" src="https://github.com/user-attachments/assets/5cbcc764-f212-47e5-9d1b-0ab9bb1dcb67" />

<img width="1330" height="331" alt="image" src="https://github.com/user-attachments/assets/6a3379cb-a670-4b8b-8601-90aeb25869a6" />

<img width="1320" height="191" alt="image" src="https://github.com/user-attachments/assets/217ea390-5989-4216-8b2b-39960e2e4ae7" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
