### PR TITLE
Fix branches-metadata.json entry for 2.15.0

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -39,6 +39,17 @@
           "namespace": "rancher",
           "name": "rancher",
           "tag": "v2.15-head"
+        },
+        "rancher-agent": {
+          "namespace": "rancher",
+          "name": "rancher-agent",
+          "tag": "v2.15-head"
+        },
+        "helm": {
+          "repo-url": "https://charts.optimus.rancher.io/server-charts/release-2.15"
+        },
+        "kube": {
+          "version": "v1.35.2+k3s1"
         }
       },
       "rancher-rancher-repo": {

--- a/scripts/e2e-k3s-start.sh
+++ b/scripts/e2e-k3s-start.sh
@@ -78,6 +78,16 @@ echo "OVERRIDE_UIS: ${OVERRIDE_UIS}"
 echo "TEST_BASE_URL: ${TEST_BASE_URL}"
 echo "--------------------------------------"
 
+if [ -z "${KUBE_VERSION}" ] || [ "${KUBE_VERSION}" = "null" ]; then
+  echo "Error: KUBE_VERSION is not set"
+  exit 1
+fi
+
+if [ -z "${RANCHER_HELM_REPO_URL}" ] || [ "${RANCHER_HELM_REPO_URL}" = "null" ]; then
+  echo "Error: RANCHER_HELM_REPO_URL is not set"
+  exit 1
+fi
+
 
 DASHBOARD_URL="${TEST_BASE_URL#https://}"
 RANCHER_NAMESPACE=cattle-system


### PR DESCRIPTION


<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
- Fix branches-metadata.json entry for 2.15.0
  - looks like a previous milestone was copied for the 2.15.0 entry which didn't contain the required new fields that were in the master entry https://github.com/rancher/dashboard/pull/18345/files
- also add better logging when installing rancher when required env vars are missing

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
