### PR TITLE
Mark container name and image fields as required in workload form

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7912,6 +7912,7 @@ workload:
   validation:
     containers: Containers
     containerImage: Container {name} - "Container Image" is required.
+    containerName: Container - "Container Name" is required.
     localhostProfile: Container {name} - "Container Localhost Profile" is required when SeccompProfile Type is Localhost.
   replicas: Replicas
   showTabs: 'Show Advanced Options'

--- a/shell/edit/workload/index.vue
+++ b/shell/edit/workload/index.vue
@@ -243,6 +243,8 @@ export default {
                       v-model:value="allContainers[i].name"
                       :mode="mode"
                       :label="t('workload.container.containerName')"
+                      required
+                      :rules="containerNameRules"
                     />
                   </div>
                   <div class="col span-6">
@@ -265,6 +267,8 @@ export default {
                       :mode="mode"
                       :label="t('workload.container.image')"
                       :placeholder="t('generic.placeholder', {text: 'nginx:latest'}, true)"
+                      required
+                      :rules="containerImageRules"
                     />
                   </div>
                   <div class="col span-6">

--- a/shell/edit/workload/mixins/__tests__/workload-container-validation.test.ts
+++ b/shell/edit/workload/mixins/__tests__/workload-container-validation.test.ts
@@ -1,0 +1,102 @@
+import workloadMixin from '@shell/edit/workload/mixins/workload.js';
+
+describe('workload mixin: container validation', () => {
+  const mockT = (key: string) => key;
+  const mockStore = {
+    getters: {
+      'i18n/t':     mockT,
+      currentStore: () => 'cluster',
+    },
+  };
+
+  function buildCtx(containers: any[], initContainers: any[] = []) {
+    return {
+      podTemplateSpec: { containers, initContainers },
+      idKey:           '_id',
+      $store:          mockStore,
+      t:               mockT,
+    } as any;
+  }
+
+  describe('computed: containerNameRules', () => {
+    it('returns an array with a required validator', () => {
+      const ctx = buildCtx([]);
+      const rules = (workloadMixin.computed as any).containerNameRules.call(ctx);
+
+      expect(rules).toHaveLength(1);
+      expect(rules[0]('')).toStrictEqual('validation.required');
+      expect(rules[0]('some-name')).toBeUndefined();
+    });
+  });
+
+  describe('computed: containerImageRules', () => {
+    it('returns an array with a required validator', () => {
+      const ctx = buildCtx([]);
+      const rules = (workloadMixin.computed as any).containerImageRules.call(ctx);
+
+      expect(rules).toHaveLength(1);
+      expect(rules[0]('')).toStrictEqual('validation.required');
+      expect(rules[0]('nginx:latest')).toBeUndefined();
+    });
+  });
+
+  describe('computed: allContainers', () => {
+    it('sets error.general when container is missing both name and image', () => {
+      const ctx = buildCtx([{ image: '' }]);
+      const result = (workloadMixin.computed as any).allContainers.call(ctx);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].error.general).toBeTruthy();
+    });
+
+    it('sets error.general when container is missing name', () => {
+      const ctx = buildCtx([{ image: 'nginx' }]);
+      const result = (workloadMixin.computed as any).allContainers.call(ctx);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].error.general).toBeTruthy();
+    });
+
+    it('sets error.general when container is missing image', () => {
+      const ctx = buildCtx([{ name: 'container-0' }]);
+      const result = (workloadMixin.computed as any).allContainers.call(ctx);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].error.general).toBeTruthy();
+    });
+
+    it('clears error.general when container has both name and image', () => {
+      const ctx = buildCtx([{ name: 'container-0', image: 'nginx' }]);
+      const result = (workloadMixin.computed as any).allContainers.call(ctx);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].error.general).toBeUndefined();
+    });
+
+    it('validates init containers the same as regular containers', () => {
+      const ctx = buildCtx(
+        [{ name: 'main', image: 'nginx' }],
+        [{ image: 'busybox' }],
+      );
+      const result = (workloadMixin.computed as any).allContainers.call(ctx);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].error.general).toBeUndefined();
+      expect(result[1].error.general).toBeTruthy();
+    });
+
+    it('reports per-container errors independently', () => {
+      const ctx = buildCtx([
+        { name: 'valid', image: 'nginx' },
+        { name: '', image: 'nginx' },
+        { name: 'no-image' },
+      ]);
+      const result = (workloadMixin.computed as any).allContainers.call(ctx);
+
+      expect(result).toHaveLength(3);
+      expect(result[0].error.general).toBeUndefined();
+      expect(result[1].error.general).toBeTruthy();
+      expect(result[2].error.general).toBeTruthy();
+    });
+  });
+});

--- a/shell/edit/workload/mixins/workload.js
+++ b/shell/edit/workload/mixins/workload.js
@@ -313,6 +313,18 @@ export default {
         }];
     },
 
