### PR TITLE
Add support for l10n globals and use for Harvester product name

### DIFF
--- a/pkg/harvester-manager/index.ts
+++ b/pkg/harvester-manager/index.ts
@@ -14,6 +14,13 @@ export default function(plugin: IPlugin) {
 
   plugin.addProduct(require('./config/harvester-manager'));
 
+  if (plugin.environment.isPrime) {
+    plugin.register('l10n-global', 'Harvester', 'SUSE Virtualization');
+    plugin.register('l10n', 'en-us', () => {
+      return { product: { harvesterManager: 'SUSE Virtualization' } };
+    });
+  }
+
   plugin.addTab(
     TabLocation.RESOURCE_CREATE_PAGE,
     {

--- a/pkg/harvester-manager/index.ts
+++ b/pkg/harvester-manager/index.ts
@@ -16,9 +16,11 @@ export default function(plugin: IPlugin) {
 
   if (plugin.environment.isPrime) {
     plugin.register('l10n-global', 'Harvester', 'SUSE Virtualization');
-    plugin.register('l10n', 'en-us', () => {
-      return { product: { harvesterManager: 'SUSE Virtualization' } };
-    });
+
+    const primeProductName = () => ({ product: { harvesterManager: 'SUSE Virtualization' } });
+
+    plugin.register('l10n', 'en-us', primeProductName);
+    plugin.register('l10n', 'zh-hans', primeProductName);
   }
 
   plugin.addTab(

--- a/pkg/harvester-manager/l10n/en-us.yaml
+++ b/pkg/harvester-manager/l10n/en-us.yaml
@@ -2,45 +2,45 @@ harvesterManager:
   manage: Manage
   tableHeaders:
     kubernetesVersion: Kubernetes Version
-    harvesterVersion: Harvester Version
+    harvesterVersion: '[[Harvester]] Version'
   cluster:
-    label: Harvester Clusters
-    none: There are no Harvester Clusters
-    learnMore: Learn more about Harvester from the <a target="_blank" href="https://harvesterhci.io/" rel="noopener noreferrer nofollow">Harvester Web Site</a> or read the <a target="_blank" href="https://docs.harvesterhci.io/" rel="noopener noreferrer nofollow">Harvester Docs</a>
-    description: Harvester is a modern Hyperconverged infrastructure (HCI) solution built for bare metal servers using enterprise-grade open source technologies including Kubernetes, Kubevirt and Longhorn.
-    supportMessage: The Harvester UI Extension only supports Harvester v1.3.0 and later versions
+    label: '[[Harvester]] Clusters'
+    none: There are no [[Harvester]] Clusters
+    learnMore: Learn more about [[Harvester]] from the <a target="_blank" href="https://harvesterhci.io/" rel="noopener noreferrer nofollow">[[Harvester]] Web Site</a> or read the <a target="_blank" href="https://docs.harvesterhci.io/" rel="noopener noreferrer nofollow">[[Harvester]] Docs</a>
+    description: '[[Harvester]] is a modern Hyperconverged infrastructure (HCI) solution built for bare metal servers using enterprise-grade open source technologies including Kubernetes, Kubevirt and Longhorn.'
+    supportMessage: The [[Harvester]] UI Extension only supports [[Harvester]] v1.3.0 and later versions
   plugins:
     loadError: Error loading harvester plugin
   extension:
     install:
-      warning: "The Harvester UI Extension is not installed"
-      prompt: "UI Integration for Harvester is now provided via the new Harvester UI Extension, which needs to be installed."
+      warning: "The [[Harvester]] UI Extension is not installed"
+      prompt: "UI Integration for [[Harvester]] is now provided via the new [[Harvester]] UI Extension, which needs to be installed."
       prompt-standard-user: Please contact your system administrator
       steps:
         repo:
           1: Go to the
           2: Apps Repositories
-          3: page and add the <a target="_blank" href="https://github.com/harvester/harvester-ui-extension" rel="noopener noreferrer nofollow">Harvester repository</a>
+          3: page and add the <a target="_blank" href="https://github.com/harvester/harvester-ui-extension" rel="noopener noreferrer nofollow">[[Harvester]] repository</a>
         ui:
           1: Go to the
           2: Extensions
-          3: page and install the Harvester Extension
+          3: page and install the [[Harvester]] Extension
     update:
-      warning: "Your current Harvester UI Extension ({currentVersion}) is not the latest."
-      prompt: "A new version ({ newVersion }) is available, please click on Update button to install the latest Harvester UI Extension"
+      warning: "Your current [[Harvester]] UI Extension ({currentVersion}) is not the latest."
+      prompt: "A new version ({ newVersion }) is available, please click on Update button to install the latest [[Harvester]] UI Extension"
       prompt-standard-user: Please contact your system administrator to install the latest version
     missingRepo:
-      warning: "The Harvester UI Extension repository is missing"
-      prompt: "Please click on Update button to add the Harvester repository and install the latest Harvester UI Extension"
-      prompt-standard-user: Please contact your system administrator to install the latest Harvester UI Extension
+      warning: "The [[Harvester]] UI Extension repository is missing"
+      prompt: "Please click on Update button to add the [[Harvester]] repository and install the latest [[Harvester]] UI Extension"
+      prompt-standard-user: Please contact your system administrator to install the latest [[Harvester]] UI Extension
     missingVersion:
       warning: "Could not find a compatible version"
-      prompt: "Please update Rancher to get the latest compatible version of the Harvester UI extension or try to install it manually"
+      prompt: "Please update Rancher to get the latest compatible version of the [[Harvester]] UI extension or try to install it manually"
       prompt-standard-user: Please contact your system administrator
     error:
-      warning: "Warning, Harvester UI extension automatic installation failed"
-      prompt: "Please refresh the page and try again or install the Harvester UI extension manually"
-      prompt-standard-user: Please contact your system administrator to install or update the Harvester extension
+      warning: "Warning, [[Harvester]] UI extension automatic installation failed"
+      prompt: "Please refresh the page and try again or install the [[Harvester]] UI extension manually"
+      prompt-standard-user: Please contact your system administrator to install or update the [[Harvester]] extension
   rke:
     templateError: Incorrect template format
   affinity:

--- a/pkg/harvester-manager/l10n/zh-hans.yaml
+++ b/pkg/harvester-manager/l10n/zh-hans.yaml
@@ -1,12 +1,12 @@
 harvesterManager:
   manage: 管理
   cluster:
-    label: Harvester 集群
-    none: 不存在 Harvester 集群
-    learnMore: 访问 <a target="_blank" href="https://harvesterhci.io/" rel="noopener noreferrer nofollow">Harvester 网站</a> 或阅读 <a target="_blank" href="https://docs.harvesterhci.io/" rel="noopener noreferrer nofollow">Harvester 官方文档</a>，以了解更多关于 Harvester 的信息。
-    description: Harvester 是一个采用企业级开源技术，包括Kubernetes、Kubevirt和Longhorn，为裸金属服务器打造的现代超融合基础设施（HCI）解决方案。
+    label: '[[Harvester]] 集群'
+    none: 不存在 [[Harvester]] 集群
+    learnMore: 访问 <a target="_blank" href="https://harvesterhci.io/" rel="noopener noreferrer nofollow">[[Harvester]] 网站</a> 或阅读 <a target="_blank" href="https://docs.harvesterhci.io/" rel="noopener noreferrer nofollow">[[Harvester]] 官方文档</a>，以了解更多关于 [[Harvester]] 的信息。
+    description: '[[Harvester]] 是一个采用企业级开源技术，包括Kubernetes、Kubevirt和Longhorn，为裸金属服务器打造的现代超融合基础设施（HCI）解决方案。'
   plugins:
-    loadError: 加载 Harvester 插件时出错
+    loadError: 加载 [[Harvester]] 插件时出错
   rke:
     templateError: 模版格式不正确
   cpuModel:

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -198,7 +198,7 @@ nav:
     sideNav: Secondary menu
     homePage: Home page navigation menu
     cluster: Cluster menu item
-    harvesterCluster: Harvester cluster menu item
+    harvesterCluster: '[[Harvester]] cluster menu item'
     seeAll: See all clusters menu item
     multiClusterApps: Main menu multi cluster app menu item
     configurationApps: Main menu configuration app menu item
@@ -215,7 +215,7 @@ nav:
     userAvatar: User avatar image
   expandAppBar: Expand the Application Bar
   collapseAppBar: Collapse the Application Bar
-  harvesterDashboard: Harvester Dashboard
+  harvesterDashboard: '[[Harvester]] Dashboard'
   backToRancher: Cluster Manager
   tools: Tools
   clusterTools: Cluster Tools
@@ -1642,7 +1642,7 @@ cluster:
       label: vSphere
       note: '<b>Important:</b> Configure the vSphere Cloud Provider and Storage Provider options in the Add-on Configuration tab.'
     harvester:
-      label: Harvester
+      label: '[[Harvester]]'
   copyConfig: Copy KubeConfig to Clipboard
   copiedConfig: Copied KubeConfig to Clipboard
   custom:
@@ -1821,7 +1821,7 @@ cluster:
       kubeconfigContent:
         label: KubeconfigContent
       placeholder: 'Namespace/Name'
-      cluster: Imported Harvester Cluster
+      cluster: Imported [[Harvester]] Cluster
       enableTpm: Enable TPM
       enableCpuPinning: Enable CPU Pinning
       cpuPinningTooltip: Enable CPU Pinning brings better performance and reduce latency for the harvester virtual machine
@@ -1829,25 +1829,25 @@ cluster:
       secureBoot: Secure Boot
       enableEfi: Booting in EFI mode
       installGuestAgent: Install guest agent
-      tokenExpirationWarning: 'Warning: Harvester Cloud Credentials use an underlying authentication token that may have an expiry time - please see the following <a href="https://harvesterhci.io/kb/renew_harvester_cloud_credentials" target="_blank" rel="noopener nofollow">knowledge base article</a> for possible implications on management operations.'
+      tokenExpirationWarning: 'Warning: [[Harvester]] Cloud Credentials use an underlying authentication token that may have an expiry time - please see the following <a href="https://harvesterhci.io/kb/renew_harvester_cloud_credentials" target="_blank" rel="noopener nofollow">knowledge base article</a> for possible implications on management operations.'
   description:
     label: Cluster Description
     placeholder: Any text you want that better describes this cluster
   harvester:
-    importNotice: Import Harvester Clusters via
+    importNotice: Import [[Harvester]] Clusters via
     warning:
-      label: This is a Harvester Cluster - enable the Harvester feature flag to manage it
+      label: This is a [[Harvester]] Cluster - enable the [[Harvester]] feature flag to manage it
       state: Warning
       cloudProvider:
         incompatible:
-          You cannot select the Harvester cloud provider as the current Harvester version is not compatible with the selected RKE2 Kubernetes version, click <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.suse.com/suse-harvester/support-matrix/all-supported-versions">here</a> to see which Kubernetes versions are supported.
+          You cannot select the [[Harvester]] cloud provider as the current [[Harvester]] version is not compatible with the selected RKE2 Kubernetes version, click <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.suse.com/suse-harvester/support-matrix/all-supported-versions">here</a> to see which Kubernetes versions are supported.
     clusterWarning: |-
       There {count, plural,
-      =1 {is 1 Harvester cluster that is not shown}
-      other {are # Harvester clusters that are not shown}
+      =1 {is 1 [[Harvester]] cluster that is not shown}
+      other {are # [[Harvester]] clusters that are not shown}
       }
     registration:
-      step1: "1. Go to the <code>Advanced / Settings</code> page of the target Harvester's UI."
+      step1: "1. Go to the <code>Advanced / Settings</code> page of the target [[Harvester]]'s UI."
       step2: '2. Find the <code>cluster-registration-url</code> setting and click the <code><i class="icon icon-actions" ></i></code> -> <code>Edit Setting</code> button.'
       step3: "3. Input the following registration URL and click the <code>Save</code> button."
       step4: "Registration URL"
@@ -1871,7 +1871,7 @@ cluster:
         toolTip: SSH user to login with the selected OS image.
     kubeconfigSecret:
         nameRequired: Cluster name is required.
-        error: 'Error generating Harvester kubeconfig secret: {err}'
+        error: 'Error generating [[Harvester]] kubeconfig secret: {err}'
   haveOneOwner: There must be at least one member with the Owner role.
   import:
     warningBanner: 'You should not import a cluster which has already been connected to another instance of Rancher as it will lead to data corruption.'
@@ -2481,7 +2481,7 @@ cluster:
     googlegke: Google GKE
     gke: GKE
     googlekubernetesengine: Google GKE (Unsupported Kev1)
-    harvester: Harvester
+    harvester: '[[Harvester]]'
     huaweicce: Huawei CCE
     import: Generic
     imported: Imported
@@ -3152,21 +3152,21 @@ fleet:
   clusters:
     harvester: |-
       There {count, plural,
-      =1 {is 1 Harvester cluster that is hidden as this can not be used with Continuous Delivery}
-      other {are # Harvester clusters that are hidden as they can not be used with Continuous Delivery}
+      =1 {is 1 [[Harvester]] cluster that is hidden as this can not be used with Continuous Delivery}
+      other {are # [[Harvester]] clusters that are hidden as they can not be used with Continuous Delivery}
       }
   tokens:
     harvester: |-
       {count, plural,
-      =1 {1 token is hidden as it belongs to a Harvester cluster that can not be used with Continuous Delivery}
-      other {# tokens are hidden as they belong to Harvester clusters that can not be used with Continuous Delivery}
+      =1 {1 token is hidden as it belongs to a [[Harvester]] cluster that can not be used with Continuous Delivery}
+      other {# tokens are hidden as they belong to [[Harvester]] clusters that can not be used with Continuous Delivery}
       }
   bundles:
     resources: Resources
     harvester: |-
       {count, plural,
-      =1 {1 bundle is hidden as it belongs to a Harvester cluster that can not be used with Continuous Delivery}
-      other {# bundles are hidden as they belong to Harvester clusters that can not be used with Continuous Delivery}
+      =1 {1 bundle is hidden as it belongs to a [[Harvester]] cluster that can not be used with Continuous Delivery}
+      other {# bundles are hidden as they belong to [[Harvester]] clusters that can not be used with Continuous Delivery}
       }
   fleetSummary:
     noClusters:
@@ -5303,7 +5303,7 @@ persistentVolume:
       disk-csi-azure-com: Azure Disk (CSI)
       file-csi-azure-com: Azure File (CSI)
       driver-longhorn-io: Longhorn (CSI)
-      driver-harvesterhci-io: Harvester (CSI)
+      driver-harvesterhci-io: '[[Harvester]] (CSI)'
       lvm-driver-harvesterhci-io: LVM
       nfs-csi-k8s-io: NFS (CSI)
       ebs-csi-aws-com: AWS Elastic Block Store (CSI)
@@ -7012,13 +7012,13 @@ storageClass:
     title: (Deprecated)
     warning: 'The {provisioner} in-tree plugin is deprecated: Find a CSI driver <a target="_blank" rel="noopener noreferrer nofollow" href="https://kubernetes-csi.github.io/docs/drivers.html">here.</a>'
   harvesterhci:
-    title: Harvester (CSI)
+    title: '[[Harvester]] (CSI)'
     warning:
-      unSatisfiesVersion: Please upgrade your Harvester CSI driver version to use this feature. (csi-driver >= v0.1.15)
+      unSatisfiesVersion: Please upgrade your [[Harvester]] CSI driver version to use this feature. (csi-driver >= v0.1.15)
     hostStorageClass:
       label: Host Storage Class
-      placeholder: Storage class name on the host Harvester cluster
-      tooltip: By default the default storage class on the host Harvester cluster is used.
+      placeholder: Storage class name on the host [[Harvester]] cluster
+      tooltip: By default the default storage class on the host [[Harvester]] cluster is used.
 
 tableHeaders:
   assuredConcurrencyShares: Assured Concurrency Shares
@@ -8642,8 +8642,8 @@ typeLabel:
     }
   harvesterhci.io.management.cluster: |-
     {count, plural,
-      one { Harvester Cluster }
-      other { Harvester Clusters }
+      one { [[Harvester]] Cluster }
+      other { [[Harvester]] Clusters }
     }
   harvesterhci.io.cloudtemplate: |-
     {count, plural,

--- a/shell/assets/translations/zh-hans.yaml
+++ b/shell/assets/translations/zh-hans.yaml
@@ -122,7 +122,7 @@ locale:
   none: (None)
 
 nav:
-  harvesterDashboard: Harvester 仪表板
+  harvesterDashboard: '[[Harvester]] 仪表板'
   backToRancher: Cluster Manager
   clusterTools: 集群工具
   kubeconfig:
@@ -1142,7 +1142,7 @@ cluster:
       label: vSphere
       note: '<b>重要</b>：在附加配置标签中配置 vSphere 云提供商和存储提供商选项。'
     harvester:
-      label: Harvester
+      label: '[[Harvester]]'
   copyConfig: 将 KubeConfig 复制到剪切板
   copiedConfig: 已将 KubeConfig 复制到剪切板
   custom:
@@ -1301,26 +1301,26 @@ cluster:
       kubeconfigContent:
         label: KubeconfigContent
       placeholder: '命名空间/名称'
-      cluster: 导入的 Harvester 集群
+      cluster: 导入的 [[Harvester]] 集群
       installGuestAgent: 安装访客代理
   description:
     label: 集群描述
     placeholder: 输入可以描述该集群的文本
   harvester:
-    importNotice: 导入 Harvester 集群的方式：
+    importNotice: 导入 [[Harvester]] 集群的方式：
     warning:
-      label: 这是一个 Harvester 集群 - 请启用 Harvester 功能开关以对其进行管理。
+      label: 这是一个 [[Harvester]] 集群 - 请启用 [[Harvester]] 功能开关以对其进行管理。
       state: 警告
       cloudProvider:
         incompatible:
-          由于当前的 Harvester 版本与所选的 RKE2 Kubernetes 版本不兼容，因此你无法选择 Harvester cloud provider。请单击 <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.suse.com/suse-harvester/support-matrix/all-supported-versions">此处</a>查看支持的 Kubernetes 版本。
+          由于当前的 [[Harvester]] 版本与所选的 RKE2 Kubernetes 版本不兼容，因此你无法选择 [[Harvester]] cloud provider。请单击 <a target="_blank" rel="noopener noreferrer nofollow" href="https://www.suse.com/suse-harvester/support-matrix/all-supported-versions">此处</a>查看支持的 Kubernetes 版本。
     clusterWarning: |-
       还有 {count, plural,
-      =1 {1 个 Harvester 集群未显示}
-      other { # 个 Harvester 集群未显示}
+      =1 {1 个 [[Harvester]] 集群未显示}
+      other { # 个 [[Harvester]] 集群未显示}
       }
     registration:
-      step1: "1. 前往目标 Harvester UI 的<code>高级设置</code>页面。"
+      step1: "1. 前往目标 [[Harvester]] UI 的<code>高级设置</code>页面。"
       step2: '2. 找到<code>cluster-registration-url</code>设置项，并点击<code><i class="icon icon-actions" ></i></code> -> <code>编辑设置</code>按钮。'
       step3: "3. 输入以下注册 URL，并点击<code>保存</code>。"
       step4: "注册 URL"
@@ -1789,7 +1789,7 @@ cluster:
     google: Google GCE
     googlegke: Google GKE
     gke: Google GKE
-    harvester: Harvester
+    harvester: '[[Harvester]]'
     huaweicce: 华为 CCE
     import: 通用
     imported: 已导入
@@ -2116,21 +2116,21 @@ fleet:
   clusters:
     harvester: |-
       还有 {count, plural,
-      =1 {1个 Harvester 集群未显示，因为它不能与持续交付一起使用。}
-      other { #个 Harvester 集群未显示，因为它们不能与持续交付一起使用。}
+      =1 {1个 [[Harvester]] 集群未显示，因为它不能与持续交付一起使用。}
+      other { #个 [[Harvester]] 集群未显示，因为它们不能与持续交付一起使用。}
       }
   tokens:
     harvester: |-
       {count, plural,
-      =1 {1个 Token 未显示，因为它属于不能与持续交付一起使用的 Harvester 集群。}
-      other {#个 Token 未显示，因为它属于不能与持续交付一起使用的 Harvester 集群。}
+      =1 {1个 Token 未显示，因为它属于不能与持续交付一起使用的 [[Harvester]] 集群。}
+      other {#个 Token 未显示，因为它属于不能与持续交付一起使用的 [[Harvester]] 集群。}
       }
   bundles:
     resources: 资源
     harvester: |-
       {count, plural,
-      =1 {1 个 Bundle 未显示，因为它属于不能与持续交付一起使用的 Harvester 集群。}
-      other {# 个 Bundle 未显示，因为它属于不能与持续交付一起使用的 Harvester 集群。}
+      =1 {1 个 Bundle 未显示，因为它属于不能与持续交付一起使用的 [[Harvester]] 集群。}
+      other {# 个 Bundle 未显示，因为它属于不能与持续交付一起使用的 [[Harvester]] 集群。}
       }
   fleetSummary:
     noClusters:
@@ -3738,7 +3738,7 @@ persistentVolume:
       disk-csi-azure-com: Azure 磁盘 (CSI)
       file-csi-azure-com: Azure 文件 (CSI)
       driver-longhorn-io: Longhorn (CSI)
-      driver-harvesterhci-io: Harvester (CSI)
+      driver-harvesterhci-io: '[[Harvester]] (CSI)'
       nfs-csi-k8s-io: NFS (CSI)
       ebs-csi-aws-com: AWS Elastic Block Store (CSI)
       rbd-csi-ceph-com: Ceph RBD (CSI)
@@ -5283,13 +5283,13 @@ storageClass:
     title: （已弃用）
     warning: '{provisioner} 树内插件已弃用。你可以在<a target="_blank" rel="noopener noreferrer nofollow" href="https://kubernetes-csi.github.io/docs/drivers.html">这里</a>查找 CSI 驱动。'
   harvesterhci:
-    title: Harvester (CSI)
+    title: '[[Harvester]] (CSI)'
     warning:
-      unSatisfiesVersion: 请升级 Harvester CSI 驱动版本来使用此功能(csi-driver >= v0.1.15)
+      unSatisfiesVersion: 请升级 [[Harvester]] CSI 驱动版本来使用此功能(csi-driver >= v0.1.15)
     hostStorageClass:
       label: 主机存储类
-      placeholder: 主机 Harvester 集群上的存储类名称
-      tooltip: 默认使用主机 Harvester 集群上的默认存储类。
+      placeholder: 主机 [[Harvester]] 集群上的存储类名称
+      tooltip: 默认使用主机 [[Harvester]] 集群上的默认存储类。
 
 tableHeaders:
   assuredConcurrencyShares: 确保并发份额
@@ -6696,8 +6696,8 @@ typeLabel:
     }
   harvesterhci.io.management.cluster: |-
     {count, plural,
-      one { Harvester 集群 }
-      other { Harvester 集群 }
+      one { [[Harvester]] 集群 }
+      other { [[Harvester]] 集群 }
     }
   harvesterhci.io.cloudtemplate: |-
     {count, plural,
@@ -7044,7 +7044,7 @@ featureFlags:
     title: 等待重启
     wait: 重启需要数分钟。
   description:
-    harvester: 接入 Harvester，以导入和管理 Harvester 集群
+    harvester: 接入 [[Harvester]]，以导入和管理 [[Harvester]] 集群
     unsupported-storage-drivers: 允许使用非默认启用的存储提供商和卷插件
     legacy: 启用旧版功能
     istio-virtual-service-ui: 暴露了一个用户界面，使用户能够创建、读取、更新和删除虚拟服务和目标规则，这是 Istio 的流量管理功能。

--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -437,7 +437,7 @@ export class Plugin implements IPlugin {
     await this._onLogOut(store);
   }
 
-  public register(type: string, name: string, fn: Function | String) {
+  public register(type: string, name: string, fn: Function | string) {
     const allowPaths = ['models', 'image'];
     const nparts = name.split('/');
 

--- a/shell/core/plugin.ts
+++ b/shell/core/plugin.ts
@@ -41,6 +41,12 @@ export const EXT_IDS = {
    * Extension can provide resources that use server-side-pagination
    */
   SERVER_SIDE_PAGINATION_RESOURCES: 'server-side-pagination',
+  /**
+   * Extensions can provide values for l10n global tokens ([[name]]) referenced
+   * from translation strings. Values may be a string or a function returning a
+   * string. If a global is not registered, the token name is used as the value.
+   */
+  I18N_GLOBAL:                      'l10n-global',
 } as const;
 export type EXT_IDS_VALUES = (typeof EXT_IDS)[keyof typeof EXT_IDS];
 
@@ -431,7 +437,7 @@ export class Plugin implements IPlugin {
     await this._onLogOut(store);
   }
 
-  public register(type: string, name: string, fn: Function) {
+  public register(type: string, name: string, fn: Function | String) {
     const allowPaths = ['models', 'image'];
     const nparts = name.split('/');
 
@@ -450,14 +456,14 @@ export class Plugin implements IPlugin {
         this.l10n[name] = [];
       }
 
-      this.l10n[name].push(fn);
+      this.l10n[name].push(fn as Function);
 
     // Accumulate model extensions
     } else if (type === EXT_IDS.MODEL_EXTENSION) {
       if (!this.modelExtensions[name]) {
         this.modelExtensions[name] = [];
       }
-      this.modelExtensions[name].push(fn);
+      this.modelExtensions[name].push(fn as Function);
     } else {
       if (!this.types[type]) {
         this.types[type] = {};

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -686,11 +686,19 @@ export interface IExtension extends IExtensionProducts {
 
   /**
    * Register 'something' that can be dynamically loaded - e.g. model, edit, create, list, i18n
+   *
+   * A special type `'l10n-global'` can be used to register a value that will be
+   * substituted for `[[name]]` tokens in translation strings, allowing shared
+   * terms (e.g. product names) to be defined once and referenced across
+   * localisations. The value can be a string or a function returning a string.
+   * If no global is registered for a given name, the token's name is used as
+   * the value.
+   *
    * @param {String} type type of thing to register, e.g. 'edit'
    * @param {String} name unique name of 'something'
-   * @param {Function} fn function that dynamically loads the module for the thing being registered
+   * @param {Function|String|Boolean} fn function that dynamically loads the module for the thing being registered, or (for `l10n-global`) the value itself
    */
-  register(type: string, name: string, fn: Function | Boolean): void;
+  register(type: string, name: string, fn: Function | Boolean | String): void;
 
   /**
    * Will return all of the configuration functions used for creating a new product.

--- a/shell/core/types.ts
+++ b/shell/core/types.ts
@@ -696,9 +696,9 @@ export interface IExtension extends IExtensionProducts {
    *
    * @param {String} type type of thing to register, e.g. 'edit'
    * @param {String} name unique name of 'something'
-   * @param {Function|String|Boolean} fn function that dynamically loads the module for the thing being registered, or (for `l10n-global`) the value itself
+   * @param {Function|string|boolean} fn function that dynamically loads the module for the thing being registered, or (for `l10n-global`) the value itself
    */
-  register(type: string, name: string, fn: Function | Boolean | String): void;
+  register(type: string, name: string, fn: Function | boolean | string): void;
 
   /**
    * Will return all of the configuration functions used for creating a new product.

--- a/shell/store/__tests__/i18n.test.ts
+++ b/shell/store/__tests__/i18n.test.ts
@@ -33,8 +33,17 @@ function makeTranslations() {
   };
 }
 
-function makeState(overrides?: Partial<ReturnType<typeof state>>): ReturnType<typeof state> {
-  const base = state();
+type I18nState = ReturnType<typeof state>;
+type TestI18nState = Omit<I18nState, 'selected' | 'previous' | 'default' | 'available' | 'translations'> & {
+  selected: string | null;
+  previous: string | null;
+  default: string;
+  available: string[];
+  translations: Record<string, any>;
+};
+
+function makeState(overrides?: Partial<TestI18nState>): TestI18nState {
+  const base = state() as TestI18nState;
 
   base.translations = makeTranslations() as any;
   base.selected = 'en-us';
@@ -46,7 +55,7 @@ function makeState(overrides?: Partial<ReturnType<typeof state>>): ReturnType<ty
 
 // ----- helpers to build mock getters (for testing getters.withFallback / multiWithFallback) -----
 
-function makeMockGetters(st: ReturnType<typeof state>) {
+function makeMockGetters(st: TestI18nState) {
   const g: Record<string, any> = {};
 
   g.t = getters.t(st);

--- a/shell/store/__tests__/i18n.test.ts
+++ b/shell/store/__tests__/i18n.test.ts
@@ -5,6 +5,8 @@ import {
   getters,
   mutations,
   actions,
+  substituteGlobals,
+  I18N_GLOBAL_TYPE,
 } from '@shell/store/i18n';
 
 jest.mock('@shell/assets/translations/en-us.yaml', () => ({}));
@@ -205,6 +207,90 @@ describe('i18n store', () => {
         const translate = getters.t(s);
 
         expect(translate('greeting', {}, 'en-us')).toStrictEqual('Hello');
+      });
+
+      describe('i18n globals ([[name]] substitution)', () => {
+        // The formatter cache in i18n.js is keyed by locale/key; use unique keys
+        // per test so results do not leak between cases.
+        function stateWithGlobalMsg(key: string, msg: string) {
+          const s = makeState({ selected: 'en-us' });
+
+          (s.translations as any)['en-us'][key] = msg;
+
+          return s;
+        }
+
+        function extensionWith(globals: Record<string, string | Function>) {
+          return {
+            getDynamic: (type: string, name: string) => {
+              return type === I18N_GLOBAL_TYPE ? globals[name] : undefined;
+            }
+          };
+        }
+
+        it('substitutes a [[name]] token with the registered global value', () => {
+          const s = stateWithGlobalMsg('i18nGlobal.registered', 'Manage your [[Harvester]] cluster');
+          const rootState = { $extension: extensionWith({ Harvester: 'Rancher Virtualization' }) };
+          const translate = getters.t(s, undefined, rootState);
+
+          expect(translate('i18nGlobal.registered')).toStrictEqual('Manage your Rancher Virtualization cluster');
+        });
+
+        it('falls back to the token name when the global is not registered', () => {
+          const s = stateWithGlobalMsg('i18nGlobal.unregistered', 'Manage your [[Harvester]] cluster');
+          const rootState = { $extension: extensionWith({}) };
+          const translate = getters.t(s, undefined, rootState);
+
+          expect(translate('i18nGlobal.unregistered')).toStrictEqual('Manage your Harvester cluster');
+        });
+
+        it('evaluates function-valued globals when substituting', () => {
+          const s = stateWithGlobalMsg('i18nGlobal.function', 'Welcome to [[Product]]');
+          const rootState = { $extension: extensionWith({ Product: () => 'Fabric' }) };
+          const translate = getters.t(s, undefined, rootState);
+
+          expect(translate('i18nGlobal.function')).toStrictEqual('Welcome to Fabric');
+        });
+
+        it('preserves the literal [[name]] when the token is escaped with a backslash', () => {
+          const s = stateWithGlobalMsg('i18nGlobal.escaped', 'Use \\[[Harvester]] to reference the global');
+          const rootState = { $extension: extensionWith({ Harvester: 'Rancher Virtualization' }) };
+          const translate = getters.t(s, undefined, rootState);
+
+          expect(translate('i18nGlobal.escaped')).toStrictEqual('Use [[Harvester]] to reference the global');
+        });
+
+        it('substitutes multiple different tokens in the same message', () => {
+          const s = stateWithGlobalMsg('i18nGlobal.multiple', '[[Product]] on [[Platform]]');
+          const rootState = { $extension: extensionWith({ Product: 'Fabric', Platform: 'Kubernetes' }) };
+          const translate = getters.t(s, undefined, rootState);
+
+          expect(translate('i18nGlobal.multiple')).toStrictEqual('Fabric on Kubernetes');
+        });
+
+        it('substitutes before IntlMessageFormat args are interpolated', () => {
+          const s = stateWithGlobalMsg('i18nGlobal.withArgs', 'Found {count} [[Harvester]] cluster(s)');
+          const rootState = { $extension: extensionWith({ Harvester: 'Rancher Virtualization' }) };
+          const translate = getters.t(s, undefined, rootState);
+
+          expect(translate('i18nGlobal.withArgs', { count: 3 })).toStrictEqual('Found 3 Rancher Virtualization cluster(s)');
+        });
+
+        it('leaves messages without [[ tokens unchanged', () => {
+          const s = stateWithGlobalMsg('i18nGlobal.noToken', 'Nothing to substitute here');
+          const rootState = { $extension: extensionWith({ Harvester: 'Rancher Virtualization' }) };
+          const translate = getters.t(s, undefined, rootState);
+
+          expect(translate('i18nGlobal.noToken')).toStrictEqual('Nothing to substitute here');
+        });
+
+        it('does not crash when rootState.$extension is unavailable', () => {
+          const s = stateWithGlobalMsg('i18nGlobal.noExtension', 'Manage your [[Harvester]] cluster');
+          const translate = getters.t(s, undefined, {});
+
+          // With no extension registry available, the token name is used as the value
+          expect(translate('i18nGlobal.noExtension')).toStrictEqual('Manage your Harvester cluster');
+        });
       });
     });
 

--- a/shell/store/__tests__/i18n.test.ts
+++ b/shell/store/__tests__/i18n.test.ts
@@ -5,7 +5,6 @@ import {
   getters,
   mutations,
   actions,
-  substituteGlobals,
   I18N_GLOBAL_TYPE,
 } from '@shell/store/i18n';
 

--- a/shell/store/__tests__/i18n.test.ts
+++ b/shell/store/__tests__/i18n.test.ts
@@ -219,7 +219,9 @@ describe('i18n store', () => {
 
       describe('i18n globals ([[name]] substitution)', () => {
         // The formatter cache in i18n.js is keyed by locale/key; use unique keys
-        // per test so results do not leak between cases.
+        // per test so results do not leak between cases. Keys must not contain
+        // dots — the store looks them up with lodash `get`, which treats dots
+        // as nested-path navigation.
         function stateWithGlobalMsg(key: string, msg: string) {
           const s = makeState({ selected: 'en-us' });
 
@@ -237,67 +239,67 @@ describe('i18n store', () => {
         }
 
         it('substitutes a [[name]] token with the registered global value', () => {
-          const s = stateWithGlobalMsg('i18nGlobal.registered', 'Manage your [[Harvester]] cluster');
+          const s = stateWithGlobalMsg('i18nGlobalRegistered', 'Manage your [[Harvester]] cluster');
           const rootState = { $extension: extensionWith({ Harvester: 'Rancher Virtualization' }) };
           const translate = getters.t(s, undefined, rootState);
 
-          expect(translate('i18nGlobal.registered')).toStrictEqual('Manage your Rancher Virtualization cluster');
+          expect(translate('i18nGlobalRegistered')).toStrictEqual('Manage your Rancher Virtualization cluster');
         });
 
         it('falls back to the token name when the global is not registered', () => {
-          const s = stateWithGlobalMsg('i18nGlobal.unregistered', 'Manage your [[Harvester]] cluster');
+          const s = stateWithGlobalMsg('i18nGlobalUnregistered', 'Manage your [[Harvester]] cluster');
           const rootState = { $extension: extensionWith({}) };
           const translate = getters.t(s, undefined, rootState);
 
-          expect(translate('i18nGlobal.unregistered')).toStrictEqual('Manage your Harvester cluster');
+          expect(translate('i18nGlobalUnregistered')).toStrictEqual('Manage your Harvester cluster');
         });
 
         it('evaluates function-valued globals when substituting', () => {
-          const s = stateWithGlobalMsg('i18nGlobal.function', 'Welcome to [[Product]]');
+          const s = stateWithGlobalMsg('i18nGlobalFunction', 'Welcome to [[Product]]');
           const rootState = { $extension: extensionWith({ Product: () => 'Fabric' }) };
           const translate = getters.t(s, undefined, rootState);
 
-          expect(translate('i18nGlobal.function')).toStrictEqual('Welcome to Fabric');
+          expect(translate('i18nGlobalFunction')).toStrictEqual('Welcome to Fabric');
         });
 
         it('preserves the literal [[name]] when the token is escaped with a backslash', () => {
-          const s = stateWithGlobalMsg('i18nGlobal.escaped', 'Use \\[[Harvester]] to reference the global');
+          const s = stateWithGlobalMsg('i18nGlobalEscaped', 'Use \\[[Harvester]] to reference the global');
           const rootState = { $extension: extensionWith({ Harvester: 'Rancher Virtualization' }) };
           const translate = getters.t(s, undefined, rootState);
 
-          expect(translate('i18nGlobal.escaped')).toStrictEqual('Use [[Harvester]] to reference the global');
+          expect(translate('i18nGlobalEscaped')).toStrictEqual('Use [[Harvester]] to reference the global');
         });
 
         it('substitutes multiple different tokens in the same message', () => {
-          const s = stateWithGlobalMsg('i18nGlobal.multiple', '[[Product]] on [[Platform]]');
+          const s = stateWithGlobalMsg('i18nGlobalMultiple', '[[Product]] on [[Platform]]');
           const rootState = { $extension: extensionWith({ Product: 'Fabric', Platform: 'Kubernetes' }) };
           const translate = getters.t(s, undefined, rootState);
 
-          expect(translate('i18nGlobal.multiple')).toStrictEqual('Fabric on Kubernetes');
+          expect(translate('i18nGlobalMultiple')).toStrictEqual('Fabric on Kubernetes');
         });
 
         it('substitutes before IntlMessageFormat args are interpolated', () => {
-          const s = stateWithGlobalMsg('i18nGlobal.withArgs', 'Found {count} [[Harvester]] cluster(s)');
+          const s = stateWithGlobalMsg('i18nGlobalWithArgs', 'Found {count} [[Harvester]] cluster(s)');
           const rootState = { $extension: extensionWith({ Harvester: 'Rancher Virtualization' }) };
           const translate = getters.t(s, undefined, rootState);
 
-          expect(translate('i18nGlobal.withArgs', { count: 3 })).toStrictEqual('Found 3 Rancher Virtualization cluster(s)');
+          expect(translate('i18nGlobalWithArgs', { count: 3 })).toStrictEqual('Found 3 Rancher Virtualization cluster(s)');
         });
 
         it('leaves messages without [[ tokens unchanged', () => {
-          const s = stateWithGlobalMsg('i18nGlobal.noToken', 'Nothing to substitute here');
+          const s = stateWithGlobalMsg('i18nGlobalNoToken', 'Nothing to substitute here');
           const rootState = { $extension: extensionWith({ Harvester: 'Rancher Virtualization' }) };
           const translate = getters.t(s, undefined, rootState);
 
-          expect(translate('i18nGlobal.noToken')).toStrictEqual('Nothing to substitute here');
+          expect(translate('i18nGlobalNoToken')).toStrictEqual('Nothing to substitute here');
         });
 
         it('does not crash when rootState.$extension is unavailable', () => {
-          const s = stateWithGlobalMsg('i18nGlobal.noExtension', 'Manage your [[Harvester]] cluster');
+          const s = stateWithGlobalMsg('i18nGlobalNoExtension', 'Manage your [[Harvester]] cluster');
           const translate = getters.t(s, undefined, {});
 
           // With no extension registry available, the token name is used as the value
-          expect(translate('i18nGlobal.noExtension')).toStrictEqual('Manage your Harvester cluster');
+          expect(translate('i18nGlobalNoExtension')).toStrictEqual('Manage your Harvester cluster');
         });
       });
     });

--- a/shell/store/i18n.js
+++ b/shell/store/i18n.js
@@ -8,6 +8,42 @@ import { loadTranslation } from '@shell/utils/dynamic-importer';
 const NONE = 'none';
 const DEFAULT_LOCALE = 'en-us';
 
+// Extension type used to register i18n global values, referenced in translation
+// strings using [[name]] notation. See `substituteGlobals` below.
+export const I18N_GLOBAL_TYPE = 'l10n-global';
+
+// Matches [[name]] where name is any character except ']' and where the opening
+// `[[` is NOT preceded by a backslash (which is the escape sequence).
+const GLOBAL_PATTERN = /(\\?)\[\[([^\]]+)\]\]/g;
+
+/**
+ * Replace [[name]] tokens with values registered as i18n globals via
+ * `extension.register('i18n-global', name, value)`. If the token is not
+ * registered, the name itself is used as the value. Use `\[[` to include a
+ * literal `[[` in a translation string.
+ *
+ * @param {string} msg
+ * @param {any} $extension
+ * @returns {string}
+ */
+export function substituteGlobals(msg, $extension) {
+  if (typeof msg !== 'string' || !msg.includes('[[')) {
+    return msg;
+  }
+
+  return msg.replace(GLOBAL_PATTERN, (_match, escape, name) => {
+    if (escape) {
+      // Preserve the literal token, stripping only the escape character
+      return `[[${ name }]]`;
+    }
+
+    const registered = $extension?.getDynamic?.(I18N_GLOBAL_TYPE, name);
+    const value = typeof registered === 'function' ? registered() : registered;
+
+    return value !== undefined && value !== null ? String(value) : name;
+  });
+}
+
 // Formatters can't be serialized into state
 const intlCache = {};
 
@@ -62,7 +98,7 @@ export const getters = {
     return state.available.length > 1;
   },
 
-  t: (state) => (key, args, language) => {
+  t: (state, _getters, rootState) => (key, args, language) => {
     if (state.selected === NONE && !language) {
       return `%${ key }%`;
     }
@@ -88,10 +124,14 @@ export const getters = {
         return undefined;
       }
 
-      if ( msg?.includes('{')) {
-        formatter = new IntlMessageFormat(msg, locale);
+      // Substitute [[name]] tokens with values registered as i18n globals.
+      const hasGlobal = msg.includes('[[');
+      const substituted = hasGlobal ? substituteGlobals(msg, rootState?.$extension) : msg;
+
+      if ( substituted?.includes('{')) {
+        formatter = new IntlMessageFormat(substituted, locale);
       } else {
-        formatter = msg;
+        formatter = substituted;
       }
 
       intlCache[cacheKey] = formatter;

--- a/shell/store/i18n.js
+++ b/shell/store/i18n.js
@@ -18,7 +18,7 @@ const GLOBAL_PATTERN = /(\\?)\[\[([^\]]+)\]\]/g;
 
 /**
  * Replace [[name]] tokens with values registered as i18n globals via
- * `extension.register('i18n-global', name, value)`. If the token is not
+ * `extension.register('l10n-global', name, value)`. If the token is not
  * registered, the name itself is used as the value. Use `\[[` to include a
  * literal `[[` in a translation string.
  *

--- a/shell/types/extension-manager.ts
+++ b/shell/types/extension-manager.ts
@@ -1,7 +1,7 @@
 import { EXT_IDS_VALUES } from '@shell/core/plugin';
 import { ClusterProvisionerContext } from '@shell/core/types';
 
-type ExtensionManagerType = { [name: string]: Function, }
+type ExtensionManagerType = { [name: string]: Function | String }
 export type ExtensionManagerTypes =
   { [type in EXT_IDS_VALUES]?: ExtensionManagerType } & // eslint-disable-line no-unused-vars
   { [name: string]: ExtensionManagerType }
@@ -17,7 +17,7 @@ export type ExtensionManager = {
   removePlugin(name: string): Promise<void>;
   removeTypeFromStore(store: any, storeName: string, types: string[]): any[];
   applyPlugin(plugin: any): void;
-  register(type: string, name: string, fn: Function): void;
+  register(type: string, name: string, fn: Function | String): void;
   unregister(type: string, name: string, fn: Function): void;
   getAll(): ExtensionManagerTypes;
   getPlugins(): any;

--- a/shell/types/extension-manager.ts
+++ b/shell/types/extension-manager.ts
@@ -17,7 +17,7 @@ export type ExtensionManager = {
   removePlugin(name: string): Promise<void>;
   removeTypeFromStore(store: any, storeName: string, types: string[]): any[];
   applyPlugin(plugin: any): void;
-  register(type: string, name: string, fn: Function | String): void;
+  register(type: string, name: string, fn: Function | string): void;
   unregister(type: string, name: string, fn: Function): void;
   getAll(): ExtensionManagerTypes;
   getPlugins(): any;

--- a/shell/types/extension-manager.ts
+++ b/shell/types/extension-manager.ts
@@ -1,7 +1,7 @@
 import { EXT_IDS_VALUES } from '@shell/core/plugin';
 import { ClusterProvisionerContext } from '@shell/core/types';
 
-type ExtensionManagerType = { [name: string]: Function | String }
+type ExtensionManagerType = { [name: string]: Function | string }
 export type ExtensionManagerTypes =
   { [type in EXT_IDS_VALUES]?: ExtensionManagerType } & // eslint-disable-line no-unused-vars
   { [name: string]: ExtensionManagerType }

--- a/shell/utils/pagination-utils.ts
+++ b/shell/utils/pagination-utils.ts
@@ -181,7 +181,7 @@ class PaginationUtils {
 
     if (paginationExtensionPoints) {
       const allowed = Object.entries(paginationExtensionPoints).find(([_, settingsFn]) => {
-        if (!settingsFn) {
+        if (typeof settingsFn !== 'function') {
           return false;
         }
 


### PR DESCRIPTION
### Summary
Fixes #18646

Adds support for i18n global tokens — `[[name]]` placeholders in translation strings that are resolved at runtime via values registered by extensions. This allows shared terms (e.g. product names) to be changed depending on whether a Community or Prime build of an extension is running.

We use this mechanism to allow us to change the product name for Harvester to 'SUSE Vitualization' when needed - this will cover the strings for Harvester that are built into dashboard.

The way this works, when Community, we will use 'Harvester' and when Prime, 'SUSE Virtualization'.

We will need to update the Harvester extension to also update its strings - it won't be able to use this mechanism for now directly, since this change will only be in 2.16, but it can do the same thing in a similar way - it can also set the i18n global, so if you install the Harvester extension (not SUSE Virt) into Prime, it will change back to Harvester.

### Occurred changes and/or fixed issues
- Added `substituteGlobals` function in `shell/store/i18n.js` to replace `[[name]]` tokens with values registered via `plugin.register('l10n-global', name, value)`.
- Extended `EXT_IDS` in `shell/core/plugin.ts` with `I18N_GLOBAL` constant and updated `register()` to accept `String` values (not only `Function`).
- Updated type definitions in `shell/core/types.ts` and `shell/types/extension-manager.ts` to reflect the new `String` union type for registered values.
- Harvester Manager uses the new feature to override the product name to `SUSE Virtualization` when running in a Rancher Prime environment.
- Corresponding translation files (`en-us.yaml`, `zh-hans.yaml`) updated to use `[[Harvester]]` tokens where the Harvester product name appears.
- Added unit tests for `substituteGlobals` in `shell/store/__tests__/i18n.test.ts`.

### Technical notes summary
- Token syntax: `[[name]]` in a translation string is replaced by the registered global value for `name`. If no global is registered, the token name itself is used as the fallback.
- Escape sequence: `\[[name]]` outputs a literal `[[name]]` without substitution.
- The value registered via `plugin.register('l10n-global', name, value)` can be a plain string or a function returning a string.
- The i18n `t` getter now receives `rootState` so it can access `$extension` for global lookups.

### Areas or cases that should be tested
- Verify `[[Harvester]]` tokens in translation strings are replaced with `Harvester` by default.
- In a Rancher Prime environment, verify `[[Harvester]]` is replaced with `SUSE Virtualization` throughout the Harvester Manager product.
- Verify `\[[Harvester]]` renders as the literal text `[[Harvester]]`.
- Verify that translation strings without `[[` tokens are unaffected (no performance regression).
- Test in both English (`en-us`) and Chinese (`zh-hans`) locales.

### Areas which could experience regressions
- Any translation string containing `[[` that was previously treated as a literal character will now be subject to token substitution. Existing strings should be audited if they contain `[[`.
- The i18n `t` getter signature change (added `rootState`) — any code that calls the getter directly may be affected.

### Screenshot/Video

With this change:

Non-Prime:

<img width="1291" height="669" alt="image" src="https://github.com/user-attachments/assets/df31a00a-ade1-4156-aa9f-39eaac9396de" />

Prime:

<img width="1291" height="669" alt="image" src="https://github.com/user-attachments/assets/51151727-d197-4027-a3a7-9f229db6c2d4" />

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
