### PR TITLE
Fix issue with 3-dot action menu on every list view that uses `ResourceTable` when it's loaded into Rancher 2.14 or older

### DIFF
--- a/shell/pkg/__tests__/vue-router.lib.test.ts
+++ b/shell/pkg/__tests__/vue-router.lib.test.ts
@@ -1,0 +1,174 @@
+import {
+  getCurrentInstance, isReactive, nextTick, shallowRef, watch
+} from 'vue';
+import * as vueRouter from 'vue-router';
+
+jest.mock('vue', () => ({
+  ...jest.requireActual('vue'),
+  getCurrentInstance: jest.fn()
+}));
+
+const mockGetCurrentInstance = getCurrentInstance as unknown as jest.Mock;
+
+// 'default' is added by the interop of `import * as`, it isn't something vue-router exports.
+const RUNTIME_EXPORTS = Object.keys(vueRouter).filter((key) => key !== 'default');
+
+const isFunctionExport = (key: string) => typeof (vueRouter as Record<string, any>)[key] === 'function';
+
+const FUNCTION_EXPORTS = RUNTIME_EXPORTS.filter(isFunctionExport);
+const VALUE_EXPORTS = RUNTIME_EXPORTS.filter((key) => !isFunctionExport(key));
+
+const loadStub = (): Record<string, any> => {
+  let stub: Record<string, any> = {};
+
+  // RouterLink/RouterView resolve when the module is first evaluated, so each test needs a
+  // fresh copy of the stub against whatever host it has set up.
+  jest.isolateModules(() => {
+    stub = require('@shell/pkg/vue-router.lib');
+  });
+
+  return stub;
+};
+
+const fakeHost = (): Record<string, any> => RUNTIME_EXPORTS.reduce((host, key) => {
+  host[key] = isFunctionExport(key) ? jest.fn(() => `${ key }-result`) : (vueRouter as Record<string, any>)[key];
+
+  return host;
+}, {} as Record<string, any>);
+
+const withHost = (): { host: Record<string, any>, stub: Record<string, any> } => {
+  const host = fakeHost();
+
+  (window as any).__vueRouter = host;
+
+  return { host, stub: loadStub() };
+};
+
+describe('fx: the extension build stub for vue-router', () => {
+  afterEach(() => {
+    delete (window as any).__vueRouter;
+    jest.clearAllMocks();
+  });
+
+  it('should export everything vue-router exports at runtime', () => {
+    // Anything missing here compiles to "export 'X' was not found in 'vue-router'" and blows up
+    // at runtime for an extension that imports it.
+    const stubbed = Object.keys(loadStub());
+    const missing = RUNTIME_EXPORTS.filter((key) => !stubbed.includes(key));
+
+    expect(missing).toStrictEqual([]);
+  });
+
+  describe('given a host that provides window.__vueRouter (Rancher >= 2.15)', () => {
+    it.each(FUNCTION_EXPORTS)('should forward %s() to the host', (key) => {
+      const { host, stub } = withHost();
+
+      expect(stub[key]('an-argument')).toBe(`${ key }-result`);
+      expect(host[key]).toHaveBeenCalledWith('an-argument');
+    });
+
+    it.each(VALUE_EXPORTS)('should hand over the host\'s own %s', (key) => {
+      const { host, stub } = withHost();
+
+      expect(stub[key]).toBe(host[key]);
+    });
+
+    it('should not touch the component instance for useRoute or useRouter', () => {
+      const { stub } = withHost();
+
+      stub.useRoute();
+      stub.useRouter();
+
+      expect(mockGetCurrentInstance).not.toHaveBeenCalledWith();
+    });
+  });
+
+  describe('given a host without window.__vueRouter (Rancher <= 2.14)', () => {
+    const route = { name: 'fallback-route', query: { page: '1' } };
+    const router = { push: jest.fn() };
+    let currentRoute: any;
+    let proxy: any;
+
+    beforeEach(() => {
+      // vue-router defines $route as a getter over the router's currentRoute ref, and replaces
+      // that ref's value on every navigation. Model it the same way, or nothing is tracked.
+      currentRoute = shallowRef(route);
+
+      proxy = {
+        get $route() {
+          return currentRoute.value;
+        },
+        $router: router
+      };
+
+      mockGetCurrentInstance.mockReturnValue({ proxy });
+    });
+
+    it('should read the route from the component proxy', () => {
+      const result = loadStub().useRoute();
+
+      expect(result.name).toBe('fallback-route');
+      expect(result.query).toStrictEqual({ page: '1' });
+    });
+
+    it('should stay live as the route changes, rather than snapshotting it', () => {
+      const result = loadStub().useRoute();
+
+      currentRoute.value = { name: 'next-route', query: {} };
+
+      expect(result.name).toBe('next-route');
+    });
+
+    it('should behave like a plain object for keys, spread and `in`', () => {
+      const result = loadStub().useRoute();
+
+      expect(Object.keys(result)).toStrictEqual(['name', 'query']);
+      expect({ ...result }).toStrictEqual(route);
+      expect('name' in result).toBe(true);
+      expect('nope' in result).toBe(false);
+    });
+
+    it('should return a reactive route, so that watchers accept it', async() => {
+      const result = loadStub().useRoute();
+      const onChange = jest.fn();
+
+      expect(isReactive(result)).toBe(true);
+
+      watch(result, onChange, { deep: true });
+
+      currentRoute.value = { name: 'next-route', query: {} };
+      await nextTick();
+
+      expect(onChange).toHaveBeenCalledWith(result, result, expect.any(Function));
+    });
+
+    it('should return undefined from useRoute outside of a component', () => {
+      mockGetCurrentInstance.mockReturnValue(null);
+
+      expect(loadStub().useRoute()).toBeUndefined();
+    });
+
+    it('should return the router from the component proxy', () => {
+      expect(loadStub().useRouter()).toStrictEqual(router);
+    });
+
+    it('should return undefined from useRouter outside of a component', () => {
+      mockGetCurrentInstance.mockReturnValue(null);
+
+      expect(loadStub().useRouter()).toBeUndefined();
+    });
+
+    it('should fall back to the globally registered router components', () => {
+      const stub = loadStub();
+
+      expect(stub.RouterLink).toBe('router-link');
+      expect(stub.RouterView).toBe('router-view');
+    });
+
+    it('should explain itself for the exports it cannot provide', () => {
+      expect(() => loadStub().onBeforeRouteUpdate(() => {})).toThrow(
+        "vue-router's onBeforeRouteUpdate() is not available to extensions on this Rancher version (requires 2.15 or later)"
+      );
+    });
+  });
+});

