### PR TITLE
[JIRA][15728][Fleet] Fix Fleet target clusters with BundleNamespaceMapping

### DIFF
--- a/shell/models/__tests__/fleet-application.test.ts
+++ b/shell/models/__tests__/fleet-application.test.ts
@@ -21,7 +21,10 @@ describe('class FleetApplication', () => {
         clusterGroups: groups,
       };
 
-      jest.spyOn(FleetApplication.prototype, '$getters', 'get').mockReturnValue({ byId: () => workspace });
+      jest.spyOn(FleetApplication.prototype, '$getters', 'get').mockReturnValue({
+        byId: () => workspace,
+        all:  () => [],
+      });
 
       return new FleetApplication({
         metadata: { namespace: workspaceId },

--- a/shell/models/__tests__/fleet.cattle.io.bundle.test.ts
+++ b/shell/models/__tests__/fleet.cattle.io.bundle.test.ts
@@ -6,17 +6,36 @@ describe('class FleetBundle', () => {
   });
 
   describe('targetClusters', () => {
-    function createFleetBundle(targets: any[], clusters: any[], workspaceId = 'fleet-default', groups: any[] = []) {
+    function createFleetBundle(targets: any[], clusters: any[], workspaceId = 'fleet-default', groups: any[] = [], bundleNamespaceMappings: any[] = [], allWorkspaces: any[] = [], bundleLabels: Record<string, string> = {}) {
       const workspace = {
         id:            workspaceId,
+        metadata:      { name: workspaceId },
         clusters,
         clusterGroups: groups,
       };
 
-      jest.spyOn(FleetBundle.prototype, '$getters', 'get').mockReturnValue({ byId: () => workspace });
+      jest.spyOn(FleetBundle.prototype, '$getters', 'get').mockReturnValue({
+        byId: (_type: string, id: string) => {
+          if (id === workspaceId) {
+            return workspace;
+          }
+
+          return allWorkspaces.find((ws: any) => ws.metadata?.name === id);
+        },
+        all: (type: string) => {
+          if (type === 'fleet.cattle.io.bundlenamespacemapping') {
+            return bundleNamespaceMappings;
+          }
+          if (type === 'management.cattle.io.fleetworkspace') {
+            return allWorkspaces;
+          }
+
+          return [];
+        },
+      });
 
       return new FleetBundle({
-        metadata: { namespace: workspaceId },
+        metadata: { namespace: workspaceId, labels: bundleLabels },
         spec:     { targets },
       });
     }
@@ -135,6 +154,76 @@ describe('class FleetBundle', () => {
       ];
 
       const bundle = createFleetBundle([{ clusterName: 'some-other-name' }], clusters);
+
+      expect(bundle.targetClusters).toStrictEqual([]);
+    });
+
+    it('should include clusters from namespaces mapped via BundleNamespaceMapping', () => {
+      const mappedClusters = [
+        {
+          id:          'fleet-default/c-m-mapped1',
+          metadata:    { name: 'c-m-mapped1' },
+          nameDisplay: 'mapped-cluster',
+        }
+      ];
+
+      const bundleNamespaceMappings = [{
+        metadata:          { namespace: 'fleet-new' },
+        bundleSelector:    { matchLabels: { team: 'one' } },
+        namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': 'fleet-default' } },
+      }];
+
+      const mappedWorkspace = {
+        id:            'fleet-default',
+        metadata:      { name: 'fleet-default', labels: {} },
+        clusters:      mappedClusters,
+        clusterGroups: [],
+      };
+
+      const bundle = createFleetBundle(
+        [{ clusterSelector: {} }],
+        [],
+        'fleet-new',
+        [],
+        bundleNamespaceMappings,
+        [mappedWorkspace],
+        { team: 'one' },
+      );
+
+      expect(bundle.targetClusters).toStrictEqual(mappedClusters);
+    });
+
+    it('should not include clusters when bundle does not match BundleNamespaceMapping selector', () => {
+      const mappedClusters = [
+        {
+          id:          'fleet-default/c-m-mapped1',
+          metadata:    { name: 'c-m-mapped1' },
+          nameDisplay: 'mapped-cluster',
+        }
+      ];
+
+      const bundleNamespaceMappings = [{
+        metadata:          { namespace: 'fleet-new' },
+        bundleSelector:    { matchLabels: { team: 'two' } },
+        namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': 'fleet-default' } },
+      }];
+
+      const mappedWorkspace = {
+        id:            'fleet-default',
+        metadata:      { name: 'fleet-default', labels: {} },
+        clusters:      mappedClusters,
+        clusterGroups: [],
+      };
+
+      const bundle = createFleetBundle(
+        [{ clusterSelector: {} }],
+        [],
+        'fleet-new',
+        [],
+        bundleNamespaceMappings,
+        [mappedWorkspace],
+        { team: 'one' },
+      );
 
       expect(bundle.targetClusters).toStrictEqual([]);
     });

--- a/shell/models/fleet-application.js
+++ b/shell/models/fleet-application.js
@@ -1,4 +1,4 @@
-import { matching, convertSelectorObj } from '@shell/utils/selector';
+import { matching, convertSelectorObj, matches } from '@shell/utils/selector';
 import isEmpty from 'lodash/isEmpty';
 import { escapeHtml } from '@shell/utils/string';
 import { FLEET, MANAGEMENT } from '@shell/config/types';
@@ -87,8 +87,8 @@ export default class FleetApplication extends SteveModel {
 
   get targetClusters() {
     const workspace = this.$getters['byId'](FLEET.WORKSPACE, this.metadata.namespace);
-    const clusters = workspace?.clusters || [];
-    const groups = workspace?.clusterGroups || [];
+    const clusters = [...(workspace?.clusters || [])];
+    const groups = [...(workspace?.clusterGroups || [])];
 
     if (workspace?.id === 'fleet-local') {
       // should we be getting the clusters from workspace.clusters instead of having to rely on the groups,
@@ -104,6 +104,44 @@ export default class FleetApplication extends SteveModel {
 
     if (!this.spec.targets) {
       return [];
+    }
+
+    const allMappings = this.$getters['all'](FLEET.BUNDLE_NAMESPACE_MAPPING) || [];
+    const bundleNs = this.metadata.namespace;
+
+    for (const mapping of allMappings) {
+      if (mapping.metadata?.namespace !== bundleNs) {
+        continue;
+      }
+
+      if (mapping.bundleSelector) {
+        const bundleExpressions = convertSelectorObj(mapping.bundleSelector);
+
+        if (!matches(this, bundleExpressions)) {
+          continue;
+        }
+      }
+
+      if (mapping.namespaceSelector) {
+        const allWorkspaces = this.$getters['all'](FLEET.WORKSPACE) || [];
+        const nsExpressions = convertSelectorObj(mapping.namespaceSelector);
+
+        for (const ws of allWorkspaces) {
+          if (ws.metadata?.name === bundleNs) {
+            continue;
+          }
+
+          const nsLabels = {
+            ...(ws.metadata?.labels || {}),
+            'kubernetes.io/metadata.name': ws.metadata?.name,
+          };
+
+          if (matches({ metadata: { labels: nsLabels } }, nsExpressions)) {
+            addObjects(clusters, ws.clusters || []);
+            addObjects(groups, ws.clusterGroups || []);
+          }
+        }
+      }
     }
 
     const out = [];

--- a/shell/models/fleet.cattle.io.bundle.js
+++ b/shell/models/fleet.cattle.io.bundle.js
@@ -3,7 +3,7 @@ import SteveModel from '@shell/plugins/steve/steve-class';
 import { addObject, addObjects, findBy } from '@shell/utils/array';
 import { FLEET } from '@shell/config/types';
 import { FLEET as FLEET_ANNOTATIONS } from '@shell/config/labels-annotations';
-import { convertSelectorObj, matching } from '@shell/utils/selector';
+import { convertSelectorObj, matches, matching } from '@shell/utils/selector';
 
 export default class FleetBundle extends SteveModel {
   get lastUpdateTime() {
@@ -31,8 +31,8 @@ export default class FleetBundle extends SteveModel {
       FLEET.WORKSPACE,
       this.metadata.namespace
     );
-    const clusters = workspace?.clusters || [];
-    const groups = workspace?.clusterGroups || [];
+    const clusters = [...(workspace?.clusters || [])];
+    const groups = [...(workspace?.clusterGroups || [])];
     const out = [];
 
     if (workspace.id === 'fleet-local') {
@@ -43,6 +43,44 @@ export default class FleetBundle extends SteveModel {
       }
 
       return [];
+    }
+
+    const allMappings = this.$getters['all'](FLEET.BUNDLE_NAMESPACE_MAPPING) || [];
+    const bundleNs = this.metadata.namespace;
+
+    for (const mapping of allMappings) {
+      if (mapping.metadata?.namespace !== bundleNs) {
+        continue;
+      }
+
+      if (mapping.bundleSelector) {
+        const bundleExpressions = convertSelectorObj(mapping.bundleSelector);
+
+        if (!matches(this, bundleExpressions)) {
+          continue;
+        }
+      }
+
+      if (mapping.namespaceSelector) {
+        const allWorkspaces = this.$getters['all'](FLEET.WORKSPACE) || [];
+        const nsExpressions = convertSelectorObj(mapping.namespaceSelector);
+
+        for (const ws of allWorkspaces) {
+          if (ws.metadata?.name === bundleNs) {
+            continue;
+          }
+
+          const nsLabels = {
+            ...(ws.metadata?.labels || {}),
+            'kubernetes.io/metadata.name': ws.metadata?.name,
+          };
+
+          if (matches({ metadata: { labels: nsLabels } }, nsExpressions)) {
+            addObjects(clusters, ws.clusters || []);
+            addObjects(groups, ws.clusterGroups || []);
+          }
+        }
+      }
     }
 
     for (const tgt of this.spec.targets) {


### PR DESCRIPTION
### Summary
Fixes #15728

Fleet `Bundle` resources failed to pick up associated resources when a `GitRepo` was used together with a `BundleNamespaceMapping`. The Bundle's `targetClusters` only considered clusters in the Bundle's own workspace, so a bundle routed to clusters in another workspace via a mapping resolved to zero target clusters — and the Bundle detail **Resources** tab was empty even though the resource was actually deployed to a cluster.

### Occurred changes and/or fixed issues
- `shell/models/fleet.cattle.io.bundle.js` — `targetClusters` now also considers clusters (and cluster groups) from workspaces selected by a `BundleNamespaceMapping` in the resource's namespace before resolving `spec.targets`.
- `shell/models/fleet-application.js` — the same resolution is applied to `GitRepo`/`HelmOp` so their target-cluster display stays consistent with the Bundle view.
- Unit tests added covering the mapped-cluster path, including the `bundleSelector` match and non-match cases.

### Technical notes summary
- For each `BundleNamespaceMapping` in the resource's namespace:
  - if it defines a `bundleSelector`, the resource must match it or the mapping is skipped;
  - workspaces whose labels (including the synthetic `kubernetes.io/metadata.name`) match the mapping's `namespaceSelector` contribute their clusters and cluster groups to the candidate pool.
- The workspace cluster/group arrays are shallow-copied before appending, so the shared store objects are not mutated.
- Deduplication is handled by `addObjects` (by reference), so a cluster present in both the own workspace and a mapped workspace is not counted twice.

### Areas or cases that should be tested
Repro from the issue:
1. Create a workspace `fleet-new`.
2. Import this `BundleNamespaceMapping` (Import YAML) into `fleet-new`:
   ```yaml
   apiVersion: fleet.cattle.io/v1alpha1
   kind: BundleNamespaceMapping
   metadata:
     name: mapping
     namespace: fleet-new
   bundleSelector:
     matchLabels:
       team: one
   namespaceSelector:
     matchLabels:
       kubernetes.io/metadata.name: fleet-default
   ```
3. With `fleet-new` selected, go to **App Bundles** and create a `GitRepo` with label `team: one`, repo `https://github.com/rancher/fleet-examples`, path `/simple`, targeting all clusters in the workspace.
4. Go to **Fleet → Resources → Bundles**, open the bundle, and check the **Resources** tab.

**Expected:** the Resources tab lists the deployed resources (previously empty).

Also verify the non-mapping case is unchanged (a GitRepo/Bundle in a workspace that already has its own clusters), and the `fleet-local` workspace.

### Areas which could experience regressions
- Target-cluster display on the GitRepo/HelmOp/Bundle detail views and the Fleet dashboard cards / summary graph (all read `targetClusters`).
- The `fleet-local` workspace path (unchanged — it early-returns before the new logic).
- Workspaces with many mappings/clusters (resolution now iterates mappings × workspaces).
- **RBAC / Global Roles:** the expansion relies on the current user being able to list `BundleNamespaceMapping`, `FleetWorkspace`, and the mapped workspace's clusters. A Standard/Base user without visibility of the mapped workspace may still see an empty result — worth verifying across roles.

### Screenshot/Video
<!-- Please attach a before/after of the Bundle Resources tab. -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
