### PR TITLE
Remove redundant shims from `shell/types/rancher/index.d.ts`

### DIFF
--- a/scripts/type-check-baseline.txt
+++ b/scripts/type-check-baseline.txt
@@ -1,8 +1,6 @@
 # Auto-generated type-check baseline. Do not edit by hand.
 # Regenerate with: yarn type-check:baseline
-# Total errors: 2031
-pkg/aks/components/AksNodePool.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/aks/components/AksNodePool.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
+# Total errors: 1771
 pkg/aks/components/AksNodePool.vue: error TS2339: Property '$emit' does not exist on type '{ 'pool.enableAutoScaling'(neu: any): void; 'pool.vmSize'(neu: any): void; validAZ(neu: any): void; }'.
 pkg/aks/components/AksNodePool.vue: error TS2339: Property '$emit' does not exist on type '{ 'pool.enableAutoScaling'(neu: any): void; 'pool.vmSize'(neu: any): void; validAZ(neu: any): void; }'.
 pkg/aks/components/AksNodePool.vue: error TS2339: Property '$emit' does not exist on type '{ addTaint(): void; updateTaint(keyedTaint: any, idx: any): void; removeTaint(idx: number): void; availabilityZonesSupport(): any; poolCountValidator(): (val: number) => any; }'.
@@ -58,9 +56,6 @@ pkg/aks/components/AksNodePool.vue: error TS7023: 'get' implicitly has return ty
 pkg/aks/components/AksNodePool.vue: error TS7023: 'isView' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
 pkg/aks/components/AksNodePool.vue: error TS7024: Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
 pkg/aks/components/AksNodePool.vue: error TS7053: Element implicitly has an 'any' type because expression of type '"taints"' can't be used to index type '{ addTaint(): void; updateTaint(keyedTaint: any, idx: any): void; removeTaint(idx: number): void; availabilityZonesSupport(): any; poolCountValidator(): (val: number) => any; }'.
-pkg/aks/components/Config.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/aks/components/Config.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-pkg/aks/components/Config.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 pkg/aks/components/Config.vue: error TS2339: Property '$emit' does not exist on type '{ immediate: boolean; handler(neu: any): void; }'.
 pkg/aks/components/Config.vue: error TS2339: Property '$emit' does not exist on type '{ immediate: boolean; handler(neu: any): void; }'.
 pkg/aks/components/Config.vue: error TS2339: Property '$nextTick' does not exist on type '{ resetCredentialDependentProperties(): void; getAksVersions(): Promise<void>; getVmSizes(): Promise<void>; getVirtualNetworks(): Promise<void>; addPool(): void; removePool(idx: number): void; poolIsValid(pool: AKSNodePool): boolean; onNetworkingAuthModeChange(authMode: string): void; }'.
@@ -249,21 +244,12 @@ pkg/aks/components/Config.vue: error TS7053: Element implicitly has an 'any' typ
 pkg/aks/components/Config.vue: error TS7053: Element implicitly has an 'any' type because expression of type '"logAnalyticsWorkspaceName"' can't be used to index type '{ handler: DebouncedFunc<(neu: any) => void>; deep: boolean; }'.
 pkg/aks/components/Config.vue: error TS7053: Element implicitly has an 'any' type because expression of type '"networkPolicy"' can't be used to index type '{ handler: DebouncedFunc<(neu: any) => void>; deep: boolean; }'.
 pkg/aks/components/Config.vue: error TS7053: Element implicitly has an 'any' type because expression of type '"privateCluster"' can't be used to index type '{ handler: DebouncedFunc<(neu: any) => void>; deep: boolean; }'.
-pkg/aks/components/CruAks.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/aks/components/CruAks.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-pkg/aks/components/CruAks.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_IMPORT'.
-pkg/aks/components/CruAks.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 pkg/aks/components/CruAks.vue: error TS2339: Property 'pending' does not exist on type 'never'.
 pkg/aks/components/CruAks.vue: error TS2345: Argument of type 'VuexStore' is not assignable to parameter of type 'Store<any>'.
 pkg/aks/components/CruAks.vue: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 pkg/aks/components/CruAks.vue: error TS7006: Parameter 'opt' implicitly has an 'any' type.
 pkg/aks/components/CruAks.vue: error TS7006: Parameter 'val' implicitly has an 'any' type.
-pkg/aks/components/Import.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
 pkg/aks/components/Import.vue: error TS2345: Argument of type 'VuexStore' is not assignable to parameter of type 'Store<any>'.
-pkg/aks/components/Taint.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/aks/components/Taint.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-pkg/aks/components/__tests__/AksNodePool.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/aks/components/__tests__/AksNodePool.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 pkg/aks/components/__tests__/AksNodePool.test.ts: error TS2322: Type 'boolean' is not assignable to type 'never'.
 pkg/aks/components/__tests__/AksNodePool.test.ts: error TS2322: Type 'boolean' is not assignable to type 'never'.
 pkg/aks/components/__tests__/AksNodePool.test.ts: error TS2339: Property 'exists' does not exist on type 'Omit<WrapperLike, "exists">'.
@@ -284,8 +270,6 @@ pkg/aks/components/__tests__/AksNodePool.test.ts: error TS2339: Property 'props'
 pkg/aks/components/__tests__/AksNodePool.test.ts: error TS2339: Property 'props' does not exist on type 'Omit<WrapperLike, "exists">'.
 pkg/aks/components/__tests__/AksNodePool.test.ts: error TS2339: Property 'vm' does not exist on type 'Omit<WrapperLike, "exists">'.
 pkg/aks/components/__tests__/AksNodePool.test.ts: error TS2339: Property 'vm' does not exist on type 'Omit<WrapperLike, "exists">'.
-pkg/aks/components/__tests__/Config.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/aks/components/__tests__/Config.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 pkg/aks/components/__tests__/Config.test.ts: error TS2305: Module '"@vue/test-utils"' has no exported member 'Wrapper'.
 pkg/aks/components/__tests__/Config.test.ts: error TS2307: Cannot find module 'types' or its corresponding type declarations.
 pkg/aks/components/__tests__/Config.test.ts: error TS2339: Property 'filter' does not exist on type 'never'.
@@ -341,13 +325,11 @@ pkg/aks/components/__tests__/Config.test.ts: error TS2353: Object literal may on
 pkg/aks/components/__tests__/Config.test.ts: error TS7006: Parameter 'enabledOpts' implicitly has an 'any' type.
 pkg/aks/components/__tests__/Config.test.ts: error TS7006: Parameter 'opt' implicitly has an 'any' type.
 pkg/aks/components/__tests__/Config.test.ts: error TS7006: Parameter 'opt' implicitly has an 'any' type.
-pkg/aks/components/__tests__/CruAks.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
 pkg/aks/components/__tests__/CruAks.test.ts: error TS2305: Module '"@vue/test-utils"' has no exported member 'Wrapper'.
 pkg/aks/components/__tests__/CruAks.test.ts: error TS2339: Property 'exists' does not exist on type 'Omit<WrapperLike, "exists">'.
 pkg/aks/components/__tests__/CruAks.test.ts: error TS2339: Property 'props' does not exist on type 'Omit<WrapperLike, "exists">'.
 pkg/aks/components/__tests__/CruAks.test.ts: error TS7006: Parameter 'args' implicitly has an 'any' type.
 pkg/aks/components/__tests__/CruAks.test.ts: error TS7006: Parameter 'cmd' implicitly has an 'any' type.
-pkg/aks/components/__tests__/Taint.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 pkg/aks/util/__tests__/validators.test.ts: error TS2307: Cannot find module '@pkg/aks/util/validators' or its corresponding type declarations.
 pkg/aks/util/__tests__/validators.test.ts: error TS2307: Cannot find module 'types' or its corresponding type declarations.
 pkg/aks/util/__tests__/validators.test.ts: error TS7006: Parameter 'ctx' implicitly has an 'any' type.
@@ -358,32 +340,18 @@ pkg/aks/util/validators.ts: error TS1530: Unicode property value expressions are
 pkg/aks/util/validators.ts: error TS1530: Unicode property value expressions are only available when the Unicode (u) flag or the Unicode Sets (v) flag is set.
 pkg/aks/util/validators.ts: error TS1530: Unicode property value expressions are only available when the Unicode (u) flag or the Unicode Sets (v) flag is set.
 pkg/aks/util/validators.ts: error TS1530: Unicode property value expressions are only available when the Unicode (u) flag or the Unicode Sets (v) flag is set.
-pkg/eks/components/AccountAccess.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/eks/components/AccountAccess.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-pkg/eks/components/Config.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/eks/components/Config.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-pkg/eks/components/Config.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 pkg/eks/components/Config.vue: error TS2345: Argument of type 'SemVer | null' is not assignable to parameter of type 'string | SemVer'.
 pkg/eks/components/Config.vue: error TS2345: Argument of type 'SemVer | null' is not assignable to parameter of type 'string | SemVer'.
 pkg/eks/components/Config.vue: error TS2345: Argument of type 'SemVer | null' is not assignable to parameter of type 'string | SemVer'.
 pkg/eks/components/Config.vue: error TS2345: Argument of type 'SemVer | null' is not assignable to parameter of type 'string | SemVer'.
 pkg/eks/components/Config.vue: error TS2345: Argument of type 'SemVer | null' is not assignable to parameter of type 'string | SemVer'.
-pkg/eks/components/CruEKS.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/eks/components/CruEKS.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-pkg/eks/components/CruEKS.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 pkg/eks/components/CruEKS.vue: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 pkg/eks/components/CruEKS.vue: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 pkg/eks/components/CruEKS.vue: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 pkg/eks/components/CruEKS.vue: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
-pkg/eks/components/Logging.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-pkg/eks/components/Networking.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/eks/components/Networking.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-pkg/eks/components/Networking.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 pkg/eks/components/Networking.vue: error TS2740: Type 'VuexStore' is missing the following properties from type 'Store<any>': state, install, replaceState, subscribe, and 6 more.
 pkg/eks/components/Networking.vue: error TS2740: Type 'VuexStore' is missing the following properties from type 'Store<any>': state, install, replaceState, subscribe, and 6 more.
 pkg/eks/components/NodeGroup.vue: error TS18046: 'opt' is of type 'unknown'.
-pkg/eks/components/NodeGroup.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-pkg/eks/components/NodeGroup.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 pkg/eks/components/NodeGroup.vue: error TS2339: Property 'label' does not exist on type '{}'.
 pkg/eks/components/NodeGroup.vue: error TS2339: Property 'supportedArchitectures' does not exist on type 'never'.
 pkg/eks/components/NodeGroup.vue: error TS2339: Property 'supportedArchitectures' does not exist on type '{}'.
@@ -396,7 +364,6 @@ pkg/eks/components/NodeGroup.vue: error TS2345: Argument of type '`update:${stri
 pkg/eks/components/NodeGroup.vue: error TS2345: Argument of type '`update:${string}`' is not assignable to parameter of type '"error" | "update:instanceType" | "update:spotInstanceTypes" | "update:ec2SshKey" | "update:launchTemplate" | "update:nodeRole" | "update:version" | "update:poolIsUpgrading" | ... 12 more ... | "update:arm"'.
 pkg/eks/components/NodeGroup.vue: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 pkg/eks/components/NodeGroup.vue: error TS7006: Parameter 'options' implicitly has an 'any' type.
-pkg/eks/components/__tests__/Config.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 pkg/eks/components/__tests__/Config.test.ts: error TS2307: Cannot find module 'types' or its corresponding type declarations.
 pkg/eks/components/__tests__/Config.test.ts: error TS2339: Property 'props' does not exist on type 'Omit<WrapperLike, "exists">'.
 pkg/eks/components/__tests__/Config.test.ts: error TS2339: Property 'props' does not exist on type 'Omit<WrapperLike, "exists">'.
@@ -440,8 +407,6 @@ pkg/eks/components/__tests__/CruEKS.test.ts: error TS2349: This expression is no
 pkg/eks/components/__tests__/CruEKS.test.ts: error TS2349: This expression is not callable.
 pkg/eks/components/__tests__/CruEKS.test.ts: error TS2614: Module '"*.vue"' has no exported member 'DEFAULT_EKS_CONFIG'. Did you mean to use 'import DEFAULT_EKS_CONFIG from "*.vue"' instead?
 pkg/eks/components/__tests__/CruEKS.test.ts: error TS2698: Spread types may only be created from object types.
-pkg/eks/components/__tests__/Networking.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/eks/components/__tests__/Networking.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 pkg/eks/components/__tests__/Networking.test.ts: error TS2339: Property 'mockImplementation' does not exist on type 'never'.
 pkg/eks/components/__tests__/Networking.test.ts: error TS2339: Property 'mockImplementation' does not exist on type 'never'.
 pkg/eks/components/__tests__/Networking.test.ts: error TS2339: Property 'mockImplementation' does not exist on type 'never'.
