### PR TITLE
add clear button to LabeledInput and replace search-box with a LabeledInput with a clear button

### DIFF
--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.test.ts
@@ -223,6 +223,193 @@ describe('component: LabeledInput', () => {
     expect(wrapper.find('label').text()).toBe(label);
   });
 
+  describe('clear button functionality', () => {
+    const i18nMock = { $store: { getters: { 'i18n/t': jest.fn() } } };
+
+    describe('type="search"', () => {
+      it('should show clear button when type is search and value is not empty', () => {
+        const wrapper = mount(LabeledInput, {
+          propsData: { type: 'search', value: 'test query' },
+          mocks:     i18nMock
+        });
+
+        const clearButton = wrapper.find('.labeled-input-clear-button');
+
+        expect(clearButton.exists()).toBe(true);
+      });
+
+      it('should not show clear button when type is search and value is empty', () => {
+        const wrapper = mount(LabeledInput, {
+          propsData: { type: 'search', value: '' },
+          mocks:     i18nMock
+        });
+
+        const clearButton = wrapper.find('.labeled-input-clear-button');
+
+        expect(clearButton.exists()).toBe(false);
+      });
+
+      it('should hide native search cancel button', () => {
+        const wrapper = mount(LabeledInput, {
+          propsData: { type: 'search', value: 'test' },
+          mocks:     i18nMock
+        });
+        const input = wrapper.find('input[type="search"]');
+
+        expect(input.exists()).toBe(true);
+      });
+
+      it('should clear input value when clear button is clicked', async() => {
+        const wrapper = mount(LabeledInput, {
+          propsData: { type: 'search', value: 'test query' },
+          mocks:     i18nMock
+        });
+
+        const clearButton = wrapper.find('.labeled-input-clear-button');
+
+        await clearButton.trigger('click');
+
+        expect(wrapper.emitted('update:value')).toHaveLength(1);
+        expect(wrapper.emitted('update:value')![0][0]).toBe('');
+      });
+
+      it('should clear input value when Enter key is pressed on clear button', async() => {
+        const wrapper = mount(LabeledInput, {
+          propsData: { type: 'search', value: 'test query' },
+          mocks:     i18nMock
+        });
+
+        const clearButton = wrapper.find('.labeled-input-clear-button');
+
+        await clearButton.trigger('keydown.enter');
+
+        expect(wrapper.emitted('update:value')).toHaveLength(1);
+        expect(wrapper.emitted('update:value')![0][0]).toBe('');
+      });
+
+      it('should clear input value when Space key is pressed on clear button', async() => {
+        const wrapper = mount(LabeledInput, {
+          propsData: { type: 'search', value: 'test query' },
+          mocks:     i18nMock
+        });
+
+        const clearButton = wrapper.find('.labeled-input-clear-button');
+
+        await clearButton.trigger('keydown.space');
+
+        expect(wrapper.emitted('update:value')).toHaveLength(1);
+        expect(wrapper.emitted('update:value')![0][0]).toBe('');
+      });
+
+      it('should have proper ARIA label for accessibility', () => {
+        const wrapper = mount(LabeledInput, {
+          propsData: { type: 'search', value: 'test query' },
+          mocks:     i18nMock
+        });
+
+        const clearButton = wrapper.find('.labeled-input-clear-button');
+
+        expect(clearButton.attributes('aria-label')).toBeDefined();
+        expect(clearButton.attributes('type')).toBe('button');
+      });
+
+      it('should be disabled when input is disabled', () => {
+        const wrapper = mount(LabeledInput, {
+          propsData: {
+            type: 'search', value: 'test query', mode: 'view'
+          },
+          mocks: i18nMock
+        });
+
+        const clearButton = wrapper.find('.labeled-input-clear-button');
+
+        expect(clearButton.attributes('disabled')).toBeDefined();
+      });
+    });
+
+    describe('clearButtonLabel prop', () => {
+      it('should fall back to the generic clear label when no custom label is given', () => {
+        const wrapper = mount(LabeledInput, {
+          propsData: { type: 'search', value: 'test query' },
+          mocks:     i18nMock
+        });
+
+        const clearButton = wrapper.find('.labeled-input-clear-button');
+
+        // The i18n helper wraps unresolved keys in `%...%`, so this asserts
+        // which translation key was requested
+        expect(clearButton.attributes('aria-label')).toBe('%generic.clear%');
+      });
+
+      it('should use the custom label when one is given', () => {
+        const wrapper = mount(LabeledInput, {
+          propsData: {
+            type: 'search', value: 'test query', clearButtonLabel: 'Clear Filter for table results'
+          },
+          mocks: i18nMock
+        });
+
+        const clearButton = wrapper.find('.labeled-input-clear-button');
+
+        expect(clearButton.attributes('aria-label')).toBe('Clear Filter for table results');
+      });
+    });
+
+    describe('showClearButton prop', () => {
+      it('should show clear button when showClearButton is true and value is not empty', () => {
+        const wrapper = mount(LabeledInput, {
+          propsData: {
+            type: 'text', value: 'test', showClearButton: true
+          },
+          mocks: i18nMock
+        });
+
+        const clearButton = wrapper.find('.labeled-input-clear-button');
+
+        expect(clearButton.exists()).toBe(true);
+      });
+
+      it('should not show clear button when showClearButton is false even for search type', () => {
+        const wrapper = mount(LabeledInput, {
+          propsData: {
+            type: 'search', value: 'test', showClearButton: false
+          },
+          mocks: i18nMock
+        });
+
+        const clearButton = wrapper.find('.labeled-input-clear-button');
+
+        expect(clearButton.exists()).toBe(false);
+      });
+
+      it('should not show clear button when showClearButton is true but value is empty', () => {
+        const wrapper = mount(LabeledInput, {
+          propsData: {
+            type: 'text', value: '', showClearButton: true
+          },
+          mocks: i18nMock
+        });
+
+        const clearButton = wrapper.find('.labeled-input-clear-button');
+
+        expect(clearButton.exists()).toBe(false);
+      });
+    });
+
+    describe('type="text" without showClearButton', () => {
+      it('should not show clear button by default for text type', () => {
+        const wrapper = mount(LabeledInput, {
+          propsData: { type: 'text', value: 'test' },
+          mocks:     i18nMock
+        });
+
+        const clearButton = wrapper.find('.labeled-input-clear-button');
+
+        expect(clearButton.exists()).toBe(false);
+      });
+    });
+  });
+
   describe('vee-validate integration', () => {
     const i18nMock = { $store: { getters: { 'i18n/t': jest.fn() } } };
 

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -598,15 +598,14 @@ export default defineComponent({
       type="button"
       size="small"
       variant="ghost"
+      left-icon="close"
       class="labeled-input-clear-button"
       :aria-label="clearButtonAriaLabel"
       :disabled="isDisabled"
       @click="clearInput"
       @keydown.enter.prevent="clearInput"
       @keydown.space.prevent="clearInput"
-    >
-      <i class="icon icon-close" />
-    </RcButton>
+    />
     <!-- informational tooltip about field -->
     <LabeledTooltip
       v-if="hasTooltip"
@@ -699,7 +698,9 @@ input[type="search"]::-webkit-search-cancel-button {
     opacity: 0.5;
   }
 
-  :deep(.icon) {
+  // RcButton renders its leftIcon with size="inherit", so pin the glyph here to
+  // keep the 14px it had before, independent of the button's font-size.
+  :deep(.rc-icon) {
     font-size: 14px;
   }
 }

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -151,7 +151,7 @@ export default defineComponent({
      */
     clearButtonLabel: {
       type:    String,
-      default: ''
+      default: undefined
     }
   },
 

--- a/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
+++ b/pkg/rancher-components/src/components/Form/LabeledInput/LabeledInput.vue
@@ -2,6 +2,7 @@
 import { defineComponent, inject, computed, toRef } from 'vue';
 import TextAreaAutoGrow from '@components/Form/TextArea/TextAreaAutoGrow.vue';
 import LabeledTooltip from '@components/LabeledTooltip/LabeledTooltip.vue';
+import RcButton from '@components/RcButton/RcButton.vue';
 import { escapeHtml, generateRandomAlphaString } from '@shell/utils/string';
 import cronstrue from 'cronstrue';
 import { isValidCron } from 'cron-validator';
@@ -21,7 +22,9 @@ const provideProps: NonReactiveProps = {
 };
 
 export default defineComponent({
-  components: { LabeledTooltip, TextAreaAutoGrow },
+  components: {
+    LabeledTooltip, RcButton, TextAreaAutoGrow
+  },
 
   inheritAttrs: false,
 
@@ -128,6 +131,27 @@ export default defineComponent({
     name: {
       type:    String,
       default: null
+    },
+
+    /**
+     * Show a clear button when the input has a value.
+     * When true, displays a keyboard-accessible clear button.
+     * When false, never shows a clear button.
+     * When undefined (default), shows the clear button only for type="search".
+     */
+    showClearButton: {
+      type:    Boolean,
+      default: undefined
+    },
+
+    /**
+     * Accessible label for the clear button. Pass an already translated string
+     * to describe what is being cleared in this specific context.
+     * Falls back to the generic "Clear" translation.
+     */
+    clearButtonLabel: {
+      type:    String,
+      default: ''
     }
   },
 
@@ -172,6 +196,17 @@ export default defineComponent({
     // formatting quirks (e.g. scientific notation for large values).
     const inputMode = computed(() => (isInteger.value ? 'numeric' : undefined));
 
+    // Determine if clear button should be shown
+    const shouldShowClearButton = computed(() => {
+      // Explicit prop takes precedence
+      if (props.showClearButton !== undefined) {
+        return props.showClearButton && !!props.value;
+      }
+
+      // Default: show for search type when there's a value
+      return props.type === 'search' && !!props.value;
+    });
+
     return {
       focused,
       onFocusLabeled,
@@ -187,6 +222,7 @@ export default defineComponent({
       isInteger,
       nativeType,
       inputMode,
+      shouldShowClearButton,
     };
   },
 
@@ -240,6 +276,14 @@ export default defineComponent({
      */
     hasSuffix(): boolean {
       return !!this.$slots.suffix;
+    },
+
+    /**
+     * Accessible label for the clear button, falling back to the generic
+     * "Clear" translation when the consumer hasn't supplied a specific one.
+     */
+    clearButtonAriaLabel(): string {
+      return this.clearButtonLabel || this.t('generic.clear');
     },
 
     /**
@@ -445,6 +489,16 @@ export default defineComponent({
       this.veeValidate();
     },
 
+    /**
+     * Clears the input value and refocuses the input field.
+     */
+    clearInput(): void {
+      this.$emit('update:value', '');
+      this.$nextTick(() => {
+        this.focus();
+      });
+    },
+
     escapeHtml
   }
 });
@@ -538,6 +592,21 @@ export default defineComponent({
     </slot>
 
     <slot name="suffix" />
+    <!-- Clear button for search inputs -->
+    <RcButton
+      v-if="shouldShowClearButton"
+      type="button"
+      size="small"
+      variant="ghost"
+      class="labeled-input-clear-button"
+      :aria-label="clearButtonAriaLabel"
+      :disabled="isDisabled"
+      @click="clearInput"
+      @keydown.enter.prevent="clearInput"
+      @keydown.space.prevent="clearInput"
+    >
+      <i class="icon icon-close" />
+    </RcButton>
     <!-- informational tooltip about field -->
     <LabeledTooltip
       v-if="hasTooltip"
@@ -573,6 +642,10 @@ export default defineComponent({
   </div>
 </template>
 <style scoped lang="scss">
+.labeled-input {
+  position: relative;
+}
+
 .multiline-password:not(:focus) {
   -webkit-text-security: disc;
 }
@@ -596,6 +669,43 @@ export default defineComponent({
   input[type=number] {
     -moz-appearance: textfield;
   }
+}
+
+/* Hide the native, mouse-only search cancel button in Chrome/Safari */
+input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+// RcButton (ghost) supplies the transparent background, flex centring and focus
+// outline. All that's left here is placing it in the field and sizing the target.
+.labeled-input-clear-button {
+  // Square 24px target (WCAG 2.5.8) - `btn-small` already gives us the height
+  --rc-button-padding: 0;
+
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  color: var(--input-text);
+
+  &:hover:not(:disabled) {
+    color: var(--primary);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  :deep(.icon) {
+    font-size: 14px;
+  }
+}
+
+.labeled-input.suffix .labeled-input-clear-button {
+  right: 40px;
 }
 </style>
 <style>

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -6707,6 +6707,7 @@ sortableTable:
       other {{from} - {to} of {count} {pluralLabel}}}
   search: Filter
   searchLabel: Filter table results
+  clearFilter: Clear Filter for table results
   in: in
   addFilter: Add Filter
   filteringDescription: Using this input will immediately filter the results in the table below

--- a/shell/components/SortableTable/index.vue
+++ b/shell/components/SortableTable/index.vue
@@ -20,6 +20,7 @@ import grouping from './grouping';
 import actions from './actions';
 import AdvancedFiltering from './advanced-filtering';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
+import { LabeledInput } from '@components/Form/LabeledInput';
 import { getParent } from '@shell/utils/dom';
 import { FORMATTERS } from '@shell/components/SortableTable/sortable-config';
 import ButtonMultiAction from '@shell/components/ButtonMultiAction.vue';
@@ -63,6 +64,7 @@ export default {
     AsyncButton,
     ActionDropdown,
     LabeledSelect,
+    LabeledInput,
     ButtonMultiAction,
     ActionMenu,
     ActionDropdownShell,
@@ -1257,13 +1259,14 @@ export default {
               v-show="advancedFilteringVisibility"
               class="advanced-filter-container"
             >
-              <input
+              <LabeledInput
                 ref="advancedSearchQuery"
-                v-model="advFilterSearchTerm"
+                v-model:value="advFilterSearchTerm"
                 type="search"
                 class="advanced-search-box"
+                :clear-button-label="t('sortableTable.clearFilter')"
                 :placeholder="t('sortableTable.filterFor')"
-              >
+              />
               <div class="middle-block">
                 <span>{{ t('sortableTable.in') }}</span>
                 <LabeledSelect
@@ -1304,16 +1307,17 @@ export default {
           >
             {{ t('sortableTable.filteringDescription') }}
           </p>
-          <input
+          <LabeledInput
             v-if="search"
             ref="searchQuery"
-            v-model="eventualSearchQuery"
+            v-model:value="eventualSearchQuery"
             type="search"
-            class="input-sm search-box"
+            class="search-box"
             :aria-label="t('sortableTable.searchLabel')"
             aria-describedby="describe-filter-sortable-table"
+            :clear-button-label="t('sortableTable.clearFilter')"
             :placeholder="t('sortableTable.search')"
-          >
+          />
           <slot name="header-button" />
         </div>
       </div>
@@ -1874,10 +1878,51 @@ export default {
     }
   }
 
+  // `.search-box` IS the `.labeled-input` root element - LabeledInput puts the `class`
+  // prop on its own root, it does not wrap it. The global `INPUT[type='search']` rules in
+  // _form.scss out-specify `.labeled-input INPUT`, so the inner input keeps its own border
+  // and padding on top of the wrapper's, giving a double border and the wrong height.
+  // Strip the inner input back and let the wrapper draw the single border.
+  .search-box,
+  .advanced-search-box {
+    &.labeled-input {
+      display: flex;
+      align-items: center;
+      min-height: 32px;
+      height: 32px;
+      padding: 0 8px;
+    }
+
+    // The inner input no longer draws its own focus border, so surface it on the wrapper
+    &.labeled-input:focus-within {
+      border-color: var(--primary-border);
+    }
+
+    :deep(input[type='search']) {
+      flex: 1;
+      height: 100%;
+      min-height: 0;
+      padding: 0 32px 0 0; // room for the 24px clear button + its 8px offset
+      border: none;
+      background-color: transparent;
+      border-radius: 0;
+      box-shadow: none;
+      outline: none;
+      line-height: normal;
+    }
+
+    :deep(.labeled-input-clear-button) {
+      right: 8px;
+    }
+  }
+
   .search-box {
-    height: 32px;
     margin-left: 10px;
     min-width: 180px;
+  }
+
+  .advanced-search-box {
+    width: 100%;
   }
 </style>
 

--- a/shell/composables/useLabeledFormElement.ts
+++ b/shell/composables/useLabeledFormElement.ts
@@ -72,14 +72,6 @@ export const labeledFormElementProps = {
   requireDirty: {
     default: true,
     type:    Boolean
-  },
-  showClearButton: {
-    type:    Boolean,
-    default: undefined
-  },
-  clearButtonLabel: {
-    type:    String,
-    default: undefined
   }
 };
 

--- a/shell/composables/useLabeledFormElement.ts
+++ b/shell/composables/useLabeledFormElement.ts
@@ -72,6 +72,14 @@ export const labeledFormElementProps = {
   requireDirty: {
     default: true,
     type:    Boolean
+  },
+  showClearButton: {
+    type:    Boolean,
+    default: undefined
+  },
+  clearButtonLabel: {
+    type:    String,
+    default: undefined
   }
 };
 

--- a/storybook/src/stories/Form/LabeledInput.stories.ts
+++ b/storybook/src/stories/Form/LabeledInput.stories.ts
@@ -1,0 +1,240 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import { ref } from 'vue';
+import { LabeledInput } from '@components/Form/LabeledInput';
+
+const meta: Meta<typeof LabeledInput> = {
+  component: LabeledInput,
+  argTypes:  {
+    type: {
+      control: 'select',
+      options: ['text', 'password', 'email', 'number', 'search', 'url', 'tel', 'cron', 'integer'],
+    },
+    mode: {
+      control: 'select',
+      options: ['edit', 'view'],
+    },
+    label:            { control: 'text' },
+    placeholder:      { control: 'text' },
+    showClearButton:  { control: 'boolean' },
+    clearButtonLabel: { control: 'text' },
+    required:         { control: 'boolean' },
+    disabled:         { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof LabeledInput>;
+
+export const Default: Story = {
+  render: (args: any) => ({
+    components: { LabeledInput },
+    setup() {
+      const value = ref('');
+
+      return { args, value };
+    },
+    template: '<LabeledInput v-bind="args" v-model:value="value" />',
+  }),
+  args: {
+    label:       'Name',
+    placeholder: 'Enter your name',
+    type:        'text',
+  },
+};
+
+export const SearchWithClearButton: Story = {
+  render: (args: any) => ({
+    components: { LabeledInput },
+    setup() {
+      const value = ref('kubernetes pods');
+
+      return { args, value };
+    },
+    template: `
+      <div>
+        <LabeledInput v-bind="args" v-model:value="value" />
+        <p style="margin-top: 10px; color: var(--input-text);">
+          Current value: "{{ value }}"
+        </p>
+      </div>
+    `,
+  }),
+  args: {
+    type:        'search',
+    placeholder: 'Search resources...',
+    label:       'Search',
+  },
+};
+
+export const SearchEmptyState: Story = {
+  render: (args: any) => ({
+    components: { LabeledInput },
+    setup() {
+      const value = ref('');
+
+      return { args, value };
+    },
+    template: `
+      <div>
+        <LabeledInput v-bind="args" v-model:value="value" />
+        <p style="margin-top: 10px; color: var(--muted);">
+          Type something to see the clear button appear
+        </p>
+      </div>
+    `,
+  }),
+  args: {
+    type:        'search',
+    placeholder: 'Search...',
+    label:       'Search',
+  },
+};
+
+export const TextWithClearButton: Story = {
+  render: (args: any) => ({
+    components: { LabeledInput },
+    setup() {
+      const value = ref('Custom text with clear button');
+
+      return { args, value };
+    },
+    template: '<LabeledInput v-bind="args" v-model:value="value" />',
+  }),
+  args: {
+    type:             'text',
+    label:            'Custom Input',
+    placeholder:      'Enter text',
+    showClearButton:  true,
+  },
+};
+
+export const SearchWithCustomClearLabel: Story = {
+  render: (args: any) => ({
+    components: { LabeledInput },
+    setup() {
+      const value = ref('nginx');
+
+      return { args, value };
+    },
+    template: `
+      <div>
+        <LabeledInput v-bind="args" v-model:value="value" />
+        <p style="margin-top: 10px; color: var(--muted);">
+          The clear button is announced as "Clear Filter for table results"
+          instead of the generic "Clear"
+        </p>
+      </div>
+    `,
+  }),
+  args: {
+    type:             'search',
+    label:            'Filter',
+    placeholder:      'Filter...',
+    clearButtonLabel: 'Clear Filter for table results',
+  },
+};
+
+export const SearchCompact: Story = {
+  render: (args: any) => ({
+    components: { LabeledInput },
+    setup() {
+      const value = ref('search query');
+
+      return { args, value };
+    },
+    template: '<LabeledInput v-bind="args" v-model:value="value" />',
+  }),
+  args: {
+    type:        'search',
+    placeholder: 'Search...',
+    mode:        'edit',
+  },
+};
+
+export const SearchDisabled: Story = {
+  render: (args: any) => ({
+    components: { LabeledInput },
+    setup() {
+      const value = ref('disabled search');
+
+      return { args, value };
+    },
+    template: '<LabeledInput v-bind="args" v-model:value="value" />',
+  }),
+  args: {
+    type:        'search',
+    label:       'Disabled Search',
+    placeholder: 'Search...',
+    mode:        'view',
+  },
+};
+
+export const Required: Story = {
+  render: (args: any) => ({
+    components: { LabeledInput },
+    setup() {
+      const value = ref('');
+
+      return { args, value };
+    },
+    template: '<LabeledInput v-bind="args" v-model:value="value" />',
+  }),
+  args: {
+    label:       'Required Field',
+    placeholder: 'This field is required',
+    type:        'text',
+    required:    true,
+  },
+};
+
+export const WithTooltip: Story = {
+  render: (args: any) => ({
+    components: { LabeledInput },
+    setup() {
+      const value = ref('');
+
+      return { args, value };
+    },
+    template: '<LabeledInput v-bind="args" v-model:value="value" />',
+  }),
+  args: {
+    label:       'Username',
+    placeholder: 'Enter username',
+    type:        'text',
+    tooltip:     'Your username must be unique across the system',
+  },
+};
+
+export const Integer: Story = {
+  render: (args: any) => ({
+    components: { LabeledInput },
+    setup() {
+      const value = ref('42');
+
+      return { args, value };
+    },
+    template: '<LabeledInput v-bind="args" v-model:value="value" />',
+  }),
+  args: {
+    label:       'Port Number',
+    placeholder: 'Enter port',
+    type:        'integer',
+  },
+};
+
+export const Cron: Story = {
+  render: (args: any) => ({
+    components: { LabeledInput },
+    setup() {
+      const value = ref('0 * * * *');
+
+      return { args, value };
+    },
+    template: '<LabeledInput v-bind="args" v-model:value="value" />',
+  }),
+  args: {
+    label:       'Schedule',
+    placeholder: 'Enter cron expression',
+    type:        'cron',
+  },
+};

--- a/storybook/src/stories/Form/LabeledInput.stories.ts
+++ b/storybook/src/stories/Form/LabeledInput.stories.ts
@@ -101,10 +101,10 @@ export const TextWithClearButton: Story = {
     template: '<LabeledInput v-bind="args" v-model:value="value" />',
   }),
   args: {
-    type:             'text',
-    label:            'Custom Input',
-    placeholder:      'Enter text',
-    showClearButton:  true,
+    type:            'text',
+    label:           'Custom Input',
+    placeholder:     'Enter text',
+    showClearButton: true,
   },
 };
 


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #16687

The native browser clear ("X") button that Chrome and Safari inject into `<input type="search">` is mouse-only — it cannot be reached with Tab or activated with Enter/Space. Firefox does not render it at all, so the behaviour is also inconsistent between browsers. Keyboard-only and screen reader users have no way to clear a table filter other than selecting the text and deleting it.

### Occurred changes and/or fixed issues
- Added an optional, keyboard-accessible clear button to the `LabeledInput` component, shown by default for `type="search"` when the field has a value
- Added a `showClearButton` prop to `LabeledInput` so consumers can force the button on for any input type, or opt out of it entirely for search inputs
- Added a `clearButtonLabel` prop so consumers can give the clear button a context-specific accessible name, falling back to a generic "Clear"
- Suppressed the native Chrome/Safari search cancel button so there is exactly one clear affordance, and it behaves the same in every browser
- Replaced both native search inputs in `SortableTable` (the main table filter and the advanced filter search) with `LabeledInput`, so table filtering now has a keyboard-operable clear button
- Added Storybook coverage for `LabeledInput` — the component had no stories before this PR

### Technical notes summary
The clear button lives in `LabeledInput` rather than in a one-off wrapper, so any consumer of the component gets the accessible behaviour for free instead of each caller reinventing it.

Visibility follows a three-state rule driven by the new `showClearButton` prop:

| `showClearButton` | Behaviour |
| --- | --- |
| `undefined` (default) | Button shows only for `type="search"`, and only when the field has a value |
| `true` | Button shows for any input type when the field has a value |
| `false` | Button never shows, even for `type="search"` |

The button itself is an `RcButton` (`variant="ghost"`, `size="small"`), matching the existing clear-button pattern in `NamespaceFilter`. That gives us the shared `focus-outline` treatment, hover and disabled states from the design system rather than hand-rolled CSS. Clicking it — or pressing Enter/Space on it — emits `update:value` with an empty string and returns focus to the input, so keyboard users are not dumped back at the top of the page.

Since `LabeledInput` is a generic component, its accessible name defaults to the generic `generic.clear` translation. The new `clearButtonLabel` prop lets a caller say what is actually being cleared — `SortableTable` passes `sortableTable.clearFilter` ("Clear Filter for table results") so a screen reader user hears something meaningful rather than a bare "Clear".

`type="search"` is deliberately retained on the underlying input. It is worth keeping for its semantics (screen readers announce it as a search field) and because mobile browsers show a search-optimised keyboard for it. The fix suppresses the *native button* only, not the input type.

### Areas or cases that should be tested
- On any resource list page (e.g. Deployments, Pods), type into the table filter box and confirm a clear "X" appears
- Tab from the filter input to the clear button and press **Enter** — the filter clears, the table resets, and focus returns to the input
- Repeat the above with **Space**
- Click the clear button with the mouse — same result, and no focus ring appears (focus ring is keyboard-only, via `:focus-visible`)
- Confirm the button is absent when the filter is empty, and appears as soon as a character is typed
- Repeat all of the above in the **advanced filter** search box (toggle advanced filtering on first)
- Verify with a screen reader that the button is announced as "Clear Filter for table results" and that the input is still announced as a search field
- Verify in **Chrome/Safari** that only one "X" is visible (the native one must be gone), and in **Firefox** that the new button is present where previously there was none
- Check the filter box height, border and focus state have not changed from before — it should look identical to the current UI
- Check light and dark mode
- Browser used for local testing: Chrome — reviewer should test with a different browser (e.g. Firefox and Safari)

### Areas which could experience regressions
- `pkg/rancher-components` `LabeledInput` — this is published to NPM and consumed by UI Extensions. `.labeled-input` gained `position: relative`, which could shift any absolutely-positioned content that extensions place inside a `LabeledInput` slot. Existing inputs are otherwise unaffected: the button only renders for `type="search"` or when `showClearButton` is explicitly set
- `LabeledInput` now imports `RcButton` — worth a sanity check that nothing in the package build or the extension bundle regressed
- `shell/components/SortableTable` — used by every resource list page in the product. The two search inputs changed from native `<input>` to a component, so filter typing, debouncing, the `searchQuery`/`advancedSearchQuery` refs and the advanced filtering flow should all be exercised
- Any consumer that relied on the SortableTable search field being a bare `<input>` (for example E2E selectors targeting `input.search-box`)

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
