### PR TITLE
address issues with a11y around describe resource slidein panel

### DIFF
--- a/pkg/kubectl-explain/components/ExplainPanel.vue
+++ b/pkg/kubectl-explain/components/ExplainPanel.vue
@@ -141,7 +141,7 @@ export default {
             class="field-type field-expander"
             tabindex="0"
             role="button"
-            :aria-expanded="expanded[field.name]"
+            :aria-expanded="!!expanded[field.name]"
             @click="expand(field.name)"
             @keyup.enter.space="expand(field.name)"
           >

--- a/pkg/kubectl-explain/components/ExplainPanel.vue
+++ b/pkg/kubectl-explain/components/ExplainPanel.vue
@@ -165,7 +165,7 @@ export default {
             class="field-type field-expander"
             tabindex="0"
             role="button"
-            :aria-expanded="expanded[field.name]"
+            :aria-expanded="!!expanded[field.name]"
             @click="expand(field.name)"
             @keyup.enter.space="expand(field.name)"
           >

--- a/pkg/kubectl-explain/components/SlideInPanel.vue
+++ b/pkg/kubectl-explain/components/SlideInPanel.vue
@@ -3,6 +3,7 @@ import ExplainPanel from './ExplainPanel';
 import { KEY } from '@shell/utils/platform';
 import { expandOpenAPIDefinition, getOpenAPISchemaName, makeOpenAPIBreadcrumb } from '../open-api-utils.ts';
 import { useWatcherBasedSetupFocusTrapWithDestroyIncluded } from '@shell/composables/focusTrap';
+import { isExplainPanelOpen } from '../slide-in';
 
 const HEADER_HEIGHT = 55;
 
@@ -73,12 +74,14 @@ export default {
     open() {
       this.busy = true;
       this.isOpen = true;
+      isExplainPanelOpen.value = true;
       this.addCloseKeyHandler();
       this.right = '0';
     },
 
     close() {
       this.isOpen = false;
+      isExplainPanelOpen.value = false;
       this.removeCloseKeyHandler();
       this.right = `-${ this.width }`;
     },
@@ -210,6 +213,10 @@ export default {
       :class="{ 'slide-in-open': isOpen }"
       :style="{ width, right, top, height }"
       data-testid="slide-in-panel-resource-explain"
+      role="dialog"
+      aria-modal="true"
+      :aria-hidden="!isOpen"
+      :aria-label="t('kubectl-explain.title')"
     >
       <div
         ref="resizer"
@@ -268,14 +275,15 @@ export default {
             v-if="!busy && !noResource && definition"
             class="icon icon-sort mr-10"
             role="button"
-            :aria-label="t('kubectl-explain.expandAll')"
+            :aria-label="expandAll ? t('kubectl-explain.collapseAll') : t('kubectl-explain.expandAll')"
+            :aria-expanded="expandAll"
             tabindex="0"
             @click="toggleAll()"
             @keydown.space.enter.stop.prevent="toggleAll()"
           />
           <i
             role="button"
-            :aria-label="t('kubectl-explain.scrollToTop')"
+            :aria-label="t('kubectl-explain.close')"
             class="icon icon-close"
             data-testid="slide-in-panel-close-resource-explain"
             tabindex="0"

--- a/pkg/kubectl-explain/components/SlideInPanel.vue
+++ b/pkg/kubectl-explain/components/SlideInPanel.vue
@@ -54,6 +54,14 @@ export default {
 
   computed: {
 
+    // The panel stays mounted when closed (it's only moved off-screen), so without `inert` all of its
+    // links and buttons remain in the tab order and can be reached by tabbing past the end of the page.
+    // Returns `undefined` rather than `false` when open so that Vue drops the attribute entirely -
+    // `inert="false"` would still be inert, since `inert` is a boolean attribute.
+    isPanelInert() {
+      return this.isOpen ? undefined : true;
+    },
+
     top() {
       const banner = document.getElementById('banner-header');
       let height = HEADER_HEIGHT;
@@ -216,6 +224,7 @@ export default {
       role="dialog"
       aria-modal="true"
       :aria-hidden="!isOpen"
+      :inert="isPanelInert"
       :aria-label="t('kubectl-explain.title')"
     >
       <div

--- a/pkg/kubectl-explain/components/SlideInPanel.vue
+++ b/pkg/kubectl-explain/components/SlideInPanel.vue
@@ -61,6 +61,14 @@ export default {
       return this.breadcrumbs?.[this.breadcrumbs.length - 1]?.id || '';
     },
 
+    // The panel stays mounted when closed (it's only moved off-screen), so without `inert` all of its
+    // links and buttons remain in the tab order and can be reached by tabbing past the end of the page.
+    // Returns `undefined` rather than `false` when open so that Vue drops the attribute entirely -
+    // `inert="false"` would still be inert, since `inert` is a boolean attribute.
+    isPanelInert() {
+      return this.isOpen ? undefined : true;
+    },
+
     top() {
       const banner = document.getElementById('banner-header');
       let height = HEADER_HEIGHT;
@@ -222,6 +230,7 @@ export default {
       role="dialog"
       aria-modal="true"
       :aria-hidden="!isOpen"
+      :inert="isPanelInert"
       :aria-label="t('kubectl-explain.title')"
     >
       <div

--- a/pkg/kubectl-explain/components/SlideInPanel.vue
+++ b/pkg/kubectl-explain/components/SlideInPanel.vue
@@ -3,6 +3,7 @@ import ExplainPanel from './ExplainPanel';
 import { KEY } from '@shell/utils/platform';
 import { expandOpenAPIDefinition, getOpenAPISchemaName, makeOpenAPIBreadcrumb } from '../open-api-utils.ts';
 import { useWatcherBasedSetupFocusTrapWithDestroyIncluded } from '@shell/composables/focusTrap';
+import { isExplainPanelOpen } from '../slide-in';
 
 const HEADER_HEIGHT = 55;
 
@@ -80,12 +81,14 @@ export default {
     open() {
       this.busy = true;
       this.isOpen = true;
+      isExplainPanelOpen.value = true;
       this.addCloseKeyHandler();
       this.right = '0';
     },
 
     close() {
       this.isOpen = false;
+      isExplainPanelOpen.value = false;
       this.removeCloseKeyHandler();
       this.right = `-${ this.width }`;
     },
@@ -216,6 +219,10 @@ export default {
       :class="{ 'slide-in-open': isOpen }"
       :style="{ width, right, top, height }"
       data-testid="slide-in-panel-resource-explain"
+      role="dialog"
+      aria-modal="true"
+      :aria-hidden="!isOpen"
+      :aria-label="t('kubectl-explain.title')"
     >
       <div
         ref="resizer"
@@ -274,14 +281,15 @@ export default {
             v-if="!busy && !noResource && definition"
             class="icon icon-sort mr-10"
             role="button"
-            :aria-label="t('kubectl-explain.expandAll')"
+            :aria-label="expandAll ? t('kubectl-explain.collapseAll') : t('kubectl-explain.expandAll')"
+            :aria-expanded="expandAll"
             tabindex="0"
             @click="toggleAll()"
             @keydown.space.enter.stop.prevent="toggleAll()"
           />
           <i
             role="button"
-            :aria-label="t('kubectl-explain.scrollToTop')"
+            :aria-label="t('kubectl-explain.close')"
             class="icon icon-close"
             data-testid="slide-in-panel-close-resource-explain"
             tabindex="0"

--- a/pkg/kubectl-explain/components/__tests__/ExplainPanel.test.ts
+++ b/pkg/kubectl-explain/components/__tests__/ExplainPanel.test.ts
@@ -1,0 +1,73 @@
+import { shallowMount } from '@vue/test-utils';
+import ExplainPanel from '@pkg/kubectl-explain/components/ExplainPanel.vue';
+
+const globalMocks = {
+  mocks: { t: (key: string) => key },
+  stubs: { Markdown: { template: '<div />' } },
+};
+
+const definitionWithRef = {
+  description: 'A pod spec.',
+  properties:  {
+    containers: {
+      type:          'array',
+      $refName:      'io.k8s.api.core.v1.Container',
+      $refNameShort: 'Container',
+      $breadcrumbs:  [],
+      $$ref:         { properties: {} },
+    },
+  },
+};
+
+describe('component: ExplainPanel', () => {
+  describe('field expander — aria-expanded', () => {
+    it('has aria-expanded="false" before the field is expanded', () => {
+      const wrapper = shallowMount(ExplainPanel as any, {
+        props:  { definition: definitionWithRef, expandAll: false },
+        global: globalMocks,
+      });
+      const expander = wrapper.find('.field-expander');
+
+      expect(expander.attributes('aria-expanded')).toBe('false');
+    });
+
+    it('has aria-expanded="true" after the field is expanded via click', async() => {
+      const wrapper = shallowMount(ExplainPanel as any, {
+        props:  { definition: definitionWithRef, expandAll: false },
+        global: globalMocks,
+      });
+      const expander = wrapper.find('.field-expander');
+
+      await expander.trigger('click');
+
+      expect(expander.attributes('aria-expanded')).toBe('true');
+    });
+
+    it('has aria-expanded="true" when expandAll prop is true', async() => {
+      const wrapper = shallowMount(ExplainPanel as any, {
+        props:  { definition: definitionWithRef, expandAll: true },
+        global: globalMocks,
+      });
+
+      await wrapper.vm.$nextTick();
+
+      const expander = wrapper.find('.field-expander');
+
+      expect(expander.attributes('aria-expanded')).toBe('true');
+    });
+
+    it('has aria-expanded="false" when expandAll is toggled back to false', async() => {
+      const wrapper = shallowMount(ExplainPanel as any, {
+        props:  { definition: definitionWithRef, expandAll: true },
+        global: globalMocks,
+      });
+
+      await wrapper.vm.$nextTick();
+      await wrapper.setProps({ expandAll: false });
+
+      const expander = wrapper.find('.field-expander');
+
+      expect(expander.attributes('aria-expanded')).toBe('false');
+    });
+  });
+});

--- a/pkg/kubectl-explain/components/__tests__/SlideInPanel.test.ts
+++ b/pkg/kubectl-explain/components/__tests__/SlideInPanel.test.ts
@@ -6,9 +6,9 @@ jest.mock('@shell/composables/focusTrap', () => ({ useWatcherBasedSetupFocusTrap
 jest.mock('@pkg/kubectl-explain/slide-in', () => ({ isExplainPanelOpen: { value: false } }));
 
 jest.mock('@pkg/kubectl-explain/open-api-utils.ts', () => ({
-  expandOpenAPIDefinition:  jest.fn(),
-  getOpenAPISchemaName:     jest.fn(),
-  makeOpenAPIBreadcrumb:    jest.fn(),
+  expandOpenAPIDefinition: jest.fn(),
+  getOpenAPISchemaName:    jest.fn(),
+  makeOpenAPIBreadcrumb:   jest.fn(),
 }));
 
 const globalMocks = {
@@ -115,6 +115,48 @@ describe('component: SlideInPanel', () => {
       });
 
       expect(wrapper.find('.icon-sort').exists()).toBe(false);
+    });
+  });
+
+  // The panel is never unmounted - closing it only slides it off-screen - so it has to be marked
+  // `inert` while closed. Otherwise tabbing past the last element of the page moves focus into the
+  // off-screen panel, which is also flagged as `aria-hidden`, so nothing gets announced.
+  describe('keyboard focus containment', () => {
+    const FOCUSABLE = 'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+    it('holds focusable elements that need to be taken out of the tab order while closed', () => {
+      const wrapper = mountPanel({ isOpen: false });
+      const aside = wrapper.find('[data-testid="slide-in-panel-resource-explain"]');
+
+      expect(aside.element.querySelectorAll(FOCUSABLE).length).toBeGreaterThan(0);
+    });
+
+    it('is inert while closed', () => {
+      const wrapper = mountPanel({ isOpen: false });
+      const aside = wrapper.find('[data-testid="slide-in-panel-resource-explain"]');
+
+      expect(aside.attributes('inert')).toBeDefined();
+    });
+
+    it('is not inert while open', () => {
+      const wrapper = mountPanel({ isOpen: true });
+      const aside = wrapper.find('[data-testid="slide-in-panel-resource-explain"]');
+
+      expect(aside.attributes('inert')).toBeUndefined();
+    });
+
+    it('becomes inert again after being opened and then closed', async() => {
+      const wrapper = mountPanel();
+
+      (wrapper.vm as any).open();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="slide-in-panel-resource-explain"]').attributes('inert')).toBeUndefined();
+
+      (wrapper.vm as any).close();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find('[data-testid="slide-in-panel-resource-explain"]').attributes('inert')).toBeDefined();
     });
   });
 });

--- a/pkg/kubectl-explain/components/__tests__/SlideInPanel.test.ts
+++ b/pkg/kubectl-explain/components/__tests__/SlideInPanel.test.ts
@@ -1,0 +1,120 @@
+import { shallowMount } from '@vue/test-utils';
+import SlideInPanel from '@pkg/kubectl-explain/components/SlideInPanel.vue';
+
+jest.mock('@shell/composables/focusTrap', () => ({ useWatcherBasedSetupFocusTrapWithDestroyIncluded: jest.fn() }));
+
+jest.mock('@pkg/kubectl-explain/slide-in', () => ({ isExplainPanelOpen: { value: false } }));
+
+jest.mock('@pkg/kubectl-explain/open-api-utils.ts', () => ({
+  expandOpenAPIDefinition:  jest.fn(),
+  getOpenAPISchemaName:     jest.fn(),
+  makeOpenAPIBreadcrumb:    jest.fn(),
+}));
+
+const globalMocks = {
+  mocks: { t: (key: string) => key },
+  stubs: { ExplainPanel: { template: '<div />' } },
+};
+
+function mountPanel(dataOverrides: Record<string, unknown> = {}) {
+  return shallowMount(SlideInPanel as any, {
+    global: globalMocks,
+    data() {
+      return { ...dataOverrides };
+    },
+  });
+}
+
+describe('component: SlideInPanel', () => {
+  describe('aside — dialog semantics', () => {
+    it('has role="dialog"', () => {
+      const wrapper = mountPanel();
+      const aside = wrapper.find('[data-testid="slide-in-panel-resource-explain"]');
+
+      expect(aside.attributes('role')).toBe('dialog');
+    });
+
+    it('has aria-modal="true"', () => {
+      const wrapper = mountPanel();
+      const aside = wrapper.find('[data-testid="slide-in-panel-resource-explain"]');
+
+      expect(aside.attributes('aria-modal')).toBe('true');
+    });
+
+    it('has aria-hidden="true" when panel is closed', () => {
+      const wrapper = mountPanel({ isOpen: false });
+      const aside = wrapper.find('[data-testid="slide-in-panel-resource-explain"]');
+
+      expect(aside.attributes('aria-hidden')).toBe('true');
+    });
+
+    it('has aria-hidden="false" when panel is open', () => {
+      const wrapper = mountPanel({ isOpen: true });
+      const aside = wrapper.find('[data-testid="slide-in-panel-resource-explain"]');
+
+      expect(aside.attributes('aria-hidden')).toBe('false');
+    });
+
+    it('has aria-label from kubectl-explain.title key', () => {
+      const wrapper = mountPanel();
+      const aside = wrapper.find('[data-testid="slide-in-panel-resource-explain"]');
+
+      expect(aside.attributes('aria-label')).toBe('kubectl-explain.title');
+    });
+  });
+
+  describe('close button', () => {
+    it('has aria-label from kubectl-explain.close key', () => {
+      const wrapper = mountPanel();
+      const closeBtn = wrapper.find('[data-testid="slide-in-panel-close-resource-explain"]');
+
+      expect(closeBtn.attributes('aria-label')).toBe('kubectl-explain.close');
+    });
+  });
+
+  describe('expand/collapse all button', () => {
+    const withDefinition = {
+      busy:       false,
+      noResource: false,
+      definition: { properties: {} },
+    };
+
+    it('shows aria-expanded="false" when expandAll is false', () => {
+      const wrapper = mountPanel({ ...withDefinition, expandAll: false });
+      const toggleBtn = wrapper.find('.icon-sort');
+
+      expect(toggleBtn.attributes('aria-expanded')).toBe('false');
+    });
+
+    it('shows aria-expanded="true" when expandAll is true', () => {
+      const wrapper = mountPanel({ ...withDefinition, expandAll: true });
+      const toggleBtn = wrapper.find('.icon-sort');
+
+      expect(toggleBtn.attributes('aria-expanded')).toBe('true');
+    });
+
+    it('uses kubectl-explain.expandAll key when not yet expanded', () => {
+      const wrapper = mountPanel({ ...withDefinition, expandAll: false });
+      const toggleBtn = wrapper.find('.icon-sort');
+
+      expect(toggleBtn.attributes('aria-label')).toBe('kubectl-explain.expandAll');
+    });
+
+    it('uses kubectl-explain.collapseAll key when expanded', () => {
+      const wrapper = mountPanel({ ...withDefinition, expandAll: true });
+      const toggleBtn = wrapper.find('.icon-sort');
+
+      expect(toggleBtn.attributes('aria-label')).toBe('kubectl-explain.collapseAll');
+    });
+
+    it('is not rendered while loading', () => {
+      const wrapper = mountPanel({
+        busy:       true,
+        noResource: false,
+        definition: { properties: {} }
+      });
+
+      expect(wrapper.find('.icon-sort').exists()).toBe(false);
+    });
+  });
+});

--- a/pkg/kubectl-explain/index.ts
+++ b/pkg/kubectl-explain/index.ts
@@ -22,7 +22,7 @@ export default function(plugin: IPlugin, internal: IInternal): void {
       'logging'
     ]
   }, {
-    labelKey:    'kubectl-explain.title',
+    labelKey:    'kubectl-explain.action',
     tooltipKey:  'kubectl-explain.tooltip',
     svg:         require('./explain.svg'),
     ariaExpanded: () => isExplainPanelOpen.value,

--- a/pkg/kubectl-explain/index.ts
+++ b/pkg/kubectl-explain/index.ts
@@ -22,11 +22,11 @@ export default function(plugin: IPlugin, internal: IInternal): void {
       'logging'
     ]
   }, {
-    labelKey:    'kubectl-explain.action',
-    tooltipKey:  'kubectl-explain.tooltip',
-    svg:         require('./explain.svg'),
+    labelKey:     'kubectl-explain.action',
+    tooltipKey:   'kubectl-explain.tooltip',
+    svg:          require('./explain.svg'),
     ariaExpanded: () => isExplainPanelOpen.value,
-    invoke:      (opts, res, globals) => {
+    invoke:       (opts, res, globals) => {
       explain(store, globals.$route);
     }
   });

--- a/pkg/kubectl-explain/index.ts
+++ b/pkg/kubectl-explain/index.ts
@@ -1,6 +1,6 @@
 import { importTypes } from '@rancher/auto-import';
 import { ActionLocation, IPlugin, IInternal } from '@shell/core/types';
-import { explain } from './slide-in';
+import { explain, isExplainPanelOpen } from './slide-in';
 
 // Init the package
 export default function(plugin: IPlugin, internal: IInternal): void {
@@ -22,10 +22,11 @@ export default function(plugin: IPlugin, internal: IInternal): void {
       'logging'
     ]
   }, {
-    labelKey:   'kubectl-explain.action',
-    tooltipKey: 'kubectl-explain.tooltip',
-    svg:        require('./explain.svg'),
-    invoke:     (opts, res, globals) => {
+    labelKey:    'kubectl-explain.title',
+    tooltipKey:  'kubectl-explain.tooltip',
+    svg:         require('./explain.svg'),
+    ariaExpanded: () => isExplainPanelOpen.value,
+    invoke:      (opts, res, globals) => {
       explain(store, globals.$route);
     }
   });

--- a/pkg/kubectl-explain/l10n/en-us.yaml
+++ b/pkg/kubectl-explain/l10n/en-us.yaml
@@ -7,13 +7,15 @@ kubectl-explain:
   informationLoading: Information loading
   navigateToBreadcrumb: Navigate to breadcrumb {breadcrumb}
   scrollToTop: Scroll to top
-  action: "Explain ..."
+  close: Close Describe Resource
+  action: "Describe Resource"
   errors:
     load: Could not load the Open API data from the cluster
     notFound: Could not find OpenAPI definition for this resource
-  expandAll: Expand/Collapse All
+  expandAll: Expand all fields
+  collapseAll: Collapse all fields
   fields: Fields
   object: Object
   prompt: Select a Kubernetes resource to get the resource explanation
-  title: Kubernetes Explain
+  title: Describe Resource
   tooltip: Describe Resource

--- a/pkg/kubectl-explain/l10n/en-us.yaml
+++ b/pkg/kubectl-explain/l10n/en-us.yaml
@@ -8,7 +8,7 @@ kubectl-explain:
   navigateToBreadcrumb: Navigate to breadcrumb {breadcrumb}
   scrollToTop: Scroll to top
   close: Close Describe Resource
-  action: "Describe Resource"
+  action: Describe Resource
   errors:
     load: Could not load the Open API data from the cluster
     notFound: Could not find OpenAPI definition for this resource

--- a/pkg/kubectl-explain/slide-in.js
+++ b/pkg/kubectl-explain/slide-in.js
@@ -1,4 +1,4 @@
-import { createApp } from 'vue';
+import { createApp, ref } from 'vue';
 import cleanHtmlDirective from '@shell/directives/clean-html';
 import i18n from '@shell/plugins/i18n';
 
@@ -12,6 +12,9 @@ const openAPI = new OpenAPI();
 
 // Slide in panel component
 let slideInPanel;
+
+// Shared reactive ref so the header button can reflect open state
+export const isExplainPanelOpen = ref(false);
 
 /**
  * Show the slide-in panel with the resource explanation

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -285,7 +285,17 @@ export default {
     // This is to enforce the logo display on certain routes like home, about, prefs, account, etc
     isLogoRoute() {
       return !this.$route.name.includes('c-cluster');
-    }
+    },
+
+    extensionHeaderActionsAriaExpanded() {
+      return this.extensionHeaderActions.map((action) => {
+        if (typeof action.ariaExpanded === 'function') {
+          return action.ariaExpanded();
+        }
+
+        return action.ariaExpanded;
+      });
+    },
   },
 
   watch: {
@@ -725,6 +735,7 @@ export default {
           role="button"
           tabindex="0"
           :aria-label="action.labelKey ? t(action.labelKey) : action.label"
+          :aria-expanded="extensionHeaderActionsAriaExpanded[i]"
           @shortkey="handleExtensionAction(action, $event)"
           @click="handleExtensionAction(action, $event)"
         >

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -289,11 +289,9 @@ export default {
 
     extensionHeaderActionsAriaExpanded() {
       return this.extensionHeaderActions.map((action) => {
-        if (typeof action.ariaExpanded === 'function') {
-          return action.ariaExpanded();
-        }
+        const expanded = typeof action.ariaExpanded === 'function' ? action.ariaExpanded() : action.ariaExpanded;
 
-        return action.ariaExpanded;
+        return typeof expanded === 'boolean' ? expanded : undefined;
       });
     },
   },
@@ -735,7 +733,7 @@ export default {
           role="button"
           tabindex="0"
           :aria-label="action.labelKey ? t(action.labelKey) : action.label"
-          :aria-expanded="typeof extensionHeaderActionsAriaExpanded[i] === 'boolean' ? extensionHeaderActionsAriaExpanded[i] : undefined"
+          :aria-expanded="extensionHeaderActionsAriaExpanded[i]"
           @shortkey="handleExtensionAction(action, $event)"
           @click="handleExtensionAction(action, $event)"
         >

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -735,7 +735,7 @@ export default {
           role="button"
           tabindex="0"
           :aria-label="action.labelKey ? t(action.labelKey) : action.label"
-          :aria-expanded="extensionHeaderActionsAriaExpanded[i]"
+          :aria-expanded="typeof extensionHeaderActionsAriaExpanded[i] === 'boolean' ? extensionHeaderActionsAriaExpanded[i] : undefined"
           @shortkey="handleExtensionAction(action, $event)"
           @click="handleExtensionAction(action, $event)"
         >

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -703,7 +703,7 @@ export default {
           role="button"
           tabindex="0"
           :aria-label="action.labelKey ? t(action.labelKey) : action.label"
-          :aria-expanded="extensionHeaderActionsAriaExpanded[i]"
+          :aria-expanded="typeof extensionHeaderActionsAriaExpanded[i] === 'boolean' ? extensionHeaderActionsAriaExpanded[i] : undefined"
           @shortkey="handleExtensionAction(action, $event)"
           @click="handleExtensionAction(action, $event)"
         >

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -279,7 +279,17 @@ export default {
     // This is to enforce the logo display on certain routes like home, about, prefs, account, etc
     isLogoRoute() {
       return !this.$route.name.includes('c-cluster');
-    }
+    },
+
+    extensionHeaderActionsAriaExpanded() {
+      return this.extensionHeaderActions.map((action) => {
+        if (typeof action.ariaExpanded === 'function') {
+          return action.ariaExpanded();
+        }
+
+        return action.ariaExpanded;
+      });
+    },
   },
 
   watch: {
@@ -693,6 +703,7 @@ export default {
           role="button"
           tabindex="0"
           :aria-label="action.labelKey ? t(action.labelKey) : action.label"
+          :aria-expanded="extensionHeaderActionsAriaExpanded[i]"
           @shortkey="handleExtensionAction(action, $event)"
           @click="handleExtensionAction(action, $event)"
         >

--- a/shell/components/nav/Header.vue
+++ b/shell/components/nav/Header.vue
@@ -283,11 +283,9 @@ export default {
 
     extensionHeaderActionsAriaExpanded() {
       return this.extensionHeaderActions.map((action) => {
-        if (typeof action.ariaExpanded === 'function') {
-          return action.ariaExpanded();
-        }
+        const expanded = typeof action.ariaExpanded === 'function' ? action.ariaExpanded() : action.ariaExpanded;
 
-        return action.ariaExpanded;
+        return typeof expanded === 'boolean' ? expanded : undefined;
       });
     },
   },
@@ -703,7 +701,7 @@ export default {
           role="button"
           tabindex="0"
           :aria-label="action.labelKey ? t(action.labelKey) : action.label"
-          :aria-expanded="typeof extensionHeaderActionsAriaExpanded[i] === 'boolean' ? extensionHeaderActionsAriaExpanded[i] : undefined"
+          :aria-expanded="extensionHeaderActionsAriaExpanded[i]"
           @shortkey="handleExtensionAction(action, $event)"
           @click="handleExtensionAction(action, $event)"
         >

--- a/shell/components/nav/__tests__/Header.test.ts
+++ b/shell/components/nav/__tests__/Header.test.ts
@@ -289,5 +289,35 @@ describe('component: Header', () => {
 
       expect((wrapper.vm as any).extensionHeaderActionsAriaExpanded).toStrictEqual([true]);
     });
+
+    it('does not render aria-expanded attribute when value is undefined', async() => {
+      const wrapper = createWrapper();
+
+      (wrapper.vm as any).extensionHeaderActions = [{ label: 'Test', invoke: jest.fn() }];
+
+      await wrapper.vm.$nextTick();
+
+      const button = wrapper.find('[data-testid="extension-header-action-Test"]');
+
+      expect(button.attributes('aria-expanded')).toBeUndefined();
+    });
+
+    it('renders aria-expanded attribute when value is a boolean', async() => {
+      const wrapper = createWrapper();
+
+      (wrapper.vm as any).extensionHeaderActions = [
+        {
+          label:        'Open',
+          invoke:       jest.fn(),
+          ariaExpanded: true
+        },
+      ];
+
+      await wrapper.vm.$nextTick();
+
+      const button = wrapper.find('[data-testid="extension-header-action-Open"]');
+
+      expect(button.attributes('aria-expanded')).toBe('true');
+    });
   });
 });

--- a/shell/components/nav/__tests__/Header.test.ts
+++ b/shell/components/nav/__tests__/Header.test.ts
@@ -247,4 +247,47 @@ describe('component: Header', () => {
       expect((wrapper.vm as any).showFilter).toBe(true);
     });
   });
+
+  describe('extensionHeaderActionsAriaExpanded', () => {
+    it('returns undefined for an action with no ariaExpanded', () => {
+      const wrapper = createWrapper();
+
+      (wrapper.vm as any).extensionHeaderActions = [{ label: 'Test', invoke: jest.fn() }];
+
+      expect((wrapper.vm as any).extensionHeaderActionsAriaExpanded).toStrictEqual([undefined]);
+    });
+
+    it('returns the boolean value when ariaExpanded is a boolean', () => {
+      const wrapper = createWrapper();
+
+      (wrapper.vm as any).extensionHeaderActions = [
+        {
+          label:        'Open',
+          invoke:       jest.fn(),
+          ariaExpanded: true
+        },
+        {
+          label:        'Closed',
+          invoke:       jest.fn(),
+          ariaExpanded: false
+        },
+      ];
+
+      expect((wrapper.vm as any).extensionHeaderActionsAriaExpanded).toStrictEqual([true, false]);
+    });
+
+    it('calls ariaExpanded and returns its result when it is a function', () => {
+      const wrapper = createWrapper();
+
+      (wrapper.vm as any).extensionHeaderActions = [
+        {
+          label:        'Dynamic',
+          invoke:       jest.fn(),
+          ariaExpanded: () => true
+        },
+      ];
+
+      expect((wrapper.vm as any).extensionHeaderActionsAriaExpanded).toStrictEqual([true]);
+    });
+  });
 });

--- a/shell/components/nav/__tests__/Header.test.ts
+++ b/shell/components/nav/__tests__/Header.test.ts
@@ -310,5 +310,35 @@ describe('component: Header', () => {
 
       expect((wrapper.vm as any).extensionHeaderActionsAriaExpanded).toStrictEqual([true]);
     });
+
+    it('does not render aria-expanded attribute when value is undefined', async() => {
+      const wrapper = createWrapper();
+
+      (wrapper.vm as any).extensionHeaderActions = [{ label: 'Test', invoke: jest.fn() }];
+
+      await wrapper.vm.$nextTick();
+
+      const button = wrapper.find('[data-testid="extension-header-action-Test"]');
+
+      expect(button.attributes('aria-expanded')).toBeUndefined();
+    });
+
+    it('renders aria-expanded attribute when value is a boolean', async() => {
+      const wrapper = createWrapper();
+
+      (wrapper.vm as any).extensionHeaderActions = [
+        {
+          label:        'Open',
+          invoke:       jest.fn(),
+          ariaExpanded: true
+        },
+      ];
+
+      await wrapper.vm.$nextTick();
+
+      const button = wrapper.find('[data-testid="extension-header-action-Open"]');
+
+      expect(button.attributes('aria-expanded')).toBe('true');
+    });
   });
 });

--- a/shell/components/nav/__tests__/Header.test.ts
+++ b/shell/components/nav/__tests__/Header.test.ts
@@ -268,4 +268,47 @@ describe('component: Header', () => {
       expect((wrapper.vm as any).navHeaderRight).toBeNull();
     });
   });
+
+  describe('extensionHeaderActionsAriaExpanded', () => {
+    it('returns undefined for an action with no ariaExpanded', () => {
+      const wrapper = createWrapper();
+
+      (wrapper.vm as any).extensionHeaderActions = [{ label: 'Test', invoke: jest.fn() }];
+
+      expect((wrapper.vm as any).extensionHeaderActionsAriaExpanded).toStrictEqual([undefined]);
+    });
+
+    it('returns the boolean value when ariaExpanded is a boolean', () => {
+      const wrapper = createWrapper();
+
+      (wrapper.vm as any).extensionHeaderActions = [
+        {
+          label:        'Open',
+          invoke:       jest.fn(),
+          ariaExpanded: true
+        },
+        {
+          label:        'Closed',
+          invoke:       jest.fn(),
+          ariaExpanded: false
+        },
+      ];
+
+      expect((wrapper.vm as any).extensionHeaderActionsAriaExpanded).toStrictEqual([true, false]);
+    });
+
+    it('calls ariaExpanded and returns its result when it is a function', () => {
+      const wrapper = createWrapper();
+
+      (wrapper.vm as any).extensionHeaderActions = [
+        {
+          label:        'Dynamic',
+          invoke:       jest.fn(),
+          ariaExpanded: () => true
+        },
+      ];
+
+      expect((wrapper.vm as any).extensionHeaderActionsAriaExpanded).toStrictEqual([true]);
+    });
+  });
 });

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -134,6 +134,7 @@ export type Action = {
   icon?: string;
   multiple?: boolean;
   enabled?: Function | boolean;
+  ariaExpanded?: boolean | (() => boolean);
   invoke: (opts: ActionOpts, resources: any[], globals?: any) => void | boolean | Promise<boolean>;
 };
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #15877

<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
- Fixed close button `aria-label` on the Describe Resource panel — was incorrectly using the "Scroll to top" key
- Fixed expand/collapse all button — `aria-label` is now dynamic ("Expand all fields" / "Collapse all fields") and `aria-expanded` reflects the current state
- Fixed field-level expander in `ExplainPanel` — `aria-expanded` was emitting `undefined` before first interaction; it now always emits `false` or `true`
- Added dialog semantics to the slide-in `<aside>` element (`role="dialog"`, `aria-modal="true"`, `aria-hidden` bound to open state)
- Added `ariaExpanded` support to extension header actions — the Describe Resource header button now reflects whether the panel is open or closed via `aria-expanded`

### Technical notes summary
The `kubectl-explain` panel runs as a separate Vue app instance (mounted independently of the main Dashboard app). To bridge reactivity between the two apps, a shared `ref` (`isExplainPanelOpen`) is exported from `slide-in.js` — both apps share the same Vue runtime module, so changes from within the panel are picked up by the main app's `Header.vue` computed. A new optional `ariaExpanded` field was added to the `Action` type to support this pattern for any extension header action.

### Areas or cases that should be tested
- Open the Describe Resource panel from the header button and verify `aria-expanded="true"` is set on the button; verify it switches back to `aria-expanded="false"` on close
- Use a screen reader to confirm the panel is announced as a dialog when it opens
- Confirm the close button (`×`) is announced as "Close Describe Resource" (not "Scroll to top")
- Toggle the expand/collapse all button and confirm the `aria-label` switches between "Expand all fields" and "Collapse all fields", and `aria-expanded` reflects the state
- Expand a field type in the panel and confirm `aria-expanded` switches from `false` to `true`
- Test with both keyboard (Enter/Space) and mouse
- Browser used for local testing: Chrome — reviewer should test with a different browser (e.g. Firefox)

### Areas which could experience regressions
- `shell/components/nav/Header.vue` — extension header action buttons (any extension registering a header action via `plugin.addAction(ActionLocation.HEADER, ...)`)
- `shell/core/types.ts` — `Action` type (extensions that define header actions)
- `pkg/kubectl-explain` panel open/close behaviour

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`