@@ -510,8 +475,6 @@ pkg/eks/components/__tests__/NodeGroup.test.ts: error TS2353: Object literal may
 pkg/eks/components/__tests__/NodeGroup.test.ts: error TS2353: Object literal may only specify known properties, and 'version' does not exist in type 'Partial<{ style?: unknown; class?: unknown; key?: PropertyKey | undefined; ref?: VNodeRef | undefined; ref_for?: boolean | undefined; ref_key?: string | undefined; onVnodeBeforeMount?: VNodeMountHook | ... 1 more ... | undefined; ... 4 more ...; onVnodeUnmounted?: VNodeMountHook | ... 1 more ... | undefined; } & Par...'.
 pkg/eks/components/__tests__/NodeGroup.test.ts: error TS2353: Object literal may only specify known properties, and 'version' does not exist in type 'Partial<{ style?: unknown; class?: unknown; key?: PropertyKey | undefined; ref?: VNodeRef | undefined; ref_for?: boolean | undefined; ref_key?: string | undefined; onVnodeBeforeMount?: VNodeMountHook | ... 1 more ... | undefined; ... 4 more ...; onVnodeUnmounted?: VNodeMountHook | ... 1 more ... | undefined; } & Par...'.
 pkg/eks/util/validators.ts: error TS2307: Cannot find module 'types' or its corresponding type declarations.
-pkg/gke/components/AdvancedOptions.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/gke/components/AuthScopes.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
 pkg/gke/components/AuthScopes.vue: error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type '"source" | "trace" | "logging" | "monitoring" | "compute" | "devstorage" | "taskqueue" | "bigquery" | "clouddatastore" | "cloud-platform" | "bigtable.data" | "bigtable.admin" | ... 5 more ... | "sqlservice"'.
 pkg/gke/components/AuthScopes.vue: error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type '"source" | "trace" | "logging" | "monitoring" | "compute" | "devstorage" | "taskqueue" | "bigquery" | "clouddatastore" | "cloud-platform" | "bigtable.data" | "bigtable.admin" | ... 5 more ... | "sqlservice"'.
 pkg/gke/components/AuthScopes.vue: error TS2345: Argument of type 'string' is not assignable to parameter of type '"source" | "trace" | "logging" | "monitoring" | "compute" | "devstorage" | "taskqueue" | "bigquery" | "clouddatastore" | "cloud-platform" | "bigtable.data" | "bigtable.admin" | ... 5 more ... | "sqlservice"'.
@@ -520,8 +483,6 @@ pkg/gke/components/AuthScopes.vue: error TS2538: Type 'undefined' cannot be used
 pkg/gke/components/AuthScopes.vue: error TS7006: Parameter 'opt' implicitly has an 'any' type.
 pkg/gke/components/AuthScopes.vue: error TS7006: Parameter 'opt' implicitly has an 'any' type.
 pkg/gke/components/AuthScopes.vue: error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ userinfo: { labelKey: string; value: string; }[]; compute: { labelKey: string; value: string; }[]; devstorage: { labelKey: string; value: string; }[]; taskqueue: { labelKey: string; value: string; }[]; bigquery: { ...; }[]; ... 12 more ...; cloud_debugger: { ...; }[]; }'.
-pkg/gke/components/Config.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/gke/components/Config.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 pkg/gke/components/Config.vue: error TS2345: Argument of type 'SemVer | null' is not assignable to parameter of type 'string | SemVer'.
 pkg/gke/components/Config.vue: error TS2345: Argument of type 'SemVer | null' is not assignable to parameter of type 'string | SemVer'.
 pkg/gke/components/Config.vue: error TS2345: Argument of type 'VuexStore' is not assignable to parameter of type 'Store<any>'.
@@ -530,9 +491,6 @@ pkg/gke/components/Config.vue: error TS2353: Object literal may only specify kno
 pkg/gke/components/Config.vue: error TS2531: Object is possibly 'null'.
 pkg/gke/components/Config.vue: error TS2554: Expected 4 arguments, but got 5.
 pkg/gke/components/Config.vue: error TS7006: Parameter 'z' implicitly has an 'any' type.
-pkg/gke/components/CruGKE.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/gke/components/CruGKE.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-pkg/gke/components/CruGKE.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 pkg/gke/components/CruGKE.vue: error TS2322: Type 'string | null | undefined' is not assignable to type 'string | undefined'.
 pkg/gke/components/CruGKE.vue: error TS2339: Property 'pending' does not exist on type 'never'.
 pkg/gke/components/CruGKE.vue: error TS2345: Argument of type 'VuexStore' is not assignable to parameter of type 'Store<any>'.
@@ -543,14 +501,9 @@ pkg/gke/components/CruGKE.vue: error TS2551: Property 'decription' does not exis
 pkg/gke/components/CruGKE.vue: error TS2554: Expected 0 arguments, but got 1.
 pkg/gke/components/CruGKE.vue: error TS7006: Parameter 'val' implicitly has an 'any' type.
 pkg/gke/components/CruGKE.vue: error TS7053: Element implicitly has an 'any' type because expression of type '"config.imageType"' can't be used to index type '{ autoscaling: { enabled?: boolean | undefined; maxNodeCount?: number | undefined; minNodeCount?: number | undefined; }; config: { diskSizeGb?: number | undefined; diskType?: string | undefined; ... 8 more ...; tags?: any; }; ... 8 more ...; _nameUnique?: boolean | undefined; }'.
-pkg/gke/components/GKENodePool.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/gke/components/GKENodePool.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-pkg/gke/components/Import.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 pkg/gke/components/Import.vue: error TS2345: Argument of type 'VuexStore' is not assignable to parameter of type 'Store<any>'.
 pkg/gke/components/Networking.vue: error TS18048: '__VLS_ctx.selectedClusterSecondaryRangeName' is possibly 'undefined'.
 pkg/gke/components/Networking.vue: error TS18048: '__VLS_ctx.selectedClusterSecondaryRangeName' is possibly 'undefined'.
-pkg/gke/components/Networking.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/gke/components/Networking.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 pkg/gke/components/Networking.vue: error TS2339: Property 'ipCidrRange' does not exist on type 'string | GKESecondaryRangeOption'.
 pkg/gke/components/Networking.vue: error TS2339: Property 'ipCidrRange' does not exist on type 'string | GKESecondaryRangeOption'.
 pkg/gke/components/Networking.vue: error TS2345: Argument of type 'VuexStore' is not assignable to parameter of type 'Store<any>'.
@@ -571,7 +524,6 @@ pkg/gke/components/__tests__/Config.test.ts: error TS2353: Object literal may on
 pkg/gke/components/__tests__/Config.test.ts: error TS2353: Object literal may only specify known properties, and 'cloudCredentialId' does not exist in type 'Partial<{ style?: unknown; class?: unknown; key?: PropertyKey | undefined; ref?: VNodeRef | undefined; ref_for?: boolean | undefined; ref_key?: string | undefined; onVnodeBeforeMount?: VNodeMountHook | ... 1 more ... | undefined; ... 4 more ...; onVnodeUnmounted?: VNodeMountHook | ... 1 more ... | undefined; } & Par...'.
 pkg/gke/components/__tests__/Config.test.ts: error TS2353: Object literal may only specify known properties, and 'projectId' does not exist in type 'Partial<{ style?: unknown; class?: unknown; key?: PropertyKey | undefined; ref?: VNodeRef | undefined; ref_for?: boolean | undefined; ref_key?: string | undefined; onVnodeBeforeMount?: VNodeMountHook | ... 1 more ... | undefined; ... 4 more ...; onVnodeUnmounted?: VNodeMountHook | ... 1 more ... | undefined; } & Par...'.
 pkg/gke/components/__tests__/Config.test.ts: error TS2532: Object is possibly 'undefined'.
-pkg/gke/components/__tests__/GKENodePool.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 pkg/gke/components/__tests__/GKENodePool.test.ts: error TS2339: Property 'props' does not exist on type 'Omit<WrapperLike, "exists">'.
 pkg/gke/components/__tests__/GKENodePool.test.ts: error TS2339: Property 'props' does not exist on type 'Omit<WrapperLike, "exists">'.
 pkg/gke/components/__tests__/GKENodePool.test.ts: error TS2339: Property 'props' does not exist on type 'Omit<WrapperLike, "exists">'.
@@ -643,8 +595,6 @@ pkg/gke/components/__tests__/Networking.test.ts: error TS2353: Object literal ma
 pkg/gke/components/__tests__/Networking.test.ts: error TS2532: Object is possibly 'undefined'.
 pkg/gke/components/__tests__/Networking.test.ts: error TS2532: Object is possibly 'undefined'.
 pkg/gke/util/__tests__/oauth.test.ts: error TS2307: Cannot find module '@pkg/gke/util/oauth' or its corresponding type declarations.
-pkg/imported/components/__tests__/CruImported.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/imported/components/__tests__/CruImported.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 pkg/imported/components/__tests__/CruImported.test.ts: error TS2307: Cannot find module '@pkg/imported/util/shared.ts' or its corresponding type declarations.
 pkg/imported/components/__tests__/CruImported.test.ts: error TS2322: Type 'string' is not assignable to type 'never'.
 pkg/imported/components/__tests__/CruImported.test.ts: error TS2339: Property 'annotations' does not exist on type 'never'.
@@ -653,22 +603,10 @@ pkg/imported/components/__tests__/CruImported.test.ts: error TS2339: Property 'a
 pkg/imported/components/__tests__/CruImported.test.ts: error TS2339: Property 'annotations' does not exist on type 'never'.
 pkg/imported/components/__tests__/CruImported.test.ts: error TS2349: This expression is not callable.
 pkg/imported/components/__tests__/CruImported.test.ts: error TS2349: This expression is not callable.
-pkg/imported/components/__tests__/DayTwoOps.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/imported/components/__tests__/DayTwoOps.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-pkg/imported/components/__tests__/DayTwoOps.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-pkg/imported/components/__tests__/versionManagement.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-pkg/imported/components/__tests__/versionManagement.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 pkg/rancher-components/src/components/Banner/Banner.test.ts: error TS2339: Property 'click' does not exist on type 'VueNode<Element>'.
 pkg/rancher-components/src/components/Card/Card.test.ts: error TS2353: Object literal may only specify known properties, and 'body' does not exist in type 'NonNullable<Partial<{ title: string; content: string; sticky: boolean; buttonAction: (event: MouseEvent) => void; buttonText: string; showHighlightBorder: boolean; showActions: boolean; }> & Omit<...>>'.
 pkg/rancher-components/src/components/Form/Checkbox/Checkbox.test.ts: error TS2305: Module '"@vue/test-utils"' has no exported member 'Wrapper'.
-pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-pkg/rancher-components/src/components/Form/Checkbox/Checkbox.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue: error TS2322: Type 'string | number | Record<string, any>' is not assignable to type 'string'.
-pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue: error TS2345: Argument of type 'LooseRequired<Readonly<ExtractPropTypes<{ type: { type: StringConstructor; default: string; }; status: { type: StringConstructor; default: null; }; subLabel: { type: StringConstructor; default: null; }; ... 19 more ...; requireDirty: { ...; }; }>> & Readonly<...> & {}>' is not assignable to parameter of type 'LabeledFormElementProps'.
-pkg/rancher-components/src/components/Form/Radio/RadioButton.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-pkg/rancher-components/src/components/Form/Radio/RadioGroup.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-pkg/rancher-components/src/components/Form/TextArea/TextAreaAutoGrow.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-pkg/rancher-components/src/components/Form/TextArea/TextAreaAutoGrow.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts: error TS2532: Object is possibly 'undefined'.
 pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts: error TS2532: Object is possibly 'undefined'.
 pkg/rancher-components/src/components/Form/ToggleSwitch/ToggleSwitch.test.ts: error TS2532: Object is possibly 'undefined'.
@@ -803,51 +741,37 @@ shell/apis/shell/system.ts: error TS2724: '"@shell/config/version"' has no expor
 shell/chart/__tests__/S3.test.ts: error TS2307: Cannot find module '@shell/chart/rancher-backup/S3' or its corresponding type declarations.
 shell/components/AppModal.vue: error TS2345: Argument of type '{ role: string; 'aria-modal': "true"; style: object; class: string; id: string; ref: string; onClick: () => void; }' is not assignable to parameter of type 'HTMLAttributes & ReservedProps & Record<string, unknown>'.
 shell/components/Certificates.vue: error TS2339: Property '$fetchState' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<{}, {}>, {}, Data, { expiredData(): any; }, {}, ComponentOptionsMixin, ComponentOptionsMixin, ... 18 more ..., {}>'.
