### PR TITLE
[Release 2.15] Step 5 - Lift code freeze & bump milestones

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -31,8 +31,8 @@
     },
     "release-2.15": {
       "milestone": {
-        "version": "v2.15.0",
-        "codeFreeze": true
+        "version": "v2.15.1",
+        "codeFreeze": false
       },
       "e2e": {
         "rancher-image": {
@@ -60,11 +60,12 @@
     },
     "release-2.14": {
       "milestone": {
-        "version": "v2.14.4",
-        "codeFreeze": true
+        "version": "v2.14.5",
+        "codeFreeze": false
       },
       "e2e": {
         "rancher-image": {
+          "registry": "stgregistry.suse.com",
           "namespace": "rancher",
           "name": "rancher",
           "tag": "v2.14-head"
@@ -78,8 +79,8 @@
     },
     "release-2.13": {
       "milestone": {
-        "version": "v2.13.8",
-        "codeFreeze": true
+        "version": "v2.13.9",
+        "codeFreeze": false
       },
       "e2e": {
         "rancher-image": {
@@ -97,8 +98,8 @@
     },
     "release-2.12": {
       "milestone": {
-        "version": "v2.12.12",
-        "codeFreeze": true
+        "version": "v2.12.13",
+        "codeFreeze": false
       },
       "e2e": {
         "rancher-image": {
@@ -116,8 +117,8 @@
     },
     "release-2.11": {
       "milestone": {
-        "version": "v2.11.16",
-        "codeFreeze": true
+        "version": "v2.11.17",
+        "codeFreeze": false
       },
       "e2e": {
         "rancher-image": {

--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -65,7 +65,6 @@
       },
       "e2e": {
         "rancher-image": {
-          "registry": "stgregistry.suse.com",
           "namespace": "rancher",
           "name": "rancher",
           "tag": "v2.14-head"


### PR DESCRIPTION
## Step 5 — Post-release: lift code freeze & bump milestones

After the **v2.15.0** release train shipped, update master's `branches-metadata.json` so each shipped release line points at its **next** milestone and its code freeze is **lifted**.

### Milestones bumped (old → new) + freeze lifted
- `release-2.15`: `v2.15.0` → **`v2.15.1`**, `codeFreeze: true → false`
- `release-2.14`: `v2.14.4` → **`v2.14.5`**, `codeFreeze: true → false`
- `release-2.13`: `v2.13.8` → **`v2.13.9`**, `codeFreeze: true → false`
- `release-2.12`: `v2.12.12` → **`v2.12.13`**, `codeFreeze: true → false`
- `release-2.11`: `v2.11.16` → **`v2.11.17`**, `codeFreeze: true → false`

### e2e registry / Prime refs
- `release-2.14` becomes **Prime only** with the release of v2.15.0 → set e2e `rancher-image.registry: stgregistry.suse.com`.
- `release-2.13` / `release-2.12` / `release-2.11` already point at `stgregistry.suse.com` (unchanged).
- `release-2.15` is Community — no staging registry.

`master`'s own milestone (`v2.16.0`) is unchanged.

> **Manual gate (out of automation):** confirm with **Gary Korhonen** that the previous minor (v2.14.4) is now **Prime only** with the v2.15.0 release. Not blocking.

Reference: rancher/dashboard#18220, rancher/dashboard#16774

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
