### PR TITLE
Show Gateway API HTTPRoutes and endpoints on workload detail

### DIFF
--- a/shell/assets/translations/en-us.yaml
+++ b/shell/assets/translations/en-us.yaml
@@ -7101,6 +7101,8 @@ tableHeaders:
   iP: IP
   image: Image
   imageSize: Size
+  httpRouteGateways: Gateways
+  httpRouteHostnames: Hostnames
   ingressClass: Ingress Class
   ingressDefaultBackend: Default
   ingressTarget: Target
@@ -7832,6 +7834,10 @@ workload:
     cannotFindIngresses: Could not find any Ingresses that forward traffic to Services that select Pods in this workload.
     ingressListCaption: "The following Ingresses forward traffic to Services that select Pods from this workload:"
     cannotViewIngressesBecauseCannotViewServices: Could not find relevant Ingresses due to lack of permission to view Services.
+    httpRoutes: HTTPRoutes
+    cannotFindHttpRoutes: Could not find any HTTPRoutes that forward traffic to Services that select Pods in this workload.
+    httpRouteListCaption: "The following HTTPRoutes forward traffic to Services that select Pods from this workload:"
+    cannotViewHttpRoutesBecauseCannotViewServices: Could not find relevant HTTPRoutes due to lack of permission to view Services.
     pods:
       title: Pods
   detailTop:
@@ -8534,6 +8540,16 @@ typeLabel:
     {count, plural,
       one { Ingress }
       other { Ingresses }
+    }
+  gateway.networking.k8s.io.httproute: |-
+    {count, plural,
+      one { HTTPRoute }
+      other { HTTPRoutes }
+    }
+  gateway.networking.k8s.io.gateway: |-
+    {count, plural,
+      one { Gateway }
+      other { Gateways }
     }
   networking.k8s.io.networkpolicy: |-
     {count, plural,
@@ -9540,6 +9556,7 @@ component:
           rows:
             services: Services
             ingresses: Ingresses
+            httpRoutes: HTTPRoutes
             referredToBy: Referred to by
             refersTo: Refers to
         podsCard:

--- a/shell/components/formatter/WorkloadDetailEndpoints.vue
+++ b/shell/components/formatter/WorkloadDetailEndpoints.vue
@@ -8,6 +8,19 @@ export default {
       type:    [Array, String],
       default: null,
     },
+    // Unused, but SortableTable passes them and undeclared props fall through onto the root element.
+    row: {
+      type:    Object,
+      default: null,
+    },
+    col: {
+      type:    Object,
+      default: null,
+    },
+    rowKey: {
+      type:    String,
+      default: null,
+    },
   },
 
   components: { Tag },
