### PR TITLE
add missing roles to `SelectIconGrid` component

### DIFF
--- a/shell/components/SelectIconGrid.vue
+++ b/shell/components/SelectIconGrid.vue
@@ -77,7 +77,12 @@ export default {
     componentTestid: {
       type:    String,
       default: 'select-icon-grid'
-    }
+    },
+
+    ariaLabel: {
+      type:    String,
+      default: null,
+    },
   },
 
   methods: {
@@ -102,15 +107,17 @@ export default {
 <template>
   <div
     v-if="rows.length"
+    role="group"
     class="grid"
+    :aria-label="ariaLabel || null"
   >
     <component
       :is="asLink ? 'a' : 'div'"
       v-for="(r, idx) in rows"
       :key="get(r, keyField)"
       v-clean-tooltip="get(r, tooltipField) || null"
-      :role="asLink ? 'link' : null"
-      :aria-disabled="asLink && get(r, disabledField) === true ? true : null"
+      :role="asLink ? null : 'button'"
+      :aria-disabled="get(r, disabledField) === true ? true : null"
       :aria-label="get(r, nameField)"
       :tabindex="get(r, disabledField) === true ? -1 : 0"
       :href="asLink ? get(r, linkField) : null"

--- a/shell/components/SelectIconGrid.vue
+++ b/shell/components/SelectIconGrid.vue
@@ -116,7 +116,7 @@ export default {
       v-for="(r, idx) in rows"
       :key="get(r, keyField)"
       v-clean-tooltip="get(r, tooltipField) || null"
-      :role="asLink ? null : 'button'"
+      :role="asLink ? null : 'link'"
       :aria-disabled="get(r, disabledField) === true ? true : null"
       :aria-label="get(r, nameField)"
       :tabindex="get(r, disabledField) === true ? -1 : 0"

--- a/shell/components/__tests__/SelectIconGrid.test.ts
+++ b/shell/components/__tests__/SelectIconGrid.test.ts
@@ -66,12 +66,12 @@ describe('component: SelectIconGrid', () => {
       });
     });
 
-    it('should have role="button" on each item when asLink is false', () => {
+    it('should have role="link" on each item when asLink is false', () => {
       const wrapper = shallowMount(SelectIconGrid, { props: { rows: mockRows } });
       const items = wrapper.findAll('.item');
 
       items.forEach((item) => {
-        expect(item.attributes('role')).toBe('button');
+        expect(item.attributes('role')).toBe('link');
       });
     });
 

--- a/shell/components/__tests__/SelectIconGrid.test.ts
+++ b/shell/components/__tests__/SelectIconGrid.test.ts
@@ -1,0 +1,250 @@
+import { shallowMount } from '@vue/test-utils';
+import SelectIconGrid from '@shell/components/SelectIconGrid.vue';
+
+const mockRows = [
+  {
+    key:         'option-a',
+    name:        'Option A',
+    description: 'First option',
+    icon:        '/icons/a.png',
+    disabled:    false,
+  },
+  {
+    key:         'option-b',
+    name:        'Option B',
+    description: 'Second option',
+    icon:        '/icons/b.png',
+    disabled:    false,
+  },
+  {
+    key:      'option-c',
+    name:     'Option C',
+    icon:     '/icons/c.png',
+    disabled: true,
+  },
+];
+
+describe('component: SelectIconGrid', () => {
+  describe('grid container', () => {
+    it('should have role="group" on the grid container', () => {
+      const wrapper = shallowMount(SelectIconGrid, { props: { rows: mockRows } });
+
+      expect(wrapper.find('.grid').attributes('role')).toBe('group');
+    });
+
+    it('should set aria-label on the grid container when ariaLabel prop is provided', () => {
+      const wrapper = shallowMount(SelectIconGrid, {
+        props: {
+          rows:      mockRows,
+          ariaLabel: 'Select a cluster type',
+        },
+      });
+
+      expect(wrapper.find('.grid').attributes('aria-label')).toBe('Select a cluster type');
+    });
+
+    it('should not set aria-label on the grid container when ariaLabel prop is not provided', () => {
+      const wrapper = shallowMount(SelectIconGrid, { props: { rows: mockRows } });
+
+      expect(wrapper.find('.grid').attributes('aria-label')).toBeUndefined();
+    });
+
+    it('should not render the grid when rows is empty', () => {
+      const wrapper = shallowMount(SelectIconGrid, { props: { rows: [] } });
+
+      expect(wrapper.find('.grid').exists()).toBe(false);
+    });
+  });
+
+  describe('item roles (asLink=false)', () => {
+    it('should render items as div elements', () => {
+      const wrapper = shallowMount(SelectIconGrid, { props: { rows: mockRows } });
+      const items = wrapper.findAll('.item');
+
+      items.forEach((item) => {
+        expect(item.element.tagName).toBe('DIV');
+      });
+    });
+
+    it('should have role="button" on each item when asLink is false', () => {
+      const wrapper = shallowMount(SelectIconGrid, { props: { rows: mockRows } });
+      const items = wrapper.findAll('.item');
+
+      items.forEach((item) => {
+        expect(item.attributes('role')).toBe('button');
+      });
+    });
+
+    it('should set aria-label on each item from the nameField', () => {
+      const wrapper = shallowMount(SelectIconGrid, { props: { rows: mockRows } });
+      const items = wrapper.findAll('.item');
+
+      expect(items[0].attributes('aria-label')).toBe('Option A');
+      expect(items[1].attributes('aria-label')).toBe('Option B');
+      expect(items[2].attributes('aria-label')).toBe('Option C');
+    });
+  });
+
+  describe('item roles (asLink=true)', () => {
+    const linkRows = [
+      {
+        _key:  'link-a',
+        label: 'Link A',
+        link:  'https://example.com/a',
+      },
+      {
+        _key:     'link-b',
+        label:    'Link B',
+        link:     'https://example.com/b',
+        disabled: true,
+      },
+    ];
+
+    it('should render items as anchor elements', () => {
+      const wrapper = shallowMount(SelectIconGrid, {
+        props: {
+          rows:      linkRows,
+          asLink:    true,
+          keyField:  '_key',
+          nameField: 'label',
+          linkField: 'link',
+        },
+      });
+      const items = wrapper.findAll('.item');
+
+      items.forEach((item) => {
+        expect(item.element.tagName).toBe('A');
+      });
+    });
+
+    it('should not set an explicit role on anchor items (relies on implicit role="link")', () => {
+      const wrapper = shallowMount(SelectIconGrid, {
+        props: {
+          rows:      linkRows,
+          asLink:    true,
+          keyField:  '_key',
+          nameField: 'label',
+          linkField: 'link',
+        },
+      });
+      const items = wrapper.findAll('.item');
+
+      items.forEach((item) => {
+        expect(item.attributes('role')).toBeUndefined();
+      });
+    });
+  });
+
+  describe('aria-disabled', () => {
+    it('should set aria-disabled="true" on a disabled item when asLink is false', () => {
+      const wrapper = shallowMount(SelectIconGrid, { props: { rows: mockRows } });
+      const disabledItem = wrapper.findAll('.item')[2];
+
+      expect(disabledItem.attributes('aria-disabled')).toBe('true');
+    });
+
+    it('should not set aria-disabled on an enabled item when asLink is false', () => {
+      const wrapper = shallowMount(SelectIconGrid, { props: { rows: mockRows } });
+      const enabledItem = wrapper.findAll('.item')[0];
+
+      expect(enabledItem.attributes('aria-disabled')).toBeUndefined();
+    });
+
+    it('should set aria-disabled="true" on a disabled item when asLink is true', () => {
+      const linkRows = [
+        {
+          _key:     'link-disabled',
+          label:    'Disabled Link',
+          link:     'https://example.com',
+          disabled: true,
+        },
+      ];
+
+      const wrapper = shallowMount(SelectIconGrid, {
+        props: {
+          rows:      linkRows,
+          asLink:    true,
+          keyField:  '_key',
+          nameField: 'label',
+          linkField: 'link',
+        },
+      });
+
+      expect(wrapper.find('.item').attributes('aria-disabled')).toBe('true');
+    });
+
+    it('should not set aria-disabled on an enabled item when asLink is true', () => {
+      const linkRows = [
+        {
+          _key:  'link-enabled',
+          label: 'Enabled Link',
+          link:  'https://example.com',
+        },
+      ];
+
+      const wrapper = shallowMount(SelectIconGrid, {
+        props: {
+          rows:      linkRows,
+          asLink:    true,
+          keyField:  '_key',
+          nameField: 'label',
+          linkField: 'link',
+        },
+      });
+
+      expect(wrapper.find('.item').attributes('aria-disabled')).toBeUndefined();
+    });
+  });
+
+  describe('interaction', () => {
+    it('should emit "clicked" when an enabled item is clicked', async() => {
+      const wrapper = shallowMount(SelectIconGrid, { props: { rows: mockRows } });
+
+      await wrapper.findAll('.item')[0].trigger('click');
+
+      expect(wrapper.emitted('clicked')).toHaveLength(1);
+      expect(wrapper.emitted('clicked')![0][0]).toStrictEqual(mockRows[0]);
+    });
+
+    it('should not emit "clicked" when a disabled item is clicked', async() => {
+      const wrapper = shallowMount(SelectIconGrid, { props: { rows: mockRows } });
+
+      await wrapper.findAll('.item')[2].trigger('click');
+
+      expect(wrapper.emitted('clicked')).toBeUndefined();
+    });
+
+    it('should emit "clicked" when Enter is pressed on an enabled item', async() => {
+      const wrapper = shallowMount(SelectIconGrid, { props: { rows: mockRows } });
+
+      await wrapper.findAll('.item')[1].trigger('keyup.enter');
+
+      expect(wrapper.emitted('clicked')).toHaveLength(1);
+      expect(wrapper.emitted('clicked')![0][0]).toStrictEqual(mockRows[1]);
+    });
+
+    it('should not emit "clicked" when Enter is pressed on a disabled item', async() => {
+      const wrapper = shallowMount(SelectIconGrid, { props: { rows: mockRows } });
+
+      await wrapper.findAll('.item')[2].trigger('keyup.enter');
+
+      expect(wrapper.emitted('clicked')).toBeUndefined();
+    });
+  });
+
+  describe('tabindex', () => {
+    it('should set tabindex="0" on enabled items', () => {
+      const wrapper = shallowMount(SelectIconGrid, { props: { rows: mockRows } });
+      const enabledItem = wrapper.findAll('.item')[0];
+
+      expect(enabledItem.attributes('tabindex')).toBe('0');
+    });
+
+    it('should set tabindex="-1" on disabled items', () => {
+      const wrapper = shallowMount(SelectIconGrid, { props: { rows: mockRows } });
+      const disabledItem = wrapper.findAll('.item')[2];
+
+      expect(disabledItem.attributes('tabindex')).toBe('-1');
+    });
+  });
+});

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -605,6 +605,7 @@ export default {
         </h4>
         <SelectIconGrid
           :rows="obj.types"
+          :aria-label="obj.label"
           key-field="id"
           name-field="label"
           side-label-field="tag"

--- a/shell/pages/c/_cluster/auth/config/index.vue
+++ b/shell/pages/c/_cluster/auth/config/index.vue
@@ -113,6 +113,7 @@ export default {
     </Banner>
     <SelectIconGrid
       :rows="rows"
+      :aria-label="displayName"
       :color-for="colorFor"
       name-field="provider"
       @clicked="(row) => goTo(row.id)"

--- a/shell/pages/c/_cluster/navlinks/_group.vue
+++ b/shell/pages/c/_cluster/navlinks/_group.vue
@@ -29,6 +29,7 @@ export default {
     <h1>{{ groupName }}</h1>
     <SelectIconGrid
       :rows="entries"
+      :aria-label="groupName"
       name-field="labelDisplay"
       description-field="spec.description"
       key-field="_key"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15881

### Occurred changes and/or fixed issues
- Add `role="group"` to the `SelectIconGrid` container so assistive technologies recognise it as a labelled group of controls
- Add `role="button"` to each card item when rendered as a `<div>` (i.e. when `asLink` is false) — previously these interactive elements had no ARIA role at all
- Remove the redundant explicit `role="link"` from `<a>` items, which already carry that role implicitly
- Fix `aria-disabled` so it is conveyed to assistive technologies on disabled items regardless of whether `asLink` is true or false
- Add `ariaLabel` prop to `SelectIconGrid` and wire it up at the three call sites (Cluster Management create, Auth Providers selection, Nav Links) so each grid is announced in context of its visible heading

### Technical notes summary
`SelectIconGrid` renders items as either `<a>` or `<div>` elements depending on the `asLink` prop. The `<div>` path was missing `role="button"` entirely, and `aria-disabled` was only applied when `asLink` was true. The container now carries `role="group"` — chosen over `role="list"` because `role="list"` mandates `role="listitem"` children, which would conflict with `role="button"`. Each call site passes the visible section heading text as `aria-label` on the grid.

### Areas or cases that should be tested
Use a screen reader (VoiceOver on macOS, NVDA on Windows) to verify announcements without moving focus:

- **Cluster Management → Create**: navigate to the cluster type selection screen. Tab through each provider group — the group name should be announced. Each card should be announced as a button with its label. Disabled cards should be skipped (tabindex=-1).
- **Authentication → Auth Providers**: open the provider selection screen. The grid should be contextually announced under the page heading. Each provider card should be announced as a button.
- **Nav Links group page**: navigate to a nav links group. Items render as anchor links and should be announced as links (not buttons). Disabled links should be announced as disabled.
- Test all three pages in both light and dark mode for visual regressions.
- Test with Admin, Standard User, and User Base roles.

### Areas which could experience regressions
- All three pages that use `SelectIconGrid`: Cluster Management create, Auth Providers selection, Nav Links group
- Cypress E2E tests that target `SelectIconGrid` items — selectors are `data-testid`-based so should be unaffected, but worth a quick smoke run

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