-shell/components/ConfigMapSettings/Settings.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/components/ConfigMapSettings/index.vue: error TS18047: 'configMap' is possibly 'null'.
 shell/components/ConfigMapSettings/index.vue: error TS18047: 'configMap' is possibly 'null'.
 shell/components/ConfigMapSettings/index.vue: error TS18047: 'configMap' is possibly 'null'.
 shell/components/ConfigMapSettings/index.vue: error TS18047: 'configMap' is possibly 'null'.
 shell/components/ConfigMapSettings/index.vue: error TS18047: 'configMap' is possibly 'null'.
-shell/components/ConfigMapSettings/index.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/ConfigMapSettings/index.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/components/ConfigMapSettings/index.vue: error TS2339: Property 'data' does not exist on type 'object'.
 shell/components/ConfigMapSettings/index.vue: error TS2339: Property 'data' does not exist on type 'object'.
 shell/components/ConfigMapSettings/index.vue: error TS2339: Property 'data' does not exist on type 'object'.
 shell/components/ConfigMapSettings/index.vue: error TS2339: Property 'data' does not exist on type 'object'.
 shell/components/ConfigMapSettings/index.vue: error TS2339: Property 'save' does not exist on type 'object'.
 shell/components/ConfigMapSettings/index.vue: error TS2345: Argument of type 'T' is not assignable to parameter of type 'string | number | null | undefined'.
-shell/components/Drawer/ResourceDetailDrawer/ConfigTab.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/components/Drawer/ResourceDetailDrawer/YamlTab.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/components/Drawer/ResourceDetailDrawer/__tests__/ConfigTab.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/components/Drawer/ResourceDetailDrawer/__tests__/ConfigTab.test.ts: error TS2322: Type '{ resource: { resource: string; }; component: Raw<DefineComponent<ExtractPropTypes<{ value: { type: ObjectConstructor; required: true; }; mode: { type: StringConstructor; required: true; }; initialValue: { ...; }; useTabbedHash: { ...; }; }>, ... 18 more ..., any>>; }' is not assignable to type 'VNodeProps & { __v_isVNode?: undefined; [Symbol.iterator]?: undefined; } & Record<string, any> & { readonly resource: any; readonly component: any; readonly resourceType: string; readonly defaultTab?: string | undefined; } & AllowedComponentProps & ComponentCustomProps'.
 shell/components/Drawer/ResourceDetailDrawer/__tests__/ConfigTab.test.ts: error TS2322: Type '{ resource: { resource: string; }; component: Raw<DefineComponent<ExtractPropTypes<{ value: { type: ObjectConstructor; required: true; }; mode: { type: StringConstructor; required: true; }; initialValue: { ...; }; useTabbedHash: { ...; }; }>, ... 18 more ..., any>>; }' is not assignable to type 'VNodeProps & { __v_isVNode?: undefined; [Symbol.iterator]?: undefined; } & Record<string, any> & { readonly resource: any; readonly component: any; readonly resourceType: string; readonly defaultTab?: string | undefined; } & AllowedComponentProps & ComponentCustomProps'.
-shell/components/Drawer/ResourceDetailDrawer/__tests__/YamlTab.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/components/Drawer/ResourceDetailDrawer/index.vue: error TS2614: Module '"@shell/components/Drawer/ResourceDetailDrawer/YamlTab.vue"' has no exported member 'Props'. Did you mean to use 'import Props from "@shell/components/Drawer/ResourceDetailDrawer/YamlTab.vue"' instead?
 shell/components/FailWhale.vue: error TS2307: Cannot find module '@shell/components/BrandImage' or its corresponding type declarations.
-shell/components/PodSecurityAdmission.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/components/PodSecurityAdmission.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/components/Questions/__tests__/Boolean.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/components/Questions/__tests__/Boolean.test.ts: error TS2307: Cannot find module '@shell/components/Questions' or its corresponding type declarations.
 shell/components/Questions/__tests__/Boolean.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/Boolean.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/Boolean.test.ts: error TS2532: Object is possibly 'undefined'.
-shell/components/Questions/__tests__/Float.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/components/Questions/__tests__/Float.test.ts: error TS2307: Cannot find module '@shell/components/Questions' or its corresponding type declarations.
 shell/components/Questions/__tests__/Float.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/Float.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/Float.test.ts: error TS2532: Object is possibly 'undefined'.
-shell/components/Questions/__tests__/Int.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/components/Questions/__tests__/Int.test.ts: error TS2307: Cannot find module '@shell/components/Questions' or its corresponding type declarations.
 shell/components/Questions/__tests__/Int.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/Int.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/Int.test.ts: error TS2532: Object is possibly 'undefined'.
-shell/components/Questions/__tests__/String.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/components/Questions/__tests__/String.test.ts: error TS2307: Cannot find module '@shell/components/Questions' or its corresponding type declarations.
 shell/components/Questions/__tests__/String.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/String.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/String.test.ts: error TS2532: Object is possibly 'undefined'.
-shell/components/Questions/__tests__/Yaml.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/components/Questions/__tests__/Yaml.test.ts: error TS2307: Cannot find module '@shell/components/Questions' or its corresponding type declarations.
 shell/components/Questions/__tests__/Yaml.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Questions/__tests__/Yaml.test.ts: error TS2532: Object is possibly 'undefined'.
@@ -874,7 +798,6 @@ shell/components/Resource/Detail/Metadata/IdentifyingInformation/__tests__/ident
 shell/components/Resource/Detail/Metadata/IdentifyingInformation/__tests__/identifying-fields.test.ts: error TS2339: Property 'type' does not exist on type 'Object'.
 shell/components/Resource/Detail/Metadata/IdentifyingInformation/__tests__/identifying-fields.test.ts: error TS2339: Property 'type' does not exist on type 'Object'.
 shell/components/Resource/Detail/Metadata/index.vue: error TS2322: Type '(returnFocusSelector: string, defaultTab: string) => void' is not assignable to type '(returnFocusSelector: string) => void'.
-shell/components/Resource/Detail/Preview/Content.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/components/Resource/Detail/Preview/__tests__/Preview.spec.ts: error TS2769: No overload matches this call.
 shell/components/Resource/Detail/ResourcePopover/__tests__/ResourcePopoverCard.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/components/Resource/Detail/TitleBar/__tests__/composables.test.ts: error TS2339: Property 'params' does not exist on type 'string | RouteLocationAsRelativeGeneric | RouteLocationAsPathGeneric'.
@@ -897,21 +820,10 @@ shell/components/Resource/Detail/TitleBar/__tests__/index.test.ts: error TS2322:
 shell/components/Resource/Detail/TitleBar/__tests__/index.test.ts: error TS2322: Type '{ resourceTypeLabel: string; resourceName: string; }' is not assignable to type 'VNodeProps & { __v_isVNode?: undefined; [Symbol.iterator]?: undefined; } & Record<string, any> & { readonly resource: any; readonly resourceTypeLabel: string; readonly resourceName: string; ... 6 more ...; readonly "onShow-configuration"?: ((...args: any[]) => any) | undefined; } & AllowedComponentProps & ComponentC...'.
 shell/components/Resource/Detail/TitleBar/__tests__/index.test.ts: error TS2322: Type '{ resourceTypeLabel: string; resourceName: string; }' is not assignable to type 'VNodeProps & { __v_isVNode?: undefined; [Symbol.iterator]?: undefined; } & Record<string, any> & { readonly resource: any; readonly resourceTypeLabel: string; readonly resourceName: string; ... 6 more ...; readonly "onShow-configuration"?: ((...args: any[]) => any) | undefined; } & AllowedComponentProps & ComponentC...'.
 shell/components/Resource/Detail/TitleBar/__tests__/index.test.ts: error TS2322: Type '{ resourceTypeLabel: string; resourceTo: string; resourceName: string; }' is not assignable to type 'VNodeProps & { __v_isVNode?: undefined; [Symbol.iterator]?: undefined; } & Record<string, any> & { readonly resource: any; readonly resourceTypeLabel: string; readonly resourceName: string; ... 6 more ...; readonly "onShow-configuration"?: ((...args: any[]) => any) | undefined; } & AllowedComponentProps & ComponentC...'.
-shell/components/Resource/Detail/TitleBar/index.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member 'AS'.
-shell/components/Resource/Detail/TitleBar/index.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CONFIG'.
 shell/components/Resource/Detail/TitleBar/index.vue: error TS2307: Cannot find module '@shell/components/TabTitle' or its corresponding type declarations.
-shell/components/Resource/Detail/ViewOptions/__tests__/index.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CONFIG'.
-shell/components/Resource/Detail/ViewOptions/__tests__/index.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_GRAPH'.
 shell/components/Resource/Detail/ViewOptions/__tests__/index.test.ts: error TS2571: Object is of type 'unknown'.
 shell/components/Resource/Detail/ViewOptions/__tests__/index.test.ts: error TS2571: Object is of type 'unknown'.
-shell/components/Resource/Detail/ViewOptions/composable.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'VIEW'.
-shell/components/Resource/Detail/ViewOptions/composable.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CONFIG'.
-shell/components/Resource/Detail/ViewOptions/index.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CONFIG'.
-shell/components/Resource/Detail/ViewOptions/index.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_GRAPH'.
 shell/components/Resource/Detail/ViewOptions/index.vue: error TS2307: Cannot find module '@shell/components/ButtonGroup' or its corresponding type declarations.
-shell/components/ResourceDetail/Masthead/__tests__/index.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/components/ResourceDetail/Masthead/index.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/components/ResourceDetail/Masthead/index.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_YAML'.
 shell/components/Tabbed/__tests__/index.test.ts: error TS2353: Object literal may only specify known properties, and 'components' does not exist in type 'VNode<RendererNode, RendererElement, { [key: string]: any; }> | (new () => any) | { template: string; } | ((...args: any[]) => any) | (string | VNode<RendererNode, RendererElement, { ...; }> | (new () => any) | { ...; } | ((...args: any[]) => any))[]'.
 shell/components/Tabbed/__tests__/index.test.ts: error TS2353: Object literal may only specify known properties, and 'components' does not exist in type 'VNode<RendererNode, RendererElement, { [key: string]: any; }> | (new () => any) | { template: string; } | ((...args: any[]) => any) | (string | VNode<RendererNode, RendererElement, { ...; }> | (new () => any) | { ...; } | ((...args: any[]) => any))[]'.
 shell/components/Tabbed/__tests__/index.test.ts: error TS2353: Object literal may only specify known properties, and 'components' does not exist in type 'VNode<RendererNode, RendererElement, { [key: string]: any; }> | (new () => any) | { template: string; } | ((...args: any[]) => any) | (string | VNode<RendererNode, RendererElement, { ...; }> | (new () => any) | { ...; } | ((...args: any[]) => any))[]'.
@@ -957,14 +869,7 @@ shell/components/__tests__/AsyncButton.test.ts: error TS2571: Object is of type 
 shell/components/__tests__/AsyncButton.test.ts: error TS2571: Object is of type 'unknown'.
 shell/components/__tests__/AsyncButton.test.ts: error TS2571: Object is of type 'unknown'.
 shell/components/__tests__/Certificates.test.ts: error TS2322: Type '() => { schema: {}; certs: { certState: string; }[]; }' is not assignable to type '() => Partial<Data>'.
-shell/components/__tests__/CodeMirror.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/__tests__/CodeMirror.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_YAML'.
 shell/components/__tests__/CodeMirror.test.ts: error TS2305: Module '"@vue/test-utils"' has no exported member 'Wrapper'.
-shell/components/__tests__/ConfigMapSettings.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/__tests__/CruResource.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/components/__tests__/CruResource.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/__tests__/CruResource.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/components/__tests__/CruResource.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_YAML'.
 shell/components/__tests__/FailWhale.test.ts: error TS2559: Type 'Error' has no properties in common with type 'FailWhaleError'.
 shell/components/__tests__/FailWhale.test.ts: error TS2559: Type 'Error' has no properties in common with type 'FailWhaleError'.
 shell/components/__tests__/FilterPanel.test.ts: error TS2322: Type '{ template: string; }' is not assignable to type 'ComponentType'.
@@ -1012,25 +917,13 @@ shell/components/fleet/AppCoChartGrid.vue: error TS2307: Cannot find module '@sh
 shell/components/fleet/AppCoChartGrid.vue: error TS2307: Cannot find module '@shell/components/form/Select' or its corresponding type declarations.
 shell/components/fleet/AppCoChartGrid.vue: error TS2307: Cannot find module '@shell/pages/c/_cluster/apps/charts/AppChartCardSubHeader' or its corresponding type declarations.
 shell/components/fleet/AppCoVersionSelect.vue: error TS2307: Cannot find module '@shell/components/form/LabeledSelect' or its corresponding type declarations.