@@ -16,47 +29,57 @@ export default {
     nodes() {
       return this.$store.getters['cluster/all'](NODE);
     },
-    // value may be JSON from "field.cattle.io/publicEndpoints" label
+    // value is either an array of endpoints or JSON from the "field.cattle.io/publicEndpoints"
+    // annotation, which holds the same array
     parsed() {
       const nodes = this.nodes;
       const nodeWithExternal = nodes.find((node) => !!node.externalIp) || {};
       const externalIp = nodeWithExternal.externalIp;
 
       if ( this.value && this.value.length ) {
-        let out ;
+        let endpoints;
 
         try {
-          out = JSON.parse(this.value);
-
-          out.forEach((endpoint) => {
-            let protocol = 'http';
-
-            if (endpoint.port === 443) {
-              protocol = 'https';
-            }
-
-            const linkDefaultDisplay = endpoint.port ? `${ endpoint.port }/${ endpoint.protocol }` : endpoint.protocol;
-
-            // If there's an ingress and it has a hostname, we use the hostname address instead
-            // https://github.com/rancher/dashboard/issues/8087
-            if (endpoint.ingressName && endpoint.hostname) {
-              endpoint.link = `${ protocol }://${ endpoint.hostname }${ endpoint.path }`;
-              endpoint.linkDisplay = endpoint.link;
-            } else if (endpoint.addresses && endpoint.addresses.length) {
-              endpoint.link = `${ protocol }://${ endpoint.addresses[0] }:${ endpoint.port }`;
-              endpoint.linkDisplay = linkDefaultDisplay;
-            } else if (externalIp) {
-              endpoint.link = `${ protocol }://${ externalIp }:${ endpoint.port }`;
-              endpoint.linkDisplay = linkDefaultDisplay;
-            } else {
-              endpoint.display = `[${ this.t('servicesPage.anyNode') }]:${ endpoint.port }`;
-            }
-          });
-
-          return out;
+          endpoints = Array.isArray(this.value) ? this.value : JSON.parse(this.value);
         } catch (err) {
-          return this.value[0];
+          return null;
         }
+
+        return endpoints.map((endpoint) => {
+          // Already resolved by the caller, for example a Gateway API endpoint, where none of the
+          // rules below apply.
+          if (endpoint.link) {
+            return endpoint;
+          }
+
+          let protocol = 'http';
+
+          if (endpoint.port === 443) {
+            protocol = 'https';
+          }
+
+          const linkDefaultDisplay = endpoint.port ? `${ endpoint.port }/${ endpoint.protocol }` : endpoint.protocol;
+
+          // If there's an ingress and it has a hostname, we use the hostname address instead
+          // https://github.com/rancher/dashboard/issues/8087
+          if (endpoint.ingressName && endpoint.hostname) {
+            const link = `${ protocol }://${ endpoint.hostname }${ endpoint.path }`;
+
+            return {
+              ...endpoint, link, linkDisplay: link
+            };
+          } else if (endpoint.addresses && endpoint.addresses.length) {
+            return {
+              ...endpoint, link: `${ protocol }://${ endpoint.addresses[0] }:${ endpoint.port }`, linkDisplay: linkDefaultDisplay
+            };
+          } else if (externalIp) {
+            return {
+              ...endpoint, link: `${ protocol }://${ externalIp }:${ endpoint.port }`, linkDisplay: linkDefaultDisplay
+            };
+          }
+
+          return { ...endpoint, display: `[${ this.t('servicesPage.anyNode') }]:${ endpoint.port }` };
+        });
       }
 
       return null;

--- a/shell/components/formatter/__tests__/WorkloadDetailEndpoints.test.ts
+++ b/shell/components/formatter/__tests__/WorkloadDetailEndpoints.test.ts
@@ -60,6 +60,7 @@ describe('component: WorkloadDetailEndpoints', () => {
       global: { mocks: { $store: { getters: { 'cluster/all': () => nodesOutput } } } }
     });
 
+    expect(wrapper.vm.parsed).toHaveLength(expectationArr.length);
     wrapper.vm.parsed.forEach((endpoint:{[key: string]: string}, i:number) => {
       expect(endpoint.link).toBe(expectationArr[i]);
     });
@@ -73,9 +74,55 @@ describe('component: WorkloadDetailEndpoints', () => {
       global: { mocks: { $store: { getters: { 'cluster/all': () => nodesOutput } } } }
     });
 
+    expect(wrapper.vm.parsed).toHaveLength(expectationArr.length);
     wrapper.vm.parsed.forEach((endpoint:{[key: string]: string}, i:number) => {
       expect(endpoint.display).toBe(expectationArr[i]);
       expect(wrapper.findComponent(Tag).exists()).toBe(true);
     });
+  });
+
+  const mount_ = (value: any, nodesOutput: any[] = []) => mount(WorkloadDetailEndpoints, {
+    props:  { value },
+    global: { mocks: { $store: { getters: { 'cluster/all': () => nodesOutput } } } }
+  });
+
+  it('should accept an array as well as the annotation string', () => {
+    const asArray = mount_(withIngressAndHostname);
+    const asString = mount_(JSON.stringify(withIngressAndHostname));
+
+    expect(asArray.vm.parsed).toStrictEqual(asString.vm.parsed);
+    expect(asArray.vm.parsed[0].link).toBe('http://tetris.kube-public.172.18.0.3.sslip.io/');
+  });
+
+  it('should leave an endpoint that already carries a link untouched', () => {
+    const resolved = { link: 'http://demo.example.com/shop', linkDisplay: 'http://demo.example.com/shop' };
+
+    const wrapper = mount_([resolved]);
+
+    expect(wrapper.vm.parsed).toStrictEqual([resolved]);
+    expect(wrapper.find('a').attributes('href')).toBe('http://demo.example.com/shop');
+  });
+
+  it('should render published endpoints alongside pre-resolved ones', () => {
+    const resolved = { link: 'http://demo.example.com/shop', linkDisplay: 'http://demo.example.com/shop' };
+
+    const wrapper = mount_([...withIngressAndHostname, resolved]);
+
+    expect(wrapper.vm.parsed.map((e: any) => e.link)).toStrictEqual([
+      'http://tetris.kube-public.172.18.0.3.sslip.io/',
+      'http://demo.example.com/shop',
+    ]);
+  });
+
+  it.each([
+    ['an empty array', []],
+    ['an empty string', ''],
+    ['null', null],
+  ])('should parse nothing for %s', (_label, value) => {
+    expect(mount_(value).vm.parsed).toBeNull();
+  });
+
+  it('should parse nothing for a malformed annotation rather than rendering one character of it', () => {
+    expect(mount_('not json').vm.parsed).toBeNull();
   });
 });

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -12,11 +12,13 @@ import {
   CAPI,
   WORKLOAD_DASHBOARD,
   CRD,
+  GATEWAY_API,
 } from '@shell/config/types';
 
 import {
   STATE, USER_STATE, NAME as NAME_COL, NAMESPACE as NAMESPACE_COL, AGE, KEYS,
   INGRESS_DEFAULT_BACKEND, INGRESS_TARGET, INGRESS_CLASS,
+  HTTP_ROUTE_HOSTNAMES, HTTP_ROUTE_GATEWAYS,
   SPEC_TYPE, TARGET_PORT, SELECTOR, NODE as NODE_COL, WORKLOAD_IMAGES, POD_IMAGES,
   USER_ID, USERNAME, USER_DISPLAY_NAME, USER_PROVIDER, USER_LAST_LOGIN, USER_DISABLED_IN, USER_DELETED_IN, WORKLOAD_ENDPOINTS, STORAGE_CLASS_DEFAULT,
   STORAGE_CLASS_PROVISIONER, PERSISTENT_VOLUME_SOURCE,
@@ -94,6 +96,8 @@ export function init(store) {
   basicType([
     SERVICE,
     INGRESS,
+    GATEWAY_API.HTTP_ROUTE,
+    GATEWAY_API.GATEWAY,
     HPA,
   ], 'serviceDiscovery');
   basicType([
@@ -283,6 +287,10 @@ export function init(store) {
     },
     STEVE_AGE_COL
   ]);
+
+  // Registering headers does not add the type to the nav, it only replaces the raw printer columns
+  // Steve falls back to, here and on the workload's HTTPRoutes tab.
+  headers(GATEWAY_API.HTTP_ROUTE, [STATE, NAME_COL, NAMESPACE_COL, HTTP_ROUTE_HOSTNAMES, HTTP_ROUTE_GATEWAYS, AGE]);
 
   headers(INGRESS,
     [STATE, NAME_COL, NAMESPACE_COL, INGRESS_TARGET, INGRESS_DEFAULT_BACKEND, INGRESS_CLASS, AGE],

--- a/shell/config/product/explorer.js
+++ b/shell/config/product/explorer.js
@@ -288,8 +288,6 @@ export function init(store) {
     STEVE_AGE_COL
   ]);
 
-  // Registering headers does not add the type to the nav, it only replaces the raw printer columns
-  // Steve falls back to, here and on the workload's HTTPRoutes tab.
   headers(GATEWAY_API.HTTP_ROUTE, [STATE, NAME_COL, NAMESPACE_COL, HTTP_ROUTE_HOSTNAMES, HTTP_ROUTE_GATEWAYS, AGE]);
 
   headers(INGRESS,

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -657,6 +657,29 @@ export const INGRESS_CLASS = {
   sort:     `$['spec']['ingressClassName']`,
 };
 
+export const HTTP_ROUTE_HOSTNAMES = {
+  name:     'httpRouteHostnames',
+  labelKey: 'tableHeaders.httpRouteHostnames',
+  value:    'hostnamesDisplay',
+  sort:     'hostnamesDisplay',
+};
+
+// No `value`: the caller supplies one, to narrow the urls to the workload whose page it is on.
+export const HTTP_ROUTE_ENDPOINTS = {
+  name:      'httpRouteEndpoints',
+  labelKey:  'tableHeaders.endpoints',
+  formatter: 'WorkloadDetailEndpoints',
+  sort:      false,
+  search:    false,
+};
+
+export const HTTP_ROUTE_GATEWAYS = {
+  name:     'httpRouteGateways',
+  labelKey: 'tableHeaders.httpRouteGateways',
+  value:    'parentRefsDisplay',
+  sort:     'parentRefsDisplay',
+};
+
 export const INGRESS_DEFAULT_BACKEND = {
   name:      'ingressDefaultBackend',
   labelKey:  'tableHeaders.ingressDefaultBackend',

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -322,7 +322,6 @@ export const ISTIO = {
   GATEWAY:          'networking.istio.io.gateway'
 };
 
-// CRDs, so these schemas only exist on clusters where the Gateway API is installed.
 export const GATEWAY_API = {
   GATEWAY:    'gateway.networking.k8s.io.gateway',
   HTTP_ROUTE: 'gateway.networking.k8s.io.httproute'

--- a/shell/config/types.js
+++ b/shell/config/types.js
@@ -322,6 +322,12 @@ export const ISTIO = {
   GATEWAY:          'networking.istio.io.gateway'
 };
 
+// CRDs, so these schemas only exist on clusters where the Gateway API is installed.
+export const GATEWAY_API = {
+  GATEWAY:    'gateway.networking.k8s.io.gateway',
+  HTTP_ROUTE: 'gateway.networking.k8s.io.httproute'
+};
+
 export const LOGGING = {
   // LOGGING:        'logging.banzaicloud.io.logging',
   CLUSTER_FLOW:   'logging.banzaicloud.io.clusterflow',

--- a/shell/detail/__tests__/workload.test.ts
+++ b/shell/detail/__tests__/workload.test.ts
@@ -1,7 +1,57 @@
 import Workload from '@shell/detail/workload/index.vue';
+import {
+  AGE, NAME, NAMESPACE, STATE, HTTP_ROUTE_HOSTNAMES, HTTP_ROUTE_GATEWAYS
+} from '@shell/config/table-headers';
 
 describe('workload detail page', () => {
   it('should not have findMatchingIngresses method (logic moved to workload model)', () => {
     expect(Workload.methods?.findMatchingIngresses).toBeUndefined();
+  });
+
+  describe('httpRouteHeaders', () => {
+    const configuredHeaders = [STATE, NAME, NAMESPACE, HTTP_ROUTE_HOSTNAMES, HTTP_ROUTE_GATEWAYS, AGE];
+
+    const stub = (overrides: any = {}) => ({
+      $store:                      { getters: { 'type-map/headersFor': () => [...configuredHeaders] } },
+      httpRouteSchema:             {},
+      gatewaySchema:               {},
+      httpRoutesAreAllInNamespace: true,
+      relatedServices:             [],
+      ...overrides,
+    });
+
+    const headers = (overrides?: any) => (Workload as any).computed.httpRouteHeaders.call(stub(overrides));
+
+    it('should place the endpoints column immediately before age', () => {
+      const names = headers().map((h: any) => h.name);
+
+      expect(names.slice(-2)).toStrictEqual(['httpRouteEndpoints', 'age']);
+    });
+
+    it('should not show the endpoints column without the gateway schema', () => {
+      const names = headers({ gatewaySchema: null }).map((h: any) => h.name);
+
+      expect(names).not.toContain('httpRouteEndpoints');
+      expect(names).toStrictEqual([STATE.name, NAME.name, HTTP_ROUTE_HOSTNAMES.name, HTTP_ROUTE_GATEWAYS.name, AGE.name]);
+    });
+
+    it('should drop the namespace column when every route is in the workload namespace', () => {
+      expect(headers().map((h: any) => h.name)).not.toContain(NAMESPACE.name);
+    });
+
+    it('should keep the namespace column when a route is in another namespace', () => {
+      expect(headers({ httpRoutesAreAllInNamespace: false }).map((h: any) => h.name)).toContain(NAMESPACE.name);
+    });
+
+    it('should resolve the endpoints value from the route, narrowed to the services of this workload', () => {
+      const relatedServices = [{ id: 'gwdemo/demo-app' }];
+      const endpoints = [{ link: 'http://demo.example.com/shop', linkDisplay: 'http://demo.example.com/shop' }];
+      const endpointsForServices = jest.fn().mockReturnValue(endpoints);
+
+      const col = headers({ relatedServices }).find((h: any) => h.name === 'httpRouteEndpoints');
+
+      expect(col.value({ endpointsForServices })).toStrictEqual(endpoints);
+      expect(endpointsForServices).toHaveBeenCalledWith(relatedServices);
+    });
   });
 });

--- a/shell/detail/workload/index.vue
+++ b/shell/detail/workload/index.vue
@@ -1,14 +1,15 @@
 <script>
 import CreateEditView from '@shell/mixins/create-edit-view';
-import { NAMESPACE as NAMESPACE_COL } from '@shell/config/table-headers';
+import { NAMESPACE as NAMESPACE_COL, HTTP_ROUTE_ENDPOINTS } from '@shell/config/table-headers';
 import {
-  POD, WORKLOAD_TYPES, SERVICE, INGRESS, NAMESPACE, WORKLOAD_TYPE_TO_KIND_MAPPING, METRICS_SUPPORTED_KINDS
+  POD, WORKLOAD_TYPES, SERVICE, INGRESS, NAMESPACE, WORKLOAD_TYPE_TO_KIND_MAPPING, METRICS_SUPPORTED_KINDS, GATEWAY_API
 } from '@shell/config/types';
 import ResourceTable from '@shell/components/ResourceTable';
 import Tab from '@shell/components/Tabbed/Tab';
 import Loading from '@shell/components/Loading';
 import ResourceTabs from '@shell/components/form/ResourceTabs';
 import { allHash } from '@shell/utils/promise';
+import { insertAt } from '@shell/utils/array';
 import DashboardMetrics from '@shell/components/DashboardMetrics';
 import { mapGetters } from 'vuex';
 import { allDashboardsExist } from '@shell/utils/grafana';
@@ -46,6 +47,14 @@ export default {
 
     if (this.serviceSchema) {
       hash.servicesInNamespace = this.$store.dispatch('cluster/findAll', { type: SERVICE, opt: { namespaced: this.value.metadata.namespace } });
+    }
+
+    if (this.httpRouteSchema) {
+      hash.allHttpRoutes = this.$store.dispatch('cluster/findAll', { type: GATEWAY_API.HTTP_ROUTE });
+    }
+
+    if (this.gatewaySchema) {
+      hash.allGateways = this.$store.dispatch('cluster/findAll', { type: GATEWAY_API.GATEWAY });
     }
 
     if (this.value.type === WORKLOAD_TYPES.CRON_JOB) {
@@ -122,6 +131,14 @@ export default {
       return this.$store.getters['cluster/schemaFor'](SERVICE);
     },
 
+    httpRouteSchema() {
+      return this.$store.getters['cluster/schemaFor'](GATEWAY_API.HTTP_ROUTE);
+    },
+
+    gatewaySchema() {
+      return this.$store.getters['cluster/schemaFor'](GATEWAY_API.GATEWAY);
+    },
+
     relatedServices() {
       return this.value.relatedServices;
     },
@@ -153,6 +170,29 @@ export default {
 
     ingressHeaders() {
       return this.$store.getters['type-map/headersFor'](this.ingressSchema).filter((h) => !h.name || h.name !== NAMESPACE_COL.name);
+    },
+
+    matchingHttpRoutes() {
+      return this.value.matchingHttpRoutes;
+    },
+
+    // An HTTPRoute may forward to a Service in another namespace, so unlike the Ingresses tab the
+    // namespace column has to stay whenever one of the listed routes is not in this namespace.
+    httpRoutesAreAllInNamespace() {
+      return this.matchingHttpRoutes.every((r) => r.metadata?.namespace === this.value.metadata?.namespace);
+    },
+
+    httpRouteHeaders() {
+      const headers = this.$store.getters['type-map/headersFor'](this.httpRouteSchema);
+      const scoped = this.httpRoutesAreAllInNamespace ? headers.filter((h) => !h.name || h.name !== NAMESPACE_COL.name) : headers;
+
+      // Empty without the Gateway schema, so the column is only worth showing when it can resolve.
+      if (this.gatewaySchema) {
+        // The configured HTTPRoute columns end with Age, so this lands immediately before it.
+        insertAt(scoped, scoped.length - 1, { ...HTTP_ROUTE_ENDPOINTS, value: (row) => row.endpointsForServices(this.relatedServices) });
+      }
+
+      return scoped;
     },
 
     serviceHeaders() {
@@ -364,6 +404,42 @@ export default {
           :headers="ingressHeaders"
           key-field="id"
           :schema="ingressSchema"
+          :namespaced="false"
+          :groupable="false"
+          :search="false"
+          :table-actions="false"
+        />
+      </Tab>
+      <Tab
+        v-if="!isJob && !isCronJob && httpRouteSchema"
+        name="httproutes"
+        :label="t('workload.detail.httpRoutes')"
+        :weight="1"
+      >
+        <p
+          v-if="!serviceSchema"
+          class="caption"
+        >
+          {{ t('workload.detail.cannotViewHttpRoutesBecauseCannotViewServices') }}
+        </p>
+        <p
+          v-else-if="matchingHttpRoutes.length === 0"
+          class="caption"
+        >
+          {{ t('workload.detail.cannotFindHttpRoutes') }}
+        </p>
+        <p
+          v-else
+          class="caption"
+        >
+          {{ t('workload.detail.httpRouteListCaption') }}
+        </p>
+        <ResourceTable
+          v-if="serviceSchema && matchingHttpRoutes.length > 0"
+          :rows="matchingHttpRoutes"
+          :headers="httpRouteHeaders"
+          key-field="id"
+          :schema="httpRouteSchema"
           :namespaced="false"
           :groupable="false"
           :search="false"

--- a/shell/models/__tests__/gateway.networking.k8s.io.httproute.test.ts
+++ b/shell/models/__tests__/gateway.networking.k8s.io.httproute.test.ts
@@ -1,0 +1,433 @@
+import HttpRoute from '@shell/models/gateway.networking.k8s.io.httproute';
+import Gateway, { schemeForListener } from '@shell/models/gateway.networking.k8s.io.gateway';
+import { GATEWAY_API } from '@shell/config/types';
+
+const service = (name: string, namespace = 'gwdemo') => ({ metadata: { name, namespace } });
+
+const gateway = (spec: any, status: any = {}, namespace = 'gwdemo', name = 'demo-gateway') => new Gateway({
+  metadata: { name, namespace },
+  spec,
+  status
+});
+
+const ALL_NAMESPACES = { namespaces: { from: 'All' } };
+
+const httpListener = {
+  name: 'http', protocol: 'HTTP', port: 80, allowedRoutes: ALL_NAMESPACES
+};
+const httpsListener = {
+  name: 'https', protocol: 'HTTPS', port: 443, allowedRoutes: ALL_NAMESPACES
+};
+
+// hasGatewaySchema false simulates a cluster without the Gateway API CRDs.
+const httpRoute = (spec: any, gateways: any[] = [], hasGatewaySchema = true, namespace = 'gwdemo') => new HttpRoute({
+  metadata: { name: 'demo-route', namespace },
+  spec
+}, {
+  rootGetters: {
+    'cluster/schemaFor': (type: string) => (hasGatewaySchema && type === GATEWAY_API.GATEWAY ? {} : undefined),
+    'cluster/all':       (type: string) => (type === GATEWAY_API.GATEWAY ? gateways : [])
+  }
+});
+
+describe('class HttpRoute', () => {
+  describe('backendRefTargets', () => {
+    it.each([
+      ['a bare ref, defaulting to a Service in the route namespace', { name: 'demo-app' }, true],
+      ['an explicit core Service', {
+        name: 'demo-app', group: '', kind: 'Service'
+      }, true],
+      ['an explicit same namespace', { name: 'demo-app', namespace: 'gwdemo' }, true],
+      ['a different service name', { name: 'other-app' }, false],
+      ['a Service in another namespace', { name: 'demo-app', namespace: 'elsewhere' }, false],
+      ['a non-Service kind', { name: 'demo-app', kind: 'ServiceImport' }, false],
+      ['a non-core group', {
+        name: 'demo-app', group: 'multicluster.x-k8s.io', kind: 'Service'
+      }, false],
+    ])('should match %s', (_label, backendRef, expected) => {
+      expect(httpRoute({}).backendRefTargets(backendRef, service('demo-app'))).toBe(expected);
+    });
+
+    it('should not match when either side is missing', () => {
+      expect(httpRoute({}).backendRefTargets(undefined, service('demo-app'))).toBe(false);
+      expect(httpRoute({}).backendRefTargets({ name: 'demo-app' }, undefined)).toBe(false);
+    });
+  });
+
+  describe('pathsForRule', () => {
+    it.each([
+      ['no matches at all', {}, ['/']],
+      ['a match with no path, for example header only', { matches: [{ headers: [{ name: 'x', value: 'y' }] }] }, ['/']],
+      ['a PathPrefix match', { matches: [{ path: { type: 'PathPrefix', value: '/shop' } }] }, ['/shop']],
+      ['an Exact match', { matches: [{ path: { type: 'Exact', value: '/shop/cart' } }] }, ['/shop/cart']],
+      ['a path with no explicit type, which defaults to PathPrefix', { matches: [{ path: { value: '/shop' } }] }, ['/shop']],
+      ['a path with no value', { matches: [{ path: { type: 'PathPrefix' } }] }, ['/']],
+      ['duplicate paths', { matches: [{ path: { value: '/shop' } }, { path: { value: '/shop' } }] }, ['/shop']],
+      ['several paths', { matches: [{ path: { value: '/shop' } }, { path: { value: '/cart' } }] }, ['/shop', '/cart']],
+      ['a literal path alongside a regular expression', { matches: [{ path: { value: '/shop' } }, { path: { type: 'RegularExpression', value: '/v[0-9]+' } }] }, ['/shop']],
+      // A match with no path serves everything below `/`, so it contributes `/` in its own right
+      // rather than being dropped in favour of its siblings.
+      ['a header-only match beside a path match, which serves both', { matches: [{ headers: [{ name: 'x', value: 'y' }] }, { path: { value: '/shop' } }] }, ['/', '/shop']],
+      ['a header-only match beside a regular expression, which serves only /', { matches: [{ path: { type: 'RegularExpression', value: '/v[0-9]+' } }, { headers: [{ name: 'x', value: 'y' }] }] }, ['/']],
+    ])('should return the paths for %s', (_label, rule, expected) => {
+      expect(httpRoute({}).pathsForRule(rule)).toStrictEqual(expected);
+    });
+
+    it('should return no paths for a rule matched only by regular expression, rather than claiming /', () => {
+      const rule = { matches: [{ path: { type: 'RegularExpression', value: '/api/v[0-9]+/.*' } }] };
+
+      expect(httpRoute({}).pathsForRule(rule)).toStrictEqual([]);
+    });
+  });
+
+  describe('rulesForServices / targetsAnyService', () => {
+    const spec = {
+      rules: [
+        { backendRefs: [{ name: 'other-app', port: 80 }] },
+        { backendRefs: [{ name: 'demo-app', port: 80 }] },
+      ]
+    };
+
+    it('should return only the rules that reference one of the services', () => {
+      expect(httpRoute(spec).rulesForServices([service('demo-app')])).toStrictEqual([spec.rules[1]]);
+      expect(httpRoute(spec).targetsAnyService([service('demo-app')])).toBe(true);
+    });
+
+    it('should ignore services the route does not reference', () => {
+      expect(httpRoute(spec).rulesForServices([service('unrelated')])).toStrictEqual([]);
+      expect(httpRoute(spec).targetsAnyService([service('unrelated')])).toBe(false);
+    });
+
+    it('should return nothing when there are no services', () => {
+      expect(httpRoute(spec).rulesForServices([])).toStrictEqual([]);
+      expect(httpRoute(spec).targetsAnyService()).toBe(false);
+    });
+
+    it('should tolerate a rule with no backendRefs and a spec with no rules', () => {
+      expect(httpRoute({ rules: [{}] }).rulesForServices([service('demo-app')])).toStrictEqual([]);
+      expect(httpRoute({}).rulesForServices([service('demo-app')])).toStrictEqual([]);
+    });
+  });
+
+  describe('parentGateways', () => {
+    const gw = gateway({ listeners: [httpListener] });
+
+    it.each([
+      ['a bare parentRef, defaulting to a Gateway in the route namespace', { name: 'demo-gateway' }, 1],
+      ['an explicit group and kind', {
+        name: 'demo-gateway', group: 'gateway.networking.k8s.io', kind: 'Gateway'
+      }, 1],
+      ['a parentRef to a gateway that does not exist', { name: 'missing' }, 0],
+      ['a parentRef in another namespace', { name: 'demo-gateway', namespace: 'elsewhere' }, 0],
+      ['a non-Gateway kind', { name: 'demo-gateway', kind: 'Mesh' }, 0],
+    ])('should resolve %s', (_label, parentRef, expected) => {
+      expect(httpRoute({ parentRefs: [parentRef] }, [gw]).parentGateways).toHaveLength(expected);
+    });
+
+    it('should return nothing when there are no parentRefs', () => {
+      expect(httpRoute({}, [gw]).parentGateways).toStrictEqual([]);
+    });
+
+    it('should not touch the store on a cluster with no Gateway schema', () => {
+      const route = httpRoute({ parentRefs: [{ name: 'demo-gateway' }] }, [gw], false);
+
+      expect(route.parentGateways).toStrictEqual([]);
+    });
+  });
+
+  describe('hostnamesDisplay / parentRefsDisplay', () => {
+    it('should join the hostnames', () => {
+      expect(httpRoute({ hostnames: ['a.example.com', 'b.example.com'] }).hostnamesDisplay).toBe('a.example.com, b.example.com');
+      expect(httpRoute({}).hostnamesDisplay).toBe('');
+    });
+
+    it('should qualify only the parentRefs that point at another namespace', () => {
+      const spec = { parentRefs: [{ name: 'local-gw' }, { name: 'same-gw', namespace: 'gwdemo' }, { name: 'far-gw', namespace: 'other' }] };
+
+      expect(httpRoute(spec).parentRefsDisplay).toBe('local-gw, same-gw, other/far-gw');
+      expect(httpRoute({}).parentRefsDisplay).toBe('');
+    });
+
+    it('should list only actual Gateways, not a mesh parentRef, under a Gateways heading', () => {
+      const spec = {
+        parentRefs: [{ name: 'demo-gateway' }, {
+          name: 'mesh-svc', kind: 'Service', group: ''
+        }]
+      };
+
+      expect(httpRoute(spec).parentRefsDisplay).toBe('demo-gateway');
+    });
+  });
+
+  describe('endpointsForServices', () => {
+    const services = [service('demo-app')];
+    const rules = [{ matches: [{ path: { type: 'PathPrefix', value: '/shop' } }], backendRefs: [{ name: 'demo-app', port: 80 }] }];
+    const parentRefs = [{ name: 'demo-gateway' }];
+
+    const endpoints = (gw: any, spec: any = {}) => httpRoute({
+      parentRefs, rules, hostnames: ['demo.example.com'], ...spec
+    }, [gw]).endpointsForServices(services);
+
+    it('should build an http url and omit the default port 80', () => {
+      expect(endpoints(gateway({ listeners: [httpListener] }))).toStrictEqual([
+        { link: 'http://demo.example.com/shop', linkDisplay: 'http://demo.example.com/shop' }
+      ]);
+    });
+
+    it('should build an https url and omit the default port 443', () => {
+      expect(endpoints(gateway({ listeners: [httpsListener] }))).toStrictEqual([
+        { link: 'https://demo.example.com/shop', linkDisplay: 'https://demo.example.com/shop' }
+      ]);
+    });
+
+    it('should include a non default port', () => {
+      const gw = gateway({
+        listeners: [{
+          name: 'http', protocol: 'HTTP', port: 8080
+        }]
+      });
+
+      expect(endpoints(gw)[0].link).toBe('http://demo.example.com:8080/shop');
+    });
+
+    it('should emit a url for every listener a bare parentRef attaches to, in either order', () => {
+      const httpFirst = gateway({ listeners: [httpListener, httpsListener] });
+      const httpsFirst = gateway({ listeners: [httpsListener, httpListener] });
+      const expected = ['http://demo.example.com/shop', 'https://demo.example.com/shop'];
+
+      expect(endpoints(httpFirst).map((e: any) => e.link).sort()).toStrictEqual(expected);
+      expect(endpoints(httpsFirst).map((e: any) => e.link).sort()).toStrictEqual(expected);
+    });
+
+    it('should fall back to the listener hostname when the route has none', () => {
+      const gw = gateway({ listeners: [{ ...httpListener, hostname: 'listener.example.com' }] });
+
+      expect(endpoints(gw, { hostnames: [] })[0].link).toBe('http://listener.example.com/shop');
+    });
+
+    it('should fall back to the gateway address when neither has a hostname', () => {
+      const gw = gateway({ listeners: [httpListener] }, { addresses: [{ type: 'IPAddress', value: '172.19.0.240' }] });
+
+      expect(endpoints(gw, { hostnames: [] })[0].link).toBe('http://172.19.0.240/shop');
+    });
+
+    it('should not offer the gateway address for a wildcard only route, which would not match its Host header', () => {
+      const gw = gateway({ listeners: [httpListener] }, { addresses: [{ type: 'IPAddress', value: '172.19.0.240' }] });
+
+      expect(endpoints(gw, { hostnames: ['*.example.com'] })).toStrictEqual([]);
+    });
+
+    it('should resolve a wildcard route against a listener that pins a concrete hostname', () => {
+      const gw = gateway({ listeners: [{ ...httpListener, hostname: 'shop.example.com' }] });
+
+      expect(endpoints(gw, { hostnames: ['*.example.com'] })[0].link).toBe('http://shop.example.com/shop');
+    });
+
+    it('should keep a route hostname that falls under a wildcard listener', () => {
+      const gw = gateway({ listeners: [{ ...httpListener, hostname: '*.example.com' }] });
+
+      expect(endpoints(gw)[0].link).toBe('http://demo.example.com/shop');
+    });
+
+    it('should emit nothing when the route and listener hostnames do not overlap', () => {
+      const gw = gateway({ listeners: [{ ...httpListener, hostname: 'other.example.com' }] });
+
+      expect(endpoints(gw)).toStrictEqual([]);
+    });
+
+    it('should emit nothing for a rule matched only by regular expression', () => {
+      const gw = gateway({ listeners: [httpListener] });
+      const regexRules = [{ matches: [{ path: { type: 'RegularExpression', value: '/v[0-9]+' } }], backendRefs: [{ name: 'demo-app' }] }];
+
+      expect(endpoints(gw, { rules: regexRules })).toStrictEqual([]);
+    });
+
+    it('should bracket an IPv6 gateway address so the url is valid', () => {
+      const gw = gateway({ listeners: [httpListener] }, { addresses: [{ type: 'IPAddress', value: '2001:db8::1' }] });
+      const link = endpoints(gw, { hostnames: [] })[0].link;
+
+      expect(link).toBe('http://[2001:db8::1]/shop');
+      expect(() => new URL(link)).not.toThrow();
+    });
+
+    it('should match a wildcard listener as a suffix over any number of labels', () => {
+      const gw = gateway({ listeners: [{ ...httpListener, hostname: '*.example.com' }] });
+
+      expect(endpoints(gw, { hostnames: ['shop.example.com'] })[0].link).toBe('http://shop.example.com/shop');
+      // `*.example.com` is a suffix match, so it covers a two label prefix as well
+      expect(endpoints(gw, { hostnames: ['eu.shop.example.com'] })[0].link).toBe('http://eu.shop.example.com/shop');
+      // but not the apex, and not a hostname that merely ends in the same characters
+      expect(endpoints(gw, { hostnames: ['example.com'] })).toStrictEqual([]);
+      expect(endpoints(gw, { hostnames: ['notexample.com'] })).toStrictEqual([]);
+    });
+
+    it('should compare hostnames case insensitively', () => {
+      const gw = gateway({ listeners: [{ ...httpListener, hostname: 'demo.example.com' }] });
+
+      expect(endpoints(gw, { hostnames: ['Demo.Example.COM'] })[0].link).toBe('http://demo.example.com/shop');
+    });
+
+    it('should not attach to a listener that only allows routes from its own namespace', () => {
+      const gw = gateway({ listeners: [{ ...httpListener, allowedRoutes: { namespaces: { from: 'Same' } } }] }, {}, 'infra');
+      const routeSpec = {
+        parentRefs: [{ name: 'demo-gateway', namespace: 'infra' }], rules, hostnames: ['demo.example.com']
+      };
+
+      expect(httpRoute(routeSpec, [gw]).endpointsForServices(services)).toStrictEqual([]);
+    });
+
+    it('should return nothing when the listener is not http(s)', () => {
+      expect(endpoints(gateway({
+        listeners: [{
+          name: 'tcp', protocol: 'TCP', port: 5432
+        }]
+      }))).toStrictEqual([]);
+    });
+
+    it('should return nothing when the gateway has no address and nothing has a hostname', () => {
+      expect(endpoints(gateway({ listeners: [httpListener] }), { hostnames: [] })).toStrictEqual([]);
+    });
+
+    it('should return nothing when the parent gateway cannot be resolved', () => {
+      expect(endpoints(gateway({ listeners: [httpListener] }, {}, 'elsewhere'))).toStrictEqual([]);
+    });
+
+    it('should return nothing when no rule targets the services', () => {
+      const gw = gateway({ listeners: [httpListener] });
+
+      expect(httpRoute({
+        parentRefs, rules, hostnames: ['demo.example.com']
+      }, [gw]).endpointsForServices([service('unrelated')])).toStrictEqual([]);
+    });
+
+    it('should honour a parentRef that pins a listener by sectionName', () => {
+      const gw = gateway({ listeners: [httpListener, httpsListener] });
+      const routeSpec = {
+        parentRefs: [{ name: 'demo-gateway', sectionName: 'https' }], rules, hostnames: ['demo.example.com']
+      };
+
+      expect(httpRoute(routeSpec, [gw]).endpointsForServices(services).map((e: any) => e.link)).toStrictEqual(['https://demo.example.com/shop']);
+    });
+
+    it('should produce one url per hostname and path, without duplicates', () => {
+      const gw = gateway({ listeners: [httpListener] });
+      const routeSpec = {
+        parentRefs: [{ name: 'demo-gateway' }, { name: 'demo-gateway' }],
+        hostnames:  ['a.example.com', 'b.example.com'],
+        rules:      [{
+          matches:     [{ path: { value: '/shop' } }, { path: { value: '/cart' } }],
+          backendRefs: [{ name: 'demo-app', port: 80 }]
+        }]
+      };
+
+      expect(httpRoute(routeSpec, [gw]).endpointsForServices(services).map((e: any) => e.link)).toStrictEqual([
+        'http://a.example.com/shop',
+        'http://a.example.com/cart',
+        'http://b.example.com/shop',
+        'http://b.example.com/cart',
+      ]);
+    });
+  });
+});
+
+describe('class Gateway', () => {
+  describe('addresses', () => {
+    it('should return the values the controller assigned', () => {
+      const gw = gateway({}, { addresses: [{ type: 'IPAddress', value: '172.19.0.240' }, { type: 'Hostname', value: 'gw.example.com' }] });
+
+      expect(gw.addresses).toStrictEqual(['172.19.0.240', 'gw.example.com']);
+    });
+
+    it.each([
+      ['no status', {}],
+      ['no addresses', { addresses: [] }],
+      ['an address with no value', { addresses: [{ type: 'IPAddress' }] }],
+    ])('should return an empty list for %s', (_label, status) => {
+      expect(gateway({}, status).addresses).toStrictEqual([]);
+    });
+  });
+
+  describe('listenersFor', () => {
+    const gw = gateway({
+      listeners: [
+        {
+          name: 'tcp', protocol: 'TCP', port: 5432
+        },
+        httpListener,
+        httpsListener,
+      ]
+    });
+
+    const names = (listeners: any[]) => listeners.map((l: any) => l.name);
+
+    it('should return every http(s) listener when nothing is pinned', () => {
+      expect(names(gw.listenersFor({}, 'gwdemo'))).toStrictEqual(['http', 'https']);
+    });
+
+    it('should honour sectionName', () => {
+      expect(names(gw.listenersFor({ sectionName: 'https' }, 'gwdemo'))).toStrictEqual(['https']);
+    });
+
+    it('should honour port', () => {
+      expect(names(gw.listenersFor({ port: 443 }, 'gwdemo'))).toStrictEqual(['https']);
+    });
+
+    it('should honour sectionName and port together', () => {
+      expect(names(gw.listenersFor({ sectionName: 'https', port: 443 }, 'gwdemo'))).toStrictEqual(['https']);
+      expect(gw.listenersFor({ sectionName: 'https', port: 80 }, 'gwdemo')).toStrictEqual([]);
+    });
+
+    it('should return nothing when nothing matches', () => {
+      expect(gw.listenersFor({ sectionName: 'nope' }, 'gwdemo')).toStrictEqual([]);
+      expect(gw.listenersFor({ sectionName: 'tcp' }, 'gwdemo')).toStrictEqual([]);
+      expect(gateway({}).listenersFor({}, 'gwdemo')).toStrictEqual([]);
+    });
+  });
+
+  describe('allowsRoute', () => {
+    const gw = gateway({});
+
+    it('should default to accepting only routes in its own namespace', () => {
+      expect(gw.allowsRoute({}, 'gwdemo', 'HTTPRoute')).toBe(true);
+      expect(gw.allowsRoute({}, 'elsewhere', 'HTTPRoute')).toBe(false);
+    });
+
+    it('should honour namespaces.from', () => {
+      expect(gw.allowsRoute({ allowedRoutes: ALL_NAMESPACES }, 'elsewhere', 'HTTPRoute')).toBe(true);
+      expect(gw.allowsRoute({ allowedRoutes: { namespaces: { from: 'Same' } } }, 'elsewhere', 'HTTPRoute')).toBe(false);
+    });
+
+    it('should be permissive for a namespace Selector, whose labels this model does not load', () => {
+      const listener = { allowedRoutes: { namespaces: { from: 'Selector', selector: { matchLabels: { env: 'prod' } } } } };
+
+      expect(gw.allowsRoute(listener, 'elsewhere', 'HTTPRoute')).toBe(true);
+    });
+
+    it('should honour allowedRoutes.kinds', () => {
+      const onlyGrpc = { allowedRoutes: { ...ALL_NAMESPACES, kinds: [{ kind: 'GRPCRoute' }] } };
+      const bothKinds = { allowedRoutes: { ...ALL_NAMESPACES, kinds: [{ kind: 'GRPCRoute' }, { kind: 'HTTPRoute' }] } };
+
+      expect(gw.allowsRoute(onlyGrpc, 'gwdemo', 'HTTPRoute')).toBe(false);
+      expect(gw.allowsRoute(bothKinds, 'gwdemo', 'HTTPRoute')).toBe(true);
+    });
+  });
+
+  describe('schemeForListener', () => {
+    it.each([
+      ['HTTP', 'http'],
+      ['HTTPS', 'https'],
+      ['TCP', undefined],
+      ['UDP', undefined],
+      [undefined, undefined],
+      // A protocol that collides with a name on Object.prototype must not resolve to it
+      ['constructor', undefined],
+      ['toString', undefined],
+    ])('should map the %s listener protocol to %s', (protocol, expected) => {
+      expect(schemeForListener({ protocol })).toBe(expected);
+    });
+
+    it('should return undefined for no listener at all', () => {
+      expect(schemeForListener(undefined)).toBeUndefined();
+    });
+  });
+});

--- a/shell/models/__tests__/workload.test.ts
+++ b/shell/models/__tests__/workload.test.ts
@@ -1,6 +1,9 @@
 import Workload from '@shell/models/workload.js';
 import { steveClassJunkObject } from '@shell/plugins/steve/__tests__/utils/steve-mocks';
-import { WORKLOAD_TYPES, SERVICE, INGRESS } from '@shell/config/types';
+import { WORKLOAD_TYPES, SERVICE, INGRESS, GATEWAY_API } from '@shell/config/types';
+import HttpRoute from '@shell/models/gateway.networking.k8s.io.httproute';
+import Gateway from '@shell/models/gateway.networking.k8s.io.gateway';
+import { CATTLE_PUBLIC_ENDPOINTS } from '@shell/config/labels-annotations';
 
 describe('class: Workload', () => {
   describe('given custom workload keys', () => {
@@ -464,8 +467,9 @@ describe('class: Workload', () => {
         getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
         dispatch:    jest.fn(),
         rootGetters: {
-          'i18n/t':      (key: string) => key,
-          'cluster/all': () => []
+          'i18n/t':            (key: string) => key,
+          'cluster/schemaFor': () => undefined,
+          'cluster/all':       () => []
         },
       });
 
@@ -491,8 +495,9 @@ describe('class: Workload', () => {
         getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
         dispatch:    jest.fn(),
         rootGetters: {
-          'i18n/t':      (key: string) => key,
-          'cluster/all': () => []
+          'i18n/t':            (key: string) => key,
+          'cluster/schemaFor': () => undefined,
+          'cluster/all':       () => []
         },
       });
 
@@ -723,8 +728,9 @@ describe('class: Workload', () => {
         getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
         dispatch:    jest.fn(),
         rootGetters: {
-          'i18n/t':      (key: string) => key,
-          'cluster/all': (type: string) => {
+          'i18n/t':            (key: string) => key,
+          'cluster/schemaFor': () => undefined,
+          'cluster/all':       (type: string) => {
             if (type === SERVICE) {
               return [mockService];
             }
@@ -769,8 +775,9 @@ describe('class: Workload', () => {
         getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
         dispatch:    jest.fn(),
         rootGetters: {
-          'i18n/t':      (key: string) => key,
-          'cluster/all': (type: string) => {
+          'i18n/t':            (key: string) => key,
+          'cluster/schemaFor': () => undefined,
+          'cluster/all':       (type: string) => {
             if (type === SERVICE) {
               return [mockService];
             }
@@ -819,8 +826,9 @@ describe('class: Workload', () => {
         getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
         dispatch:    jest.fn(),
         rootGetters: {
-          'i18n/t':      (key: string) => key,
-          'cluster/all': (type: string) => {
+          'i18n/t':            (key: string) => key,
+          'cluster/schemaFor': () => undefined,
+          'cluster/all':       (type: string) => {
             if (type === SERVICE) {
               return [mockService];
             }
@@ -862,8 +870,9 @@ describe('class: Workload', () => {
         getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
         dispatch:    jest.fn(),
         rootGetters: {
-          'i18n/t':      (key: string) => key,
-          'cluster/all': (type: string) => {
+          'i18n/t':            (key: string) => key,
+          'cluster/schemaFor': () => undefined,
+          'cluster/all':       (type: string) => {
             if (type === SERVICE) {
               return [mockService];
             }
@@ -879,6 +888,188 @@ describe('class: Workload', () => {
       const ingressesRow = rows.find((r: any) => r.label === 'component.resource.detail.card.resourcesCard.rows.ingresses');
 
       expect(ingressesRow).toBeUndefined();
+    });
+  });
+
+  describe('getter: matchingHttpRoutes', () => {
+    const mockService = {
+      metadata: { name: 'svc1', namespace: 'default' },
+      spec:     { selector: { app: 'my-app' } }
+    };
+
+    const makeHttpRoute = (spec: any, gateways: any[] = [], namespace = 'default') => new HttpRoute({
+      metadata: { name: 'route1', namespace },
+      spec
+    }, {
+      rootGetters: {
+        'cluster/schemaFor': () => ({}),
+        'cluster/all':       (type: string) => (type === GATEWAY_API.GATEWAY ? gateways : [])
+      }
+    });
+
+    const makeWorkload = (services: any[], httpRoutes: any[], hasGatewayApi = true) => new Workload({
+      type:     WORKLOAD_TYPES.DEPLOYMENT,
+      metadata: { name: 'test', namespace: 'default' },
+      spec:     { template: { metadata: { labels: { app: 'my-app' } } } }
+    }, {
+      getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
+      dispatch:    jest.fn(),
+      rootGetters: {
+        'i18n/t':            jest.fn(),
+        'cluster/schemaFor': () => (hasGatewayApi ? {} : undefined),
+        'cluster/all':       (type: string) => {
+          if (type === SERVICE) {
+            return services;
+          }
+          if (type === GATEWAY_API.HTTP_ROUTE) {
+            return httpRoutes;
+          }
+
+          return [];
+        }
+      },
+    });
+
+    it('should return an empty array when there are no related services', () => {
+      const route = makeHttpRoute({ rules: [{ backendRefs: [{ name: 'svc1' }] }] });
+
+      expect(makeWorkload([], [route]).matchingHttpRoutes).toStrictEqual([]);
+    });
+
+    it('should return an empty array when no HTTPRoutes exist', () => {
+      expect(makeWorkload([mockService], []).matchingHttpRoutes).toStrictEqual([]);
+    });
+
+    it('should not ask the store for a type with no schema, on a cluster without the Gateway API', () => {
+      const clusterAll = jest.fn().mockReturnValue([]);
+      const workload = new Workload({
+        type:     WORKLOAD_TYPES.DEPLOYMENT,
+        metadata: { name: 'test', namespace: 'default' },
+        spec:     { template: { metadata: { labels: { app: 'my-app' } } } }
+      }, {
+        getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
+        dispatch:    jest.fn(),
+        rootGetters: {
+          'i18n/t':            jest.fn(),
+          'cluster/schemaFor': () => undefined,
+          'cluster/all':       clusterAll,
+        },
+      });
+
+      expect(workload.matchingHttpRoutes).toStrictEqual([]);
+      expect(clusterAll).not.toHaveBeenCalledWith(GATEWAY_API.HTTP_ROUTE);
+    });
+
+    it('should find the routes that send traffic to a related service', () => {
+      const route = makeHttpRoute({ rules: [{ backendRefs: [{ name: 'svc1' }] }] });
+      const other = makeHttpRoute({ rules: [{ backendRefs: [{ name: 'svc2' }] }] });
+
+      expect(makeWorkload([mockService], [other, route]).matchingHttpRoutes).toStrictEqual([route]);
+    });
+
+    it('should not match a route whose backendRef points at another namespace', () => {
+      const route = makeHttpRoute({ rules: [{ backendRefs: [{ name: 'svc1', namespace: 'elsewhere' }] }] });
+
+      expect(makeWorkload([mockService], [route]).matchingHttpRoutes).toStrictEqual([]);
+    });
+  });
+
+  describe('getters: publicEndpoints / gatewayEndpoints / detailEndpoints', () => {
+    const publicEndpoint = {
+      addresses: ['172.18.0.3'], port: 80, protocol: 'HTTP', serviceName: 'default:svc1'
+    };
+
+    const mockService = {
+      metadata: { name: 'svc1', namespace: 'default' },
+      spec:     { selector: { app: 'my-app' } }
+    };
+
+    const mockGateway = new Gateway({
+      metadata: { name: 'gw', namespace: 'default' },
+      spec:     {
+        listeners: [{
+          name: 'http', protocol: 'HTTP', port: 80
+        }]
+      },
+      status: {}
+    });
+
+    const mockRoute = new HttpRoute({
+      metadata: { name: 'route1', namespace: 'default' },
+      spec:     {
+        parentRefs: [{ name: 'gw' }],
+        hostnames:  ['demo.example.com'],
+        rules:      [{ matches: [{ path: { value: '/shop' } }], backendRefs: [{ name: 'svc1' }] }]
+      }
+    }, {
+      rootGetters: {
+        'cluster/schemaFor': () => ({}),
+        'cluster/all':       (type: string) => (type === GATEWAY_API.GATEWAY ? [mockGateway] : [])
+      }
+    });
+
+    const makeWorkload = (annotations: any, httpRoutes: any[] = []) => new Workload({
+      type:     WORKLOAD_TYPES.DEPLOYMENT,
+      metadata: {
+        name: 'test', namespace: 'default', annotations
+      },
+      spec: { template: { metadata: { labels: { app: 'my-app' } } } }
+    }, {
+      getters:     { schemaFor: () => ({ linkFor: jest.fn() }) },
+      dispatch:    jest.fn(),
+      rootGetters: {
+        'i18n/t':            jest.fn(),
+        'cluster/schemaFor': () => ({}),
+        'cluster/all':       (type: string) => {
+          if (type === SERVICE) {
+            return [mockService];
+          }
+          if (type === GATEWAY_API.HTTP_ROUTE) {
+            return httpRoutes;
+          }
+
+          return [];
+        }
+      },
+    });
+
+    it('should parse the publicEndpoints annotation', () => {
+      const workload = makeWorkload({ [CATTLE_PUBLIC_ENDPOINTS]: JSON.stringify([publicEndpoint]) });
+
+      expect(workload.publicEndpoints).toStrictEqual([publicEndpoint]);
+    });
+
+    it.each([
+      ['no annotations at all', undefined],
+      ['no publicEndpoints annotation', { other: 'value' }],
+      ['a malformed annotation', { [CATTLE_PUBLIC_ENDPOINTS]: 'not json' }],
+      ['an annotation that is not an array', { [CATTLE_PUBLIC_ENDPOINTS]: '{"a":1}' }],
+    ])('should return no public endpoints for %s', (_label, annotations) => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      expect(makeWorkload(annotations).publicEndpoints).toStrictEqual([]);
+
+      warn.mockRestore();
+    });
+
+    it('should resolve gateway endpoints through the matching routes', () => {
+      expect(makeWorkload(undefined, [mockRoute]).gatewayEndpoints).toStrictEqual([
+        { link: 'http://demo.example.com/shop', linkDisplay: 'http://demo.example.com/shop' }
+      ]);
+    });
+
+    it('should combine published endpoints with gateway endpoints', () => {
+      const workload = makeWorkload({ [CATTLE_PUBLIC_ENDPOINTS]: JSON.stringify([publicEndpoint]) }, [mockRoute]);
+
+      expect(workload.detailEndpoints).toStrictEqual([
+        publicEndpoint,
+        { link: 'http://demo.example.com/shop', linkDisplay: 'http://demo.example.com/shop' }
+      ]);
+    });
+
+    it('should be undefined when the workload is exposed by nothing, so the masthead row stays hidden', () => {
+      // An empty array would be truthy and leave a labelled Endpoints row with no value.
+      expect(makeWorkload(undefined).detailEndpoints).toBeUndefined();
     });
   });
 });

--- a/shell/models/gateway.networking.k8s.io.gateway.js
+++ b/shell/models/gateway.networking.k8s.io.gateway.js
@@ -1,0 +1,66 @@
+import SteveModel from '@shell/plugins/steve/steve-class';
+
+export const GATEWAY_GROUP = 'gateway.networking.k8s.io';
+
+const HTTP_SCHEMES = {
+  HTTP:  'http',
+  HTTPS: 'https'
+};
+
+export function schemeForListener(listener) {
+  const protocol = listener?.protocol;
+
+  // hasOwn, not a bare index: a protocol of `constructor` would otherwise resolve off the prototype.
+  return Object.hasOwn(HTTP_SCHEMES, protocol) ? HTTP_SCHEMES[protocol] : undefined;
+}
+
+export default class Gateway extends SteveModel {
+  get addresses() {
+    return (this.status?.addresses || []).map((address) => address.value).filter((value) => !!value);
+  }
+
+  get listeners() {
+    return this.spec?.listeners || [];
+  }
+
+  // `namespaces.from` defaults to `Same`, so a listener that says nothing accepts only routes beside
+  // it. `Selector` needs namespace labels this model does not load, so it is treated as permissive:
+  // showing one endpoint too many beats hiding a working one.
+  allowsRoute(listener, routeNamespace, kind) {
+    const allowedRoutes = listener?.allowedRoutes;
+    const kinds = allowedRoutes?.kinds;
+
+    if (kinds?.length && !kinds.some((k) => k?.kind === kind && (k?.group ?? GATEWAY_GROUP) === GATEWAY_GROUP)) {
+      return false;
+    }
+
+    if ((allowedRoutes?.namespaces?.from ?? 'Same') === 'Same') {
+      return routeNamespace === this.metadata?.namespace;
+    }
+
+    return true;
+  }
+
+  // A parentRef that pins neither sectionName nor port attaches to every compatible listener, so
+  // all of them are returned: a gateway that redirects on :80 and serves on :443 must not advertise
+  // only whichever listener happens to be written first.
+  listenersFor(parentRef, routeNamespace, kind = 'HTTPRoute') {
+    const { sectionName, port } = parentRef || {};
+
+    return this.listeners.filter((listener) => {
+      if (!schemeForListener(listener)) {
+        return false;
+      }
+
+      if (sectionName && listener.name !== sectionName) {
+        return false;
+      }
+
+      if (port && listener.port !== port) {
+        return false;
+      }
+
+      return this.allowsRoute(listener, routeNamespace, kind);
+    });
+  }
+}

--- a/shell/models/gateway.networking.k8s.io.httproute.js
+++ b/shell/models/gateway.networking.k8s.io.httproute.js
@@ -1,0 +1,190 @@
+import { GATEWAY_API } from '@shell/config/types';
+import { uniq } from '@shell/utils/array';
+import SteveModel from '@shell/plugins/steve/steve-class';
+import { schemeForListener, GATEWAY_GROUP } from '@shell/models/gateway.networking.k8s.io.gateway';
+
+// Implied by the scheme, so omitted from the url.
+const DEFAULT_PORTS = {
+  http:  80,
+  https: 443
+};
+
+// A `RegularExpression` match cannot be turned back into a browsable path, so it yields no url.
+const LITERAL_PATH_TYPES = ['Exact', 'PathPrefix'];
+
+const isWildcard = (hostname) => !!hostname?.startsWith('*.');
+
+// A Gateway API wildcard is a suffix match over any number of labels, not the single-label TLS
+// certificate rule: `*.example.com` covers `eu.shop.example.com`. Keeping the leading dot is what
+// stops it also matching the apex `example.com` or `notexample.com`.
+function matchesWildcard(hostname, wildcard) {
+  return hostname.endsWith(wildcard.slice(1));
+}
+
+// Either side may be a wildcard and the more specific wins. A listener with no hostname matches
+// anything.
+function intersectHostnames(routeHostname, listenerHostname) {
+  const route = routeHostname?.toLowerCase();
+  const listener = listenerHostname?.toLowerCase();
+
+  if (!listener || route === listener) {
+    return route;
+  }
+
+  if (isWildcard(listener) && !isWildcard(route) && matchesWildcard(route, listener)) {
+    return route;
+  }
+
+  if (isWildcard(route) && !isWildcard(listener) && matchesWildcard(listener, route)) {
+    return listener;
+  }
+
+  return undefined;
+}
+
+// An IPv6 literal has to be bracketed before it can go in a url.
+const hostForUrl = (host) => (host.includes(':') ? `[${ host }]` : host);
+
+// `group` and `kind` are optional, defaulting to `gateway.networking.k8s.io` and `Gateway`.
+const isGatewayRef = (parentRef) => (parentRef?.group ?? GATEWAY_GROUP) === GATEWAY_GROUP &&
+  (parentRef?.kind ?? 'Gateway') === 'Gateway';
+
+export default class HttpRoute extends SteveModel {
+  get rules() {
+    return this.spec?.rules || [];
+  }
+
+  // Steve's printer column for this field is the raw array, which renders as JSON.
+  get hostnamesDisplay() {
+    return (this.spec?.hostnames || []).join(', ');
+  }
+
+  // Read from the spec rather than resolved through the store, so the column does not depend on
+  // Gateways being loaded. Only cross-namespace refs are qualified, since only those are ambiguous.
+  get parentRefsDisplay() {
+    return (this.spec?.parentRefs || []).filter(isGatewayRef).map((parentRef) => {
+      const namespace = parentRef.namespace;
+
+      return namespace && namespace !== this.metadata?.namespace ? `${ namespace }/${ parentRef.name }` : parentRef.name;
+    }).join(', ');
+  }
+
+  // `group`, `kind` and `namespace` default to the core group, `Service`, and the route's own
+  // namespace. Unlike Ingress, an HTTPRoute may reference a Service in another namespace, so the
+  // namespace is compared rather than assumed.
+  backendRefTargets(backendRef, service) {
+    if (!backendRef || !service) {
+      return false;
+    }
+
+    const group = backendRef.group ?? '';
+    const kind = backendRef.kind ?? 'Service';
+    const namespace = backendRef.namespace ?? this.metadata?.namespace;
+
+    return group === '' &&
+      kind === 'Service' &&
+      backendRef.name === service.metadata?.name &&
+      namespace === service.metadata?.namespace;
+  }
+
+  rulesForServices(services = []) {
+    if (!services.length) {
+      return [];
+    }
+
+    return this.rules.filter((rule) => (rule?.backendRefs || []).some(
+      (backendRef) => services.some((service) => this.backendRefTargets(backendRef, service))
+    ));
+  }
+
+  targetsAnyService(services = []) {
+    return this.rulesForServices(services).length > 0;
+  }
+
+  pathsForRule(rule) {
+    // A match with no `path` is a prefix match on `/` per the spec default, so it is defaulted
+    // rather than dropped: dropping it would lose the `/` url when it sits beside an explicit path.
+    const matchedPaths = (rule?.matches || []).map((match) => match?.path ?? { type: 'PathPrefix', value: '/' });
+
+    if (!matchedPaths.length) {
+      return ['/'];
+    }
+
+    return uniq(matchedPaths
+      .filter((path) => LITERAL_PATH_TYPES.includes(path.type ?? 'PathPrefix'))
+      .map((path) => path.value || '/'));
+  }
+
+  get parentGateways() {
+    // Asking `cluster/all` for a type with no schema warns and registers a phantom type, so the
+    // schema is checked first on clusters without the Gateway API CRDs.
+    if (!this.$rootGetters['cluster/schemaFor'](GATEWAY_API.GATEWAY)) {
+      return [];
+    }
+
+    const parentRefs = (this.spec?.parentRefs || []).filter(isGatewayRef);
+
+    if (!parentRefs.length) {
+      return [];
+    }
+
+    const allGateways = this.$rootGetters['cluster/all'](GATEWAY_API.GATEWAY) || [];
+
+    return parentRefs.reduce((out, parentRef) => {
+      const namespace = parentRef.namespace ?? this.metadata?.namespace;
+      const gateway = allGateways.find((g) => g.metadata?.name === parentRef.name && g.metadata?.namespace === namespace);
+
+      if (gateway) {
+        out.push({ parentRef, gateway });
+      }
+
+      return out;
+    }, []);
+  }
+
+  // Wildcards are dropped because they are not a url anyone can open, and that yields nothing
+  // rather than falling back to the gateway address: the gateway matches on the `Host` header, so a
+  // link to the bare address would not reach this route.
+  hostsFor(gateway, listener) {
+    const routeHostnames = this.spec?.hostnames || [];
+    const listenerHostname = listener?.hostname;
+
+    if (routeHostnames.length) {
+      return uniq(routeHostnames
+        .map((hostname) => intersectHostnames(hostname, listenerHostname))
+        .filter((hostname) => hostname && !isWildcard(hostname)));
+    }
+
+    if (listenerHostname) {
+      return isWildcard(listenerHostname) ? [] : [listenerHostname];
+    }
+
+    return gateway?.addresses || [];
+  }
+
+  endpointsForServices(services = []) {
+    const rules = this.rulesForServices(services);
+
+    if (!rules.length) {
+      return [];
+    }
+
+    const paths = uniq(rules.flatMap((rule) => this.pathsForRule(rule)));
+
+    if (!paths.length) {
+      return [];
+    }
+
+    const links = this.parentGateways.flatMap(({ parentRef, gateway }) => {
+      return gateway.listenersFor(parentRef, this.metadata?.namespace).flatMap((listener) => {
+        const scheme = schemeForListener(listener);
+        const port = listener.port && listener.port !== DEFAULT_PORTS[scheme] ? `:${ listener.port }` : '';
+
+        return this.hostsFor(gateway, listener)
+          .flatMap((host) => paths.map((path) => `${ scheme }://${ hostForUrl(host) }${ port }${ path }`));
+      });
+    });
+
+    return uniq(links).map((link) => ({ link, linkDisplay: link }));
+  }
+}

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -1,6 +1,8 @@
 import { findBy, insertAt } from '@shell/utils/array';
 import { CATTLE_PUBLIC_ENDPOINTS } from '@shell/config/labels-annotations';
-import { WORKLOAD_TYPES, SERVICE, INGRESS, POD } from '@shell/config/types';
+import {
+  WORKLOAD_TYPES, SERVICE, INGRESS, POD, GATEWAY_API
+} from '@shell/config/types';
 import { set } from '@shell/utils/object';
 import day from 'dayjs';
 import { convertSelectorObj, parse, matches, convert } from '@shell/utils/selector';
@@ -328,6 +330,32 @@ export default class Workload extends WorkloadService {
     return this?.metadata?.annotations?.[CATTLE_PUBLIC_ENDPOINTS];
   }
 
+  get publicEndpoints() {
+    const annotation = this.endpoint;
+
+    if (!annotation) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(annotation);
+
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (err) {
+      console.warn(`publicEndpoints: failed to parse the ${ CATTLE_PUBLIC_ENDPOINTS } annotation on "${ this.id }"`, err); // eslint-disable-line no-console
+
+      return [];
+    }
+  }
+
+  // Undefined rather than an empty array when there is nothing to show: the masthead filters on
+  // the value, and an empty array is truthy and would leave a labelled row with no value.
+  get detailEndpoints() {
+    const endpoints = [...this.publicEndpoints, ...this.gatewayEndpoints];
+
+    return endpoints.length ? endpoints : undefined;
+  }
+
   get desired() {
     return this.spec?.replicas || 0;
   }
@@ -365,7 +393,7 @@ export default class Workload extends WorkloadService {
       },
       endpoint: {
         label:     'Endpoints',
-        content:   this.endpoint,
+        content:   this.detailEndpoints,
         formatter: 'WorkloadDetailEndpoints'
       },
       ready: {
@@ -845,6 +873,38 @@ export default class Workload extends WorkloadService {
     });
   }
 
+  // Asking `cluster/all` for a type with no schema warns and registers a phantom type, so the
+  // schema is checked first on clusters without the Gateway API CRDs.
+  get matchingHttpRoutes() {
+    if (!this.$rootGetters['cluster/schemaFor'](GATEWAY_API.HTTP_ROUTE)) {
+      return [];
+    }
+
+    const services = this.relatedServices;
+
+    if (!services.length) {
+      return [];
+    }
+
+    const allHttpRoutes = this.$rootGetters['cluster/all'](GATEWAY_API.HTTP_ROUTE) || [];
+
+    return allHttpRoutes.filter((httpRoute) => httpRoute.targetsAnyService(services));
+  }
+
+  // The `field.cattle.io/publicEndpoints` annotation is written by a Rancher controller that only
+  // knows Ingresses and LoadBalancer Services, so gateway endpoints are resolved here instead.
+  get gatewayEndpoints() {
+    const httpRoutes = this.matchingHttpRoutes;
+
+    if (!httpRoutes.length) {
+      return [];
+    }
+
+    const services = this.relatedServices;
+
+    return httpRoutes.flatMap((httpRoute) => httpRoute.endpointsForServices(services));
+  }
+
   get resourcesCardRows() {
     const rows = [...this._resourcesCardRows];
     const showsIngressesAndServices = this.type !== WORKLOAD_TYPES.JOB && this.type !== WORKLOAD_TYPES.CRON_JOB;
@@ -852,6 +912,11 @@ export default class Workload extends WorkloadService {
     if (showsIngressesAndServices) {
       const services = this.relatedServices || [];
       const ingresses = this.matchingIngresses || [];
+      const httpRoutes = this.matchingHttpRoutes || [];
+
+      if (httpRoutes.length) {
+        rows.unshift(useResourceCardRow(this.t('component.resource.detail.card.resourcesCard.rows.httpRoutes'), httpRoutes, undefined, undefined, '#httproutes'));
+      }
 
       if (ingresses.length) {
         rows.unshift(useResourceCardRow(this.t('component.resource.detail.card.resourcesCard.rows.ingresses'), ingresses, undefined, undefined, '#ingresses'));

--- a/shell/models/workload.js
+++ b/shell/models/workload.js
@@ -873,8 +873,6 @@ export default class Workload extends WorkloadService {
     });
   }
 
-  // Asking `cluster/all` for a type with no schema warns and registers a phantom type, so the
-  // schema is checked first on clusters without the Gateway API CRDs.
   get matchingHttpRoutes() {
     if (!this.$rootGetters['cluster/schemaFor'](GATEWAY_API.HTTP_ROUTE)) {
       return [];


### PR DESCRIPTION
### Summary
Fixes #17992
Part of #18004

### Occurred changes and/or fixed issues

- Adds an **HTTPRoutes** tab and Resources-card row beside Ingresses, listing the routes whose `backendRefs` reach one of the workload's Services.
- Resolves the masthead **Endpoints** links along `Workload -> Service -> HTTPRoute -> parent Gateway`.
- Registers list headers for `HTTPRoute`; without them the table renders `spec.hostnames` as a raw JSON array.
- Raises `HTTPRoute` and `Gateway` into the **Service Discovery** nav group (#18004 item 1). The issue names only HttpRoutes; a route is unreadable without its gateway.
- Adds an **Endpoints** column to the HTTPRoutes tab, narrowed per row to this workload's Services so it decomposes the masthead row rather than exceeding it.

### Technical notes summary

- `field.cattle.io/publicEndpoints`, the annotation behind the Endpoints row, is written by a Rancher controller that only knows Ingress and LoadBalancer Services, so gateway endpoints are resolved in the UI instead.
- Every entry point is gated on `schemaFor`, so a CRD-less cluster fetches nothing and `cluster/all` is never asked for an unregistered type.
- A Gateway API wildcard hostname is a **suffix** match, not the TLS certificate rule: `*.example.com` covers `eu.shop.example.com`. A wildcard-only route yields no link, since nothing would match the `Host` header.
- Resolution emits nothing rather than a URL that would not reach the workload: `RegularExpression`-only rules, denied `allowedRoutes`, a Gateway with no addresses.

- The Endpoints column is on the tab only. The generic HTTPRoute list cannot resolve it without loading every Gateway, and `cluster/all` on an unfetched type warns per row.

### Areas or cases that should be tested

Nothing here exists in a stock cluster.

```bash
kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
kubectl apply -f gwdemo.yaml
```

<details>
<summary><code>gwdemo.yaml</code></summary>

```yaml
apiVersion: v1
kind: Namespace
metadata: { name: gwdemo }
---
apiVersion: apps/v1
kind: Deployment
metadata: { name: demo-app, namespace: gwdemo, labels: { app: demo-app } }
spec:
  replicas: 1
  selector: { matchLabels: { app: demo-app } }
  template:
    metadata: { labels: { app: demo-app } }
    spec:
      containers:
        - name: nginx
          image: nginx:alpine
          ports: [{ containerPort: 80 }]
---
apiVersion: v1
kind: Service
metadata: { name: demo-app, namespace: gwdemo }
spec:
  selector: { app: demo-app }
  ports: [{ name: http, port: 80, targetPort: 80 }]
---
apiVersion: gateway.networking.k8s.io/v1
kind: GatewayClass
metadata: { name: demo-gateway-class }
spec: { controllerName: example.com/demo-gateway-controller }
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata: { name: demo-gateway, namespace: gwdemo }
spec:
  gatewayClassName: demo-gateway-class
  listeners:
    - name: http
      port: 80
      protocol: HTTP
      allowedRoutes: { namespaces: { from: All } }
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata: { name: demo-route, namespace: gwdemo }
spec:
  hostnames: [demo.example.com]
  parentRefs: [{ name: demo-gateway }]
  rules:
    - backendRefs: [{ name: demo-app, port: 80 }]
      matches: [{ path: { type: PathPrefix, value: /shop } }]
```

</details>

Open *Workloads > Deployments > demo-app*: Endpoints shows `http://demo.example.com/shop`, and the HTTPRoutes tab lists `demo-route`.

Beyond the happy path:

- A cluster **without** the CRDs, or a user with no RBAC on `httproutes`: no nav entry, no tab, Endpoints row unchanged.
- Legacy **Ingress** and **LoadBalancer Service** workloads: links unchanged. A workload exposed by nothing: no Endpoints row at all, not an empty one.
- Vary the Gateway (https listener, non-default port, `allowedRoutes.namespaces.from: Same`) and the route (several hostnames or paths, a wildcard, a missing parent).

```bash
npx jest --ci shell/models/__tests__ shell/detail/__tests__ shell/components/formatter/__tests__
```

### Areas which could experience regressions

- The masthead Endpoints row on **every** workload type, since `details.endpoint.content` changed from the raw annotation string to a resolved array.
- The workload **list** Endpoints column is deliberately untouched: it is server-side sortable on the annotation, so extending it is a separate change.

### Screenshot/Video

**Before** - no HTTPRoutes tab, no Endpoints row, and the Ingresses tab is empty:

https://github.com/user-attachments/assets/ee60776f-9e3d-4f76-bf0d-138ed49fb651

**After** - the same walk, with the Endpoints link and the HTTPRoutes tab:

https://github.com/user-attachments/assets/ae1c8411-7591-4695-873d-bb85de6a95ca

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`


