### PR TITLE
fix extensions issue with hard refresh on a list page route

### DIFF
--- a/shell/components/ResourceList/Masthead.vue
+++ b/shell/components/ResourceList/Masthead.vue
@@ -99,7 +99,12 @@ export default {
     let currPluginName = '';
     let formRoute;
     let overrideCreateLocationByExtension = false;
-    const plugins = this.$extension.getPlugins();
+    // `data()` runs during the very first render, which is before Vue assigns `__vue_app__`,
+    // so the `$extension`/`$plugin` compat shim in `@shell/pkg/auto-import` cannot have run
+    // yet when this component is bundled into an extension loaded on an older Rancher.
+    // Fall through to `{}` there: `topLevelProduct` is a V2 product registration flag that
+    // doesn't exist on those versions, so the non-override branch below is correct for them.
+    const plugins = this.$extension?.getPlugins?.() || {};
 
     Object.keys(plugins).forEach((key) => {
       if (plugins[key].productNames.includes(this.$store.getters['productId'])) {

--- a/shell/components/ResourceList/__tests__/Masthead.test.ts
+++ b/shell/components/ResourceList/__tests__/Masthead.test.ts
@@ -1,0 +1,77 @@
+import { shallowMount } from '@vue/test-utils';
+import Masthead from '@shell/components/ResourceList/Masthead.vue';
+
+const PRODUCT_ID = 'sr';
+const RESOURCE = 'sr.cattle.io.reviewbundle';
+const ROUTE_NAME = 'c-cluster-product-resource';
+
+const createStore = () => ({
+  getters: {
+    productId:                PRODUCT_ID,
+    isExplorer:               false,
+    currentCluster:           null,
+    'type-map/hasCustomEdit': () => true,
+    'type-map/labelFor':      () => 'Review Bundle',
+    'type-map/optionsFor':    () => ({ isCreatable: true, canYaml: false }),
+  },
+});
+
+const createWrapper = (mocks: Record<string, any> = {}) => shallowMount(Masthead as any, {
+  props:  { resource: RESOURCE, schema: { collectionMethods: ['post'] } },
+  global: {
+    mocks: {
+      $store: createStore(),
+      $route: {
+        name:   ROUTE_NAME,
+        params: {
+          cluster: '_', product: PRODUCT_ID, resource: RESOURCE
+        }
+      },
+      t: (key: string) => key,
+      ...mocks,
+    },
+  },
+});
+
+describe('component: MastheadResourceList', () => {
+  describe('given an extension manager exposed as $extension', () => {
+    it('should override the create route for a V2 top level product', () => {
+      const wrapper = createWrapper({ $extension: { getPlugins: () => ({ srPlugin: { productNames: [PRODUCT_ID], topLevelProduct: true } }) } });
+
+      expect((wrapper.vm as any).overrideCreateLocationByExtension).toBe(true);
+      expect((wrapper.vm as any).formRoute).toStrictEqual({
+        name:   `${ ROUTE_NAME }-create`,
+        params: {
+          cluster: '_', product: PRODUCT_ID, resource: RESOURCE
+        },
+      });
+    });
+
+    it('should use the original create route when no plugin owns the current product', () => {
+      const wrapper = createWrapper({ $extension: { getPlugins: () => ({ otherPlugin: { productNames: ['other'], topLevelProduct: true } }) } });
+
+      expect((wrapper.vm as any).overrideCreateLocationByExtension).toBe(false);
+    });
+  });
+
+  // https://github.com/rancher/dashboard/issues/18634 - on Rancher 2.11/2.12/2.13 the manager
+  // lives on `$plugin`, and the compat shim that aliases the two cannot have run by the time
+  // `data()` executes on the first render, so this component must not assume `$extension`.
+  describe('given an extension manager that is not reachable via $extension', () => {
+    it.each([
+      ['$extension is undefined', { $extension: undefined }],
+      ['$extension has no getPlugins yet', { $extension: {} }],
+    ])('should render and fall back to the original create route when %s', (_label, mocks) => {
+      const wrapper = createWrapper(mocks);
+
+      expect(wrapper.find('header').exists()).toBe(true);
+      expect((wrapper.vm as any).overrideCreateLocationByExtension).toBe(false);
+      expect((wrapper.vm as any).formRoute).toStrictEqual({
+        name:   `${ ROUTE_NAME }-create`,
+        params: {
+          cluster: '_', product: PRODUCT_ID, resource: RESOURCE
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18634

Any extension built against the current `@rancher/shell` white-screens when you hard-refresh the browser on one of its list routes, on Rancher 2.13 and older:

```
TypeError: Cannot read properties of undefined (reading 'getPlugins')
    at shell/components/ResourceList/Masthead.vue:102
```

`Masthead.vue` reads the extension manager off Vue's globalProperties inside `data()`. On 2.11, 2.12 and 2.13 the manager lives under `$plugin` — the rename to `$extension` only exists on `master` — so `this.$extension` is `undefined` and the dereference throws. Because it happens in `data()`, it takes the whole route render down rather than just breaking a widget, hence a blank page.

Navigating to the same list from inside the UI works fine. Only a hard refresh breaks.

### Occurred changes and/or fixed issues
- fix the blank page and `Cannot read properties of undefined (reading 'getPlugins')` when hard-refreshing an extension list route on Rancher 2.11 through 2.13
- fall through to the pre-`topLevelProduct` create route on those hosts, which is the correct behaviour for them — V2 product registration doesn't exist there, so there was never an override to apply
- no behaviour change whatsoever on `master`
- add unit tests for `Masthead.vue`, which had none

### Technical notes summary
The copy of `Masthead.vue` that crashes is the one **bundled into the extension**, compiled from whichever `@rancher/shell` the extension was built against. The host's own 2.11 Masthead doesn't contain this code at all.

There's already a compatibility shim in `@shell/pkg/auto-import` whose whole job is to alias `$extension` and `$plugin` to each other so extensions work regardless of which name the host uses — but it can't reach this one, and that's the interesting part.

The shim finds the Vue app through the DOM, via `document.getElementById('app').__vue_app__`. Line up the boot order and you can see why that never works in time: extensions are loaded and the route resolved *before* the app is mounted, and Vue only assigns `__vue_app__` **after** the first render has already run. So on a cold load the shim's first attempt always finds nothing, and the retry it arms doesn't land until after Masthead's `data()` has already executed. No tighter retry interval and no `MutationObserver` changes that — it's structurally too late. There's no earlier handle to reach for either: an extension's entry point only receives the `Plugin` instance, whose constructor takes nothing but an `id`.

That also explains the navigate-versus-refresh split cleanly. On a client-side navigation the retry fired long ago and the globalProperties are already patched; on a hard refresh Masthead is one of the first things rendered.

So the fix is a guard at the call site, `this.$extension?.getPlugins?.() || {}`. This is a fall-through to correct behaviour rather than crash suppression, and the existing code says so itself — with no plugins matched, execution lands in the branch already labelled *"this was the original logic before the topLevelProduct override was added"*. The double optional-chain is deliberate rather than belt-and-braces noise: the store seeds the manager keys with an empty object and swaps in the real manager later, so "present but not yet usable" is a real state.

Note this only helps extensions that are **rebuilt** against a shell containing the fix. Already-published bundles are unaffected until they're republished. Nothing changes for the host itself.

There's a companion issue, #18633, covering the same `$extension`/`$plugin` mismatch reached through the Vuex root state. That one *is* fixable in the shim; this one isn't. The two fixes are complementary and don't overlap.

### Areas or cases that should be tested
Tested locally in Chrome — reviewer should use a different browser.

Unit tests:

```
yarn test:ci shell/components/ResourceList/__tests__/Masthead.test.ts
```

Manual, end to end against the extension that reported the bug:

1. Run `./shell/scripts/typegen.sh` to generate the type definitions
2. Run `yarn link` in the `shell` package of this branch
3. On the extension side — https://github.com/rancher/supportability-review-app, branch `main` — run `yarn link "@rancher/shell"`
4. Run `yarn build-pkg supportability-review-app` to build the extension
5. Confirm the guard actually made it into the bundle: `grep -c 'getPlugins?.()' dist-pkg/supportability-review-app-*/supportability-review-app-*.umd.min.js` should return `1` (it returns `0` without this fix — the emitted form is `this.$extension?.getPlugins?.()||{}`)
6. Run `yarn serve-pkgs` to serve the built assets
7. Do a dev load of the extension into a Rancher **2.11.x** instance
8. Install the Helm chart the extension needs
9. Navigate to `sr.cattle.io.reviewbundle` from inside the UI and confirm the list loads — this worked before the fix too, and should still work
10. **Hard-refresh the browser on that same URL** (`/sr/c/_/sr.cattle.io.reviewbundle`)
11. Confirm the list renders instead of a blank page
12. Open the browser console and confirm the `Cannot read properties of undefined (reading 'getPlugins')` error does **not** appear (there's another PR https://github.com/rancher/dashboard/pull/18650 for a similar reported `getPlugins` issue - this one covers the hard refresh scenario. If the page loads after a hard refresh, then fix is correct)
13. Confirm the Create button is present and takes you to the create form

Worth repeating the same steps on 2.12.x and 2.13.x — they're all missing `$extension` — and on a current `master` build to confirm the `topLevelProduct` create route override still behaves exactly as before.

### Areas which could experience regressions
- **Extension list views on `master`.** This is the main thing to check. `?.` and `?.()` are transparent when `$extension` resolves normally, so the override branch should run exactly as it does today — but it's on the path for every extension list page. The Create button on an extension list registered with `topLevelProduct` should still route to the product-scoped create form, not the cluster-scoped one.
- **Core Rancher list views.** `Masthead.vue` is used by every `ResourceList`, not just extension ones. No expected impact, but the Create and Create-from-YAML buttons on a few built-in resource types are worth a click.
- **Extension list views on older Rancher, specifically the create route.** These get the pre-V2 create route rather than the `topLevelProduct` override. That isn't a regression — they were crashing before, not getting the override — but the outcome is "the original create route", not "V2 behaviour, working". An extension that genuinely depends on `topLevelProduct` routing needs a Rancher version that supports V2 product registration.
- **Failure mode on a modern host.** If `$extension` were ever unexpectedly missing on `master`, this now quietly takes the non-override path instead of throwing. That's the usual trade when a crash becomes a fallback, and the fallback is a documented, previously-correct code path — but it's a real change in failure mode.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
