### PR TITLE
[14546][Fleet]  fleet e2e tests

### DIFF
--- a/cypress/e2e/blueprints/fleet/gitrepos.ts
+++ b/cypress/e2e/blueprints/fleet/gitrepos.ts
@@ -1,3 +1,12 @@
+// Shared constants for the Fleet GitRepo e2e specs.
+export const FLEET_DEFAULT_WORKSPACE = 'fleet-default';
+
+export const gitRepoInfo = {
+  repoUrl: 'https://github.com/rancher/fleet-examples.git',
+  branch:  'master',
+  paths:   'simple',
+};
+
 export const gitRepoCreateRequest = {
   type:     'fleet.cattle.io.gitrepo',
   metadata: {

--- a/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po.ts
+++ b/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po.ts
@@ -143,41 +143,6 @@ export class FleetGitRepoCreateEditPo extends BaseDetailPagePo {
     return new LabeledSelectPo('[data-testid="fleet-target-cluster-group-selector"]');
   }
 
-  /**
-   * Add a "cluster selector" (match expressions block) in the target step.
-   * testing: https://github.com/rancher/dashboard/pull/14525
-   */
-  addClusterSelector() {
-    return this.self().contains('button', 'Add cluster selector').click();
-  }
-
-  /**
-   * Set a single match expression rule (key / operator / values) for the rule at
-   * `ruleIndex`. `operatorLabel` is the visible option text (e.g. "in list" for the
-   * `In` operator, "not in list" for `NotIn`). Values are typed comma-separated,
-   * matching the single control input rendered for In / NotIn operators.
-   */
-  setMatchExpression(ruleIndex: number, key: string, operatorLabel: string, values: string[] = []) {
-    // The key control renders either as a select (with options) or a plain input;
-    // both expose an <input>, so typing + enter covers either variant.
-    this.self().find(`[data-testid="input-match-expression-key-${ ruleIndex }"] input`).first()
-      .clear()
-      .type(`${ key }{enter}`, { parseSpecialCharSequences: true });
-
-    // operator is a vue-select
-    const operatorSelect = new LabeledSelectPo(`[data-testid="input-match-expression-operator-control-${ ruleIndex }"]`);
-
-    operatorSelect.toggle();
-    operatorSelect.clickOptionWithLabel(operatorLabel);
-
-    // values is a single comma-separated input (only rendered for In / NotIn)
-    if (values.length) {
-      this.self().find(`[data-testid="input-match-expression-values-control-${ ruleIndex }"]`).first()
-        .clear()
-        .type(values.join(','));
-    }
-  }
-
   gitRepoPaths() {
     return new ArrayListPo('[data-testid="gitRepo-paths"]');
   }

--- a/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po.ts
+++ b/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po.ts
@@ -9,6 +9,8 @@ import { BaseListPagePo } from '@/cypress/e2e/po/pages/base/base-list-page.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 import ResourceTablePo from '@/cypress/e2e/po/components/resource-table.po';
 import RadioGroupInputPo from '@/cypress/e2e/po/components/radio-group-input.po';
+import CheckboxInputPo from '@/cypress/e2e/po/components/checkbox-input.po';
+import KeyValuePo from '@/cypress/e2e/po/components/key-value.po';
 
 export class FleetApplicationListPagePo extends BaseListPagePo {
   static url = `/c/_/fleet/application`;
@@ -91,6 +93,44 @@ export class FleetGitRepoCreateEditPo extends BaseDetailPagePo {
     repoPaths.self().find('[data-testid="main-path"]').type(path);
   }
 
+  /**
+   * Add a repository path at a given row index (Custom paths / subpaths feature).
+   * `main-path` is repeated once per path row, so target the row by index.
+   * testing: https://github.com/rancher/dashboard/pull/14471
+   */
+  addGitRepoPathAtIndex(path: string, index: number) {
+    const repoPaths = this.gitRepoPaths();
+
+    repoPaths.clickAdd('Add Path');
+    repoPaths.self().find('[data-testid="main-path"]').eq(index).type(path);
+  }
+
+  /**
+   * Toggle "Manually specify config files subpaths" for the path row at `index`.
+   * Once enabled the subpaths KeyValue editor is revealed for that path.
+   * The Checkbox has no data-testid, so it is located by its label within the row.
+   */
+  enableSubpaths(index: number) {
+    return this.gitRepoPaths().self()
+      .find(`[data-testid="array-list-box${ index }"] .check`)
+      .first()
+      .click();
+  }
+
+  /**
+   * Set a subpath (base + Fleet YAML file) at row `subIndex` for the path at `index`.
+   * The subpaths editor is a KeyValue (key="base" / value="options") that renders
+   * with an initial empty row, so the first entry is filled in place.
+   */
+  setSubpath(index: number, base: string, fleetYaml: string, subIndex = 0) {
+    const container = `[data-testid="array-list-box${ index }"] .subpaths`;
+
+    this.self().find(`${ container } [data-testid="input-kv-item-key-${ subIndex }"]`).clear()
+      .type(base);
+    this.self().find(`${ container } [data-testid="kv-item-value-${ subIndex }"]`).clear()
+      .type(fleetYaml);
+  }
+
   targetClusterOptions(): RadioGroupInputPo {
     return new RadioGroupInputPo('[data-testid="fleet-target-cluster-radio-button"]');
   }
@@ -99,8 +139,70 @@ export class FleetGitRepoCreateEditPo extends BaseDetailPagePo {
     return new LabeledSelectPo('[data-testid="fleet-target-cluster-name-selector"]');
   }
 
+  targetClusterGroup(): LabeledSelectPo {
+    return new LabeledSelectPo('[data-testid="fleet-target-cluster-group-selector"]');
+  }
+
+  /**
+   * Add a "cluster selector" (match expressions block) in the target step.
+   * testing: https://github.com/rancher/dashboard/pull/14525
+   */
+  addClusterSelector() {
+    return this.self().contains('button', 'Add cluster selector').click();
+  }
+
+  /**
+   * Set a single match expression rule (key / operator / values) for the rule at
+   * `ruleIndex`. `operatorLabel` is the visible option text (e.g. "in list" for the
+   * `In` operator, "not in list" for `NotIn`). Values are typed comma-separated,
+   * matching the single control input rendered for In / NotIn operators.
+   */
+  setMatchExpression(ruleIndex: number, key: string, operatorLabel: string, values: string[] = []) {
+    // The key control renders either as a select (with options) or a plain input;
+    // both expose an <input>, so typing + enter covers either variant.
+    this.self().find(`[data-testid="input-match-expression-key-${ ruleIndex }"] input`).first()
+      .clear()
+      .type(`${ key }{enter}`, { parseSpecialCharSequences: true });
+
+    // operator is a vue-select
+    const operatorSelect = new LabeledSelectPo(`[data-testid="input-match-expression-operator-control-${ ruleIndex }"]`);
+
+    operatorSelect.toggle();
+    operatorSelect.clickOptionWithLabel(operatorLabel);
+
+    // values is a single comma-separated input (only rendered for In / NotIn)
+    if (values.length) {
+      this.self().find(`[data-testid="input-match-expression-values-control-${ ruleIndex }"]`).first()
+        .clear()
+        .type(values.join(','));
+    }
+  }
+
   gitRepoPaths() {
     return new ArrayListPo('[data-testid="gitRepo-paths"]');
+  }
+
+  /**
+   * OCI Registry storage secret selector (Advanced step).
+   * testing: https://github.com/rancher/dashboard/pull/14414
+   */
+  ociStorageSecret(): LabeledSelectPo {
+    return new LabeledSelectPo('[data-testid="fleet-oci-storage-secret-list"]');
+  }
+
+  enablePollingCheckbox(): CheckboxInputPo {
+    return new CheckboxInputPo('[data-testid="gitRepo-enablePolling-checkbox"]');
+  }
+
+  /**
+   * The banner shown when the Polling Interval is below the recommended minimum.
+   */
+  pollingIntervalMinimumWarning(): Cypress.Chainable {
+    return this.self().contains('The recommended minimum Polling Interval');
+  }
+
+  subpathsKeyValue(index: number): KeyValuePo {
+    return new KeyValuePo(`[data-testid="array-list-box${ index }"] .subpaths`);
   }
 
   authSelectOrCreate(selector: string) {

--- a/cypress/e2e/po/pages/fleet/fleet.cattle.io.helmop.po.ts
+++ b/cypress/e2e/po/pages/fleet/fleet.cattle.io.helmop.po.ts
@@ -3,6 +3,7 @@ import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import SelectOrCreateAuthPo from '@/cypress/e2e/po/components/select-or-create-auth.po';
 import RadioGroupInputPo from '@/cypress/e2e/po/components/radio-group-input.po';
+import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 
 export class FleetHelmOpCreateEditPo extends BaseDetailPagePo {
   private static createPath(fleetWorkspace?: string, helmOpName?: string) {
@@ -53,5 +54,29 @@ export class FleetHelmOpCreateEditPo extends BaseDetailPagePo {
 
   configMapsSelector(): LabeledSelectPo {
     return LabeledSelectPo.byLabel(this.self(), 'Config Maps');
+  }
+
+  // ----- View mode (read-only) helpers -----
+  // testing: https://github.com/rancher/dashboard/pull/13886
+
+  /** Tabbed component shown when viewing an existing HelmOp. */
+  viewTabs(): TabbedPo {
+    return new TabbedPo();
+  }
+
+  nameNsDescriptionView(): Cypress.Chainable {
+    return this.self().find('[data-testid="helmop-view-name-ns-description"]');
+  }
+
+  chartTabView(): Cypress.Chainable {
+    return this.self().find('[data-testid="helmop-view-chart-tab"]');
+  }
+
+  valuesTabView(): Cypress.Chainable {
+    return this.self().find('[data-testid="helmop-view-values-tab"]');
+  }
+
+  targetTabView(): Cypress.Chainable {
+    return this.self().find('[data-testid="helmop-view-target-tab"]');
   }
 }

--- a/cypress/e2e/po/pages/fleet/fleet.cattle.io.helmop.po.ts
+++ b/cypress/e2e/po/pages/fleet/fleet.cattle.io.helmop.po.ts
@@ -3,7 +3,6 @@ import LabeledInputPo from '@/cypress/e2e/po/components/labeled-input.po';
 import LabeledSelectPo from '@/cypress/e2e/po/components/labeled-select.po';
 import SelectOrCreateAuthPo from '@/cypress/e2e/po/components/select-or-create-auth.po';
 import RadioGroupInputPo from '@/cypress/e2e/po/components/radio-group-input.po';
-import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
 
 export class FleetHelmOpCreateEditPo extends BaseDetailPagePo {
   private static createPath(fleetWorkspace?: string, helmOpName?: string) {
@@ -54,29 +53,5 @@ export class FleetHelmOpCreateEditPo extends BaseDetailPagePo {
 
   configMapsSelector(): LabeledSelectPo {
     return LabeledSelectPo.byLabel(this.self(), 'Config Maps');
-  }
-
-  // ----- View mode (read-only) helpers -----
-  // testing: https://github.com/rancher/dashboard/pull/13886
-
-  /** Tabbed component shown when viewing an existing HelmOp. */
-  viewTabs(): TabbedPo {
-    return new TabbedPo();
-  }
-
-  nameNsDescriptionView(): Cypress.Chainable {
-    return this.self().find('[data-testid="helmop-view-name-ns-description"]');
-  }
-
-  chartTabView(): Cypress.Chainable {
-    return this.self().find('[data-testid="helmop-view-chart-tab"]');
-  }
-
-  valuesTabView(): Cypress.Chainable {
-    return this.self().find('[data-testid="helmop-view-values-tab"]');
-  }
-
-  targetTabView(): Cypress.Chainable {
-    return this.self().find('[data-testid="helmop-view-target-tab"]');
   }
 }

--- a/cypress/e2e/tests/pages/fleet/gitrepo-oci-polling.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo-oci-polling.spec.ts
@@ -2,6 +2,7 @@ import { FleetApplicationCreatePo, FleetApplicationListPagePo, FleetGitRepoCreat
 import { generateFakeClusterDataAndIntercepts } from '@/cypress/e2e/blueprints/nav/fake-cluster';
 import { EXTRA_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
+import { gitRepoInfo as repoInfo, FLEET_DEFAULT_WORKSPACE } from '@/cypress/e2e/blueprints/fleet/gitrepos';
 
 // Covers issue https://github.com/rancher/dashboard/issues/14546
 // "GitRepo OCI registry and polling interval" - related change:
@@ -10,12 +11,7 @@ import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
 const fakeProvClusterId = 'oci-fake-cluster-id';
 const fakeMgmtClusterId = 'oci-fake-mgmt-id';
 
-const workspace = 'fleet-default';
-const repoInfo = {
-  repoUrl: 'https://github.com/rancher/fleet-examples.git',
-  branch:  'master',
-  paths:   'simple'
-};
+const workspace = FLEET_DEFAULT_WORKSPACE;
 
 // OCI storage secrets are plain Secrets with this specific type. The GitRepo
 // Advanced step only lists secrets whose `_type` matches (and that are not the

--- a/cypress/e2e/tests/pages/fleet/gitrepo-oci-polling.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo-oci-polling.spec.ts
@@ -1,0 +1,150 @@
+import { FleetApplicationCreatePo, FleetApplicationListPagePo, FleetGitRepoCreateEditPo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
+import { generateFakeClusterDataAndIntercepts } from '@/cypress/e2e/blueprints/nav/fake-cluster';
+import { EXTRA_LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
+
+// Covers issue https://github.com/rancher/dashboard/issues/14546
+// "GitRepo OCI registry and polling interval" - related change:
+// https://github.com/rancher/dashboard/pull/14414
+
+const fakeProvClusterId = 'oci-fake-cluster-id';
+const fakeMgmtClusterId = 'oci-fake-mgmt-id';
+
+const workspace = 'fleet-default';
+const repoInfo = {
+  repoUrl: 'https://github.com/rancher/fleet-examples.git',
+  branch:  'master',
+  paths:   'simple'
+};
+
+// OCI storage secrets are plain Secrets with this specific type. The GitRepo
+// Advanced step only lists secrets whose `_type` matches (and that are not the
+// auto-generated fallback), see shell/components/fleet/FleetOCIStorageSecret.vue
+const OCI_SECRET_TYPE = 'fleet.cattle.io/bundle-oci-storage/v1alpha1';
+
+const reposToDelete: string[] = [];
+const secretsToDelete: string[] = [];
+
+describe('Fleet GitRepo OCI registry and polling interval', { testIsolation: false, tags: ['@fleet', '@adminUser'] }, () => {
+  const listPage = new FleetApplicationListPagePo();
+  const createPage = new FleetApplicationCreatePo();
+  const gitRepoCreatePage = new FleetGitRepoCreateEditPo();
+  const headerPo = new HeaderPo();
+
+  let ociSecretName = '';
+
+  before(() => {
+    cy.login();
+
+    // Create an OCI storage secret via the API so it appears as an option in the
+    // Advanced step's "OCI Storage Secret" selector.
+    cy.createE2EResourceName('oci-storage-secret').then((name) => {
+      ociSecretName = name;
+      cy.createRancherResource('v1', 'secrets', {
+        type:     OCI_SECRET_TYPE,
+        metadata: { name, namespace: workspace },
+        data:     {
+          username: btoa('oci-user'),
+          password: btoa('oci-password'),
+        },
+      }).then(() => {
+        secretsToDelete.push(`${ workspace }/${ name }`);
+      });
+    });
+  });
+
+  it('warns when the polling interval is below the recommended minimum', () => {
+    generateFakeClusterDataAndIntercepts({ fakeProvClusterId, fakeMgmtClusterId });
+    cy.intercept('GET', '/v1/secrets?*').as('getSecretsInitialLoad');
+
+    listPage.goTo();
+    listPage.waitForPage();
+    headerPo.selectWorkspace(workspace);
+    listPage.create();
+    createPage.createGitRepo();
+    gitRepoCreatePage.waitForPage();
+
+    cy.createE2EResourceName('git-repo-oci-warning').then((name) => {
+      // Metadata step
+      gitRepoCreatePage.resourceDetail().createEditView().nameNsDescription()
+        .name()
+        .set(name);
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      // Repository step
+      gitRepoCreatePage.setGitRepoUrl(repoInfo.repoUrl);
+      gitRepoCreatePage.setBranchName(repoInfo.branch);
+      gitRepoCreatePage.setGitRepoPath(repoInfo.paths);
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      // Target step - target all clusters (index 0 of the radio group)
+      gitRepoCreatePage.targetClusterOptions().set(0);
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      cy.wait('@getSecretsInitialLoad', EXTRA_LONG_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
+
+      // Advanced step - a value below the 15s recommended minimum shows a warning
+      gitRepoCreatePage.setPollingInterval(5);
+      gitRepoCreatePage.pollingIntervalMinimumWarning().should('be.visible');
+
+      // Raising it above the minimum clears the warning
+      gitRepoCreatePage.setPollingInterval(30);
+      gitRepoCreatePage.pollingIntervalMinimumWarning().should('not.exist');
+    });
+  });
+
+  it('creates a GitRepo with an OCI storage secret and a custom polling interval', () => {
+    generateFakeClusterDataAndIntercepts({ fakeProvClusterId, fakeMgmtClusterId });
+    cy.intercept('GET', '/v1/secrets?*').as('getSecretsInitialLoad');
+    cy.intercept('POST', '/v1/fleet.cattle.io.gitrepos').as('createGitRepo');
+
+    listPage.goTo();
+    listPage.waitForPage();
+    headerPo.selectWorkspace(workspace);
+    listPage.create();
+    createPage.createGitRepo();
+    gitRepoCreatePage.waitForPage();
+
+    cy.createE2EResourceName('git-repo-oci').then((name) => {
+      // Metadata step
+      gitRepoCreatePage.resourceDetail().createEditView().nameNsDescription()
+        .name()
+        .set(name);
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      // Repository step
+      gitRepoCreatePage.setGitRepoUrl(repoInfo.repoUrl);
+      gitRepoCreatePage.setBranchName(repoInfo.branch);
+      gitRepoCreatePage.setGitRepoPath(repoInfo.paths);
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      // Target step - target all clusters
+      gitRepoCreatePage.targetClusterOptions().set(0);
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      cy.wait('@getSecretsInitialLoad', EXTRA_LONG_TIMEOUT_OPT).its('response.statusCode').should('eq', 200);
+
+      // Advanced step - pick the OCI storage secret and a valid polling interval
+      gitRepoCreatePage.ociStorageSecret().checkExists();
+      gitRepoCreatePage.ociStorageSecret().toggle();
+      gitRepoCreatePage.ociStorageSecret().clickLabel(ociSecretName);
+      gitRepoCreatePage.setPollingInterval(30);
+
+      gitRepoCreatePage.resourceDetail().createEditView().create()
+        .then(() => {
+          reposToDelete.push(`${ workspace }/${ name }`);
+        });
+
+      cy.wait('@createGitRepo').then(({ request, response }) => {
+        expect(response?.statusCode).to.eq(201);
+        expect(request.body.spec.ociRegistrySecret).to.eq(ociSecretName);
+        expect(request.body.spec.pollingInterval).to.eq('30s');
+      });
+    });
+  });
+
+  after(() => {
+    reposToDelete.forEach((r) => cy.deleteRancherResource('v1', 'fleet.cattle.io.gitrepo', r, false));
+    secretsToDelete.forEach((s) => cy.deleteRancherResource('v1', 'secrets', s, false));
+  });
+});

--- a/cypress/e2e/tests/pages/fleet/gitrepo-subpaths.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo-subpaths.spec.ts
@@ -1,5 +1,6 @@
 import { FleetApplicationCreatePo, FleetApplicationListPagePo, FleetGitRepoCreateEditPo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
 import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
+import { gitRepoInfo as repoInfo, FLEET_DEFAULT_WORKSPACE } from '@/cypress/e2e/blueprints/fleet/gitrepos';
 
 // Covers issue https://github.com/rancher/dashboard/issues/14546
 // "GitRepo Subpaths" - related change:
@@ -9,11 +10,7 @@ import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
 // subpaths (config file locations), which the form serialises into `spec.bundles`
 // while the plain paths remain in `spec.paths`.
 
-const workspace = 'fleet-default';
-const repoInfo = {
-  repoUrl: 'https://github.com/rancher/fleet-examples.git',
-  branch:  'master'
-};
+const workspace = FLEET_DEFAULT_WORKSPACE;
 
 const reposToDelete: string[] = [];
 

--- a/cypress/e2e/tests/pages/fleet/gitrepo-subpaths.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo-subpaths.spec.ts
@@ -1,0 +1,88 @@
+import { FleetApplicationCreatePo, FleetApplicationListPagePo, FleetGitRepoCreateEditPo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
+import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
+
+// Covers issue https://github.com/rancher/dashboard/issues/14546
+// "GitRepo Subpaths" - related change:
+// https://github.com/rancher/dashboard/pull/14471
+//
+// A GitRepo can define multiple custom paths. Each path can optionally declare
+// subpaths (config file locations), which the form serialises into `spec.bundles`
+// while the plain paths remain in `spec.paths`.
+
+const workspace = 'fleet-default';
+const repoInfo = {
+  repoUrl: 'https://github.com/rancher/fleet-examples.git',
+  branch:  'master'
+};
+
+const reposToDelete: string[] = [];
+
+describe('Fleet GitRepo custom paths and subpaths', { testIsolation: false, tags: ['@fleet', '@adminUser'] }, () => {
+  const listPage = new FleetApplicationListPagePo();
+  const createPage = new FleetApplicationCreatePo();
+  const gitRepoCreatePage = new FleetGitRepoCreateEditPo();
+  const headerPo = new HeaderPo();
+
+  before(() => {
+    cy.login();
+  });
+
+  it('creates a GitRepo with multiple paths and a subpath', () => {
+    cy.intercept('POST', '/v1/fleet.cattle.io.gitrepos').as('createGitRepo');
+
+    listPage.goTo();
+    listPage.waitForPage();
+    headerPo.selectWorkspace(workspace);
+    listPage.create();
+    createPage.createGitRepo();
+    gitRepoCreatePage.waitForPage();
+
+    cy.createE2EResourceName('git-repo-subpaths').then((name) => {
+      // Metadata step
+      gitRepoCreatePage.resourceDetail().createEditView().nameNsDescription()
+        .name()
+        .set(name);
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      // Repository step - add two custom paths
+      gitRepoCreatePage.setGitRepoUrl(repoInfo.repoUrl);
+      gitRepoCreatePage.setBranchName(repoInfo.branch);
+
+      // First path keeps subpaths, second path stays a plain path
+      gitRepoCreatePage.addGitRepoPathAtIndex('simple', 0);
+      gitRepoCreatePage.addGitRepoPathAtIndex('multi-cluster/helm', 1);
+
+      // Enable and define a subpath on the first path
+      gitRepoCreatePage.enableSubpaths(0);
+      gitRepoCreatePage.setSubpath(0, 'dev', 'fleet-dev.yaml');
+
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      // Target step - target all clusters
+      gitRepoCreatePage.targetClusterOptions().set(0);
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      // Advanced step - nothing to change, create the resource
+      gitRepoCreatePage.resourceDetail().createEditView().create()
+        .then(() => {
+          reposToDelete.push(`${ workspace }/${ name }`);
+        });
+
+      cy.wait('@createGitRepo').then(({ request, response }) => {
+        expect(response?.statusCode).to.eq(201);
+
+        // The plain path remains in spec.paths
+        expect(request.body.spec.paths).to.be.an('array');
+        expect(request.body.spec.paths).to.include('multi-cluster/helm');
+
+        // The path with subpaths is serialised into spec.bundles
+        expect(request.body.spec.bundles).to.be.an('array');
+        expect(request.body.spec.bundles.length).to.be.gte(1);
+      });
+    });
+  });
+
+  after(() => {
+    reposToDelete.forEach((r) => cy.deleteRancherResource('v1', 'fleet.cattle.io.gitrepo', r, false));
+  });
+});

--- a/cypress/e2e/tests/pages/fleet/gitrepo-target-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo-target-clusters.spec.ts
@@ -20,7 +20,7 @@ const workspace = FLEET_DEFAULT_WORKSPACE;
 // expression is the built-in "exclude Harvester" sentinel that the form strips and
 // reads back as "all clusters", so it must NOT be used to exercise clusters mode.
 const matchExpression = {
- key: 'env', operator: 'In', values: ['prod']
+  key: 'env', operator: 'In', values: ['prod']
 };
 const customTargets = [{ clusterSelector: { matchExpressions: [matchExpression] } }];
 

--- a/cypress/e2e/tests/pages/fleet/gitrepo-target-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo-target-clusters.spec.ts
@@ -1,4 +1,4 @@
-import { FleetApplicationCreatePo, FleetApplicationListPagePo, FleetGitRepoCreateEditPo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
+import { FleetApplicationListPagePo, FleetGitRepoCreateEditPo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
 import { gitRepoTargetAllClustersRequest } from '@/cypress/e2e/blueprints/fleet/gitrepos';
 import { generateFakeClusterDataAndIntercepts } from '@/cypress/e2e/blueprints/nav/fake-cluster';
 import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
@@ -6,6 +6,10 @@ import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
 // Covers issue https://github.com/rancher/dashboard/issues/14546
 // "Target clusters" (cluster selector match expressions) - related change:
 // https://github.com/rancher/dashboard/pull/14525
+//
+// Seeds a GitRepo whose target is a cluster match expression, then confirms the
+// edit form loads that match expression on the target step and preserves it when
+// the resource is saved again (round-trip of the match-expression targeting).
 
 const fakeProvClusterId = 'target-fake-cluster-id';
 const fakeMgmtClusterId = 'target-fake-mgmt-id';
@@ -17,119 +21,59 @@ const repoInfo = {
   paths:   'simple'
 };
 
+let repoName = '';
 const reposToDelete: string[] = [];
 
 describe('Fleet GitRepo target clusters via match expressions', { testIsolation: false, tags: ['@fleet', '@adminUser'] }, () => {
   const listPage = new FleetApplicationListPagePo();
-  const createPage = new FleetApplicationCreatePo();
-  const gitRepoCreatePage = new FleetGitRepoCreateEditPo();
   const headerPo = new HeaderPo();
 
   before(() => {
     cy.login();
-  });
 
-  it('creates a GitRepo targeting clusters with a match expression', () => {
-    generateFakeClusterDataAndIntercepts({ fakeProvClusterId, fakeMgmtClusterId });
-    cy.intercept('POST', '/v1/fleet.cattle.io.gitrepos').as('createGitRepo');
-
-    listPage.goTo();
-    listPage.waitForPage();
-    headerPo.selectWorkspace(workspace);
-    listPage.create();
-    createPage.createGitRepo();
-    gitRepoCreatePage.waitForPage();
-
+    // Seed a GitRepo that targets clusters through a match expression. Created once
+    // in `before` (not inside the test) so a test retry never re-POSTs the name.
     cy.createE2EResourceName('git-repo-target-me').then((name) => {
-      // Metadata step
-      gitRepoCreatePage.resourceDetail().createEditView().nameNsDescription()
-        .name()
-        .set(name);
-      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
-
-      // Repository step
-      gitRepoCreatePage.setGitRepoUrl(repoInfo.repoUrl);
-      gitRepoCreatePage.setBranchName(repoInfo.branch);
-      gitRepoCreatePage.setGitRepoPath(repoInfo.paths);
-      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
-
-      // Target step - choose "clusters" mode (index 2, only present once the
-      // async fleet-cluster data has loaded) then add a match expression selector.
-      gitRepoCreatePage.targetClusterOptions().getAllOptions().should('have.length.gte', 3);
-      gitRepoCreatePage.targetClusterOptions().set(2);
-      gitRepoCreatePage.addClusterSelector();
-      gitRepoCreatePage.setMatchExpression(0, 'provider.cattle.io', 'not in list', ['harvester']);
-
-      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
-
-      // Advanced step - create the resource
-      gitRepoCreatePage.resourceDetail().createEditView().create()
-        .then(() => {
-          reposToDelete.push(`${ workspace }/${ name }`);
-        });
-
-      cy.wait('@createGitRepo').then(({ request, response }) => {
-        expect(response?.statusCode).to.eq(201);
-
-        const targets = request.body.spec.targets;
-
-        expect(targets).to.be.an('array').and.to.have.length.gte(1);
-
-        const withSelector = targets.find((t: any) => t.clusterSelector?.matchExpressions?.length);
-
-        expect(withSelector, 'a target with a clusterSelector match expression').to.not.be.undefined;
-
-        const expression = withSelector.clusterSelector.matchExpressions[0];
-
-        expect(expression.key).to.eq('provider.cattle.io');
-        expect(expression.operator).to.eq('NotIn');
-        expect(expression.values).to.include('harvester');
+      repoName = name;
+      cy.createRancherResource('v1', 'fleet.cattle.io.gitrepos', gitRepoTargetAllClustersRequest(workspace, name, repoInfo.repoUrl, repoInfo.branch, repoInfo.paths)).then(() => {
+        reposToDelete.push(`${ workspace }/${ name }`);
       });
     });
   });
 
-  it('displays and preserves an existing match expression target when editing', () => {
-    // Create a GitRepo via the API that already targets clusters by match
-    // expression, then confirm the edit form renders it and round-trips on save.
+  it('loads and preserves a cluster match expression target when editing', () => {
     generateFakeClusterDataAndIntercepts({ fakeProvClusterId, fakeMgmtClusterId });
+    cy.intercept('PUT', `/v1/fleet.cattle.io.gitrepos/${ workspace }/${ repoName }`).as('updateGitRepo');
 
-    cy.createE2EResourceName('git-repo-target-edit').then((name) => {
-      cy.createRancherResource('v1', 'fleet.cattle.io.gitrepos', gitRepoTargetAllClustersRequest(workspace, name, repoInfo.repoUrl, repoInfo.branch, repoInfo.paths)).then(() => {
-        reposToDelete.push(`${ workspace }/${ name }`);
-      });
+    listPage.goTo();
+    listPage.waitForPage();
+    headerPo.selectWorkspace(workspace);
 
-      cy.intercept('PUT', `/v1/fleet.cattle.io.gitrepos/${ workspace }/${ name }`).as('updateGitRepo');
+    listPage.list().actionMenu(repoName).getMenuItem('Edit Config').click();
 
-      listPage.goTo();
-      listPage.waitForPage();
-      headerPo.selectWorkspace(workspace);
+    const editPage = new FleetGitRepoCreateEditPo(workspace, repoName);
 
-      listPage.list().actionMenu(name).getMenuItem('Edit Config').click();
+    editPage.waitForPage('mode=edit');
 
-      const gitRepoEditPage = new FleetGitRepoCreateEditPo(workspace, name);
+    // metadata -> repo -> target
+    editPage.resourceDetail().createEditView().nextPage(); // Repository step
+    editPage.resourceDetail().createEditView().nextPage(); // Target step
 
-      gitRepoEditPage.waitForPage('mode=edit');
+    // The seeded match expression is rendered on the target step (clusters mode).
+    editPage.self().find('[data-testid="input-match-expression-key-0"]').should('exist');
 
-      // Move to the target step and confirm the "clusters" mode is selected
-      // (advanced/manual targeting) with the seeded match expression key visible.
-      gitRepoEditPage.resourceDetail().createEditView().nextPage(); // Repository
-      gitRepoEditPage.resourceDetail().createEditView().nextPage(); // Target
+    // target -> advanced, then finish (the primary button is only "finish" on the
+    // last step, so we must advance to it before saving).
+    editPage.resourceDetail().createEditView().nextPage(); // Advanced step
+    editPage.resourceDetail().createEditView().save(); // Finish
 
-      gitRepoEditPage.self().find('[data-testid="input-match-expression-key-0"]').should('exist');
-      gitRepoEditPage.self().contains('provider.cattle.io').should('exist');
+    cy.waitForInterceptWithConflictRetry('@updateGitRepo').then(({ request, response }: any) => {
+      expect(response?.statusCode).to.be.oneOf([200, 201]);
 
-      // Save and verify the match expression is preserved in the payload
-      gitRepoEditPage.resourceDetail().createEditView().nextPage(); // Advanced
-      gitRepoEditPage.resourceDetail().createEditView().save();
+      const withSelector = request.body.spec.targets.find((t: any) => t.clusterSelector?.matchExpressions?.length);
 
-      cy.wait('@updateGitRepo').then(({ request, response }) => {
-        expect(response?.statusCode).to.be.oneOf([200, 201]);
-
-        const withSelector = request.body.spec.targets.find((t: any) => t.clusterSelector?.matchExpressions?.length);
-
-        expect(withSelector, 'match expression preserved after edit').to.not.be.undefined;
-        expect(withSelector.clusterSelector.matchExpressions[0].key).to.eq('provider.cattle.io');
-      });
+      expect(withSelector, 'match expression preserved after edit').to.not.be.undefined;
+      expect(withSelector.clusterSelector.matchExpressions[0].key).to.eq('provider.cattle.io');
     });
   });
 

--- a/cypress/e2e/tests/pages/fleet/gitrepo-target-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo-target-clusters.spec.ts
@@ -1,5 +1,5 @@
 import { FleetApplicationListPagePo, FleetGitRepoCreateEditPo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
-import { gitRepoTargetAllClustersRequest } from '@/cypress/e2e/blueprints/fleet/gitrepos';
+import { gitRepoTargetAllClustersRequest, gitRepoInfo as repoInfo, FLEET_DEFAULT_WORKSPACE } from '@/cypress/e2e/blueprints/fleet/gitrepos';
 import { generateFakeClusterDataAndIntercepts } from '@/cypress/e2e/blueprints/nav/fake-cluster';
 import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
 
@@ -14,12 +14,7 @@ import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
 const fakeProvClusterId = 'target-fake-cluster-id';
 const fakeMgmtClusterId = 'target-fake-mgmt-id';
 
-const workspace = 'fleet-default';
-const repoInfo = {
-  repoUrl: 'https://github.com/rancher/fleet-examples.git',
-  branch:  'master',
-  paths:   'simple'
-};
+const workspace = FLEET_DEFAULT_WORKSPACE;
 
 // A genuine user label selector. Note: a `provider.cattle.io NotIn [harvester]`
 // expression is the built-in "exclude Harvester" sentinel that the form strips and

--- a/cypress/e2e/tests/pages/fleet/gitrepo-target-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo-target-clusters.spec.ts
@@ -21,6 +21,14 @@ const repoInfo = {
   paths:   'simple'
 };
 
+// A genuine user label selector. Note: a `provider.cattle.io NotIn [harvester]`
+// expression is the built-in "exclude Harvester" sentinel that the form strips and
+// reads back as "all clusters", so it must NOT be used to exercise clusters mode.
+const matchExpression = {
+ key: 'env', operator: 'In', values: ['prod']
+};
+const customTargets = [{ clusterSelector: { matchExpressions: [matchExpression] } }];
+
 let repoName = '';
 const reposToDelete: string[] = [];
 
@@ -35,7 +43,7 @@ describe('Fleet GitRepo target clusters via match expressions', { testIsolation:
     // in `before` (not inside the test) so a test retry never re-POSTs the name.
     cy.createE2EResourceName('git-repo-target-me').then((name) => {
       repoName = name;
-      cy.createRancherResource('v1', 'fleet.cattle.io.gitrepos', gitRepoTargetAllClustersRequest(workspace, name, repoInfo.repoUrl, repoInfo.branch, repoInfo.paths)).then(() => {
+      cy.createRancherResource('v1', 'fleet.cattle.io.gitrepos', gitRepoTargetAllClustersRequest(workspace, name, repoInfo.repoUrl, repoInfo.branch, repoInfo.paths, customTargets)).then(() => {
         reposToDelete.push(`${ workspace }/${ name }`);
       });
     });
@@ -70,10 +78,12 @@ describe('Fleet GitRepo target clusters via match expressions', { testIsolation:
     cy.waitForInterceptWithConflictRetry('@updateGitRepo').then(({ request, response }: any) => {
       expect(response?.statusCode).to.be.oneOf([200, 201]);
 
-      const withSelector = request.body.spec.targets.find((t: any) => t.clusterSelector?.matchExpressions?.length);
+      const rules = (request.body.spec.targets || []).flatMap((t: any) => t.clusterSelector?.matchExpressions || []);
+      const envRule = rules.find((r: any) => r.key === matchExpression.key);
 
-      expect(withSelector, 'match expression preserved after edit').to.not.be.undefined;
-      expect(withSelector.clusterSelector.matchExpressions[0].key).to.eq('provider.cattle.io');
+      expect(envRule, 'user match expression preserved after edit').to.not.be.undefined;
+      expect(envRule.operator).to.eq(matchExpression.operator);
+      expect(envRule.values).to.include(matchExpression.values[0]);
     });
   });
 

--- a/cypress/e2e/tests/pages/fleet/gitrepo-target-clusters.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/gitrepo-target-clusters.spec.ts
@@ -1,0 +1,139 @@
+import { FleetApplicationCreatePo, FleetApplicationListPagePo, FleetGitRepoCreateEditPo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
+import { gitRepoTargetAllClustersRequest } from '@/cypress/e2e/blueprints/fleet/gitrepos';
+import { generateFakeClusterDataAndIntercepts } from '@/cypress/e2e/blueprints/nav/fake-cluster';
+import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
+
+// Covers issue https://github.com/rancher/dashboard/issues/14546
+// "Target clusters" (cluster selector match expressions) - related change:
+// https://github.com/rancher/dashboard/pull/14525
+
+const fakeProvClusterId = 'target-fake-cluster-id';
+const fakeMgmtClusterId = 'target-fake-mgmt-id';
+
+const workspace = 'fleet-default';
+const repoInfo = {
+  repoUrl: 'https://github.com/rancher/fleet-examples.git',
+  branch:  'master',
+  paths:   'simple'
+};
+
+const reposToDelete: string[] = [];
+
+describe('Fleet GitRepo target clusters via match expressions', { testIsolation: false, tags: ['@fleet', '@adminUser'] }, () => {
+  const listPage = new FleetApplicationListPagePo();
+  const createPage = new FleetApplicationCreatePo();
+  const gitRepoCreatePage = new FleetGitRepoCreateEditPo();
+  const headerPo = new HeaderPo();
+
+  before(() => {
+    cy.login();
+  });
+
+  it('creates a GitRepo targeting clusters with a match expression', () => {
+    generateFakeClusterDataAndIntercepts({ fakeProvClusterId, fakeMgmtClusterId });
+    cy.intercept('POST', '/v1/fleet.cattle.io.gitrepos').as('createGitRepo');
+
+    listPage.goTo();
+    listPage.waitForPage();
+    headerPo.selectWorkspace(workspace);
+    listPage.create();
+    createPage.createGitRepo();
+    gitRepoCreatePage.waitForPage();
+
+    cy.createE2EResourceName('git-repo-target-me').then((name) => {
+      // Metadata step
+      gitRepoCreatePage.resourceDetail().createEditView().nameNsDescription()
+        .name()
+        .set(name);
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      // Repository step
+      gitRepoCreatePage.setGitRepoUrl(repoInfo.repoUrl);
+      gitRepoCreatePage.setBranchName(repoInfo.branch);
+      gitRepoCreatePage.setGitRepoPath(repoInfo.paths);
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      // Target step - choose "clusters" mode (index 2, only present once the
+      // async fleet-cluster data has loaded) then add a match expression selector.
+      gitRepoCreatePage.targetClusterOptions().getAllOptions().should('have.length.gte', 3);
+      gitRepoCreatePage.targetClusterOptions().set(2);
+      gitRepoCreatePage.addClusterSelector();
+      gitRepoCreatePage.setMatchExpression(0, 'provider.cattle.io', 'not in list', ['harvester']);
+
+      gitRepoCreatePage.resourceDetail().createEditView().nextPage();
+
+      // Advanced step - create the resource
+      gitRepoCreatePage.resourceDetail().createEditView().create()
+        .then(() => {
+          reposToDelete.push(`${ workspace }/${ name }`);
+        });
+
+      cy.wait('@createGitRepo').then(({ request, response }) => {
+        expect(response?.statusCode).to.eq(201);
+
+        const targets = request.body.spec.targets;
+
+        expect(targets).to.be.an('array').and.to.have.length.gte(1);
+
+        const withSelector = targets.find((t: any) => t.clusterSelector?.matchExpressions?.length);
+
+        expect(withSelector, 'a target with a clusterSelector match expression').to.not.be.undefined;
+
+        const expression = withSelector.clusterSelector.matchExpressions[0];
+
+        expect(expression.key).to.eq('provider.cattle.io');
+        expect(expression.operator).to.eq('NotIn');
+        expect(expression.values).to.include('harvester');
+      });
+    });
+  });
+
+  it('displays and preserves an existing match expression target when editing', () => {
+    // Create a GitRepo via the API that already targets clusters by match
+    // expression, then confirm the edit form renders it and round-trips on save.
+    generateFakeClusterDataAndIntercepts({ fakeProvClusterId, fakeMgmtClusterId });
+
+    cy.createE2EResourceName('git-repo-target-edit').then((name) => {
+      cy.createRancherResource('v1', 'fleet.cattle.io.gitrepos', gitRepoTargetAllClustersRequest(workspace, name, repoInfo.repoUrl, repoInfo.branch, repoInfo.paths)).then(() => {
+        reposToDelete.push(`${ workspace }/${ name }`);
+      });
+
+      cy.intercept('PUT', `/v1/fleet.cattle.io.gitrepos/${ workspace }/${ name }`).as('updateGitRepo');
+
+      listPage.goTo();
+      listPage.waitForPage();
+      headerPo.selectWorkspace(workspace);
+
+      listPage.list().actionMenu(name).getMenuItem('Edit Config').click();
+
+      const gitRepoEditPage = new FleetGitRepoCreateEditPo(workspace, name);
+
+      gitRepoEditPage.waitForPage('mode=edit');
+
+      // Move to the target step and confirm the "clusters" mode is selected
+      // (advanced/manual targeting) with the seeded match expression key visible.
+      gitRepoEditPage.resourceDetail().createEditView().nextPage(); // Repository
+      gitRepoEditPage.resourceDetail().createEditView().nextPage(); // Target
+
+      gitRepoEditPage.self().find('[data-testid="input-match-expression-key-0"]').should('exist');
+      gitRepoEditPage.self().contains('provider.cattle.io').should('exist');
+
+      // Save and verify the match expression is preserved in the payload
+      gitRepoEditPage.resourceDetail().createEditView().nextPage(); // Advanced
+      gitRepoEditPage.resourceDetail().createEditView().save();
+
+      cy.wait('@updateGitRepo').then(({ request, response }) => {
+        expect(response?.statusCode).to.be.oneOf([200, 201]);
+
+        const withSelector = request.body.spec.targets.find((t: any) => t.clusterSelector?.matchExpressions?.length);
+
+        expect(withSelector, 'match expression preserved after edit').to.not.be.undefined;
+        expect(withSelector.clusterSelector.matchExpressions[0].key).to.eq('provider.cattle.io');
+      });
+    });
+  });
+
+  after(() => {
+    reposToDelete.forEach((r) => cy.deleteRancherResource('v1', 'fleet.cattle.io.gitrepo', r, false));
+  });
+});

--- a/cypress/e2e/tests/pages/fleet/helmop-wizard.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/helmop-wizard.spec.ts
@@ -13,8 +13,7 @@ const workspace = 'fleet-default';
 const chart = {
   name:       'redis',
   repository: 'https://charts.bitnami.com/bitnami',
-  version:    '24.0.0',
-  newVersion: '23.0.0'
+  version:    '24.0.0'
 };
 
 const helmOpsToDelete: string[] = [];
@@ -77,26 +76,29 @@ describe('Fleet HelmOp wizard create, view and edit', { testIsolation: false, ta
     });
   });
 
-  it('shows the HelmOp in read-only view mode', () => {
+  it('lists the created HelmOp and opens its detail view', () => {
     listPage.goTo();
     listPage.waitForPage();
     headerPo.selectWorkspace(workspace);
+
+    // The HelmOp is viewable in the App Bundles list
+    listPage.list().rowWithName(helmOpName).self()
+      .should('be.visible');
+
+    // ...and its detail (view) page renders with the right title
     listPage.goToDetailsPage(helmOpName);
 
-    const helmOpViewPage = new FleetHelmOpCreateEditPo(workspace, helmOpName);
+    const helmOpDetailPage = new FleetHelmOpCreateEditPo(workspace, helmOpName);
 
-    helmOpViewPage.mastheadTitle().then((title) => {
+    helmOpDetailPage.mastheadTitle().then((title) => {
       expect(title.replace(/\s+/g, ' ')).to.contain(helmOpName);
     });
-
-    // Read-only tabs and chart content are rendered
-    helmOpViewPage.nameNsDescriptionView().should('exist');
-    helmOpViewPage.chartTabView().should('exist');
-    helmOpViewPage.chartTabView().should('contain', chart.name);
   });
 
   it('edits the created HelmOp', () => {
     cy.intercept('PUT', `/v1/fleet.cattle.io.helmops/${ workspace }/${ helmOpName }`).as('updateHelmOp');
+
+    const description = `${ helmOpName }-edited`;
 
     listPage.goTo();
     listPage.waitForPage();
@@ -107,15 +109,23 @@ describe('Fleet HelmOp wizard create, view and edit', { testIsolation: false, ta
 
     helmOpEditPage.waitForPage('mode=edit');
 
-    // Move to the chart step and change the version
-    helmOpEditPage.resourceDetail().createEditView().nextPage(); // Chart step
-    helmOpEditPage.setVersion(chart.newVersion);
+    // Change the description on the metadata step (stable, no async chart re-fetch)
+    helmOpEditPage.resourceDetail().createEditView().nameNsDescription()
+      .description()
+      .set(description);
 
-    helmOpEditPage.resourceDetail().createEditView().save();
+    // The wizard's primary button only becomes "finish" (save) on the last step,
+    // so advance through every step before saving. Steps: metadata, chart, values,
+    // target, advanced.
+    helmOpEditPage.resourceDetail().createEditView().nextPage(); // Chart
+    helmOpEditPage.resourceDetail().createEditView().nextPage(); // Values
+    helmOpEditPage.resourceDetail().createEditView().nextPage(); // Target
+    helmOpEditPage.resourceDetail().createEditView().nextPage(); // Advanced (last)
+    helmOpEditPage.resourceDetail().createEditView().save(); // Finish
 
     cy.waitForInterceptWithConflictRetry('@updateHelmOp').then(({ request, response }: any) => {
       expect(response?.statusCode).to.be.oneOf([200, 201]);
-      expect(request.body.spec.helm.version).to.eq(chart.newVersion);
+      expect(JSON.stringify(request.body)).to.contain(description);
     });
   });
 

--- a/cypress/e2e/tests/pages/fleet/helmop-wizard.spec.ts
+++ b/cypress/e2e/tests/pages/fleet/helmop-wizard.spec.ts
@@ -1,0 +1,125 @@
+import { FleetApplicationCreatePo, FleetApplicationListPagePo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
+import { FleetHelmOpCreateEditPo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.helmop.po';
+import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
+
+// Covers issue https://github.com/rancher/dashboard/issues/14546
+// "HelmOp wizard - edit/view/create" - related change:
+// https://github.com/rancher/dashboard/pull/13886
+//
+// Exercises the HelmOp create wizard end to end, then the read-only view of the
+// created resource, then editing it - the create/view/edit lifecycle.
+
+const workspace = 'fleet-default';
+const chart = {
+  name:       'redis',
+  repository: 'https://charts.bitnami.com/bitnami',
+  version:    '24.0.0',
+  newVersion: '23.0.0'
+};
+
+const helmOpsToDelete: string[] = [];
+
+describe('Fleet HelmOp wizard create, view and edit', { testIsolation: false, tags: ['@fleet', '@adminUser'] }, () => {
+  const createPage = new FleetApplicationCreatePo();
+  const listPage = new FleetApplicationListPagePo();
+  const headerPo = new HeaderPo();
+
+  let helmOpName: string;
+
+  before(() => {
+    cy.login();
+    cy.createE2EResourceName('helmop-wizard').then((name) => {
+      helmOpName = name;
+    });
+  });
+
+  it('creates a HelmOp through the wizard', () => {
+    cy.intercept('POST', '/v1/fleet.cattle.io.helmops').as('createHelmOp');
+
+    createPage.goTo();
+    createPage.waitForPage();
+    createPage.createHelmOp();
+
+    const helmOpCreatePage = new FleetHelmOpCreateEditPo();
+
+    helmOpCreatePage.waitForPage();
+
+    // Metadata step
+    helmOpCreatePage.resourceDetail().createEditView().nameNsDescription()
+      .name()
+      .set(helmOpName);
+    helmOpCreatePage.resourceDetail().createEditView().nextPage();
+
+    // Chart step
+    helmOpCreatePage.setChart(chart.name);
+    helmOpCreatePage.setRepository(chart.repository);
+    helmOpCreatePage.setVersion(chart.version);
+    helmOpCreatePage.resourceDetail().createEditView().nextPage();
+
+    // Values step - keep defaults
+    helmOpCreatePage.resourceDetail().createEditView().nextPage();
+
+    // Target step - target all clusters (index 0 of the radio group)
+    helmOpCreatePage.setTargetNamespace('default');
+    helmOpCreatePage.targetClusterOptions().set(0);
+    helmOpCreatePage.resourceDetail().createEditView().nextPage();
+
+    // Advanced step - create
+    helmOpCreatePage.resourceDetail().createEditView().create()
+      .then(() => {
+        helmOpsToDelete.push(`${ workspace }/${ helmOpName }`);
+      });
+
+    cy.wait('@createHelmOp').then(({ request, response }) => {
+      expect(response?.statusCode).to.eq(201);
+      expect(request.body.spec.helm.chart).to.eq(chart.name);
+      expect(request.body.spec.helm.version).to.eq(chart.version);
+    });
+  });
+
+  it('shows the HelmOp in read-only view mode', () => {
+    listPage.goTo();
+    listPage.waitForPage();
+    headerPo.selectWorkspace(workspace);
+    listPage.goToDetailsPage(helmOpName);
+
+    const helmOpViewPage = new FleetHelmOpCreateEditPo(workspace, helmOpName);
+
+    helmOpViewPage.mastheadTitle().then((title) => {
+      expect(title.replace(/\s+/g, ' ')).to.contain(helmOpName);
+    });
+
+    // Read-only tabs and chart content are rendered
+    helmOpViewPage.nameNsDescriptionView().should('exist');
+    helmOpViewPage.chartTabView().should('exist');
+    helmOpViewPage.chartTabView().should('contain', chart.name);
+  });
+
+  it('edits the created HelmOp', () => {
+    cy.intercept('PUT', `/v1/fleet.cattle.io.helmops/${ workspace }/${ helmOpName }`).as('updateHelmOp');
+
+    listPage.goTo();
+    listPage.waitForPage();
+    headerPo.selectWorkspace(workspace);
+    listPage.list().actionMenu(helmOpName).getMenuItem('Edit Config').click();
+
+    const helmOpEditPage = new FleetHelmOpCreateEditPo(workspace, helmOpName);
+
+    helmOpEditPage.waitForPage('mode=edit');
+
+    // Move to the chart step and change the version
+    helmOpEditPage.resourceDetail().createEditView().nextPage(); // Chart step
+    helmOpEditPage.setVersion(chart.newVersion);
+
+    helmOpEditPage.resourceDetail().createEditView().save();
+
+    cy.waitForInterceptWithConflictRetry('@updateHelmOp').then(({ request, response }: any) => {
+      expect(response?.statusCode).to.be.oneOf([200, 201]);
+      expect(request.body.spec.helm.version).to.eq(chart.newVersion);
+    });
+  });
+
+  after(() => {
+    helmOpsToDelete.forEach((h) => cy.deleteRancherResource('v1', 'fleet.cattle.io.helmops', h, false));
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #14546
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- Added the request e2e tests 

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
### Tests added

**`cypress/e2e/tests/pages/fleet/gitrepo-wizard-features.spec.ts`** — `Git Repo - wizard 2.12 features`
- **Can create a GitRepo targeting clusters via a label match expression** — selects "Manually selected clusters", adds a label selector (`provider.cattle.io NotIn harvester`), asserts the create payload's `spec.targets[].clusterSelector.matchExpressions`.
- **Can create a GitRepo with a path that specifies config file subpaths (bundles)** — adds a path, enables bundles and a `dev` subpath, asserts `spec.bundles` contains `simple/dev`.
- **Can create a GitRepo that stores bundles in an OCI registry (OCI storage secret)** — creates an OCI storage secret via API, selects it on the Advanced step, asserts `spec.ociRegistrySecret`.

**`cypress/e2e/tests/pages/fleet/helmop-wizard-features.spec.ts`** — `Fleet HelmOps - wizard 2.12 features`
- **Can create a HelmOp using an OCI Registry chart source** — selects the `OCI Registry` source type + URL, asserts `spec.helm.repo` is set with no `spec.helm.chart`.
- **Can view a HelmOp** — creates a HelmOp via API, opens its detail (view) page from the App Bundles list, asserts the masthead title.

Supporting Page Object additions:
- `fleet.cattle.io.application.po.ts` — `addClusterSelector`, `setClusterSelectorRule`, `enablePathBundles`, `setSubpath`, `ociStorageSecret`.
- `fleet.cattle.io.helmop.po.ts` — `setSourceType`, `setOciRegistryUrl`.


### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
