### PR TITLE
Fix editing virtual clusters

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/subtype-detection.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/subtype-detection.test.ts
@@ -1,0 +1,392 @@
+import { resolveSubType } from '@shell/edit/provisioning.cattle.io.cluster/subtype-detection';
+import { SUB_TYPE } from '@shell/config/query-params';
+import { CAPI as CAPI_ANNOTATIONS } from '@shell/config/labels-annotations';
+
+describe('CruCluster: resolveSubType()', () => {
+  describe('annotation-based detection (ui.rancher/provider)', () => {
+    it('should use UI_CUSTOM_PROVIDER annotation when matching extension exists', () => {
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:          'some-cluster-id',
+          isImported:  true,
+          isLocal:     false,
+          isRke2:      false,
+          provisioner: 'K3S',
+          annotations: { [CAPI_ANNOTATIONS.UI_CUSTOM_PROVIDER]: 'k3k' },
+        },
+        extensions: [{ id: 'k3k' }],
+        realMode:   'edit',
+      });
+
+      expect(result).toStrictEqual('k3k');
+    });
+
+    it('should fall back to imported when annotation has no matching extension', () => {
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:          'some-cluster-id',
+          isImported:  true,
+          isLocal:     false,
+          isRke2:      false,
+          provisioner: 'K3S',
+          annotations: { [CAPI_ANNOTATIONS.UI_CUSTOM_PROVIDER]: 'k3k' },
+        },
+        extensions: [{ id: 'aks' }],
+        realMode:   'edit',
+      });
+
+      expect(result).toStrictEqual('imported');
+    });
+
+    it('should prioritize annotation over isImported', () => {
+      // This is the exact virtual cluster (k3k) scenario https://github.com/rancher/dashboard/issues/18544
+      // - isImported is true (k3k uses k3s, so status.provider = 'k3s', status.driver = 'k3s')
+      // - provisioner is 'K3S' (doesn't match extension ID 'k3k')
+      // - annotation 'ui.rancher/provider' = 'k3k' (matches extension)
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:          'fleet-default/my-vcluster',
+          isImported:  true,
+          isLocal:     false,
+          isRke2:      false,
+          provisioner: 'K3S',
+          annotations: { [CAPI_ANNOTATIONS.UI_CUSTOM_PROVIDER]: 'k3k' },
+        },
+        extensions: [
+          { id: 'k3k' },
+          { id: 'aks' },
+        ],
+        realMode: 'edit',
+      });
+
+      expect(result).toStrictEqual('k3k');
+    });
+
+    it('should use annotation even when cluster is not classified as imported', () => {
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:          'some-cluster-id',
+          isImported:  false,
+          isLocal:     false,
+          isRke2:      false,
+          provisioner: 'SomeDriver',
+          annotations: { [CAPI_ANNOTATIONS.UI_CUSTOM_PROVIDER]: 'k3k' },
+        },
+        extensions: [{ id: 'k3k' }],
+        realMode:   'edit',
+      });
+
+      expect(result).toStrictEqual('k3k');
+    });
+  });
+
+  describe('imported cluster handling', () => {
+    it('should use imported subType for generic imported clusters without annotation', () => {
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:          'some-cluster-id',
+          isImported:  true,
+          isLocal:     false,
+          isRke2:      false,
+          provisioner: 'imported',
+          annotations: {},
+        },
+        extensions: [],
+        realMode:   'edit',
+      });
+
+      expect(result).toStrictEqual('imported');
+    });
+
+    it('should override imported subType when provisioner matches an extension (GKE)', () => {
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:          'some-cluster-id',
+          isImported:  true,
+          isLocal:     false,
+          isRke2:      false,
+          provisioner: 'GKE',
+          annotations: {},
+        },
+        extensions: [{ id: 'gke' }],
+        realMode:   'edit',
+      });
+
+      expect(result).toStrictEqual('gke');
+    });
+
+    it('should remain imported when provisioner does not match any extension', () => {
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:          'some-cluster-id',
+          isImported:  true,
+          isLocal:     false,
+          isRke2:      false,
+          provisioner: 'K3S',
+          annotations: {},
+        },
+        extensions: [{ id: 'aks' }],
+        realMode:   'edit',
+      });
+
+      expect(result).toStrictEqual('imported');
+    });
+  });
+
+  describe('local cluster handling', () => {
+    it('should set local subType for local clusters', () => {
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:          'fleet-local/local',
+          isImported:  false,
+          isLocal:     true,
+          isRke2:      false,
+          provisioner: 'K3S',
+          annotations: {},
+        },
+        extensions: [],
+        realMode:   'edit',
+      });
+
+      expect(result).toStrictEqual('local');
+    });
+  });
+
+  describe('query parameter priority', () => {
+    it('should prefer SUB_TYPE query parameter over annotation', () => {
+      const result = resolveSubType({
+        query: { [SUB_TYPE]: 'custom' },
+        value: {
+          id:          'some-cluster-id',
+          isImported:  true,
+          isLocal:     false,
+          isRke2:      false,
+          provisioner: 'K3S',
+          annotations: { [CAPI_ANNOTATIONS.UI_CUSTOM_PROVIDER]: 'k3k' },
+        },
+        extensions: [{ id: 'k3k' }],
+        realMode:   'edit',
+      });
+
+      expect(result).toStrictEqual('custom');
+    });
+
+    it('should prefer SUB_TYPE query parameter over isImported', () => {
+      const result = resolveSubType({
+        query: { [SUB_TYPE]: 'amazonec2' },
+        value: {
+          id:          'some-cluster-id',
+          isImported:  true,
+          isLocal:     false,
+          isRke2:      false,
+          provisioner: 'imported',
+          annotations: {},
+        },
+        extensions: [],
+        realMode:   'edit',
+      });
+
+      expect(result).toStrictEqual('amazonec2');
+    });
+  });
+
+  describe('RKE2 cluster auto-detection', () => {
+    it('should detect custom RKE2 cluster in edit mode', () => {
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:          'some-cluster-id',
+          isImported:  false,
+          isLocal:     false,
+          isRke2:      true,
+          isCustom:    true,
+          provisioner: 'rke2',
+          annotations: {},
+        },
+        extensions: [],
+        realMode:   'edit',
+      });
+
+      expect(result).toStrictEqual('custom');
+    });
+
+    it('should detect custom RKE2 cluster in view mode when as=config', () => {
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:          'some-cluster-id',
+          isImported:  false,
+          isLocal:     false,
+          isRke2:      true,
+          isCustom:    true,
+          provisioner: 'rke2',
+          annotations: {},
+        },
+        extensions: [],
+        realMode:   'view',
+        as:         'config',
+      });
+
+      expect(result).toStrictEqual('custom');
+    });
+
+    it('should use machineProvider for RKE2 clusters with machine pools', () => {
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:              'some-cluster-id',
+          isImported:      false,
+          isLocal:         false,
+          isRke2:          true,
+          isCustom:        false,
+          provisioner:     'rke2',
+          machineProvider: 'amazonec2',
+          annotations:     {},
+        },
+        extensions: [],
+        realMode:   'edit',
+      });
+
+      expect(result).toStrictEqual('amazonec2');
+    });
+  });
+
+  describe('create mode (new cluster, no id)', () => {
+    it('should return null when no query param and cluster has no id', () => {
+      const result = resolveSubType({
+        query: {},
+        value: {
+          isImported:  false,
+          isLocal:     false,
+          isRke2:      false,
+          annotations: {},
+        },
+        extensions: [],
+        realMode:   'create',
+      });
+
+      expect(result).toStrictEqual(null);
+    });
+
+    it('should still respect query param even without cluster id', () => {
+      const result = resolveSubType({
+        query: { [SUB_TYPE]: 'amazonec2' },
+        value: {
+          isImported:  false,
+          isLocal:     false,
+          isRke2:      false,
+          annotations: {},
+        },
+        extensions: [],
+        realMode:   'create',
+      });
+
+      expect(result).toStrictEqual('amazonec2');
+    });
+  });
+
+  describe('edge cases with undefined/empty values', () => {
+    it('should handle undefined annotations gracefully', () => {
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:         'some-cluster-id',
+          isImported: true,
+          isLocal:    false,
+          isRke2:     false,
+        },
+        extensions: [{ id: 'k3k' }],
+        realMode:   'edit',
+      });
+
+      expect(result).toStrictEqual('imported');
+    });
+
+    it('should handle empty string annotation value', () => {
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:          'some-cluster-id',
+          isImported:  true,
+          isLocal:     false,
+          isRke2:      false,
+          annotations: { [CAPI_ANNOTATIONS.UI_CUSTOM_PROVIDER]: '' },
+        },
+        extensions: [{ id: '' }],
+        realMode:   'edit',
+      });
+
+      // Empty string is falsy, so annotation check is skipped
+      expect(result).toStrictEqual('imported');
+    });
+
+    it('should handle undefined provisioner for imported cluster', () => {
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:          'some-cluster-id',
+          isImported:  true,
+          isLocal:     false,
+          isRke2:      false,
+          provisioner: undefined,
+          annotations: {},
+        },
+        extensions: [{ id: 'aks' }],
+        realMode:   'edit',
+      });
+
+      // No provisioner means the provisioner-to-extension override is skipped
+      expect(result).toStrictEqual('imported');
+    });
+  });
+
+  describe('priority conflicts between annotation and provisioner', () => {
+    it('should use annotation over provisioner-to-extension match when both apply', () => {
+      // Cluster is imported, has annotation=k3k, AND provisioner=AKS with AKS extension loaded
+      // Annotation should win since it's checked first
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:          'some-cluster-id',
+          isImported:  true,
+          isLocal:     false,
+          isRke2:      false,
+          provisioner: 'AKS',
+          annotations: { [CAPI_ANNOTATIONS.UI_CUSTOM_PROVIDER]: 'k3k' },
+        },
+        extensions: [{ id: 'k3k' }, { id: 'aks' }],
+        realMode:   'edit',
+      });
+
+      expect(result).toStrictEqual('k3k');
+    });
+
+    it('should use provisioner-to-extension match when annotation is present but extension not loaded', () => {
+      // Annotation = k3k (no extension), provisioner = AKS (extension loaded)
+      const result = resolveSubType({
+        query: {},
+        value: {
+          id:          'some-cluster-id',
+          isImported:  true,
+          isLocal:     false,
+          isRke2:      false,
+          provisioner: 'AKS',
+          annotations: { [CAPI_ANNOTATIONS.UI_CUSTOM_PROVIDER]: 'k3k' },
+        },
+        extensions: [{ id: 'aks' }],
+        realMode:   'edit',
+      });
+
+      // Annotation doesn't match any extension → falls to imported → provisioner override kicks in
+      expect(result).toStrictEqual('aks');
+    });
+  });
+});

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -5,13 +5,13 @@ import { Banner } from '@components/Banner';
 import CruResource from '@shell/components/CruResource';
 import SelectIconGrid from '@shell/components/SelectIconGrid';
 import {
-  CHART, FROM_CLUSTER, SUB_TYPE, RKE_TYPE, _EDIT, _IMPORT, _CONFIG, _VIEW, _CREATE
+  CHART, FROM_CLUSTER, SUB_TYPE, RKE_TYPE, _EDIT, _IMPORT, _CREATE
 } from '@shell/config/query-params';
 import { mapGetters } from 'vuex';
 import { sortBy } from '@shell/utils/sort';
 import { PROVISIONER, _RKE2 } from '@shell/store/prefs';
 import { filterAndArrangeCharts } from '@shell/store/catalog';
