### PR TITLE
make sure axe tests are done with the Prime theme and in light mode

### DIFF
--- a/cypress/e2e/tests/accessibility/shell.spec.ts
+++ b/cypress/e2e/tests/accessibility/shell.spec.ts
@@ -43,6 +43,23 @@ import { USERS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
 import { FleetApplicationCreatePo, FleetGitRepoCreateEditPo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
 
 describe('Shell a11y testing', { tags: ['@adminUser', '@accessibility'] }, () => {
+  // Colour contrast results are only meaningful against a known palette, so pin the whole suite to
+  // Prime branding in light mode instead of relying on the server/browser defaults. See #18621.
+  let originalBrand = '';
+
+  before(() => {
+    cy.login();
+
+    cy.getRancherResource('v3', 'settings', 'ui-brand').then((resp: Cypress.Response<any>) => {
+      originalBrand = resp.body.value || '';
+    });
+
+    cy.setRancherResource('v3', 'settings', 'ui-brand', { value: 'suse' });
+    // The stored form of the `light` theme preference is `ui-light` (see `mangleWrite` on `THEME` in
+    // `shell/store/prefs.js`). `true` verifies the preference actually landed.
+    cy.setUserPreference({ theme: 'ui-light' }, true);
+  });
+
   describe('Login page', () => {
     it('login page', () => {
       const loginPage = new LoginPagePo();
@@ -839,6 +856,8 @@ describe('Shell a11y testing', { tags: ['@adminUser', '@accessibility'] }, () =>
   });
 
   after(() => {
+    cy.setRancherResource('v3', 'settings', 'ui-brand', { value: originalBrand });
+    cy.setUserPreference({ theme: '' });
     cy.updateNamespaceFilter('local', 'none', '{"local":["all://user"]}');
     cy.setUserPreference({ 'plugin-developer': false });
   });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #18621

<!-- Define findings related to the feature or bug issue. -->

The accessibility (Axe) suite never pinned the theme, so the colour contrast checks were being measured against whatever palette the server and browser happened to give us: community `modern` branding, and light mode only by accident (headless Chrome reports `prefers-color-scheme: light`, so the `auto` theme preference happens to resolve to light — it falls back to **dark** when that signal is missing).

Worth noting for the reviewer: the `color-contrast` rule itself is **not** disabled and hasn't been since May 2025. There is no axe config file — the run options are passed inline as the second argument to the two `cy.checkA11y(...)` calls in `cypress/support/commands/accessiblity.ts`, and both pass `{}`, so axe's default (rule enabled) applies. The old `const RULES = { rules: { 'color-contrast': { enabled: false } } }` override was removed by #14372, and the later "disable colour contrast" PR (#15610) was closed, never merged. So no change was needed there — the actual gap was the palette.

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- pin the accessibility suite to Rancher Prime branding (`ui-brand` = `suse`) so colour contrast is checked against the Prime palette
- pin the suite to light mode explicitly instead of relying on the browser's `prefers-color-scheme`
- restore the original `ui-brand` value and clear the forced theme preference once the suite finishes

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
Everything is contained in the one spec file, `cypress/e2e/tests/accessibility/shell.spec.ts`. A `before()` hook at the top of the suite logs in, remembers the current `ui-brand` value, sets it to `suse`, and sets the user's theme preference to light. The existing `after()` puts both back.

The login happens in that hook because `ui-brand` is a server-side setting and changing it needs an authenticated request. Because it's a server setting rather than a user preference, it also covers the two logged-out "Login page" checks, which are a big branded colour surface. Cypress test isolation still clears cookies before each test, so those two keep running logged out exactly as before.

Nothing shared was touched — no changes to the axe options, to `applyDefaultTestTheme` / `restoreProductDefaultTestTheme` (used by the Percy visual specs), or to any config. The accessibility directory is only ever included in the spec pattern when `TEST_A11Y` is set, and when it is, it's the only directory that runs, so these settings can't leak into the other e2e suites.

The Prime brand works on a community Rancher — the brand assets and stylesheet ship in every dashboard build, so no Prime server is required to run this.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
The change only affects the `a11y-test` CI job, so the verification is mostly in its artifact:

1. Let the `a11y-test` job run on this PR and download the `accessibility-report` artifact.
2. Open the `screenshots/` folder and confirm the UI is rendered with the **SUSE/Prime light palette** — previously these showed the blue community Rancher logo and colours. Baseline to compare against: master run `31008652446`.
3. Open `accessibility.json` and check whether `color-contrast` now appears in the results. On that master baseline there were **zero** `color-contrast` entries across 50 checks (top offenders were `aria-required-parent` 51, `listitem` 34, `heading-order` 17, `aria-required-children` 11).
4. Confirm the two "Login page" checks still run logged out and pass.

To run it locally: `yarn e2e:docker`, then `TEST_A11Y=true TEST_SKIP=setup GREP_TAGS="@adminUser+@accessibility --@jenkins" yarn e2e:prod`.

After the run, confirm `ui-brand` is back to its original value in Global Settings and the user's theme preference is no longer forced to light.

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- **The rest of the e2e suites** — should be unaffected, since the accessibility directory only runs under `TEST_A11Y` and is the only directory that runs when it does. Still worth a sanity check that the regular e2e jobs are green.
- **Percy visual tests** — they use `applyDefaultTestTheme` / `restoreProductDefaultTestTheme`, both left untouched, so their `modern` + light snapshots shouldn't move.
- **`a11y-test` job runtime and artifact size** — the violation callback takes a screenshot per violating *node*. If the Prime palette surfaces high-node-count contrast violations, the job will get slower and the artifact bigger. Worth watching on the first run; capping screenshots would be a separate change.
- **Leftover state on a shared test server** — if the suite crashes before `after()` runs, `ui-brand` stays on `suse` and the admin's theme stays light. Only affects the throwaway CI Rancher, but it's a thing to be aware of when running locally.

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<!-- TODO: attach a before/after pair from the accessibility report screenshots — master (community blue) vs this PR (Prime light). -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
