### PR TITLE
Backport #18458 to release-2.13: Update EOM message for community

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2877,6 +2877,9 @@ dynamicContent:
   eol:
     title: End of Life reached
     message: This version of Rancher ({version}) has reached End of Life. Consider upgrading to a supported version.
+  eoc:
+    title: No more updates
+    message: This version of Rancher ({version}) will no longer receive updates. Consider upgrading to a newer version.
 
 etcdInfoBanner:
   hasLeader: "Etcd has a leader:"

--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -2878,8 +2878,8 @@ dynamicContent:
     title: End of Life reached
     message: This version of Rancher ({version}) has reached End of Life. Consider upgrading to a supported version.
   eoc:
-    title: No more updates
-    message: This version of Rancher ({version}) will no longer receive updates. Consider upgrading to a newer version.
+    title: Updates have ended
+    message: This version of Rancher ({version}) will no longer receive updates. Consider upgrading to a newer version or to Rancher Prime.
 
 etcdInfoBanner:
   hasLeader: "Etcd has a leader:"

--- a/shell/utils/dynamic-content/__tests__/support-notice.test.ts
+++ b/shell/utils/dynamic-content/__tests__/support-notice.test.ts
@@ -24,6 +24,8 @@ describe('processSupportNotices', () => {
         if (key === 'dynamicContent.eol.message') return `EOL Message for ${ version }`;
         if (key === 'dynamicContent.eom.title') return `EOM Title for ${ version }`;
         if (key === 'dynamicContent.eom.message') return `EOM Message for ${ version }`;
+        if (key === 'dynamicContent.eoc.title') return `EOC Title for ${ version }`;
+        if (key === 'dynamicContent.eoc.message') return `EOC Message for ${ version }`;
         if (key === 'dynamicContent.upcomingEol.title') return `Upcoming EOL Title for ${ version } in ${ days } days`;
         if (key === 'dynamicContent.upcomingEol.message') return `Upcoming EOL Message for ${ version } in ${ days } days`;
         if (key === 'dynamicContent.upcomingEom.title') return `Upcoming EOM Title for ${ version } in ${ days } days`;
@@ -68,121 +70,237 @@ describe('processSupportNotices', () => {
   });
 
   it('should return early if statusInfo is null/undefined', async() => {
-    const versionInfo: VersionInfo = { version: semver.coerce('2.12.0')!, isPrime: false };
+    const versionInfo: VersionInfo = { version: semver.coerce('2.12.0')!, isPrime: true };
 
     await processSupportNotices(mockContext, null as any, versionInfo);
     expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   it('should return early if versionInfo is null/undefined or version is missing', async() => {
-    const statusInfo: SupportInfo = { status: { eol: '<= 2.11', eom: '<= 2.12' }, upcoming: {} as any };
+    const statusInfo: SupportInfo = {
+      status: {
+        eol: '<= 2.11', eom: '<= 2.12', eoc: '<= 2.11'
+      },
+      upcoming: {} as any
+    };
 
     await processSupportNotices(mockContext, statusInfo, null as any);
     expect(mockDispatch).not.toHaveBeenCalled();
-    await processSupportNotices(mockContext, statusInfo, { version: null, isPrime: false });
+    await processSupportNotices(mockContext, statusInfo, { version: null, isPrime: true });
     expect(mockDispatch).not.toHaveBeenCalled();
   });
 
-  it('should not add notification if no support status matches', async() => {
-    const versionInfo: VersionInfo = { version: semver.coerce('2.13.0')!, isPrime: false };
-    const statusInfo: SupportInfo = {
-      status:   { eol: '<= 2.11.x', eom: '<= 2.12.x' },
-      upcoming: {
-        eom: { version: '= 2.13.x', date: day().add(40, 'day').toDate() },
-        eol: { version: '= 2.13.x', date: day().add(40, 'day').toDate() },
-      }
-    };
-
-    await processSupportNotices(mockContext, statusInfo, versionInfo);
-    expect(mockDispatch).not.toHaveBeenCalled();
-    expect(mockLogger.info).not.toHaveBeenCalled();
-  });
-
-  it('should add EOL notification if version is EOL', async() => {
-    const versionInfo: VersionInfo = { version: semver.coerce('2.11.5')!, isPrime: false };
-    const statusInfo: SupportInfo = {
-      status:   { eol: '<= 2.11.x', eom: '<= 2.12.x' },
-      upcoming: {} as any
-    };
-
-    await processSupportNotices(mockContext, statusInfo, versionInfo);
-
-    expect(mockLogger.info).toHaveBeenCalledWith('This version (2.11.5) is End of Life');
-    expect(mockDispatch).toHaveBeenCalledWith('notifications/add', expect.objectContaining({
-      id:    'support-notice-eol-2.11',
-      level: NotificationLevel.Warning,
-      title: 'EOL Title for 2.11',
-    }));
-  });
-
-  it('should add EOM notification if version is EOM but not EOL', async() => {
-    const versionInfo: VersionInfo = { version: semver.coerce('2.12.3')!, isPrime: false };
-    const statusInfo: SupportInfo = {
-      status:   { eol: '<= 2.11.x', eom: '<= 2.12.x' },
-      upcoming: {} as any
-    };
-
-    await processSupportNotices(mockContext, statusInfo, versionInfo);
-
-    expect(mockLogger.info).toHaveBeenCalledWith('This version (2.12.3) is End of Maintenance');
-    expect(mockDispatch).toHaveBeenCalledWith('notifications/add', expect.objectContaining({
-      id:    'support-notice-eom-2.12',
-      level: NotificationLevel.Warning,
-      title: 'EOM Title for 2.12',
-    }));
-  });
-
-  it('should add upcoming EOL notification', async() => {
-    const versionInfo: VersionInfo = { version: semver.coerce('2.12.0')!, isPrime: false };
-    const statusInfo: SupportInfo = {
-      status:   { eol: '<= 2.11.x', eom: '<= 2.11.x' },
-      upcoming: {
-        eol: { version: '= 2.12.x', date: day().add(15, 'day').toDate() },
-        eom: {} as any,
-      }
-    };
-
-    await processSupportNotices(mockContext, statusInfo, versionInfo);
-
-    expect(mockDispatch).toHaveBeenCalledWith('notifications/add', expect.objectContaining({
-      id:    'upcoming-support-notice-eol-2.12',
-      level: NotificationLevel.Warning,
-      title: 'Upcoming EOL Title for 2.12 in 15 days',
-    }));
-  });
-
-  it('should add upcoming EOM notification', async() => {
-    const versionInfo: VersionInfo = { version: semver.coerce('2.13.0')!, isPrime: false };
-    const statusInfo: SupportInfo = {
-      status:   { eol: '<= 2.12.x', eom: '<= 2.12.x' },
-      upcoming: {
-        eom: {
-          version: '= 2.13.x', date: day().add(20, 'day').toDate(), noticeDays: 25
+  describe('Prime', () => {
+    it('should not add notification if no support status matches', async() => {
+      const versionInfo: VersionInfo = { version: semver.coerce('2.13.0')!, isPrime: true };
+      const statusInfo: SupportInfo = {
+        status: {
+          eol: '<= 2.11.x', eom: '<= 2.12.x', eoc: '<= 2.12.x'
         },
-        eol: {} as any,
-      }
-    };
+        upcoming: {
+          eom: { version: '= 2.13.x', date: day().add(40, 'day').toDate() },
+          eol: { version: '= 2.13.x', date: day().add(40, 'day').toDate() },
+        }
+      };
 
-    await processSupportNotices(mockContext, statusInfo, versionInfo);
+      await processSupportNotices(mockContext, statusInfo, versionInfo);
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockLogger.info).not.toHaveBeenCalled();
+    });
 
-    expect(mockDispatch).toHaveBeenCalledWith('notifications/add', expect.objectContaining({
-      id:    'upcoming-support-notice-eom-2.13',
-      level: NotificationLevel.Warning,
-      title: 'Upcoming EOM Title for 2.13 in 20 days',
-    }));
+    it('should add EOL notification if version is EOL', async() => {
+      const versionInfo: VersionInfo = { version: semver.coerce('2.11.5')!, isPrime: true };
+      const statusInfo: SupportInfo = {
+        status: {
+          eol: '<= 2.11.x', eom: '<= 2.12.x', eoc: '<= 2.12.x'
+        },
+        upcoming: {} as any
+      };
+
+      await processSupportNotices(mockContext, statusInfo, versionInfo);
+
+      expect(mockLogger.info).toHaveBeenCalledWith('This version (2.11.5) is End of Life');
+      expect(mockDispatch).toHaveBeenCalledWith('notifications/add', expect.objectContaining({
+        id:    'support-notice-eol-2.11',
+        level: NotificationLevel.Warning,
+        title: 'EOL Title for 2.11',
+      }));
+    });
+
+    it('should add EOM notification if version is EOM but not EOL', async() => {
+      const versionInfo: VersionInfo = { version: semver.coerce('2.12.3')!, isPrime: true };
+      const statusInfo: SupportInfo = {
+        status: {
+          eol: '<= 2.11.x', eom: '<= 2.12.x', eoc: '<= 2.12.x'
+        },
+        upcoming: {} as any
+      };
+
+      await processSupportNotices(mockContext, statusInfo, versionInfo);
+
+      expect(mockLogger.info).toHaveBeenCalledWith('This version (2.12.3) is End of Maintenance');
+      expect(mockDispatch).toHaveBeenCalledWith('notifications/add', expect.objectContaining({
+        id:    'support-notice-eom-2.12',
+        level: NotificationLevel.Warning,
+        title: 'EOM Title for 2.12',
+      }));
+    });
+
+    it('should not add an EOC notification for Prime even when eoc matches', async() => {
+      const versionInfo: VersionInfo = { version: semver.coerce('2.13.0')!, isPrime: true };
+      const statusInfo: SupportInfo = {
+        status: {
+          eol: '<= 2.11.x', eom: '<= 2.11.x', eoc: '<= 2.13.x'
+        },
+        upcoming: {} as any
+      };
+
+      await processSupportNotices(mockContext, statusInfo, versionInfo);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it('should add upcoming EOL notification', async() => {
+      const versionInfo: VersionInfo = { version: semver.coerce('2.12.0')!, isPrime: true };
+      const statusInfo: SupportInfo = {
+        status: {
+          eol: '<= 2.11.x', eom: '<= 2.11.x', eoc: '<= 2.11.x'
+        },
+        upcoming: {
+          eol: { version: '= 2.12.x', date: day().add(15, 'day').toDate() },
+          eom: {} as any,
+        }
+      };
+
+      await processSupportNotices(mockContext, statusInfo, versionInfo);
+
+      expect(mockDispatch).toHaveBeenCalledWith('notifications/add', expect.objectContaining({
+        id:    'upcoming-support-notice-eol-2.12',
+        level: NotificationLevel.Warning,
+        title: 'Upcoming EOL Title for 2.12 in 15 days',
+      }));
+    });
+
+    it('should add upcoming EOM notification', async() => {
+      const versionInfo: VersionInfo = { version: semver.coerce('2.13.0')!, isPrime: true };
+      const statusInfo: SupportInfo = {
+        status: {
+          eol: '<= 2.12.x', eom: '<= 2.12.x', eoc: '<= 2.12.x'
+        },
+        upcoming: {
+          eom: {
+            version: '= 2.13.x', date: day().add(20, 'day').toDate(), noticeDays: 25
+          },
+          eol: {} as any,
+        }
+      };
+
+      await processSupportNotices(mockContext, statusInfo, versionInfo);
+
+      expect(mockDispatch).toHaveBeenCalledWith('notifications/add', expect.objectContaining({
+        id:    'upcoming-support-notice-eom-2.13',
+        level: NotificationLevel.Warning,
+        title: 'Upcoming EOM Title for 2.13 in 20 days',
+      }));
+    });
+
+    it('should not add notification if removeMatchingNotifications indicates it exists', async() => {
+      mockRemoveMatchingNotifications.mockResolvedValue(true); // Simulate notification already exists
+      const versionInfo: VersionInfo = { version: semver.coerce('2.11.5')!, isPrime: true };
+      const statusInfo: SupportInfo = {
+        status: {
+          eol: '<= 2.11.x', eom: '<= 2.12.x', eoc: '<= 2.12.x'
+        },
+        upcoming: {} as any
+      };
+
+      await processSupportNotices(mockContext, statusInfo, versionInfo);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
   });
 
-  it('should not add notification if removeMatchingNotifications indicates it exists', async() => {
-    mockRemoveMatchingNotifications.mockResolvedValue(true); // Simulate notification already exists
-    const versionInfo: VersionInfo = { version: semver.coerce('2.11.5')!, isPrime: false };
-    const statusInfo: SupportInfo = {
-      status:   { eol: '<= 2.11.x', eom: '<= 2.12.x' },
-      upcoming: {} as any
-    };
+  describe('Community', () => {
+    it('should add EOC notification and log when version matches eoc range', async() => {
+      const versionInfo: VersionInfo = { version: semver.coerce('2.11.5')!, isPrime: false };
+      const statusInfo: SupportInfo = {
+        status: {
+          eol: '<= 2.10.x', eom: '<= 2.10.x', eoc: '<= 2.11.x'
+        },
+        upcoming: {} as any
+      };
 
-    await processSupportNotices(mockContext, statusInfo, versionInfo);
+      await processSupportNotices(mockContext, statusInfo, versionInfo);
 
-    expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockLogger.info).toHaveBeenCalledWith('This version (2.11.5) will no longer receive updates');
+      expect(mockDispatch).toHaveBeenCalledWith('notifications/add', expect.objectContaining({
+        id:    'support-notice-eom-2.11',
+        level: NotificationLevel.Warning,
+        title: 'EOC Title for 2.11',
+      }));
+    });
+
+    it('should not add an EOL notification for Community even when eol matches', async() => {
+      const versionInfo: VersionInfo = { version: semver.coerce('2.11.5')!, isPrime: false };
+      const statusInfo: SupportInfo = {
+        status: {
+          eol: '<= 2.11.x', eom: '<= 2.11.x', eoc: '<= 2.10.x'
+        },
+        upcoming: {} as any
+      };
+
+      await processSupportNotices(mockContext, statusInfo, versionInfo);
+
+      expect(mockLogger.info).not.toHaveBeenCalledWith('This version (2.11.5) is End of Life');
+      expect(mockDispatch).not.toHaveBeenCalledWith('notifications/add', expect.objectContaining({ id: 'support-notice-eol-2.11' }));
+    });
+
+    it('should not add an EOC notification when version does not match eoc range', async() => {
+      const versionInfo: VersionInfo = { version: semver.coerce('2.13.0')!, isPrime: false };
+      const statusInfo: SupportInfo = {
+        status: {
+          eol: '<= 2.11.x', eom: '<= 2.11.x', eoc: '<= 2.12.x'
+        },
+        upcoming: {} as any
+      };
+
+      await processSupportNotices(mockContext, statusInfo, versionInfo);
+
+      expect(mockLogger.info).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it('should not check upcoming EOL/EOM for community versions', async() => {
+      const versionInfo: VersionInfo = { version: semver.coerce('2.12.0')!, isPrime: false };
+      const statusInfo: SupportInfo = {
+        status: {
+          eol: '<= 2.10.x', eom: '<= 2.10.x', eoc: '<= 2.10.x'
+        },
+        upcoming: {
+          eol: { version: '= 2.12.x', date: day().add(15, 'day').toDate() },
+          eom: { version: '= 2.12.x', date: day().add(15, 'day').toDate() },
+        }
+      };
+
+      await processSupportNotices(mockContext, statusInfo, versionInfo);
+
+      expect(mockDispatch).not.toHaveBeenCalledWith('notifications/add', expect.objectContaining({ id: expect.stringContaining('upcoming-support-notice-') }));
+    });
+
+    it('should not add EOC notification if removeMatchingNotifications indicates it exists', async() => {
+      mockRemoveMatchingNotifications.mockResolvedValue(true);
+      const versionInfo: VersionInfo = { version: semver.coerce('2.11.5')!, isPrime: false };
+      const statusInfo: SupportInfo = {
+        status: {
+          eol: '<= 2.10.x', eom: '<= 2.10.x', eoc: '<= 2.11.x'
+        },
+        upcoming: {} as any
+      };
+
+      await processSupportNotices(mockContext, statusInfo, versionInfo);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
   });
 
   describe('user preferences', () => {
@@ -192,9 +310,11 @@ describe('processSupportNotices', () => {
 
         return '';
       });
-      const versionInfo: VersionInfo = { version: semver.coerce('2.11.5')!, isPrime: false };
+      const versionInfo: VersionInfo = { version: semver.coerce('2.11.5')!, isPrime: true };
       const statusInfo: SupportInfo = {
-        status:   { eol: '<= 2.11.x', eom: '<= 2.12.x' },
+        status: {
+          eol: '<= 2.11.x', eom: '<= 2.12.x', eoc: '<= 2.12.x'
+        },
         upcoming: {} as any
       };
 
@@ -209,9 +329,31 @@ describe('processSupportNotices', () => {
 
         return '';
       });
-      const versionInfo: VersionInfo = { version: semver.coerce('2.12.3')!, isPrime: false };
+      const versionInfo: VersionInfo = { version: semver.coerce('2.12.3')!, isPrime: true };
       const statusInfo: SupportInfo = {
-        status:   { eol: '<= 2.11.x', eom: '<= 2.12.x' },
+        status: {
+          eol: '<= 2.11.x', eom: '<= 2.12.x', eoc: '<= 2.12.x'
+        },
+        upcoming: {} as any
+      };
+
+      await processSupportNotices(mockContext, statusInfo, versionInfo);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+    });
+
+    it('should not add EOC notification if it was already read', async() => {
+      mockGetters['prefs/get'].mockImplementation((key: string) => {
+        // Community reuses the EOM prefix (see PREFIX.EOM comment in support-notice.ts)
+        if (key === READ_SUPPORT_NOTICE) return 'eom-2.11';
+
+        return '';
+      });
+      const versionInfo: VersionInfo = { version: semver.coerce('2.11.5')!, isPrime: false };
+      const statusInfo: SupportInfo = {
+        status: {
+          eol: '<= 2.10.x', eom: '<= 2.10.x', eoc: '<= 2.11.x'
+        },
         upcoming: {} as any
       };
 
@@ -226,9 +368,11 @@ describe('processSupportNotices', () => {
 
         return '';
       });
-      const versionInfo: VersionInfo = { version: semver.coerce('2.12.0')!, isPrime: false };
+      const versionInfo: VersionInfo = { version: semver.coerce('2.12.0')!, isPrime: true };
       const statusInfo: SupportInfo = {
-        status:   { eol: '<= 2.11.x', eom: '<= 2.11.x' },
+        status: {
+          eol: '<= 2.11.x', eom: '<= 2.11.x', eoc: '<= 2.11.x'
+        },
         upcoming: { eol: { version: '= 2.12.x', date: day().add(145, 'day').toDate() }, eom: {} as any }
       };
 
@@ -243,9 +387,11 @@ describe('processSupportNotices', () => {
 
         return '';
       });
-      const versionInfo: VersionInfo = { version: semver.coerce('2.13.0')!, isPrime: false };
+      const versionInfo: VersionInfo = { version: semver.coerce('2.13.0')!, isPrime: true };
       const statusInfo: SupportInfo = {
-        status:   { eol: '<= 2.12.x', eom: '<= 2.12.x' },
+        status: {
+          eol: '<= 2.12.x', eom: '<= 2.12.x', eoc: '<= 2.12.x'
+        },
         upcoming: {
           eom: {
             version: '= 2.13.x', date: day().add(20, 'day').toDate(), noticeDays: 25

--- a/shell/utils/dynamic-content/__tests__/support-notice.test.ts
+++ b/shell/utils/dynamic-content/__tests__/support-notice.test.ts
@@ -90,7 +90,7 @@ describe('processSupportNotices', () => {
     expect(mockDispatch).not.toHaveBeenCalled();
   });
 
-  describe('Prime', () => {
+  describe('prime', () => {
     it('should not add notification if no support status matches', async() => {
       const versionInfo: VersionInfo = { version: semver.coerce('2.13.0')!, isPrime: true };
       const statusInfo: SupportInfo = {
@@ -220,7 +220,7 @@ describe('processSupportNotices', () => {
     });
   });
 
-  describe('Community', () => {
+  describe('community', () => {
     it('should add EOC notification and log when version matches eoc range', async() => {
       const versionInfo: VersionInfo = { version: semver.coerce('2.11.5')!, isPrime: false };
       const statusInfo: SupportInfo = {

--- a/shell/utils/dynamic-content/support-notice.ts
+++ b/shell/utils/dynamic-content/support-notice.ts
@@ -57,7 +57,7 @@ export async function processSupportNotices(context: Context, statusInfo: Suppor
     return;
   }
 
-  const { version } = versionInfo;
+  const { version, isPrime } = versionInfo;
   const { logger } = context;
 
   // TODO: ****************************************************************************************
@@ -82,14 +82,18 @@ export async function processSupportNotices(context: Context, statusInfo: Suppor
   }
 
   if (status.eom && semver.satisfies(version, status.eom)) {
-    logger.info(`This version (${ version }) is End of Maintenance`);
+    if (isPrime) {
+      logger.info(`This version (${ version }) is End of Maintenance`);
+    } else {
+      logger.info(`This version (${ version }) will no longer receive updates`);
+    }
 
     return await checkAndAddNotification(context, {
       prefValuePrefix:    PREFIX.EOM,
       pref:               READ_SUPPORT_NOTICE,
       notificationPrefix: SUPPORT_NOTICE_PREFIX,
-      titleKey:           'dynamicContent.eom.title',
-      messageKey:         'dynamicContent.eom.message',
+      titleKey:           isPrime ? 'dynamicContent.eom.title' : 'dynamicContent.eoc.title',
+      messageKey:         isPrime ? 'dynamicContent.eom.message' : 'dynamicContent.eoc.message',
     }, majorMinor);
   }
 

--- a/shell/utils/dynamic-content/support-notice.ts
+++ b/shell/utils/dynamic-content/support-notice.ts
@@ -31,7 +31,7 @@ const UPCOMING_SUPPORT_NOTICE_PREFIX = 'upcoming-support-notice-';
 
 // Prefixes used in the value of the user preference to track which notifications the user has read
 const PREFIX = {
-  EOM: 'eom',
+  EOM: 'eom', // Also used for eoc for community
   EOL: 'eol',
 };
 
@@ -67,24 +67,36 @@ export async function processSupportNotices(context: Context, statusInfo: Suppor
   const status = statusInfo.status || {};
   const majorMinor = `${ semver.major(version) }.${ semver.minor(version) }`;
 
-  // Check if this version is EOL - we warn of EOL
-  // If a version is EOL, then is has passed EOM, so we don't need to check that
-  if (status.eol && semver.satisfies(version, status.eol)) {
-    logger.info(`This version (${ version }) is End of Life`);
+  // Prime
+  if (isPrime) {
+    // Check if this version is EOL - we warn of EOL
+    // If a version is EOL, then is has passed EOM, so we don't need to check that
+    if (status.eol && semver.satisfies(version, status.eol)) {
+      logger.info(`This version (${ version }) is End of Life`);
 
-    return await checkAndAddNotification(context, {
-      prefValuePrefix:    PREFIX.EOL,
-      pref:               READ_SUPPORT_NOTICE,
-      notificationPrefix: SUPPORT_NOTICE_PREFIX,
-      titleKey:           'dynamicContent.eol.title',
-      messageKey:         'dynamicContent.eol.message',
-    }, majorMinor);
-  }
+      return await checkAndAddNotification(context, {
+        prefValuePrefix:    PREFIX.EOL,
+        pref:               READ_SUPPORT_NOTICE,
+        notificationPrefix: SUPPORT_NOTICE_PREFIX,
+        titleKey:           'dynamicContent.eol.title',
+        messageKey:         'dynamicContent.eol.message',
+      }, majorMinor);
+    }
 
-  if (status.eom && semver.satisfies(version, status.eom)) {
-    if (isPrime) {
+    if (status.eom && semver.satisfies(version, status.eom)) {
       logger.info(`This version (${ version }) is End of Maintenance`);
-    } else {
+
+      return await checkAndAddNotification(context, {
+        prefValuePrefix:    PREFIX.EOM,
+        pref:               READ_SUPPORT_NOTICE,
+        notificationPrefix: SUPPORT_NOTICE_PREFIX,
+        titleKey:           'dynamicContent.eom.title',
+        messageKey:         'dynamicContent.eom.message',
+      }, majorMinor);
+    }
+  } else {
+    // Community version 
+    if (status.eoc && semver.satisfies(version, status.eoc)) {
       logger.info(`This version (${ version }) will no longer receive updates`);
     }
 
@@ -92,12 +104,15 @@ export async function processSupportNotices(context: Context, statusInfo: Suppor
       prefValuePrefix:    PREFIX.EOM,
       pref:               READ_SUPPORT_NOTICE,
       notificationPrefix: SUPPORT_NOTICE_PREFIX,
-      titleKey:           isPrime ? 'dynamicContent.eom.title' : 'dynamicContent.eoc.title',
-      messageKey:         isPrime ? 'dynamicContent.eom.message' : 'dynamicContent.eoc.message',
+      titleKey:           'dynamicContent.eoc.title',
+      messageKey:         'dynamicContent.eoc.message',
     }, majorMinor);
   }
 
-  // Now check for upcoming EOL or EOM
+  // Now check for upcoming EOL or EOM for Prime
+  if (!isPrime) {
+    return;
+  }
 
   // Upcoming EOL
   if (statusInfo.upcoming?.eol && semver.satisfies(version, statusInfo.upcoming.eol.version)) {

--- a/shell/utils/dynamic-content/support-notice.ts
+++ b/shell/utils/dynamic-content/support-notice.ts
@@ -95,18 +95,20 @@ export async function processSupportNotices(context: Context, statusInfo: Suppor
       }, majorMinor);
     }
   } else {
-    // Community version 
+    // Community version
     if (status.eoc && semver.satisfies(version, status.eoc)) {
       logger.info(`This version (${ version }) will no longer receive updates`);
+
+      return await checkAndAddNotification(context, {
+        prefValuePrefix:    PREFIX.EOM,
+        pref:               READ_SUPPORT_NOTICE,
+        notificationPrefix: SUPPORT_NOTICE_PREFIX,
+        titleKey:           'dynamicContent.eoc.title',
+        messageKey:         'dynamicContent.eoc.message',
+      }, majorMinor);
     }
 
-    return await checkAndAddNotification(context, {
-      prefValuePrefix:    PREFIX.EOM,
-      pref:               READ_SUPPORT_NOTICE,
-      notificationPrefix: SUPPORT_NOTICE_PREFIX,
-      titleKey:           'dynamicContent.eoc.title',
-      messageKey:         'dynamicContent.eoc.message',
-    }, majorMinor);
+    return;
   }
 
   // Now check for upcoming EOL or EOM for Prime

--- a/shell/utils/dynamic-content/types.d.ts
+++ b/shell/utils/dynamic-content/types.d.ts
@@ -83,6 +83,7 @@ export type SupportInfo = {
   status: {
     eom: string,
     eol: string,
+    eoc: string,
   },
   upcoming: {
     eom: UpcomingSupportInfo,


### PR DESCRIPTION
### Summary
Backport of #18458 to release-2.13.

Fixes #18322.

### Changes Included
- Update end-of-maintenance messaging for community context.
- Add end-of-community (EOC) support handling in dynamic content support notices.
- Include associated lint/test follow-up adjustments from the original PR.

### Backport Notes
- Source PR: #18458
- Target branch: release-2.13
- Backported commits:
  - 27d189815d Update EOM message for community
  - 0f946f6ac7 Add support for eoc
  - 57db6ef8bb FIx lint and tests

### Testing
- Cherry-pick applied cleanly onto release-2.13.

### Regression Risk
- Low to medium. Scope is limited to support notice messaging and dynamic-content handling logic.
- Primary regression surface: support/EOM/EOC notice rendering behavior.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