-import { CATALOG, CAPI as CAPI_ANNOTATIONS } from '@shell/config/labels-annotations';
+import { CATALOG } from '@shell/config/labels-annotations';
 import { CAPI, MANAGEMENT, DEFAULT_WORKSPACE } from '@shell/config/types';
 import { mapFeature, RKE2 as RKE2_FEATURE } from '@shell/store/features';
 import { allHash } from '@shell/utils/promise';
@@ -20,6 +20,7 @@ import { ELEMENTAL_PRODUCT_NAME, ELEMENTAL_CLUSTER_PROVIDER } from '../../config
 import { KONTAINER_TO_DRIVER } from '@shell/models/management.cattle.io.kontainerdriver';
 import Rke2Config from './rke2';
 import { requireAsset } from '@shell/utils/require-asset';
+import { resolveSubType } from './subtype-detection';
 
 const SORT_GROUPS = {
   template:  1,
@@ -33,8 +34,6 @@ const SORT_GROUPS = {
 
 // uSed to proxy stylesheets for custom drivers that provide custom UI (RKE1)
 const PROXY_ENDPOINT = '/meta/proxy';
-const IMPORTED = 'imported';
-const LOCAL = 'local';
 
 export default {
   name: 'CruCluster',
@@ -154,58 +153,13 @@ export default {
 
     this.extensions = this.$extension.getProviders(context);
 
-    // At this point, we know we definitely have the mgmt cluster, so we can access `isImported` and `isLocal`
-    let subType = null;
-
-    subType = this.$route.query[SUB_TYPE] || null;
-    const subTypeFromAnnotation = this.value?.annotations?.[CAPI_ANNOTATIONS.UI_CUSTOM_PROVIDER];
-
-    if ( this.$route.query[SUB_TYPE]) {
-      subType = this.$route.query[SUB_TYPE];
-      // check the UI_CUSTOM_PROVIDER annotation - used to load custom provisioning forms when value.provisioner can't/shouldn't be overwritten
-    } else if (subTypeFromAnnotation && this.extensions.some((ext) => ext.id === subTypeFromAnnotation)) {
-      subType = subTypeFromAnnotation;
-    } else if (this.value.isImported) {
-      // Default imported clusters to the generic imported subType.
-      // Imported clusters (e.g. AKS, EKS, GKE) that have an extension-provided
-      // component will be overridden below to load the correct custom form.
-      subType = IMPORTED;
-    } else if (this.value.isLocal) {
-      subType = LOCAL;
-    }
-
-    // For imported clusters, check if the provisioner has a matching extension
-    // component and override the subType so the correct custom form loads instead of
-    // the generic imported configuration page.
-    if (subType === IMPORTED && this.value?.id && this.value.provisioner) {
-      const provisionerLower = this.value.provisioner.toLowerCase();
-      const hasExtension = this.extensions.some((ext) => ext.id === provisionerLower);
-
-      if (hasExtension) {
-        subType = provisionerLower;
-      }
-    }
-
-    // Auto-detect subType for existing clusters being edited
-    if ( !subType && this.value?.id ) {
-      if ( this.value.isRke2 ) {
-        // For custom RKE2 clusters
-        if ( this.value.isCustom && (this.realMode === _EDIT || (this.as === _CONFIG && this.realMode === _VIEW)) ) {
-          subType = 'custom';
-        } else if ( this.value.machineProvider ) {
-          // For RKE2/K3s clusters provisioned in Rancher, use the machine pool provisioner
-          subType = this.value.machineProvider;
-        }
-      } else if ( this.value.provisioner ) {
-        // For non-RKE2 clusters, try to match against extension-provided subtypes
-        const provisionerLower = this.value.provisioner.toLowerCase();
-
-        // This will be checked against available subtypes after they're computed
-        subType = provisionerLower;
-      }
-    }
-
-    this.subType = subType;
+    this.subType = resolveSubType({
+      query:      this.$route.query,
+      value:      this.value,
+      extensions: this.extensions,
+      realMode:   this.realMode,
+      as:         this.as,
+    });
   },
 
   data() {

--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -158,18 +158,23 @@ export default {
     let subType = null;
 
     subType = this.$route.query[SUB_TYPE] || null;
+    const subTypeFromAnnotation = this.value?.annotations?.[CAPI_ANNOTATIONS.UI_CUSTOM_PROVIDER];
+
     if ( this.$route.query[SUB_TYPE]) {
       subType = this.$route.query[SUB_TYPE];
+      // check the UI_CUSTOM_PROVIDER annotation - used to load custom provisioning forms when value.provisioner can't/shouldn't be overwritten
+    } else if (subTypeFromAnnotation && this.extensions.some((ext) => ext.id === subTypeFromAnnotation)) {
+      subType = subTypeFromAnnotation;
     } else if (this.value.isImported) {
       // Default imported clusters to the generic imported subType.
-      // Imported hosted clusters (e.g. AKS, EKS, GKE) that have an extension-provided
+      // Imported clusters (e.g. AKS, EKS, GKE) that have an extension-provided
       // component will be overridden below to load the correct custom form.
       subType = IMPORTED;
     } else if (this.value.isLocal) {
       subType = LOCAL;
     }
 
-    // For imported hosted clusters, check if the provisioner has a matching extension
+    // For imported clusters, check if the provisioner has a matching extension
     // component and override the subType so the correct custom form loads instead of
     // the generic imported configuration page.
     if (subType === IMPORTED && this.value?.id && this.value.provisioner) {
@@ -183,12 +188,7 @@ export default {
 
     // Auto-detect subType for existing clusters being edited
     if ( !subType && this.value?.id ) {
-      // Check for extension annotation first
-      const fromAnnotation = this.value.annotations?.[CAPI_ANNOTATIONS.UI_CUSTOM_PROVIDER];
-
-      if (fromAnnotation) {
-        subType = fromAnnotation;
-      } else if ( this.value.isRke2 ) {
+      if ( this.value.isRke2 ) {
         // For custom RKE2 clusters
         if ( this.value.isCustom && (this.realMode === _EDIT || (this.as === _CONFIG && this.realMode === _VIEW)) ) {
           subType = 'custom';

--- a/shell/edit/provisioning.cattle.io.cluster/subtype-detection.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/subtype-detection.ts
@@ -1,0 +1,84 @@
+import { CAPI as CAPI_ANNOTATIONS } from '@shell/config/labels-annotations';
+import { SUB_TYPE, _EDIT, _CONFIG, _VIEW } from '@shell/config/query-params';
+
+const IMPORTED = 'imported';
+const LOCAL = 'local';
+
+export interface SubTypeDetectionParams {
+  query: Record<string, string>;
+  value: {
+    id?: string;
+    isImported?: boolean;
+    isLocal?: boolean;
+    isRke2?: boolean;
+    isCustom?: boolean;
+    provisioner?: string;
+    machineProvider?: string;
+    annotations?: Record<string, string>;
+  };
+  extensions: Array<{ id: string }>;
+  realMode: string;
+  as?: string;
+}
+
+/**
+ * Resolves the subType for the cluster edit page.
+ *
+ * Priority order:
+ * 1. SUB_TYPE query parameter (explicit navigation)
+ * 2. UI_CUSTOM_PROVIDER annotation with a matching loaded extension
+ * 3. isImported → 'imported' (with provisioner-to-extension override for hosted providers)
+ * 4. isLocal → 'local'
+ * 5. Auto-detect from RKE2/provisioner for existing clusters
+ */
+export function resolveSubType({
+  query, value, extensions, realMode, as
+}: SubTypeDetectionParams): string | null {
+  let subType: string | null = query[SUB_TYPE] || null;
+  const subTypeFromAnnotation = value?.annotations?.[CAPI_ANNOTATIONS.UI_CUSTOM_PROVIDER];
+
+  if (query[SUB_TYPE]) {
+    subType = query[SUB_TYPE];
+  } else if (subTypeFromAnnotation && extensions.some((ext) => ext.id === subTypeFromAnnotation)) {
+    // Check the UI_CUSTOM_PROVIDER annotation - used to load custom provisioning
+    // forms when value.provisioner can't/shouldn't be overwritten
+    subType = subTypeFromAnnotation;
+  } else if (value.isImported) {
+    // Default imported clusters to the generic imported subType.
+    // Imported clusters (e.g. AKS, EKS, GKE) that have an extension-provided
+    // component will be overridden below to load the correct custom form.
+    subType = IMPORTED;
+  } else if (value.isLocal) {
+    subType = LOCAL;
+  }
+
+  // For imported clusters, check if the provisioner has a matching extension
+  // component and override the subType so the correct custom form loads instead of
+  // the generic imported configuration page.
+  if (subType === IMPORTED && value?.id && value.provisioner) {
+    const provisionerLower = value.provisioner.toLowerCase();
+    const hasExtension = extensions.some((ext) => ext.id === provisionerLower);
+
+    if (hasExtension) {
+      subType = provisionerLower;
+    }
+  }
+
+  // Auto-detect subType for existing clusters being edited
+  if (!subType && value?.id) {
+    if (value.isRke2) {
+      // For custom RKE2 clusters
+      if (value.isCustom && (realMode === _EDIT || (as === _CONFIG && realMode === _VIEW))) {
+        subType = 'custom';
+      } else if (value.machineProvider) {
+        // For RKE2/K3s clusters provisioned in Rancher, use the machine pool provisioner
+        subType = value.machineProvider;
+      }
+    } else if (value.provisioner) {
+      // For non-RKE2 clusters, try to match against extension-provided subtypes
+      subType = value.provisioner.toLowerCase();
+    }
+  }
+
+  return subType;
+}


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18544 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
#16966 removed the `emberLink` computed property from the provisioning cluster edit page. This computed prop contained logic that checked the `ui.rancher/provider` annotation on provisioning clusters and used that to load a matching extension provisioning form.

The detection logic was migrated into the fetch() method, but introduced a priority ordering bug. The `ui.rancher/provider` annotation check was placed inside a `if (!subType && ...)` block that is unreachable when `isImported` is true ( `subType` is set to `imported`).

This breaks virtual cluster editing because the provisioning cluster associated with each virtual cluster is technically a generic imported cluster. Unlike hosted or CAPI clusters, the provisioning cluster contains no reference to virtual clusters in its provisioner status field or in machine provider fields; the extension relies on this annotation applied by the UI in the cluster creation process.

I've tweaked the subType selection logic to give greater priority to the `ui.rancher/provider` annotation, so that imported clusters with this annotation attempt to load an extension-provided form matching the annotation, before falling back to the generic imported form.

### Technical notes summary
I suggest looking at this commit-by-commit to see what changed in the subType detection logic - the second commit moves this logic into a utility so it can be tested more easily.

The priority order is now:

- SUB_TYPE query parameter (explicit navigation)
- `ui.rancher/provider` annotation with a matching loaded extension
- isImported -> 'imported' 
- isLocal -> 'local'
- extension-based override for hosted providers like AKS/EKS/GKE where the cluster's provisioner matches the extension name 
- Auto-detect from RKE2/provisioner for existing clusters
- The annotation check validates that a matching extension is actually loaded before using the annotation value: if the extension is uninstalled, the cluster falls back to the normal imported path.

### Areas or cases that should be tested
You can borrow my environment if you'd like to see what I've tested these changes against; ping in slack for details.

If you want to use your own env for testing you'll need to do a little setup for virtual clusters. You can install the virtual cluster extension from the prime extension repo. You will need a 'host cluster' in which to provision your virtual cluster: an rke2/k3s cluster created in Rancher will work fine.

- create/edit/show configuration should be checked for the following categories:
  - provisioned hosted (aks, eks, or gke)
  - imported hosted
  - imported generic
  - provisioned rke2/k3s w/ node driver
  - provisioned rke2/k3s generic
  - local cluster (edit/view config only)
  - virtual clusters with extension installed (custom ui should load)

- When the virtual cluster extension is uninstalled, editing a virtual cluster should load the generic imported form.

### Areas which could experience regressions
described above

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
