### PR TITLE
Automation: Scope Default project lookup by clusterName in project-secrets spec

### DIFF
--- a/cypress/e2e/tests/pages/explorer2/storage/project-secrets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/project-secrets.spec.ts
@@ -1,38 +1,44 @@
 import { ProjectSecretsListPagePo, ProjectSecretsCreateEditPo } from '@/cypress/e2e/po/pages/explorer/project-secrets.po';
-import { NamespaceFilterPo } from '@/cypress/e2e/po/components/namespace-filter.po';
+import { qase } from '@/cypress/support/qase';
 
-const projectSecretsListPage = new ProjectSecretsListPagePo('local');
-const namespaceFilter = new NamespaceFilterPo();
+const cluster_id = 'local';
+const projectSecretsListPage = new ProjectSecretsListPagePo(cluster_id);
 const targetProject = {
   name: 'default', label: 'Default', namespace: ''
 };
-const projectScopedSecretName = 'e2e-project-scoped-secret-name';
+let projectScopedSecretName: string;
 const username = 'test';
 const password = 'test-password';
 
-describe('Project Secrets', { testIsolation: false, tags: ['@explorer2', '@adminUser'] }, () => {
+describe('Project Secrets', { tags: ['@explorer2', '@adminUser'] }, () => {
   beforeEach(() => {
     cy.login();
 
+    cy.createE2EResourceName('project-scoped-secret').then((name) => {
+      projectScopedSecretName = name;
+    });
+
     cy.getRancherResource('v1', 'management.cattle.io.projects').then((resp: Cypress.Response<any>) => {
-      targetProject.namespace = resp.body.data.find((item: any) => item.spec.displayName === 'Default').status.backingNamespace;
+      // Scope by clusterName in addition to displayName: multiple clusters can each have their
+      // own "Default" project, and an unscoped find() can resolve to the wrong cluster's project
+      // (mismatching the namespace the UI actually uses for the "local" cluster's secret).
+      targetProject.namespace = resp.body.data.find((item: any) => item.spec.displayName === targetProject.label && item.spec.clusterName === cluster_id).status.backingNamespace;
     });
 
     cy.intercept('POST', '/v1/secrets?exclude=metadata.managedFields').as('createProjectScopedSecret');
   });
 
-  it('has the correct title', () => {
+  qase(24277, it('has the correct title', () => {
     projectSecretsListPage.goTo();
     projectSecretsListPage.title().should('include', 'Project Secrets');
 
     cy.title().should('eq', 'Rancher - local - Project Secrets');
-  });
+  }));
 
-  it('creates a project-scoped secret and displays it in the list', () => {
-    namespaceFilter.toggle();
-    namespaceFilter.clickOptionByLabel('All Namespaces');
-    namespaceFilter.closeDropdown();
-    const secretCreatePage = new ProjectSecretsCreateEditPo('local');
+  qase(27179, it('creates a project-scoped secret and displays it in the list', () => {
+    cy.updateNamespaceFilter('local', 'none', '{"local":[]}');
+
+    const secretCreatePage = new ProjectSecretsCreateEditPo(cluster_id);
 
     projectSecretsListPage.goTo();
 
@@ -56,8 +62,11 @@ describe('Project Secrets', { testIsolation: false, tags: ['@explorer2', '@admin
       expect(payload.metadata.labels['management.cattle.io/project-scoped-secret']).to.eq(targetProject.namespace);
       expect(payload.metadata.name).to.eq(projectScopedSecretName);
     });
+  }));
 
+  after(() => {
     cy.deleteRancherResource('v1', `secrets/${ targetProject.name }`, projectScopedSecretName, true);
     cy.deleteRancherResource('v1', `secrets/${ targetProject.namespace }`, projectScopedSecretName, true);
+    cy.updateNamespaceFilter('local', 'none', '{"local":["all://user"]}');
   });
 });

--- a/cypress/e2e/tests/pages/explorer2/storage/project-secrets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/project-secrets.spec.ts
@@ -6,7 +6,8 @@ const projectSecretsListPage = new ProjectSecretsListPagePo(clusterId);
 const targetProject = {
   name: 'default', label: 'Default', namespace: ''
 };
-let projectScopedSecretName: string;
+let projectScopedSecretName = '';
+let removeProjectScopedSecret = false;
 const username = 'test';
 const password = 'test-password';
 
@@ -61,6 +62,8 @@ describe('Project Secrets', { tags: ['@explorer2', '@adminUser'] }, () => {
     cy.wait('@createProjectScopedSecret', { requestTimeout: 10000 }).then((req) => {
       const payload = req.request?.body;
 
+      expect(req.response?.statusCode).to.eq(201);
+      removeProjectScopedSecret = true;
       expect(payload.metadata.namespace).to.eq(targetProject.namespace);
       expect(payload.metadata.labels['management.cattle.io/project-scoped-secret']).to.eq(targetProject.namespace);
       expect(payload.metadata.name).to.eq(projectScopedSecretName);
@@ -68,8 +71,11 @@ describe('Project Secrets', { tags: ['@explorer2', '@adminUser'] }, () => {
   }));
 
   afterEach(() => {
-    cy.deleteRancherResource('v1', `secrets/${ targetProject.name }`, projectScopedSecretName, false);
-    cy.deleteRancherResource('v1', `secrets/${ targetProject.namespace }`, projectScopedSecretName, false);
+    if (removeProjectScopedSecret) {
+      cy.deleteRancherResource('v1', `secrets/${ targetProject.name }`, projectScopedSecretName, false);
+      cy.deleteRancherResource('v1', `secrets/${ targetProject.namespace }`, projectScopedSecretName, false);
+    }
+
     cy.updateNamespaceFilter('local', 'none', '{"local":["all://user"]}');
   });
 });

--- a/cypress/e2e/tests/pages/explorer2/storage/project-secrets.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/storage/project-secrets.spec.ts
@@ -1,8 +1,8 @@
 import { ProjectSecretsListPagePo, ProjectSecretsCreateEditPo } from '@/cypress/e2e/po/pages/explorer/project-secrets.po';
 import { qase } from '@/cypress/support/qase';
 
-const cluster_id = 'local';
-const projectSecretsListPage = new ProjectSecretsListPagePo(cluster_id);
+const clusterId = 'local';
+const projectSecretsListPage = new ProjectSecretsListPagePo(clusterId);
 const targetProject = {
   name: 'default', label: 'Default', namespace: ''
 };
@@ -22,7 +22,10 @@ describe('Project Secrets', { tags: ['@explorer2', '@adminUser'] }, () => {
       // Scope by clusterName in addition to displayName: multiple clusters can each have their
       // own "Default" project, and an unscoped find() can resolve to the wrong cluster's project
       // (mismatching the namespace the UI actually uses for the "local" cluster's secret).
-      targetProject.namespace = resp.body.data.find((item: any) => item.spec.displayName === targetProject.label && item.spec.clusterName === cluster_id).status.backingNamespace;
+      const project = resp.body.data.find((item: any) => item.spec.displayName === targetProject.label && item.spec.clusterName === clusterId);
+
+      expect(project, `project "${ targetProject.label }" in cluster "${ clusterId }"`).to.exist;
+      targetProject.namespace = project.status.backingNamespace;
     });
 
     cy.intercept('POST', '/v1/secrets?exclude=metadata.managedFields').as('createProjectScopedSecret');
@@ -38,7 +41,7 @@ describe('Project Secrets', { tags: ['@explorer2', '@adminUser'] }, () => {
   qase(27179, it('creates a project-scoped secret and displays it in the list', () => {
     cy.updateNamespaceFilter('local', 'none', '{"local":[]}');
 
-    const secretCreatePage = new ProjectSecretsCreateEditPo(cluster_id);
+    const secretCreatePage = new ProjectSecretsCreateEditPo(clusterId);
 
     projectSecretsListPage.goTo();
 
@@ -64,9 +67,9 @@ describe('Project Secrets', { tags: ['@explorer2', '@adminUser'] }, () => {
     });
   }));
 
-  after(() => {
-    cy.deleteRancherResource('v1', `secrets/${ targetProject.name }`, projectScopedSecretName, true);
-    cy.deleteRancherResource('v1', `secrets/${ targetProject.namespace }`, projectScopedSecretName, true);
+  afterEach(() => {
+    cy.deleteRancherResource('v1', `secrets/${ targetProject.name }`, projectScopedSecretName, false);
+    cy.deleteRancherResource('v1', `secrets/${ targetProject.namespace }`, projectScopedSecretName, false);
     cy.updateNamespaceFilter('local', 'none', '{"local":["all://user"]}');
   });
 });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #https://github.com/rancher/qa-tasks/issues/2457

1. Scope  Default  project lookup by  clusterName  — prevents  find()  resolving to the wrong cluster's "Default" project in multi-cluster environments.
2. Remove  testIsolation: false  — lets Cypress clear browser/cookie state between retries, fixing downstream 401s.
3. Replace UI namespace filter toggle with  cy.updateNamespaceFilter()  — more reliable and idempotent across retries.
<!-- Define findings related to the feature or bug issue. -->

### Screenshot/Video
<img width="825" height="237" alt="Screenshot 2026-08-04 at 9 33 42 PM" src="https://github.com/user-attachments/assets/1b27955b-9267-49c6-8f68-677f42431c2b" />


<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
