### PR TITLE
support setting cluster name annotation

### DIFF
--- a/cypress/e2e/po/components/key-value.po.ts
+++ b/cypress/e2e/po/components/key-value.po.ts
@@ -1,6 +1,13 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
 
 export default class KeyValuePo extends ComponentPo {
+  private multiline: boolean;
+
+  constructor(self: any, multiline = false) {
+    super(self);
+    this.multiline = multiline;
+  }
+
   addButton(label: string) {
     return this.self().find('[data-testid="add_row_item_button"]').contains(label);
   }
@@ -9,5 +16,45 @@ export default class KeyValuePo extends ComponentPo {
     this.addButton(label).click();
     this.self().find(`${ selector } [data-testid="input-kv-item-key-${ index }"]`).type(key);
     this.self().find(`${ selector } [data-testid="kv-item-value-${ index }"]`).type(value);
+  }
+
+  addRow() {
+    return this.self().find('[data-testid="add_row_item_button"]').click();
+  }
+
+  keyInput(index: number) {
+    return this.self().find(`[data-testid="input-kv-item-key-${ index }"]`);
+  }
+
+  valueInput(index: number) {
+    if (this.multiline) {
+      return this.self().find(`[data-testid="kv-item-value-${ index }"] [data-testid="value-multiline"]`);
+    }
+
+    return this.self().find(`[data-testid="input-kv-item-value-${ index }"]`);
+  }
+
+  setKeyAtIndex(key: string, index: number) {
+    return this.keyInput(index).type(key);
+  }
+
+  setValueAtIndex(value: string, index: number) {
+    return this.valueInput(index).type(value);
+  }
+
+  keyAtIndex(index: number) {
+    return this.keyInput(index).invoke('val');
+  }
+
+  valueAtIndex(index: number) {
+    return this.valueInput(index).invoke('val');
+  }
+
+  keyWarningIcon(index: number) {
+    return this.keyInput(index).parents('.kv-item.key').find('.icon-warning');
+  }
+
+  valueWarningIcon(index: number) {
+    return this.valueInput(index).parents('.kv-item.value').find('.icon-warning');
   }
 }

