### PR TITLE
Fix member list rendering after removal

### DIFF
--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -115,10 +115,6 @@ export default {
       type:    String,
       default: 'array-list',
     },
-    rowKey: {
-      type:    Function,
-      default: null,
-    },
 
     /**
      * Field name for vee-validate integration. When provided, the component
@@ -365,7 +361,7 @@ export default {
         </div>
         <div
           v-for="(row, idx) in rows"
-          :key="rowKey ? rowKey(row.value, idx) : idx"
+          :key="idx"
           :data-testid="`${componentTestid}-box${ idx }`"
           class="box"
           :class="{'hide-remove-is-view': isView}"

--- a/shell/components/form/ArrayList.vue
+++ b/shell/components/form/ArrayList.vue
@@ -115,6 +115,10 @@ export default {
       type:    String,
       default: 'array-list',
     },
+    rowKey: {
+      type:    Function,
+      default: null,
+    },
 
     /**
      * Field name for vee-validate integration. When provided, the component
@@ -361,7 +365,7 @@ export default {
         </div>
         <div
           v-for="(row, idx) in rows"
-          :key="idx"
+          :key="rowKey ? rowKey(row.value, idx) : idx"
           :data-testid="`${componentTestid}-box${ idx }`"
           class="box"
           :class="{'hide-remove-is-view': isView}"

--- a/shell/components/form/Members/MembershipEditor.vue
+++ b/shell/components/form/Members/MembershipEditor.vue
@@ -157,6 +157,14 @@ export default {
     onAddMember(bindings) {
       this['bindings'] = [...this.bindings, ...bindings];
     },
+
+    bindingKey(binding) {
+      if (binding.id) {
+        return binding.id;
+      }
+
+      return [binding.principalId || binding.userPrincipalId || binding.groupPrincipalId, binding.roleTemplateId].join('-');
+    },
   }
 };
 </script>
@@ -166,6 +174,7 @@ export default {
     v-else
     v-model:value="bindings"
     :mode="mode"
+    :row-key="bindingKey"
     :show-header="true"
   >
     <template #column-headers>

--- a/shell/components/form/Members/MembershipEditor.vue
+++ b/shell/components/form/Members/MembershipEditor.vue
@@ -60,6 +60,21 @@ export default {
     }
   },
 
+  setup() {
+    const bindingKeys = new Map();
+    let nextBindingKey = 0;
+
+    const getBindingKey = (binding) => {
+      if (!bindingKeys.has(binding)) {
+        bindingKeys.set(binding, nextBindingKey++);
+      }
+
+      return bindingKeys.get(binding);
+    };
+
+    return { getBindingKey };
+  },
+
   async fetch() {
     const roleBindingRequestParams = { type: this.type, opt: { force: true } };
 
@@ -157,14 +172,6 @@ export default {
     onAddMember(bindings) {
       this['bindings'] = [...this.bindings, ...bindings];
     },
-
-    bindingKey(binding) {
-      if (binding.id) {
-        return binding.id;
-      }
-
-      return [binding.principalId || binding.userPrincipalId || binding.groupPrincipalId, binding.roleTemplateId].join('-');
-    },
   }
 };
 </script>
@@ -174,7 +181,6 @@ export default {
     v-else
     v-model:value="bindings"
     :mode="mode"
-    :row-key="bindingKey"
     :show-header="true"
   >
     <template #column-headers>
@@ -193,6 +199,7 @@ export default {
       <div class="columns row">
         <div class="col span-6">
           <Principal
+            :key="getBindingKey(row.value)"
             :value="row.value.principalId"
           />
         </div>

--- a/shell/components/form/Members/__tests__/MembershipEditor.remove.test.ts
+++ b/shell/components/form/Members/__tests__/MembershipEditor.remove.test.ts
@@ -2,8 +2,13 @@ import { mount } from '@vue/test-utils';
 import MembershipEditor from '@shell/components/form/Members/MembershipEditor.vue';
 
 const CachedPrincipal = {
-  props: ['value'],
-  data() {
+  props: {
+    value: {
+      type:     String,
+      required: true,
+    },
+  },
+  data(this: { value: string }): { principal: string } {
     return { principal: this.value };
   },
   template: '<span class="principal">{{ principal }}</span>',
@@ -20,7 +25,7 @@ describe('component: MembershipEditor removal', () => {
             principalId:    `local://user-${ number }`,
             roleDisplay:    `Member ${ number }`,
             roleTemplateId: 'member',
-          })),
+          })) as any,
         };
       },
       props: {

--- a/shell/components/form/Members/__tests__/MembershipEditor.remove.test.ts
+++ b/shell/components/form/Members/__tests__/MembershipEditor.remove.test.ts
@@ -1,0 +1,50 @@
+import { mount } from '@vue/test-utils';
+import MembershipEditor from '@shell/components/form/Members/MembershipEditor.vue';
+
+const CachedPrincipal = {
+  props: ['value'],
+  data() {
+    return { principal: this.value };
+  },
+  template: '<span class="principal">{{ principal }}</span>',
+};
+
+describe('component: MembershipEditor removal', () => {
+  it('renders the remaining member after removing a member in the middle of the list', async() => {
+    const wrapper = mount(MembershipEditor, {
+      data() {
+        return {
+          schema:            null,
+          lastSavedBindings: [],
+          bindings:          [1, 2, 3, 4, 5].map((number) => ({
+            principalId:    `local://user-${ number }`,
+            roleDisplay:    `Member ${ number }`,
+            roleTemplateId: 'member',
+          })),
+        };
+      },
+      props: {
+        addMemberDialogName: 'addMemberDialogName',
+        parentKey:           'parentKey',
+        mode:                'edit',
+        type:                'no idea',
+      },
+      global: {
+        mocks: {
+          $store:      { getters: { 'rancher/schemaFor': () => ({ type: 'object' }) } },
+          $fetchState: { pending: false },
+        },
+        stubs: { Principal: CachedPrincipal },
+      }
+    });
+
+    await wrapper.find('[data-testid="remove-item-3"]').trigger('click');
+
+    expect(wrapper.findAll('.principal').map((principal) => principal.text())).toStrictEqual([
+      'local://user-1',
+      'local://user-2',
+      'local://user-3',
+      'local://user-5',
+    ]);
+  });
+});

--- a/shell/components/form/Members/__tests__/MembershipEditor.remove.test.ts
+++ b/shell/components/form/Members/__tests__/MembershipEditor.remove.test.ts
@@ -10,13 +10,13 @@ const CachedPrincipal = {
 };
 
 describe('component: MembershipEditor removal', () => {
-  it('renders the remaining member after removing a member in the middle of the list', async() => {
+  it('renders the correct remaining members after removing a duplicated principal', async() => {
     const wrapper = mount(MembershipEditor, {
       data() {
         return {
           schema:            null,
           lastSavedBindings: [],
-          bindings:          [1, 2, 3, 4, 5].map((number) => ({
+          bindings:          [1, 1, 2, 3, 4].map((number) => ({
             principalId:    `local://user-${ number }`,
             roleDisplay:    `Member ${ number }`,
             roleTemplateId: 'member',
@@ -38,13 +38,13 @@ describe('component: MembershipEditor removal', () => {
       }
     });
 
-    await wrapper.find('[data-testid="remove-item-3"]').trigger('click');
+    await wrapper.find('[data-testid="remove-item-1"]').trigger('click');
 
     expect(wrapper.findAll('.principal').map((principal) => principal.text())).toStrictEqual([
       'local://user-1',
       'local://user-2',
       'local://user-3',
-      'local://user-5',
+      'local://user-4',
     ]);
   });
 });


### PR DESCRIPTION
### Summary

Fixes #18851

Fix an issue where removing a member from the middle of the member list could make the next member appear to disappear in the UI before saving.

### Occurred changes and/or fixed issues

- Added support for an optional stable row key in `ArrayList`.
- Passed a stable key for membership bindings in `MembershipEditor`.
- Removing the fourth member from a five-member list now immediately displays members 1, 2, 3, and 5.
- The fix applies to editors that use `MembershipEditor`, including Project Members and Cluster Membership.

### Technical notes summary

`ArrayList` used the row index as the Vue key. After a member was removed, Vue reused the following row's component instance. This could leave `Principal` displaying cached data for the removed member position.

`MembershipEditor` now provides a stable key based on the binding ID when available, or the principal and role template identifiers for unsaved bindings.

Added a regression test covering removal of a member in the middle of the list.

### Areas or cases that should be tested

1. Open a Cluster or Project membership editor with at least five members.
2. Remove a member that is not the last member.
3. Verify that the selected member disappears immediately and all remaining members stay visible in the correct order.
4. Save the changes.
5. Reload the page and verify that the saved membership list matches the displayed list.

Automated tests run:

```text
yarn test:ci shell/components/form/Members/__tests__/MembershipEditor.test.ts shell/components/form/Members/__tests__/MembershipEditor.remove.test.ts shell/components/form/__tests__/ArrayList.test.ts
```

### Areas which could experience regressions

- Project and Cluster membership editing flows.
- Adding and removing unsaved membership bindings.
- Other ArrayList consumers that opt in to rowKey.

### Screenshot/Video
Not applicable. This change corrects row rendering after a removal action.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
