### PR TITLE
Print every Cypress retry attempt to the terminal

### DIFF
--- a/cypress/base-config.ts
+++ b/cypress/base-config.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import { defineConfig } from 'cypress';
 import websocketTasks from './support/utils/webSocket-utils';
+import { FailedAttempt, formatFailedAttempt } from './support/utils/retry-logging';
 import path from 'path';
 import * as os from 'os';
 const { removeDirectory } = require('cypress-delete-downloads-folder');
@@ -208,6 +209,14 @@ const baseConfig = defineConfig({
             processCpu: `${ cpuUsage.toFixed(2) }%`,
           };
         },
+        // Prints a retried test's failure to the terminal. Without this only the last
+        // attempt's error is shown, see `support/utils/retry-logging.ts`.
+        logFailedAttempt: (failure: FailedAttempt) => {
+          console.log(formatFailedAttempt(failure));
+
+          // Cypress tasks must not return undefined
+          return null;
+        },
       });
       // Signals to the shared `afterEach` in `support/e2e.ts` that the `getHostStats`
       // task has been registered by this config. Consumers of `@rancher/cypress` that
@@ -215,6 +224,8 @@ const baseConfig = defineConfig({
       // flag, so the `afterEach` will skip calling the task and avoid failing the
       // hook (which would skip all remaining tests in the spec).
       config.env.hasHostStats = true;
+      // Same again for the `logFailedAttempt` task
+      config.env.hasRetryLogging = true;
       websocketTasks(on, config);
 
       require('cypress-terminal-report/src/installLogsPrinter')(on, {

--- a/cypress/base-config.ts
+++ b/cypress/base-config.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { defineConfig } from 'cypress';
 import websocketTasks from './support/utils/webSocket-utils';
-import { FailedAttempt, formatFailedAttempt } from './support/utils/retry-logging';
+import { CypressFailedAttempt, formatFailedCypressAttempt } from './support/utils/retry-logging';
 import path from 'path';
 import * as os from 'os';
 const { removeDirectory } = require('cypress-delete-downloads-folder');
@@ -211,8 +211,8 @@ const baseConfig = defineConfig({
         },
         // Prints a retried test's failure to the terminal. Without this only the last
         // attempt's error is shown, see `support/utils/retry-logging.ts`.
-        logFailedAttempt: (failure: FailedAttempt) => {
-          console.log(formatFailedAttempt(failure));
+        logFailedAttempt: (failure: CypressFailedAttempt) => {
+          console.log(formatFailedCypressAttempt(failure));
 
           // Cypress tasks must not return undefined
           return null;

--- a/cypress/e2e/tests/retry-logging/retry-logging.spec.ts
+++ b/cypress/e2e/tests/retry-logging/retry-logging.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * THIS SPEC IS EXPECTED TO FAIL.
+ *
+ * It exists to verify that every Cypress retry attempt is printed to the terminal, and not just
+ * the last one (see the `logFailedAttempt` task in `cypress/base-config.ts` and the `afterEach`
+ * in `cypress/support/e2e.ts`). Each attempt fails with a different message, so a successful
+ * run shows `retry-marker-1`, `retry-marker-2` and `retry-marker-3` in the terminal output.
+ *
+ * It is never run by CI. `retry-logging` isn't one of the `testDirs` in `cypress/base-config.ts`,
+ * so the default `specPattern` cannot match it, and the `@retryLogging` tag matches none of the
+ * `GREP_TAGS` expressions in `.github/workflows/test.yaml`. Run it on demand with
+ *
+ *   yarn cy:run --config specPattern=cypress/e2e/tests/retry-logging/**\/*.spec.ts
+ *
+ * `--spec` on its own is not enough - Cypress filters it against `specPattern`, which never
+ * matches this directory, so `specPattern` has to be overridden instead. `baseUrl` still has to
+ * point at a reachable server (Cypress verifies it before every run) even though this spec never
+ * visits it, so add `,baseUrl=<url>` if nothing is serving the default.
+ *
+ * The spec module is only evaluated once, so the counter below increments on each retry of the
+ * test body.
+ */
+let attempt = 0;
+
+describe('Retry attempt logging', { tags: ['@retryLogging'] }, () => {
+  it('should fail with a unique message on every attempt', { tags: ['@retryLogging'] }, () => {
+    attempt++;
+
+    expect(`retry-marker-${ attempt }`).to.equal('retry-marker-never');
+  });
+});

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -5,7 +5,7 @@ import './commands/chainable';
 import './commands/rancher-api-commands';
 import './commands/accessiblity';
 
-import { FailedAttempt } from './utils/retry-logging';
+import { CypressFailedAttempt } from './utils/retry-logging';
 import 'cypress-mochawesome-reporter/register';
 import '@percy/cypress';
 import 'cypress-axe';
@@ -72,7 +72,7 @@ afterEach(function() {
     return;
   }
 
-  let failure: FailedAttempt;
+  let failure: CypressFailedAttempt;
 
   try {
     const test = this.currentTest as unknown as RetryableTest;

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -5,6 +5,7 @@ import './commands/chainable';
 import './commands/rancher-api-commands';
 import './commands/accessiblity';
 
+import { FailedAttempt } from './utils/retry-logging';
 import 'cypress-mochawesome-reporter/register';
 import '@percy/cypress';
 import 'cypress-axe';
@@ -46,4 +47,55 @@ afterEach(function() {
       cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
     });
   }
+});
+
+/**
+ * The parts of the running mocha test that we need. `currentRetry` and `retries` are typed as
+ * protected on mocha's `Runnable`, so they aren't reachable via `this.currentTest`
+ */
+interface RetryableTest {
+  titlePath(): string[];
+  currentRetry(): number;
+  retries(): number;
+  err?: Error;
+}
+
+/**
+ * Cypress retries failed tests, but the terminal reporter only shows the error from the last
+ * attempt. Send every failed attempt to the node process so they all appear in the terminal.
+ *
+ * See `support/utils/retry-logging.ts`
+ */
+afterEach(function() {
+  // We use a regular function to have access to `this.currentTest`.
+  if (this.currentTest?.state !== 'failed' || !Cypress.env('hasRetryLogging')) {
+    return;
+  }
+
+  let failure: FailedAttempt;
+
+  try {
+    const test = this.currentTest as unknown as RetryableTest;
+    const totalAttempts = test.retries() + 1;
+
+    if (totalAttempts <= 1) {
+      // Retries are disabled, so the reporter's output is already complete
+      return;
+    }
+
+    failure = {
+      spec:    Cypress.spec.relative,
+      title:   test.titlePath().join(' > '),
+      attempt: test.currentRetry() + 1,
+      totalAttempts,
+      name:    test.err?.name,
+      message: test.err?.message,
+      stack:   test.err?.stack,
+    };
+  } catch (e) {
+    // Never fail this hook, doing so would skip all remaining tests in the spec
+    return;
+  }
+
+  cy.task('logFailedAttempt', failure, { log: false });
 });

--- a/cypress/support/utils/retry-logging.ts
+++ b/cypress/support/utils/retry-logging.ts
@@ -9,7 +9,7 @@
  * `logFailedAttempt` task registered in `cypress/base-config.ts`, which prints it with the
  * formatter below.
  */
-export interface FailedAttempt {
+export interface CypressFailedAttempt {
   /** Spec file the test belongs to, relative to the project root */
   spec: string;
   /** Full title of the test, including the enclosing describe blocks */
@@ -37,7 +37,7 @@ const indent = (text: string, prefix: string): string => text
 /**
  * Format a single failed attempt as a block of terminal output
  */
-export const formatFailedAttempt = (failure: FailedAttempt): string => {
+export const formatFailedCypressAttempt = (failure: CypressFailedAttempt): string => {
   const {
     spec, title, attempt, totalAttempts, name, message, stack
   } = failure;

--- a/cypress/support/utils/retry-logging.ts
+++ b/cypress/support/utils/retry-logging.ts
@@ -1,0 +1,68 @@
+/**
+ * Cypress retries failed tests (see `retries.runMode` in `cypress/base-config.ts`), but the
+ * terminal reporter only ever shows the error from the *final* attempt. Mocha's spec reporter
+ * (used for console output by `cypress-mochawesome-reporter`) handles the `fail` event and
+ * ignores `retry`, so a flaky test that fails differently on each attempt loses everything
+ * except the last failure - which is usually the information needed to diagnose the flake.
+ *
+ * The `afterEach` in `cypress/support/e2e.ts` collects each failed attempt and hands it to the
+ * `logFailedAttempt` task registered in `cypress/base-config.ts`, which prints it with the
+ * formatter below.
+ */
+export interface FailedAttempt {
+  /** Spec file the test belongs to, relative to the project root */
+  spec: string;
+  /** Full title of the test, including the enclosing describe blocks */
+  title: string;
+  /** 1 based attempt number */
+  attempt: number;
+  /** Total number of attempts the test is allowed */
+  totalAttempts: number;
+  name?: string;
+  message?: string;
+  stack?: string;
+}
+
+const HEADER_INDENT = '  ';
+const BODY_INDENT = '      ';
+
+/** Number of stack frames to show. Enough to locate the failure without burying the message */
+const STACK_FRAMES = 5;
+
+const indent = (text: string, prefix: string): string => text
+  .split('\n')
+  .map((line) => `${ prefix }${ line.trim() }`)
+  .join('\n');
+
+/**
+ * Format a single failed attempt as a block of terminal output
+ */
+export const formatFailedAttempt = (failure: FailedAttempt): string => {
+  const {
+    spec, title, attempt, totalAttempts, name, message, stack
+  } = failure;
+
+  const lines = [
+    '',
+    `${ HEADER_INDENT }(Attempt ${ attempt } of ${ totalAttempts }) ${ title }`,
+    `${ HEADER_INDENT }${ spec }`
+  ];
+
+  const error = [name, message].filter((part) => !!part).join(': ');
+
+  if (error) {
+    lines.push(indent(error, BODY_INDENT));
+  }
+
+  // Cypress error stacks repeat the message in their leading lines, so only keep the frames
+  const frames = (stack || '')
+    .split('\n')
+    .filter((line) => line.trim().startsWith('at '))
+    .slice(0, STACK_FRAMES);
+
+  frames.forEach((frame) => lines.push(indent(frame, BODY_INDENT)));
+
+  lines.push('');
+
+  return lines.join('\n');
+};

--- a/shell/utils/validators/__tests__/zod-helpers.test.ts
+++ b/shell/utils/validators/__tests__/zod-helpers.test.ts
@@ -1,6 +1,6 @@
 import { zodValidators } from '@shell/utils/validators/zod-helpers';
 
-const mockT = (key: string, args?: Record<string, unknown>): string => {
+const mockT = (key: string, args?: unknown): string => {
   if (args) {
     return `${ key }[${ Object.values(args).join(',') }]`;
   }


### PR DESCRIPTION
### Summary
No linked issue — e2e tooling improvement.

Cypress retries a failed test up to three times in CI (`retries.runMode: 2`), but only the final attempt's error reaches the terminal. A flaky test that fails differently on each attempt therefore loses the very information needed to diagnose it.

### Occurred changes and/or fixed issues
- Every failed attempt of a retried test is now printed to the terminal, as the retry happens
- `cypress/support/utils/retry-logging.ts` (new) — formats a single failed attempt
- `cypress/base-config.ts` — registers a `logFailedAttempt` task and a `hasRetryLogging` env flag
- `cypress/support/e2e.ts` — collects each failed attempt in a shared `afterEach`
- `cypress/e2e/tests/retry-logging/retry-logging.spec.ts` (new) — deliberately failing spec that validates the output

Example output, previously only the third of these appeared:

```
  (Attempt 1 of 3) Retry attempt logging > should fail with a unique message on every attempt
  cypress/e2e/tests/retry-logging/retry-logging.spec.ts
      AssertionError: expected 'retry-marker-1' to equal 'retry-marker-never'
      at Context.eval (webpack:///./cypress/e2e/tests/retry-logging/retry-logging.spec.ts:22:0)

  (Attempt 2 of 3) ...
      AssertionError: expected 'retry-marker-2' to equal 'retry-marker-never'

    1) should fail with a unique message on every attempt

  (Attempt 3 of 3) ...
      AssertionError: expected 'retry-marker-3' to equal 'retry-marker-never'
```

### Technical notes summary
- Root cause: the console output of `cypress-mochawesome-reporter` comes from mocha's spec reporter, which handles the `fail` event and ignores `retry`, so intermediate attempts were never printed. The mochawesome HTML/JSON report already contained them — this is purely a terminal-output gap.
- The task is added to the **existing** `on('task', …)` block. Cypress merges `task` registrations, unlike `after:run`/`after:spec` where the last registration silently wins.
- The `afterEach` is guarded by `Cypress.env('hasRetryLogging')`, set next to the existing `hasHostStats` flag, so consumers of `@rancher/cypress` that supply their own `setupNodeEvents` never call an unregistered task. Payload building is wrapped in `try/catch` for the same reason — a throwing `afterEach` skips every remaining test in the spec.
- `currentRetry()` and `retries()` are typed as `protected` on mocha's `Runnable`, hence the local `RetryableTest` interface rather than `Mocha.Test`.

### Areas or cases that should be tested
Tested locally with Chrome 151 (headless). Reviewer should use a different browser.

Run the validation spec — it is **expected to fail**, that is the point:

```
yarn cy:run --config specPattern=cypress/e2e/tests/retry-logging/**/*.spec.ts
```

Expected: three `(Attempt N of 3)` blocks containing `retry-marker-1`, `retry-marker-2` and `retry-marker-3`. Note `--spec` alone will not work — Cypress filters it against `specPattern`, which never matches this directory. Add `,baseUrl=<url>` if nothing is serving the default, as Cypress verifies `baseUrl` before every run.

Append `,retries=0` to confirm the guard produces no extra output.

Then run any normal spec and confirm output is unchanged and `cypress/reports` is still generated.

### Areas which could experience regressions
- All e2e specs — the new `afterEach` runs in every one, though it returns immediately unless the test failed *and* retries are enabled
- Anything parsing e2e terminal output
- `@rancher/cypress` consumers supplying their own `setupNodeEvents` (covered by the env flag)

### Screenshot/Video
Terminal output included under "Occurred changes" above.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
