### PR TITLE
test(e2e): match home-page counts/namespaces waits with or without pagesize

### DIFF
--- a/cypress/e2e/po/pages/home.po.ts
+++ b/cypress/e2e/po/pages/home.po.ts
@@ -7,7 +7,6 @@ import HomeClusterListPo from '@/cypress/e2e/po/lists/home-cluster-list.po';
 import BurgerMenuPo from '@/cypress/e2e/po/side-bars/burger-side-menu.po';
 import NotificationsCenterPo from '@/cypress/e2e/po/components/notification-center.po';
 import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
-import { PAGINATION_UTILS } from '@/cypress/support/utils/shell';
 
 const burgerMenu = new BurgerMenuPo();
 
@@ -22,9 +21,12 @@ export default class HomePagePo extends PagePo {
     // There's issues reporting when this page is ready, specifically for the user avatar click
     // To help with this be super sure the page is ready
 
+    // Match these calls whether or not the backend paginates them: newer Rancher adds
+    // `pagesize=<n>` while older backends omit it. Using a regex fires the wait on the
+    // real request against both, keeping the readiness guard without pinning a version.
     PagePo.goToAndWaitForGet(HomePagePo.goTo, [
-      `v1/counts?pagesize=${ PAGINATION_UTILS.defaultPageSize }&exclude=metadata.managedFields`,
-      `v1/namespaces?pagesize=${ PAGINATION_UTILS.defaultPageSize }&exclude=metadata.managedFields`,
+      /\/v1\/counts\?.*exclude=metadata\.managedFields/,
+      /\/v1\/namespaces\?.*exclude=metadata\.managedFields/,
     ]);
 
     const homePage = new HomePagePo();

--- a/cypress/e2e/po/pages/page.po.ts
+++ b/cypress/e2e/po/pages/page.po.ts
@@ -19,7 +19,7 @@ export default class PagePo extends ComponentPo {
    * If using this on a page with a specific cluster context it will make another counts request for counts for it (cluster/counts)
    * Note - If that cluster is the upstream one the request will be the same as management (v1/counts)
    */
-  static goToAndWaitForGet(goTo: () => Cypress.Chainable, getUrls = [
+  static goToAndWaitForGet(goTo: () => Cypress.Chainable, getUrls: (string | RegExp)[] = [
     'v1/counts',
   ], timeout = 10000) {
     getUrls.forEach((cUrl, i) => {


### PR DESCRIPTION
### Summary
The Cypress home-page readiness helper (`HomePagePo.goToAndWaitForGet`) intercepts and
waits for the `v1/counts` and `v1/namespaces` requests with a **hardcoded**
`pagesize=<defaultPageSize>` query param:

```
v1/counts?pagesize=100000&exclude=metadata.managedFields
v1/namespaces?pagesize=100000&exclude=metadata.managedFields
```

That param is only sent when the dashboard uses server-side (sql-cache) pagination — i.e.
it depends on the dashboard build and the backend advertising pagination support. Against a
backend/UI that does **not** paginate those calls, the request is `v1/counts?exclude=…`
(no `pagesize`), so the intercept never matches and `cy.wait('@getUrl0')` times out after
10s. The result is a flaky/failing readiness wait when the specs run against a backend whose
UI doesn't send `pagesize` (e.g. an older release line), even though login and the page load
fine.

### Occurred changes and/or fixed issues
- `HomePagePo.goToAndWaitForGet` now matches these calls with a **regex** that fires the wait
  whether or not `pagesize` is present (and regardless of its value):
  ```
  /\/v1\/counts\?.*exclude=metadata\.managedFields/
  /\/v1\/namespaces\?.*exclude=metadata\.managedFields/
  ```
- `PagePo.goToAndWaitForGet` signature widened from `string[]` to `(string | RegExp)[]` so
  regex matchers are accepted (backwards compatible — existing string callers are unaffected).
- Removed the now-unused `PAGINATION_UTILS` import from `home.po.ts`.

### Technical notes summary
- The wait is still a genuine readiness guard: it waits for the actual `counts` / `namespaces`
  response before proceeding; it just no longer pins the exact URL shape.
- It also stops being coupled to the `PAGINATION_UTILS.defaultPageSize` value, so a future
  change to the default page size won't silently break the wait.
- No product code changes; test-infra only.

### Areas or cases that should be tested
- Any spec that starts on the home page via `HomePagePo.goToAndWaitForGet` (a large portion of
  the suite) — confirm the page-ready wait still passes on CI (paginated backend).
- If available, confirm the same specs also pass against a backend/UI that does not send
  `pagesize` (older release line).

### Areas which could experience regressions
- Only the home-page readiness wait. The regex is scoped to the exact `counts` / `namespaces`
  collection calls (anchored on `?…exclude=metadata.managedFields`), so it won't match
  unrelated requests.

### Screenshot/Video
N/A — test-infrastructure change, no UI impact.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