--- a/shell/pkg/vue-router.lib.js
+++ b/shell/pkg/vue-router.lib.js
@@ -1,0 +1,92 @@
+// Stub for extension library builds — keeps vue-router out of extension bundles without
+// hard-requiring a host global.
+//
+// Rancher >= 2.15 exposes the real vue-router as window.__vueRouter (see
+// core/plugins-loader.js). Rancher <= 2.14 never sets it, and because the UMD wrapper binds
+// externals at script-load time, an externalised 'vue-router' resolves to undefined there —
+// so every useRoute() call, in @shell components and in extension code alike, throws inside
+// setup(). See https://github.com/rancher/dashboard/issues/18635.
+//
+// Every export below forwards to the host global, so on Rancher >= 2.15 an extension gets the
+// host's real vue-router, identity-equal and unchanged. useRoute()/useRouter() additionally
+// have a fallback for older hosts, built on the $route/$router that vue-router installs on
+// every component proxy. The rest fail with a readable message rather than as
+// "undefined is not a function".
+
+import { getCurrentInstance, reactive } from 'vue';
+
+const host = () => (typeof window === 'undefined' ? undefined : window.__vueRouter);
+
+const vm = () => getCurrentInstance()?.proxy;
+
+// Forward a vue-router function to the host, or explain why it isn't there.
+const delegate = (name) => (...args) => {
+  const fn = host()?.[name];
+
+  if (!fn) {
+    throw new Error(`vue-router's ${ name }() is not available to extensions on this Rancher version (requires 2.15 or later)`);
+  }
+
+  return fn(...args);
+};
+
+// Forward a vue-router constant, symbol or component to the host, with an optional fallback.
+const value = (name, fallback) => host()?.[name] || fallback;
+
+// The real useRoute() returns a reactive object tracking the router's current location.
+// vue-router installs the same thing as $route on every component, but swaps the object out on
+// each navigation, so we read through to it on every property access instead of capturing it.
+// reactive() keeps watch(route, cb) working, the way it does with the real thing.
+const fallbackUseRoute = () => {
+  const instance = vm();
+
+  if (!instance) {
+    return undefined;
+  }
+
+  return reactive(new Proxy({}, {
+    get:                      (_target, key) => instance.$route?.[key],
+    has:                      (_target, key) => key in (instance.$route || {}),
+    ownKeys:                  () => Reflect.ownKeys(instance.$route || {}),
+    getOwnPropertyDescriptor: () => ({ enumerable: true, configurable: true })
+  }));
+};
+
+export function useRoute(...args) {
+  const router = host();
+
+  return router ? router.useRoute(...args) : fallbackUseRoute();
+}
+
+export function useRouter(...args) {
+  const router = host();
+
+  return router ? router.useRouter(...args) : vm()?.$router;
+}
+
+// app.use(router) registers both of these globally, so the string name resolves in a template.
+export const RouterLink = value('RouterLink', 'router-link');
+export const RouterView = value('RouterView', 'router-view');
+
+// The rest of the vue-router surface, forwarded verbatim. None of it is reachable from shell
+// code today, but extensions may import any of it and did get the real thing before this stub.
+export const createMemoryHistory = delegate('createMemoryHistory');
+export const createRouter = delegate('createRouter');
+export const createRouterMatcher = delegate('createRouterMatcher');
+export const createWebHashHistory = delegate('createWebHashHistory');
+export const createWebHistory = delegate('createWebHistory');
+export const isNavigationFailure = delegate('isNavigationFailure');
+export const loadRouteLocation = delegate('loadRouteLocation');
+export const onBeforeRouteLeave = delegate('onBeforeRouteLeave');
+export const onBeforeRouteUpdate = delegate('onBeforeRouteUpdate');
+export const parseQuery = delegate('parseQuery');
+export const stringifyQuery = delegate('stringifyQuery');
+export const useLink = delegate('useLink');
+
+export const NavigationFailureType = value('NavigationFailureType');
+export const START_LOCATION = value('START_LOCATION');
+export const matchedRouteKey = value('matchedRouteKey');
+export const routeLocationKey = value('routeLocationKey');
+export const routerKey = value('routerKey');
+export const routerViewLocationKey = value('routerViewLocationKey');
+export const viewDepthKey = value('viewDepthKey');

