### PR TITLE
fix extensions issues on `resource-class`

### DIFF
--- a/shell/pkg/__tests__/auto-import.test.ts
+++ b/shell/pkg/__tests__/auto-import.test.ts
@@ -1,0 +1,217 @@
+import { COMPAT_SHIM, generateTypeImport, generateDynamicTypeImport } from '@shell/pkg/auto-import';
+
+/**
+ * The extension manager. Only 'getPlugins' matters here - the shim uses it as the marker that
+ * tells a real manager apart from the empty object the store seeds the root state with.
+ */
+type Manager = { getPlugins: () => Record<string, unknown> };
+
+type RootState = { $extension?: unknown, $plugin?: unknown };
+
+type GlobalProps = { $extension?: unknown, $plugin?: unknown, $store?: { state: RootState } };
+
+type VueAppElement = HTMLElement & { __vue_app__?: { config?: { globalProperties?: GlobalProps } } };
+
+const makeManager = (): Manager => ({ getPlugins: () => ({}) });
+
+/**
+ * COMPAT_SHIM is injected as the first statements of the generated importTypes() function, so it
+ * is a valid function body and can be run as-is against a simulated host.
+ */
+// eslint-disable-next-line no-new-func
+const runShim = () => new Function(COMPAT_SHIM)();
+
+/**
+ * Stand in for a mounted dashboard: a '#app' element carrying __vue_app__, which is where the
+ * shim looks for Vue's globalProperties (and, through those, the Vuex store).
+ */
+const mountHost = (globalProperties: GlobalProps, mounted = true) => {
+  const el = document.createElement('div') as VueAppElement;
+
+  el.id = 'app';
+
+  if (mounted) {
+    el.__vue_app__ = { config: { globalProperties } };
+  }
+
+  document.body.appendChild(el);
+
+  return el;
+};
+
+describe('fx: COMPAT_SHIM', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  describe('given an older host that only sets $plugin', () => {
+    it('should alias the manager on both globalProperties and the root state', () => {
+      const manager = makeManager();
+      const state: RootState = { $plugin: manager };
+      const globalProperties: GlobalProps = { $plugin: manager, $store: { state } };
+
+      mountHost(globalProperties);
+      runShim();
+
+      expect(globalProperties.$extension).toBe(manager);
+      expect(globalProperties.$plugin).toBe(manager);
+      expect(state.$extension).toBe(manager);
+      expect(state.$plugin).toBe(manager);
+    });
+
+    it('should not schedule a retry once everything is patched', () => {
+      const manager = makeManager();
+      const state: RootState = { $plugin: manager };
+
+      mountHost({ $plugin: manager, $store: { state } });
+      runShim();
+
+      expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it('should patch globalProperties on the first pass even when the store is not ready', () => {
+      const manager = makeManager();
+      // What the store seeds the root state with before the 'setPlugin' mutation runs
+      const seeded = {};
+      const state: RootState = { $plugin: seeded };
+      const globalProperties: GlobalProps = { $plugin: manager, $store: { state } };
+
+      mountHost(globalProperties);
+      runShim();
+
+      expect(globalProperties.$extension).toBe(manager);
+      // Must not bind to the throwaway object - 'setPlugin' rebinds rather than mutates it
+      expect(state.$extension).toBeUndefined();
+      expect(state.$plugin).toBe(seeded);
+    });
+
+    it('should alias the root state on a later tick, once setPlugin has run', () => {
+      const manager = makeManager();
+      const state: RootState = { $plugin: {} };
+
+      mountHost({ $plugin: manager, $store: { state } });
+      runShim();
+
+      // The retry interval plus the 10s safety timeout
+      expect(jest.getTimerCount()).toBe(2);
+
+      state.$plugin = manager;
+      jest.advanceTimersByTime(100);
+
+      expect(state.$extension).toBe(manager);
+      expect(state.$plugin).toBe(manager);
+      // Interval cleared, only the safety timeout is left
+      expect(jest.getTimerCount()).toBe(1);
+    });
+  });
+
+  describe('given a host that only sets $extension', () => {
+    it('should alias the manager back onto $plugin', () => {
+      const manager = makeManager();
+      const state: RootState = { $extension: manager };
+      const globalProperties: GlobalProps = { $extension: manager, $store: { state } };
+
+      mountHost(globalProperties);
+      runShim();
+
+      expect(globalProperties.$plugin).toBe(manager);
+      expect(state.$plugin).toBe(manager);
+      expect(state.$extension).toBe(manager);
+    });
+  });
+
+  describe('given a host that already sets both keys', () => {
+    it('should be a no-op', () => {
+      const manager = makeManager();
+      const state: RootState = { $extension: manager, $plugin: manager };
+      const globalProperties: GlobalProps = {
+        $extension: manager, $plugin: manager, $store: { state }
+      };
+
+      mountHost(globalProperties);
+      runShim();
+
+      expect(globalProperties.$extension).toBe(manager);
+      expect(globalProperties.$plugin).toBe(manager);
+      expect(state.$extension).toBe(manager);
+      expect(state.$plugin).toBe(manager);
+      expect(jest.getTimerCount()).toBe(0);
+    });
+  });
+
+  describe('given #app is not in the DOM yet', () => {
+    it('should not throw', () => {
+      expect(() => runShim()).not.toThrow();
+    });
+
+    it('should patch once the app mounts', () => {
+      const manager = makeManager();
+      const state: RootState = { $plugin: manager };
+      const globalProperties: GlobalProps = { $plugin: manager, $store: { state } };
+
+      runShim();
+      mountHost(globalProperties);
+      jest.advanceTimersByTime(100);
+
+      expect(globalProperties.$extension).toBe(manager);
+      expect(state.$extension).toBe(manager);
+    });
+  });
+
+  describe('given #app exists but has not been mounted by Vue', () => {
+    it('should not throw and should recover on a later tick', () => {
+      const manager = makeManager();
+      const state: RootState = { $plugin: manager };
+      const globalProperties: GlobalProps = { $plugin: manager, $store: { state } };
+      const el = mountHost(globalProperties, false);
+
+      expect(() => runShim()).not.toThrow();
+      expect(state.$extension).toBeUndefined();
+
+      el.__vue_app__ = { config: { globalProperties } };
+      jest.advanceTimersByTime(100);
+
+      expect(state.$extension).toBe(manager);
+    });
+  });
+
+  describe('given a host that never exposes $store on globalProperties', () => {
+    it('should still patch globalProperties and give up after the 10s ceiling', () => {
+      const manager = makeManager();
+      const globalProperties: GlobalProps = { $plugin: manager };
+
+      mountHost(globalProperties);
+
+      expect(() => runShim()).not.toThrow();
+      expect(globalProperties.$extension).toBe(manager);
+
+      jest.advanceTimersByTime(10000);
+
+      expect(jest.getTimerCount()).toBe(0);
+    });
+  });
+});
+
+describe('fx: generateTypeImport', () => {
+  it('should inject the compat shim into the generated importTypes', () => {
+    const content = generateTypeImport('test-pkg', '/does/not/exist');
+
+    expect(content).toContain('export function importTypes($extension) {');
+    expect(content).toContain(COMPAT_SHIM);
+  });
+});
+
+describe('fx: generateDynamicTypeImport', () => {
+  it('should inject the compat shim into the generated importTypes', () => {
+    const content = generateDynamicTypeImport('test-pkg', '/does/not/exist');
+
+    expect(content).toContain('export function importTypes($extension) {');
+    expect(content).toContain(COMPAT_SHIM);
+  });
+});

--- a/shell/pkg/auto-import.js
+++ b/shell/pkg/auto-import.js
@@ -13,26 +13,53 @@ function replaceAll(str, find, replace) {
 
 // Injected at the top of every generated importTypes() function.
 // Ensures both $extension (newer Rancher) and $plugin (older Rancher) are available on
-// Vue globalProperties, regardless of which one the host injected. This makes all
-// extensions compatible across Rancher versions without any per-extension code changes.
+// Vue globalProperties *and* on the Vuex root state, regardless of which one the host
+// injected. This makes all extensions compatible across Rancher versions without any
+// per-extension code changes.
 const COMPAT_SHIM = `  if (typeof document !== 'undefined') {
     var patchGlobalProps = function() {
-      var __vueApp = document.getElementById('app').__vue_app__;
+      var __el = document.getElementById('app');
+      var __vueApp = __el && __el.__vue_app__;
 
-      if (!__vueApp) {
+      if (!__vueApp || !__vueApp.config || !__vueApp.config.globalProperties) {
         // no __vue_app__, vueApp.mount('#app') has not been called yet
         return false;
       }
 
-      if (__vueApp.config && __vueApp.config.globalProperties) {
-        var __gp = __vueApp.config.globalProperties;
-        if (!__gp.$extension && __gp.$plugin) { __gp.$extension = __gp.$plugin; }
-        else if (!__gp.$plugin && __gp.$extension) { __gp.$plugin = __gp.$extension; }
-        return true;
+      var __gp = __vueApp.config.globalProperties;
+
+      // Components reach the extension manager through globalProperties (this.$extension).
+      // Done first and unconditionally, so it still lands even if the store isn't ready yet.
+      if (!__gp.$extension && __gp.$plugin) { __gp.$extension = __gp.$plugin; }
+      else if (!__gp.$plugin && __gp.$extension) { __gp.$plugin = __gp.$extension; }
+
+      // Models reach it through the Vuex root state instead - either via the '$extension'
+      // accessor on the model base class, or directly as 'this.$rootState.$extension'.
+      // Rancher versions before the rename only ever set '$plugin' there, so without this
+      // an extension built against this shell resolves 'undefined' and either throws on
+      // first use or silently does nothing.
+      var __state = __gp.$store && __gp.$store.state;
+
+      if (!__state) {
+        return false;
       }
 
-      // Fallback to failure case
-      return false;
+      // Only alias once the manager is actually populated. The store seeds both keys with
+      // an empty object and swaps in the real manager later via the 'setPlugin' mutation,
+      // so aliasing too early would permanently bind to the throwaway object.
+      var __mgr = null;
+
+      if (__state.$extension && __state.$extension.getPlugins) { __mgr = __state.$extension; }
+      else if (__state.$plugin && __state.$plugin.getPlugins) { __mgr = __state.$plugin; }
+
+      if (!__mgr) {
+        return false;
+      }
+
+      __state.$extension = __mgr;
+      __state.$plugin = __mgr;
+
+      return true;
     };
 
     if (!patchGlobalProps()) {
@@ -155,5 +182,6 @@ module.exports = {
   contextFolders,
   contextMap,
   generateTypeImport,
-  generateDynamicTypeImport
+  generateDynamicTypeImport,
+  COMPAT_SHIM
 };

--- a/shell/plugins/dashboard-store/__tests__/resource-class.test.ts
+++ b/shell/plugins/dashboard-store/__tests__/resource-class.test.ts
@@ -822,4 +822,69 @@ describe('class: Resource', () => {
       expect(result).toStrictEqual(JSON.stringify({ message: 'validation.required', key: 'Value' }));
     });
   });
+
+  describe('getters: $plugin and $extension', () => {
+    const makeResource = (rootState: any) => new Resource({ type: 'test.resource' }, {
+      getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
+      dispatch:    jest.fn(),
+      rootState,
+      rootGetters: { 'i18n/t': jest.fn() },
+    });
+
+    it('should resolve the extension manager from rootState.$extension', () => {
+      const manager = { getPlugins: () => ({}) };
+      const resource = makeResource({ $extension: manager });
+
+      expect(resource.$extension).toBe(manager);
+      expect(resource.$plugin).toBe(manager);
+    });
+
+    it('should fall back to rootState.$plugin, which is all older Rancher versions set', () => {
+      const manager = { getPlugins: () => ({}) };
+      const resource = makeResource({ $plugin: manager });
+
+      expect(resource.$extension).toBe(manager);
+      expect(resource.$plugin).toBe(manager);
+    });
+
+    it('should prefer rootState.$extension when both are set', () => {
+      const manager = { getPlugins: () => ({}) };
+      const legacyManager = { getPlugins: () => ({}) };
+      const resource = makeResource({ $extension: manager, $plugin: legacyManager });
+
+      expect(resource.$extension).toBe(manager);
+      expect(resource.$plugin).toBe(manager);
+    });
+
+    it('should be undefined when neither is set', () => {
+      const resource = makeResource({});
+
+      expect(resource.$extension).toBeUndefined();
+      expect(resource.$plugin).toBeUndefined();
+    });
+  });
+
+  describe('getter: isProdRegistrationV2TopLevelProductResoure', () => {
+    const makeResource = (rootState: any) => new Resource({ type: 'test.resource' }, {
+      getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
+      dispatch:    jest.fn(),
+      rootState,
+      rootGetters: {
+        'i18n/t':  jest.fn(),
+        productId: 'some-product',
+      },
+    });
+
+    it('should not throw on an older Rancher that only sets rootState.$plugin', () => {
+      const resource = makeResource({ $plugin: { getPlugins: () => ({ somePlugin: { productNames: [] } }) } });
+
+      expect(resource.isProdRegistrationV2TopLevelProductResoure).toBe(false);
+    });
+
+    it('should be true when the matching plugin is registered as a top level product', () => {
+      const resource = makeResource({ $extension: { getPlugins: () => ({ somePlugin: { productNames: ['some-product'], topLevelProduct: true } }) } });
+
+      expect(resource.isProdRegistrationV2TopLevelProductResoure).toBe(true);
+    });
+  });
 });

--- a/shell/plugins/dashboard-store/resource-class.js
+++ b/shell/plugins/dashboard-store/resource-class.js
@@ -624,12 +624,18 @@ export default class Resource {
     return this.$ctx.rootState;
   }
 
+  /**
+   * '$extension' is the current root state key for the extension manager, but Rancher versions
+   * before that rename only ever set '$plugin'. Extensions ship a compiled copy of this shell,
+   * so this code can end up running inside one of those older hosts - fall back to '$plugin'
+   * there rather than resolving 'undefined'.
+   */
   get '$plugin'() {
-    return this.$ctx.rootState?.$extension;
+    return this.$ctx.rootState?.$extension || this.$ctx.rootState?.$plugin;
   }
 
   get '$extension'() {
-    return this.$ctx.rootState?.$extension;
+    return this.$ctx.rootState?.$extension || this.$ctx.rootState?.$plugin;
   }
 
   get customValidationRules() {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18633

Extensions built against the current `@rancher/shell` blow up as soon as one of their models is used on Rancher 2.11, 2.12 or 2.13:

```
TypeError: Cannot read properties of undefined (reading 'getPlugins')
    at get isProdRegistrationV2TopLevelProductResoure (resource-class.js:1422)
    at get _detailLocation (resource-class.js:1462)
    at get detailLocation (sr.cattle.io.reviewbundle.js:7)
    at Proxy.to (LinkDetail.vue:37)
```

The extension manager moved from `rootState.$plugin` to `rootState.$extension`, and that rename only exists on `master`. Older Rancher versions only ever set `$plugin`, so shell code compiled *into* an extension bundle resolves `undefined` and either throws or silently no-ops when it runs inside one of those hosts.

### Occurred changes and/or fixed issues
- fix `TypeError: Cannot read properties of undefined (reading 'getPlugins')` when an extension model resolves its `detailLocation` / `listLocation` on Rancher 2.11–2.13
- fix the same crash in `SteveModel.modelExtensions`, which reaches the manager the same way and dies the same way for any extension registering model extensions
- fix extension-provided custom validators silently not being found on older Rancher (`this.$rootState.$extension?.getValidator(...)` resolved `undefined` and fell through to `validation.custom.missing`)
- fix `this.$plugin` returning `undefined` in extension models on older Rancher, even though `$plugin` is exactly what those hosts have
- fix a pre-existing crash risk in the compatibility shim, where `document.getElementById('app').__vue_app__` was dereferenced with no null check while running synchronously at the top of `importTypes()` — if `#app` wasn't in the DOM yet it took the whole extension load down

### Technical notes summary
There are two doors into the extension manager: Vue `globalProperties` (how components get `this.$extension`) and the Vuex root state (how models get it). The compatibility shim that gets injected into every extension's generated `importTypes()` already aliased `$extension` ↔ `$plugin` on the first door — this PR completes it so it does the second one too, which is where all three broken call sites live.

Because the shim aliases the root state once, every reader of it is covered, including `getValidator`, which reads `$rootState` directly and so can't be fixed by patching the model accessors. It's a build-time injection, so it aliases whichever name the host actually provides and works without changing anything on the Rancher versions being targeted.

Two details in the shim are deliberate. The `globalProperties` patch runs first and unconditionally, so the original formatter fix can't regress if the store isn't ready yet. And the root-state alias only happens once the manager actually has `getPlugins` on it — the store seeds both keys with an empty object and *rebinds* them later in the `setPlugin` mutation, so aliasing too early would bind to the throwaway object permanently, which is a worse failure than the crash because it's silent.

On top of that, the two `$plugin` / `$extension` accessors on the model base class now fall back to `rootState.$plugin`. The shim is a retry loop, so its first pass runs before Vue has assigned `__vue_app__`; a lazy getter has no such window, so this covers the two accessor-based sites even during initial paint. It's a fallback, not a replacement — `getValidator` still needs the shim.

On current `master` the whole thing is a no-op: both keys already point at the same manager.

Note this only helps extensions that are **rebuilt** against a shell containing the fix. Already-published bundles are unaffected until they're republished.

### Areas or cases that should be tested
Tested locally in Chrome — reviewer should use a different browser.

Unit tests:

```
yarn test:ci shell/pkg/__tests__/auto-import.test.ts
yarn test:ci shell/plugins/dashboard-store/__tests__/resource-class.test.ts
```

Manual, end to end against the extension that reported the bug:

1. Run `./shell/scripts/typegen.sh` to generate the type definitions
2. Run `yarn link` in the `shell` package of this branch
3. On the extension side — https://github.com/rancher/supportability-review-app, branch `main` — run `yarn link "@rancher/shell"`
4. Run `yarn build-pkg supportability-review-app` to build the extension
5. Run `yarn serve-pkgs` to serve the built assets
6. Do a dev load of the extension into a Rancher **2.11.x** instance
7. Install the Helm chart the extension needs
8. Navigate to `sr.cattle.io.reviewbundle`
9. Open the browser console and confirm the `Cannot read properties of undefined (reading 'getPlugins')` error does **not** appear, and that the detail links on the list rows resolve

Worth repeating the same steps on 2.12.x and 2.13.x, and on a current `master` build to confirm nothing changed there.

### Areas which could experience regressions
- **Any extension load, on any Rancher version.** The shim is injected into every extension's `importTypes()`, so a mistake here breaks extension loading everywhere, not just on older hosts. Worth loading a couple of unrelated extensions and confirming they still register their types, formatters, models and l10n.
- **Extension formatters.** The `globalProperties` half of the shim is the existing #16960 fix. It was moved above the new store logic specifically so it can't regress, but it's the thing to check if something breaks — custom formatters in an extension should still render.
- **Extension custom validators.** Behaviour changes here on older hosts: they go from silently missing to actually being found. Should be confirmed working, not just non-crashing.
- **Model `$plugin` / `$extension` accessors.** These are on the base `Resource` class, so every model in the product reads them. On current Rancher the fallback never fires (`$extension` is always set), but it's a hot path.
- **Product registration / routing.** `isProdRegistrationV2TopLevelProductResoure` feeds `detailLocation` and `listLocation`, so top-level-product extensions on `master` should still route to `product-c-cluster-resource` and non-top-level ones to `c-cluster-product-resource`.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
