### PR TITLE
Use aria-pressed for the cluster pin toggle

### DIFF
--- a/shell/components/nav/Pinned.vue
+++ b/shell/components/nav/Pinned.vue
@@ -33,7 +33,7 @@ export default {
 <template>
   <i
     :tabindex="tabOrder"
-    :aria-checked="!!pinned"
+    :aria-pressed="!!pinned"
     class="pin icon"
     :class="{'icon-pin-outlined': !pinned, 'icon-pin': pinned}"
     role="button"

--- a/shell/components/nav/__tests__/Pinned.test.ts
+++ b/shell/components/nav/__tests__/Pinned.test.ts
@@ -1,0 +1,86 @@
+import { shallowMount } from '@vue/test-utils';
+import Pinned from '@shell/components/nav/Pinned.vue';
+
+const mountPinned = (pinned: boolean, tabOrder: number | null = 0) => {
+  const cluster = {
+    label: 'local',
+    pinned,
+    pin:   jest.fn(),
+    unpin: jest.fn(),
+  };
+
+  const wrapper = shallowMount(Pinned as any, { props: { cluster, tabOrder } });
+
+  return { wrapper, cluster };
+};
+
+describe('component: Pinned', () => {
+  describe('aria attributes', () => {
+    it.each([
+      ['pinned', true, 'true'],
+      ['unpinned', false, 'false'],
+    ])('should expose the %s state as aria-pressed="%s"', (_label, pinned, expected) => {
+      const { wrapper } = mountPinned(pinned as boolean);
+
+      expect(wrapper.attributes('aria-pressed')).toStrictEqual(expected);
+    });
+
+    // role="button" does not support aria-checked, which axe reports as a critical
+    // aria-allowed-attr violation. The toggle state has to ride on aria-pressed.
+    it.each([
+      ['pinned', true],
+      ['unpinned', false],
+    ])('should not set aria-checked when %s', (_label, pinned) => {
+      const { wrapper } = mountPinned(pinned as boolean);
+
+      expect(wrapper.attributes('aria-checked')).toBeUndefined();
+    });
+
+    it('should keep role="button" and a descriptive aria-label', () => {
+      const { wrapper } = mountPinned(false);
+
+      expect(wrapper.attributes('role')).toStrictEqual('button');
+      expect(wrapper.attributes('aria-label')).toContain('nav.ariaLabel.pinCluster');
+    });
+
+    it.each([
+      ['reachable', 0, '0'],
+      ['unreachable', -1, '-1'],
+    ])('should be keyboard %s when tabOrder is %s', (_label, tabOrder, expected) => {
+      const { wrapper } = mountPinned(false, tabOrder as number);
+
+      expect(wrapper.attributes('tabindex')).toStrictEqual(expected);
+    });
+  });
+
+  describe('toggling', () => {
+    it('should pin an unpinned cluster on click', async() => {
+      const { wrapper, cluster } = mountPinned(false);
+
+      await wrapper.trigger('click');
+
+      expect(cluster.pin).toHaveBeenCalledWith();
+      expect(cluster.unpin).not.toHaveBeenCalledWith();
+    });
+
+    it('should unpin a pinned cluster on click', async() => {
+      const { wrapper, cluster } = mountPinned(true);
+
+      await wrapper.trigger('click');
+
+      expect(cluster.unpin).toHaveBeenCalledWith();
+      expect(cluster.pin).not.toHaveBeenCalledWith();
+    });
+
+    it.each([
+      ['enter'],
+      ['space'],
+    ])('should toggle on %s keydown', async(key) => {
+      const { wrapper, cluster } = mountPinned(false);
+
+      await wrapper.trigger(`keydown.${ key }`);
+
+      expect(cluster.pin).toHaveBeenCalledWith();
+    });
+  });
+});


### PR DESCRIPTION
### Summary
Fixes #18602

### Occurred changes and/or fixed issues

The cluster pin toggle set `aria-checked` on an element with `role="button"`. That role does not support `aria-checked`, so axe reports a critical `aria-allowed-attr` violation and the state is never announced. Moved it to `aria-pressed`, the valid toggle-button equivalent.

```diff
-    :aria-checked="!!pinned"
+    :aria-pressed="!!pinned"
```

### Technical notes summary

One attribute rename in `Pinned.vue`. The bound expression is unchanged, as are `role`, `tabindex`, the `aria-label`, and the click/keydown handlers. Adds `Pinned.test.ts` covering the aria contract and pin/unpin via click and enter/space.

### Areas or cases that should be tested

- Pin and unpin a cluster from the top level menu; icon still swaps and the cluster moves in/out of the pinned list.
- `aria-pressed` tracks the state, no `aria-checked` present.
- Screen reader announces a toggle button with a pressed state; enter and space both activate it.
- axe scan of the menu: 0 `aria-allowed-attr` violations.

### Areas which could experience regressions

Low risk, scoped to `Pinned.vue`. The only `[aria-checked]` selectors in the repo belong to the radio and checkbox components, and no e2e page object targets the pin by that attribute.

### Screenshot/Video

Both videos run axe live against the page and render the real element markup and violation list into an on-screen panel, since the bug is an invisible attribute. Nothing in the panel is hardcoded.

Before - `aria-checked` on `role="button"`, 1 critical violation:

https://github.com/user-attachments/assets/4a7efd8c-3154-4eeb-a3c1-5e2f421f977c

![before - axe aria-allowed-attr violation](https://github.com/user-attachments/assets/ef8c8493-43a2-44ae-b510-80e32c4ba687)

After - `aria-pressed` carries the state, 0 violations:

https://github.com/user-attachments/assets/0816a050-8dc7-4403-8a40-3524b3358437

![after - axe clean](https://github.com/user-attachments/assets/6a306da7-5883-41ba-9775-f409291facdb)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