+    containerNameRules() {
+      const { required } = formRulesGenerator(this.$store.getters['i18n/t'], { key: this.t('workload.container.containerName') });
+
+      return [required];
+    },
+
+    containerImageRules() {
+      const { required } = formRulesGenerator(this.$store.getters['i18n/t'], { key: this.t('workload.container.image') });
+
+      return [required];
+    },
+
     tabErrors() {
       const tabErrors = { podSecurityContext: this.fvGetPathErrors(['podTemplateSpec.securityContext.seccompProfile.localhostProfile'])?.length > 0 };
 
@@ -492,14 +504,13 @@ export default {
           return each;
         }),
       ].map((container) => {
-        const containerImageRule = formRulesGenerator(this.$store.getters['i18n/t'], { name: container.name }).containerImage;
-        const localhostProfileRule = formRulesGenerator(this.$store.getters['i18n/t'], { name: container.name }).localhostProfile;
-
-        const imageError = containerImageRule(container);
-        const localhostProfileError = localhostProfileRule(container);
+        const rules = formRulesGenerator(this.$store.getters['i18n/t'], { name: container.name });
+        const imageError = rules.containerImage(container);
+        const nameError = rules.containerName(container);
+        const localhostProfileError = rules.localhostProfile(container);
 
         container.error = {
-          general:          imageError,
+          general:          nameError || imageError,
           localhostProfile: localhostProfileError
         };
 

--- a/shell/utils/validators/formRules/__tests__/index.test.ts
+++ b/shell/utils/validators/formRules/__tests__/index.test.ts
@@ -373,6 +373,35 @@ describe('formRules', () => {
     expect(formRuleResult).toStrictEqual(expectedResult);
   });
 
+  it('"containerName" : returns undefined when valid container with name is supplied', () => {
+    const testValue = { name: 'testName' };
+    const formRuleResult = formRules.containerName(testValue);
+
+    expect(formRuleResult).toBeUndefined();
+  });
+
+  it('"containerName" : returns correct message when container without name is supplied', () => {
+    const testValue = { image: 'nginx' };
+    const formRuleResult = formRules.containerName(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'workload.validation.containerName',
+      name:    undefined
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
+  it('"containerName" : returns correct message when container name is empty string', () => {
+    const testValue = { name: '' };
+    const formRuleResult = formRules.containerName(testValue);
+    const expectedResult = JSON.stringify({
+      message: 'workload.validation.containerName',
+      name:    ''
+    });
+
+    expect(formRuleResult).toStrictEqual(expectedResult);
+  });
+
   it('"containerImage" : returns undefined when valid container with image is supplied', () => {
     const testValue = { image: 'imageName' };
     const formRuleResult = formRules.containerImage(testValue);

--- a/shell/utils/validators/formRules/index.ts
+++ b/shell/utils/validators/formRules/index.ts
@@ -270,6 +270,8 @@ export default function(
 
   const containerImage: Validator = (val: any) => !val?.image ? t('workload.validation.containerImage', { name: val.name }) : undefined;
 
+  const containerName: Validator = (val: any) => !val?.name ? t('workload.validation.containerName', { name: val.name }) : undefined;
+
   const localhostProfile: Validator = (val: any) => (val?.securityContext?.seccompProfile?.type === 'Localhost' && !val?.securityContext.seccompProfile?.localhostProfile && !val?.securityContext?.privileged) ? t('workload.validation.localhostProfile', { name: val.name }) : undefined;
 
   const containerImages: Validator = (val: any | [any]) => {
@@ -604,6 +606,7 @@ export default function(
     clusterName,
     containerImage,
     containerImages,
+    containerName,
     localhostProfile,
     cronSchedule,
     dnsLabel,


### PR DESCRIPTION
### Summary
Fixes #7535

### Occurred changes and/or fixed issues
Making sure the required field indicators are visible in prod builds.

### Technical notes summary
The Container Name and Container Image `LabeledInput` fields were never given the `required` prop or `:rules`, so they had no way to show asterisks or inline validation errors.

### Areas or cases that should be tested
- Create a Deployment: verify Container Name and Container Image fields show required asterisks
- Clear the Container Name field, blur it: verify inline validation error appears

#### Verifying with a production build (dashboard-index)
1. Set the `ui-dashboard-index` to `https://releases.rancher.com/dashboard/issue-7535-dev/index.html`
2. Remember to refresh the page to get the new index.

### Areas which could experience regressions
- Workload creation/editing forms for all workload types
- Container tab error indicators
- Form-level validation (Create button disabled state)

### Screenshot/Video

<img width="2564" height="376" alt="image" src="https://github.com/user-attachments/assets/1bd9f86c-d82e-4bee-9396-0592c904e2b4" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