-shell/components/fleet/FleetClusterTargets/index.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/components/fleet/FleetClusterTargets/index.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/fleet/FleetClusterTargets/index.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/components/fleet/FleetClusterTargets/index.vue: error TS2345: Argument of type '{ raw: boolean; }' is not assignable to parameter of type 'boolean | undefined'.
-shell/components/fleet/FleetConfigMapSelector.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/components/fleet/FleetConfigMapSelector.vue: error TS2339: Property '$fetchState' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<ExtractPropTypes<{ value: { type: ObjectConstructor; required: true; }; namespace: { type: StringConstructor; required: true; }; inStore: { type: StringConstructor; default: string; }; mode: { ...; }; label: { ...; }; }>, { ...; }>, ... 24 more ..., { ...; }>'.
-shell/components/fleet/FleetGitRepoPaths.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/fleet/FleetGitRepoPaths.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/components/fleet/FleetSecretSelector.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/components/fleet/FleetSecretSelector.vue: error TS2339: Property '$fetchState' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<ExtractPropTypes<{ value: { type: ObjectConstructor; required: true; }; namespace: { type: StringConstructor; required: true; }; inStore: { type: StringConstructor; default: string; }; mode: { ...; }; label: { ...; }; lockedOptions: { ...; }; }>, { ...; }>, ......'.
-shell/components/fleet/FleetValuesFrom.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/fleet/FleetValuesFrom.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/components/fleet/HelmOpAdvancedTab.vue: error TS2307: Cannot find module '@shell/components/form/SelectOrCreateAuthSecret' or its corresponding type declarations.
 shell/components/fleet/HelmOpAdvancedTab.vue: error TS2307: Cannot find module '@shell/components/form/UnitInput' or its corresponding type declarations.
 shell/components/fleet/HelmOpAdvancedTab.vue: error TS2322: Type 'unknown[]' is not assignable to type 'string[]'.
 shell/components/fleet/HelmOpAdvancedTab.vue: error TS2322: Type 'unknown[]' is not assignable to type 'string[]'.
-shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS2307: Cannot find module '@shell/components/LazyImage' or its corresponding type declarations.
 shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS2307: Cannot find module '@shell/components/form/Labels' or its corresponding type declarations.
 shell/components/fleet/HelmOpAppCoConfigTab.vue: error TS2307: Cannot find module '@shell/components/form/NameNsDescription' or its corresponding type declarations.
@@ -1047,45 +940,25 @@ shell/components/fleet/HelmOpTargetTab.vue: error TS2322: Type 'string' is not a
 shell/components/fleet/HelmOpValuesTab.vue: error TS2307: Cannot find module '@shell/components/ButtonGroup' or its corresponding type declarations.
 shell/components/fleet/HelmOpValuesTab.vue: error TS2307: Cannot find module '@shell/components/YamlEditor' or its corresponding type declarations.
 shell/components/fleet/HelmOpValuesTab.vue: error TS2322: Type 'unknown' is not assignable to type 'ValueFrom[] | undefined'.
-shell/components/fleet/__tests__/AppCoVersionSelect.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/fleet/__tests__/ClusterSelectionFields.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/fleet/__tests__/ClusterSelectionFields.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/components/fleet/__tests__/ClusterSelectionFields.test.ts: error TS2339: Property 'vm' does not exist on type 'WrapperLike'.
 shell/components/fleet/__tests__/ClusterSelectionFields.test.ts: error TS2339: Property 'vm' does not exist on type 'WrapperLike'.
-shell/components/fleet/__tests__/FleetClusterTargets.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/components/fleet/__tests__/FleetClusterTargets.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/components/fleet/__tests__/FleetClusters.test.ts: error TS2339: Property 'search' does not exist on type '{ name: string; labelKey: string; sort: string[]; value: string; getValue: (row: any) => any; width: number; default: string; formatter: string; } | { name: string; labelKey: string; value: string; getValue: (row: any) => any; sort: string[]; formatter: string; canBeVariable: boolean; } | { ...; } | { ...; } | { ......'.
 shell/components/fleet/__tests__/FleetClusters.test.ts: error TS2339: Property 'search' does not exist on type '{ name: string; labelKey: string; sort: string[]; value: string; getValue: (row: any) => any; width: number; default: string; formatter: string; } | { name: string; labelKey: string; value: string; getValue: (row: any) => any; sort: string[]; formatter: string; canBeVariable: boolean; } | { ...; } | { ...; } | { ......'.
 shell/components/fleet/__tests__/FleetClusters.test.ts: error TS2339: Property 'search' does not exist on type '{ name: string; labelKey: string; sort: string[]; value: string; getValue: (row: any) => any; width: number; default: string; formatter: string; } | { name: string; labelKey: string; value: string; getValue: (row: any) => any; sort: string[]; formatter: string; canBeVariable: boolean; } | { ...; } | { ...; } | { ......'.
 shell/components/fleet/__tests__/FleetClusters.test.ts: error TS2339: Property 'width' does not exist on type '{ name: string; labelKey: string; sort: string[]; value: string; getValue: (row: any) => any; width: number; default: string; formatter: string; } | { name: string; labelKey: string; value: string; getValue: (row: any) => any; sort: string[]; formatter: string; canBeVariable: boolean; } | { ...; } | { ...; } | { ......'.
 shell/components/fleet/__tests__/FleetClusters.test.ts: error TS2551: Property 'formatterOpts' does not exist on type '{ name: string; labelKey: string; sort: string[]; value: string; getValue: (row: any) => any; width: number; default: string; formatter: string; } | { name: string; labelKey: string; value: string; getValue: (row: any) => any; sort: string[]; formatter: string; canBeVariable: boolean; } | { ...; } | { ...; } | { ......'. Did you mean 'formatter'?
-shell/components/fleet/__tests__/FleetConfigMapSelector.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/fleet/__tests__/FleetGitRepoPaths.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/fleet/__tests__/FleetOCIStorageSecret.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/components/fleet/__tests__/FleetOCIStorageSecret.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/fleet/__tests__/FleetSecretSelector.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/components/fleet/__tests__/FleetSummary.test.ts: error TS7006: Parameter 'fallback' implicitly has an 'any' type.
 shell/components/fleet/__tests__/FleetSummary.test.ts: error TS7006: Parameter 'key' implicitly has an 'any' type.
 shell/components/fleet/__tests__/FleetSummary.test.ts: error TS7006: Parameter 'opt' implicitly has an 'any' type.
-shell/components/fleet/__tests__/FleetValuesFrom.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/components/fleet/__tests__/FleetValuesFrom.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/fleet/__tests__/HelmOpAppCoConfigTab.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/fleet/__tests__/HelmOpAppCoResourcesSection.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/fleet/__tests__/HelmOpResourcesSection.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/fleet/__tests__/HelmOpTargetOptionsSection.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/fleet/__tests__/HelmOpValuesTab.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/components/fleet/dashboard/ResourceCard.vue: error TS2307: Cannot find module '@shell/assets/images/content/dark/suse.svg' or its corresponding type declarations.
 shell/components/fleet/dashboard/ResourceCard.vue: error TS2307: Cannot find module '@shell/assets/images/content/suse.svg' or its corresponding type declarations.
 shell/components/fleet/dashboard/ResourceDetails.vue: error TS2307: Cannot find module '@shell/assets/images/content/dark/suse.svg' or its corresponding type declarations.
 shell/components/fleet/dashboard/ResourceDetails.vue: error TS2307: Cannot find module '@shell/assets/images/content/suse.svg' or its corresponding type declarations.
 shell/components/fleet/dashboard/__tests__/ResourceCard.test.ts: error TS2307: Cannot find module '@shell/assets/images/content/dark/suse.svg' or its corresponding type declarations.
 shell/components/fleet/dashboard/__tests__/ResourceCard.test.ts: error TS2307: Cannot find module '@shell/assets/images/content/suse.svg' or its corresponding type declarations.
-shell/components/form/Footer.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/components/form/GitPicker.vue: error TS2322: Type 'unknown' is not assignable to type 'unknown[] | undefined'.
 shell/components/form/GitPicker.vue: error TS2322: Type 'unknown' is not assignable to type 'unknown[] | undefined'.