--- a/shell/pkg/vue.config.js
+++ b/shell/pkg/vue.config.js
@@ -78,12 +78,22 @@ module.exports = function(dir) {
         resource.request = path.join(__dirname, 'require-asset.lib.js');
       });
 
+      // vue-router can't simply be externalised: the UMD wrapper binds externals at load time,
+      // so on hosts that don't define window.__vueRouter (Rancher <= 2.14) it resolves to
+      // undefined and every useRoute()/useRouter() call throws in setup(). The stub forwards to
+      // the host global when it exists and falls back to $route/$router when it doesn't, so a
+      // single extension build works on Rancher 2.11 through 2.15 and later.
+      const vueRouterOverride = new webpack.NormalModuleReplacementPlugin(/^vue-router$/, (resource) => {
+        resource.request = path.join(__dirname, 'vue-router.lib.js');
+      });
+
       // Auto-generate module to import the types (model, detail, edit etc)
       const autoImportPlugin = new VirtualModulesPlugin({ 'node_modules/@rancher/auto-import': generateTypeImport('@pkg', dir) });
 
       config.plugins.unshift(dynamicImporterOverride);
       config.plugins.unshift(modelLoaderImporterOverride);
       config.plugins.unshift(requireAssetOverride);
+      config.plugins.unshift(vueRouterOverride);
       config.plugins.unshift(autoImportPlugin);
       config.plugins.unshift(new NodePolyfillPlugin()); // required from Webpack 5 to polyfill node modules
       // config.plugins.unshift(debug);
