### PR TITLE
[17943][Fleet] Fix Fleet docs links in the AppCo HelmOp integration

### DIFF
--- a/shell/components/fleet/HelmOpAppCoResourcesSection.vue
+++ b/shell/components/fleet/HelmOpAppCoResourcesSection.vue
@@ -9,7 +9,6 @@ import { RcSection } from '@components/RcSection';
 import FleetSecretSelector from '@shell/components/fleet/FleetSecretSelector.vue';
 import FleetConfigMapSelector from '@shell/components/fleet/FleetConfigMapSelector.vue';
 import { RcIcon } from '@components/RcIcon';
-import { isRancherPrime } from '@shell/config/version';
 import { getDownstreamResourcesDocsUrl } from '@shell/utils/fleet-appco';
 
 const props = withDefaults(defineProps<{
@@ -30,7 +29,7 @@ const emit = defineEmits<{
 const store = useStore();
 const { t } = useI18n(store);
 
-const DOCS_URL = getDownstreamResourcesDocsUrl(isRancherPrime());
+const DOCS_URL = getDownstreamResourcesDocsUrl();
 
 const { updateCorrectDrift, updateSecrets, updateDownstreamResources } = useHelmOpResources(emit, toRef(props, 'lockedSecrets'));
 </script>

--- a/shell/components/fleet/HelmOpAppCoResourcesSection.vue
+++ b/shell/components/fleet/HelmOpAppCoResourcesSection.vue
@@ -9,7 +9,7 @@ import { RcSection } from '@components/RcSection';
 import FleetSecretSelector from '@shell/components/fleet/FleetSecretSelector.vue';
 import FleetConfigMapSelector from '@shell/components/fleet/FleetConfigMapSelector.vue';
 import { RcIcon } from '@components/RcIcon';
-import { getVersionData, isRancherPrime } from '@shell/config/version';
+import { isRancherPrime } from '@shell/config/version';
 import { getDownstreamResourcesDocsUrl } from '@shell/utils/fleet-appco';
 
 const props = withDefaults(defineProps<{
@@ -30,7 +30,7 @@ const emit = defineEmits<{
 const store = useStore();
 const { t } = useI18n(store);
 
-const DOCS_URL = getDownstreamResourcesDocsUrl(getVersionData()?.Version, isRancherPrime());
+const DOCS_URL = getDownstreamResourcesDocsUrl(isRancherPrime());
 
 const { updateCorrectDrift, updateSecrets, updateDownstreamResources } = useHelmOpResources(emit, toRef(props, 'lockedSecrets'));
 </script>

--- a/shell/components/fleet/HelmOpAppCoResourcesSection.vue
+++ b/shell/components/fleet/HelmOpAppCoResourcesSection.vue
@@ -9,7 +9,7 @@ import { RcSection } from '@components/RcSection';
 import FleetSecretSelector from '@shell/components/fleet/FleetSecretSelector.vue';
 import FleetConfigMapSelector from '@shell/components/fleet/FleetConfigMapSelector.vue';
 import { RcIcon } from '@components/RcIcon';
-import { getVersionData } from '@shell/config/version';
+import { getVersionData, isRancherPrime } from '@shell/config/version';
 import { getDownstreamResourcesDocsUrl } from '@shell/utils/fleet-appco';
 
 const props = withDefaults(defineProps<{
@@ -30,7 +30,7 @@ const emit = defineEmits<{
 const store = useStore();
 const { t } = useI18n(store);
 
-const DOCS_URL = getDownstreamResourcesDocsUrl(getVersionData()?.Version);
+const DOCS_URL = getDownstreamResourcesDocsUrl(getVersionData()?.Version, isRancherPrime());
 
 const { updateCorrectDrift, updateSecrets, updateDownstreamResources } = useHelmOpResources(emit, toRef(props, 'lockedSecrets'));
 </script>

--- a/shell/components/fleet/HelmOpTargetOptionsSection.vue
+++ b/shell/components/fleet/HelmOpTargetOptionsSection.vue
@@ -3,7 +3,7 @@ import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
 import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 import { RcIcon } from '@components/RcIcon';
-import { getVersionData, isRancherPrime } from '@shell/config/version';
+import { isRancherPrime } from '@shell/config/version';
 import { getBundleDeploymentOptionsDocsUrl } from '@shell/utils/fleet-appco';
 
 withDefaults(defineProps<{
@@ -15,7 +15,7 @@ withDefaults(defineProps<{
 const store = useStore();
 const { t } = useI18n(store);
 
-const DOCS_URL = getBundleDeploymentOptionsDocsUrl(getVersionData()?.Version, isRancherPrime());
+const DOCS_URL = getBundleDeploymentOptionsDocsUrl(isRancherPrime());
 </script>
 
 <template>

--- a/shell/components/fleet/HelmOpTargetOptionsSection.vue
+++ b/shell/components/fleet/HelmOpTargetOptionsSection.vue
@@ -3,6 +3,8 @@ import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
 import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 import { RcIcon } from '@components/RcIcon';
+import { getVersionData, isRancherPrime } from '@shell/config/version';
+import { getBundleDeploymentOptionsDocsUrl } from '@shell/utils/fleet-appco';
 
 withDefaults(defineProps<{
   value: { spec: { serviceAccount?: string; namespace?: string } };
@@ -13,7 +15,7 @@ withDefaults(defineProps<{
 const store = useStore();
 const { t } = useI18n(store);
 
-const DOCS_URL = 'https://fleet.rancher.io/reference/ref-crds#_bundledeploymentoptions';
+const DOCS_URL = getBundleDeploymentOptionsDocsUrl(getVersionData()?.Version, isRancherPrime());
 </script>
 
 <template>

--- a/shell/components/fleet/HelmOpTargetOptionsSection.vue
+++ b/shell/components/fleet/HelmOpTargetOptionsSection.vue
@@ -3,7 +3,6 @@ import { useStore } from 'vuex';
 import { useI18n } from '@shell/composables/useI18n';
 import LabeledInput from '@components/Form/LabeledInput/LabeledInput.vue';
 import { RcIcon } from '@components/RcIcon';
-import { isRancherPrime } from '@shell/config/version';
 import { getBundleDeploymentOptionsDocsUrl } from '@shell/utils/fleet-appco';
 
 withDefaults(defineProps<{
@@ -15,7 +14,7 @@ withDefaults(defineProps<{
 const store = useStore();
 const { t } = useI18n(store);
 
-const DOCS_URL = getBundleDeploymentOptionsDocsUrl(isRancherPrime());
+const DOCS_URL = getBundleDeploymentOptionsDocsUrl();
 </script>
 
 <template>

--- a/shell/components/fleet/__tests__/__snapshots__/HelmOpTargetOptionsSection.test.ts.snap
+++ b/shell/components/fleet/__tests__/__snapshots__/HelmOpTargetOptionsSection.test.ts.snap
@@ -10,7 +10,7 @@ exports[`component: HelmOpTargetOptionsSection should match snapshot in compact 
     <br />
      %generic.learnMoreAbout% 
     <a
-      href="https://fleet.rancher.io/reference/ref-crds#_bundledeploymentoptions"
+      href="https://fleet.rancher.io/next/reference/ref-crds#_bundledeploymentoptions"
       rel="noopener noreferrer nofollow"
       target="_blank"
     >

--- a/shell/utils/__tests__/fleet-appco.test.ts
+++ b/shell/utils/__tests__/fleet-appco.test.ts
@@ -72,7 +72,7 @@ describe('fleet-appco utils', () => {
   });
 
   describe('getDownstreamResourcesDocsUrl', () => {
-    describe('when running past the release that introduced the docs (current channel)', () => {
+    describe('when running a later release than the one that introduced the docs (current channel)', () => {
       beforeEach(() => mockRunningVersion('v2.15.1'));
 
       it('should use the community docs at the root when not Prime', () => {
@@ -86,9 +86,15 @@ describe('fleet-appco utils', () => {
       it('should use the latest SUSE docs when Prime', () => {
         expect(getDownstreamResourcesDocsUrl(true)).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/how-tos-for-users/downstream-resource-propagation.html');
       });
+
+      it('should also use the current docs on a later minor', () => {
+        mockRunningVersion('v2.16.0');
+        expect(getDownstreamResourcesDocsUrl(false)).toStrictEqual('https://fleet.rancher.io/how-tos-for-users/downstream-resource-propagation');
+        expect(getDownstreamResourcesDocsUrl(true)).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/how-tos-for-users/downstream-resource-propagation.html');
+      });
     });
 
-    describe('when running the release that introduced the docs (next channel)', () => {
+    describe('when running the exact release that introduced the docs (next channel)', () => {
       beforeEach(() => mockRunningVersion('v2.15.0'));
 
       it('should use the community "next" docs when not Prime', () => {
@@ -111,7 +117,7 @@ describe('fleet-appco utils', () => {
   });
 
   describe('getBundleDeploymentOptionsDocsUrl', () => {
-    describe('when running past the release that introduced the docs (current channel)', () => {
+    describe('when running a later release than the one that introduced the docs (current channel)', () => {
       beforeEach(() => mockRunningVersion('v2.15.1'));
 
       it('should use the community CRD reference (with anchor) at the root when not Prime', () => {
@@ -127,7 +133,7 @@ describe('fleet-appco utils', () => {
       });
     });
 
-    describe('when running the release that introduced the docs (next channel)', () => {
+    describe('when running the exact release that introduced the docs (next channel)', () => {
       beforeEach(() => mockRunningVersion('v2.15.0'));
 
       it('should use the community "next" CRD reference (with anchor) when not Prime', () => {

--- a/shell/utils/__tests__/fleet-appco.test.ts
+++ b/shell/utils/__tests__/fleet-appco.test.ts
@@ -1,5 +1,5 @@
 import {
-  deriveRepoName, fetchAppCoCharts, ensureAppCoResources, ensureAppCoImagePullSecret, getDownstreamResourcesDocsUrl, FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL, FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_FALLBACK_URL, getBundleDeploymentOptionsDocsUrl, FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL, FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_FALLBACK_URL
+  deriveRepoName, fetchAppCoCharts, ensureAppCoResources, ensureAppCoImagePullSecret, getDownstreamResourcesDocsUrl, FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL, FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_URL, getBundleDeploymentOptionsDocsUrl, FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL, FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_URL
 } from '@shell/utils/fleet-appco';
 import { SECRET, CATALOG as CATALOG_TYPES } from '@shell/config/types';
 import { SECRET_TYPES } from '@shell/config/secret';
@@ -62,84 +62,34 @@ describe('fleet-appco utils', () => {
   });
 
   describe('getDownstreamResourcesDocsUrl', () => {
-    describe('community (non-Prime)', () => {
-      it.each([
-        ['v2.15.0'],
-        ['v2.20.0'],
-        ['dev'],
-        [''],
-        [undefined],
-      ])('should always use the unversioned community docs, regardless of version (%s)', (version) => {
-        expect(getDownstreamResourcesDocsUrl(version, false)).toStrictEqual(FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL);
-      });
-
-      it('should default to community docs when isPrime is omitted', () => {
-        expect(getDownstreamResourcesDocsUrl('v2.15.0')).toStrictEqual(FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL);
-      });
+    it('should use the unversioned community docs when not Prime', () => {
+      expect(getDownstreamResourcesDocsUrl(false)).toStrictEqual(FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL);
+      expect(FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL).toStrictEqual('https://fleet.rancher.io/how-tos-for-users/downstream-resource-propagation');
     });
 
-    describe('Prime', () => {
-      it.each([
-        ['v2.15.0', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.16/en/how-tos-for-users/downstream-resource-propagation.html'],
-        ['2.15.0', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.16/en/how-tos-for-users/downstream-resource-propagation.html'],
-        ['v2.16.3', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.17/en/how-tos-for-users/downstream-resource-propagation.html'],
-        ['v2.15.0-rc1', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.16/en/how-tos-for-users/downstream-resource-propagation.html'],
-        ['v2.15-head', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.16/en/how-tos-for-users/downstream-resource-propagation.html'],
-        ['v2.20.0', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.21/en/how-tos-for-users/downstream-resource-propagation.html'],
-      ])('should map Rancher %s to versioned SUSE docs %s', (version, expected) => {
-        expect(getDownstreamResourcesDocsUrl(version, true)).toStrictEqual(expected);
-      });
+    it('should default to the community docs when isPrime is omitted', () => {
+      expect(getDownstreamResourcesDocsUrl()).toStrictEqual(FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL);
+    });
 
-      it.each([
-        ['v2.14.0'],
-        ['v2.9.0'],
-        ['dev'],
-        [''],
-        [undefined],
-      ])('should fall back to the latest SUSE docs for %s', (version) => {
-        expect(getDownstreamResourcesDocsUrl(version, true)).toStrictEqual(FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_FALLBACK_URL);
-      });
+    it('should use the latest SUSE docs when Prime', () => {
+      expect(getDownstreamResourcesDocsUrl(true)).toStrictEqual(FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_URL);
+      expect(FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_URL).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/how-tos-for-users/downstream-resource-propagation.html');
     });
   });
 
   describe('getBundleDeploymentOptionsDocsUrl', () => {
-    describe('community (non-Prime)', () => {
-      it.each([
-        ['v2.15.0'],
-        ['v2.20.0'],
-        ['dev'],
-        [''],
-        [undefined],
-      ])('should always use the unversioned community CRD reference, regardless of version (%s)', (version) => {
-        expect(getBundleDeploymentOptionsDocsUrl(version, false)).toStrictEqual(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL);
-      });
-
-      it('should keep the bundledeploymentoptions anchor', () => {
-        expect(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL).toStrictEqual('https://fleet.rancher.io/reference/ref-crds#_bundledeploymentoptions');
-      });
-
-      it('should default to community docs when isPrime is omitted', () => {
-        expect(getBundleDeploymentOptionsDocsUrl('v2.15.0')).toStrictEqual(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL);
-      });
+    it('should use the unversioned community CRD reference (with anchor) when not Prime', () => {
+      expect(getBundleDeploymentOptionsDocsUrl(false)).toStrictEqual(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL);
+      expect(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL).toStrictEqual('https://fleet.rancher.io/reference/ref-crds#_bundledeploymentoptions');
     });
 
-    describe('Prime', () => {
-      it.each([
-        ['v2.15.0', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.16/en/reference/ref-crds.html#_bundledeploymentoptions'],
-        ['v2.16.3', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.17/en/reference/ref-crds.html#_bundledeploymentoptions'],
-        ['v2.20.0', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.21/en/reference/ref-crds.html#_bundledeploymentoptions'],
-      ])('should map Rancher %s to versioned SUSE CRD reference %s', (version, expected) => {
-        expect(getBundleDeploymentOptionsDocsUrl(version, true)).toStrictEqual(expected);
-      });
+    it('should default to the community docs when isPrime is omitted', () => {
+      expect(getBundleDeploymentOptionsDocsUrl()).toStrictEqual(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL);
+    });
 
-      it.each([
-        ['v2.14.0'],
-        ['dev'],
-        [''],
-        [undefined],
-      ])('should fall back to the latest SUSE docs for %s', (version) => {
-        expect(getBundleDeploymentOptionsDocsUrl(version, true)).toStrictEqual(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_FALLBACK_URL);
-      });
+    it('should use the latest SUSE CRD reference (with anchor) when Prime', () => {
+      expect(getBundleDeploymentOptionsDocsUrl(true)).toStrictEqual(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_URL);
+      expect(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_URL).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/reference/ref-crds.html#_bundledeploymentoptions');
     });
   });
 

--- a/shell/utils/__tests__/fleet-appco.test.ts
+++ b/shell/utils/__tests__/fleet-appco.test.ts
@@ -1,8 +1,18 @@
 import {
-  deriveRepoName, fetchAppCoCharts, ensureAppCoResources, ensureAppCoImagePullSecret, getDownstreamResourcesDocsUrl, FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL, FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_URL, getBundleDeploymentOptionsDocsUrl, FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL, FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_URL
+  deriveRepoName, fetchAppCoCharts, ensureAppCoResources, ensureAppCoImagePullSecret, getDownstreamResourcesDocsUrl, getBundleDeploymentOptionsDocsUrl
 } from '@shell/utils/fleet-appco';
+import { getVersionData } from '@shell/config/version';
 import { SECRET, CATALOG as CATALOG_TYPES } from '@shell/config/types';
 import { SECRET_TYPES } from '@shell/config/secret';
+
+// The docs URLs depend on the running Rancher version, so mock it. CURRENT_RANCHER_VERSION
+// is the fallback used for dev/head builds that don't report a clean X.Y.Z.
+jest.mock('@shell/config/version', () => ({
+  getVersionData:          jest.fn(() => ({ Version: 'v2.15.1' })),
+  CURRENT_RANCHER_VERSION: '2.15',
+}));
+
+const mockRunningVersion = (version: string) => (getVersionData as jest.Mock).mockReturnValue({ Version: version });
 
 /**
  * Build a fake ClusterRepo resource. Its `waitForTestFn` emulates the real
@@ -62,34 +72,80 @@ describe('fleet-appco utils', () => {
   });
 
   describe('getDownstreamResourcesDocsUrl', () => {
-    it('should use the unversioned community docs when not Prime', () => {
-      expect(getDownstreamResourcesDocsUrl(false)).toStrictEqual(FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL);
-      expect(FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL).toStrictEqual('https://fleet.rancher.io/how-tos-for-users/downstream-resource-propagation');
+    describe('when running past the release that introduced the docs (current channel)', () => {
+      beforeEach(() => mockRunningVersion('v2.15.1'));
+
+      it('should use the community docs at the root when not Prime', () => {
+        expect(getDownstreamResourcesDocsUrl(false)).toStrictEqual('https://fleet.rancher.io/how-tos-for-users/downstream-resource-propagation');
+      });
+
+      it('should default to the community docs when isPrime is omitted', () => {
+        expect(getDownstreamResourcesDocsUrl()).toStrictEqual('https://fleet.rancher.io/how-tos-for-users/downstream-resource-propagation');
+      });
+
+      it('should use the latest SUSE docs when Prime', () => {
+        expect(getDownstreamResourcesDocsUrl(true)).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/how-tos-for-users/downstream-resource-propagation.html');
+      });
     });
 
-    it('should default to the community docs when isPrime is omitted', () => {
-      expect(getDownstreamResourcesDocsUrl()).toStrictEqual(FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL);
+    describe('when running the release that introduced the docs (next channel)', () => {
+      beforeEach(() => mockRunningVersion('v2.15.0'));
+
+      it('should use the community "next" docs when not Prime', () => {
+        expect(getDownstreamResourcesDocsUrl(false)).toStrictEqual('https://fleet.rancher.io/next/how-tos-for-users/downstream-resource-propagation');
+      });
+
+      it('should use the SUSE "next" docs when Prime', () => {
+        expect(getDownstreamResourcesDocsUrl(true)).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/next/en/how-tos-for-users/downstream-resource-propagation.html');
+      });
     });
 
-    it('should use the latest SUSE docs when Prime', () => {
-      expect(getDownstreamResourcesDocsUrl(true)).toStrictEqual(FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_URL);
-      expect(FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_URL).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/how-tos-for-users/downstream-resource-propagation.html');
+    describe('when the running version cannot be parsed (dev/head build)', () => {
+      beforeEach(() => mockRunningVersion('master-head'));
+
+      it('should fall back to the "next" docs for the current build line', () => {
+        expect(getDownstreamResourcesDocsUrl(false)).toStrictEqual('https://fleet.rancher.io/next/how-tos-for-users/downstream-resource-propagation');
+        expect(getDownstreamResourcesDocsUrl(true)).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/next/en/how-tos-for-users/downstream-resource-propagation.html');
+      });
     });
   });
 
   describe('getBundleDeploymentOptionsDocsUrl', () => {
-    it('should use the unversioned community CRD reference (with anchor) when not Prime', () => {
-      expect(getBundleDeploymentOptionsDocsUrl(false)).toStrictEqual(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL);
-      expect(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL).toStrictEqual('https://fleet.rancher.io/reference/ref-crds#_bundledeploymentoptions');
+    describe('when running past the release that introduced the docs (current channel)', () => {
+      beforeEach(() => mockRunningVersion('v2.15.1'));
+
+      it('should use the community CRD reference (with anchor) at the root when not Prime', () => {
+        expect(getBundleDeploymentOptionsDocsUrl(false)).toStrictEqual('https://fleet.rancher.io/reference/ref-crds#_bundledeploymentoptions');
+      });
+
+      it('should default to the community docs when isPrime is omitted', () => {
+        expect(getBundleDeploymentOptionsDocsUrl()).toStrictEqual('https://fleet.rancher.io/reference/ref-crds#_bundledeploymentoptions');
+      });
+
+      it('should use the latest SUSE CRD reference (with anchor) when Prime', () => {
+        expect(getBundleDeploymentOptionsDocsUrl(true)).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/reference/ref-crds.html#_bundledeploymentoptions');
+      });
     });
 
-    it('should default to the community docs when isPrime is omitted', () => {
-      expect(getBundleDeploymentOptionsDocsUrl()).toStrictEqual(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL);
+    describe('when running the release that introduced the docs (next channel)', () => {
+      beforeEach(() => mockRunningVersion('v2.15.0'));
+
+      it('should use the community "next" CRD reference (with anchor) when not Prime', () => {
+        expect(getBundleDeploymentOptionsDocsUrl(false)).toStrictEqual('https://fleet.rancher.io/next/reference/ref-crds#_bundledeploymentoptions');
+      });
+
+      it('should use the SUSE "next" CRD reference (with anchor) when Prime', () => {
+        expect(getBundleDeploymentOptionsDocsUrl(true)).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/next/en/reference/ref-crds.html#_bundledeploymentoptions');
+      });
     });
 
-    it('should use the latest SUSE CRD reference (with anchor) when Prime', () => {
-      expect(getBundleDeploymentOptionsDocsUrl(true)).toStrictEqual(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_URL);
-      expect(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_URL).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/reference/ref-crds.html#_bundledeploymentoptions');
+    describe('when the running version cannot be parsed (dev/head build)', () => {
+      beforeEach(() => mockRunningVersion('master-head'));
+
+      it('should fall back to the "next" docs for the current build line', () => {
+        expect(getBundleDeploymentOptionsDocsUrl(false)).toStrictEqual('https://fleet.rancher.io/next/reference/ref-crds#_bundledeploymentoptions');
+        expect(getBundleDeploymentOptionsDocsUrl(true)).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/next/en/reference/ref-crds.html#_bundledeploymentoptions');
+      });
     });
   });
 

--- a/shell/utils/__tests__/fleet-appco.test.ts
+++ b/shell/utils/__tests__/fleet-appco.test.ts
@@ -1,5 +1,5 @@
 import {
-  deriveRepoName, fetchAppCoCharts, ensureAppCoResources, ensureAppCoImagePullSecret, getDownstreamResourcesDocsUrl, FLEET_DOWNSTREAM_RESOURCES_DOCS_FALLBACK_URL
+  deriveRepoName, fetchAppCoCharts, ensureAppCoResources, ensureAppCoImagePullSecret, getDownstreamResourcesDocsUrl, FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL, FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_FALLBACK_URL
 } from '@shell/utils/fleet-appco';
 import { SECRET, CATALOG as CATALOG_TYPES } from '@shell/config/types';
 import { SECRET_TYPES } from '@shell/config/secret';
@@ -62,25 +62,43 @@ describe('fleet-appco utils', () => {
   });
 
   describe('getDownstreamResourcesDocsUrl', () => {
-    it.each([
-      ['v2.15.0', 'https://fleet.rancher.io/0.16/downstream-resources'],
-      ['2.15.0', 'https://fleet.rancher.io/0.16/downstream-resources'],
-      ['v2.16.3', 'https://fleet.rancher.io/0.17/downstream-resources'],
-      ['v2.15.0-rc1', 'https://fleet.rancher.io/0.16/downstream-resources'],
-      ['v2.15-head', 'https://fleet.rancher.io/0.16/downstream-resources'],
-      ['v2.20.0', 'https://fleet.rancher.io/0.21/downstream-resources'],
-    ])('should map Rancher %s to Fleet docs %s', (version, expected) => {
-      expect(getDownstreamResourcesDocsUrl(version)).toStrictEqual(expected);
+    describe('community (non-Prime)', () => {
+      it.each([
+        ['v2.15.0'],
+        ['v2.20.0'],
+        ['dev'],
+        [''],
+        [undefined],
+      ])('should always use the unversioned community docs, regardless of version (%s)', (version) => {
+        expect(getDownstreamResourcesDocsUrl(version, false)).toStrictEqual(FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL);
+      });
+
+      it('should default to community docs when isPrime is omitted', () => {
+        expect(getDownstreamResourcesDocsUrl('v2.15.0')).toStrictEqual(FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL);
+      });
     });
 
-    it.each([
-      ['v2.14.0'],
-      ['v2.9.0'],
-      ['dev'],
-      [''],
-      [undefined],
-    ])('should fall back to the unversioned docs for %s', (version) => {
-      expect(getDownstreamResourcesDocsUrl(version)).toStrictEqual(FLEET_DOWNSTREAM_RESOURCES_DOCS_FALLBACK_URL);
+    describe('Prime', () => {
+      it.each([
+        ['v2.15.0', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.16/en/how-tos-for-users/downstream-resource-propagation.html'],
+        ['2.15.0', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.16/en/how-tos-for-users/downstream-resource-propagation.html'],
+        ['v2.16.3', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.17/en/how-tos-for-users/downstream-resource-propagation.html'],
+        ['v2.15.0-rc1', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.16/en/how-tos-for-users/downstream-resource-propagation.html'],
+        ['v2.15-head', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.16/en/how-tos-for-users/downstream-resource-propagation.html'],
+        ['v2.20.0', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.21/en/how-tos-for-users/downstream-resource-propagation.html'],
+      ])('should map Rancher %s to versioned SUSE docs %s', (version, expected) => {
+        expect(getDownstreamResourcesDocsUrl(version, true)).toStrictEqual(expected);
+      });
+
+      it.each([
+        ['v2.14.0'],
+        ['v2.9.0'],
+        ['dev'],
+        [''],
+        [undefined],
+      ])('should fall back to the latest SUSE docs for %s', (version) => {
+        expect(getDownstreamResourcesDocsUrl(version, true)).toStrictEqual(FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_FALLBACK_URL);
+      });
     });
   });
 

--- a/shell/utils/__tests__/fleet-appco.test.ts
+++ b/shell/utils/__tests__/fleet-appco.test.ts
@@ -5,14 +5,16 @@ import { getVersionData } from '@shell/config/version';
 import { SECRET, CATALOG as CATALOG_TYPES } from '@shell/config/types';
 import { SECRET_TYPES } from '@shell/config/secret';
 
-// The docs URLs depend on the running Rancher version, so mock it. CURRENT_RANCHER_VERSION
-// is the fallback used for dev/head builds that don't report a clean X.Y.Z.
+// The docs URLs depend on the running Rancher version and whether it is a Prime install, both
+// read from the server version data, so mock it. CURRENT_RANCHER_VERSION is the fallback used
+// for dev/head builds that don't report a clean X.Y.Z.
 jest.mock('@shell/config/version', () => ({
-  getVersionData:          jest.fn(() => ({ Version: 'v2.15.1' })),
+  getVersionData:          jest.fn(() => ({ Version: 'v2.15.1', RancherPrime: 'false' })),
   CURRENT_RANCHER_VERSION: '2.15',
 }));
 
-const mockRunningVersion = (version: string) => (getVersionData as jest.Mock).mockReturnValue({ Version: version });
+const mockVersionData = (version: string, isPrime = false) => (getVersionData as jest.Mock)
+  .mockReturnValue({ Version: version, RancherPrime: isPrime ? 'true' : 'false' });
 
 /**
  * Build a fake ClusterRepo resource. Its `waitForTestFn` emulates the real
@@ -72,85 +74,78 @@ describe('fleet-appco utils', () => {
   });
 
   describe('getDownstreamResourcesDocsUrl', () => {
-    describe('when running a later release than the one that introduced the docs (current channel)', () => {
-      beforeEach(() => mockRunningVersion('v2.15.1'));
-
-      it('should use the community docs at the root when not Prime', () => {
-        expect(getDownstreamResourcesDocsUrl(false)).toStrictEqual('https://fleet.rancher.io/how-tos-for-users/downstream-resource-propagation');
-      });
-
-      it('should default to the community docs when isPrime is omitted', () => {
+    describe('community (not a Prime install)', () => {
+      it('should use the current docs at the root on a later release', () => {
+        mockVersionData('v2.15.1', false);
         expect(getDownstreamResourcesDocsUrl()).toStrictEqual('https://fleet.rancher.io/how-tos-for-users/downstream-resource-propagation');
       });
 
-      it('should use the latest SUSE docs when Prime', () => {
-        expect(getDownstreamResourcesDocsUrl(true)).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/how-tos-for-users/downstream-resource-propagation.html');
+      it('should use the current docs at the root on a later minor', () => {
+        mockVersionData('v2.16.0', false);
+        expect(getDownstreamResourcesDocsUrl()).toStrictEqual('https://fleet.rancher.io/how-tos-for-users/downstream-resource-propagation');
       });
 
-      it('should also use the current docs on a later minor', () => {
-        mockRunningVersion('v2.16.0');
-        expect(getDownstreamResourcesDocsUrl(false)).toStrictEqual('https://fleet.rancher.io/how-tos-for-users/downstream-resource-propagation');
-        expect(getDownstreamResourcesDocsUrl(true)).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/how-tos-for-users/downstream-resource-propagation.html');
-      });
-    });
-
-    describe('when running the exact release that introduced the docs (next channel)', () => {
-      beforeEach(() => mockRunningVersion('v2.15.0'));
-
-      it('should use the community "next" docs when not Prime', () => {
-        expect(getDownstreamResourcesDocsUrl(false)).toStrictEqual('https://fleet.rancher.io/next/how-tos-for-users/downstream-resource-propagation');
+      it('should use the "next" docs on the exact release that introduced them', () => {
+        mockVersionData('v2.15.0', false);
+        expect(getDownstreamResourcesDocsUrl()).toStrictEqual('https://fleet.rancher.io/next/how-tos-for-users/downstream-resource-propagation');
       });
 
-      it('should use the SUSE "next" docs when Prime', () => {
-        expect(getDownstreamResourcesDocsUrl(true)).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/next/en/how-tos-for-users/downstream-resource-propagation.html');
+      it('should fall back to the "next" docs for dev/head builds', () => {
+        mockVersionData('master-head', false);
+        expect(getDownstreamResourcesDocsUrl()).toStrictEqual('https://fleet.rancher.io/next/how-tos-for-users/downstream-resource-propagation');
       });
     });
 
-    describe('when the running version cannot be parsed (dev/head build)', () => {
-      beforeEach(() => mockRunningVersion('master-head'));
+    describe('Rancher Prime', () => {
+      it('should use the latest SUSE docs on a later release', () => {
+        mockVersionData('v2.15.1', true);
+        expect(getDownstreamResourcesDocsUrl()).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/how-tos-for-users/downstream-resource-propagation.html');
+      });
 
-      it('should fall back to the "next" docs for the current build line', () => {
-        expect(getDownstreamResourcesDocsUrl(false)).toStrictEqual('https://fleet.rancher.io/next/how-tos-for-users/downstream-resource-propagation');
-        expect(getDownstreamResourcesDocsUrl(true)).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/next/en/how-tos-for-users/downstream-resource-propagation.html');
+      it('should use the SUSE "next" docs on the exact release that introduced them', () => {
+        mockVersionData('v2.15.0', true);
+        expect(getDownstreamResourcesDocsUrl()).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/next/en/how-tos-for-users/downstream-resource-propagation.html');
+      });
+
+      it('should fall back to the SUSE "next" docs for dev/head builds', () => {
+        mockVersionData('master-head', true);
+        expect(getDownstreamResourcesDocsUrl()).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/next/en/how-tos-for-users/downstream-resource-propagation.html');
       });
     });
   });
 
   describe('getBundleDeploymentOptionsDocsUrl', () => {
-    describe('when running a later release than the one that introduced the docs (current channel)', () => {
-      beforeEach(() => mockRunningVersion('v2.15.1'));
-
-      it('should use the community CRD reference (with anchor) at the root when not Prime', () => {
-        expect(getBundleDeploymentOptionsDocsUrl(false)).toStrictEqual('https://fleet.rancher.io/reference/ref-crds#_bundledeploymentoptions');
-      });
-
-      it('should default to the community docs when isPrime is omitted', () => {
+    describe('community (not a Prime install)', () => {
+      it('should use the current CRD reference (with anchor) at the root on a later release', () => {
+        mockVersionData('v2.15.1', false);
         expect(getBundleDeploymentOptionsDocsUrl()).toStrictEqual('https://fleet.rancher.io/reference/ref-crds#_bundledeploymentoptions');
       });
 
-      it('should use the latest SUSE CRD reference (with anchor) when Prime', () => {
-        expect(getBundleDeploymentOptionsDocsUrl(true)).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/reference/ref-crds.html#_bundledeploymentoptions');
+      it('should use the "next" CRD reference (with anchor) on the exact release that introduced them', () => {
+        mockVersionData('v2.15.0', false);
+        expect(getBundleDeploymentOptionsDocsUrl()).toStrictEqual('https://fleet.rancher.io/next/reference/ref-crds#_bundledeploymentoptions');
+      });
+
+      it('should fall back to the "next" CRD reference for dev/head builds', () => {
+        mockVersionData('master-head', false);
+        expect(getBundleDeploymentOptionsDocsUrl()).toStrictEqual('https://fleet.rancher.io/next/reference/ref-crds#_bundledeploymentoptions');
       });
     });
 
-    describe('when running the exact release that introduced the docs (next channel)', () => {
-      beforeEach(() => mockRunningVersion('v2.15.0'));
-
-      it('should use the community "next" CRD reference (with anchor) when not Prime', () => {
-        expect(getBundleDeploymentOptionsDocsUrl(false)).toStrictEqual('https://fleet.rancher.io/next/reference/ref-crds#_bundledeploymentoptions');
+    describe('Rancher Prime', () => {
+      it('should use the latest SUSE CRD reference (with anchor) on a later release', () => {
+        mockVersionData('v2.15.1', true);
+        expect(getBundleDeploymentOptionsDocsUrl()).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/latest/en/reference/ref-crds.html#_bundledeploymentoptions');
       });
 
-      it('should use the SUSE "next" CRD reference (with anchor) when Prime', () => {
-        expect(getBundleDeploymentOptionsDocsUrl(true)).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/next/en/reference/ref-crds.html#_bundledeploymentoptions');
+      it('should use the SUSE "next" CRD reference (with anchor) on the exact release that introduced them', () => {
+        mockVersionData('v2.15.0', true);
+        expect(getBundleDeploymentOptionsDocsUrl()).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/next/en/reference/ref-crds.html#_bundledeploymentoptions');
       });
-    });
 
-    describe('when the running version cannot be parsed (dev/head build)', () => {
-      beforeEach(() => mockRunningVersion('master-head'));
-
-      it('should fall back to the "next" docs for the current build line', () => {
-        expect(getBundleDeploymentOptionsDocsUrl(false)).toStrictEqual('https://fleet.rancher.io/next/reference/ref-crds#_bundledeploymentoptions');
-        expect(getBundleDeploymentOptionsDocsUrl(true)).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/next/en/reference/ref-crds.html#_bundledeploymentoptions');
+      it('should fall back to the SUSE "next" CRD reference for dev/head builds', () => {
+        mockVersionData('master-head', true);
+        expect(getBundleDeploymentOptionsDocsUrl()).toStrictEqual('https://documentation.suse.com/cloudnative/continuous-delivery/next/en/reference/ref-crds.html#_bundledeploymentoptions');
       });
     });
   });

--- a/shell/utils/__tests__/fleet-appco.test.ts
+++ b/shell/utils/__tests__/fleet-appco.test.ts
@@ -1,5 +1,5 @@
 import {
-  deriveRepoName, fetchAppCoCharts, ensureAppCoResources, ensureAppCoImagePullSecret, getDownstreamResourcesDocsUrl, FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL, FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_FALLBACK_URL
+  deriveRepoName, fetchAppCoCharts, ensureAppCoResources, ensureAppCoImagePullSecret, getDownstreamResourcesDocsUrl, FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL, FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_FALLBACK_URL, getBundleDeploymentOptionsDocsUrl, FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL, FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_FALLBACK_URL
 } from '@shell/utils/fleet-appco';
 import { SECRET, CATALOG as CATALOG_TYPES } from '@shell/config/types';
 import { SECRET_TYPES } from '@shell/config/secret';
@@ -98,6 +98,47 @@ describe('fleet-appco utils', () => {
         [undefined],
       ])('should fall back to the latest SUSE docs for %s', (version) => {
         expect(getDownstreamResourcesDocsUrl(version, true)).toStrictEqual(FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_FALLBACK_URL);
+      });
+    });
+  });
+
+  describe('getBundleDeploymentOptionsDocsUrl', () => {
+    describe('community (non-Prime)', () => {
+      it.each([
+        ['v2.15.0'],
+        ['v2.20.0'],
+        ['dev'],
+        [''],
+        [undefined],
+      ])('should always use the unversioned community CRD reference, regardless of version (%s)', (version) => {
+        expect(getBundleDeploymentOptionsDocsUrl(version, false)).toStrictEqual(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL);
+      });
+
+      it('should keep the bundledeploymentoptions anchor', () => {
+        expect(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL).toStrictEqual('https://fleet.rancher.io/reference/ref-crds#_bundledeploymentoptions');
+      });
+
+      it('should default to community docs when isPrime is omitted', () => {
+        expect(getBundleDeploymentOptionsDocsUrl('v2.15.0')).toStrictEqual(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL);
+      });
+    });
+
+    describe('Prime', () => {
+      it.each([
+        ['v2.15.0', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.16/en/reference/ref-crds.html#_bundledeploymentoptions'],
+        ['v2.16.3', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.17/en/reference/ref-crds.html#_bundledeploymentoptions'],
+        ['v2.20.0', 'https://documentation.suse.com/cloudnative/continuous-delivery/v0.21/en/reference/ref-crds.html#_bundledeploymentoptions'],
+      ])('should map Rancher %s to versioned SUSE CRD reference %s', (version, expected) => {
+        expect(getBundleDeploymentOptionsDocsUrl(version, true)).toStrictEqual(expected);
+      });
+
+      it.each([
+        ['v2.14.0'],
+        ['dev'],
+        [''],
+        [undefined],
+      ])('should fall back to the latest SUSE docs for %s', (version) => {
+        expect(getBundleDeploymentOptionsDocsUrl(version, true)).toStrictEqual(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_FALLBACK_URL);
       });
     });
   });

--- a/shell/utils/fleet-appco.ts
+++ b/shell/utils/fleet-appco.ts
@@ -96,12 +96,21 @@ function fleetDocsUrl(doc: FleetDoc, isPrime: boolean): string {
   return `${ FLEET_COMMUNITY_DOCS_BASE }/${ communityPath }${ hash }`;
 }
 
-export function getDownstreamResourcesDocsUrl(isPrime = false): string {
-  return fleetDocsUrl(FLEET_DOCS.downstreamResources, isPrime);
+/**
+ * Whether this is a Rancher Prime install. Read from the same server version data as the docs
+ * channel (`getVersionData`) instead of importing `isRancherPrime` from `@shell/config/version`,
+ * whose exports vue-tsc cannot currently resolve from that JS module.
+ */
+function isPrimeInstall(): boolean {
+  return getVersionData().RancherPrime?.toLowerCase() === 'true';
 }
 
-export function getBundleDeploymentOptionsDocsUrl(isPrime = false): string {
-  return fleetDocsUrl(FLEET_DOCS.bundleDeploymentOptions, isPrime);
+export function getDownstreamResourcesDocsUrl(): string {
+  return fleetDocsUrl(FLEET_DOCS.downstreamResources, isPrimeInstall());
+}
+
+export function getBundleDeploymentOptionsDocsUrl(): string {
+  return fleetDocsUrl(FLEET_DOCS.bundleDeploymentOptions, isPrimeInstall());
 }
 
 interface AuthCredentials {

--- a/shell/utils/fleet-appco.ts
+++ b/shell/utils/fleet-appco.ts
@@ -16,44 +16,38 @@ const FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOC_PATH = 'reference/ref-crds';
 const FLEET_BUNDLE_DEPLOYMENT_OPTIONS_ANCHOR = '_bundledeploymentoptions';
 
 /**
- * Build a Fleet docs URL, choosing between the community and Rancher Prime docs.
+ * Build a Fleet docs URL, choosing between the community and Rancher Prime docs. Both point
+ * at the *current* docs rather than a pinned version:
  *
- * - Community (fleet.rancher.io): the unversioned page. The old `0.X` deep links 404
- *   after the docs were restructured, so we always link the current page.
- * - Prime (documentation.suse.com): the versioned page. Rancher `2.X` ships Fleet
- *   `0.(X+1)`, so we map to `v0.<minor + 1>`; older or unparseable versions fall back
- *   to `latest`. Harcoded to `2.X`, so fragile if that correlation changes.
+ * - Community (fleet.rancher.io): the unversioned page. The current release is served at the
+ *   root; versioned `0.X` deep links don't exist for it.
+ * - Prime (documentation.suse.com): the `latest` page. There is no unversioned SUSE path, and
+ *   a specific `v0.X` 404s until that release's docs are published, whereas `latest` always
+ *   resolves.
+ *
+ * Because both link the current docs, a brand-new page only resolves once it ships in the
+ * current release — verify a path exists before wiring it up.
  */
-function fleetDocsUrl(path: string, { rancherVersion, isPrime, anchor = '' }: { rancherVersion?: string; isPrime?: boolean; anchor?: string }): string {
+function fleetDocsUrl(path: string, { isPrime, anchor = '' }: { isPrime?: boolean; anchor?: string }): string {
   const hash = anchor ? `#${ anchor }` : '';
 
-  if (!isPrime) {
-    return `${ FLEET_COMMUNITY_DOCS_BASE }/${ path }${ hash }`;
-  }
-
-  const match = /^v?2\.(\d+)/.exec(rancherVersion || '');
-  const minor = match ? parseInt(match[1], 10) : NaN;
-  const version = !isNaN(minor) && minor >= 15 ? `v0.${ minor + 1 }` : 'latest';
-
-  return `${ FLEET_PRIME_DOCS_BASE }/${ version }/en/${ path }.html${ hash }`;
+  return isPrime ? `${ FLEET_PRIME_DOCS_BASE }/latest/en/${ path }.html${ hash }` : `${ FLEET_COMMUNITY_DOCS_BASE }/${ path }${ hash }`;
 }
 
 // Fleet "downstream resources" docs.
 export const FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL = fleetDocsUrl(FLEET_DOWNSTREAM_RESOURCES_DOC_PATH, { isPrime: false });
-export const FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_FALLBACK_URL = fleetDocsUrl(FLEET_DOWNSTREAM_RESOURCES_DOC_PATH, { isPrime: true });
+export const FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_URL = fleetDocsUrl(FLEET_DOWNSTREAM_RESOURCES_DOC_PATH, { isPrime: true });
 
-export function getDownstreamResourcesDocsUrl(rancherVersion?: string, isPrime = false): string {
-  return fleetDocsUrl(FLEET_DOWNSTREAM_RESOURCES_DOC_PATH, { rancherVersion, isPrime });
+export function getDownstreamResourcesDocsUrl(isPrime = false): string {
+  return isPrime ? FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_URL : FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL;
 }
 
 // Fleet "BundleDeploymentOptions" (CRD reference) docs.
 export const FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL = fleetDocsUrl(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOC_PATH, { isPrime: false, anchor: FLEET_BUNDLE_DEPLOYMENT_OPTIONS_ANCHOR });
-export const FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_FALLBACK_URL = fleetDocsUrl(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOC_PATH, { isPrime: true, anchor: FLEET_BUNDLE_DEPLOYMENT_OPTIONS_ANCHOR });
+export const FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_URL = fleetDocsUrl(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOC_PATH, { isPrime: true, anchor: FLEET_BUNDLE_DEPLOYMENT_OPTIONS_ANCHOR });
 
-export function getBundleDeploymentOptionsDocsUrl(rancherVersion?: string, isPrime = false): string {
-  return fleetDocsUrl(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOC_PATH, {
-    rancherVersion, isPrime, anchor: FLEET_BUNDLE_DEPLOYMENT_OPTIONS_ANCHOR
-  });
+export function getBundleDeploymentOptionsDocsUrl(isPrime = false): string {
+  return isPrime ? FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_URL : FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL;
 }
 
 interface AuthCredentials {

--- a/shell/utils/fleet-appco.ts
+++ b/shell/utils/fleet-appco.ts
@@ -12,79 +12,96 @@ export const SUSE_APPCO_DISPLAY_NAME = 'SUSE AppCo';
 const FLEET_COMMUNITY_DOCS_BASE = 'https://fleet.rancher.io';
 const FLEET_PRIME_DOCS_BASE = 'https://documentation.suse.com/cloudnative/continuous-delivery';
 
-const FLEET_DOWNSTREAM_RESOURCES_DOC_PATH = 'how-tos-for-users/downstream-resource-propagation';
-const FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOC_PATH = 'reference/ref-crds';
-const FLEET_BUNDLE_DEPLOYMENT_OPTIONS_ANCHOR = '_bundledeploymentoptions';
+interface FleetDoc {
+  /** Path under the docs base, without a leading slash, file extension, or anchor. */
+  path: string;
+  /** Optional in-page anchor, without the leading '#'. */
+  anchor?: string;
+  /** Rancher minor that introduced the page (paired with minRancherPatch). */
+  minRancherMinor: number;
+  /**
+   * Rancher patch that introduced the page. The page's docs live only in the "next"
+   * (unreleased) site while exactly this minor.patch is running, and are published to the
+   * current docs from the following release (any later patch or minor) onward.
+   */
+  minRancherPatch: number;
+}
 
-// Rancher version that first shipped the AppCo Fleet docs pages below. A page lands in the
-// "next" (unreleased) docs and only moves to the current docs once the *following* release
-// ships, so while this exact version is running the pages exist only under "next".
-const FLEET_APPCO_DOCS_ADDED_IN = '2.15.0';
+export const FLEET_DOCS = {
+  downstreamResources: {
+    path: 'how-tos-for-users/downstream-resource-propagation', minRancherMinor: 15, minRancherPatch: 0
+  },
+  bundleDeploymentOptions: {
+    path: 'reference/ref-crds', anchor: '_bundledeploymentoptions', minRancherMinor: 15, minRancherPatch: 0
+  },
+} as const satisfies Record<string, FleetDoc>;
 
-interface ParsedVersion { major: number; minor: number; patch: number }
+interface RancherVersion { minor: number; patch: number }
 
-/** Extract an X.Y.Z version from a string like "v2.15.0" or "v2.16.0-rc1"; null if none. */
-function parseVersion(version: string): ParsedVersion | null {
-  const match = /(\d+)\.(\d+)\.(\d+)/.exec(version || '');
+/**
+ * Extract the Rancher minor and patch from a version string like "v2.15.1", "v2.16.0-rc1",
+ * or "2.15" (patch defaults to 0); null if no X.Y is present.
+ */
+function parseRancherVersion(version: string): RancherVersion | null {
+  const match = /\d+\.(\d+)(?:\.(\d+))?/.exec(version || '');
 
-  return match ? {
-    major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3])
-  } : null;
+  return match ? { minor: Number(match[1]), patch: Number(match[2] ?? 0) } : null;
 }
 
 /**
- * Pick the docs channel for a page introduced in `addedIn`. A page lands in the unreleased
- * ("next") site and only moves to the current docs from the *following* release onward:
+ * Pick the docs channel for `doc`. Its docs live only in the "next" (unreleased) site while
+ * exactly the release that introduced the page is running, and are published to the current
+ * docs from the following release (any later patch or minor) onward:
  *
- * - running version === the release that introduced the page -> "next" (not published yet)
- * - any later release                                        -> "current"
+ * - running release === the release that introduced the page -> "next" (not published yet)
+ * - a later release                                          -> "current"
  *
  * The running version comes from the server (`getVersionData().Version`). Dev/head builds
- * don't report a clean X.Y.Z, so they fall back to the `.0` of the line this UI was built
- * for (`CURRENT_RANCHER_VERSION`), whose docs are likewise still in "next".
+ * don't report a clean version, so they fall back to the minor this UI was built for
+ * (`CURRENT_RANCHER_VERSION`, patch 0), whose docs are likewise still in "next".
  */
-function fleetDocsChannel(addedIn: string): 'next' | 'current' {
-  const added = parseVersion(addedIn);
-  const running = parseVersion(getVersionData().Version) ?? parseVersion(`${ CURRENT_RANCHER_VERSION }.0`);
+function fleetDocsChannel(doc: FleetDoc): 'next' | 'current' {
+  const running = parseRancherVersion(getVersionData().Version) ?? parseRancherVersion(CURRENT_RANCHER_VERSION);
 
-  if (!added || !running) {
+  if (!running) {
     return 'current';
   }
 
-  const sameRelease = running.major === added.major && running.minor === added.minor && running.patch === added.patch;
+  if (running.minor !== doc.minRancherMinor) {
+    return running.minor > doc.minRancherMinor ? 'current' : 'next';
+  }
 
-  return sameRelease ? 'next' : 'current';
+  return running.patch > doc.minRancherPatch ? 'current' : 'next';
 }
 
 /**
- * Build a Fleet docs URL, choosing between the community and Rancher Prime docs and between
- * the current and "next" (unreleased) channel for a page introduced in `addedIn` (see
- * fleetDocsChannel):
+ * Build a Fleet docs URL for `doc`, choosing between the community and Rancher Prime docs and
+ * between the current and "next" (unreleased) channel (see fleetDocsChannel):
  *
  * - Community (fleet.rancher.io): current release at the root, unreleased under `/next/`.
  * - Prime (documentation.suse.com): current release at `/latest/`, unreleased at `/next/`.
  */
-function fleetDocsUrl(path: string, addedIn: string, { isPrime, anchor = '' }: { isPrime?: boolean; anchor?: string }): string {
-  const hash = anchor ? `#${ anchor }` : '';
-  const channel = fleetDocsChannel(addedIn);
+function fleetDocsUrl(doc: FleetDoc, isPrime: boolean): string {
+  const hash = doc.anchor ? `#${ doc.anchor }` : '';
+  const channel = fleetDocsChannel(doc);
 
   if (isPrime) {
     const segment = channel === 'next' ? 'next' : 'latest';
 
-    return `${ FLEET_PRIME_DOCS_BASE }/${ segment }/en/${ path }.html${ hash }`;
+    return `${ FLEET_PRIME_DOCS_BASE }/${ segment }/en/${ doc.path }.html${ hash }`;
   }
 
-  const communityPath = channel === 'next' ? `next/${ path }` : path;
+  const communityPath = channel === 'next' ? `next/${ doc.path }` : doc.path;
 
   return `${ FLEET_COMMUNITY_DOCS_BASE }/${ communityPath }${ hash }`;
 }
 
 export function getDownstreamResourcesDocsUrl(isPrime = false): string {
-  return fleetDocsUrl(FLEET_DOWNSTREAM_RESOURCES_DOC_PATH, FLEET_APPCO_DOCS_ADDED_IN, { isPrime });
+  return fleetDocsUrl(FLEET_DOCS.downstreamResources, isPrime);
 }
 
 export function getBundleDeploymentOptionsDocsUrl(isPrime = false): string {
-  return fleetDocsUrl(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOC_PATH, FLEET_APPCO_DOCS_ADDED_IN, { isPrime, anchor: FLEET_BUNDLE_DEPLOYMENT_OPTIONS_ANCHOR });
+  return fleetDocsUrl(FLEET_DOCS.bundleDeploymentOptions, isPrime);
 }
 
 interface AuthCredentials {

--- a/shell/utils/fleet-appco.ts
+++ b/shell/utils/fleet-appco.ts
@@ -8,42 +8,52 @@ export const FLEET_APPCO_AUTH_GENERATE_NAME = 'fleet-appco-auth-';
 export const IMAGE_PULL_SECRET_SUFFIX = '-image-pull-secret';
 export const SUSE_APPCO_DISPLAY_NAME = 'SUSE AppCo';
 
-const FLEET_DOWNSTREAM_RESOURCES_DOC_PATH = 'how-tos-for-users/downstream-resource-propagation';
-
-// Community (fleet.rancher.io) docs are unversioned: the previous `0.X` deep links no
-// longer resolve after the docs restructure, so we link the current, unversioned page.
-export const FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL = `https://fleet.rancher.io/${ FLEET_DOWNSTREAM_RESOURCES_DOC_PATH }`;
-
-// Rancher Prime docs live on documentation.suse.com and ARE versioned. Used when the
-// version can't be parsed (e.g. dev builds), pointing at the latest published docs.
+const FLEET_COMMUNITY_DOCS_BASE = 'https://fleet.rancher.io';
 const FLEET_PRIME_DOCS_BASE = 'https://documentation.suse.com/cloudnative/continuous-delivery';
 
-export const FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_FALLBACK_URL = `${ FLEET_PRIME_DOCS_BASE }/latest/en/${ FLEET_DOWNSTREAM_RESOURCES_DOC_PATH }.html`;
+const FLEET_DOWNSTREAM_RESOURCES_DOC_PATH = 'how-tos-for-users/downstream-resource-propagation';
+const FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOC_PATH = 'reference/ref-crds';
+const FLEET_BUNDLE_DEPLOYMENT_OPTIONS_ANCHOR = '_bundledeploymentoptions';
 
 /**
- * Build the URL to the Fleet "downstream resources" docs.
+ * Build a Fleet docs URL, choosing between the community and Rancher Prime docs.
  *
- * - Community: the unversioned fleet.rancher.io page (the old `0.X/downstream-resources`
- *   deep links 404 after the docs were restructured).
- * - Prime: the versioned documentation.suse.com page. Rancher `2.X` ships Fleet `0.(X+1)`,
- *   so we map to `v0.<minor + 1>`; older or unparseable versions fall back to `latest`.
+ * - Community (fleet.rancher.io): the unversioned page. The old `0.X` deep links 404
+ *   after the docs were restructured, so we always link the current page.
+ * - Prime (documentation.suse.com): the versioned page. Rancher `2.X` ships Fleet
+ *   `0.(X+1)`, so we map to `v0.<minor + 1>`; older or unparseable versions fall back
+ *   to `latest`. Harcoded to `2.X`, so fragile if that correlation changes.
  */
-export function getDownstreamResourcesDocsUrl(rancherVersion?: string, isPrime = false): string {
+function fleetDocsUrl(path: string, { rancherVersion, isPrime, anchor = '' }: { rancherVersion?: string; isPrime?: boolean; anchor?: string }): string {
+  const hash = anchor ? `#${ anchor }` : '';
+
   if (!isPrime) {
-    return FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL;
+    return `${ FLEET_COMMUNITY_DOCS_BASE }/${ path }${ hash }`;
   }
 
-  // Harcoded to 2.X.0, it is fragile because if the version changes it will break.
-  // Ideally it would require a correlation between versions, but we have the fallback in place.
   const match = /^v?2\.(\d+)/.exec(rancherVersion || '');
   const minor = match ? parseInt(match[1], 10) : NaN;
+  const version = !isNaN(minor) && minor >= 15 ? `v0.${ minor + 1 }` : 'latest';
 
-  // Downstream-resource docs exist from Fleet 0.16 (Rancher 2.15) onwards.
-  if (!isNaN(minor) && minor >= 15) {
-    return `${ FLEET_PRIME_DOCS_BASE }/v0.${ minor + 1 }/en/${ FLEET_DOWNSTREAM_RESOURCES_DOC_PATH }.html`;
-  }
+  return `${ FLEET_PRIME_DOCS_BASE }/${ version }/en/${ path }.html${ hash }`;
+}
 
-  return FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_FALLBACK_URL;
+// Fleet "downstream resources" docs.
+export const FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL = fleetDocsUrl(FLEET_DOWNSTREAM_RESOURCES_DOC_PATH, { isPrime: false });
+export const FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_FALLBACK_URL = fleetDocsUrl(FLEET_DOWNSTREAM_RESOURCES_DOC_PATH, { isPrime: true });
+
+export function getDownstreamResourcesDocsUrl(rancherVersion?: string, isPrime = false): string {
+  return fleetDocsUrl(FLEET_DOWNSTREAM_RESOURCES_DOC_PATH, { rancherVersion, isPrime });
+}
+
+// Fleet "BundleDeploymentOptions" (CRD reference) docs.
+export const FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL = fleetDocsUrl(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOC_PATH, { isPrime: false, anchor: FLEET_BUNDLE_DEPLOYMENT_OPTIONS_ANCHOR });
+export const FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_FALLBACK_URL = fleetDocsUrl(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOC_PATH, { isPrime: true, anchor: FLEET_BUNDLE_DEPLOYMENT_OPTIONS_ANCHOR });
+
+export function getBundleDeploymentOptionsDocsUrl(rancherVersion?: string, isPrime = false): string {
+  return fleetDocsUrl(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOC_PATH, {
+    rancherVersion, isPrime, anchor: FLEET_BUNDLE_DEPLOYMENT_OPTIONS_ANCHOR
+  });
 }
 
 interface AuthCredentials {

--- a/shell/utils/fleet-appco.ts
+++ b/shell/utils/fleet-appco.ts
@@ -2,6 +2,7 @@ import { base64Encode } from '@shell/utils/crypto';
 import { CATALOG as CATALOG_TYPES, SECRET } from '@shell/config/types';
 import { CATALOG, DESCRIPTION, FLEET as FLEET_LABELS } from '@shell/config/labels-annotations';
 import { SECRET_TYPES } from '@shell/config/secret';
+import { getVersionData, CURRENT_RANCHER_VERSION } from '@shell/config/version';
 
 export const SUSE_APP_COLLECTION_REPO_URL = 'oci://dp.apps.rancher.io/charts';
 export const FLEET_APPCO_AUTH_GENERATE_NAME = 'fleet-appco-auth-';
@@ -15,39 +16,75 @@ const FLEET_DOWNSTREAM_RESOURCES_DOC_PATH = 'how-tos-for-users/downstream-resour
 const FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOC_PATH = 'reference/ref-crds';
 const FLEET_BUNDLE_DEPLOYMENT_OPTIONS_ANCHOR = '_bundledeploymentoptions';
 
-/**
- * Build a Fleet docs URL, choosing between the community and Rancher Prime docs. Both point
- * at the *current* docs rather than a pinned version:
- *
- * - Community (fleet.rancher.io): the unversioned page. The current release is served at the
- *   root; versioned `0.X` deep links don't exist for it.
- * - Prime (documentation.suse.com): the `latest` page. There is no unversioned SUSE path, and
- *   a specific `v0.X` 404s until that release's docs are published, whereas `latest` always
- *   resolves.
- *
- * Because both link the current docs, a brand-new page only resolves once it ships in the
- * current release — verify a path exists before wiring it up.
- */
-function fleetDocsUrl(path: string, { isPrime, anchor = '' }: { isPrime?: boolean; anchor?: string }): string {
-  const hash = anchor ? `#${ anchor }` : '';
+// Rancher version that first shipped the AppCo Fleet docs pages below. A page lands in the
+// "next" (unreleased) docs and only moves to the current docs once the *following* release
+// ships, so while this exact version is running the pages exist only under "next".
+const FLEET_APPCO_DOCS_ADDED_IN = '2.15.0';
 
-  return isPrime ? `${ FLEET_PRIME_DOCS_BASE }/latest/en/${ path }.html${ hash }` : `${ FLEET_COMMUNITY_DOCS_BASE }/${ path }${ hash }`;
+interface ParsedVersion { major: number; minor: number; patch: number }
+
+/** Extract an X.Y.Z version from a string like "v2.15.0" or "v2.16.0-rc1"; null if none. */
+function parseVersion(version: string): ParsedVersion | null {
+  const match = /(\d+)\.(\d+)\.(\d+)/.exec(version || '');
+
+  return match ? {
+    major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3])
+  } : null;
 }
 
-// Fleet "downstream resources" docs.
-export const FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL = fleetDocsUrl(FLEET_DOWNSTREAM_RESOURCES_DOC_PATH, { isPrime: false });
-export const FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_URL = fleetDocsUrl(FLEET_DOWNSTREAM_RESOURCES_DOC_PATH, { isPrime: true });
+/**
+ * Pick the docs channel for a page introduced in `addedIn`. A page lands in the unreleased
+ * ("next") site and only moves to the current docs from the *following* release onward:
+ *
+ * - running version === the release that introduced the page -> "next" (not published yet)
+ * - any later release                                        -> "current"
+ *
+ * The running version comes from the server (`getVersionData().Version`). Dev/head builds
+ * don't report a clean X.Y.Z, so they fall back to the `.0` of the line this UI was built
+ * for (`CURRENT_RANCHER_VERSION`), whose docs are likewise still in "next".
+ */
+function fleetDocsChannel(addedIn: string): 'next' | 'current' {
+  const added = parseVersion(addedIn);
+  const running = parseVersion(getVersionData().Version) ?? parseVersion(`${ CURRENT_RANCHER_VERSION }.0`);
+
+  if (!added || !running) {
+    return 'current';
+  }
+
+  const sameRelease = running.major === added.major && running.minor === added.minor && running.patch === added.patch;
+
+  return sameRelease ? 'next' : 'current';
+}
+
+/**
+ * Build a Fleet docs URL, choosing between the community and Rancher Prime docs and between
+ * the current and "next" (unreleased) channel for a page introduced in `addedIn` (see
+ * fleetDocsChannel):
+ *
+ * - Community (fleet.rancher.io): current release at the root, unreleased under `/next/`.
+ * - Prime (documentation.suse.com): current release at `/latest/`, unreleased at `/next/`.
+ */
+function fleetDocsUrl(path: string, addedIn: string, { isPrime, anchor = '' }: { isPrime?: boolean; anchor?: string }): string {
+  const hash = anchor ? `#${ anchor }` : '';
+  const channel = fleetDocsChannel(addedIn);
+
+  if (isPrime) {
+    const segment = channel === 'next' ? 'next' : 'latest';
+
+    return `${ FLEET_PRIME_DOCS_BASE }/${ segment }/en/${ path }.html${ hash }`;
+  }
+
+  const communityPath = channel === 'next' ? `next/${ path }` : path;
+
+  return `${ FLEET_COMMUNITY_DOCS_BASE }/${ communityPath }${ hash }`;
+}
 
 export function getDownstreamResourcesDocsUrl(isPrime = false): string {
-  return isPrime ? FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_URL : FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL;
+  return fleetDocsUrl(FLEET_DOWNSTREAM_RESOURCES_DOC_PATH, FLEET_APPCO_DOCS_ADDED_IN, { isPrime });
 }
 
-// Fleet "BundleDeploymentOptions" (CRD reference) docs.
-export const FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL = fleetDocsUrl(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOC_PATH, { isPrime: false, anchor: FLEET_BUNDLE_DEPLOYMENT_OPTIONS_ANCHOR });
-export const FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_URL = fleetDocsUrl(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOC_PATH, { isPrime: true, anchor: FLEET_BUNDLE_DEPLOYMENT_OPTIONS_ANCHOR });
-
 export function getBundleDeploymentOptionsDocsUrl(isPrime = false): string {
-  return isPrime ? FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_PRIME_URL : FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOCS_COMMUNITY_URL;
+  return fleetDocsUrl(FLEET_BUNDLE_DEPLOYMENT_OPTIONS_DOC_PATH, FLEET_APPCO_DOCS_ADDED_IN, { isPrime, anchor: FLEET_BUNDLE_DEPLOYMENT_OPTIONS_ANCHOR });
 }
 
 interface AuthCredentials {

--- a/shell/utils/fleet-appco.ts
+++ b/shell/utils/fleet-appco.ts
@@ -8,29 +8,42 @@ export const FLEET_APPCO_AUTH_GENERATE_NAME = 'fleet-appco-auth-';
 export const IMAGE_PULL_SECRET_SUFFIX = '-image-pull-secret';
 export const SUSE_APPCO_DISPLAY_NAME = 'SUSE AppCo';
 
-// Used when the Rancher version can't be parsed (e.g. dev builds), so we point
-// at the latest, unversioned Fleet docs.
-export const FLEET_DOWNSTREAM_RESOURCES_DOCS_FALLBACK_URL = 'https://fleet.rancher.io/next/downstream-resources';
+const FLEET_DOWNSTREAM_RESOURCES_DOC_PATH = 'how-tos-for-users/downstream-resource-propagation';
+
+// Community (fleet.rancher.io) docs are unversioned: the previous `0.X` deep links no
+// longer resolve after the docs restructure, so we link the current, unversioned page.
+export const FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL = `https://fleet.rancher.io/${ FLEET_DOWNSTREAM_RESOURCES_DOC_PATH }`;
+
+// Rancher Prime docs live on documentation.suse.com and ARE versioned. Used when the
+// version can't be parsed (e.g. dev builds), pointing at the latest published docs.
+const FLEET_PRIME_DOCS_BASE = 'https://documentation.suse.com/cloudnative/continuous-delivery';
+
+export const FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_FALLBACK_URL = `${ FLEET_PRIME_DOCS_BASE }/latest/en/${ FLEET_DOWNSTREAM_RESOURCES_DOC_PATH }.html`;
 
 /**
- * Build the URL to the Fleet "downstream resources" docs for the running Rancher version.
+ * Build the URL to the Fleet "downstream resources" docs.
  *
- * Rancher `2.X.0` (for X >= 15) ships with Fleet `0.(X+1)`, whose docs are published at
- * `https://fleet.rancher.io/0.<minor + 1>/downstream-resources`. For anything older or
- * unparseable we fall back to the unversioned `next` docs.
+ * - Community: the unversioned fleet.rancher.io page (the old `0.X/downstream-resources`
+ *   deep links 404 after the docs were restructured).
+ * - Prime: the versioned documentation.suse.com page. Rancher `2.X` ships Fleet `0.(X+1)`,
+ *   so we map to `v0.<minor + 1>`; older or unparseable versions fall back to `latest`.
  */
-export function getDownstreamResourcesDocsUrl(rancherVersion?: string): string {
+export function getDownstreamResourcesDocsUrl(rancherVersion?: string, isPrime = false): string {
+  if (!isPrime) {
+    return FLEET_DOWNSTREAM_RESOURCES_DOCS_COMMUNITY_URL;
+  }
+
   // Harcoded to 2.X.0, it is fragile because if the version changes it will break.
   // Ideally it would require a correlation between versions, but we have the fallback in place.
   const match = /^v?2\.(\d+)/.exec(rancherVersion || '');
   const minor = match ? parseInt(match[1], 10) : NaN;
 
-  // It should only exists after version 0.15.0, which will be fleet 0.16.0.
+  // Downstream-resource docs exist from Fleet 0.16 (Rancher 2.15) onwards.
   if (!isNaN(minor) && minor >= 15) {
-    return `https://fleet.rancher.io/0.${ minor + 1 }/downstream-resources`;
+    return `${ FLEET_PRIME_DOCS_BASE }/v0.${ minor + 1 }/en/${ FLEET_DOWNSTREAM_RESOURCES_DOC_PATH }.html`;
   }
 
-  return FLEET_DOWNSTREAM_RESOURCES_DOCS_FALLBACK_URL;
+  return FLEET_DOWNSTREAM_RESOURCES_DOCS_PRIME_FALLBACK_URL;
 }
 
 interface AuthCredentials {


### PR DESCRIPTION
### Summary
Fixes #17943

The Fleet "learn more" documentation links in the SUSE AppCo HelmOp integration
were wrong in two ways:

- They always pointed at the community docs (`fleet.rancher.io`), even on Rancher
  Prime, where the correct docs live on `documentation.suse.com`.
- The `BundleDeploymentOptions` link was hardcoded, and the community link carried
  a version segment that no longer resolves.

### Occurred changes and/or fixed issues
- The two AppCo HelmOp doc links now resolve to the right site for the install:
  - **Community**: `https://fleet.rancher.io/…`
  - **Rancher Prime**: `https://documentation.suse.com/cloudnative/continuous-delivery/…`
  Which one is used is decided by `isRancherPrime()`.
- The links are also **release-aware** so they never 404: a page's docs live only
  in the `next` (unreleased) site while exactly the release that introduced it is
  running, and move to the current docs (community root / Prime `/latest/`) from the
  following patch or minor onward.
- Both consuming components (`HelmOpAppCoResourcesSection.vue`,
  `HelmOpTargetOptionsSection.vue`) now build their link through the same helper
  instead of using hardcoded / static URLs.

### Technical notes summary
- All doc links are declared in a single typed `FLEET_DOCS` map in
  `shell/utils/fleet-appco.ts`. Each entry declares its `path`, optional `anchor`,
  and the exact release that introduced it (`minRancherMinor` + `minRancherPatch`).
  Adding a newly documented page is now one typed entry.
- The channel (`next` vs current) is chosen from the server-reported running version
  (`getVersionData().Version`) — a synchronous read, no extra API call or permissions.
  Dev/head builds that don't report a clean version fall back to the minor this UI was
  built for (`CURRENT_RANCHER_VERSION`, patch 0), whose docs are still in `next`.
- No behaviour change for the components beyond the resolved URL; the getters keep the
  same `(isPrime)` signature.

### Areas or cases that should be tested
- Create/edit a Fleet **HelmOp** with the SUSE AppCo integration and open both
  "learn more" links:
  - the *Additional resources to sync* link (downstream resource propagation)
  - the *cluster deployment* link (BundleDeploymentOptions)
- Verify on both a **community** Rancher and a **Rancher Prime** install that each link
  opens the correct docs site and resolves (no 404).
- Local testing was done in Chrome — reviewer please verify in a different browser.

### Areas which could experience regressions
- Only the two AppCo HelmOp documentation links. No functional/data changes; the doc
  URLs are the only observable output.

### Screenshot/Video
N/A — the change is the target URL of existing "learn more" links (text/placement
unchanged).

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