--- a/cypress/e2e/po/components/key-value.po.ts
+++ b/cypress/e2e/po/components/key-value.po.ts
@@ -35,11 +35,11 @@ export default class KeyValuePo extends ComponentPo {
   }
 
   setKeyAtIndex(key: string, index: number) {
-    return this.keyInput(index).type(key);
+    return this.keyInput(index).clear().type(key);
   }
 
   setValueAtIndex(value: string, index: number) {
-    return this.valueInput(index).type(value);
+    return this.valueInput(index).clear().type(value);
   }
 
   keyAtIndex(index: number) {

--- a/cypress/e2e/po/components/key-value.po.ts
+++ b/cypress/e2e/po/components/key-value.po.ts
@@ -1,10 +1,15 @@
 import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import { CypressChainable } from '@/cypress/e2e/po/po.types';
 
 export default class KeyValuePo extends ComponentPo {
   private multiline: boolean;
 
-  constructor(self: any, multiline = false) {
-    super(self);
+  constructor(self: any, parent?: CypressChainable, multiline = false) {
+    if (typeof self === 'string' && parent) {
+      super(self, parent);
+    } else {
+      super(self);
+    }
     this.multiline = multiline;
   }
 
@@ -56,5 +61,9 @@ export default class KeyValuePo extends ComponentPo {
 
   valueWarningIcon(index: number) {
     return this.valueInput(index).parents('.kv-item.value').find('.icon-warning');
+  }
+
+  removeButton(index: number) {
+    return this.self().find(`[data-testid="remove-column-${ index }"]`);
   }
 }

--- a/cypress/e2e/po/components/labels-annotations.po.ts
+++ b/cypress/e2e/po/components/labels-annotations.po.ts
@@ -1,0 +1,16 @@
+import ComponentPo from '@/cypress/e2e/po/components/component.po';
+import KeyValuePo from '@/cypress/e2e/po/components/key-value.po';
+
+/**
+ * Page object for the Labels.vue component (shell/components/form/Labels.vue).
+ * Returns KeyValuePo instances for the labels and annotations sections.
+ */
+export default class LabelsAnnotationsPo extends ComponentPo {
+  labels(): KeyValuePo {
+    return new KeyValuePo(`[data-testid="labels-keyvalue"]`, true);
+  }
+
+  annotations(): KeyValuePo {
+    return new KeyValuePo(`[data-testid="annotations-keyvalue"]`, true);
+  }
+}

--- a/cypress/e2e/po/components/labels-annotations.po.ts
+++ b/cypress/e2e/po/components/labels-annotations.po.ts
@@ -7,10 +7,10 @@ import KeyValuePo from '@/cypress/e2e/po/components/key-value.po';
  */
 export default class LabelsAnnotationsPo extends ComponentPo {
   labels(): KeyValuePo {
-    return new KeyValuePo(`[data-testid="labels-keyvalue"]`, true);
+    return new KeyValuePo(`[data-testid="labels-keyvalue"]`, undefined, true);
   }
 
   annotations(): KeyValuePo {
-    return new KeyValuePo(`[data-testid="annotations-keyvalue"]`, true);
+    return new KeyValuePo(`[data-testid="annotations-keyvalue"]`, undefined, true);
   }
 }

--- a/cypress/e2e/tests/pages/manager/name-annotation.spec.ts
+++ b/cypress/e2e/tests/pages/manager/name-annotation.spec.ts
@@ -4,7 +4,6 @@ import ClusterManagerDetailRke2CustomPagePo from '@/cypress/e2e/po/detail/provis
 import ClusterManagerEditRke2CustomPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-rke2-custom.po';
 import LabelsAnnotationsPo from '@/cypress/e2e/po/components/labels-annotations.po';
 import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
-import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
 import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 
 const MANAGEMENT_CLUSTER_NAME_ANNOTATION = 'provisioning.cattle.io/management-cluster-name';
@@ -24,26 +23,19 @@ describe('Management Cluster Name Annotation', { testIsolation: false, tags: ['@
   const tabbedPo = new TabbedPo('[data-testid="tabbed-block"]');
 
   let clusterName: string;
+  let removedClusterName: string;
 
   before(() => {
     cy.login();
     clusterName = createClusterTestName('name-annotation');
+    removedClusterName = createClusterTestName('name-annotation-removed');
   });
 
   after(() => {
-    // Clean up: delete the cluster
-    cy.intercept('DELETE', `/v1/provisioning.cattle.io.clusters/${ namespace }/${ clusterName }`).as('deleteCluster');
-
-    clusterList.goTo();
-    clusterList.waitForPage();
-    clusterList.sortableTable().rowElementWithName(clusterName, MEDIUM_TIMEOUT_OPT).should('be.visible').scrollIntoView();
-    clusterList.list().actionMenu(clusterName).getMenuItem('Delete').click({ force: true });
-
-    const promptRemove = new PromptRemove();
-
-    promptRemove.confirm(clusterName);
-    promptRemove.remove();
-    cy.wait('@deleteCluster', { requestTimeout: LONG_TIMEOUT_OPT.timeout }).its('response.statusCode').should('be.oneOf', [200, 204]);
+    // Clean up: delete both clusters via API
+    [clusterName, removedClusterName].forEach((name) => {
+      cy.deleteRancherResource('v1', 'provisioning.cattle.io.clusters', `${ namespace }/${ name }`, false);
+    });
   });
 
   it('can set the management-cluster-name annotation during creation without an error icon', () => {
@@ -98,6 +90,43 @@ describe('Management Cluster Name Annotation', { testIsolation: false, tags: ['@
     });
   });
 
+  it('does not include the annotation in the request when it is removed before creation', () => {
+    cy.intercept('POST', `/v1/${ type }s`).as('createRemovedRequest');
+
+    clusterList.goTo();
+    clusterList.checkIsCurrentPage();
+    clusterList.createCluster();
+
+    createRKE2ClusterPage.waitForPage();
+    createRKE2ClusterPage.selectCustom(0);
+    createRKE2ClusterPage.nameNsDescription().name().set(removedClusterName);
+
+    // Navigate to Labels and Annotations tab
+    createRKE2ClusterPage.selectTab(tabbedPo, '[data-testid="btn-labels"]');
+
+    const labelsAnnotations = new LabelsAnnotationsPo('[data-testid="tabbed-block"]');
+
+    // Add the management-cluster-name annotation
+    labelsAnnotations.annotations().addRow();
+    labelsAnnotations.annotations().setKeyAtIndex(MANAGEMENT_CLUSTER_NAME_ANNOTATION, 0);
+    labelsAnnotations.annotations().setValueAtIndex(mgmtClusterNameValue, 0);
+
+    // Remove the annotation row
+    labelsAnnotations.annotations().removeButton(0).find('button').click();
+
+    // Create the cluster
+    createRKE2ClusterPage.create();
+
+    // Verify the annotation is NOT in the POST request
+    cy.wait('@createRemovedRequest', { requestTimeout: LONG_TIMEOUT_OPT.timeout }).then((intercept) => {
+      expect(intercept.response?.statusCode, 'Cluster create POST status').to.be.oneOf([200, 201]);
+
+      const annotations = intercept.request.body.metadata?.annotations || {};
+
+      expect(annotations).to.not.have.property(MANAGEMENT_CLUSTER_NAME_ANNOTATION);
+    });
+  });
+
   it('shows the annotation as read-only with an error icon when editing the cluster', () => {
     const editClusterPage = new ClusterManagerEditRke2CustomPagePo(undefined, clusterName);
 
@@ -119,8 +148,12 @@ describe('Management Cluster Name Annotation', { testIsolation: false, tags: ['@
     labelsAnnotations.annotations().keyInput(0).should('have.value', MANAGEMENT_CLUSTER_NAME_ANNOTATION);
     labelsAnnotations.annotations().keyWarningIcon(0).should('exist');
 
-    // Attempt to change the annotation value
-    labelsAnnotations.annotations().setValueAtIndex('modified-value', 0);
+    // The key and value inputs should be disabled
+    labelsAnnotations.annotations().keyInput(0).should('be.disabled');
+    labelsAnnotations.annotations().valueInput(0).should('be.disabled');
+
+    // The remove button should be hidden for the read-only row
+    labelsAnnotations.annotations().removeButton(0).should('not.exist');
 
     // Save the cluster
     editClusterPage.save();

--- a/cypress/e2e/tests/pages/manager/name-annotation.spec.ts
+++ b/cypress/e2e/tests/pages/manager/name-annotation.spec.ts
@@ -96,7 +96,6 @@ describe('Management Cluster Name Annotation', { testIsolation: false, tags: ['@
         MANAGEMENT_CLUSTER_NAME_ANNOTATION, mgmtClusterNameValue
       );
     });
-
   });
 
   it('shows the annotation as read-only with an error icon when editing the cluster', () => {

--- a/cypress/e2e/tests/pages/manager/name-annotation.spec.ts
+++ b/cypress/e2e/tests/pages/manager/name-annotation.spec.ts
@@ -1,0 +1,146 @@
+import ClusterManagerCreateRke2CustomPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/create/cluster-create-rke2-custom.po';
+import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
+import ClusterManagerDetailRke2CustomPagePo from '@/cypress/e2e/po/detail/provisioning.cattle.io.cluster/cluster-detail-rke2-custom.po';
+import ClusterManagerEditRke2CustomPagePo from '@/cypress/e2e/po/edit/provisioning.cattle.io.cluster/edit/cluster-edit-rke2-custom.po';
+import LabelsAnnotationsPo from '@/cypress/e2e/po/components/labels-annotations.po';
+import TabbedPo from '@/cypress/e2e/po/components/tabbed.po';
+import PromptRemove from '@/cypress/e2e/po/prompts/promptRemove.po';
+import { LONG_TIMEOUT_OPT, MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+
+const MANAGEMENT_CLUSTER_NAME_ANNOTATION = 'provisioning.cattle.io/management-cluster-name';
+const OTHER_CATTLE_ANNOTATION = 'some.cattle.io/other-annotation';
+
+const mgmtClusterNameValue = 'custom-mgmt-id';
+const otherAnnotationValue = 'some-value';
+
+const namespace = 'fleet-default';
+const type = 'provisioning.cattle.io.cluster';
+
+const createClusterTestName = (suffix: string) => `e2e-test-${ +new Date() }-${ suffix }`;
+
+describe('Management Cluster Name Annotation', { testIsolation: false, tags: ['@manager', '@adminUser'] }, () => {
+  const clusterList = new ClusterManagerListPagePo();
+  const createRKE2ClusterPage = new ClusterManagerCreateRke2CustomPagePo();
+  const tabbedPo = new TabbedPo('[data-testid="tabbed-block"]');
+
+  let clusterName: string;
+
+  before(() => {
+    cy.login();
+    clusterName = createClusterTestName('name-annotation');
+  });
+
+  after(() => {
+    // Clean up: delete the cluster
+    cy.intercept('DELETE', `/v1/provisioning.cattle.io.clusters/${ namespace }/${ clusterName }`).as('deleteCluster');
+
+    clusterList.goTo();
+    clusterList.waitForPage();
+    clusterList.sortableTable().rowElementWithName(clusterName, MEDIUM_TIMEOUT_OPT).should('be.visible').scrollIntoView();
+    clusterList.list().actionMenu(clusterName).getMenuItem('Delete').click({ force: true });
+
+    const promptRemove = new PromptRemove();
+
+    promptRemove.confirm(clusterName);
+    promptRemove.remove();
+    cy.wait('@deleteCluster', { requestTimeout: LONG_TIMEOUT_OPT.timeout }).its('response.statusCode').should('be.oneOf', [200, 204]);
+  });
+
+  it('can set the management-cluster-name annotation during creation without an error icon', () => {
+    cy.intercept('POST', `/v1/${ type }s`).as('createRequest');
+
+    clusterList.goTo();
+    clusterList.checkIsCurrentPage();
+    clusterList.createCluster();
+
+    createRKE2ClusterPage.waitForPage();
+    createRKE2ClusterPage.selectCustom(0);
+    createRKE2ClusterPage.nameNsDescription().name().set(clusterName);
+
+    // Navigate to Labels and Annotations tab
+    createRKE2ClusterPage.selectTab(tabbedPo, '[data-testid="btn-labels"]');
+
+    const labelsAnnotations = new LabelsAnnotationsPo('[data-testid="tabbed-block"]');
+
+    // Add the management-cluster-name annotation
+    labelsAnnotations.annotations().addRow();
+    labelsAnnotations.annotations().setKeyAtIndex(MANAGEMENT_CLUSTER_NAME_ANNOTATION, 0);
+    labelsAnnotations.annotations().setValueAtIndex(mgmtClusterNameValue, 0);
+
+    // Verify NO error icon (icon-warning) is shown for the management-cluster-name annotation row
+    labelsAnnotations.annotations().keyWarningIcon(0).should('not.exist');
+
+    // Add another cattle.io annotation to prove it IS still protected
+    labelsAnnotations.annotations().addRow();
+    labelsAnnotations.annotations().setKeyAtIndex(OTHER_CATTLE_ANNOTATION, 1);
+    labelsAnnotations.annotations().setValueAtIndex(otherAnnotationValue, 1);
+
+    // Verify the other cattle.io annotation DOES show an error icon
+    labelsAnnotations.annotations().keyWarningIcon(1).should('exist');
+
+    // Create the cluster
+    createRKE2ClusterPage.create();
+
+    // Verify POST request includes the management-cluster-name annotation but NOT the other cattle.io annotation
+    cy.wait('@createRequest', { requestTimeout: LONG_TIMEOUT_OPT.timeout }).then((intercept) => {
+      expect(intercept.response?.statusCode, 'Cluster create POST status').to.be.oneOf([200, 201]);
+
+      // Request body should include the management-cluster-name annotation
+      expect(intercept.request.body.metadata.annotations).to.have.property(
+        MANAGEMENT_CLUSTER_NAME_ANNOTATION, mgmtClusterNameValue
+      );
+
+
+      // Response should also include the annotation
+      expect(intercept.response?.body.metadata.annotations).to.have.property(
+        MANAGEMENT_CLUSTER_NAME_ANNOTATION, mgmtClusterNameValue
+      );
+    });
+
+  });
+
+  it('shows the annotation as read-only with an error icon when editing the cluster', () => {
+    const editClusterPage = new ClusterManagerEditRke2CustomPagePo(undefined, clusterName);
+
+    clusterList.goTo();
+    clusterList.waitForPage();
+    clusterList.sortableTable().rowElementWithName(clusterName, MEDIUM_TIMEOUT_OPT).should('be.visible').scrollIntoView();
+    clusterList.list().actionMenu(clusterName).getMenuItem('Edit Config').click({ force: true });
+
+    editClusterPage.waitForPage('mode=edit', 'basic', LONG_TIMEOUT_OPT);
+
+    // Navigate to Labels and Annotations tab
+    editClusterPage.selectTab(tabbedPo, '[data-testid="btn-labels"]');
+
+    const labelsAnnotations = new LabelsAnnotationsPo('[data-testid="tabbed-block"]');
+
+
+    // The management-cluster-name annotation should have an error/warning icon (read-only indicator)
+    labelsAnnotations.annotations().keyInput(0).should('have.value', MANAGEMENT_CLUSTER_NAME_ANNOTATION);
+    labelsAnnotations.annotations().keyWarningIcon(0).should('exist');
+  });
+
+  it('displays the annotation in the detail page masthead annotations section', () => {
+    const detailPage = new ClusterManagerDetailRke2CustomPagePo(undefined, clusterName);
+
+    detailPage.goTo();
+    detailPage.waitForPage(undefined, undefined, LONG_TIMEOUT_OPT);
+
+    // The annotations section in the masthead metadata area should contain the annotation
+    cy.get('[data-testid="resource-detail-annotations"]').should('contain.text', MANAGEMENT_CLUSTER_NAME_ANNOTATION);
+    cy.get('[data-testid="resource-detail-annotations"]').should('contain.text', mgmtClusterNameValue);
+  });
+
+  it('shows the management cluster named with the annotation value in related resources', () => {
+    const detailPage = new ClusterManagerDetailRke2CustomPagePo(undefined, clusterName);
+
+    detailPage.goTo();
+    detailPage.waitForPage(undefined, undefined, LONG_TIMEOUT_OPT);
+
+    // Navigate to the Related Resources tab
+    detailPage.selectTab(tabbedPo, '[data-testid="btn-related"]');
+
+    // The management.cattle.io.cluster resource should be named with the annotation value
+    cy.get('.tab-container').should('contain.text', mgmtClusterNameValue);
+  });
+});

--- a/cypress/e2e/tests/pages/manager/name-annotation.spec.ts
+++ b/cypress/e2e/tests/pages/manager/name-annotation.spec.ts
@@ -102,6 +102,8 @@ describe('Management Cluster Name Annotation', { testIsolation: false, tags: ['@
   it('shows the annotation as read-only with an error icon when editing the cluster', () => {
     const editClusterPage = new ClusterManagerEditRke2CustomPagePo(undefined, clusterName);
 
+    cy.intercept('PUT', `/v1/${ type }s/${ namespace }/${ clusterName }`).as('updateRequest');
+
     clusterList.goTo();
     clusterList.waitForPage();
     clusterList.sortableTable().rowElementWithName(clusterName, MEDIUM_TIMEOUT_OPT).should('be.visible').scrollIntoView();
@@ -114,10 +116,25 @@ describe('Management Cluster Name Annotation', { testIsolation: false, tags: ['@
 
     const labelsAnnotations = new LabelsAnnotationsPo('[data-testid="tabbed-block"]');
 
-
     // The management-cluster-name annotation should have an error/warning icon (read-only indicator)
     labelsAnnotations.annotations().keyInput(0).should('have.value', MANAGEMENT_CLUSTER_NAME_ANNOTATION);
     labelsAnnotations.annotations().keyWarningIcon(0).should('exist');
+
+    // Attempt to change the annotation value
+    labelsAnnotations.annotations().setValueAtIndex('modified-value', 0);
+
+    // Save the cluster
+    editClusterPage.save();
+
+    // Verify the PUT request preserves the original annotation value, not the modified one
+    cy.wait('@updateRequest', { requestTimeout: LONG_TIMEOUT_OPT.timeout }).then((intercept) => {
+      expect(intercept.response?.statusCode, 'Cluster update PUT status').to.be.oneOf([200, 201]);
+
+      // The original annotation value should be preserved
+      expect(intercept.request.body.metadata.annotations).to.have.property(
+        MANAGEMENT_CLUSTER_NAME_ANNOTATION, mgmtClusterNameValue
+      );
+    });
   });
 
   it('displays the annotation in the detail page masthead annotations section', () => {

--- a/scripts/type-check-baseline.txt
+++ b/scripts/type-check-baseline.txt
@@ -1,6 +1,6 @@
 # Auto-generated type-check baseline. Do not edit by hand.
 # Regenerate with: yarn type-check:baseline
-# Total errors: 2039
+# Total errors: 2031
 pkg/aks/components/AksNodePool.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
 pkg/aks/components/AksNodePool.vue: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 pkg/aks/components/AksNodePool.vue: error TS2339: Property '$emit' does not exist on type '{ 'pool.enableAutoScaling'(neu: any): void; 'pool.vmSize'(neu: any): void; validAZ(neu: any): void; }'.
@@ -1112,13 +1112,6 @@ shell/components/form/__tests__/FileImageSelector.test.ts: error TS2307: Cannot 
 shell/components/form/__tests__/FileImageSelector.test.ts: error TS2307: Cannot find module '@shell/components/form/FileSelector' or its corresponding type declarations.
 shell/components/form/__tests__/FileSelector.test.ts: error TS2307: Cannot find module '@shell/components/form/FileSelector' or its corresponding type declarations.
 shell/components/form/__tests__/HookOption.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/components/form/__tests__/KeyValue.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
-shell/components/form/__tests__/KeyValue.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
-shell/components/form/__tests__/KeyValue.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
-shell/components/form/__tests__/KeyValue.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
-shell/components/form/__tests__/KeyValue.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
-shell/components/form/__tests__/KeyValue.test.ts: error TS2339: Property 'value' does not exist on type 'VueNode<Element>'.
-shell/components/form/__tests__/KeyValue.test.ts: error TS2352: Conversion of type 'VueNode<HTMLTextAreaElement>' to type 'HTMLInputElement' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 shell/components/form/__tests__/LabeledSelect.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_CREATE'.
 shell/components/form/__tests__/LabeledSelect.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/components/form/__tests__/LabeledSelect.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
@@ -1434,7 +1427,6 @@ shell/edit/secret/__tests__/ssh.test.ts: error TS2305: Module '"@shell/config/qu
 shell/edit/secret/__tests__/ssh.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
 shell/edit/secret/__tests__/ssh.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_VIEW'.
 shell/edit/workload/__tests__/Job.test.ts: error TS2305: Module '"@shell/config/query-params"' has no exported member '_EDIT'.
-shell/edit/workload/__tests__/Upgrading.test.ts: error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'ComponentPublicInstance<NonNullable<Partial<{ mode: string; value: Record<string, any>; type: string; noPodSpec: boolean; noDeploymentSpec: boolean; }> & Omit<{ readonly value: Record<string, any>; ... 4 more ...; readonly "onUpdate:value"?: ((...args: any[]) => any) | undefined; } & VNodeProps & AllowedComponentPro...'.
 shell/list/__tests__/workload.test.ts: error TS2307: Cannot find module 'vue/types/options' or its corresponding type declarations.
 shell/list/__tests__/workload.test.ts: error TS2307: Cannot find module 'vue/types/vue' or its corresponding type declarations.
 shell/list/node.vue: error TS2339: Property 'id' does not exist on type 'string'.

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -4194,6 +4194,7 @@ labels:
   addTaint: Add Taint
   addAnnotation: Add Annotation
   protectedWarning: This key is protected and will be discarded
+  readOnlyWarning: This key is read-only and changes will not be persisted
   labels:
     title: Labels
     description: Key/value pairs that are attached to objects which specify identifying attributes.

--- a/shell/components/Resource/Detail/Metadata/index.vue
+++ b/shell/components/Resource/Detail/Metadata/index.vue
@@ -64,6 +64,7 @@ const showBothEmpty = computed(() => labels.length === 0 && annotations.length =
     <div
       v-if="!showBothEmpty"
       class="annotations"
+      data-testid="resource-detail-annotations"
     >
       <Annotations
         :annotations="annotations"

--- a/shell/components/form/KeyValue.vue
+++ b/shell/components/form/KeyValue.vue
@@ -244,6 +244,10 @@ export default {
       type:    Object,
       default: () => ({})
     },
+    disabledKeys: {
+      type:    Array,
+      default: () => []
+    },
     useRcButton: {
       type:    Boolean,
       default: false
@@ -728,7 +732,7 @@ export default {
                   v-else
                   ref="key"
                   v-model="row[keyName]"
-                  :disabled="isView || disabled || !keyEditable"
+                  :disabled="isView || disabled || !keyEditable || disabledKeys.includes(row[keyName])"
                   :placeholder="_keyPlaceholder"
                   :data-testid="`input-kv-item-key-${i}`"
                   :aria-label="t('generic.ariaLabel.key', {index: i+1})"
@@ -794,7 +798,7 @@ export default {
                     v-else-if="valueMultiline && row[valueName] !== undefined"
                     v-model:value="row[valueName]"
                     data-testid="value-multiline"
-                    :disabled="disabled"
+                    :disabled="disabled || disabledKeys.includes(row[keyName])"
                     :mode="mode"
                     :placeholder="_valuePlaceholder"
                     :min-height="40"
@@ -805,7 +809,7 @@ export default {
                   <input
                     v-else
                     v-model="row[valueName]"
-                    :disabled="isView || disabled"
+                    :disabled="isView || disabled || disabledKeys.includes(row[keyName])"
                     :type="valueConcealed ? 'password' : 'text'"
                     :placeholder="_valuePlaceholder"
                     autocorrect="off"
@@ -843,7 +847,7 @@ export default {
               />
             </div>
             <div
-              v-if="canRemove"
+              v-if="canRemove && !disabledKeys.includes(row[keyName])"
               :key="i"
               class="kv-item remove"
               role="gridcell"

--- a/shell/components/form/Labels.vue
+++ b/shell/components/form/Labels.vue
@@ -79,8 +79,9 @@ export class Factory {
     const neu = value || {};
 
     callbackFn({
-      ...this.omitProtected(neu),
+      ...omitBy(this.omitProtected(neu), (_, key) => this.isReadOnly(key)), //remove new labels/annotations that are readOnly
       ...this.pickProtected(this.initValue),
+      ...pickBy(this.initValue, (_, key) => this.isReadOnly(key)), // add in initial labels/annotations that are readOnly
     });
 
     this.value = neu;

--- a/shell/components/form/Labels.vue
+++ b/shell/components/form/Labels.vue
@@ -266,6 +266,7 @@ export default {
         :read-allowed="false"
         :value-can-be-empty="true"
         :key-errors="annotations.keyErrors"
+        :disabled-keys="value.readOnlyAnnotationKeys || []"
         :use-rc-button="useRcButton"
         @update:value="annotations.update($event, (x) => value.setAnnotations(x))"
       />

--- a/shell/components/form/Labels.vue
+++ b/shell/components/form/Labels.vue
@@ -9,10 +9,23 @@ import { _VIEW } from '@shell/config/query-params';
 export class Factory {
   private protectedKeys: string[] = [];
   private protectedRegexes: RegExp[] = [];
+  private exceptedKeys: string[] = [];
+  private readOnlyKeys: string[] = [];
   private protectedWarning = '';
+  private readOnlyWarning = '';
 
   private isProtected(key: string) {
+    // exceptions to ANNOTATIONS_TO_IGNORE_REGEX, as defined in resource models' allowedSystemAnnotationKeys
+    if (this.exceptedKeys.includes(key)) {
+      return false;
+    }
+
     return this.protectedKeys.includes(key) || matchesSomeRegex(key, this.protectedRegexes);
+  }
+
+  // keys in this list are visible in forms but changes will not be persisted (a warning is shown communicating this)
+  private isReadOnly(key: string) {
+    return this.readOnlyKeys.includes(key);
   }
 
   private omitProtected(obj: object) {
@@ -24,17 +37,28 @@ export class Factory {
   }
 
   private keyErrorMap(elems: object) {
-    return mapValues(this.pickProtected(elems), () => this.protectedWarning);
+    return {
+      ...mapValues(this.pickProtected(elems), () => this.protectedWarning),
+      ...mapValues(pickBy(elems, (_, key) => this.isReadOnly(key)), () => this.readOnlyWarning),
+    };
   }
 
-  constructor(protectedKeys: string[], protectedRegexes: RegExp[], msg: string, initValue: object) {
+  constructor(protectedKeys: string[], protectedRegexes: RegExp[], msg: string, initValue: object, exceptedKeys: string[] = [], readOnlyKeys: string[] = [], readOnlyMsg = '') {
     // Init privates
     this.protectedKeys = protectedKeys || [];
     this.protectedRegexes = protectedRegexes || [];
+    this.exceptedKeys = exceptedKeys || [];
+    this.readOnlyKeys = readOnlyKeys || [];
     this.protectedWarning = msg || '';
+    this.readOnlyWarning = readOnlyMsg || msg || '';
 
     this.initValue = initValue || {};
     this.value = this.omitProtected(this.initValue);
+
+    // Read-only keys are visible in the value but shown with a warning and preserved on save
+    const readOnlyFromInit = pickBy(this.initValue, (_, key) => this.isReadOnly(key));
+
+    this.value = { ...this.value, ...readOnlyFromInit };
     this.keyErrors = this.keyErrorMap(this.value);
     this.hasProtectedKeys = Object.keys(this.pickProtected(this.initValue)).length > 0;
   }
@@ -145,10 +169,19 @@ export default {
 
   data(): DataType {
     const protectedWarning = this.t('labels.protectedWarning');
+    const readOnlyWarning = this.t('labels.readOnlyWarning');
 
     return {
       labels:      new Factory(this.value.systemLabels, LABELS_TO_IGNORE_REGEX, protectedWarning, this.value.labels),
-      annotations: new Factory(this.value.systemAnnotations, ANNOTATIONS_TO_IGNORE_REGEX, protectedWarning, this.value.annotations),
+      annotations: new Factory(
+        this.value.systemAnnotations,
+        ANNOTATIONS_TO_IGNORE_REGEX,
+        protectedWarning,
+        this.value.annotations,
+        this.value.allowedSystemAnnotationKeys,
+        this.value.readOnlyAnnotationKeys,
+        readOnlyWarning
+      ),
       toggler:     false
     };
   },
@@ -200,6 +233,7 @@ export default {
           <slot name="labels">
             <KeyValue
               key="labels"
+              data-testid="labels-keyvalue"
               :value="toggler ? labels.initValue : labels.value"
               :add-label="t('labels.addLabel')"
               :add-icon="addIcon"
@@ -221,6 +255,7 @@ export default {
     >
       <KeyValue
         key="annotations"
+        data-testid="annotations-keyvalue"
         :value="toggler ? annotations.initValue : annotations.value"
         :add-label="t('labels.addAnnotation')"
         :add-icon="addIcon"

--- a/shell/components/form/Labels.vue
+++ b/shell/components/form/Labels.vue
@@ -79,7 +79,7 @@ export class Factory {
     const neu = value || {};
 
     callbackFn({
-      ...omitBy(this.omitProtected(neu), (_, key) => this.isReadOnly(key)), //remove new labels/annotations that are readOnly
+      ...omitBy(this.omitProtected(neu), (_, key) => this.isReadOnly(key)), // remove new labels/annotations that are readOnly
       ...this.pickProtected(this.initValue),
       ...pickBy(this.initValue, (_, key) => this.isReadOnly(key)), // add in initial labels/annotations that are readOnly
     });
@@ -183,7 +183,7 @@ export default {
         this.value.readOnlyAnnotationKeys,
         readOnlyWarning
       ),
-      toggler:     false
+      toggler: false
     };
   },
 

--- a/shell/components/form/__tests__/KeyValue.test.ts
+++ b/shell/components/form/__tests__/KeyValue.test.ts
@@ -14,7 +14,7 @@ describe('component: KeyValue', () => {
       },
     });
 
-    const inputValue = wrapper.find('textarea').element as HTMLInputElement;
+    const inputValue = wrapper.find('textarea').element as HTMLTextAreaElement;
 
     expect(inputValue.value).toBe(value);
   });
@@ -82,8 +82,8 @@ describe('component: KeyValue', () => {
 
     const firstValueInput = wrapper.find('[data-testid="input-kv-item-value-0"]');
 
-    expect(firstKeyInput.element.value).toBe('testkey');
-    expect(firstValueInput.element.value).toBe('testvalue');
+    expect((firstKeyInput.element as HTMLInputElement).value).toBe('testkey');
+    expect((firstValueInput.element as HTMLInputElement).value).toBe('testvalue');
 
     let secondKeyInput = wrapper.find('[data-testid="input-kv-item-key-1"]');
 
@@ -102,8 +102,8 @@ describe('component: KeyValue', () => {
 
     expect(secondKeyInput.exists()).toBe(true);
 
-    expect(secondKeyInput.element.value).toBe('testkey1');
-    expect(secondValueInput.element.value).toBe('testvalue1');
+    expect((secondKeyInput.element as HTMLInputElement).value).toBe('testkey1');
+    expect((secondValueInput.element as HTMLInputElement).value).toBe('testvalue1');
   });
 
   it.each([
@@ -173,8 +173,8 @@ describe('component: KeyValue', () => {
 
     const firstValueInput = wrapper.find('[data-testid="input-kv-item-value-0"]');
 
-    expect(firstKeyInput.element.value).toBe('testkey1');
-    expect(firstValueInput.element.value).toBe('testvalue1');
+    expect((firstKeyInput.element as HTMLInputElement).value).toBe('testkey1');
+    expect((firstValueInput.element as HTMLInputElement).value).toBe('testvalue1');
   });
 
   describe('valueConcealed', () => {
@@ -277,5 +277,70 @@ describe('component: KeyValue', () => {
     expect(rowRemove.attributes('aria-label')).toBe('%generic.ariaLabel.remove%');
     expect(rowAdd.attributes('aria-label')).toBe('%generic.ariaLabel.addKeyValue%');
     expect(readKeyValueFromFile.attributes('aria-label')).toBe('%generic.ariaLabel.readKeyValue%');
+  });
+
+  describe('disabledKeys', () => {
+    it('should disable key and value inputs for rows with keys in disabledKeys', () => {
+      const wrapper = mount(KeyValue, {
+        props: {
+          value:          { protectedKey: 'protectedValue', normalKey: 'normalValue' },
+          mode:           'edit',
+          asMap:          true,
+          valueMultiline: false,
+          disabledKeys:   ['protectedKey'],
+        },
+
+        global: { mocks: { $store: { getters: { 'i18n/t': jest.fn() } } } },
+      });
+
+      const protectedKeyInput = wrapper.find('[data-testid="input-kv-item-key-0"]').element as HTMLInputElement;
+      const protectedValueInput = wrapper.find('[data-testid="input-kv-item-value-0"]').element as HTMLInputElement;
+      const normalKeyInput = wrapper.find('[data-testid="input-kv-item-key-1"]').element as HTMLInputElement;
+      const normalValueInput = wrapper.find('[data-testid="input-kv-item-value-1"]').element as HTMLInputElement;
+
+      expect(protectedKeyInput.disabled).toBe(true);
+      expect(protectedValueInput.disabled).toBe(true);
+      expect(normalKeyInput.disabled).toBe(false);
+      expect(normalValueInput.disabled).toBe(false);
+    });
+
+    it('should hide the remove button for rows with keys in disabledKeys', () => {
+      const wrapper = mount(KeyValue, {
+        props: {
+          value:          { protectedKey: 'protectedValue', normalKey: 'normalValue' },
+          mode:           'edit',
+          asMap:          true,
+          valueMultiline: false,
+          disabledKeys:   ['protectedKey'],
+        },
+
+        global: { mocks: { $store: { getters: { 'i18n/t': jest.fn() } } } },
+      });
+
+      const protectedRemove = wrapper.find('[data-testid="remove-column-0"]');
+      const normalRemove = wrapper.find('[data-testid="remove-column-1"]');
+
+      expect(protectedRemove.exists()).toBe(false);
+      expect(normalRemove.exists()).toBe(true);
+    });
+
+    it('should disable value textarea when valueMultiline is true and key is in disabledKeys', () => {
+      const wrapper = mount(KeyValue, {
+        props: {
+          value:          { protectedKey: 'protectedValue' },
+          mode:           'edit',
+          asMap:          true,
+          valueMultiline: true,
+          disabledKeys:   ['protectedKey'],
+        },
+
+        global: { mocks: { $store: { getters: { 'i18n/t': jest.fn() } } } },
+      });
+
+      const textarea = wrapper.find('[data-testid="value-multiline"]');
+
+      expect(textarea.exists()).toBe(true);
+      expect(textarea.attributes('disabled')).toBeDefined();
+    });
   });
 });

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -54,10 +54,11 @@ export const MACHINE_ROLES = {
 };
 
 export const CAPI = {
-  DEPLOYMENT_NAME:      'cluster.x-k8s.io/deployment-name',
-  CREDENTIAL_DRIVER:    'provisioning.cattle.io/driver',
-  CLUSTER_NAMESPACE:    'cluster.x-k8s.io/cluster-namespace',
-  FORCE_MACHINE_REMOVE: 'provisioning.cattle.io/force-machine-remove',
+  DEPLOYMENT_NAME:           'cluster.x-k8s.io/deployment-name',
+  CREDENTIAL_DRIVER:         'provisioning.cattle.io/driver',
+  CLUSTER_NAMESPACE:         'cluster.x-k8s.io/cluster-namespace',
+  FORCE_MACHINE_REMOVE:      'provisioning.cattle.io/force-machine-remove',
+  MANAGEMENT_CLUSTER_NAME:   'provisioning.cattle.io/management-cluster-name',
   MACHINE_NAME:         'cluster.x-k8s.io/machine',
   DELETE_MACHINE:       'cluster.x-k8s.io/delete-machine',
   PROVIDER:             'provider.cattle.io',

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -54,26 +54,26 @@ export const MACHINE_ROLES = {
 };
 
 export const CAPI = {
-  DEPLOYMENT_NAME:           'cluster.x-k8s.io/deployment-name',
-  CREDENTIAL_DRIVER:         'provisioning.cattle.io/driver',
-  CLUSTER_NAMESPACE:         'cluster.x-k8s.io/cluster-namespace',
-  FORCE_MACHINE_REMOVE:      'provisioning.cattle.io/force-machine-remove',
-  MANAGEMENT_CLUSTER_NAME:   'provisioning.cattle.io/management-cluster-name',
-  MACHINE_NAME:         'cluster.x-k8s.io/machine',
-  DELETE_MACHINE:       'cluster.x-k8s.io/delete-machine',
-  PROVIDER:             'provider.cattle.io',
+  DEPLOYMENT_NAME:         'cluster.x-k8s.io/deployment-name',
+  CREDENTIAL_DRIVER:       'provisioning.cattle.io/driver',
+  CLUSTER_NAMESPACE:       'cluster.x-k8s.io/cluster-namespace',
+  FORCE_MACHINE_REMOVE:    'provisioning.cattle.io/force-machine-remove',
+  MANAGEMENT_CLUSTER_NAME: 'provisioning.cattle.io/management-cluster-name',
+  MACHINE_NAME:            'cluster.x-k8s.io/machine',
+  DELETE_MACHINE:          'cluster.x-k8s.io/delete-machine',
+  PROVIDER:                'provider.cattle.io',
   /**
    * RKE2 - metadata.name is human name
    * RKE1 and some others - metadata.name is v1 mgmt id and it's the v1 mgmt cluster that contains human name
    * This label ensures something is in the v1 prov cluster that can be sorted/filtered on
    */
-  HUMAN_NAME:           'provisioning.cattle.io/management-cluster-display-name',
-  SECRET_AUTH:          'v2prov-secret-authorized-for-cluster',
-  SECRET_WILL_DELETE:   'v2prov-authorized-secret-deletes-on-cluster-removal',
+  HUMAN_NAME:              'provisioning.cattle.io/management-cluster-display-name',
+  SECRET_AUTH:             'v2prov-secret-authorized-for-cluster',
+  SECRET_WILL_DELETE:      'v2prov-authorized-secret-deletes-on-cluster-removal',
   /**
    * Annotation for overriding the cluster provider,
    */
-  UI_CUSTOM_PROVIDER:   'ui.rancher/provider',
+  UI_CUSTOM_PROVIDER:      'ui.rancher/provider',
 
   /**
    * Annotations for autoscaler

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -37,6 +37,39 @@ const AUTOSCALER_STATUS = {
  * @extends SteveModel
  */
 export default class ProvCluster extends SteveModel {
+  get annotations() {
+    // HybridModel.annotations filters out all cattle.io/ keys via ANNOTATIONS_TO_IGNORE_REGEX.
+    // We re-expose the management-cluster-name annotation so users can set it during creation
+    // and view it on existing clusters via the standard Labels & Annotations UI.
+    const base = super.annotations;
+    const raw = this.metadata?.annotations || {};
+
+    if (raw[CAPI_ANNOTATIONS.MANAGEMENT_CLUSTER_NAME]) {
+      return { ...base, [CAPI_ANNOTATIONS.MANAGEMENT_CLUSTER_NAME]: raw[CAPI_ANNOTATIONS.MANAGEMENT_CLUSTER_NAME] };
+    }
+
+    return base;
+  }
+
+  get allowedSystemAnnotationKeys() {
+    // Allow this annotation to bypass the cattle.io/ regex protection in the Labels UI
+    // so that users can set it during cluster creation
+    if (!this.id) {
+      return [CAPI_ANNOTATIONS.MANAGEMENT_CLUSTER_NAME];
+    }
+
+    return [];
+  }
+
+  get readOnlyAnnotationKeys() {
+    // On edit, show the annotation with a warning that changes will not be persisted
+    if (this.id && this.metadata?.annotations?.[CAPI_ANNOTATIONS.MANAGEMENT_CLUSTER_NAME]) {
+      return [CAPI_ANNOTATIONS.MANAGEMENT_CLUSTER_NAME];
+    }
+
+    return [];
+  }
+
   get details() {
     const out = [
       {

--- a/shell/models/provisioning.cattle.io.cluster.js
+++ b/shell/models/provisioning.cattle.io.cluster.js
@@ -37,18 +37,12 @@ const AUTOSCALER_STATUS = {
  * @extends SteveModel
  */
 export default class ProvCluster extends SteveModel {
-  get annotations() {
-    // HybridModel.annotations filters out all cattle.io/ keys via ANNOTATIONS_TO_IGNORE_REGEX.
-    // We re-expose the management-cluster-name annotation so users can set it during creation
-    // and view it on existing clusters via the standard Labels & Annotations UI.
-    const base = super.annotations;
-    const raw = this.metadata?.annotations || {};
-
-    if (raw[CAPI_ANNOTATIONS.MANAGEMENT_CLUSTER_NAME]) {
-      return { ...base, [CAPI_ANNOTATIONS.MANAGEMENT_CLUSTER_NAME]: raw[CAPI_ANNOTATIONS.MANAGEMENT_CLUSTER_NAME] };
+  isAnnotationIgnored(key) {
+    if (key === CAPI_ANNOTATIONS.MANAGEMENT_CLUSTER_NAME) {
+      return false;
     }
 
-    return base;
+    return super.isAnnotationIgnored(key);
   }
 
   get allowedSystemAnnotationKeys() {

--- a/shell/plugins/steve/hybrid-class.js
+++ b/shell/plugins/steve/hybrid-class.js
@@ -62,8 +62,17 @@ export default class HybridModel extends Resource {
     const all = this.metadata?.annotations || {};
 
     return omitBy(all, (value, key) => {
-      return matchesSomeRegex(key, ANNOTATIONS_TO_IGNORE_REGEX);
+      return this.isAnnotationIgnored(key);
     });
+  }
+
+  /**
+   * Determines if an annotation key should be hidden from the annotations getter
+   * and preserved as-is by setAnnotations. Override in subclasses to expose
+   * specific system annotations (e.g. cattle.io/) to the UI.
+   */
+  isAnnotationIgnored(key) {
+    return matchesSomeRegex(key, ANNOTATIONS_TO_IGNORE_REGEX);
   }
 
   setAnnotations(val) {
@@ -73,7 +82,7 @@ export default class HybridModel extends Resource {
 
     const all = this.metadata.annotations || {};
     const wasIgnored = pickBy(all, (value, key) => {
-      return matchesSomeRegex(key, ANNOTATIONS_TO_IGNORE_REGEX);
+      return this.isAnnotationIgnored(key);
     });
 
     this.metadata['annotations'] = { ...wasIgnored, ...val };


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18147 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
This PR exposes the `provisioning.cattle.io/management-cluster-name` annotation in the Rancher Dashboard UI for provisioning clusters. Previously this annotation was treated as a system annotation (matching the cattle.io/ regex) and was hidden/discarded by the Labels & Annotations UI.

On create: Users can now set the annotation without seeing a "protected" warning
On edit: The annotation is displayed as read-only with a warning that changes will not be persisted
On detail view: The annotation is visible in the masthead annotations section

### Technical notes summary
#### Provisioning Cluster Model Changes
~`get annotations`
This overrides the hybridmodel annotations getter, which filters out all annotations matching ANNOTATIONS_TO_IGNORE_REGEX (cattle.io annotations). This is needed to make the cluster name annotation show up in the resource detail masthead.~

UPDATE: reworked hybrid-class logic a little so the same filtering exception could be passed to both `get annotations` and `setAnnotations`. The provisioning cluster model now overwrites a new method, `isAnnotationIgnored` which is used by both the annotation getter and setter.

`get allowedSystemAnnotationKeys`
The annotations getter overrides the filtering done in HybridModel, but annotations are filtered _again_ in the Labels.vue component (used to create/edit labels and annotations). This getter is passed into the Labels component to exclude the cluster name annotation from that filtering, ensuring it is rendered without a warning icon and is preserved on save.

`get readOnlyAnnotationKeys`
This getter covers new functionality required by this github issue: annotations that can only be set during creation. The readOnlyAnnotationKeys getter is passed into Labels.vue so that Labels.vue will display the annotation with a warning that changes wont be saved, and exclude it from the PUT request

#### Labels.vue changes
- added `exceptedKeys` parameter to allow model-defined annotation keys to bypass the ANNOTATIONS_TO_IGNORE_REGEX filtering
- added `readOnlyKeys` parameter to introduce the concept of immutable annotations (allowed to be set only during creation)

### Areas or cases that should be tested

- Create an RKE2 custom cluster and set the `provisioning.cattle.io/management-cluster-name` annotation: verify no warning icon and the annotation persists in the API response
- Attempt to set another cattle.io/ annotation (e.g. `some.cattle.io/foo`) during creation: verify the warning icon appears and the annotation is not included in the save request.
- Edit an existing cluster that has the annotation set: verify it is visible with a read-only warning and cannot be changed
- View the cluster detail page: verify the annotation appears in the masthead
- Verify that the associated management cluster has a metadata.name matching the value of the annotation
- Verify that other resources using the Labels component (namespaces, workloads, etc.) are unaffected by the Factory changes

### Areas which could experience regressions
New functionality has been introduced at the model level to reduce the potential for regression in other form elements, but some quick testing that system labels are still hidden in other resource forms would be a good idea.

### Screenshot/Video
<img width="1178" height="810" alt="Screenshot 2026-08-04 at 12 18 59 PM" src="https://github.com/user-attachments/assets/432c28aa-f21e-41ae-b2d5-cbd99741ab10" />
<img width="1168" height="220" alt="Screenshot 2026-08-04 at 12 19 18 PM" src="https://github.com/user-attachments/assets/277d51cd-f11d-43c1-9fb4-da7820072a53" />
<img width="1172" height="882" alt="Screenshot 2026-08-04 at 12 19 37 PM" src="https://github.com/user-attachments/assets/083cdfa6-f504-46cb-8977-48e10146a606" />


### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
