### PR TITLE
Bump fast-uri from 3.1.4 to 3.1.5

### DIFF
--- a/cypress/yarn.lock
+++ b/cypress/yarn.lock
@@ -2662,9 +2662,9 @@ fast-printf@^1.6.9:
   integrity sha512-GwTgG9O4FVIdShhbVF3JxOgSBY2+ePGsu2V/UONgoCPzF9VY6ZdBMKsHKCYQHZwNk3qNouUolRDsgVxcVA5G1w==
 
 fast-uri@^3.0.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
-  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fastq@^1.6.0:
   version "1.20.1"

--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -5035,9 +5035,9 @@ fast-json-stable-stringify@^2.0.0:
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-uri@^3.0.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
-  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fastq@^1.6.0:
   version "1.20.1"

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -7157,9 +7157,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
-  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fast-xml-builder@^1.1.5:
   version "1.2.0"

--- a/storybook/yarn.lock
+++ b/storybook/yarn.lock
@@ -2466,9 +2466,9 @@ fast-json-stable-stringify@^2.0.0:
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-uri@^3.0.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
-  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fill-range@^7.1.1:
   version "7.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8349,9 +8349,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
-  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fast-xml-builder@^1.1.5:
   version "1.2.0"


### PR DESCRIPTION
### Summary
Bumps `fast-uri` from `3.1.4` to `3.1.5` to resolve a security advisory (host confusion via backslash authority introducer).

### Occurred changes and/or fixed issues
Updates the `fast-uri` dependency across the affected manifests (`yarn.lock`, `shell/yarn.lock`, `cypress/yarn.lock`, `docusaurus/yarn.lock`, `storybook/yarn.lock`). No application-logic changes.

### Technical notes summary
Transitive/direct dependency bump only. `fast-uri` 3.1.5 fixes host confusion when parsing URIs that use a backslash as the authority introducer.

### Areas or cases that should be tested
Standard dependency-bump verification. No functional UI changes expected; smoke test of areas relying on URI parsing.

### Areas which could experience regressions
Any code paths using `fast-uri` for URI parsing/normalization.

### Screenshot/Video

Verification recording (Playwright):

https://github.com/user-attachments/assets/d30f48ed-b1e8-4375-8644-2282d06c909d

**Playwright checks performed** (video recorded, 1280×800):

1. **App boots + local-auth login** — logged in via `[data-testid="local-login-username"]` /
   `[data-testid="login-submit"]` and reached `/dashboard/home` with no "Error" masthead, proving the
   production bundle built from the bumped lockfiles loads and runs. **✅ PASS**
2. **Live cluster resource list** — opened the `local` cluster ConfigMaps list
   (`/c/local/explorer/configmap`); it rendered **100 real rows** proxied from the live cluster
   (e.g. `access-console-app`), proving API proxy + list rendering are intact. **✅ PASS**
3. **YAML editor read/dump path** — opened an existing ConfigMap's YAML view; the editor dumped valid
   YAML (`kind: ConfigMap`, `apiVersion: v1` present), confirming the parse→dump path works. **✅ PASS**
4. **YAML create round-trip (write → store → dump)** — created a ConfigMap through the "Create from
   YAML" editor, then reopened its YAML view and confirmed the stored `name` and `data.verified-by`
   value round-tripped from the live cluster. The throwaway resource was deleted afterward
   (Steve `DELETE` → 204, subsequent `GET` → 404). **✅ PASS**

**Verdict:** **4/4 checks passed.** The production build (which is what actually exercises `fast-uri` via `ajv`) succeeded, and the built dashboard logs in, lists live cluster data, and round-trips a ConfigMap through the YAML editor — the `fast-uri` 3.1.4 → 3.1.5 bump introduces no regression for how the dashboard uses the package.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.


### Vulnerabilities fixed
Bumping `fast-uri` to `3.1.5` resolves the following Dependabot alert(s):

- [**Dependabot #1082**](https://github.com/rancher/dashboard/security/dependabot/1082) · **HIGH** — [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) / CVE-2026-18446: fast-uri vulnerable to host confusion via backslash authority introducer Vulnerable `>= 3.0.0, < 3.1.5`, patched in `3.1.5`.
- [**Dependabot #1078**](https://github.com/rancher/dashboard/security/dependabot/1078) · **HIGH** — [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) / CVE-2026-18446: fast-uri vulnerable to host confusion via backslash authority introducer Vulnerable `>= 3.0.0, < 3.1.5`, patched in `3.1.5`.
- [**Dependabot #1074**](https://github.com/rancher/dashboard/security/dependabot/1074) · **HIGH** — [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) / CVE-2026-18446: fast-uri vulnerable to host confusion via backslash authority introducer Vulnerable `>= 3.0.0, < 3.1.5`, patched in `3.1.5`.
- [**Dependabot #1070**](https://github.com/rancher/dashboard/security/dependabot/1070) · **HIGH** — [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) / CVE-2026-18446: fast-uri vulnerable to host confusion via backslash authority introducer Vulnerable `>= 3.0.0, < 3.1.5`, patched in `3.1.5`.
- [**Dependabot #1065**](https://github.com/rancher/dashboard/security/dependabot/1065) · **HIGH** — [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) / CVE-2026-18446: fast-uri vulnerable to host confusion via backslash authority introducer Vulnerable `>= 3.0.0, < 3.1.5`, patched in `3.1.5`.

