### PR TITLE
Added CAPI provisioning cluster section

### DIFF
--- a/shell/core/types-provisioning.ts
+++ b/shell/core/types-provisioning.ts
@@ -1,3 +1,5 @@
+import type { Component } from 'vue';
+
 /**
  * A function to run as part of the save cluster process
  */
@@ -12,6 +14,26 @@ export type ClusterSaveHook = (cluster: any) => Promise<any>
  * @param fnContext the `this` context from inside the function. If left blank will be a Vue component (where this.value will be the cluster)
  */
 export type RegisterClusterSaveHook = (hook: ClusterSaveHook, name: string, priority?: number, fnContext?: any) => void;
+
+/**
+ * Props for the `extensionInfrastructureSection` component.
+ *
+ * Either a plain object merged over the default props, or a function that receives the default props
+ * and returns an object of additional/overridden props
+ */
+export type ExtensionInfrastructureSectionProps =
+  | { [key: string]: any }
+  | ((context: { value: any, mode: string, credentialId: string, provisioningCluster: any, infrastructureCluster: any }) => { [key: string]: any });
+
+/**
+ * Props for the `extensionProvisioningSection` component
+ *
+ * Either a plain object merged over the default props, or a function that receives the default props
+ * and returns an object of additional/overridden props
+ */
+export type ExtensionProvisioningSectionProps =
+  | { [key: string]: any }
+  | ((context: { value: any, mode: string, provisioningCluster: any }) => { [key: string]: any });
 
 export type ClusterDetailTabs = {
   /**
@@ -287,7 +309,22 @@ export interface IClusterProvisioner {
   /**
    * Optional custom UI section for infrastructure-cluster-specific configuration.
    */
-  extensionInfrastructureSection?: any
+  extensionInfrastructureSection?: Component
+
+  /**
+   * Props (or a function returning props) passed to `extensionInfrastructureSection`
+   */
+  extensionInfrastructureSectionProps?: ExtensionInfrastructureSectionProps
+
+  /**
+   * Optional custom UI section for provisioning-cluster-specific configuration.
+   */
+  extensionProvisioningSection?: Component
+
+  /**
+   * Props (or a function returning props) passed to `extensionProvisioningSection`
+   */
+  extensionProvisioningSectionProps?: ExtensionProvisioningSectionProps
 
   /**
    * Indicates the provisioner manages upstream CAPI infrastructure resources directly.

--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -228,11 +228,11 @@ describe('component: rke2', () => {
         provider: 'custom'
       },
 
-      data: () => ({
+      data: (() => ({
         credentialId: 'I am authenticated',
         credential:   { decodedData: { clusterId: 'some-cluster-id' } },
         machinePools: [],
-      }),
+      })) as any,
 
       global: {
         mocks: {
@@ -590,7 +590,7 @@ describe('component: rke2', () => {
         },
         provider: 'custom'
       },
-      data: () => ({
+      data: (() => ({
         credentialId:    'I am authenticated',
         userChartValues: chartValues,
         rke2Versions:    [
@@ -617,7 +617,7 @@ describe('component: rke2', () => {
             }
           }
         ]
-      }),
+      })) as any,
 
       global: {
         mocks: {
@@ -933,6 +933,77 @@ describe('component: rke2', () => {
       const canEditAsYaml = rke2.computed!.canEditAsYaml.call(vm);
 
       expect(canEditAsYaml).toBe(true);
+    });
+  });
+  describe('computed: validationPassed (extension provisioning section)', () => {
+    const baseVm = {
+      hasMachinePools:            false,
+      provider:                   'custom',
+      machinePoolValidation:      {},
+      addonConfigValidation:      {},
+      isUpstreamCAPIProvider:     true,
+      infrastructureClusterValid: true,
+      provisioningClusterValid:   true,
+      stackPreferenceError:       false,
+    };
+
+    it('should return true when provisioningClusterValid is true', () => {
+      const vm = { ...baseVm } as any;
+
+      const validationPassed = rke2.computed!.validationPassed.call(vm);
+
+      expect(validationPassed).toBe(true);
+    });
+
+    it('should return false when provisioningClusterValid is false and isUpstreamCAPIProvider is true', () => {
+      const vm = { ...baseVm, provisioningClusterValid: false } as any;
+
+      const validationPassed = rke2.computed!.validationPassed.call(vm);
+
+      expect(validationPassed).toBe(false);
+    });
+
+    it('should ignore provisioningClusterValid when isUpstreamCAPIProvider is false', () => {
+      const vm = {
+        ...baseVm, provisioningClusterValid: false, isUpstreamCAPIProvider: false
+      } as any;
+
+      const validationPassed = rke2.computed!.validationPassed.call(vm);
+
+      expect(validationPassed).toBe(true);
+    });
+  });
+
+  describe('methods: updateExtensionProvisioningSection', () => {
+    it('should do nothing when the emitted value is not an object', () => {
+      const originalValue = { spec: { foo: 'bar' } };
+      const vm = { value: originalValue } as any;
+
+      (rke2.methods as any).updateExtensionProvisioningSection.call(vm, null);
+
+      expect(vm.value).toBe(originalValue);
+      expect(vm.value).toStrictEqual({ spec: { foo: 'bar' } });
+    });
+
+    it('should assign the emitted value directly when there is no existing value', () => {
+      const vm = { value: null } as any;
+      const neu = { spec: { kubernetesVersion: 'v1.31.0+rke2r1' } };
+
+      (rke2.methods as any).updateExtensionProvisioningSection.call(vm, neu);
+
+      expect(vm.value).toBe(neu);
+    });
+
+    it('should merge the emitted value into the existing value, preserving the original reference', () => {
+      const original = { spec: { kubernetesVersion: 'v1.30.0+rke2r1', existing: 'field' } };
+      const vm = { value: original } as any;
+      const neu = { spec: { kubernetesVersion: 'v1.31.0+rke2r1' } };
+
+      (rke2.methods as any).updateExtensionProvisioningSection.call(vm, neu);
+
+      expect(vm.value).toBe(original);
+      expect(vm.value.spec.kubernetesVersion).toBe('v1.31.0+rke2r1');
+      expect(vm.value.spec.existing).toBe('field');
     });
   });
 });

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -275,6 +275,7 @@ export default {
       busy:                                     false,
       machinePoolValidation:                    {}, // map of validation states for each machine pool
       infrastructureClusterValid:               true,
+      provisioningClusterValid:                 true,
       machinePoolErrors:                        {},
       addonConfigValidation:                    {}, // validation state of each addon config (boolean of whether codemirror's yaml lint passed)
       stackPreferenceError:                     false, //  spec.networking.stackPreference is validated in conjunction with hasOnlyIpv6Pools
@@ -836,12 +837,79 @@ export default {
       return null;
     },
 
+    showForm() {
+      return !!this.credentialId || !this.needCredential;
+    },
+
     extensionInfrastructureSection() {
       return this.extensionProvider?.extensionInfrastructureSection || null;
     },
+    extensionProvisioningSection() {
+      return this.extensionProvider?.extensionProvisioningSection || null;
+    },
 
-    showForm() {
-      return !!this.credentialId || !this.needCredential;
+    extensionInfrastructureSectionProps() {
+      const defaultProps = {
+        value:               this.infrastructureCluster,
+        mode:                this.mode,
+        credentialId:        this.credentialId,
+        provisioningCluster: this.value,
+      };
+
+      const extensionProps = this.extensionProvider?.extensionInfrastructureSectionProps;
+
+      if (typeof extensionProps === 'function') {
+        const extensionContext = { ...defaultProps };
+
+        extensionContext.infrastructureCluster = this.infrastructureCluster;
+
+        let out;
+
+        try {
+          out = extensionProps(extensionContext);
+        } catch {
+          return defaultProps;
+        }
+
+        if (out && typeof out === 'object') {
+          return { ...defaultProps, ...out };
+        }
+      } else if (extensionProps && typeof extensionProps === 'object') {
+        return { ...defaultProps, ...extensionProps };
+      }
+
+      return defaultProps;
+    },
+
+    extensionProvisioningSectionProps() {
+      const defaultProps = {
+        value: this.value,
+        mode:  this.mode,
+      };
+
+      const extensionProps = this.extensionProvider?.extensionProvisioningSectionProps;
+
+      if (typeof extensionProps === 'function') {
+        const extensionContext = { ...defaultProps };
+
+        extensionContext.provisioningCluster = this.value;
+
+        let out;
+
+        try {
+          out = extensionProps(extensionContext);
+        } catch {
+          return defaultProps;
+        }
+
+        if (out && typeof out === 'object') {
+          return { ...defaultProps, ...out };
+        }
+      } else if (extensionProps && typeof extensionProps === 'object') {
+        return { ...defaultProps, ...extensionProps };
+      }
+
+      return defaultProps;
     },
 
     isHarvesterExternalCredential() {
@@ -894,8 +962,9 @@ export default {
       const hasAddonConfigErrors = Object.values(this.addonConfigValidation).filter((v) => v === false).length > 0;
 
       const hasInfrastructureClusterError = this.isUpstreamCAPIProvider ? !this.infrastructureClusterValid : false;
+      const hasProvisioningClusterError = this.isUpstreamCAPIProvider ? !this.provisioningClusterValid : false;
 
-      return validRequiredPools && base && !hasAddonConfigErrors && !hasInfrastructureClusterError && !this.stackPreferenceError;
+      return validRequiredPools && base && !hasAddonConfigErrors && !hasInfrastructureClusterError && !hasProvisioningClusterError && !this.stackPreferenceError;
     },
 
     currentCluster() {
@@ -1071,6 +1140,21 @@ export default {
 
       // Preserve the original resource model instance while applying extension updates.
       mergeWithReplace(this.infrastructureCluster, neu, { mutateOriginal: true });
+    },
+
+    updateExtensionProvisioningSection(neu) {
+      if (!neu || typeof neu !== 'object') {
+        return;
+      }
+
+      if (!this.value || typeof this.value !== 'object') {
+        this.value = neu;
+
+        return;
+      }
+
+      // Preserve the original resource model instance while applying extension updates.
+      mergeWithReplace(this.value, neu, { mutateOriginal: true });
     },
 
     async handleVsphereCpiSecret() {
@@ -2503,7 +2587,6 @@ export default {
         data-testid="select-credential"
         class="mt-20"
       />
-
       <div
         v-if="showForm"
         data-testid="form"
@@ -2541,12 +2624,7 @@ export default {
           <component
             :is="extensionInfrastructureSection"
             v-if="extensionInfrastructureSection"
-            :value="infrastructureCluster"
-            :mode="mode"
-            :provider="provider"
-            :credential-id="credentialId"
-            :provisioning-cluster="value"
-            data-testid="extension-top-section"
+            v-bind="extensionInfrastructureSectionProps"
             class="span-12"
             @update:value="updateExtensionInfrastructureSection"
             @error="e => errors.push(e)"
@@ -2636,6 +2714,15 @@ export default {
 
         <!-- Cluster Tabs -->
         <h2 v-t="'cluster.tabs.cluster'" />
+        <component
+          :is="extensionProvisioningSection"
+          v-if="extensionProvisioningSection"
+          v-bind="extensionProvisioningSectionProps"
+          class="span-12"
+          @update:value="updateExtensionProvisioningSection"
+          @error="e => errors.push(e)"
+          @validationChanged="(val) => provisioningClusterValid = val"
+        />
         <Tabbed
           :side-tabs="true"
           class="min-height"


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18300 
<!-- Define findings related to the feature or bug issue. -->
Added a provisioning cluster component to handle changes to provisioning cluster from CAPI extensions.
Should be tested with https://github.com/rancher/prov-capi-ui-extensions/pull/21

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
Added new Provisioning cluster section to allow extensions to track and update provisioning cluster directly

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
This needs to be tested with https://github.com/rancher/prov-capi-ui-extensions/pull/21
Validate that infrastructure cluster section is displayed correctly
Validate that if additional manifest or machine selector config is missing, the banner is displayed above Cluster Configuration tabs
Validate that changing between RKE2 and K3s versions changes machine selector config accordingly

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
No existing behavior should be changed

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
