### PR TITLE
add correct aria-labels to convey state in the hamburguer menu toggle button

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -212,7 +212,8 @@ nav:
     mainMenuIcon: Main menu icon
     mainMenuRancherLogo: Main menu Rancher logo
     userAvatar: User avatar image
-  expandCollapseAppBar: Expand/Collapse the Application Bar
+  expandAppBar: Expand the Application Bar
+  collapseAppBar: Collapse the Application Bar
   harvesterDashboard: Harvester Dashboard
   backToRancher: Cluster Manager
   tools: Tools

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -558,7 +558,7 @@ export default {
         <div class="title">
           <div
             data-testid="top-level-menu"
-            :aria-label="t('nav.expandCollapseAppBar')"
+            :aria-label="shown ? t('nav.collapseAppBar') : t('nav.expandAppBar')"
             role="button"
             tabindex="0"
             class="menu"

--- a/shell/components/nav/TopLevelMenu.vue
+++ b/shell/components/nav/TopLevelMenu.vue
@@ -559,6 +559,8 @@ export default {
           <div
             data-testid="top-level-menu"
             :aria-label="shown ? t('nav.collapseAppBar') : t('nav.expandAppBar')"
+            :aria-expanded="shown"
+            aria-controls="top-level-menu-body"
             role="button"
             tabindex="0"
             class="menu"
@@ -588,7 +590,10 @@ export default {
         </div>
 
         <!-- Menu body -->
-        <div class="body">
+        <div
+          id="top-level-menu-body"
+          class="body"
+        >
           <div>
             <!-- Home button -->
             <div @click="hide()">

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -878,45 +878,40 @@ describe('topLevelMenu', () => {
     });
 
     describe('toggle button aria-label', () => {
-      const mountWithI18n = (shownState = false) => {
-        const baseStore = generateStore([]);
-
+      const mountToggleButton = (shownState = false) => {
         return mount(TopLevelMenu, {
           data:   () => ({ shown: shownState }),
           global: {
             mocks: {
               $route: {},
-              $store: {
-                ...baseStore,
-                getters: { ...baseStore.getters, 'i18n/t': (key: string) => key },
-              },
+              $store: { ...generateStore([]) },
             },
             stubs: ['BrandImage', 'router-link'],
           },
         });
       };
 
-      it('should show "expandAppBar" key as aria-label when menu is collapsed', () => {
-        const wrapper = mountWithI18n(false);
+      it('should use "expandAppBar" translation key as aria-label when menu is collapsed', () => {
+        const wrapper = mountToggleButton(false);
 
-        expect(wrapper.find('[data-testid="top-level-menu"]').attributes('aria-label')).toStrictEqual('nav.expandAppBar');
+        expect(wrapper.find('[data-testid="top-level-menu"]').attributes('aria-label')).toStrictEqual('%nav.expandAppBar%');
       });
 
-      it('should show "collapseAppBar" key as aria-label when menu is expanded', () => {
-        const wrapper = mountWithI18n(true);
+      it('should use "collapseAppBar" translation key as aria-label when menu is expanded', () => {
+        const wrapper = mountToggleButton(true);
 
-        expect(wrapper.find('[data-testid="top-level-menu"]').attributes('aria-label')).toStrictEqual('nav.collapseAppBar');
+        expect(wrapper.find('[data-testid="top-level-menu"]').attributes('aria-label')).toStrictEqual('%nav.collapseAppBar%');
       });
 
       it('should update aria-label reactively when shown state changes', async() => {
-        const wrapper = mountWithI18n(false);
+        const wrapper = mountToggleButton(false);
         const button = wrapper.find('[data-testid="top-level-menu"]');
 
-        expect(button.attributes('aria-label')).toStrictEqual('nav.expandAppBar');
+        expect(button.attributes('aria-label')).toStrictEqual('%nav.expandAppBar%');
 
         await wrapper.setData({ shown: true });
 
-        expect(button.attributes('aria-label')).toStrictEqual('nav.collapseAppBar');
+        expect(button.attributes('aria-label')).toStrictEqual('%nav.collapseAppBar%');
       });
     });
 

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -877,7 +877,7 @@ describe('topLevelMenu', () => {
       });
     });
 
-    describe('toggle button aria-label', () => {
+    describe('toggle button a11y attributes', () => {
       const mountToggleButton = (shownState = false) => {
         return mount(TopLevelMenu, {
           data:   () => ({ shown: shownState }),
@@ -912,6 +912,32 @@ describe('topLevelMenu', () => {
         await wrapper.setData({ shown: true });
 
         expect(button.attributes('aria-label')).toStrictEqual('%nav.collapseAppBar%');
+      });
+
+      it('should expose aria-expanded false and point aria-controls at the menu body when collapsed', () => {
+        const wrapper = mountToggleButton(false);
+        const button = wrapper.find('[data-testid="top-level-menu"]');
+
+        expect(button.attributes('aria-expanded')).toStrictEqual('false');
+        expect(button.attributes('aria-controls')).toStrictEqual('top-level-menu-body');
+        expect(wrapper.find('#top-level-menu-body').exists()).toBe(true);
+      });
+
+      it('should expose aria-expanded true when the menu is expanded', () => {
+        const wrapper = mountToggleButton(true);
+
+        expect(wrapper.find('[data-testid="top-level-menu"]').attributes('aria-expanded')).toStrictEqual('true');
+      });
+
+      it('should update aria-expanded reactively when shown state changes', async() => {
+        const wrapper = mountToggleButton(false);
+        const button = wrapper.find('[data-testid="top-level-menu"]');
+
+        expect(button.attributes('aria-expanded')).toStrictEqual('false');
+
+        await wrapper.setData({ shown: true });
+
+        expect(button.attributes('aria-expanded')).toStrictEqual('true');
       });
     });
 

--- a/shell/components/nav/__tests__/TopLevelMenu.test.ts
+++ b/shell/components/nav/__tests__/TopLevelMenu.test.ts
@@ -877,6 +877,49 @@ describe('topLevelMenu', () => {
       });
     });
 
+    describe('toggle button aria-label', () => {
+      const mountWithI18n = (shownState = false) => {
+        const baseStore = generateStore([]);
+
+        return mount(TopLevelMenu, {
+          data:   () => ({ shown: shownState }),
+          global: {
+            mocks: {
+              $route: {},
+              $store: {
+                ...baseStore,
+                getters: { ...baseStore.getters, 'i18n/t': (key: string) => key },
+              },
+            },
+            stubs: ['BrandImage', 'router-link'],
+          },
+        });
+      };
+
+      it('should show "expandAppBar" key as aria-label when menu is collapsed', () => {
+        const wrapper = mountWithI18n(false);
+
+        expect(wrapper.find('[data-testid="top-level-menu"]').attributes('aria-label')).toStrictEqual('nav.expandAppBar');
+      });
+
+      it('should show "collapseAppBar" key as aria-label when menu is expanded', () => {
+        const wrapper = mountWithI18n(true);
+
+        expect(wrapper.find('[data-testid="top-level-menu"]').attributes('aria-label')).toStrictEqual('nav.collapseAppBar');
+      });
+
+      it('should update aria-label reactively when shown state changes', async() => {
+        const wrapper = mountWithI18n(false);
+        const button = wrapper.find('[data-testid="top-level-menu"]');
+
+        expect(button.attributes('aria-label')).toStrictEqual('nav.expandAppBar');
+
+        await wrapper.setData({ shown: true });
+
+        expect(button.attributes('aria-label')).toStrictEqual('nav.collapseAppBar');
+      });
+    });
+
     describe('clusterMenuClick', () => {
       it('should navigate normally on non-explorer c-cluster route even with routeCombo set', async() => {
         const mockPush = jest.fn();


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15882 
<!-- Define findings related to the feature or bug issue. -->
- add correct aria-labels to convey state in the hamburguer menu toggle button
- add unit tests

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- check if `aria-label` on the hamburguer menu toggle in the different states
- check screen reader on the hamburguer menu toggle in the different states

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
