### PR TITLE
Add kind/tech-debt to the stalebot's considered labels

### DIFF
--- a/.github/workflows/scripts/__tests__/weekly-stale-issue-manager.candidates.test.ts
+++ b/.github/workflows/scripts/__tests__/weekly-stale-issue-manager.candidates.test.ts
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+// Verifies which labels the stalebot treats as candidates. The set is driven by
+// STALE_TARGET_LABELS (read at module load), so each case reloads the module with
+// a different value. request.graphql is mocked to return issues per searched label.
+const mockGraphql = jest.fn();
+
+jest.mock('../request', () => ({ graphql: mockGraphql }));
+
+const OLD = '2020-01-01T00:00:00Z';
+
+// Reload the module with a given STALE_TARGET_LABELS value.
+function loadWith(targetLabels: string) {
+  jest.resetModules();
+  process.env.STALE_TARGET_LABELS = targetLabels;
+  process.env.GH_TOKEN = 'test-token';
+
+  return require('../weekly-stale-issue-manager');
+}
+
+// Make each search return the issue numbers registered for the label it queried.
+function searchReturns(byLabel: Record<string, number[]>) {
+  mockGraphql.mockImplementation((query: string) => {
+    const label = (query.match(/label:\\?"?([\w/-]+)/) || [])[1];
+    const nodes = (byLabel[label] || []).map((number) => ({
+      number,
+      createdAt: OLD,
+      labels:    { nodes: [{ name: label }] },
+    }));
+
+    return Promise.resolve({ data: { search: { pageInfo: { hasNextPage: false }, nodes } } });
+  });
+}
+
+const searchedLabels = () => mockGraphql.mock.calls
+  .map((c: any[]) => c[0])
+  .filter((q: string) => q.includes('search('));
+
+describe('fetchCandidates — configured target labels', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('searches kind/tech-debt as well as kind/enhancement and unions the results', async () => {
+    const mgr = loadWith('kind/enhancement,kind/tech-debt');
+
+    searchReturns({ 'kind/enhancement': [1], 'kind/tech-debt': [2] });
+
+    const candidates = await mgr.fetchCandidates('octo', 'repo');
+    const queries = searchedLabels();
+
+    expect(queries.some((q: string) => q.includes('kind/enhancement'))).toStrictEqual(true);
+    expect(queries.some((q: string) => q.includes('kind/tech-debt'))).toStrictEqual(true);
+    expect(candidates.map((c: any) => c.number).sort()).toStrictEqual([1, 2]);
+  });
+
+  it('does not consider kind/tech-debt issues when that label is not configured', async () => {
+    const mgr = loadWith('kind/enhancement');
+
+    searchReturns({ 'kind/enhancement': [1], 'kind/tech-debt': [2] });
+
+    const candidates = await mgr.fetchCandidates('octo', 'repo');
+
+    expect(searchedLabels().some((q: string) => q.includes('kind/tech-debt'))).toStrictEqual(false);
+    expect(candidates.map((c: any) => c.number)).toStrictEqual([1]);
+  });
+
+  it('de-duplicates an issue that carries more than one configured label', async () => {
+    const mgr = loadWith('kind/enhancement,kind/tech-debt');
+
+    searchReturns({ 'kind/enhancement': [5], 'kind/tech-debt': [5] });
+
+    const candidates = await mgr.fetchCandidates('octo', 'repo');
+
+    expect(candidates.map((c: any) => c.number)).toStrictEqual([5]);
+  });
+});

--- a/.github/workflows/weekly-stale-issue-manager.yaml
+++ b/.github/workflows/weekly-stale-issue-manager.yaml
@@ -34,7 +34,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           # The stalebot only manages issues carrying one of these labels (comma-separated).
-          STALE_TARGET_LABELS: kind/enhancement
+          STALE_TARGET_LABELS: kind/enhancement,kind/tech-debt
           # Max mark-or-close actions per run (closes first); the rest wait for next run.
           STALE_MAX_ACTIONS: "20"
         run: node .github/workflows/scripts/weekly-stale-issue-manager.js


### PR DESCRIPTION
### Summary
Adds `kind/tech-debt` to the labels the Weekly Stale Issue Manager considers, so stale tech-debt issues are warned and closed the same way as `kind/enhancement`. No linked issue (small config change to an existing workflow).

We have had [one successful run](https://github.com/rancher/dashboard/actions/runs/30749059837/job/91499700916) on master of just the `kind/enhancement` labels. It only labeled issues, it didn't close any as there weren't any opportunities but I don't think that should hold this change up. 

_**I'll make an announcement in our channel before merging.**_

### Occurred changes and/or fixed issues
- `STALE_TARGET_LABELS` in the workflow is now `kind/enhancement,kind/tech-debt`. The script already supports a comma-separated union of labels, so this is a one-line config change.

### Technical notes summary
- No script logic change — only the configured label set plus a test.

### Areas or cases that should be tested
Read-only dry run (any token with repo read; no writes happen in dry-run):
```bash
DRY_RUN=true GITHUB_REPOSITORY=rancher/dashboard \
  STALE_TARGET_LABELS=kind/enhancement,kind/tech-debt GH_TOKEN=<token> \
  node .github/workflows/scripts/weekly-stale-issue-manager.js
```
Verified via that dry-run and a real [GitHub Actions run](https://github.com/codyrancher/dashboard/actions/runs/30667202722) on a fork that marked a `kind/tech-debt` issue (label + warning comment) end-to-end on the plain `GITHUB_TOKEN`. Unit tests: `yarn test:ci` (see `weekly-stale-issue-manager.candidates.test.ts`).

### Areas which could experience regressions
None outside this workflow; no application code is touched. The only behavioral change is that `kind/tech-debt` issues now enter the same stale lifecycle as `kind/enhancement`.

### Screenshot/Video
N/A — CI/tooling change, no UI.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
