### PR TITLE
Bump js-yaml from 3.14.2 to 3.15.0 and from 4.2.0 to 4.3.0 in /cypress

### DIFF
--- a/cypress/yarn.lock
+++ b/cypress/yarn.lock
@@ -3766,7 +3766,7 @@ istanbul-reports@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.3.0, js-yaml@^4.1.1:
+js-yaml@4.3.0, js-yaml@^4.1.0, js-yaml@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
   integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
@@ -3774,19 +3774,12 @@ js-yaml@4.3.0, js-yaml@^4.1.1:
     argparse "^2.0.1"
 
 js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.0.tgz#586e5214eafe3e893756a41e979b50d89d3e4a67"
+  integrity sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-js-yaml@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
-  dependencies:
-    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"


### PR DESCRIPTION
### Summary
Bumps `js-yaml` to a non-vulnerable version to resolve open Dependabot security advisories. No issue is needed for an automated dependency security bump.

### Occurred changes and/or fixed issues
Bumps `js-yaml` in `/cypress`:
- `3.14.2` → `3.15.0` (the `^3.13.1` line)
- `4.2.0` → `4.3.0` (the `^4.1.0` line)

Only `cypress/yarn.lock` is touched — this is a clean transitive dependency bump with no application-logic changes.

### Vulnerabilities fixed
Bumping `js-yaml` to `3.15.0` / `4.3.0` resolves the following Dependabot alert(s):

- [**Dependabot #973**](https://github.com/rancher/dashboard/security/dependabot/973) · **HIGH** — [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) / CVE-2026-59869: js-yaml: YAML merge-key chains can force quadratic CPU consumption Vulnerable `>= 3.0.0, < 3.15.0`, patched in `3.15.0`.
- [**Dependabot #952**](https://github.com/rancher/dashboard/security/dependabot/952) · **HIGH** — [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) / CVE-2026-59869: js-yaml: YAML merge-key chains can force quadratic CPU consumption Vulnerable `>= 4.0.0, < 4.3.0`, patched in `4.3.0`.
- [**Dependabot #924**](https://github.com/rancher/dashboard/security/dependabot/924) · **MEDIUM** — [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) / CVE-2026-53550: JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases Vulnerable `< 3.15.0`, patched in `3.15.0`.

### Technical notes summary
Transitive dependency of the Cypress dev/test tooling. The resolutions in `cypress/yarn.lock` are updated to the patched versions; no source files change.

### Areas or cases that should be tested
None at runtime — `js-yaml` here is only pulled in by the Cypress test tooling, not shipped in the dashboard bundle. The e2e suite continues to pass.

### Areas which could experience regressions
None expected. Patch/minor version bumps within the same major line; no API changes affecting our usage.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/d5bb4606-d594-4c8b-9ec1-3f4a3fed04e1

**Playwright checks performed** (video recorded, 1280×800):

1. **Log in to the preview and reach the dashboard.** Local-user login with the console credentials landed on
   `/dashboard/home`; the app (which registers the js-yaml plugin at boot) compiled and booted cleanly. ✅ PASS
2. **ConfigMap Create → Edit as YAML dumps valid YAML.** Filled name + a data key/value, switched to **Edit as YAML**;
   the CodeMirror editor showed a well-formed document containing the resource name and `kind: ConfigMap` — proof
   `jsyaml.dump` serialized the form object correctly. ✅ PASS
3. **Create parses the submitted YAML and stores the resource.** Clicked **Create**; the ConfigMap was accepted by the
   real `local` cluster (Steve API proxied through the preview) and appeared in the ConfigMap list — proof `jsyaml.load`
   parsed the submitted YAML on save. ✅ PASS
4. **Reopen the saved resource's YAML view round-trips.** Opened the stored ConfigMap's **edit-as-YAML** view; the editor
   rendered `kind: ConfigMap`, the resource name, and the `greeting: hello-jsyaml` data — a full load → store → dump
   round-trip through the bumped js-yaml. ✅ PASS

**Verdict:** **4/4 checks passed.** The js-yaml bump (3.15.0 / 4.3.0) leaves the dashboard's YAML load/dump/round-trip behavior
unchanged; the resource YAML editor and ConfigMap create/save flow work against live cluster data on the preview build.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.


