### PR TITLE
Bump postcss from 8.5.18 to 8.5.25

### DIFF
--- a/docusaurus/yarn.lock
+++ b/docusaurus/yarn.lock
@@ -7158,7 +7158,7 @@ multicast-dns@^7.2.5:
     dns-packet "^5.2.2"
     thunky "^1.0.2"
 
-nanoid@^3.3.12:
+nanoid@^3.3.16:
   version "3.3.16"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
   integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
@@ -8093,11 +8093,11 @@ postcss-zindex@^6.0.2:
   integrity sha512-5BxW9l1evPB/4ZIc+2GobEBoKC+h8gPGCMi+jxsYvd2x0mjq7wazk6DrP71pStqxE9Foxh5TVnonbWpFZzXaYg==
 
 postcss@^8.4.21, postcss@^8.4.24, postcss@^8.4.33, postcss@^8.5.4, postcss@^8.5.6:
-  version "8.5.18"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.18.tgz#8717e5a33a3b15fe8a538d2431a1e1bbbfb07614"
-  integrity sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==
+  version "8.5.25"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.25.tgz#5012a598eaaa897f21bbe8553be3cb7bd2bd78cb"
+  integrity sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==
   dependencies:
-    nanoid "^3.3.12"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
     "diff2html/diff": "5.2.2",
     "@cypress/code-coverage/js-yaml": "4.3.0",
     "webpack-dev-server": "5.2.6",
-    "postcss": "8.5.18",
+    "postcss": "8.5.25",
     "@tootallnate/once": "^2.0.1",
     "cookie": "0.7.2"
   }

--- a/shell/package.json
+++ b/shell/package.json
@@ -150,7 +150,7 @@
     "diff2html/diff": "5.2.2",
     "@vue/cli-service/html-webpack-plugin": "^5.0.0",
     "webpack-dev-server": "5.2.6",
-    "postcss": "8.5.18",
+    "postcss": "8.5.25",
     "@tootallnate/once": "^2.0.1",
     "cookie": "0.7.2"
   },

--- a/shell/yarn.lock
+++ b/shell/yarn.lock
@@ -9606,7 +9606,7 @@ mz@^2.4.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nanoid@^3.3.12:
+nanoid@^3.3.16:
   version "3.3.16"
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
   integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
@@ -10598,12 +10598,12 @@ postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.5.18, postcss@^7.0.36, postcss@^8.2.6, postcss@^8.3.5, postcss@^8.4.19, postcss@^8.4.33, postcss@^8.5.6, postcss@^8.5.8:
-  version "8.5.18"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.18.tgz#8717e5a33a3b15fe8a538d2431a1e1bbbfb07614"
-  integrity sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==
+postcss@8.5.25, postcss@^7.0.36, postcss@^8.2.6, postcss@^8.3.5, postcss@^8.4.19, postcss@^8.4.33, postcss@^8.5.6, postcss@^8.5.8:
+  version "8.5.25"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.25.tgz#5012a598eaaa897f21bbe8553be3cb7bd2bd78cb"
+  integrity sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==
   dependencies:
-    nanoid "^3.3.12"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 

--- a/storybook/yarn.lock
+++ b/storybook/yarn.lock
@@ -3761,7 +3761,7 @@ muggle-string@^0.4.1:
   resolved "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz#3b366bd43b32f809dc20659534dd30e7c8a0d328"
   integrity sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==
 
-nanoid@^3.3.12:
+nanoid@^3.3.16:
   version "3.3.16"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
   integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
@@ -4078,11 +4078,11 @@ postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss@^8.4.33, postcss@^8.4.48:
-  version "8.5.18"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.18.tgz#8717e5a33a3b15fe8a538d2431a1e1bbbfb07614"
-  integrity sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==
+  version "8.5.25"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.25.tgz#5012a598eaaa897f21bbe8553be3cb7bd2bd78cb"
+  integrity sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==
   dependencies:
-    nanoid "^3.3.12"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11465,7 +11465,7 @@ nanoid@3.3.3:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
   integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
-nanoid@^3.3.12:
+nanoid@^3.3.16:
   version "3.3.16"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
   integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
@@ -12668,12 +12668,12 @@ postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.5.18, postcss@^7.0.36, postcss@^8.2.6, postcss@^8.3.5, postcss@^8.4.33, postcss@^8.5.6, postcss@^8.5.8:
-  version "8.5.18"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.18.tgz#8717e5a33a3b15fe8a538d2431a1e1bbbfb07614"
-  integrity sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==
+postcss@8.5.25, postcss@^7.0.36, postcss@^8.2.6, postcss@^8.3.5, postcss@^8.4.33, postcss@^8.5.6, postcss@^8.5.8:
+  version "8.5.25"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.25.tgz#5012a598eaaa897f21bbe8553be3cb7bd2bd78cb"
+  integrity sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==
   dependencies:
-    nanoid "^3.3.12"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 


