### PR TITLE
Improve port-pr workflow

### DIFF
--- a/.github/workflows/port-pr.yaml
+++ b/.github/workflows/port-pr.yaml
@@ -36,14 +36,12 @@ jobs:
         run: |
           if gh api orgs/${GITHUB_REPOSITORY_OWNER}/members --paginate | jq -e --arg GITHUB_ACTOR "$GITHUB_ACTOR" '.[] | select(.login == $GITHUB_ACTOR)' > /dev/null; then
               echo "${GITHUB_ACTOR} is a member"
-              echo "is_member=true" >> $GITHUB_ENV
           else
               echo "${GITHUB_ACTOR} is not a member" >> $GITHUB_STEP_SUMMARY
-              echo "is_member=false" >> $GITHUB_ENV
+              exit 1
           fi
 
       - name: Check milestone
-        if: ${{ env.is_member == 'true' }}
         env:
           APP_TOKEN: ${{ steps.generate-token.outputs.token }}
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
@@ -55,31 +53,28 @@ jobs:
           MILESTONE=${BODY_MILESTONE//[^a-zA-Z0-9\-\.]/}
           if gh api repos/${GITHUB_REPOSITORY}/milestones --paginate | jq -e --arg MILESTONE "$MILESTONE" '.[] | select(.title == $MILESTONE)' > /dev/null; then
               echo "Milestone exists"
-              echo "milestone_exists=true" >> $GITHUB_ENV
               echo "milestone=${MILESTONE}" >> $GITHUB_ENV
            else
               echo "Milestone ${MILESTONE} does not exist" >> $GITHUB_STEP_SUMMARY
               gh issue comment -R ${GITHUB_REPOSITORY} ${ORIGINAL_ISSUE_NUMBER} --body "Not creating port issue, milestone ${MILESTONE} does not exist or is not an open milestone"
-              echo "milestone_exists=false" >> $GITHUB_ENV
+              exit 1
            fi
 
       - name: Checkout scripts
-        if: ${{ env.is_member == 'true' }} && ${{ env.milestone_exists == 'true' }}
         uses: actions/checkout@v6
         with:
           token: ${{ steps.generate-token.outputs.token }}
           sparse-checkout: .github/workflows/scripts
 
       - name: Get target branch and issue
-        if: ${{ env.is_member == 'true' }} && ${{ env.milestone_exists == 'true' }}
         env:
           APP_TOKEN: ${{ steps.generate-token.outputs.token }}
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           COMMENT_BODY: ${{ github.event.comment.body }}
+          ORIGINAL_ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: bash .github/workflows/scripts/port-pr-get-branch-and-issue.sh
 
       - name: Checkout
-        if: ${{ env.is_member == 'true' }} && ${{ env.milestone_exists == 'true' }} && ${{ env.target_branch_exists == 'true' }}
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: ${{ env.target_branch }}
@@ -87,7 +82,6 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Port PR
-        if: ${{ env.is_member == 'true' }} && ${{ env.milestone_exists == 'true' }} && ${{ env.target_branch_exists == 'true' }}
         env:
           APP_TOKEN: ${{ steps.generate-token.outputs.token }}
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/scripts/port-pr-get-branch-and-issue.sh
+++ b/.github/workflows/scripts/port-pr-get-branch-and-issue.sh
@@ -72,3 +72,11 @@ target_branch=${TARGET_BRANCH}
 issue_number=${ISSUE_NUMBER}
 target_branch_exists=${TARGET_BRANCH_EXISTS}
 EOF
+
+# Stop the workflow if the target branch does not exist
+if [ "$TARGET_BRANCH_EXISTS" != "true" ]; then
+  if [ -n "$ORIGINAL_ISSUE_NUMBER" ]; then
+    gh issue comment -R "${GITHUB_REPOSITORY}" "${ORIGINAL_ISSUE_NUMBER}" --body "Not creating port PR, target branch ${TARGET_BRANCH} does not exist"
+  fi
+  exit 1
+fi

--- a/.github/workflows/scripts/port-pr-get-branch-and-issue.sh
+++ b/.github/workflows/scripts/port-pr-get-branch-and-issue.sh
@@ -48,6 +48,9 @@ else # Fallback on branch given milestone in branches-metadata
     exit 1
   }
   TARGET_BRANCH=$(echo "$METADATA_JSON" | jq -r --arg milestone "$TARGET_MILESTONE" '.branches | to_entries[] | select(.value.milestone.version == $milestone) | .key')
+  if [ -z "$TARGET_BRANCH" ]; then
+    echo "No branch found for milestone ${TARGET_MILESTONE} in branches-metadata.json"
+  fi
 fi
 
 # Confirm target branch exists


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Tidy up port-pr workflow, add help output for when a branch cannot be determined from branches-metadata

### Occurred changes and/or fixed issues
- tidy port-pr workflow such that it exists early instead of requiring steps to bit skipped. this means we also get a failure result instead of a pass when something goes wrong
- improve the script that determines the branch. this will correctly fail if there's no matching entry in branches-metadata but it wasn't clear from workflow logs / comments
  - Example run - https://github.com/rancher/dashboard/actions/runs/30542562239/job/90870583832

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
