### PR TITLE
Align key-spacing in ArrayList disabledList prop

### DIFF
--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -94,7 +94,7 @@ export default {
       default: false,
     },
     disabledList: {
-      type: Array,
+      type:    Array,
       default: null
     },
     required: {


### PR DESCRIPTION
### Summary
No linked issue — small lint cleanup.

`shell/components/form/ArrayList.vue` triggered an eslint `key-spacing`
(value-alignment) warning on the `disabledList` prop, which fails the
`lint` gate (`eslint --max-warnings 0`).

### Occurred changes and/or fixed issues
- Aligned the `type:` value with the sibling `default:` value in the `disabledList` prop so the object matches the repo's `key-spacing` alignment rule.

### Technical notes summary
- Whitespace-only change (three spaces added after `type:`); no runtime or template behaviour changes.

### Areas or cases that should be tested
- `yarn lint` passes cleanly (`--max-warnings 0`).
- No functional testing needed — `ArrayList` renders and behaves identically.

### Areas which could experience regressions
- None. The change is whitespace inside a prop definition.

### Screenshot/Video
N/A — no visual change.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
