### PR TITLE
Add dynamic `aria-label` to the side nav group toggle icon

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -205,6 +205,8 @@ nav:
     about: About page link
     pinCluster: Pin/Unpin {cluster} cluster
     collapseExpand: Collapse/Expand menu group
+    expand: "Expand {group} menu group"
+    collapse: "Collapse {group} menu group"
     productAboutPage: Product about page link
   alt:
     mainMenuIcon: Main menu icon

--- a/shell/components/nav/Group.vue
+++ b/shell/components/nav/Group.vue
@@ -312,7 +312,7 @@ export default {
         :class="{'icon-chevron-right': !isExpanded, 'icon-chevron-down': isExpanded}"
         role="button"
         tabindex="0"
-        :aria-label="t('nav.ariaLabel.collapseExpand')"
+        :aria-label="isExpanded ? t('nav.ariaLabel.collapse', { group: group.labelDisplay || group.label }) : t('nav.ariaLabel.expand', { group: group.labelDisplay || group.label })"
         :aria-expanded="isExpanded"
         :aria-controls="`group-${id}`"
         @click="peek($event, true)"

--- a/shell/components/nav/__tests__/Group.test.ts
+++ b/shell/components/nav/__tests__/Group.test.ts
@@ -280,4 +280,76 @@ describe('component: Group', () => {
       });
     });
   });
+
+  describe('toggle icon dynamic aria-label (issue #15883)', () => {
+    const group = {
+      name:     'workloads',
+      label:    'Workloads',
+      children: [{ route: { name: 'child-route', params: {} } }],
+    };
+
+    const tStub = (key: string, vals?: Record<string, string>) => (vals ? `${ key }:${ vals.group }` : key);
+
+    const mountGroupForIcon = (extraProps: Record<string, unknown> = {}) => shallowMount(Group as any, {
+      props: {
+        group,
+        canCollapse: true,
+        idPrefix:    '',
+        ...extraProps,
+      },
+      global: {
+        mocks: {
+          $route: {
+            params: {}, path: '/test', fullPath: '/test', matched: [],
+          },
+          $router: {
+            resolve:   jest.fn().mockReturnValue({ path: '/test', fullPath: '/test' }),
+            getRoutes: jest.fn().mockReturnValue([]),
+          },
+          t: tStub,
+        },
+      },
+    });
+
+    it('uses the collapse translation key when the group is expanded', async() => {
+      const wrapper = mountGroupForIcon();
+
+      (wrapper.vm as any).isExpanded = true;
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('.toggle-accordion').attributes('aria-label')).toBe('nav.ariaLabel.collapse:Workloads');
+    });
+
+    it('uses the expand translation key when the group is collapsed', async() => {
+      const wrapper = mountGroupForIcon();
+
+      (wrapper.vm as any).isExpanded = false;
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('.toggle-accordion').attributes('aria-label')).toBe('nav.ariaLabel.expand:Workloads');
+    });
+
+    it('prefers labelDisplay over label in the aria-label', async() => {
+      const groupWithDisplayLabel = { ...group, labelDisplay: 'Workloads Display' };
+      const wrapper = shallowMount(Group as any, {
+        props: {
+          group: groupWithDisplayLabel, canCollapse: true, idPrefix: '',
+        },
+        global: {
+          mocks: {
+            $route: {
+              params: {}, path: '/test', fullPath: '/test', matched: [],
+            },
+            $router: { resolve: jest.fn().mockReturnValue({ path: '/test', fullPath: '/test' }), getRoutes: jest.fn().mockReturnValue([]) },
+            t:       tStub,
+          },
+        },
+      });
+
+      (wrapper.vm as any).isExpanded = false;
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('.toggle-accordion').attributes('aria-label')).toBe('nav.ariaLabel.expand:Workloads Display');
+    });
+  });
 });


### PR DESCRIPTION
### Summary
Fixes #15883

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Add dynamic `aria-label` to the side nav group toggle icon, so screen readers announce the current state and the name of the group being toggled (e.g. "Expand Workloads menu group" / "Collapse Workloads menu group") instead of the previous static "Collapse/Expand menu group"
- Add `nav.ariaLabel.expand` and `nav.ariaLabel.collapse` translation keys with `{group}` interpolation to support the above
- Add unit tests covering the dynamic label behaviour (collapsed state, expanded state, and `labelDisplay` preference over `label`)

The two other bullet points from the issue were already addressed in earlier PRs and are listed here for traceability:
- `aria-expanded` on the header button — resolved in [#16410](https://github.com/rancher/dashboard/pull/16410)
- Nested-interactive a11y violations (related issue [#17260](https://github.com/rancher/dashboard/issues/17260)) — resolved in [#18480](https://github.com/rancher/dashboard/pull/18480)

### Technical notes summary
The side nav group toggle icon (`<i class="toggle-accordion">`) now uses two new i18n keys to produce a label that reflects both the action (expand vs. collapse) and the name of the group it controls. The `labelDisplay` field is preferred over `label` when available, consistent with how the rest of the Group component renders group names.

### Areas or cases that should be tested
- Open the side nav and use a screen reader (e.g. VoiceOver on Mac or NVDA on Windows)
- Verify that tabbing to the chevron icon on a collapsed group announces something like **"Expand Workloads menu group"** (or equivalent group name)
- Click/activate the chevron to expand the group and verify the announced label changes to **"Collapse Workloads menu group"**
- Repeat for nested groups (depth > 0)
- Verify groups with a `labelDisplay` value use that label in the announcement rather than `label`
- Browser used for local testing: Chrome — reviewer should test with Firefox or Safari

### Areas which could experience regressions
- Side nav group expand/collapse keyboard behaviour
- Screen reader announcements for any side nav group header or toggle icon

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