-shell/components/form/Labels.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/components/form/NodeScheduling.vue: error TS18046: 'n' is of type 'unknown'.
-shell/components/form/NodeScheduling.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/components/form/NodeScheduling.vue: error TS2322: Type 'string | null' is not assignable to type 'string | boolean | Record<string, any> | undefined'.
 shell/components/form/NodeScheduling.vue: error TS2554: Expected 1-2 arguments, but got 3.
 shell/components/form/ResourceLabeledSelect.vue: error TS2339: Property '$fetchState' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<ExtractPropTypes<{ resourceType: { type: StringConstructor; required: true; }; context: { type: StringConstructor; default: null; }; inStore: { type: StringConstructor; default: undefined; }; paginateMode: { ...; }; allResourcesSettings: { ...; }; paginatedReso...'.
@@ -1093,15 +966,10 @@ shell/components/form/ResourceLabeledSelect.vue: error TS2339: Property '$fetchS
 shell/components/form/ResourceQuota/ResourceQuotaEntry.vue: error TS2307: Cannot find module '@shell/components/form/Select' or its corresponding type declarations.
 shell/components/form/ResourceQuota/ResourceQuotaEntry.vue: error TS2307: Cannot find module '@shell/components/form/UnitInput' or its corresponding type declarations.
 shell/components/form/ResourceQuota/__tests__/ResourceQuotaEntry.test.ts: error TS2322: Type '{ id: string; mode: string; types: { value: string; inputExponent: number; baseUnit: string; placeholder: string; increment: number; }[]; resourceType: string; resourceIdentifier: string; projectLimit: string; namespaceDefaultLimit: string; }' is not assignable to type 'VNodeProps & { __v_isVNode?: undefined; [Symbol.iterator]?: undefined; } & Record<string, any> & { readonly id: string; readonly index: number; readonly mode: string; ... 9 more ...; readonly "onUpdate:namespaceDefaultLimit"?: ((value: string | undefined) => any) | undefined; } & AllowedComponentProps & ComponentCus...'.
-shell/components/form/SSHKnownHosts/index.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/form/SSHKnownHosts/index.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/components/form/__tests__/ArrayList.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/form/__tests__/ArrayList.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/components/form/__tests__/ArrayList.test.ts: error TS2307: Cannot find module 'vue/types/options' or its corresponding type declarations.
 shell/components/form/__tests__/ArrayList.test.ts: error TS2307: Cannot find module 'vue/types/vue' or its corresponding type declarations.
 shell/components/form/__tests__/BannerSettings.test.ts: error TS2322: Type '() => { vendor: string; uiPLSetting: { vendor: string; }; uiBannerSetting: null; bannerVal: {}; errors: never[]; }' is not assignable to type '() => Partial<{ showAsDialog: boolean; buttonText: any; uiBannerFontSizeOptions: string[]; themeVars: { bannerBgColor: string; bannerTextColor: string; }; bannerTitleId: string; isHtml: boolean; }>'.
 shell/components/form/__tests__/BannerSettings.test.ts: error TS2339: Property 'style' does not exist on type 'VueNode<Element>'.
-shell/components/form/__tests__/Command.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/components/form/__tests__/Command.test.ts: error TS2339: Property 'vm' does not exist on type 'Omit<WrapperLike, "exists">'.
 shell/components/form/__tests__/Error.test.ts: error TS2719: Type 'Rule[]' is not assignable to type 'Rule[]'. Two different types with this name exist, but they are unrelated.
 shell/components/form/__tests__/Error.test.ts: error TS2719: Type 'Rule[]' is not assignable to type 'Rule[]'. Two different types with this name exist, but they are unrelated.
@@ -1111,41 +979,20 @@ shell/components/form/__tests__/Error.test.ts: error TS2719: Type 'Rule[]' is no
 shell/components/form/__tests__/FileImageSelector.test.ts: error TS2307: Cannot find module '@shell/components/form/FileImageSelector' or its corresponding type declarations.
 shell/components/form/__tests__/FileImageSelector.test.ts: error TS2307: Cannot find module '@shell/components/form/FileSelector' or its corresponding type declarations.
 shell/components/form/__tests__/FileSelector.test.ts: error TS2307: Cannot find module '@shell/components/form/FileSelector' or its corresponding type declarations.
-shell/components/form/__tests__/HookOption.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/form/__tests__/LabeledSelect.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/components/form/__tests__/LabeledSelect.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/form/__tests__/LabeledSelect.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/components/form/__tests__/Labels.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/form/__tests__/Labels.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/components/form/__tests__/MatchExpressions.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
 shell/components/form/__tests__/NameNsDescription.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
 shell/components/form/__tests__/NameNsDescription.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
 shell/components/form/__tests__/NameNsDescription.test.ts: error TS2571: Object is of type 'unknown'.
 shell/components/form/__tests__/Networking.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
 shell/components/form/__tests__/Networking.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
-shell/components/form/__tests__/NodeAffinity.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/components/form/__tests__/NodeScheduling.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/components/form/__tests__/NodeScheduling.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/form/__tests__/NodeScheduling.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/components/form/__tests__/PodAffinity.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
 shell/components/form/__tests__/PrivateRegistry.test.ts: error TS2339: Property 'vm' does not exist on type 'WrapperLike'.
 shell/components/form/__tests__/PrivateRegistry.test.ts: error TS2339: Property 'vm' does not exist on type 'WrapperLike'.
 shell/components/form/__tests__/PrivateRegistry.test.ts: error TS2339: Property 'vm' does not exist on type 'WrapperLike'.
 shell/components/form/__tests__/PrivateRegistry.test.ts: error TS2339: Property 'vm' does not exist on type 'WrapperLike'.
-shell/components/form/__tests__/Probe.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/components/form/__tests__/Probe.test.ts: error TS2307: Cannot find module 'vue/types/options' or its corresponding type declarations.
 shell/components/form/__tests__/Probe.test.ts: error TS2307: Cannot find module 'vue/types/vue' or its corresponding type declarations.
 shell/components/form/__tests__/Probe.test.ts: error TS2339: Property 'vm' does not exist on type 'Omit<WrapperLike, "exists">'.
 shell/components/form/__tests__/Probe.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '0' can't be used to index type '{}'.
-shell/components/form/__tests__/SSHKnownHosts.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/form/__tests__/SSHKnownHosts.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/components/form/__tests__/SchedulingCustomization.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/components/form/__tests__/SchedulingCustomization.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/form/__tests__/Security.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/form/__tests__/Select.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/form/__tests__/Select.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/components/form/__tests__/Select.test.ts: error TS2769: No overload matches this call.
-shell/components/form/__tests__/SelectOrCreateAuthSecret.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/components/form/__tests__/Taints.test.ts: error TS2339: Property 'props' does not exist on type 'WrapperLike'.
 shell/components/form/__tests__/Taints.test.ts: error TS2339: Property 'props' does not exist on type 'WrapperLike'.
 shell/components/form/__tests__/Taints.test.ts: error TS2339: Property 'props' does not exist on type 'WrapperLike'.
@@ -1165,8 +1012,6 @@ shell/components/formatter/__tests__/LiveDate.test.ts: error TS2307: Cannot find
 shell/components/formatter/__tests__/LiveDate.test.ts: error TS2307: Cannot find module 'vue/types/vue' or its corresponding type declarations.
 shell/components/formatter/__tests__/ServiceTargets.test.ts: error TS2322: Type 'null' is not assignable to type 'string | unknown[] | undefined'.
 shell/components/formatter/__tests__/WorkloadDetailEndpoints.test.ts: error TS2307: Cannot find module '@shell/components/Tag' or its corresponding type declarations.
-shell/components/google/AccountAccess.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/components/google/AccountAccess.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/components/google/AccountAccess.vue: error TS2339: Property 'data' does not exist on type '{}'.
 shell/components/google/AccountAccess.vue: error TS7006: Parameter 'e' implicitly has an 'any' type.
 shell/components/google/util/__mocks__/gcp.ts: error TS7006: Parameter 'zone' implicitly has an 'any' type.
@@ -1175,14 +1020,9 @@ shell/components/nav/NotificationCenter/Notification.vue: error TS7053: Element 
 shell/components/nav/__tests__/Group.test.ts: error TS2322: Type 'Record<string, unknown>' is not assignable to type 'Stubs | undefined'.
 shell/components/nav/__tests__/TopLevelMenu.test.ts: error TS2305: Module '"@vue/test-utils"' has no exported member 'Wrapper'.
 shell/components/user.retention/user-retention-header.vue: error TS2307: Cannot find module '@shell/components/TabTitle' or its corresponding type declarations.
-shell/composables/__tests__/useLabeledFormElement.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/composables/__tests__/useLabeledFormElement.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/composables/useIsNewDetailPageEnabled.test.ts: error TS2322: Type 'null' is not assignable to type 'string'.
 shell/composables/useIsNewDetailPageEnabled.test.ts: error TS2322: Type 'undefined' is not assignable to type 'string'.
 shell/composables/useIsNewDetailPageEnabled.test.ts: error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.
-shell/composables/useIsNewDetailPageEnabled.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'LEGACY'.
-shell/composables/useLabeledFormElement.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/composables/useLabeledFormElement.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/composables/useUserRetentionValidation.ts: error TS2769: No overload matches this call.
 shell/config/__test__/home-links.test.ts: error TS2345: Argument of type '(language: String, value: string | boolean | null) => void' is not assignable to parameter of type '(...args: (string | boolean)[] | (boolean | null)[]) => any'.
 shell/config/__test__/home-links.test.ts: error TS7006: Parameter 'link' implicitly has an 'any' type.
@@ -1213,10 +1053,6 @@ shell/core/__tests__/plugin-products-helpers.test.ts: error TS2532: Object is po
 shell/core/__tests__/plugin-products-helpers.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/core/__tests__/plugin-products-helpers.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/core/__tests__/plugin-products-helpers.test.ts: error TS2532: Object is possibly 'undefined'.
-shell/core/plugin-helpers.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CONFIG'.
-shell/core/plugin-helpers.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/core/plugin-helpers.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/core/plugin-helpers.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_LIST'.
 shell/detail/__tests__/autoscaling.horizontalpodautoscaler.test.ts: error TS18048: 'currentMatch' is possibly 'undefined'.
 shell/detail/__tests__/autoscaling.horizontalpodautoscaler.test.ts: error TS2339: Property 'current' does not exist on type 'string | { metric: { name: string; }; current: { averageValue: number; }; }'.
 shell/detail/__tests__/autoscaling.horizontalpodautoscaler.test.ts: error TS2339: Property 'metric' does not exist on type 'string | { metric: { name: string; }; current: { averageValue: number; }; }'.
@@ -1227,7 +1063,6 @@ shell/detail/__tests__/workload.test.ts: error TS2339: Property 'findMatchingIng
 shell/detail/auditlog.cattle.io.auditpolicy.vue: error TS2339: Property 'pending' does not exist on type 'never'.
 shell/detail/management.cattle.io.oidcclient.vue: error TS2307: Cannot find module '~shell/assets/images/key.svg' or its corresponding type declarations.
 shell/dialog/RedeployWorkloadDialog.vue: error TS2307: Cannot find module '@shell/components/AsyncButton' or its corresponding type declarations.
-shell/dialog/__tests__/KnownHostsEditDialog.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/dialog/__tests__/KnownHostsEditDialog.test.ts: error TS2769: No overload matches this call.
 shell/dialog/__tests__/KnownHostsEditDialog.test.ts: error TS2769: No overload matches this call.
 shell/dialog/__tests__/RedeployWorkloadDialog.test.ts: error TS2322: Type 'boolean' is not assignable to type 'Directive'.
@@ -1242,27 +1077,12 @@ shell/dialog/__tests__/RedeployWorkloadDialog.test.ts: error TS7053: Element imp
 shell/dialog/__tests__/RedeployWorkloadDialog.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"kubectl.kubernetes.io/restartedAt"' can't be used to index type '{}'.
 shell/dialog/__tests__/RotateEncryptionKeyDialog.test.ts: error TS2322: Type 'boolean' is not assignable to type 'Directive'.
 shell/dialog/__tests__/ScaleMachineDownDialog.test.ts: error TS2322: Type 'boolean' is not assignable to type 'Directive'.
-shell/edit/__tests__/catalog.cattle.io.clusterrepo.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/edit/__tests__/catalog.cattle.io.clusterrepo.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/__tests__/fleet.cattle.io.gitrepo.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/edit/__tests__/fleet.cattle.io.helmop.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/edit/__tests__/fleet.cattle.io.helmop.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/__tests__/fleet.cattle.io.helmop.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/edit/__tests__/kontainerDriver.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
 shell/edit/__tests__/management.cattle.io.clusterroletemplatebinding.test.ts: error TS2307: Cannot find module '@shell/components/CruResource' or its corresponding type declarations.
 shell/edit/__tests__/management.cattle.io.clusterroletemplatebinding.test.ts: error TS7006: Parameter 'val' implicitly has an 'any' type.
 shell/edit/__tests__/management.cattle.io.clusterroletemplatebinding.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{ 'management/findAll': () => never[]; 'cru-resource/setCreateNamespace': Mock<any, any, any>; }'.
 shell/edit/__tests__/management.cattle.io.clusterroletemplatebinding.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{ 'management/findAll': () => never[]; 'cru-resource/setCreateNamespace': Mock<any, any, any>; }'.
-shell/edit/__tests__/monitoring.coreos.com.prometheusrule.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/edit/__tests__/monitoring.coreos.com.prometheusrule.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/edit/__tests__/monitoring.coreos.com.prometheusrule.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/edit/__tests__/namespace.test.ts: error TS2339: Property 'props' does not exist on type 'WrapperLike'.
-shell/edit/__tests__/nodeDriver.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/edit/__tests__/resources.cattle.io.restore.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/edit/__tests__/service.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CLONE'.
-shell/edit/__tests__/service.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
 shell/edit/__tests__/token.test.ts: error TS2339: Property 'clusterScope' does not exist on type 'never'.
 shell/edit/__tests__/token.test.ts: error TS2339: Property 'clusterScope' does not exist on type 'never'.
 shell/edit/__tests__/token.test.ts: error TS2339: Property 'clusterScope' does not exist on type 'never'.
@@ -1288,11 +1108,9 @@ shell/edit/__tests__/token.test.ts: error TS2339: Property 'value' does not exis
 shell/edit/__tests__/token.test.ts: error TS2339: Property 'value' does not exist on type 'never'.
 shell/edit/__tests__/token.test.ts: error TS2339: Property 'value' does not exist on type 'never'.
 shell/edit/__tests__/token.test.ts: error TS2339: Property 'value' does not exist on type 'never'.
-shell/edit/__tests__/ui.cattle.io.navlink.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
 shell/edit/__tests__/ui.cattle.io.navlink.test.ts: error TS2307: Cannot find module '@shell/components/CruResource' or its corresponding type declarations.
 shell/edit/__tests__/ui.cattle.io.navlink.test.ts: error TS7006: Parameter 'val' implicitly has an 'any' type.
 shell/edit/auditlog.cattle.io.auditpolicy/index.vue: error TS2339: Property 'pending' does not exist on type 'never'.
-shell/edit/auth/__tests__/azuread.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/edit/auth/__tests__/azuread.test.ts: error TS2322: Type '() => { isEnabling: boolean; editConfig: boolean; model: { logoutAllSupported: boolean; tenantId: string; applicationId: string; applicationSecret: string; graphEndpoint: string; tokenEndpoint: string; ... 5 more ...; type: string; }; ... 5 more ...; authConfigName: string; }' is not assignable to type '() => Partial<{ isGroupMembershipFilterEnabled: boolean; endpoint: string; oldEndpoint: boolean; SLO_OPTION_VALUES: { rancher: string; all: string; both: string; }; applicationSecret: any; }>'.
 shell/edit/auth/__tests__/azuread.test.ts: error TS2322: Type '() => { sloType: string; isEnabling: boolean; editConfig: boolean; model: { enabled: boolean; id: string; endpoint: string; type: string; }; serverSetting: null; errors: never[]; originalModel: null; principals: never[]; authConfigName: string; }' is not assignable to type '() => Partial<{ isGroupMembershipFilterEnabled: boolean; endpoint: string; oldEndpoint: boolean; SLO_OPTION_VALUES: { rancher: string; all: string; both: string; }; applicationSecret: any; }>'.
 shell/edit/auth/__tests__/azuread.test.ts: error TS2322: Type '() => { sloType: string; isEnabling: boolean; editConfig: boolean; model: { enabled: boolean; id: string; endpoint: string; type: string; }; serverSetting: null; errors: never[]; originalModel: null; principals: never[]; authConfigName: string; }' is not assignable to type '() => Partial<{ isGroupMembershipFilterEnabled: boolean; endpoint: string; oldEndpoint: boolean; SLO_OPTION_VALUES: { rancher: string; all: string; both: string; }; applicationSecret: any; }>'.
@@ -1305,16 +1123,12 @@ shell/edit/auth/__tests__/azuread.test.ts: error TS2345: Argument of type '{ dat
 shell/edit/auth/__tests__/azuread.test.ts: error TS2345: Argument of type '{ data(): { isEnabling: boolean; editConfig: boolean; model: { enabled: boolean; id: string; endpoint: string; type: string; }; serverSetting: null; errors: never[]; originalModel: null; principals: never[]; authConfigName: string; }; global: { ...; }; propsData: { ...; }; }' is not assignable to parameter of type 'ComponentMountingOptions<DefineComponent<{}, { getRules: (path: string) => Validator[]; isFormValid: ComputedRef<boolean>; editMemberConfigRef: Ref<boolean, boolean>; isLogoutAllSupported: Ref<...>; sloTypeRef: Ref<...>; sloEndSessionEndpointUiEnabled: ComputedRef<...>; }, ... 17 more ..., any>, { ...; }>'.
 shell/edit/auth/__tests__/azuread.test.ts: error TS2345: Argument of type '{ data(): { isEnabling: boolean; editConfig: boolean; model: { enabled: boolean; id: string; endpoint: string; type: string; }; serverSetting: null; errors: never[]; originalModel: null; principals: never[]; authConfigName: string; }; global: { ...; }; propsData: { ...; }; }' is not assignable to parameter of type 'ComponentMountingOptions<DefineComponent<{}, { getRules: (path: string) => Validator[]; isFormValid: ComputedRef<boolean>; editMemberConfigRef: Ref<boolean, boolean>; isLogoutAllSupported: Ref<...>; sloTypeRef: Ref<...>; sloEndSessionEndpointUiEnabled: ComputedRef<...>; }, ... 17 more ..., any>, { ...; }>'.
 shell/edit/auth/__tests__/azuread.test.ts: error TS2345: Argument of type '{ data(): { isEnabling: boolean; editConfig: boolean; model: { enabled: boolean; id: string; endpoint: string; type: string; }; serverSetting: null; errors: never[]; originalModel: null; principals: never[]; authConfigName: string; }; global: { ...; }; propsData: { ...; }; }' is not assignable to parameter of type 'ComponentMountingOptions<DefineComponent<{}, { getRules: (path: string) => Validator[]; isFormValid: ComputedRef<boolean>; editMemberConfigRef: Ref<boolean, boolean>; isLogoutAllSupported: Ref<...>; sloTypeRef: Ref<...>; sloEndSessionEndpointUiEnabled: ComputedRef<...>; }, ... 17 more ..., any>, { ...; }>'.
-shell/edit/auth/__tests__/github.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/auth/__tests__/oidc.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/auth/__tests__/saml.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/edit/auth/github-app-steps.vue: error TS2307: Cannot find module '@shell/components/CopyToClipboard' or its corresponding type declarations.
 shell/edit/auth/github-app-steps.vue: error TS2307: Cannot find module '@shell/components/InfoBox' or its corresponding type declarations.
 shell/edit/auth/github-steps.vue: error TS2307: Cannot find module '@shell/components/CopyToClipboard' or its corresponding type declarations.
 shell/edit/auth/github-steps.vue: error TS2307: Cannot find module '@shell/components/InfoBox' or its corresponding type declarations.
 shell/edit/auth/ldap/__tests__/config.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
 shell/edit/auth/ldap/__tests__/config.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
-shell/edit/auth/ldap/__tests__/index.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/edit/autoscaling.horizontalpodautoscaler/index.vue: error TS2307: Cannot find module '@shell/components/Tabbed' or its corresponding type declarations.
 shell/edit/autoscaling.horizontalpodautoscaler/index.vue: error TS2339: Property 'pending' does not exist on type 'never'.
 shell/edit/catalog.cattle.io.clusterrepo.vue: error TS2322: Type '{ selected: string; } | null' is not assignable to type 'Record<string, any> | undefined'.
@@ -1326,11 +1140,7 @@ shell/edit/catalog.cattle.io.clusterrepo.vue: error TS7006: Parameter 'newVal' i
 shell/edit/catalog.cattle.io.clusterrepo.vue: error TS7006: Parameter 'old' implicitly has an 'any' type.
 shell/edit/management.cattle.io.podsecurityadmissionconfigurationtemplate.vue: error TS2339: Property 'pending' does not exist on type 'never'.
 shell/edit/monitoring.coreos.com.alertmanagerconfig/__tests__/auth.spec.ts: error TS2307: Cannot find module '@shell/components/form/SimpleSecretSelector' or its corresponding type declarations.
-shell/edit/monitoring.coreos.com.alertmanagerconfig/__tests__/index.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/monitoring.coreos.com.alertmanagerconfig/__tests__/index.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/edit/monitoring.coreos.com.alertmanagerconfig/__tests__/index.test.ts: error TS2322: Type 'typeof PointerEvent' is not assignable to type '{ new (type: string, eventInitDict?: PointerEventInit | undefined): PointerEvent; prototype: PointerEvent; }'.
-shell/edit/monitoring.coreos.com.alertmanagerconfig/__tests__/tls.spec.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/monitoring.coreos.com.alertmanagerconfig/__tests__/tls.spec.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/edit/monitoring.coreos.com.alertmanagerconfig/__tests__/tls.spec.ts: error TS2322: Type 'undefined' is not assignable to type 'string'.
 shell/edit/monitoring.coreos.com.alertmanagerconfig/__tests__/tls.spec.ts: error TS2722: Cannot invoke an object which is possibly 'undefined'.
 shell/edit/monitoring.coreos.com.alertmanagerconfig/__tests__/tls.spec.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"keySecret"' can't be used to index type '{}'.
@@ -1339,26 +1149,15 @@ shell/edit/monitoring.coreos.com.alertmanagerconfig/__tests__/tls.spec.ts: error
 shell/edit/monitoring.coreos.com.alertmanagerconfig/__tests__/tls.spec.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
 shell/edit/monitoring.coreos.com.alertmanagerconfig/__tests__/tls.spec.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
 shell/edit/monitoring.coreos.com.alertmanagerconfig/__tests__/tls.spec.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
-shell/edit/monitoring.coreos.com.alertmanagerconfig/types/__tests__/slack.spec.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
 shell/edit/monitoring.coreos.com.receiver/__tests__/auth.spec.ts: error TS2307: Cannot find module '@shell/components/form/LabeledSelect' or its corresponding type declarations.
-shell/edit/monitoring.coreos.com.receiver/__tests__/index.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/edit/monitoring.coreos.com.receiver/__tests__/index.test.ts: error TS2322: Type '{ host: string; port: string; }' is not assignable to type 'never'.
 shell/edit/monitoring.coreos.com.receiver/__tests__/index.test.ts: error TS2322: Type '{ smarthost: string; }' is not assignable to type 'never'.
 shell/edit/monitoring.coreos.com.receiver/__tests__/index.test.ts: error TS2339: Property 'host' does not exist on type 'never'.
 shell/edit/monitoring.coreos.com.receiver/__tests__/index.test.ts: error TS2339: Property 'port' does not exist on type 'never'.
 shell/edit/monitoring.coreos.com.receiver/__tests__/index.test.ts: error TS2339: Property 'smarthost' does not exist on type 'never'.
 shell/edit/monitoring.coreos.com.receiver/__tests__/index.test.ts: error TS7006: Parameter 'key' implicitly has an 'any' type.
-shell/edit/monitoring.coreos.com.receiver/types/__tests__/email.spec.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/edit/monitoring.coreos.com.receiver/types/__tests__/email.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
 shell/edit/monitoring.coreos.com.receiver/types/__tests__/email.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
-shell/edit/monitoring.coreos.com.receiver/types/__tests__/opsgenie.spec.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/monitoring.coreos.com.receiver/types/__tests__/opsgenie.spec.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/edit/monitoring.coreos.com.receiver/types/__tests__/pagerduty.spec.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/monitoring.coreos.com.receiver/types/__tests__/slack.spec.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/edit/monitoring.coreos.com.receiver/types/__tests__/slack.spec.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/monitoring.coreos.com.receiver/types/__tests__/webhook.spec.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/edit/monitoring.coreos.com.receiver/types/__tests__/webhook.spec.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/monitoring.coreos.com.receiver/types/__tests__/webhook.spec.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/edit/networking.k8s.io.ingress/__tests__/Certificate.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/edit/networking.k8s.io.ingress/__tests__/Certificate.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/edit/networking.k8s.io.ingress/__tests__/Certificate.test.ts: error TS2532: Object is possibly 'undefined'.
@@ -1368,7 +1167,6 @@ shell/edit/networking.k8s.io.ingress/__tests__/Certificate.test.ts: error TS2571
 shell/edit/networking.k8s.io.ingress/__tests__/Certificate.test.ts: error TS2571: Object is of type 'unknown'.
 shell/edit/networking.k8s.io.ingress/__tests__/Certificate.test.ts: error TS2571: Object is of type 'unknown'.
 shell/edit/networking.k8s.io.ingress/__tests__/Certificate.test.ts: error TS2571: Object is of type 'unknown'.
-shell/edit/networking.k8s.io.ingress/__tests__/IngressClass.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/edit/networking.k8s.io.ingress/__tests__/IngressClass.test.ts: error TS2307: Cannot find module '@shell/components/form/LabeledSelect' or its corresponding type declarations.
 shell/edit/networking.k8s.io.ingress/__tests__/IngressClass.test.ts: error TS2532: Object is possibly 'undefined'.
 shell/edit/networking.k8s.io.ingress/__tests__/IngressClass.test.ts: error TS2532: Object is possibly 'undefined'.
@@ -1378,9 +1176,6 @@ shell/edit/networking.k8s.io.networkpolicy/__tests__/PolicyRuleTarget.test.ts: e
 shell/edit/persistentvolume/__tests__/persistentvolume.test.ts: error TS2307: Cannot find module '@shell/edit/persistentvolume/index' or its corresponding type declarations.
 shell/edit/persistentvolume/__tests__/persistentvolume.test.ts: error TS2307: Cannot find module 'vue/types/vue' or its corresponding type declarations.
 shell/edit/persistentvolume/__tests__/persistentvolume.test.ts: error TS2339: Property 'vm' does not exist on type 'WrapperLike'.
-shell/edit/provisioning.cattle.io.cluster/__tests__/Advanced.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/provisioning.cattle.io.cluster/__tests__/Advanced.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/edit/provisioning.cattle.io.cluster/__tests__/Advanced.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_YAML'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/Advanced.test.ts: error TS2305: Module '"@vue/test-utils"' has no exported member 'Wrapper'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/Basics.test.ts: error TS2322: Type '{ mode: string; value: { agentConfig: { profile: string; 'cloud-provider-name': string; }; spec: { defaultPodSecurityAdmissionConfigurationTemplateName: string; kubernetesVersion: string; rkeConfig: { ...; }; chartValues: {}; }; }; ... 18 more ...; cloudProviderOptions: { ...; }[]; }' is not assignable to type 'VNodeProps & { __v_isVNode?: undefined; [Symbol.iterator]?: undefined; } & Record<string, any> & Partial<{ mode: string; as: string; defaultTab: string; initialValue: Record<string, any>; liveValue: Record<...>; doneEvent: boolean; realMode: string; useTabbedHash: boolean; } & { ...; }> & Omit<...>'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/Basics.test.ts: error TS2322: Type '{ mode: string; value: { spec: { defaultPodSecurityAdmissionConfigurationTemplateName: string; kubernetesVersion: string; rkeConfig: { etcd: { disableSnapshots: boolean; }; machineGlobalConfig: { ...; }; }; chartValues: {}; }; agentConfig: { ...; }; }; ... 18 more ...; cloudProviderOptions: { ...; }[]; }' is not assignable to type 'VNodeProps & { __v_isVNode?: undefined; [Symbol.iterator]?: undefined; } & Record<string, any> & Partial<{ mode: string; as: string; defaultTab: string; initialValue: Record<string, any>; liveValue: Record<...>; doneEvent: boolean; realMode: string; useTabbedHash: boolean; } & { ...; }> & Omit<...>'.
@@ -1391,16 +1186,11 @@ shell/edit/provisioning.cattle.io.cluster/__tests__/Basics.test.ts: error TS2571
 shell/edit/provisioning.cattle.io.cluster/__tests__/Basics.test.ts: error TS2571: Object is of type 'unknown'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/Basics.test.ts: error TS2571: Object is of type 'unknown'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/Basics.test.ts: error TS2571: Object is of type 'unknown'.
-shell/edit/provisioning.cattle.io.cluster/__tests__/DirectoryConfig.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/edit/provisioning.cattle.io.cluster/__tests__/DirectoryConfig.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/DirectoryConfig.test.ts: error TS2305: Module '"@vue/test-utils"' has no exported member 'Wrapper'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/DrainOptions.test.ts: error TS2307: Cannot find module '@shell/edit/provisioning.cattle.io.cluster/tabs/upgrade/DrainOptions' or its corresponding type declarations.
-shell/edit/provisioning.cattle.io.cluster/__tests__/Ingress.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/Ingress.test.ts: error TS2339: Property 'EDITOR_MODES' does not exist on type '{ name: string; template: string; props: string[]; methods: { updateValue: Mock<any, any, any>; }; }'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/Networking.test.ts: error TS2339: Property 'props' does not exist on type 'WrapperLike'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS18047: 'wrapper.vm.machinePools' is possibly 'null'.
-shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2322: Type '() => { credentialId: string; credential: { decodedData: { clusterId: string; }; }; machinePools: never[]; }' is not assignable to type '() => Partial<{ loadedOnce: boolean; lastIdx: number; allPSAs: never[]; credentialId: string; credential: null; initialMachinePoolsValues: {}; machinePools: null; rke2Versions: null; k3sVersions: null; ... 47 more ...; infrastructureCluster: null; }>'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2322: Type '() => { credentialId: string; userChartValues: { 'rke2-calico': {}; 'rke2-ingress-nginx': { controller: { extraArgs: { 'enable-ssl-passthrough': boolean; 'watch-ingress-without-class': boolean; }; }; }; 'rke2-ingress-nginx-invalid': { ...; }; } | { ...; }; rke2Versions: { ...; }[]; }' is not assignable to type '() => Partial<{ loadedOnce: boolean; lastIdx: number; allPSAs: never[]; credentialId: string; credential: null; initialMachinePoolsValues: {}; machinePools: null; rke2Versions: null; k3sVersions: null; ... 47 more ...; infrastructureCluster: null; }>'.
 shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2339: Property 'dataDirectories' does not exist on type '{ etcd: { disableSnapshots: boolean; }; }'.
@@ -1408,41 +1198,14 @@ shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2349: 
 shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2349: This expression is not callable.
 shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2349: This expression is not callable.
 shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2349: This expression is not callable.
-shell/edit/provisioning.cattle.io.cluster/__tests__/subtype-detection.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'SUB_TYPE'.
-shell/edit/provisioning.cattle.io.cluster/ingress/IngressCards.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/edit/provisioning.cattle.io.cluster/ingress/IngressCards.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/edit/provisioning.cattle.io.cluster/ingress/IngressConfiguration.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/edit/provisioning.cattle.io.cluster/subtype-detection.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'SUB_TYPE'.
-shell/edit/provisioning.cattle.io.cluster/subtype-detection.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CONFIG'.
-shell/edit/provisioning.cattle.io.cluster/subtype-detection.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/provisioning.cattle.io.cluster/subtype-detection.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/edit/provisioning.cattle.io.cluster/tabs/Ingress.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/edit/provisioning.cattle.io.cluster/tabs/Ingress.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/provisioning.cattle.io.cluster/tabs/Ingress.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/edit/provisioning.cattle.io.cluster/tabs/Ingress.vue: error TS2307: Cannot find module '@shell/components/YamlEditor' or its corresponding type declarations.
 shell/edit/provisioning.cattle.io.cluster/tabs/etcd/__tests__/S3Config.test.ts: error TS7006: Parameter 'key' implicitly has an 'any' type.
-shell/edit/provisioning.cattle.io.cluster/tabs/registries/__tests__/RegistryConfigs.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/edit/provisioning.cattle.io.cluster/tabs/registries/__tests__/RegistryConfigs.test.ts: error TS2305: Module '"@vue/test-utils"' has no exported member 'Wrapper'.
-shell/edit/secret/__tests__/ssh.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/edit/secret/__tests__/ssh.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/secret/__tests__/ssh.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
-shell/edit/workload/__tests__/Job.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/list/__tests__/workload.test.ts: error TS2307: Cannot find module 'vue/types/options' or its corresponding type declarations.
 shell/list/__tests__/workload.test.ts: error TS2307: Cannot find module 'vue/types/vue' or its corresponding type declarations.
 shell/list/node.vue: error TS2339: Property 'id' does not exist on type 'string'.
-shell/list/projectsecret.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member 'SECRET_QUERY_PARAMS'.
-shell/list/projectsecret.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member 'SECRET_SCOPE'.
-shell/list/projectsecret.vue: error TS2307: Cannot find module '@shell/components/PaginatedResourceTable' or its corresponding type declarations.
-shell/list/projectsecret.vue: error TS2307: Cannot find module '@shell/components/ResourceList/Masthead' or its corresponding type declarations.
 shell/list/projectsecret.vue: error TS2322: Type 'false' is not assignable to type 'string | string[] | undefined'.
-shell/list/projectsecret.vue: error TS2339: Property '$fetchState' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<ExtractPropTypes<{ resource: { type: StringConstructor; required: true; }; useQueryParamsForSimpleFiltering: { type: BooleanConstructor; default: boolean; }; }>, {}>, ... 24 more ..., { ...; }>'.
-shell/list/projectsecret.vue: error TS2339: Property 'metadata' does not exist on type 'never'.
-shell/list/projectsecret.vue: error TS2339: Property 'metadata' does not exist on type 'never'.
 shell/list/projectsecret.vue: error TS2339: Property 'row' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<ExtractPropTypes<{ resource: { type: StringConstructor; required: true; }; useQueryParamsForSimpleFiltering: { type: BooleanConstructor; default: boolean; }; }>, {}>, ... 24 more ..., {}>'.
-shell/list/provisioning.cattle.io.cluster.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member 'MODE'.
-shell/list/provisioning.cattle.io.cluster.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_IMPORT'.
-shell/list/secret.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member 'SECRET_QUERY_PARAMS'.
-shell/list/secret.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member 'SECRET_SCOPE'.
 shell/list/secret.vue: error TS2307: Cannot find module '@shell/components/PaginatedResourceTable' or its corresponding type declarations.
 shell/list/secret.vue: error TS2307: Cannot find module '@shell/components/ResourceList/Masthead' or its corresponding type declarations.
 shell/machine-config/__tests__/generic.test.ts: error TS2307: Cannot find module '@shell/components/Questions' or its corresponding type declarations.
@@ -1488,7 +1251,6 @@ shell/mixins/__tests__/chart.test.ts: error TS2349: This expression is not calla
 shell/mixins/__tests__/chart.test.ts: error TS2349: This expression is not callable.
 shell/mixins/__tests__/chart.test.ts: error TS2349: This expression is not callable.
 shell/mixins/__tests__/chart.test.ts: error TS2349: This expression is not callable.
-shell/mixins/__tests__/create-edit-view.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/mixins/compact-input.ts: error TS2339: Property 'label' does not exist on type '{ isCompact(): boolean; }'.
 shell/mixins/compact-input.ts: error TS2339: Property 'labelKey' does not exist on type '{ isCompact(): boolean; }'.
 shell/mixins/compact-input.ts: error TS2551: Property 'compact' does not exist on type '{ isCompact(): boolean; }'. Did you mean 'isCompact'?
@@ -1530,11 +1292,6 @@ shell/models/steve-schema.ts: error TS2345: Argument of type 'unknown' is not as
 shell/pages/__tests__/diagnostic.test.ts: error TS7006: Parameter 'args' implicitly has an 'any' type.
 shell/pages/__tests__/diagnostic.test.ts: error TS7006: Parameter 'key' implicitly has an 'any' type.
 shell/pages/c/_cluster/apps/charts/AppChartCardSubHeader.vue: error TS2314: Generic type 'Record' requires 2 type argument(s).
-shell/pages/c/_cluster/apps/charts/__tests__/chart.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'CHART'.
-shell/pages/c/_cluster/apps/charts/__tests__/chart.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'DEPRECATED'.
-shell/pages/c/_cluster/apps/charts/__tests__/chart.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'REPO'.
-shell/pages/c/_cluster/apps/charts/__tests__/chart.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'REPO_TYPE'.
-shell/pages/c/_cluster/apps/charts/__tests__/chart.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'VERSION'.
 shell/pages/c/_cluster/apps/charts/__tests__/install.test.ts: error TS18047: 'wrapper.vm.value' is possibly 'null'.
 shell/pages/c/_cluster/apps/charts/__tests__/install.test.ts: error TS2339: Property 'imagePullSecrets' does not exist on type '{}'.
 shell/pages/c/_cluster/explorer/__tests__/index.test.ts: error TS2322: Type '() => { disconnected: string | number | boolean | { status: string; }[]; canViewAgents: boolean; }' is not assignable to type '() => Partial<{ nodeHeaders: ({ name: string; labelKey: string; sort: string[]; value: string; getValue: (row: any) => any; width: number; default: string; formatter: string; } | { name: string; labelKey: string; ... 4 more ...; canBeVariable: boolean; } | { ...; })[]; ... 21 more ...; clusterServiceIcons: { ...; };...'.
@@ -1548,7 +1305,6 @@ shell/pages/c/_cluster/explorer/__tests__/index.test.ts: error TS2696: The 'Obje
 shell/pages/c/_cluster/explorer/__tests__/index.test.ts: error TS2740: Type '(type: string) => boolean' is missing the following properties from type 'Mock<any, any, any>': getMockName, mock, mockClear, mockReset, and 13 more.
 shell/pages/c/_cluster/explorer/workload-dashboard/index.vue: error TS2307: Cannot find module '@shell/components/Loading' or its corresponding type declarations.
 shell/pages/c/_cluster/explorer/workload-dashboard/index.vue: error TS2307: Cannot find module '@shell/components/ResourceList/Masthead' or its corresponding type declarations.
-shell/pages/c/_cluster/fleet/application/create.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member 'SUB_TYPE'.
 shell/pages/c/_cluster/fleet/application/create.vue: error TS2305: Module '"@shell/config/version"' has no exported member 'isRancherPrime'.
 shell/pages/c/_cluster/fleet/application/create.vue: error TS2307: Cannot find module '@shell/assets/images/content/dark/suse.svg' or its corresponding type declarations.
 shell/pages/c/_cluster/fleet/application/create.vue: error TS2307: Cannot find module '@shell/assets/images/content/suse.svg' or its corresponding type declarations.
@@ -1558,15 +1314,8 @@ shell/pages/c/_cluster/fleet/application/create.vue: error TS2339: Property 'typ
 shell/pages/c/_cluster/fleet/application/suse-app-collection/ChartDetailBody.vue: error TS2307: Cannot find module '@shell/components/ChartReadme' or its corresponding type declarations.
 shell/pages/c/_cluster/fleet/application/suse-app-collection/ChartDetailHeader.vue: error TS2307: Cannot find module '@shell/components/LazyImage' or its corresponding type declarations.
 shell/pages/c/_cluster/fleet/application/suse-app-collection/ChartDetailHeader.vue: error TS2307: Cannot find module '@shell/pages/c/_cluster/apps/charts/AppChartCardSubHeader' or its corresponding type declarations.
-shell/pages/c/_cluster/fleet/application/suse-app-collection/chart.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member 'CHART'.
-shell/pages/c/_cluster/fleet/application/suse-app-collection/chart.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member 'REPO'.
-shell/pages/c/_cluster/fleet/application/suse-app-collection/chart.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member 'REPO_TYPE'.
-shell/pages/c/_cluster/fleet/application/suse-app-collection/chart.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member 'VERSION'.
 shell/pages/c/_cluster/fleet/application/suse-app-collection/chart.vue: error TS2307: Cannot find module '@shell/components/Loading' or its corresponding type declarations.
 shell/pages/c/_cluster/fleet/application/suse-app-collection/chart.vue: error TS2322: Type '{ id: string; label: string; href: string | null; name: string | undefined; }[]' is not assignable to type 'ChartMaintainer[]'.
-shell/pages/c/_cluster/fleet/application/suse-app-collection/charts.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member 'CHART'.
-shell/pages/c/_cluster/fleet/application/suse-app-collection/charts.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member 'REPO'.
-shell/pages/c/_cluster/fleet/application/suse-app-collection/charts.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member 'REPO_TYPE'.
 shell/pages/c/_cluster/fleet/application/suse-app-collection/charts.vue: error TS2307: Cannot find module '@shell/components/Loading' or its corresponding type declarations.
 shell/pages/c/_cluster/fleet/application/suse-app-collection/charts.vue: error TS2322: Type '(chartValue: { name: string; }) => void' is not assignable to type '(value: unknown) => void'.
 shell/pages/c/_cluster/fleet/application/suse-app-collection/credentials.vue: error TS2307: Cannot find module '@shell/components/Loading' or its corresponding type declarations.
@@ -1692,8 +1441,6 @@ shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts: error TS2339: Property
 shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts: error TS2339: Property 'installing' does not exist on type '{ name: any; label: any; description: any; id: any; versions: any[]; installed: boolean; builtin: boolean; chart: any; incompatibilityMessage: string; }'.
 shell/pages/c/_cluster/uiplugins/__tests__/index.test.ts: error TS2339: Property 'primeOnly' does not exist on type '{ name: any; label: any; description: any; id: any; versions: any[]; installed: boolean; builtin: boolean; chart: any; incompatibilityMessage: string; }'.
 shell/pages/home.vue: error TS18048: '__VLS_ctx.altClusterListFeature.configuration' is possibly 'undefined'.
-shell/pages/home.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member 'MODE'.
-shell/pages/home.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_IMPORT'.
 shell/pages/home.vue: error TS2345: Argument of type '{ maxExponent: number; minExponent: number; addSuffix: boolean; firstSuffix: string; increment: number; maxPrecision: number; startingExponent: number; suffix: string; }' is not assignable to parameter of type '{ increment?: number | undefined; addSuffix?: boolean | undefined; addSuffixSpace?: boolean | undefined; suffix?: string | undefined; firstSuffix?: null | undefined; startingExponent?: number | undefined; minExponent?: number | undefined; maxExponent?: number | undefined; maxPrecision?: number | undefined; canRoundT...'.
 shell/plugins/__tests__/mutations.tests.ts: error TS18048: 'ctx.getters' is possibly 'undefined'.
 shell/plugins/__tests__/mutations.tests.ts: error TS18048: 'originalResourceRef.metadata' is possibly 'undefined'.
@@ -1920,11 +1667,6 @@ shell/types/store/__tests__/pagination.types.spec.ts: error TS2322: Type 'null' 
 shell/utils/__tests__/banners.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"bannerFooter"' can't be used to index type '{}'.
 shell/utils/__tests__/banners.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"bannerHeader"' can't be used to index type '{}'.
 shell/utils/__tests__/banners.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
-shell/utils/__tests__/chart.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'CHART'.
-shell/utils/__tests__/chart.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'DEPRECATED'.
-shell/utils/__tests__/chart.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'REPO'.
-shell/utils/__tests__/chart.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'REPO_TYPE'.
-shell/utils/__tests__/chart.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'VERSION'.
 shell/utils/__tests__/chart.test.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
 shell/utils/__tests__/chart.test.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
 shell/utils/__tests__/chart.test.ts: error TS2345: Argument of type 'null' is not assignable to parameter of type 'string'.
@@ -1932,8 +1674,6 @@ shell/utils/__tests__/chart.test.ts: error TS2345: Argument of type 'undefined' 
 shell/utils/__tests__/chart.test.ts: error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'string'.
 shell/utils/__tests__/chart.test.ts: error TS2353: Object literal may only specify known properties, and 'cluster' does not exist in type '{ showAppReadme?: boolean | undefined; hideReadmeFirstTitle?: boolean | undefined; }'.
 shell/utils/__tests__/chart.test.ts: error TS2353: Object literal may only specify known properties, and 'cluster' does not exist in type '{ showAppReadme?: boolean | undefined; hideReadmeFirstTitle?: boolean | undefined; }'.
-shell/utils/__tests__/cluster-agent-configuration.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
-shell/utils/__tests__/cluster-agent-configuration.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/utils/__tests__/cspAdaptor.test.ts: error TS18048: 'args' is possibly 'undefined'.
 shell/utils/__tests__/cspAdaptor.test.ts: error TS18048: 'args' is possibly 'undefined'.
 shell/utils/__tests__/cspAdaptor.test.ts: error TS18048: 'args' is possibly 'undefined'.

--- a/scripts/type-check-baseline.txt
+++ b/scripts/type-check-baseline.txt
@@ -1,6 +1,6 @@
 # Auto-generated type-check baseline. Do not edit by hand.
 # Regenerate with: yarn type-check:baseline
-# Total errors: 1771
+# Total errors: 1770
 pkg/aks/components/AksNodePool.vue: error TS2339: Property '$emit' does not exist on type '{ 'pool.enableAutoScaling'(neu: any): void; 'pool.vmSize'(neu: any): void; validAZ(neu: any): void; }'.
 pkg/aks/components/AksNodePool.vue: error TS2339: Property '$emit' does not exist on type '{ 'pool.enableAutoScaling'(neu: any): void; 'pool.vmSize'(neu: any): void; validAZ(neu: any): void; }'.
 pkg/aks/components/AksNodePool.vue: error TS2339: Property '$emit' does not exist on type '{ addTaint(): void; updateTaint(keyedTaint: any, idx: any): void; removeTaint(idx: number): void; availabilityZonesSupport(): any; poolCountValidator(): (val: number) => any; }'.
@@ -635,7 +635,6 @@ pkg/rancher-components/src/components/StringList/StringList.test.ts: error TS257
 pkg/rancher-components/src/components/StringList/StringList.test.ts: error TS2571: Object is of type 'unknown'.
 pkg/rancher-components/src/components/StringList/StringList.test.ts: error TS2571: Object is of type 'unknown'.
 pkg/rancher-components/src/components/StringList/StringList.test.ts: error TS2571: Object is of type 'unknown'.
-pkg/rancher-prime/config/navigation.ts: error TS2305: Module '"@shell/store/type-map"' has no exported member 'IF_HAVE'.
 pkg/rancher-prime/config/navigation.ts: error TS2353: Object literal may only specify known properties, and 'ifFeature' does not exist in type 'ConfigureVirtualTypeOptions'.
 pkg/rancher-prime/pages/Registration.test.ts: error TS2445: Property 'isDisabled' is protected and only accessible within class 'BaseWrapper<ElementType>' and its subclasses.
 pkg/rancher-prime/pages/Registration.test.ts: error TS2445: Property 'isDisabled' is protected and only accessible within class 'BaseWrapper<ElementType>' and its subclasses.

--- a/shell/plugins/dashboard-store/index.js
+++ b/shell/plugins/dashboard-store/index.js
@@ -25,7 +25,9 @@ export const coreStoreState = (namespace, baseUrl, isClusterStore) => ({
   },
   types:       {},
   savedCounts: {}, // Saved counts for resource types (from paginated API called where marked)
-  $ctx:        markRaw({}),
+  // Annotated so `typegen.sh` can emit a declaration for this module; without it
+  // declaration emit fails on the private `RawSymbol` type behind `markRaw`.
+  $ctx:        /** @type {any} */ (markRaw({})),
 });
 
 export default (vuexModule, config, init) => {

--- a/shell/plugins/steve/index.js
+++ b/shell/plugins/steve/index.js
@@ -1,4 +1,4 @@
-import coreStore, { coreStoreModule, coreStoreState } from '@shell/plugins/dashboard-store/index';
+import coreStore, { coreStoreModule, coreStoreState } from '@shell/plugins/dashboard-store';
 import {
   createWorker,
   mutations as subscribeMutations,

--- a/shell/scripts/typegen.sh
+++ b/shell/scripts/typegen.sh
@@ -54,6 +54,12 @@ ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/models/catalog.cattle.io.clusterr
 
 #./node_modules/.bin/tsc ${SHELL_DIR}/plugins/dashboard-store/*.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/plugins/dashboard-store
 
+# Drop transitively-emitted declarations we do not want to publish
+rm -f ${SHELL_DIR}/tmp/plugins/dashboard-store/getters.d.ts
+rm -f ${SHELL_DIR}/tmp/plugins/dashboard-store/mutations.d.ts
+rm -f ${SHELL_DIR}/tmp/plugins/dashboard-store/model-loader.d.ts
+rm -f ${SHELL_DIR}/tmp/plugins/dashboard-store/model-loader-require.d.ts
+
 # Go through all of the folders and combine by wrapping with 'declare module'
 
 echo "Contents of ${SHELL_DIR}/tmp after tsc commands:"

--- a/shell/scripts/typegen.sh
+++ b/shell/scripts/typegen.sh
@@ -56,7 +56,6 @@ ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/models/catalog.cattle.io.clusterr
 
 # Drop transitively-emitted declarations we do not want to publish
 rm -f ${SHELL_DIR}/tmp/plugins/dashboard-store/getters.d.ts
-rm -f ${SHELL_DIR}/tmp/plugins/dashboard-store/mutations.d.ts
 rm -f ${SHELL_DIR}/tmp/plugins/dashboard-store/model-loader.d.ts
 rm -f ${SHELL_DIR}/tmp/plugins/dashboard-store/model-loader-require.d.ts
 
@@ -78,6 +77,15 @@ echo "// Do not modify this file as changes will get overwritten" >> ${INDEX}
 
 echo "/// <reference types=\"@rancher/shell/types/vue-shim\" />" >> ${INDEX}
 echo "/// <reference types=\"@rancher/shell/types/global-vue\" />" >> ${INDEX}
+
+# Append a declaration body, rewriting inline relative type imports to the
+# published module name
+function appendBody() {
+  local entry=$1
+  local basePkg=$2
+
+  sed 's#import("\./#import("'"${basePkg}"'/#g' $entry >> ${INDEX}
+}
 
 function processDir() {
   local dir=$1
@@ -101,7 +109,7 @@ function processDir() {
 
         echo -e "\n// ${module}\n" >> ${INDEX}
         echo "declare module '${module}' {" >> ${INDEX}
-        cat $entry >> ${INDEX}
+        appendBody $entry $basePkg
         echo -e "}" >> ${INDEX}
 
         # Also generate a module declaration with .js extension for JS source files
@@ -110,7 +118,7 @@ function processDir() {
           local moduleWithJs=${basePkg}/${name}.js
           echo -e "\n// ${moduleWithJs}\n" >> ${INDEX}
           echo "declare module '${moduleWithJs}' {" >> ${INDEX}
-          cat $entry >> ${INDEX}
+          appendBody $entry $basePkg
           echo -e "}" >> ${INDEX}
         fi
       fi

--- a/shell/scripts/typegen.sh
+++ b/shell/scripts/typegen.sh
@@ -29,9 +29,11 @@ ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/store/features.js --declaration -
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/store/plugins.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/store > /dev/null
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/store/prefs.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/store > /dev/null
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/store/store-types.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/store > /dev/null
+${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/store/type-map.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/store > /dev/null
 
 # # plugins
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/plugins/i18n.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/ > /dev/null
+${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/plugins/dashboard-store/index.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/plugins/dashboard-store/ > /dev/null
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/plugins/dashboard-store/normalize.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/plugins/dashboard-store/ > /dev/null
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/plugins/dashboard-store/resource-class.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/plugins/dashboard-store/ > /dev/null
 ${BASE_DIR}/node_modules/.bin/tsc ${SHELL_DIR}/plugins/dashboard-store/classify.js --declaration --allowJs --emitDeclarationOnly --outDir ${SHELL_DIR}/tmp/plugins/dashboard-store/ > /dev/null

--- a/shell/types/rancher/index.d.ts
+++ b/shell/types/rancher/index.d.ts
@@ -2,13 +2,6 @@ declare module '@rancher/auto-import' {
   export function importTypes(ext: any): void;
 }
 
-declare module '@shell/store/type-map' {
-  export function DSL(store: any, name: string): any;
-  export function isAdminUser(getters: any): boolean;
-}
-
-declare module '@shell/plugins/dashboard-store';
-
 declare module '@shell/config/version' {
   export const CURRENT_RANCHER_VERSION: string;
   export function getVersionData(): any;

--- a/shell/types/rancher/index.d.ts
+++ b/shell/types/rancher/index.d.ts
@@ -9,15 +9,6 @@ declare module '@shell/store/type-map' {
 
 declare module '@shell/plugins/dashboard-store';
 
-declare module '@shell/config/query-params' {
-  export const _DETAIL: string;
-  export const SECRET_SCOPE: 'scope';
-  export const SECRET_QUERY_PARAMS: {
-    NAMESPACED: 'namespaced',
-    PROJECT_SCOPED: 'project-scoped'
-  };
-}
-
 declare module '@shell/config/version' {
   export const CURRENT_RANCHER_VERSION: string;
   export function getVersionData(): any;

--- a/tsconfig.type-check.json
+++ b/tsconfig.type-check.json
@@ -12,6 +12,7 @@
     "./cypress.config.ts",
     "docusaurus",
     "scripts/standalone",
-    "storybook"
+    "storybook",
+    "shell/types/shell"
   ]
 }


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
This removes shims that were at the root of common type errors related to imports throughout Rancher Dashboard.

Fixes #18548 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->

Removed:
- `declare module '@shell/store/type-map'`
- `declare module '@shell/plugins/dashboard-store'`
- `declare module '@shell/config/query-params'`

Resolved type errors in `shell/edit/workload/__tests__/Upgrading.test.ts` that arose as a result of the shim change

Updated the baseline, reducing the total errors down from 1977 to 1725

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

I think this is fairly low-hanging fruit to pay down some of the debt. If I recall, I think that most of these shims were introduced to deal with Vue2 deficiencies when working with typescript.

Each of these shims appear to be safe to remove. In quite a few cases, they were inaccurate and out of date, so their removal is warranted. 

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

CI should pass all gates. No new type check warnings should be raised as a result of this change.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

No behavior should be altered as a result of this change. 

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

NA

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
