### PR TITLE
add new query-params ts errors to baseline

### DIFF
--- a/scripts/type-check-baseline.txt
+++ b/scripts/type-check-baseline.txt
@@ -1,6 +1,6 @@
 # Auto-generated type-check baseline. Do not edit by hand.
 # Regenerate with: yarn type-check:baseline
-# Total errors: 1977
+# Total errors: 1982
 pkg/aks/components/AksNodePool.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
 pkg/aks/components/AksNodePool.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 pkg/aks/components/AksNodePool.vue: error TS2339: Property '$emit' does not exist on type '{ 'pool.enableAutoScaling'(neu: any): void; 'pool.vmSize'(neu: any): void; validAZ(neu: any): void; }'.
@@ -1359,9 +1359,14 @@ shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2349: 
 shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2349: This expression is not callable.
 shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2349: This expression is not callable.
 shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts: error TS2349: This expression is not callable.
+shell/edit/provisioning.cattle.io.cluster/__tests__/subtype-detection.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'SUB_TYPE'.
 shell/edit/provisioning.cattle.io.cluster/ingress/IngressCards.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
 shell/edit/provisioning.cattle.io.cluster/ingress/IngressCards.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/edit/provisioning.cattle.io.cluster/ingress/IngressConfiguration.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
+shell/edit/provisioning.cattle.io.cluster/subtype-detection.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member 'SUB_TYPE'.
+shell/edit/provisioning.cattle.io.cluster/subtype-detection.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CONFIG'.
+shell/edit/provisioning.cattle.io.cluster/subtype-detection.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
+shell/edit/provisioning.cattle.io.cluster/subtype-detection.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/edit/provisioning.cattle.io.cluster/tabs/Ingress.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
 shell/edit/provisioning.cattle.io.cluster/tabs/Ingress.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/edit/provisioning.cattle.io.cluster/tabs/Ingress.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR adds errors related to new query-params imports to the type-check baseline. There are already many references to this file causing TS errors in the baseline. These ones were introduced by https://github.com/rancher/dashboard/pull/18547


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