### PR DESCRIPTION
### Summary
Bumps `postcss` from `8.5.18` to `8.5.25` to resolve a Dependabot security alert. `postcss` is a build-time CSS processor pulled in transitively by the dashboard's build toolchain (autoprefixer, css-loader, postcss-loader, cssnano); it has no application-runtime import surface.


### Vulnerabilities fixed
Bumping `postcss` to `8.5.25` resolves the following Dependabot alert(s):

- [**Dependabot #1081**](https://github.com/rancher/dashboard/security/dependabot/1081) · **MEDIUM** — [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) / CVE-2026-69153: PostCSS: incomplete fix of GHSA-6g55-p6wh-862q — attacker-controlled sourceMappingURL reads arbitrary .map files when `from` is unset Vulnerable `<= 8.5.22`, patched in `8.5.23`.
- [**Dependabot #1077**](https://github.com/rancher/dashboard/security/dependabot/1077) · **MEDIUM** — [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) / CVE-2026-69153: PostCSS: incomplete fix of GHSA-6g55-p6wh-862q — attacker-controlled sourceMappingURL reads arbitrary .map files when `from` is unset Vulnerable `<= 8.5.22`, patched in `8.5.23`.
- [**Dependabot #1073**](https://github.com/rancher/dashboard/security/dependabot/1073) · **MEDIUM** — [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) / CVE-2026-69153: PostCSS: incomplete fix of GHSA-6g55-p6wh-862q — attacker-controlled sourceMappingURL reads arbitrary .map files when `from` is unset Vulnerable `<= 8.5.22`, patched in `8.5.23`.
- [**Dependabot #1069**](https://github.com/rancher/dashboard/security/dependabot/1069) · **MEDIUM** — [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) / CVE-2026-69153: PostCSS: incomplete fix of GHSA-6g55-p6wh-862q — attacker-controlled sourceMappingURL reads arbitrary .map files when `from` is unset Vulnerable `<= 8.5.22`, patched in `8.5.23`.
### Occurred changes and/or fixed issues
- `postcss` bumped `8.5.18` → `8.5.25` in the root and `shell/` manifests (`resolutions.postcss` pin updated in both `package.json` files).
- All four lockfiles' `postcss` entry bumped surgically: `yarn.lock`, `shell/yarn.lock`, `storybook/yarn.lock`, `docusaurus/yarn.lock`.
- No net-new packages added; the diff touches only `package.json`/`yarn.lock` files.

### Technical notes summary
`8.5.25` is the latest `8.5.x` patch line and is fully backward-compatible with `8.5.18` for how the dashboard consumes postcss (build-time CSS processing only). The advisory concerns source-map `.map` reads when `from` is unset — a build-time concern with no change to emitted CSS semantics.

### Areas or cases that should be tested
- Production build succeeds and the compiled/autoprefixed CSS bundle renders correctly.
- UI styling across login, authenticated dashboard layout, and data-heavy views (tables/grids).

### Areas which could experience regressions
- Any compiled CSS output (autoprefixing, minification). Verified below via the Playwright recording — styling renders identically to the prior version.

### Screenshot/Video
Verification recording (Playwright):

https://github.com/user-attachments/assets/8b216e3f-37cc-424f-b76e-4e147dbca312

**Playwright checks performed** (video recorded, 1280×800):
1. **Login page renders with postcss-built styling** — the `login-submit` button carries real computed styling from the compiled CSS bundle: `background: rgb(0, 134, 87)` (Rancher green), `border-radius: 4px`, font `Lato`. Non-default styling confirms the postcss-processed stylesheet loaded and applied. ✅ PASS
2. **postcss/autoprefixer build output present in served CSS** — walked all loaded stylesheets: **3294 CSS rules**, of which **16 carry vendor prefixes** (`-webkit-`/`-moz-`/`-ms-`) and **34 declare CSS custom properties** — concrete artifacts of the autoprefixer (a postcss plugin) + postcss pipeline having processed the CSS at build time. ✅ PASS
3. **Authenticated dashboard renders themed layout** — logged in with the real local provider; landed on `/dashboard/home` with the side-nav present and laid out (width 70px), themed body background, and **no error masthead** — the app-wide postcss-built theme CSS applies post-auth. ✅ PASS
4. **Real cluster ConfigMap list renders with styled table** — navigated to `/dashboard/c/local/explorer/configmap`; the sortable table rendered **100 real ConfigMap rows** from the proxied Steve API with `border-collapse: collapse` table styling and no error masthead — the postcss-built table/grid CSS renders correctly against live cluster data. ✅ PASS

**Verdict:** **4/4 checks passed.** postcss 8.5.25 produces a clean production build and the compiled CSS renders identically across login, themed authenticated layout, and a real proxied-cluster data view — the bump is safe for how the dashboard uses postcss. No vulnerable postcss (`<= 8.5.22`) remains in any lockfile and the diff adds zero net-new packages.
### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [ ] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [ ] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [ ] The PR has been reviewed in terms of Accessibility
- [ ] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Requested via the Rancher vulnerability console by marcelo.fukumoto@suse.com.


