### PR TITLE
Prevent removal of required OIDC scopes in auth config

### DIFF
--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -93,6 +93,10 @@ export default {
       type:    Boolean,
       default: false,
     },
+    disabledList: {
+      type: Array,
+      default: null
+    },
     required: {
       type:    Boolean,
       default: false
@@ -246,6 +250,12 @@ export default {
       }
 
       return !this.valueMultiline && this.protip;
+    },
+    // Return the index of the disabled rows based on the disabledList prop
+    // The value is not used directly because only the first instance of a value is disabled
+    // Usually they are at the top of the list and that is how this has been designed
+    disabledIndexList() {
+      return this.disabledList?.map((value) => this.rows.findIndex((row) => row.value === value));
     }
   },
   created() {
@@ -381,7 +391,7 @@ export default {
                   :data-testid="`${componentTestid}-textarea-${idx}`"
                   :placeholder="valuePlaceholder"
                   :mode="mode"
-                  :disabled="disabled"
+                  :disabled="disabled || disabledIndexList?.includes(idx)"
                   :aria-label="a11yLabel ? `${a11yLabel} ${t('generic.ariaLabel.genericRow', {index: idx+1})}` : undefined"
                   @paste="onPaste(idx, $event)"
                   @update:value="queueUpdate"
@@ -393,7 +403,7 @@ export default {
                   v-model:value="row.value"
                   :data-testid="`${componentTestid}-labeled-input-${idx}`"
                   :placeholder="valuePlaceholder"
-                  :disabled="isView || disabled"
+                  :disabled="isView || disabled || disabledIndexList?.includes(idx)"
                   :rules="rules"
                   :compact="false"
                   :aria-label="a11yLabel ? `${a11yLabel} ${t('generic.ariaLabel.genericRow', {index: idx+1})}` : undefined"
@@ -407,7 +417,7 @@ export default {
                   v-model="row.value"
                   :data-testid="`${componentTestid}-input-${idx}`"
                   :placeholder="valuePlaceholder"
-                  :disabled="isView || disabled"
+                  :disabled="isView || disabled || disabledIndexList?.includes(idx)"
                   :aria-label="a11yLabel ? `${a11yLabel} ${t('generic.ariaLabel.genericRow', {index: idx+1})}` : undefined"
                   @paste="onPaste(idx, $event)"
                   @blur="validate"
@@ -416,7 +426,7 @@ export default {
             </div>
           </slot>
           <div
-            v-if="showRemove && !isView"
+            v-if="showRemove && !isView && !disabledIndexList?.includes(idx)"
             class="remove"
           >
             <slot

--- a/shell/components/form/__tests__/ArrayList.test.ts
+++ b/shell/components/form/__tests__/ArrayList.test.ts
@@ -156,4 +156,111 @@ describe('the ArrayList', () => {
       expect(wrapper.emitted('update:value')?.[0][0]).toStrictEqual(expectation);
     });
   });
+
+  describe('disabledList', () => {
+    it('does not disable any row by default', () => {
+      const wrapper = mount(ArrayList, {
+        props: {
+          value: ['string 0', 'string 1'],
+          mode:  _EDIT,
+        },
+      });
+
+      expect(wrapper.vm.disabledIndexList).toBeUndefined();
+      expect((wrapper.find('[data-testid="array-list-input-0"]').element as HTMLInputElement).disabled).toBe(false);
+      expect((wrapper.find('[data-testid="array-list-input-1"]').element as HTMLInputElement).disabled).toBe(false);
+      expect(wrapper.find('[data-testid="array-list-remove-item-0"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="array-list-remove-item-1"]').exists()).toBe(true);
+    });
+
+    it('computes the row index for each value in disabledList', () => {
+      const wrapper = mount(ArrayList, {
+        props: {
+          value:        ['openid', 'profile', 'email', 'custom'],
+          mode:         _EDIT,
+          disabledList: ['email', 'openid'],
+        },
+      });
+
+      // Maps each disabled value to the index of its matching row, in disabledList order
+      expect(wrapper.vm.disabledIndexList).toStrictEqual([2, 0]);
+    });
+
+    it('disables the input of rows in disabledList and leaves the others editable', () => {
+      const wrapper = mount(ArrayList, {
+        props: {
+          value:        ['openid', 'profile', 'email', 'custom'],
+          mode:         _EDIT,
+          disabledList: ['openid', 'email'],
+        },
+      });
+
+      expect((wrapper.find('[data-testid="array-list-input-0"]').element as HTMLInputElement).disabled).toBe(true);
+      expect((wrapper.find('[data-testid="array-list-input-1"]').element as HTMLInputElement).disabled).toBe(false);
+      expect((wrapper.find('[data-testid="array-list-input-2"]').element as HTMLInputElement).disabled).toBe(true);
+      expect((wrapper.find('[data-testid="array-list-input-3"]').element as HTMLInputElement).disabled).toBe(false);
+    });
+
+    it('hides the remove button of rows in disabledList and keeps it for the others', () => {
+      const wrapper = mount(ArrayList, {
+        props: {
+          value:        ['openid', 'profile', 'email', 'custom'],
+          mode:         _EDIT,
+          disabledList: ['openid', 'email'],
+        },
+      });
+
+      expect(wrapper.find('[data-testid="array-list-remove-item-0"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="array-list-remove-item-1"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="array-list-remove-item-2"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="array-list-remove-item-3"]').exists()).toBe(true);
+    });
+
+    it('only disables the first occurrence when a disabled value is duplicated', () => {
+      const wrapper = mount(ArrayList, {
+        props: {
+          value:        ['openid', 'profile', 'openid'],
+          mode:         _EDIT,
+          disabledList: ['openid'],
+        },
+      });
+
+      expect(wrapper.vm.disabledIndexList).toStrictEqual([0]);
+      expect((wrapper.find('[data-testid="array-list-input-0"]').element as HTMLInputElement).disabled).toBe(true);
+      expect((wrapper.find('[data-testid="array-list-input-2"]').element as HTMLInputElement).disabled).toBe(false);
+      expect(wrapper.find('[data-testid="array-list-remove-item-0"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="array-list-remove-item-2"]').exists()).toBe(true);
+    });
+
+    it('disables nothing when a disabled value is not present in the rows', () => {
+      const wrapper = mount(ArrayList, {
+        props: {
+          value:        ['openid', 'profile'],
+          mode:         _EDIT,
+          disabledList: ['not-a-scope'],
+        },
+      });
+
+      // findIndex returns -1 for a missing value, which never matches a real row index
+      expect(wrapper.vm.disabledIndexList).toStrictEqual([-1]);
+      expect((wrapper.find('[data-testid="array-list-input-0"]').element as HTMLInputElement).disabled).toBe(false);
+      expect((wrapper.find('[data-testid="array-list-input-1"]').element as HTMLInputElement).disabled).toBe(false);
+      expect(wrapper.find('[data-testid="array-list-remove-item-0"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="array-list-remove-item-1"]').exists()).toBe(true);
+    });
+
+    it('returns an empty index list when disabledList is empty', () => {
+      const wrapper = mount(ArrayList, {
+        props: {
+          value:        ['openid', 'profile'],
+          mode:         _EDIT,
+          disabledList: [],
+        },
+      });
+
+      expect(wrapper.vm.disabledIndexList).toStrictEqual([]);
+      expect(wrapper.find('[data-testid="array-list-remove-item-0"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="array-list-remove-item-1"]').exists()).toBe(true);
+    });
+  });
 });

--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -4,6 +4,7 @@ import { mount, type VueWrapper, flushPromises } from '@vue/test-utils';
 import { _EDIT } from '@shell/config/query-params';
 
 import oidc from '@shell/edit/auth/oidc.vue';
+import ArrayList from '@shell/components/form/ArrayList';
 
 jest.mock('@shell/utils/clipboard', () => {
   return { copyTextToClipboard: jest.fn(() => Promise.resolve({})) };
@@ -319,67 +320,6 @@ describe('oidc.vue', () => {
       expect(emailClaim.exists()).toBe(false);
     });
 
-    describe('required scopes', () => {
-      it('computes requiredScopes from BASE_SCOPES for genericoidc', async() => {
-        await flushPromises();
-
-        expect(wrapper.vm.requiredScopes).toStrictEqual(['openid', 'profile', 'email']);
-      });
-
-      it('computes requiredScopes for keycloakoidc', async() => {
-        await wrapper.setData({ model: { ...mockModel, id: 'keycloakoidc' } });
-        await flushPromises();
-
-        expect(wrapper.vm.requiredScopes).toStrictEqual(['openid', 'profile', 'email']);
-      });
-
-      it('computes requiredScopes for cognito', async() => {
-        await wrapper.setData({ model: { ...mockModel, id: 'cognito' } });
-        await flushPromises();
-
-        expect(wrapper.vm.requiredScopes).toStrictEqual(['openid', 'email']);
-      });
-
-      it('returns empty requiredScopes for azuread', async() => {
-        await wrapper.setData({ model: { ...mockModel, id: 'azuread' } });
-        await flushPromises();
-
-        expect(wrapper.vm.requiredScopes).toStrictEqual([]);
-      });
-
-      it('disables Enable button when a required scope is removed', async() => {
-        wrapper.setData({ oidcScope: ['profile', 'email'] });
-        await wrapper.vm.validateAllFields();
-        await flushPromises();
-
-        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
-
-        expect(saveButton.disabled).toBe(true);
-      });
-
-      it('disables Enable button when all required scopes are removed', async() => {
-        wrapper.setData({ oidcScope: ['custom-scope'] });
-        await wrapper.vm.validateAllFields();
-        await flushPromises();
-
-        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
-
-        expect(saveButton.disabled).toBe(true);
-      });
-
-      it('enables Enable button when all required scopes are present', async() => {
-        wrapper.setData({
-          oidcUrls:  { url: validUrl, realm: validRealm },
-          oidcScope: ['openid', 'profile', 'email', 'custom-scope'],
-        });
-        await nextTick();
-
-        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
-
-        expect(saveButton.disabled).toBe(false);
-      });
-    });
-
     describe('clientAuthenticatedSearch checkbox', () => {
       it('is not rendered for genericoidc', async() => {
         const checkbox = wrapper.find('[data-testid="input-client-authenticated-group-search"]');
@@ -431,6 +371,26 @@ describe('oidc.vue', () => {
         });
 
         expect(wrapper.vm.model.clientAuthenticatedSearch).toBe(true);
+      });
+    });
+
+    describe('required scopes', () => {
+      it('passes the required scopes to the scope list so they cannot be removed', async() => {
+        await flushPromises();
+
+        const scopeList = wrapper.findComponent(ArrayList);
+
+        expect(scopeList.exists()).toBe(true);
+        expect(scopeList.props('disabledList')).toStrictEqual(['openid', 'profile', 'email']);
+      });
+
+      it('updates the protected scopes when the provider changes', async() => {
+        await wrapper.setData({ model: { ...mockModel, id: 'cognito' } });
+        await flushPromises();
+
+        const scopeList = wrapper.findComponent(ArrayList);
+
+        expect(scopeList.props('disabledList')).toStrictEqual(['openid', 'email']);
       });
     });
   });

--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -319,6 +319,67 @@ describe('oidc.vue', () => {
       expect(emailClaim.exists()).toBe(false);
     });
 
+    describe('required scopes', () => {
+      it('computes requiredScopes from BASE_SCOPES for genericoidc', async() => {
+        await flushPromises();
+
+        expect(wrapper.vm.requiredScopes).toStrictEqual(['openid', 'profile', 'email']);
+      });
+
+      it('computes requiredScopes for keycloakoidc', async() => {
+        await wrapper.setData({ model: { ...mockModel, id: 'keycloakoidc' } });
+        await flushPromises();
+
+        expect(wrapper.vm.requiredScopes).toStrictEqual(['openid', 'profile', 'email']);
+      });
+
+      it('computes requiredScopes for cognito', async() => {
+        await wrapper.setData({ model: { ...mockModel, id: 'cognito' } });
+        await flushPromises();
+
+        expect(wrapper.vm.requiredScopes).toStrictEqual(['openid', 'email']);
+      });
+
+      it('returns empty requiredScopes for azuread', async() => {
+        await wrapper.setData({ model: { ...mockModel, id: 'azuread' } });
+        await flushPromises();
+
+        expect(wrapper.vm.requiredScopes).toStrictEqual([]);
+      });
+
+      it('disables Enable button when a required scope is removed', async() => {
+        wrapper.setData({ oidcScope: ['profile', 'email'] });
+        await wrapper.vm.validateAllFields();
+        await flushPromises();
+
+        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+
+        expect(saveButton.disabled).toBe(true);
+      });
+
+      it('disables Enable button when all required scopes are removed', async() => {
+        wrapper.setData({ oidcScope: ['custom-scope'] });
+        await wrapper.vm.validateAllFields();
+        await flushPromises();
+
+        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+
+        expect(saveButton.disabled).toBe(true);
+      });
+
+      it('enables Enable button when all required scopes are present', async() => {
+        wrapper.setData({
+          oidcUrls:  { url: validUrl, realm: validRealm },
+          oidcScope: ['openid', 'profile', 'email', 'custom-scope'],
+        });
+        await nextTick();
+
+        const saveButton = wrapper.find('[data-testid="form-save"]').element as HTMLInputElement;
+
+        expect(saveButton.disabled).toBe(false);
+      });
+    });
+
     describe('clientAuthenticatedSearch checkbox', () => {
       it('is not rendered for genericoidc', async() => {
         const checkbox = wrapper.find('[data-testid="input-client-authenticated-group-search"]');

--- a/shell/edit/auth/__tests__/oidc.test.ts
+++ b/shell/edit/auth/__tests__/oidc.test.ts
@@ -4,7 +4,7 @@ import { mount, type VueWrapper, flushPromises } from '@vue/test-utils';
 import { _EDIT } from '@shell/config/query-params';
 
 import oidc from '@shell/edit/auth/oidc.vue';
-import ArrayList from '@shell/components/form/ArrayList';
+import ArrayList from '@shell/components/form/ArrayList.vue';
 
 jest.mock('@shell/utils/clipboard', () => {
   return { copyTextToClipboard: jest.fn(() => Promise.resolve({})) };

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -696,21 +696,9 @@ export default {
               :title="t('authConfig.oidc.scope.label')"
               :value-placeholder="t('authConfig.oidc.scope.placeholder')"
               :protip="t('authConfig.oidc.scope.protip', {}, true)"
+              :disabled-list="requiredScopes"
               @update:value="updateScope"
-            >
-              <template #remove-button="{ row, remove, i }">
-                <button
-                  v-if="!requiredScopes.includes(row.value)"
-                  type="button"
-                  class="btn role-link"
-                  :data-testid="`array-list-remove-item-${i}`"
-                  role="button"
-                  @click="remove"
-                >
-                  {{ t('generic.remove') }}
-                </button>
-              </template>
-            </ArrayList>
+            />
           </div>
         </div>
 

--- a/shell/edit/auth/oidc.vue
+++ b/shell/edit/auth/oidc.vue
@@ -131,6 +131,7 @@ export default {
       requiresCert,
       requiresAuthEndpoint,
       sloEndSessionEndpointUiEnabled,
+      requiredScopes,
     };
   },
 
@@ -696,7 +697,20 @@ export default {
               :value-placeholder="t('authConfig.oidc.scope.placeholder')"
               :protip="t('authConfig.oidc.scope.protip', {}, true)"
               @update:value="updateScope"
-            />
+            >
+              <template #remove-button="{ row, remove, i }">
+                <button
+                  v-if="!requiredScopes.includes(row.value)"
+                  type="button"
+                  class="btn role-link"
+                  :data-testid="`array-list-remove-item-${i}`"
+                  role="button"
+                  @click="remove"
+                >
+                  {{ t('generic.remove') }}
+                </button>
+              </template>
+            </ArrayList>
           </div>
         </div>
 


### PR DESCRIPTION
### Summary
Fixes #15707

### Occurred changes and/or fixed issues

The Generic OIDC auth config page allowed users to remove mandatory scopes (`openid`, `profile`, `email`) via a "Remove" link. After removal, the Enable button became disabled with no explanation, leaving users confused.

This change hides the Remove button for required scopes by using a custom `#remove-button` slot on the `ArrayList` component. The set of required scopes is derived per provider (e.g. `openid`, `profile`, `email` for Generic OIDC and Keycloak; `openid`, `email` for Cognito; none for Azure AD).

### Technical notes summary

- In [`oidc.vue`](https://github.com/rancher/dashboard/blob/c3125681b8ff3f273122730198460b6a2cc1e9b2/shell/edit/auth/oidc.vue#L703-L714), a `#remove-button` slot conditionally renders the Remove button only when the scope is not in `requiredScopes`.
- The `requiredScopes` computed property is derived from the existing `BASE_SCOPES` constant, which already defines the mandatory scopes per OIDC provider type.
- Unit tests added in [`oidc.test.ts`](https://github.com/rancher/dashboard/blob/c3125681b8ff3f273122730198460b6a2cc1e9b2/shell/edit/auth/__tests__/oidc.test.ts#L322-L385) verify: required scope computation per provider, Enable button disabled when required scopes are missing, and Enable button enabled when all required scopes are present.

### Areas or cases that should be tested

- Navigate to Users & Authentication > Auth Provider > Generic OIDC and confirm the three mandatory scopes (openid, profile, email) no longer show a Remove button.
- Confirm that custom/user-added scopes still have a Remove button and can be removed.
- Verify Enable button remains active when all required scopes are present.
- Test with other OIDC providers (Keycloak OIDC, Cognito) to confirm their required scopes are also protected.

### Areas which could experience regressions

- OIDC auth provider configuration (scope management).
- ArrayList component usage elsewhere if the slot interface changes (no changes were made to ArrayList itself).

### Screenshot/Video

**Before** (required scopes have Remove buttons, removing one silently disables Enable):
![before](https://github.com/marcelofukumoto/dashboard/releases/download/issue-15707-artifacts/before-fix.png)

**After** (required scopes no longer show Remove buttons):
![after](https://github.com/marcelofukumoto/dashboard/releases/download/issue-15707-artifacts/after-fix.png)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`