### PR TITLE
[backport v2.14.5] [16905] Add additional configurations for color to be used, added secondary based on primary and added the other status as well

### DIFF
--- a/shell/utils/__tests__/color.test.ts
+++ b/shell/utils/__tests__/color.test.ts
@@ -1,0 +1,281 @@
+import {
+  contrastColor,
+  parseColor,
+  textColor,
+  hexToRgb,
+  mapStandardColors,
+  rgbToRgb,
+  colorToRgb,
+  normalizeHex,
+  createCssVars,
+} from '@shell/utils/color';
+
+describe('shell/utils/color', () => {
+  describe('hexToRgb', () => {
+    it.each([
+      {
+        desc:     'a lowercase hex color',
+        input:    '#ff0080',
+        expected: {
+          r: 255, g: 0, b: 128
+        },
+      },
+      {
+        desc:     'a hex color without # prefix',
+        input:    'ff0080',
+        expected: {
+          r: 255, g: 0, b: 128
+        },
+      },
+      {
+        desc:     'an uppercase hex color',
+        input:    '#AABBCC',
+        expected: {
+          r: 170, g: 187, b: 204
+        },
+      },
+    ])('parses $desc', ({ input, expected }) => {
+      expect(hexToRgb(input)).toStrictEqual(expected);
+    });
+
+    it.each([
+      { desc: 'an invalid hex string', input: 'not-a-color' },
+      { desc: 'a short 3-character hex (not supported by hexToRgb)', input: '#abc' },
+    ])('returns null for $desc', ({ input }) => {
+      expect(hexToRgb(input)).toBeNull();
+    });
+  });
+
+  describe('rgbToRgb', () => {
+    it.each([
+      {
+        desc:     'a valid rgb() string with spaces',
+        input:    'rgb(10, 20, 30)',
+        expected: {
+          r: 10, g: 20, b: 30
+        },
+      },
+      {
+        desc:     'an rgb() string without spaces',
+        input:    'rgb(0,128,255)',
+        expected: {
+          r: 0, g: 128, b: 255
+        },
+      },
+    ])('parses $desc', ({ input, expected }) => {
+      expect(rgbToRgb(input)).toStrictEqual(expected);
+    });
+
+    it.each([
+      { desc: 'an rgba string', input: 'rgba(10,20,30,0.5)' },
+      { desc: 'a plain color name', input: 'red' },
+    ])('returns null for $desc', ({ input }) => {
+      expect(rgbToRgb(input)).toBeNull();
+    });
+  });
+
+  describe('colorToRgb', () => {
+    it('converts a hex color to rgb object', () => {
+      expect(colorToRgb('#ff0000')).toStrictEqual({
+        r: 255, g: 0, b: 0
+      });
+    });
+
+    it('converts an rgb() string to rgb object', () => {
+      expect(colorToRgb('rgb(0, 0, 255)')).toStrictEqual({
+        r: 0, g: 0, b: 255
+      });
+    });
+
+    it('returns { r:0, g:0, b:0 } for an unrecognized format', () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      expect(colorToRgb('hsl(0,100%,50%)')).toStrictEqual({
+        r: 0, g: 0, b: 0
+      });
+      consoleSpy.mockRestore();
+    });
+
+    it('warns for unrecognized color formats', () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      colorToRgb('blue');
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Unable to parse color: blue'));
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('normalizeHex', () => {
+    it.each([
+      {
+        desc: '3-char hex with # to 6-char', input: '#abc', expected: '#aabbcc'
+      },
+      {
+        desc: '3-char hex without # to 6-char', input: 'abc', expected: 'aabbcc'
+      },
+      {
+        desc: '6-char hex with # unchanged', input: '#aabbcc', expected: '#aabbcc'
+      },
+      {
+        desc: '6-char hex without # unchanged', input: 'aabbcc', expected: 'aabbcc'
+      },
+    ])('handles $desc', ({ input, expected }) => {
+      expect(normalizeHex(input)).toStrictEqual(expected);
+    });
+  });
+
+  describe('mapStandardColors', () => {
+    it.each([
+      {
+        desc: '"black" to its hex value', input: 'black', expected: '#000000'
+      },
+      {
+        desc: '"white" to its hex value', input: 'white', expected: '#ffffff'
+      },
+      {
+        desc: 'an unknown color string unchanged', input: '#123456', expected: '#123456'
+      },
+    ])('maps $desc', ({ input, expected }) => {
+      expect(mapStandardColors(input)).toStrictEqual(expected);
+    });
+  });
+
+  describe('textColor', () => {
+    it.each([
+      {
+        desc: '"black" for a light color (#ffffff)', input: '#ffffff', expected: 'black'
+      },
+      {
+        desc: '"white" for a dark color (#000000)', input: '#000000', expected: 'white'
+      },
+      {
+        desc: '"black" for brightness above threshold (rgb 200,200,200)', input: 'rgb(200, 200, 200)', expected: 'black'
+      },
+      {
+        desc: '"white" for brightness below threshold (rgb 50,50,50)', input: 'rgb(50, 50, 50)', expected: 'white'
+      },
+    ])('returns $desc', ({ input, expected }) => {
+      const color = parseColor(input);
+
+      expect(textColor(color)).toStrictEqual(expected);
+    });
+  });
+
+  describe('contrastColor', () => {
+    it('returns light text on a very dark background (light theme)', () => {
+      expect(contrastColor('#000000')).toStrictEqual('rgb(255, 255, 255)');
+    });
+
+    it('returns dark text on a very light background (light theme)', () => {
+      expect(contrastColor('#ffffff')).toStrictEqual('rgb(20, 20, 25)');
+    });
+
+    it('uses custom contrast options when provided', () => {
+      const opts = { dark: '#000000', light: '#ffffff' };
+
+      // white background → dark text has higher contrast
+      expect(contrastColor('#ffffff', opts)).toStrictEqual('#000000');
+    });
+  });
+
+  describe('createCssVars', () => {
+    it('returns an object with expected CSS variable keys for light theme', () => {
+      const vars = createCssVars('#4a90d9', 'light', 'primary');
+      const expectedKeys = [
+        '--primary',
+        '--primary-text ',
+        '--primary-hover-bg',
+        '--primary-active-bg',
+        '--primary-active-text',
+        '--primary-border',
+        '--primary-banner-bg',
+        '--primary-light-bg',
+        '--primary-keyboard-focus',
+        '--active',
+        '--active-nav',
+        '--active-hover',
+        '--on-active',
+        '--category-active',
+        '--non-primary-hover',
+        '--secondary-border',
+        '--on-secondary',
+      ];
+
+      expect(Object.keys(vars)).toStrictEqual(expectedKeys);
+    });
+
+    // Regression test for https://github.com/rancher/dashboard/issues/16905
+    // The side-nav / top-nav in the modern theme are painted with these vars, which don't
+    // derive from --primary, so a custom branding color must override them too.
+    it('overrides the modern-theme nav/active vars with the custom primary color', () => {
+      const vars = createCssVars('#4a90d9', 'light', 'primary');
+
+      expect(vars['--active']).toStrictEqual('#4a90d9');
+      expect(vars['--active-nav']).toStrictEqual('#4a90d9');
+      expect(vars['--active-hover']).toBeDefined();
+      expect(vars['--on-active']).toBeDefined();
+      expect(vars['--category-active']).toContain('rgba');
+      expect(vars['--non-primary-hover']).toContain('rgba');
+      expect(vars['--secondary-border']).toStrictEqual('#4a90d9');
+      expect(vars['--on-secondary']).toStrictEqual('#4a90d9');
+    });
+
+    it('does not emit primary-only nav/active vars for the link name', () => {
+      const vars = createCssVars('#4a90d9', 'light', 'link');
+
+      expect(vars).not.toHaveProperty('--active');
+      expect(vars).not.toHaveProperty('--active-nav');
+      expect(vars).not.toHaveProperty('--category-active');
+      expect(vars).not.toHaveProperty('--non-primary-hover');
+      expect(vars).not.toHaveProperty('--secondary-border');
+      expect(vars).not.toHaveProperty('--on-secondary');
+    });
+
+    // Regression test for https://github.com/rancher/dashboard/issues/16905
+    // The Prime (.suse) theme decouples the tertiary family from --link and hardcodes it green,
+    // so a custom link color must override the tertiary vars to reach the nav icons on Prime.
+    it('overrides the tertiary family with the custom link color for the link name', () => {
+      const vars = createCssVars('#bda400', 'light', 'link');
+
+      expect(vars['--on-tertiary']).toStrictEqual('#bda400');
+      expect(vars['--on-tertiary-hover']).toStrictEqual('#bda400');
+      expect(vars['--on-tertiary-header']).toStrictEqual('#bda400');
+      expect(vars['--on-tertiary-header-hover']).toStrictEqual('#bda400');
+      expect(vars['--tertiary-hover-app-bar']).toStrictEqual('#bda400');
+    });
+
+    it('does not emit tertiary vars for the primary name', () => {
+      const vars = createCssVars('#4a90d9', 'light', 'primary');
+
+      expect(vars).not.toHaveProperty('--on-tertiary');
+      expect(vars).not.toHaveProperty('--tertiary-hover-app-bar');
+    });
+
+    it('sets --primary to the input color', () => {
+      const vars = createCssVars('#4a90d9');
+
+      expect(vars['--primary']).toStrictEqual('#4a90d9');
+    });
+
+    it('sets --primary-border to the input color', () => {
+      const vars = createCssVars('#4a90d9');
+
+      expect(vars['--primary-border']).toStrictEqual('#4a90d9');
+    });
+
+    it('uses a custom name prefix', () => {
+      const vars = createCssVars('#ff0000', 'light', 'accent');
+
+      expect(vars).toHaveProperty('--accent');
+      expect(vars).toHaveProperty('--accent-hover-bg');
+    });
+
+    it('produces opacity-based banner-bg and light-bg values', () => {
+      const vars = createCssVars('#ff0000');
+
+      // opacity(color, 0.15) and opacity(color, 0.05) produce rgba strings
+      expect(vars['--primary-banner-bg']).toContain('rgba');
+      expect(vars['--primary-light-bg']).toContain('rgba');
+    });
+  });
+});

--- a/shell/utils/color.js
+++ b/shell/utils/color.js
@@ -18,7 +18,7 @@ import Color from 'color';
 export function createCssVars(color, theme = 'light', name = 'primary') {
   const contrastOpts = theme === 'light' ? LIGHT_CONTRAST_COLORS : DARK_CONTRAST_COLORS;
 
-  return {
+  const vars = {
     [`--${ name }`]:                color,
     [`--${ name }-text `]:          contrastColor(color, contrastOpts),
     [`--${ name }-hover-bg`]:       lighten(color, -10),
@@ -29,6 +29,45 @@ export function createCssVars(color, theme = 'light', name = 'primary') {
     [`--${ name }-light-bg`]:       opacity(color, 0.05),
     [`--${ name }-keyboard-focus`]: lighten(color, -10),
   };
+
+  // The "modern" theme (introduced in 2.13) paints the side-nav active item, the expanded
+  // category background and the header/nav hovers using a separate set of variables that are
+  // baked to build-time shades of the default primary color ($primary-*). Those don't derive
+  // from `--primary`, so overriding only the `--primary-*` vars above left the nav showing the
+  // default (prime) color. Derive them from the custom color so branding applies everywhere.
+  // See https://github.com/rancher/dashboard/issues/16905
+  if (name === 'primary') {
+    Object.assign(vars, {
+      '--active':            color,
+      '--active-nav':        color,
+      '--active-hover':      lighten(color, -10),
+      '--on-active':         contrastColor(color, contrastOpts),
+      '--category-active':   opacity(color, 0.15),
+      '--non-primary-hover': opacity(color, 0.1),
+      // Secondary (outlined/ghost) buttons draw their border and text from these, which the
+      // modern theme also bakes to a shade of the default primary color.
+      '--secondary-border':  color,
+      '--on-secondary':      color,
+    });
+  }
+
+  // In the base modern theme the tertiary family (side/top-nav icons, tertiary/ghost button
+  // text) is defined as `var(--link)`, so a custom link color already reaches it. The Prime
+  // (.suse) theme instead re-points these at its own hardcoded green (--non-primary-text),
+  // decoupling them from --link — so a custom link color never reached the nav icons on Prime.
+  // Re-tie them to the custom link color, restoring the base-theme behaviour.
+  // See https://github.com/rancher/dashboard/issues/16905
+  if (name === 'link') {
+    Object.assign(vars, {
+      '--on-tertiary':              color,
+      '--on-tertiary-hover':        color,
+      '--on-tertiary-header':       color,
+      '--on-tertiary-header-hover': color,
+      '--tertiary-hover-app-bar':   color,
+    });
+  }
+
+  return vars;
 }
 
 // scss 'lighten(color, percent)' increases color's hsl lightness by percent amount, not scaled


### PR DESCRIPTION
Automated backport of #18271 to release-2.14.

The `/backport` command could not apply because `git am -3` failed: `shell/utils/__tests__/color.test.ts` does not exist on release-2.14, so its pre-image blob was unavailable to build the 3-way merge base. release-2.14's `color.js` is byte-identical to the PR's base, so the change ports cleanly by taking master's post-PR `color.js` + `color.test.ts`.

---

Original PR body:




<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Original text redacted by port-pr.yaml 
<!-- Define findings related to the feature or bug issue. -->

### Occurred changes and/or fixed issues
<!-- Include information of the changes, including collateral areas which have been affected by this PR as requirement or for convenience. -->
- There are 2 problems 2 problems that I found, the colors for primary were not being passed to values that uses the primary relatively like the secondary and other ones.
- For prime there are specific cases where the link color was not being passed as well.

### Technical notes summary
<!-- Outline technical changes which may pass unobserved or may help to understand the process of solving the issue -->
- Added additional overrides for the color to respect those changes.

### Areas or cases that should be tested
<!-- Areas that should be tested can include Airgap checks, Rancher upgrades, K8s upgrade, etc. -->
<!-- Which browser did you use for local testing? The reviewer should test with a different browser. -->
<!-- Add missing steps or rewrite them if have been missed or to complement existing information. This should define a clear way to reproduce it and not an approximation. -->
- Colors for the LINK/BRANDING Color on Community Version
- Colors for the LINK/BRANDING color on Prime Version

### Areas which could experience regressions
<!-- Create a detailed list of areas to be analyzed which may be affected by the changes, which would require a prior research to avoid regressions. -->
- There are problems with the original colors for Community Version and Prime

### Screenshot/Video
<!-- Attach screenshot or video of the changes and eventual comparison if you find it necessary -->
<img width="1654" height="1255" alt="image" src="https://github.com/user-attachments/assets/549e08ce-9862-45b4-b812-1398813764ec" />
Example of a prime version with RED branding and a YELLOWISH link

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`

Fixes #18394