### PR TITLE
make useRouter available for extension components

### DIFF
--- a/cypress/e2e/tests/pages/manager/edit-fake-cluster.spec.ts
+++ b/cypress/e2e/tests/pages/manager/edit-fake-cluster.spec.ts
@@ -67,7 +67,7 @@ describe('Cluster Edit', { tags: ['@manager', '@adminUser'] }, () => {
         })
         .click();
 
-      cy.url().should('include', `https://ranchermanager.docs.rancher.com/v${ CURRENT_RANCHER_VERSION }/how-to-guides/new-user-guides/launch-kubernetes-with-rancher#launching-kubernetes-on-new-nodes-in-an-infrastructure-provider`);
+      cy.url().should('include', `https://ranchermanager.docs.rancher.com/v${ CURRENT_RANCHER_VERSION }/how-to-guides/new-user-guides/launch-kubernetes-with-rancher/#launching-kubernetes-on-new-nodes-in-an-infrastructure-provider`);
     });
   });
 });

--- a/shell/core/plugins-loader.js
+++ b/shell/core/plugins-loader.js
@@ -1,4 +1,5 @@
 import * as vue3 from 'vue';
+import * as vueRouter from 'vue-router';
 import $ from 'jquery';
 import JSZip from 'jszip';
 import jsyaml from 'js-yaml';
@@ -25,6 +26,7 @@ export default function({
 
   // Global libraries - allows us to externalise these to reduce package bundle size
   window.Vue = vue3;
+  window.__vueRouter = vueRouter;
   window.$ = $;
   window.__jszip = JSZip;
   window.__jsyaml = jsyaml;

--- a/shell/pkg/vue.config.js
+++ b/shell/pkg/vue.config.js
@@ -84,9 +84,10 @@ module.exports = function(dir) {
       // These modules will be externalised and not included with the build of a package library
       // This helps reduce the package size, but these dependencies must be provided by the hosting application
       config.externals = {
-        jquery:    '$',
-        jszip:     '__jszip',
-        'js-yaml': '__jsyaml'
+        jquery:       '$',
+        jszip:        '__jszip',
+        'js-yaml':    '__jsyaml',
+        'vue-router': '__vueRouter'
       };
 
       // Prevent warning in log with the md files in the content folder


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18654
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- make `useRouter` available for extension components

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->

The fix requires both the running UI **and** the extension build to have this change. Follow the steps below to validate end-to-end.

#### Prerequisites
- A running Rancher system with this PR's changes loaded locally
- The [`simple-extension`](https://github.com/mantis-toboggan-md/simple-extension) repo cloned locally

#### Steps

1. In your dashboard fork (with this PR), link the shell package locally:
   ```bash
   cd shell && yarn link
   ```

2. In the `simple-extension` repo, point to the linked shell and rebuild:
   ```bash
   yarn link "@rancher/shell"
   yarn build-pkg <pkg-name>
   ```

3. Developer-load the newly built extension into your local Rancher UI.

4. Navigate to **Cluster Explorer → More Resources → Policy → LimitRanges → Create** (`/c/local/explorer/limitrange/create`).

5. Open the browser DevTools console.

#### Expected result
No `TypeError: Cannot read properties of undefined (reading 'currentRoute')` error in the console. The LimitRange create page renders correctly (shows a URL).


### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
