### PR TITLE
[backport v2.15.1] [Automation] - Fix flaky login landing page tests

### DIFF
--- a/cypress/e2e/tests/pages/user-menu/preferences.spec.ts
+++ b/cypress/e2e/tests/pages/user-menu/preferences.spec.ts
@@ -9,6 +9,7 @@ import { HeaderPo } from '@/cypress/e2e/po/components/header.po';
 import ResourceYamlEditorPagePo from '@/cypress/e2e/po/pages/explorer/yaml-editor.po';
 import { FeatureFlagsPagePo } from '@/cypress/e2e/po/pages/global-settings/feature-flags.po';
 import { CLUSTER_REPOS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
+import { MEDIUM_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
 // import ClusterManagerListPagePo from '@/cypress/e2e/po/pages/cluster-manager/cluster-manager-list.po';
 // import TooltipPo from '@/cypress/e2e/po/components/tooltip.po'; // Used in the below commented test
 
@@ -478,15 +479,30 @@ describe('User can update their preferences', () => {
 
     // Verify that an auth redirect works (a user visits a page while not authorized and will be redirect to that page after loggin in, only active when "Take me to the area I last visited" is selected)
     if (key.index === '1') {
-      userMenu.clickMenuItem('Log Out');
-      cy.url().should('contain', 'auth/login?logged-out');
-
       const redirectUrl = '/c/local/explorer/node';
 
-      cy.visit(redirectUrl);
-      cy.url().should('contain', 'auth/login?timed-out');
+      const attemptAuthRedirect = () => {
+        userMenu.clickMenuItem('Log Out');
+        cy.url().should('contain', 'auth/login?logged-out');
 
-      cy.login(undefined, undefined, false, true);
+        cy.visit(redirectUrl);
+        cy.url().should('contain', 'auth/login?timed-out');
+
+        cy.login(undefined, undefined, false, true);
+        cy.url().should('not.contain', 'auth/login');
+      };
+
+      attemptAuthRedirect();
+      // Wait for the redirect chain to settle on either the expected page or the home page.
+      // A transient failure fetching preferences after login lands the user on the home page
+      // instead - retry the flow once to recover (authRedirect only lives in the store, so
+      // the whole timed-out flow needs to run again)
+      cy.location('pathname', MEDIUM_TIMEOUT_OPT).should('match', new RegExp(`(/home|${ redirectUrl })`));
+      cy.location('pathname').then((pathname) => {
+        if (pathname.endsWith('/home')) {
+          attemptAuthRedirect();
+        }
+      });
       cy.url().should('contain', redirectUrl);
       prefPage.goTo();
       prefPage.landingPageRadioBtn().checkVisible();
@@ -496,6 +512,16 @@ describe('User can update their preferences', () => {
     userMenu.clickMenuItem('Log Out');
     cy.url().should('contain', 'auth/login?logged-out');
     cy.login(undefined, undefined, false);
+    // Wait for the redirect chain to settle on either the expected landing page or the home
+    // page. A transient failure fetching preferences after login lands the user on the home
+    // page instead - re-navigating to the root re-runs a full app bootstrap which fetches the
+    // preferences again and re-runs the landing page redirect.
+    cy.location('pathname', MEDIUM_TIMEOUT_OPT).should('match', new RegExp(`(/home|${ key.page })`));
+    cy.location('pathname').then((pathname) => {
+      if (key.page !== '/home' && pathname.endsWith('/home')) {
+        cy.visit('/');
+      }
+    });
     cy.url().should('contain', key.page);
   }
 


### PR DESCRIPTION
This is a backport of #18528 to `release-2.15`.

The commit applied cleanly, so the changes are the same as on master.

---

### Summary
Fixes rancher/qa-tasks#2455
Fixes rancher/qa-tasks#2456

### Occurred changes and/or fixed issues
After login the app fetches user preferences before evaluating the after-login-route redirect. A transient failure of that fetch (e.g. a `401` while the session token propagates right after login) is silently swallowed by the app, which then falls back to the home page terminally, failing the URL assertion.

Reproduced locally by replying `401` to the first `GET /v1/userpreferences` after login, which produced the exact CI failure signature.

Wait for the post-login redirect chain to settle, and if it landed on the home page:
- for the regular landing flow, re-visit the root so a full app bootstrap fetches preferences again and re-runs the redirect
- for the auth redirect flow, retry the whole timed-out flow once, since authRedirect only lives in the store

### Technical notes summary
Updated `cypress/e2e/tests/pages/user-menu/preferences.spec.ts`:
- Added settling logic (`cy.location('pathname', MEDIUM_TIMEOUT_OPT)`) to allow asynchronous preference fetching and SPA store state updates to resolve cleanly after login.
- Added recovery handling: if a transient auth propagation delay causes an initial fallback to `/home`, the test retries the bootstrap flow cleanly before asserting the final target URL.

Test only changes, no product code affected.

### Testing done

Ran the `@userMenu` suite against a freshly provisioned Rancher on this branch:

| Spec | Result |
| :--- | :--- |
| `pages/user-menu/preferences.spec.ts` | 17/17 passed |
| `pages/user-menu/account-api-keys.spec.ts` | 1/1 passed |
| `pages/user-menu/logout.spec.ts` | 2/2 passed |

20/20 passed with no retries, including the three affected tests:
- `Can select login landing page - home page`
- `Can select login landing page - last visited` (qa-tasks#2455)
- `Can select login landing page - specific cluster` (qa-tasks#2456)

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