@@ -91,10 +101,9 @@ module.exports = function(dir) {
       // These modules will be externalised and not included with the build of a package library
       // This helps reduce the package size, but these dependencies must be provided by the hosting application
       config.externals = {
-        jquery:       '$',
-        jszip:        '__jszip',
-        'js-yaml':    '__jsyaml',
-        'vue-router': '__vueRouter'
+        jquery:    '$',
+        jszip:     '__jszip',
+        'js-yaml': '__jsyaml'
       };
 
       // Prevent warning in log with the md files in the content folder


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18635

Any extension built against the current `@rancher/shell` loses the 3-dot action menu on every list view that uses `ResourceTable` when it's loaded into Rancher 2.14 or older:

```
TypeError: Cannot read properties of undefined (reading 'useRoute')
    at setup (ActionMenuShell.vue:43:48)
```

Extension builds externalise `vue-router` as `window.__vueRouter`, and only Rancher 2.15+ sets that global. On older hosts it resolves to `undefined`, so every `useRoute()` / `useRouter()` call throws inside `setup()`, the component never mounts, and the menu simply isn't rendered.

### Occurred changes and/or fixed issues
- fix `TypeError: Cannot read properties of undefined (reading 'useRoute')` on extension list views using `ResourceTable`, when loaded into Rancher 2.11 through 2.14
- fix the same crash in every other `@shell` component that gets bundled into extensions and calls `useRoute()` / `useRouter()` — `SlideInPanelManager`, `Resource/Detail/TitleBar`, `Resource/Detail/ViewOptions`, `DynamicContent`, `NotificationCenter/Notification` and the `composables/resources` helpers
- fix extension authors' own `import { useRoute } from 'vue-router'` throwing on those same hosts — this is what #17999 enabled for 2.15, and it now works everywhere
- keep `window.__vueRouter` in place, so extensions already published against `@rancher/shell@3.0.12` continue to work unchanged

### Technical notes summary
Extension bundles don't carry their own copy of `vue-router` — they expect the host Rancher to hand one over through a global. That arrangement was added in #17999 and only ever landed on 2.15, so on anything older the extension asks for a router and gets nothing. It can't work around it either: the global is read in the bundle's UMD wrapper at script-load time, before any of the extension's own code runs.

So instead of pointing extension builds straight at the host global, they now go through a small compatibility module that ships inside the shell package, wired up with the same `NormalModuleReplacementPlugin` idiom already used for `dynamic-importer`, `model-loader-require` and `require-asset`.

That module hands over the host's real `vue-router` whenever the host provides one, so on Rancher 2.15 and later nothing changes at all — every export is the genuine article, identity and all. When the host doesn't provide one, it falls back to the router that `app.use(router)` installs on every Vue component, which every Rancher back to 2.11 has. One extension build, working across all of them.

It covers the full `vue-router` surface rather than just the two functions shell happens to use, because extension authors can import any of it and used to get the real library on 2.15. The handful of host-only APIs that have no sensible fallback throw a message naming the API and the version it needs, instead of failing as `undefined is not a function`.

Only `shell/pkg/vue.config.js` changes, and that file is only read when building an extension as a library — the Rancher dashboard build itself is untouched. Type-only imports are unaffected too, since the swap happens in webpack rather than in `tsc`.

Note this only helps extensions that are **rebuilt** against a shell containing the fix. Already-published bundles are unaffected until they're republished.

### Areas or cases that should be tested
Tested locally in Chrome — reviewer should use a different browser.

Unit tests:

```
yarn test:ci shell/pkg/__tests__/vue-router.lib.test.ts
```

Manual, end to end against the extension that reported the bug:

1. Run `./shell/scripts/typegen.sh` to generate the type definitions
2. Run `yarn link` in the `shell` package of this branch
3. On the extension side — https://github.com/rancher/supportability-review-app, branch `main` — run `yarn link "@rancher/shell"`
4. Run `yarn build-pkg supportability-review-app` to build the extension
5. Confirm the built bundle no longer reaches for the host global: `grep -c "__vueRouter" dist-pkg/supportability-review-app-*/supportability-review-app-*.umd.min.js` should return `0` (it returns `1` without this fix)
6. Scan the build log for `export 'X' was not found in 'vue-router'` — there should be none
7. Run `yarn serve-pkgs` to serve the built assets
8. Do a dev load of the extension into a Rancher **2.14.x** instance
9. Install the Helm chart the extension needs
10. Navigate to `sr.cattle.io.reviewbundle`
11. Confirm the 3-dot action menu is present on every row, opens, and its actions run
12. Open the browser console and confirm the `Cannot read properties of undefined (reading 'useRoute')` error does **not** appear

Worth repeating the same steps on 2.11.x, 2.12.x and 2.13.x — they're all missing the same global — and on a current `master` build to confirm nothing changed there.

### Areas which could experience regressions
- **Extensions on Rancher 2.15 and master.** This is the main thing to check. `vue-router` is no longer externalised, so every extension's router usage now goes through the compatibility module rather than straight to the host global. It's a pass-through on those hosts, but it's on the path for all of them — navigation from extension pages, action menus, slide-in panels and detail-page title bars should all behave exactly as before.
- **Extension bundle size.** The module pulls in no `vue-router` code, so bundles should stay the size they are today. Worth a glance at the bundle analyzer output if anything looks off — a jump of ~25KB would mean a real copy got bundled somewhere.
- **`RouterLink` in extension components.** `SubtleLink` uses it, and on older hosts it resolves by name through the globally registered component rather than by direct reference. Links rendered by extensions should still navigate.
- **Any extension load, on any Rancher version.** The change is in the shared extension build config, so a mistake here affects how every extension is built, not just the ones using list views. Worth building and loading a couple of unrelated extensions.
- **The Rancher dashboard itself.** No expected impact — `shell/pkg/vue.config.js` isn't part of the host build — but a smoke test of normal navigation costs nothing.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
