### PR TITLE
[2.15] fix legacy (pre 2.12) project scoped secrets

### DIFF
--- a/cypress/e2e/tests/pages/explorer2/workloads/jobs.spec.ts
+++ b/cypress/e2e/tests/pages/explorer2/workloads/jobs.spec.ts
@@ -14,78 +14,103 @@ describe('Jobs', { testIsolation: 'off', tags: ['@explorer2', '@adminUser'] }, (
 
   describe('CRUD', () => {
     const namespaceName = 'custom-namespace';
-    const jobName = 'my-job-custom-name';
+    const rootJobName = 'my-job-custom-name';
     const containerImageName = 'nginx';
 
     it('Creating a job while creating a new namespace should succeed', () => {
-      cy.intercept('POST', 'v1/namespaces').as('createNamespace');
-      cy.intercept('POST', 'v1/batch.jobs').as('createJob');
+      let jobName;
 
-      // list view jobs
-      const workloadsJobsListPage = new WorkloadsJobsListPagePo(localCluster);
+      cy.createE2EResourceName(rootJobName).then((name) => {
+        jobName = name;
 
-      workloadsJobsListPage.goTo();
-      workloadsJobsListPage.baseResourceList().masthead().create();
+        cy.intercept('POST', 'v1/namespaces').as('createNamespace');
+        cy.intercept('POST', 'v1/batch.jobs').as('createJob');
 
-      // create view jobs
-      const workloadsJobDetailsPage = new WorkLoadsJobDetailsPagePo(localCluster);
+        // list view jobs
+        const workloadsJobsListPage = new WorkloadsJobsListPagePo(localCluster);
 
-      workloadsJobDetailsPage.selectNamespaceOption(1);
-      workloadsJobDetailsPage.namespace().set(namespaceName);
-      workloadsJobDetailsPage.resourceDetail().createEditView().nameNsDescription().name()
-        .set(jobName);
-      workloadsJobDetailsPage.containerImage().set(containerImageName);
-      workloadsJobDetailsPage.resourceDetail().createEditView().save();
-      cy.wait('@createNamespace').its('response.statusCode').should('eq', 201);
-      cy.wait('@createJob').its('response.statusCode').should('eq', 201);
+        workloadsJobsListPage.goTo();
+        workloadsJobsListPage.waitForPage();
+        // We need to confirm that the list has actually finished loading given we're flicking quickly between list + create
+        workloadsJobsListPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+        workloadsJobsListPage.baseResourceList().masthead().create();
 
-      workloadsJobsListPage.list().resourceTable().sortableTable().rowElementWithName(jobName)
-        .should('exist');
+        // create view jobs
+        const workloadsJobDetailsPage = new WorkLoadsJobDetailsPagePo(localCluster);
 
-      // navigate to namespace and check existence of namespace
-      cy.visit('/c/local/explorer/projectsnamespaces');
-      workloadsJobsListPage.list().resourceTable().sortableTable().rowElementWithName(namespaceName)
-        .should('exist');
+        workloadsJobDetailsPage.selectNamespaceOption(1);
+        workloadsJobDetailsPage.namespace().set(namespaceName);
+        workloadsJobDetailsPage.resourceDetail().createEditView().nameNsDescription().name()
+          .set(jobName);
+        workloadsJobDetailsPage.containerImage().set(containerImageName);
+        workloadsJobDetailsPage.resourceDetail().createEditView().save();
+        cy.wait('@createNamespace').its('response.statusCode').should('eq', 201);
+        cy.wait('@createJob').its('response.statusCode').should('eq', 201);
+
+        workloadsJobsListPage.list().resourceTable().sortableTable().rowElementWithName(jobName)
+          .should('exist');
+
+        // navigate to namespace and check existence of namespace
+        cy.visit('/c/local/explorer/projectsnamespaces');
+        workloadsJobsListPage.list().resourceTable().sortableTable().rowElementWithName(namespaceName)
+          .should('exist');
+      });
     });
 
     it('Should be able to clone a job', () => {
-      const jobName2 = `${ jobName }-2`;
-      const jobNameClone = `${ jobName }-3`;
+      let jobName;
 
-      // list view jobs
-      const workloadsJobsListPage = new WorkloadsJobsListPagePo('local');
+      cy.createE2EResourceName(rootJobName).then((name) => {
+        jobName = name;
 
-      workloadsJobsListPage.goTo();
-      workloadsJobsListPage.waitForPage();
-      workloadsJobsListPage.baseResourceList().checkVisible();
-      workloadsJobsListPage.baseResourceList().masthead().create();
+        const jobName2 = `${ jobName }-2`;
+        const jobNameClone = `${ jobName }-3`;
 
-      // create view jobs
-      const workloadsJobDetailsPage = new WorkLoadsJobDetailsPagePo('local');
+        // list view jobs
+        const workloadsJobsListPage = new WorkloadsJobsListPagePo('local');
 
-      workloadsJobDetailsPage.selectNamespaceOption(1);
-      workloadsJobDetailsPage.namespace().set(namespaceName);
-      workloadsJobDetailsPage.resourceDetail().createEditView().nameNsDescription().name()
-        .set(jobName2);
-      workloadsJobDetailsPage.containerImage().set(containerImageName);
-      workloadsJobDetailsPage.resourceDetail().createEditView().save();
+        workloadsJobsListPage.goTo();
+        workloadsJobsListPage.waitForPage();
+        workloadsJobsListPage.baseResourceList().checkVisible();
+        // We need to confirm that the list has actually finished loading given we're flicking quickly between list + create
+        workloadsJobsListPage.list().resourceTable().sortableTable().checkLoadingIndicatorNotVisible();
+        workloadsJobsListPage.baseResourceList().masthead().create();
 
-      workloadsJobsListPage.list().resourceTable().sortableTable().rowElementWithName(jobName2)
-        .should('exist');
+        // create view jobs
+        const workloadsJobDetailsPage = new WorkLoadsJobDetailsPagePo('local');
 
-      // Clone the job
-      workloadsJobsListPage.list().actionMenu(jobName2).getMenuItem('Clone').click();
+        workloadsJobDetailsPage.selectNamespaceOption(1);
+        workloadsJobDetailsPage.namespace().set(namespaceName);
+        workloadsJobDetailsPage.resourceDetail().createEditView().nameNsDescription().name()
+          .set(jobName2);
+        workloadsJobDetailsPage.containerImage().set(containerImageName);
+        workloadsJobDetailsPage.resourceDetail().createEditView().save();
 
-      const cloneJobDetailsPage = new WorkLoadsJobDetailsPagePo(jobName2, {}, 'local', namespaceName);
+        // Saving returns the user to the list page (create-edit-view `done()` does a
+        // router.replace to `doneRoute`), so just wait for that navigation to settle
+        // before querying the table.
+        workloadsJobsListPage.waitForPage();
+        workloadsJobsListPage.list().resourceTable().sortableTable().rowElementWithName(jobName2)
+          .should('exist');
 
-      cloneJobDetailsPage.waitForPage();
-      cloneJobDetailsPage.resourceDetail().createEditView().nameNsDescription().name()
-        .set(jobNameClone);
-      cloneJobDetailsPage.resourceDetail().createEditView().save();
-      cloneJobDetailsPage.errorBanner().should('not.exist');
+        // Clone the job
+        workloadsJobsListPage.list().actionMenu(jobName2).getMenuItem('Clone').click();
 
-      workloadsJobsListPage.list().resourceTable().sortableTable().rowElementWithName(jobNameClone)
-        .should('exist');
+        const cloneJobDetailsPage = new WorkLoadsJobDetailsPagePo(jobName2, {}, 'local', namespaceName);
+
+        cloneJobDetailsPage.waitForPage();
+        cloneJobDetailsPage.resourceDetail().createEditView().nameNsDescription().name()
+          .set(jobNameClone);
+        cloneJobDetailsPage.resourceDetail().createEditView().save();
+        cloneJobDetailsPage.errorBanner().should('not.exist');
+
+        // Saving returns the user to the list page (create-edit-view `done()` does a
+        // router.replace to `doneRoute`), so just wait for that navigation to settle
+        // before querying the table.
+        workloadsJobsListPage.waitForPage();
+        workloadsJobsListPage.list().resourceTable().sortableTable().rowElementWithName(jobNameClone)
+          .should('exist');
+      });
     });
 
     after(() => {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "generate": "yarn build",
     "dev-debug": "node --inspect ./node_modules/.bin/vue-cli-service serve",
     "cy:e2e": "cypress open --e2e --browser chrome",
-    "cy:open": "cypress open --config numTestsKeptInMemory=10",
+    "cy:open": "cypress open",
     "cy:run": "cypress run --browser chrome",
     "cy:run:sorry": "./scripts/e2e $SPEC_FILE",
     "e2e:pre-dev": "yarn docker:local:stop && yarn docker:local:start && NODE_ENV=dev TEST_INSTRUMENT=true yarn build",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "generate": "yarn build",
     "dev-debug": "node --inspect ./node_modules/.bin/vue-cli-service serve",
     "cy:e2e": "cypress open --e2e --browser chrome",
-    "cy:open": "cypress open",
+    "cy:open": "cypress open --config numTestsKeptInMemory=10",
     "cy:run": "cypress run --browser chrome",
     "cy:run:sorry": "./scripts/e2e $SPEC_FILE",
     "e2e:pre-dev": "yarn docker:local:stop && yarn docker:local:start && NODE_ENV=dev TEST_INSTRUMENT=true yarn build",

--- a/shell/components/formatter/SecretOrigin.vue
+++ b/shell/components/formatter/SecretOrigin.vue
@@ -36,19 +36,12 @@ export default {
     },
     tooltip() {
       if (this.row.isProjectScoped) {
-        const projectName = this.row.project?.nameDisplay || this.row.projectScopedProjectId;
+        const projectName = this.row.project?.nameDisplay || this.row.projectScopedProjectName;
         const clusterName = this.row.projectCluster?.nameDisplay || this.row.projectScopedClusterId;
 
         return this.t('secret.projectScoped.tooltip.source', { project: projectName, cluster: clusterName });
       } else if (this.row.isProjectSecretCopy) {
-        const projectID = this.row.projectScopedProjectId;
-        const clusterId = this.currentCluster?.id;
-
-        // Try to fetch the project.
-        // Note: The management store might not have the project loaded if we haven't visited the cluster list or project list.
-        // However, if we are in the dashboard, we usually have projects loaded.
-        const project = this.$store.getters[`${ STORE.MANAGEMENT }/byId`](MANAGEMENT.PROJECT, `${ clusterId }/${ projectID }`);
-        const projectName = project?.nameDisplay || projectID;
+        const projectName = this.row.project?.nameDisplay || this.row.projectSecretCopyProjectName;
 
         return this.t('secret.projectScoped.tooltip.copy', { secret: this.row.nameDisplay, project: projectName });
       }

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -19,6 +19,8 @@ export const NODE_ARCHITECTURE = 'kubernetes.io/arch';
 export const IMPORTED_CLUSTER_VERSION_MANAGEMENT = 'rancher.io/imported-cluster-version-management';
 export const UI_PROJECT_SECRET = 'management.cattle.io/project-scoped-secret';
 export const UI_PROJECT_SECRET_COPY = 'management.cattle.io/project-scoped-secret-copy';
+export const UI_PROJECT_SECRET_CLUSTER = 'management.cattle.io/project-scoped-secret-cluster';
+
 export const SERVICE_LINKS = 'ui.rancher/service-links';
 export const NODE_DRIVER_FIELD_HINTS = 'io.cattle.nodedriver/ui-field-hints';
 

--- a/shell/config/pagination-table-headers.js
+++ b/shell/config/pagination-table-headers.js
@@ -95,9 +95,17 @@ export const STEVE_LIST_GROUPS = [{
 
 export const STEVE_SECRET_ORIGIN = {
   ...SECRET_ORIGIN,
-  // We can't sort by the 'UI_PROJECT_SECRET' label (management.cattle.io/project-scoped-secret) due to backend limitations.
-  // So we sort by the 'UI_PROJECT_SECRET_COPY' annotation (management.cattle.io/project-scoped-secret-copy) which at least groups the copies.
-  sort: `metadata.annotations[${ UI_PROJECT_SECRET_COPY }]:desc`,
+  // We would like to sort on
+  // 1. if this is a project scoped secret copy
+  // 2. if this is a project scoped secret on it's clusters mgmt id
+  //   - field not shown in response but allowed to sort/filter via vai
+  // 3. if this is a project scoped secret on it's project's human name
+  //   - field not shown in response but allowed to sort/filter via vai
+  sort: [
+    `metadata.annotations[${ UI_PROJECT_SECRET_COPY }]:desc`,
+    `spec.clusterName:desc`,
+    `spec.displayName`,
+  ],
 };
 
 export const STEVE_WORKLOAD_HEALTH_SCALE = {

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -1,4 +1,4 @@
-import { CATTLE_PUBLIC_ENDPOINTS } from '@shell/config/labels-annotations';
+import { CATTLE_PUBLIC_ENDPOINTS, UI_PROJECT_SECRET_COPY } from '@shell/config/labels-annotations';
 import { NODE as NODE_TYPE, NAMESPACE as NAMESPACE_TYPE } from '@shell/config/types';
 import { COLUMN_BREAKPOINTS } from '@shell/types/store/type-map';
 
@@ -395,8 +395,12 @@ export const SECRET_ORIGIN = {
   labelKey:  'tableHeaders.secret.origin',
   tooltip:   'tableHeaders.secret.originTooltip',
   formatter: 'SecretOrigin',
-  sort:      'project.spec.displayName',
-  search:    false,
+  sort:      [
+    `metadata.annotations."${ UI_PROJECT_SECRET_COPY }":desc`,
+    `projectSecretCopyCluster.spec.displayName`,
+    'project.spec.displayName',
+  ],
+  search: false,
 };
 
 export const TARGET_KIND = {

--- a/shell/config/table-headers.js
+++ b/shell/config/table-headers.js
@@ -395,11 +395,7 @@ export const SECRET_ORIGIN = {
   labelKey:  'tableHeaders.secret.origin',
   tooltip:   'tableHeaders.secret.originTooltip',
   formatter: 'SecretOrigin',
-  // Cannot _sort_ upstream secrets by if they are cluster scoped
-  // https://github.com/rancher/rancher/issues/51001
-  // metadata.labels[management.cattle.io/project-scoped-secret] - covers both cluster scoped AND clones
-  // metadata.annotations[management.cattle.io/project-scoped-secret-copy]
-  // sort:     [`metadata.labels[${ UI_PROJECT_SECRET }]`, `metadata.annotations[${ UI_PROJECT_SECRET_COPY }]`],
+  sort:      'project.spec.displayName',
   search:    false,
 };
 

--- a/shell/list/projectsecret.vue
+++ b/shell/list/projectsecret.vue
@@ -1,46 +1,20 @@
 <script lang="ts">
-import Masthead from '@shell/components/ResourceList/Masthead';
+import Masthead from '@shell/components/ResourceList/Masthead.vue';
 import { SECRET_SCOPE, SECRET_QUERY_PARAMS } from '@shell/config/query-params';
-import { MANAGEMENT, SECRET, VIRTUAL_TYPES } from '@shell/config/types';
+import { SECRET, VIRTUAL_TYPES } from '@shell/config/types';
 import { STORE } from '@shell/store/store-types';
-import PaginatedResourceTable from '@shell/components/PaginatedResourceTable';
+import PaginatedResourceTable from '@shell/components/PaginatedResourceTable.vue';
 import { PaginationArgs, PaginationFilterField, PaginationParamFilter } from '@shell/types/store/pagination.types';
 import Secret from '@shell/models/secret';
 import { TableColumn } from '@shell/types/store/type-map';
 import { mapGetters } from 'vuex';
 import { GROUP_RESOURCES, mapPref } from '@shell/store/prefs';
-import { DEFAULT_PROJECT, SYSTEM_PROJECT, UI_PROJECT_SECRET, UI_PROJECT_SECRET_COPY } from '@shell/config/labels-annotations';
-import { RancherKubeMetadata } from '@shell/types/rancher/steve.api';
+import { UI_PROJECT_SECRET, UI_PROJECT_SECRET_COPY } from '@shell/config/labels-annotations';
 import {
   AGE, SECRET_DATA, STATE, SUB_TYPE, NAME as NAME_COL,
 } from '@shell/config/table-headers';
 import { STEVE_AGE_COL, STEVE_NAME_COL, STEVE_STATE_COL } from '@shell/config/pagination-table-headers';
 import { escapeHtml } from '@shell/utils/string';
-
-const findSystemDefaultProjects = (projects: any[], currentClusterId: string): { systemProject?: any, defaultProject?: any } => {
-  let systemProject;
-  let defaultProject;
-
-  for (let i = 0; i < projects.length; i++) {
-    const p = projects[i];
-
-    if (p.metadata.namespace === currentClusterId) {
-      if (p.isSystem) {
-        systemProject = p;
-      }
-
-      if (p.isDefault) {
-        defaultProject = p;
-      }
-
-      if (systemProject && defaultProject) {
-        break;
-      }
-    }
-  }
-
-  return { systemProject, defaultProject };
-};
 
 export default {
   name:       'ListProjectScopedSecrets',
@@ -90,38 +64,7 @@ export default {
         vai:   `metadata.labels[${ UI_PROJECT_SECRET }]`,
       },
 
-      systemProject:  undefined,
-      defaultProject: undefined,
     };
-  },
-
-  async fetch() {
-    // Upstream pss's created in default and system namespaces don't follow the usual naming convention of <cluster>-<project>
-    // we use that pattern to filter out pss from other clusters
-    // in order to not also filter upstream default and system namespace also search for their exact namespace
-    // this finding them...
-    if (this.currentCluster.isLocal) {
-      // First check if we already have them
-      const projects = this.$store.getters[`${ STORE.MANAGEMENT }/all`](MANAGEMENT.PROJECT);
-      const res = findSystemDefaultProjects(projects, this.currentCluster.id);
-
-      this.defaultProject = res.defaultProject;
-      this.systemProject = res.systemProject;
-
-      if (!this.systemProject || !this.defaultProject) {
-        // If not, make a http fetch (this is blocking, but should rarely happen, and should be super quick)
-        const url = this.$store.getters[`${ STORE.MANAGEMENT }/urlFor`](MANAGEMENT.PROJECT, null, { namespaced: this.currentCluster.id });
-        const response = await this.$store.dispatch(`${ STORE.MANAGEMENT }/request`, {
-          type: MANAGEMENT.PROJECT,
-          opt:  { url: `${ url }&filter=metadata.labels[${ DEFAULT_PROJECT }]=true,metadata.labels[${ SYSTEM_PROJECT }]=true` }
-        });
-        const projects = await this.$store.dispatch(`${ STORE.MANAGEMENT }/createMany`, response.data);
-        const res = findSystemDefaultProjects(projects, this.currentCluster.id);
-
-        this.defaultProject = this.defaultProject || res.defaultProject;
-        this.systemProject = this.systemProject || res.systemProject;
-      }
-    }
   },
 
   async created() {
@@ -142,12 +85,11 @@ export default {
     this.projectedScopedHeadersSsp = [
       STEVE_STATE_COL,
       STEVE_NAME_COL, {
-        name:  'project',
-        label: this.t('tableHeaders.project'),
-        value: 'project.nameDisplay',
-        // blocked on https://github.com/rancher/rancher/issues/51001
-        // search: `metadata.labels[${ UI_PROJECT_SECRET }]`,
-        sort:  `metadata.labels[${ UI_PROJECT_SECRET }]`,
+        name:   'project',
+        label:  this.t('tableHeaders.project'),
+        value:  'project.nameDisplay',
+        search: `spec.displayName`,
+        sort:   `spec.displayName`,
       }, {
         ...SUB_TYPE,
         value:  'metadata.fields.1',
@@ -191,20 +133,13 @@ export default {
      */
     filterRowsLocal(rows: Secret[]) {
       return rows.filter((r: Secret) => {
-        const metadata = r.metadata as RancherKubeMetadata; // Secrets will always have metadata, but hybrid-class does nasty things which breaks typing
-
         // Filter in pss but not the copies
         if (!r.isProjectScoped) {
           return;
         }
 
         // Filter in if this cluster
-        if (metadata.namespace?.startsWith(this.currentCluster.id)) {
-          return true;
-        }
-
-        // Filter in if upstream and default/system
-        if (this.currentCluster.isLocal && (r.project?.isSystem || r.project?.isDefault)) {
+        if (r.projectScopedClusterId === this.currentCluster.id) {
           return true;
         }
 
@@ -244,38 +179,13 @@ export default {
 
       // Filter in the current clusters pss
       const nsFields: PaginationFilterField[] = [{
-        field:  'metadata.namespace',
-        value:  `${ this.currentCluster.id }-`,
+        field:  'spec.clusterName',
+        value:  this.currentCluster.id,
         equals: true,
-        exact:  false,
+        exact:  true,
       }];
 
-      let namespaceFilter;
-
-      if (this.currentCluster.isLocal) {
-        // See where these are populated, but basically filter in upstream system and default projects
-        if (this.systemProject) {
-          nsFields.push({
-            field:  'metadata.namespace',
-            value:  this.systemProject.metadata.name,
-            equals: true,
-            exact:  true,
-          });
-        }
-
-        if (this.defaultProject) {
-          nsFields.push({
-            field:  'metadata.namespace',
-            value:  this.defaultProject.metadata.name,
-            equals: true,
-            exact:  true,
-          });
-        }
-
-        namespaceFilter = PaginationParamFilter.createMultipleFields(nsFields);
-      } else {
-        namespaceFilter = PaginationParamFilter.createSingleField(nsFields[0]);
-      }
+      const namespaceFilter = PaginationParamFilter.createSingleField(nsFields[0]);
 
       let foundLabelFilter = false;
       let foundAnnotationFilter = false;
@@ -318,7 +228,7 @@ export default {
 </script>
 
 <template>
-  <div v-if="!$fetchState.pending">
+  <div>
     <Masthead
       component-testid="secrets-list"
       :schema="schema"

--- a/shell/list/secret.vue
+++ b/shell/list/secret.vue
@@ -7,6 +7,7 @@ import PaginatedResourceTable from '@shell/components/PaginatedResourceTable';
 import { TableColumn } from '@shell/types/store/type-map';
 import ResourceFetch from '@shell/mixins/resource-fetch';
 import { mapGetters } from 'vuex';
+import { PagTableFetchPageSecondaryResourcesOpts } from '@shell/types/components/paginatedResourceTable';
 import { SECRET_ORIGIN } from '@shell/config/table-headers';
 import { STEVE_SECRET_ORIGIN } from '@shell/config/pagination-table-headers';
 
@@ -83,6 +84,23 @@ export default {
     ...mapGetters(['currentCluster']),
   },
 
+  methods: {
+    async fetchPageSecondaryResources({ canPaginate, page }: PagTableFetchPageSecondaryResourcesOpts) {
+      if (!canPaginate || !page?.length) {
+        return;
+      }
+
+      // Fetch clusters other than the current one in order to populate the `Project Secret` column (specifically the cluster name where this PSS is in)
+      await Promise.all(page.map((s) => {
+        if (s.projectScopedClusterId) {
+          return this.$store.dispatch(`${ STORE.MANAGEMENT }/find`, { type: MANAGEMENT.CLUSTER, id: s.projectScopedClusterId }).catch((e: any) => {
+            console.error(`Unable to fetch cluster '${ s.projectScopedClusterId }' for secret '${ s.name }'`, e); // eslint-disable-line no-console
+          });
+        }
+      }));
+    }
+  }
+
 };
 </script>
 
@@ -99,6 +117,8 @@ export default {
       :headers="namespacedHeaders"
       :pagination-headers="namespacedHeadersSsp"
       :use-query-params-for-simple-filtering="useQueryParamsForSimpleFiltering"
+
+      :fetchPageSecondaryResources="fetchPageSecondaryResources"
     />
   </div>
 </template>

--- a/shell/models/__tests__/secret.projects.test.ts
+++ b/shell/models/__tests__/secret.projects.test.ts
@@ -1,0 +1,94 @@
+import Secret from '@shell/models/secret';
+import { MANAGEMENT } from '@shell/config/types';
+import { UI_PROJECT_SECRET, UI_PROJECT_SECRET_CLUSTER, UI_PROJECT_SECRET_COPY } from '@shell/config/labels-annotations';
+import { STORE } from '@shell/store/store-types';
+
+describe('class Secret (project scoped secret getters)', () => {
+  const clusterId = 'c-m-abc123';
+  const projectName = 'p-xyz789';
+
+  it('isProjectScoped is true when the PSS labels are present and isRancher is true', () => {
+    const secret = new Secret({ metadata: { labels: { [UI_PROJECT_SECRET]: projectName, [UI_PROJECT_SECRET_CLUSTER]: clusterId } } }, { rootGetters: { isRancher: true } });
+
+    expect(secret.isProjectScoped).toBe(true);
+    expect(secret.projectScopedProjectName).toBe(projectName);
+    expect(secret.projectScopedClusterId).toBe(clusterId);
+  });
+
+  it('isProjectScoped is false when isRancher is false', () => {
+    const secret = new Secret({ metadata: { labels: { [UI_PROJECT_SECRET]: projectName, [UI_PROJECT_SECRET_CLUSTER]: clusterId } } }, { rootGetters: { isRancher: false } });
+
+    expect(secret.isProjectScoped).toBe(false);
+  });
+
+  it('isProjectScoped is false when it is itself a copy created by a PSS', () => {
+    const secret = new Secret({
+      metadata: {
+        labels:      { [UI_PROJECT_SECRET]: projectName, [UI_PROJECT_SECRET_CLUSTER]: clusterId },
+        annotations: { [UI_PROJECT_SECRET_COPY]: 'true' }
+      }
+    }, { rootGetters: { isRancher: true } });
+
+    expect(secret.isProjectScoped).toBe(false);
+    expect(secret.isProjectSecretCopy).toBe(true);
+    expect(secret.projectSecretCopyProjectName).toBe(projectName);
+    expect(secret.projectSecretCopyClusterId).toBe(clusterId);
+  });
+
+  it('isProjectScoped is false without the PSS project label', () => {
+    const secret = new Secret({ metadata: { labels: {} } }, { rootGetters: { isRancher: true } });
+
+    expect(secret.isProjectScoped).toBe(false);
+  });
+
+  it('projectCluster looks up the cluster via the management store when project scoped', () => {
+    const cluster = { id: clusterId };
+    const byId = jest.fn().mockReturnValue(cluster);
+    const secret = new Secret({ metadata: { labels: { [UI_PROJECT_SECRET]: projectName, [UI_PROJECT_SECRET_CLUSTER]: clusterId } } }, { rootGetters: { isRancher: true, [`${ STORE.MANAGEMENT }/byId`]: byId } });
+
+    expect(secret.projectCluster).toBe(cluster);
+    expect(byId).toHaveBeenCalledWith(MANAGEMENT.CLUSTER, clusterId);
+  });
+
+  it('projectCluster is undefined when the secret is not project scoped', () => {
+    const secret = new Secret({ metadata: { labels: {} } }, { rootGetters: { isRancher: true } });
+
+    expect(secret.projectCluster).toBeUndefined();
+  });
+
+  it('project resolves via the composite clusterId/projectName id first', () => {
+    const project = { id: `${ clusterId }/${ projectName }` };
+    const byId = jest.fn().mockImplementation((_type, id) => (id === `${ clusterId }/${ projectName }` ? project : undefined));
+    const secret = new Secret({ metadata: { labels: { [UI_PROJECT_SECRET]: projectName, [UI_PROJECT_SECRET_CLUSTER]: clusterId } } }, { rootGetters: { isRancher: true, [`${ STORE.MANAGEMENT }/byId`]: byId } });
+
+    expect(secret.project).toBe(project);
+    expect(byId).toHaveBeenCalledWith(MANAGEMENT.PROJECT, `${ clusterId }/${ projectName }`);
+  });
+
+  it('project falls back to the plain project name id when the composite id is not found', () => {
+    const project = { id: projectName };
+    const byId = jest.fn().mockImplementation((_type, id) => (id === projectName ? project : undefined));
+    const secret = new Secret({ metadata: { labels: { [UI_PROJECT_SECRET]: projectName, [UI_PROJECT_SECRET_CLUSTER]: clusterId } } }, { rootGetters: { isRancher: true, [`${ STORE.MANAGEMENT }/byId`]: byId } });
+
+    expect(secret.project).toBe(project);
+  });
+
+  it('project resolves for a PSS-created copy using the copy labels', () => {
+    const project = { id: `${ clusterId }/${ projectName }` };
+    const byId = jest.fn().mockReturnValue(project);
+    const secret = new Secret({
+      metadata: {
+        labels:      { [UI_PROJECT_SECRET]: projectName, [UI_PROJECT_SECRET_CLUSTER]: clusterId },
+        annotations: { [UI_PROJECT_SECRET_COPY]: 'true' }
+      }
+    }, { rootGetters: { isRancher: true, [`${ STORE.MANAGEMENT }/byId`]: byId } });
+
+    expect(secret.project).toBe(project);
+  });
+
+  it('project is undefined when there is no project name', () => {
+    const secret = new Secret({ metadata: { labels: {} } }, { rootGetters: { isRancher: true } });
+
+    expect(secret.project).toBeUndefined();
+  });
+});

--- a/shell/models/__tests__/secret.steve.test.ts
+++ b/shell/models/__tests__/secret.steve.test.ts
@@ -1,0 +1,265 @@
+import Secret from '@shell/models/secret';
+import { SECRET_TYPES as TYPES } from '@shell/config/secret';
+import { VIRTUAL_TYPES, SERVICE_ACCOUNT } from '@shell/config/types';
+import { UI_PROJECT_SECRET, UI_PROJECT_SECRET_CLUSTER, UI_PROJECT_SECRET_COPY } from '@shell/config/labels-annotations';
+import { SECRET_SCOPE, SECRET_QUERY_PARAMS } from '@shell/config/query-params';
+import { NAME as MANAGER } from '@shell/config/product/manager';
+
+// Tests in this file exercise Secret's overrides of SteveModel/Resource behaviour
+// (permissions, save/download cleanup, done routing) rather than Secret's own
+// certificate/PSS/data-preview domain logic - see secret.test.ts for those.
+describe('class Secret (SteveModel/Resource overrides)', () => {
+  describe('detailLocation', () => {
+    it('should return correct route for project scoped secret', () => {
+      const secret = new Secret({
+        metadata: {
+          namespace: 'c-cluster-p-project',
+          labels:    { [UI_PROJECT_SECRET]: 'p-project' }
+        },
+        id: 'c-cluster-p-project/my-secret'
+      });
+
+      // Mock $rootGetters
+      Object.defineProperty(secret, '$rootGetters', {
+        value: {
+          productId: 'explorer',
+          clusterId: 'c-cluster',
+          isRancher: true
+        }
+      });
+
+      const location = secret.detailLocation;
+
+      expect(location.name).toBe(`c-cluster-product-${ VIRTUAL_TYPES.PROJECT_SECRETS }-namespace-id`);
+      expect(location.params.resource).toBe(VIRTUAL_TYPES.PROJECT_SECRETS);
+      expect(location.params.product).toBe('explorer');
+      expect(location.params.cluster).toBe('c-cluster');
+      expect(location.params.namespace).toBe('c-cluster-p-project');
+      expect(location.params.id).toBe('my-secret');
+    });
+
+    it('should return default detailLocation for non-project scoped secret', () => {
+      const secret = new Secret({
+        metadata: { namespace: 'default' },
+        id:       'default/my-secret'
+      });
+
+      // Mock $rootGetters
+      Object.defineProperty(secret, '$rootGetters', {
+        value: {
+          productId: 'explorer',
+          clusterId: 'c-cluster',
+          isRancher: true
+        }
+      });
+
+      const expectedLocation = { name: 'some-route' };
+
+      // Mock _detailLocation (the parent class implementation or default behavior)
+      Object.defineProperty(secret, '_detailLocation', { value: expectedLocation });
+
+      expect(secret.detailLocation).toBe(expectedLocation);
+    });
+  });
+
+  describe('listLocation', () => {
+    const rootGetters = {
+      productId: 'explorer',
+      clusterId: 'c-cluster',
+      isRancher: true
+    };
+
+    it('points at the project secrets list when the project-scoped query param is set', () => {
+      const secret = new Secret({}, { rootGetters });
+
+      jest.spyOn(secret, 'currentRoute').mockReturnValue({ query: { [SECRET_SCOPE]: SECRET_QUERY_PARAMS.PROJECT_SCOPED } } as any);
+
+      const location = secret.listLocation;
+
+      expect(location.name).toBe('c-cluster-product-resource');
+      expect(location.params.resource).toBe(VIRTUAL_TYPES.PROJECT_SECRETS);
+    });
+
+    it('points at the project secrets list when the secret is project scoped', () => {
+      const secret = new Secret({ metadata: { labels: { [UI_PROJECT_SECRET]: 'p-project', [UI_PROJECT_SECRET_CLUSTER]: 'c-cluster' } } }, { rootGetters });
+
+      jest.spyOn(secret, 'currentRoute').mockReturnValue({ query: {} } as any);
+
+      const location = secret.listLocation;
+
+      expect(location.params.resource).toBe(VIRTUAL_TYPES.PROJECT_SECRETS);
+    });
+
+    it('falls back to the default secret list location otherwise', () => {
+      const secret = new Secret({ type: SERVICE_ACCOUNT, metadata: {} }, {
+        rootGetters,
+        rootState: { $extension: { getPlugins: () => ({}) } }
+      });
+
+      jest.spyOn(secret, 'currentRoute').mockReturnValue({ query: {} } as any);
+
+      const location = secret.listLocation;
+
+      expect(location.params.resource).toBe(SERVICE_ACCOUNT);
+    });
+  });
+
+  describe('parentNameOverride / parentLocationOverride', () => {
+    it('override to the project secrets label/location when project scoped via query param', () => {
+      const t = jest.fn().mockReturnValue('Project Secrets ');
+      const secret = new Secret({}, {
+        rootGetters: {
+          productId: 'explorer', clusterId: 'c-cluster', isRancher: true, 'i18n/t': t
+        }
+      });
+
+      jest.spyOn(secret, 'currentRoute').mockReturnValue({ query: { [SECRET_SCOPE]: SECRET_QUERY_PARAMS.PROJECT_SCOPED } } as any);
+
+      expect(secret.parentNameOverride).toBe('Project Secrets');
+      expect(secret.parentLocationOverride).toStrictEqual(secret.listLocation);
+    });
+
+    it('fall back to undefined (no base override) otherwise', () => {
+      const secret = new Secret({ metadata: {} });
+
+      jest.spyOn(secret, 'currentRoute').mockReturnValue({ query: {} } as any);
+
+      expect(secret.parentNameOverride).toBeUndefined();
+      expect(secret.parentLocationOverride).toBeUndefined();
+    });
+  });
+
+  describe('cleanForDownload', () => {
+    it('should contains the type attribute if cleanForDownload', async() => {
+      const secret = new Secret({});
+      const yaml = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+type: Opaque
+`;
+      const cleanYaml = await secret.cleanForDownload(yaml);
+
+      expect(cleanYaml).toBe(yaml);
+    });
+
+    it('should remove id, links and actions keys if cleanForDownload', async() => {
+      const secret = new Secret({});
+      const expectedYamlStr = `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: default
+type: Opaque
+`;
+      const part = `id: test_id
+links:
+  view: https://example.com
+actions:
+  remove: https://example.com`;
+      const yaml = `${ expectedYamlStr }
+${ part }`;
+      const cleanYaml = await secret.cleanForDownload(yaml);
+
+      expect(cleanYaml).toBe(expectedYamlStr);
+    });
+  });
+
+  describe('cleanForSave', () => {
+    it('removes _type when creating a new secret', () => {
+      const secret = new Secret({ _type: TYPES.OPAQUE, metadata: { name: 'my-secret' } });
+
+      const val = secret.cleanForSave({ _type: TYPES.OPAQUE, metadata: { name: 'my-secret' } }, true);
+
+      expect(val._type).toBeUndefined();
+    });
+
+    it('keeps _type when updating an existing secret', () => {
+      const secret = new Secret({ _type: TYPES.OPAQUE, metadata: { name: 'my-secret' } });
+
+      const val = secret.cleanForSave({ _type: TYPES.OPAQUE, metadata: { name: 'my-secret' } }, false);
+
+      expect(val._type).toBe(TYPES.OPAQUE);
+    });
+  });
+
+  describe('doneRoute', () => {
+    it('returns the manager route when the current product is the manager', () => {
+      const secret = new Secret({}, { rootGetters: { currentProduct: { name: MANAGER } } });
+
+      expect(secret.doneRoute).toBe('c-cluster-manager-secret');
+    });
+
+    it('returns the generic resource route otherwise', () => {
+      const secret = new Secret({}, { rootGetters: { currentProduct: { name: 'explorer' } } });
+
+      expect(secret.doneRoute).toBe('c-cluster-product-resource');
+    });
+  });
+
+  describe('permissions (canUpdate, canDelete, canCreate, canEditYaml)', () => {
+    const makeSecret = (data: any, { isEditable = true, isRemovable = true, isCreatable = true } = {}) => {
+      return new Secret(data, {
+        getters:     { schemaFor: () => undefined },
+        rootGetters: {
+          'type-map/optionsFor': () => ({
+            isEditable, isRemovable, isCreatable
+          })
+        }
+      });
+    };
+
+    it('are all false when the secret is a project scoped secret copy', () => {
+      const secret = makeSecret({
+        links:    { update: 'u', remove: 'r' },
+        metadata: { annotations: { [UI_PROJECT_SECRET_COPY]: 'true' } }
+      });
+
+      expect(secret.canUpdate).toBe(false);
+      expect(secret.canDelete).toBe(false);
+      expect(secret.canCreate).toBe(false);
+      expect(secret.canEditYaml).toBe(false);
+    });
+
+    it('canUpdate is false without an update link', () => {
+      const secret = makeSecret({ links: {} });
+
+      expect(secret.canUpdate).toBe(false);
+    });
+
+    it('canUpdate is false for service account secrets even with an update link and edit permission', () => {
+      const secret = makeSecret({ links: { update: 'u' }, _type: TYPES.SERVICE_ACCT });
+
+      expect(secret.canUpdate).toBe(false);
+    });
+
+    it('canUpdate delegates to the update link and edit permission for other types', () => {
+      const secret = makeSecret({ links: { update: 'u' }, _type: TYPES.OPAQUE });
+
+      expect(secret.canUpdate).toBe(true);
+    });
+
+    it('canDelete delegates to the remove link and remove permission', () => {
+      const canDeleteSecret = makeSecret({ links: { remove: 'r' } });
+      const cannotDeleteSecret = makeSecret({ links: {} });
+
+      expect(canDeleteSecret.canDelete).toBe(true);
+      expect(cannotDeleteSecret.canDelete).toBe(false);
+    });
+
+    it('canCreate delegates to the create permission', () => {
+      const canCreateSecret = makeSecret({ links: {} }, { isCreatable: true });
+      const cannotCreateSecret = makeSecret({ links: {} }, { isCreatable: false });
+
+      expect(canCreateSecret.canCreate).toBe(true);
+      expect(cannotCreateSecret.canCreate).toBe(false);
+    });
+
+    it('canEditYaml mirrors canUpdate', () => {
+      const secret = makeSecret({ links: { update: 'u' }, _type: TYPES.OPAQUE });
+
+      expect(secret.canEditYaml).toBe(secret.canUpdate);
+      expect(secret.canEditYaml).toBe(true);
+    });
+  });
+});

--- a/shell/models/__tests__/secret.test.ts
+++ b/shell/models/__tests__/secret.test.ts
@@ -1,99 +1,38 @@
 import Secret from '@shell/models/secret';
 import { SECRET_TYPES as TYPES, GITHUB_APP_SECRET_KEYS } from '@shell/config/secret';
-import { VIRTUAL_TYPES } from '@shell/config/types';
-import { UI_PROJECT_SECRET } from '@shell/config/labels-annotations';
-import { base64Encode } from '@shell/utils/crypto';
+import { SERVICE_ACCOUNT } from '@shell/config/types';
+import { UI_PROJECT_SECRET, UI_PROJECT_SECRET_CLUSTER, CERTMANAGER } from '@shell/config/labels-annotations';
+import { SECRET_SCOPE, SECRET_QUERY_PARAMS } from '@shell/config/query-params';
+import { STORE } from '@shell/store/store-types';
+import { STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
+import { base64Encode, base64Decode } from '@shell/utils/crypto';
+
+// A valid, self-signed 10 year certificate used to exercise the real jsrsasign parsing path.
+// CN=test.example.com, SANs: test.example.com, *.example.com, www.example.com
+// notBefore: 2026-08-06T12:39:13Z, notAfter: 2036-08-03T12:39:13Z
+const TEST_CERT_PEM = `-----BEGIN CERTIFICATE-----
+MIIDVjCCAj6gAwIBAgIUCSnVWva2lqhAIsYNiWQ6/z5KX6AwDQYJKoZIhvcNAQEL
+BQAwGzEZMBcGA1UEAwwQdGVzdC5leGFtcGxlLmNvbTAeFw0yNjA4MDYxMjM5MTNa
+Fw0zNjA4MDMxMjM5MTNaMBsxGTAXBgNVBAMMEHRlc3QuZXhhbXBsZS5jb20wggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDW+mkSeXRrbO0DnTOD3nG4C254
+I33MOwqaBMP49y2u0W8oDHRznEVGo3mCLs3eP7upikoDhtG8Z0vAp24s6hiiYjOZ
+0xg00lcxy2zQ927vupbNcDexCVrPTltR6FEZeZpuBx3U1AgOu5+50BQBQf/p5Q2G
+7XXDYrGMV3zPfwfFACEm28ws4LzWJp6ZULRHtIYANRXuosuRPcZ3ivMD7lZ5Fbj7
+5E9zm/f267sQVlKc56abSHOPyxgvizD32PSOyOx65h0QGHsC4pNO+xuQK6nQlr7l
+xO3WLQxcsaXwbcmr3kqgpJN1LPY4B4ulIEvp7TlqWU8gl0z/Lkr1QSEN5/mhAgMB
+AAGjgZEwgY4wHQYDVR0OBBYEFEpsogHCd0+ofQgnKRnJ3r4l/nHyMB8GA1UdIwQY
+MBaAFEpsogHCd0+ofQgnKRnJ3r4l/nHyMA8GA1UdEwEB/wQFMAMBAf8wOwYDVR0R
+BDQwMoIQdGVzdC5leGFtcGxlLmNvbYINKi5leGFtcGxlLmNvbYIPd3d3LmV4YW1w
+bGUuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQBzkPzuNf61zMFEfMKUKhNT1AHqey1e
+sBhaazf3FEcdIJBc6thFtaURUnAf4TwUpBCp03vZtAfqp43IG2J1E9ls5cLix/IH
+VGl/VSDkJonIEgDf82uHMe3G0z7TT7s1ip8WqfSy/dPEnrSzZZzegh0iKUZACEW5
+ypd+n4cocaIunTTN0wjaEujoPmm5iqiGAVa7ThXVnjiMF339hcdoJvdS4wtEEcND
+OXBBoVgfus15ldfG1GWYjFgVL2yagdzDcp0xTD7VsFkn2DA4nm/LmO/LhpaSR4Zh
+y+lCdK7a+W0LW1MJu/aKYlCzkSEyErPA7hgxpeu95Wt5OdG/WH0UAVec
+-----END CERTIFICATE-----
+`;
 
 describe('class Secret', () => {
-  describe('detailLocation', () => {
-    it('should return correct route for project scoped secret', () => {
-      const secret = new Secret({
-        metadata: {
-          namespace: 'c-cluster-p-project',
-          labels:    { [UI_PROJECT_SECRET]: 'p-project' }
-        },
-        id: 'c-cluster-p-project/my-secret'
-      });
-
-      // Mock $rootGetters
-      Object.defineProperty(secret, '$rootGetters', {
-        value: {
-          productId: 'explorer',
-          clusterId: 'c-cluster',
-          isRancher: true
-        }
-      });
-
-      const location = secret.detailLocation;
-
-      expect(location.name).toBe(`c-cluster-product-${ VIRTUAL_TYPES.PROJECT_SECRETS }-namespace-id`);
-      expect(location.params.resource).toBe(VIRTUAL_TYPES.PROJECT_SECRETS);
-      expect(location.params.product).toBe('explorer');
-      expect(location.params.cluster).toBe('c-cluster');
-      expect(location.params.namespace).toBe('c-cluster-p-project');
-      expect(location.params.id).toBe('my-secret');
-    });
-
-    it('should return default detailLocation for non-project scoped secret', () => {
-      const secret = new Secret({
-        metadata: { namespace: 'default' },
-        id:       'default/my-secret'
-      });
-
-      // Mock $rootGetters
-      Object.defineProperty(secret, '$rootGetters', {
-        value: {
-          productId: 'explorer',
-          clusterId: 'c-cluster',
-          isRancher: true
-        }
-      });
-
-      const expectedLocation = { name: 'some-route' };
-
-      // Mock _detailLocation (the parent class implementation or default behavior)
-      Object.defineProperty(secret, '_detailLocation', { value: expectedLocation });
-
-      expect(secret.detailLocation).toBe(expectedLocation);
-    });
-  });
-
-  describe('cleanForDownload', () => {
-    it('should contains the type attribute if cleanForDownload', async() => {
-      const secret = new Secret({});
-      const yaml = `apiVersion: v1
-kind: Secret
-metadata:
-  name: my-secret
-type: Opaque
-`;
-      const cleanYaml = await secret.cleanForDownload(yaml);
-
-      expect(cleanYaml).toBe(yaml);
-    });
-
-    it('should remove id, links and actions keys if cleanForDownload', async() => {
-      const secret = new Secret({});
-      const expectedYamlStr = `apiVersion: v1
-kind: Secret
-metadata:
-  name: my-secret
-  namespace: default
-type: Opaque
-`;
-      const part = `id: test_id
-links:
-  view: https://example.com
-actions:
-  remove: https://example.com`;
-      const yaml = `${ expectedYamlStr }
-${ part }`;
-      const cleanYaml = await secret.cleanForDownload(yaml);
-
-      expect(cleanYaml).toBe(expectedYamlStr);
-    });
-  });
-
   describe('supportsSshKnownHosts', () => {
     it.each([
       [
@@ -197,6 +136,493 @@ ${ part }`;
       const secret = new Secret({ _type: TYPES.OPAQUE, data: githubAppData }, ctx);
 
       expect(secret.subTypeDisplay).toBe('GitHub App');
+    });
+
+    it('subTypeDisplay should fall back to a stripped type name for non-GitHub-App secrets', () => {
+      const withFallback = jest.fn((_key: string, _args: any, fallback: string) => fallback);
+      const secret = new Secret({ _type: TYPES.BASIC, data: { username: base64Encode('bob') } }, { rootGetters: { 'i18n/withFallback': withFallback } });
+
+      expect(secret.subTypeDisplay).toBe('basic-auth');
+      expect(withFallback).toHaveBeenCalledWith(`secret.types."${ TYPES.BASIC }"`, null, 'basic-auth');
+    });
+  });
+
+  describe('type classification', () => {
+    it.each([
+      ['isCertificate', TYPES.TLS, true],
+      ['isCertificate', TYPES.OPAQUE, false],
+      ['isRegistry', TYPES.DOCKER_JSON, true],
+      ['isRegistry', TYPES.TLS, false],
+    ])('%s is %p for type %s', (getter, _type, expected) => {
+      const secret = new Secret({ _type }) as any;
+
+      expect(secret[getter]).toBe(expected);
+    });
+
+    it('isCloudCredential is true when _type is the cloud credential type', () => {
+      const secret = new Secret({ _type: TYPES.CLOUD_CREDENTIAL });
+
+      expect(secret.isCloudCredential).toBe(true);
+    });
+
+    it('isCloudCredential is true when namespace is cattle-global-data and generateName is cc-', () => {
+      const secret = new Secret({
+        _type:    TYPES.OPAQUE,
+        metadata: { namespace: 'cattle-global-data', generateName: 'cc-' }
+      });
+
+      expect(secret.isCloudCredential).toBe(true);
+    });
+
+    it('isCloudCredential is false for an unrelated opaque secret', () => {
+      const secret = new Secret({ _type: TYPES.OPAQUE, metadata: { namespace: 'default' } });
+
+      expect(secret.isCloudCredential).toBe(false);
+    });
+  });
+
+  describe('certInfo (real PEM parsing)', () => {
+    it('parses issuer, cn, notBefore, notAfter and sans from a valid TLS cert', () => {
+      const secret = new Secret({ _type: TYPES.TLS, data: { 'tls.crt': base64Encode(TEST_CERT_PEM) } });
+
+      const info: any = secret.certInfo;
+
+      expect(info.cn).toBe('test.example.com');
+      expect(info.issuer).toBe('test.example.com');
+      expect(info.notBefore.getUTCFullYear()).toBe(2026);
+      expect(info.notAfter.getUTCFullYear()).toBe(2036);
+      expect(info.sans.array).toHaveLength(3);
+    });
+
+    it('returns null when there is no tls.crt data key', () => {
+      const secret = new Secret({ _type: TYPES.TLS, data: {} });
+
+      expect(secret.certInfo).toBeNull();
+    });
+
+    it('returns null when the PEM cannot be parsed', () => {
+      const secret = new Secret({ _type: TYPES.TLS, data: { 'tls.crt': base64Encode('not-a-real-certificate') } });
+
+      expect(secret.certInfo).toBeNull();
+    });
+
+    it('isCertificate derived getters resolve using the parsed cert when there is no cert-manager annotation', () => {
+      const secret = new Secret({
+        _type: TYPES.TLS, data: { 'tls.crt': base64Encode(TEST_CERT_PEM) }, metadata: {}
+      });
+
+      expect(secret.cn).toBe('test.example.com');
+      expect(secret.issuer).toBe('test.example.com');
+      expect(secret.plusMoreNames).toBe(3);
+    });
+
+    it('issuer prefers the cert-manager annotation over the parsed cert issuer', () => {
+      const secret = new Secret({
+        _type:    TYPES.TLS,
+        data:     { 'tls.crt': base64Encode(TEST_CERT_PEM) },
+        metadata: { annotations: { [CERTMANAGER.ISSUER]: 'letsencrypt-prod' } }
+      });
+
+      expect(secret.issuer).toBe('letsencrypt-prod');
+    });
+
+    it('cn, issuer, notAfter and plusMoreNames are null for non-certificate secrets', () => {
+      const secret = new Secret({
+        _type: TYPES.OPAQUE, data: {}, metadata: {}
+      });
+
+      expect(secret.cn).toBeNull();
+      expect(secret.issuer).toBeNull();
+      expect(secret.notAfter).toBeNull();
+      expect(secret.plusMoreNames).toBeNull();
+    });
+  });
+
+  describe('cachedCertInfo', () => {
+    it('parses certInfo once and reuses the cached value', () => {
+      const secret = new Secret({ _type: TYPES.TLS, data: { 'tls.crt': base64Encode(TEST_CERT_PEM) } });
+      const spy = jest.spyOn(secret, 'certInfo', 'get');
+
+      const first = secret.cachedCertInfo;
+      const second = secret.cachedCertInfo;
+
+      expect(first).toBe(second);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('unrepeatedSans', () => {
+    const makeCertSecretWithSans = (sans: any) => {
+      const secret = new Secret({ _type: TYPES.TLS, data: {} });
+
+      Object.defineProperty(secret, 'cachedCertInfo', { get: () => ({ sans }), configurable: true });
+
+      return secret;
+    };
+
+    it('returns null for non-certificate secrets', () => {
+      const secret = new Secret({ _type: TYPES.OPAQUE, data: {} });
+
+      expect(secret.unrepeatedSans).toBeNull();
+    });
+
+    it('removes sans that exactly match the suffix of a wildcard/www entry', () => {
+      const secret = makeCertSecretWithSans(['app.example.com', '.example.com', '*.example.com']);
+
+      expect(secret.unrepeatedSans).toStrictEqual(['app.example.com', '*.example.com']);
+    });
+
+    it('leaves sans unchanged when no entry matches the wildcard/www suffix', () => {
+      const secret = makeCertSecretWithSans(['test.example.com', '*.example.com', 'www.example.com']);
+
+      expect(secret.unrepeatedSans).toStrictEqual(['test.example.com', '*.example.com', 'www.example.com']);
+    });
+
+    it('falls back to the .array property when sans is not a plain array (jsrsasign getExtSubjectAltName shape)', () => {
+      const dnsEntries = [{ dns: 'test.example.com' }, { dns: '*.example.com' }];
+      const secret = makeCertSecretWithSans({ extname: 'subjectAltName', array: dnsEntries });
+
+      expect(secret.unrepeatedSans).toBe(dnsEntries);
+    });
+
+    it('returns an empty array when there are no sans', () => {
+      const secret = makeCertSecretWithSans(undefined);
+
+      expect(secret.unrepeatedSans).toStrictEqual([]);
+    });
+  });
+
+  describe('TLS expiration state (dateClass, certState, certStateDisplay, certStateBackground, timeTilExpiration, timeTilExpirationDate)', () => {
+    const DAY = 1000 * 60 * 60 * 24;
+
+    const makeCertSecretWithNotAfter = (notAfter: Date | undefined) => {
+      const secret = new Secret({ _type: TYPES.TLS, data: {} });
+
+      Object.defineProperty(secret, 'cachedCertInfo', { get: () => ({ notAfter }), configurable: true });
+
+      return secret;
+    };
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('is not expiring when notAfter is well beyond the expiring window', () => {
+      const notAfter = new Date(Date.now() + 30 * DAY);
+      const secret = makeCertSecretWithNotAfter(notAfter);
+
+      expect(secret.certState).toBe('');
+      expect(secret.dateClass).toBe('');
+      expect(secret.certStateDisplay).toBe('Active');
+      expect(secret.timeTilExpiration).toBeGreaterThan(8 * DAY);
+      expect(secret.timeTilExpirationDate).toBe(notAfter.valueOf());
+    });
+
+    it('is expiring when notAfter is within the 8 day expiring window but still in the future', () => {
+      const notAfter = new Date(Date.now() + 3 * DAY);
+      const secret = makeCertSecretWithNotAfter(notAfter);
+
+      expect(secret.certState).toBe(STATES_ENUM.EXPIRING);
+      expect(secret.dateClass).toBe('text-warning');
+      expect(secret.certStateDisplay).toBe('Expiring');
+      expect(secret.certStateBackground).toBe('bg-warning');
+      expect(secret.timeTilExpiration).toBeGreaterThan(0);
+      expect(secret.timeTilExpirationDate).toBe(notAfter.valueOf());
+    });
+
+    it('is expired when notAfter is in the past', () => {
+      const notAfter = new Date(Date.now() - DAY);
+      const secret = makeCertSecretWithNotAfter(notAfter);
+
+      expect(secret.certState).toBe(STATES_ENUM.EXPIRED);
+      expect(secret.dateClass).toBe('text-error');
+      expect(secret.certStateDisplay).toBe('Expired');
+      expect(secret.certStateBackground).toBe('bg-error');
+      expect(secret.timeTilExpiration).toBe(0);
+      expect(secret.timeTilExpirationDate).toBeNull();
+    });
+
+    it('is undefined/null for non-certificate secrets', () => {
+      const secret = new Secret({ _type: TYPES.OPAQUE, data: {} });
+
+      expect(secret.certState).toBeUndefined();
+      expect(secret.certStateDisplay).toBeUndefined();
+      expect(secret.certStateBackground).toBeUndefined();
+      expect(secret.dateClass).toBeNull();
+      expect(secret.timeTilExpiration).toBeNull();
+      expect(secret.timeTilExpirationDate).toBeNull();
+    });
+  });
+
+  describe('certLifetime', () => {
+    const t = (key: string) => key;
+
+    it('returns a formatted duration string for a certificate', () => {
+      const secret = new Secret({ _type: TYPES.TLS, data: {} }, { rootGetters: { 'i18n/t': t } });
+
+      Object.defineProperty(secret, 'cachedCertInfo', {
+        get:          () => ({ notBefore: new Date('2026-01-01T00:00:00Z'), notAfter: new Date('2026-01-11T00:00:00Z') }),
+        configurable: true
+      });
+
+      expect(secret.certLifetime).toBe('10 unit.day');
+    });
+
+    it('returns null when there is no cert info', () => {
+      const secret = new Secret({ _type: TYPES.TLS, data: {} }, { rootGetters: { 'i18n/t': t } });
+
+      Object.defineProperty(secret, 'cachedCertInfo', { get: () => null, configurable: true });
+
+      expect(secret.certLifetime).toBeNull();
+    });
+
+    it('returns null for non-certificate secrets', () => {
+      const secret = new Secret({ _type: TYPES.OPAQUE, data: {} }, { rootGetters: { 'i18n/t': t } });
+
+      expect(secret.certLifetime).toBeNull();
+    });
+  });
+
+  describe('keysDisplay', () => {
+    it('joins data and binaryData keys', () => {
+      const secret = new Secret({ data: { foo: 'YmFy' }, binaryData: { img: 'aW1n' } });
+
+      expect(secret.keysDisplay).toBe('foo, img');
+    });
+
+    it('returns (none) when there are no keys', () => {
+      const secret = new Secret({});
+
+      expect(secret.keysDisplay).toBe('(none)');
+    });
+  });
+
+  describe('dataPreview', () => {
+    it('lists the auths domains for a valid dockerconfigjson secret', () => {
+      const dockerConfig = { auths: { 'index.docker.io': {}, 'quay.io': {} } };
+      const secret = new Secret({ _type: TYPES.DOCKER_JSON, data: { '.dockerconfigjson': base64Encode(JSON.stringify(dockerConfig)) } });
+
+      expect(secret.dataPreview).toBe('index.docker.io, quay.io');
+    });
+
+    it('falls back to the raw decoded string when dockerconfigjson is not valid JSON', () => {
+      const secret = new Secret({ _type: TYPES.DOCKER_JSON, data: { '.dockerconfigjson': base64Encode('not json') } });
+
+      expect(secret.dataPreview).toBe('not json');
+    });
+
+    it('shows the decoded username for basic-auth secrets', () => {
+      const secret = new Secret({ _type: TYPES.BASIC, data: { username: base64Encode('my-user') } });
+
+      expect(secret.dataPreview).toBe('my-user');
+    });
+
+    it('shows the sshUser for ssh-auth secrets', () => {
+      const secret = new Secret({
+        _type: TYPES.SSH,
+        data:  { 'ssh-publickey': base64Encode('ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC user@host') }
+      });
+
+      expect(secret.dataPreview).toBe('user@host');
+    });
+
+    it('shows the service account name annotation for service account secrets', () => {
+      const secret = new Secret({
+        _type:    TYPES.SERVICE_ACCT,
+        metadata: { annotations: { 'kubernetes.io/service-account.name': 'my-sa' } }
+      });
+
+      expect(secret.dataPreview).toBe('my-sa');
+    });
+
+    it('shows the cert info for TLS secrets', () => {
+      const secret = new Secret({ _type: TYPES.TLS, data: { 'tls.crt': base64Encode(TEST_CERT_PEM) } });
+
+      expect(secret.dataPreview).toStrictEqual(secret.certInfo);
+    });
+
+    it('falls back to keysDisplay for unrecognized secret types', () => {
+      const secret = new Secret({ _type: TYPES.OPAQUE, data: { key1: 'dmFsdWU=' } });
+
+      expect(secret.dataPreview).toBe('key1');
+    });
+  });
+
+  describe('sshUser', () => {
+    it('returns null when the secret is not an SSH secret', () => {
+      const secret = new Secret({ _type: TYPES.OPAQUE, data: {} });
+
+      expect(secret.sshUser).toBeNull();
+    });
+
+    it('returns null when there is no ssh-publickey data', () => {
+      const secret = new Secret({ _type: TYPES.SSH, data: {} });
+
+      expect(secret.sshUser).toBeNull();
+    });
+
+    it('extracts the user from an OpenSSH format public key', () => {
+      const secret = new Secret({
+        _type: TYPES.SSH,
+        data:  { 'ssh-publickey': base64Encode('ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC user@example.com') }
+      });
+
+      expect(secret.sshUser).toBe('user@example.com');
+    });
+
+    it('extracts the user from a PEM format public key comment', () => {
+      const secret = new Secret({
+        _type: TYPES.SSH,
+        data:  { 'ssh-publickey': base64Encode('----BEGIN SSH2 PUBLIC KEY----\nComment: "imported-openssh-key from OpenSSH by someuser@host"\nAAAA\n----END SSH2 PUBLIC KEY----') }
+      });
+
+      expect(secret.sshUser).toBe('someuser@host');
+    });
+
+    it('returns null when the public key format is unrecognized', () => {
+      const secret = new Secret({ _type: TYPES.SSH, data: { 'ssh-publickey': base64Encode('not-a-key') } });
+
+      expect(secret.sshUser).toBeNull();
+    });
+  });
+
+  describe('decodedData', () => {
+    it('base64 decodes every key in data', () => {
+      const secret = new Secret({ data: { foo: base64Encode('bar'), baz: base64Encode('qux') } });
+
+      expect(secret.decodedData).toStrictEqual({ foo: 'bar', baz: 'qux' });
+    });
+
+    it('returns an empty object when there is no data', () => {
+      const secret = new Secret({});
+
+      expect(secret.decodedData).toStrictEqual({});
+    });
+  });
+
+  describe('setData', () => {
+    it('sets and base64 encodes a single key/value pair, initializing data', () => {
+      const secret = new Secret({});
+
+      secret.setData('foo', 'bar');
+
+      expect(base64Decode((secret as any).data.foo)).toBe('bar');
+    });
+
+    it('sets a map of key/value pairs, replacing existing data', () => {
+      const secret = new Secret({ data: { existing: base64Encode('old') } });
+
+      secret.setData({ foo: 'bar', baz: 'qux' });
+
+      expect((secret as any).data.existing).toBeUndefined();
+      expect(base64Decode((secret as any).data.foo)).toBe('bar');
+      expect(base64Decode((secret as any).data.baz)).toBe('qux');
+    });
+
+    it('handles keys containing dots without treating them as a path', () => {
+      const secret = new Secret({});
+
+      secret.setData('.dockerconfigjson', '{}');
+
+      expect(base64Decode((secret as any).data['.dockerconfigjson'])).toBe('{}');
+    });
+  });
+
+  describe('hasProjectScopedUrlQueryParam', () => {
+    it('is true when the current route has the project-scoped query param', () => {
+      const secret = new Secret({});
+
+      jest.spyOn(secret, 'currentRoute').mockReturnValue({ query: { [SECRET_SCOPE]: SECRET_QUERY_PARAMS.PROJECT_SCOPED } } as any);
+
+      expect(secret.hasProjectScopedUrlQueryParam).toBe(true);
+    });
+
+    it('is false without the query param', () => {
+      const secret = new Secret({});
+
+      jest.spyOn(secret, 'currentRoute').mockReturnValue({ query: {} } as any);
+
+      expect(secret.hasProjectScopedUrlQueryParam).toBe(false);
+    });
+
+    it('is false when there is no current route', () => {
+      const secret = new Secret({});
+
+      jest.spyOn(secret, 'currentRoute').mockReturnValue(undefined as any);
+
+      expect(secret.hasProjectScopedUrlQueryParam).toBe(false);
+    });
+  });
+
+  describe('groupByProject', () => {
+    it('is undefined when the secret is not project scoped', () => {
+      const secret = new Secret({ metadata: { labels: {} } }, { rootGetters: { isRancher: true } });
+
+      expect(secret.groupByProject).toBeUndefined();
+    });
+
+    it('renders a translated group label using the project display name when project scoped', () => {
+      const project = { nameDisplay: 'My Project' };
+      const t = jest.fn().mockImplementation((key: string, args: any) => `${ key }:${ args.name }`);
+      const secret = new Secret({ metadata: { labels: { [UI_PROJECT_SECRET]: 'p-project', [UI_PROJECT_SECRET_CLUSTER]: 'c-cluster' } } }, {
+        rootGetters: {
+          isRancher: true, 'i18n/t': t, [`${ STORE.MANAGEMENT }/byId`]: () => project
+        }
+      });
+
+      expect(secret.groupByProject).toBe('resourceTable.groupLabel.project:My Project');
+    });
+  });
+
+  describe('fullDetailPageOverride', () => {
+    it('is always true', () => {
+      const secret = new Secret({});
+
+      expect(secret.fullDetailPageOverride).toBe(true);
+    });
+  });
+
+  describe('details', () => {
+    const ctx = {
+      getters:     { schemaFor: () => ({ id: 'secret' }) },
+      rootGetters: {
+        'type-map/labelFor': () => 'Secret',
+        'i18n/t':            (key: string) => key
+      }
+    };
+
+    it('includes only the type by default', () => {
+      const secret = new Secret({ _type: TYPES.OPAQUE, metadata: {} }, ctx);
+
+      expect(secret.details).toStrictEqual([{ label: 'secret.type', content: 'Secret' }]);
+    });
+
+    it('includes a Service Account link for service account secrets', () => {
+      const secret = new Secret({
+        _type:    TYPES.SERVICE_ACCT,
+        metadata: { namespace: 'default', annotations: { 'kubernetes.io/service-account.name': 'my-sa' } }
+      }, ctx);
+
+      const serviceAccountDetail = secret.details.find((d: any) => d.label === 'Service Account');
+
+      expect(serviceAccountDetail).toStrictEqual({
+        label:         'Service Account',
+        formatter:     'LinkName',
+        formatterOpts: {
+          value: 'my-sa', type: SERVICE_ACCOUNT, namespace: 'default'
+        },
+        content: 'my-sa'
+      });
+    });
+
+    it('includes cn, issuer and expiry for certificate secrets', () => {
+      const secret = new Secret({
+        _type: TYPES.TLS, data: { 'tls.crt': base64Encode(TEST_CERT_PEM) }, metadata: {}
+      }, ctx);
+
+      const labels = secret.details.map((d: any) => d.label);
+
+      expect(labels).toStrictEqual(['secret.type', 'secret.certificate.cn', 'secret.certificate.issuer', 'Expires']);
     });
   });
 });

--- a/shell/models/secret.js
+++ b/shell/models/secret.js
@@ -627,7 +627,6 @@ export default class Secret extends SteveModel {
     return undefined;
   }
 
-
   get detailLocation() {
     if (this.isProjectScoped) {
       const id = this.id?.replace(/.*\//, '');

--- a/shell/models/secret.js
+++ b/shell/models/secret.js
@@ -1,5 +1,7 @@
 import r from 'jsrsasign';
-import { CERTMANAGER, KUBERNETES, UI_PROJECT_SECRET, UI_PROJECT_SECRET_COPY } from '@shell/config/labels-annotations';
+import {
+  CERTMANAGER, KUBERNETES, UI_PROJECT_SECRET, UI_PROJECT_SECRET_CLUSTER, UI_PROJECT_SECRET_COPY
+} from '@shell/config/labels-annotations';
 import { GITHUB_APP_SECRET_KEYS } from '@shell/config/secret';
 import { base64Decode, base64Encode } from '@shell/utils/crypto';
 import { removeObjects } from '@shell/utils/array';
@@ -33,6 +35,29 @@ export const TYPES = {
 
 /** Class a cert as expiring if in eight days */
 const certExpiringPeriod = 1000 * 60 * 60 * 24 * 8;
+
+/**
+ * Project Scoped Secret Information
+ *
+ * There's lots of different weirdnesses with these.
+ *
+ * A project scoped secret is a secret in the upstream cluster with special annotations/labels
+ * A project scoped secret creates secrets in all namespaces in the associated project. These have special annotations/labels
+ *
+ * - Secret (PSS)
+ *   - Labels
+ *       - "management.cattle.io/project-scoped-secret": "<project metadata name>”,
+ *       - "management.cattle.io/project-scoped-secret-cluster": <cluster id>"
+ * - Secret (created by PSS)
+ *    - Labels
+ *       - "management.cattle.io/project-scoped-secret": "<project metadata name>”,
+ *       - "management.cattle.io/project-scoped-secret-cluster": <cluster id>"
+ *    - Annotations
+ *        - "management.cattle.io/project-scoped-secret-copy": "true",
+ *
+ * VAI connects a secret (created by PSS) to it's project and allows sort/filter on it's projects spec.clusterName (cluster's id) and spec.displayName (projects human name)
+ * This allows us to show a cluster's Project Scoped Secrets (filter on spec.clusterName) and Secret (created by PSS) project information easily
+ */
 
 export default class Secret extends SteveModel {
   _cachedCertInfo;
@@ -515,33 +540,28 @@ export default class Secret extends SteveModel {
    * is this a project scoped secret
    */
   get isProjectScoped() {
-    /**
-     * is this a project scoped secret .... or also a cloned project scoped secret
-     */
-    const isProjectScopedRelated = !!this.metadata.labels?.[UI_PROJECT_SECRET];
-
-    return isProjectScopedRelated && !this.isProjectSecretCopy && this.$rootGetters['isRancher'];
+    return !!this.projectScopedProjectName && !this.isProjectSecretCopy && this.$rootGetters['isRancher'];
   }
 
-  get projectScopedClusterId() {
-    if (!this.projectScopedProjectId) {
-      return undefined;
-    }
-
-    const clusterId = this.metadata.namespace.replace(`-${ this.projectScopedProjectId }`, '');
-
-    // default and system pss don't follow the patter of <cluster>-<project>, so if they match assume its one of them
-    return clusterId === this.metadata.namespace ? 'local' : clusterId;
-  }
-
-  get projectScopedProjectId() {
+  /**
+   * If this is a project scoped secret, return the Project's metadata.name
+   *
+   * It's metadata.name as that's what the backend supplies. If can be anything the user wants if the project was created outside the UI
+   */
+  get projectScopedProjectName() {
     return this.metadata.labels?.[UI_PROJECT_SECRET];
   }
 
-  get isProjectSecretCopy() {
-    return this.metadata?.annotations?.[UI_PROJECT_SECRET_COPY] === 'true';
+  /**
+   * If this is a project scoped secret, return the cluster id the project is in
+   */
+  get projectScopedClusterId() {
+    return this.metadata?.labels?.[UI_PROJECT_SECRET_CLUSTER];
   }
 
+  /**
+   * If this is a project scoped secret, return the cluster the project is in
+   */
   get projectCluster() {
     if (!this.isProjectScoped) {
       return undefined;
@@ -551,23 +571,62 @@ export default class Secret extends SteveModel {
   }
 
   /**
-   * If this is a project scoped secret, return it
+   * Is this a secret created by a project scoped secret?
+   */
+  get isProjectSecretCopy() {
+    return this.metadata?.annotations?.[UI_PROJECT_SECRET_COPY] === 'true';
+  }
+
+  /**
+   * If this is a secret created by a project scoped secret, return the Project's metadata.name
+   *
+   * It's metadata.name as that's what the backend supplies. If can be anything the user wants if the project was created outside the UI
+   */
+  get projectSecretCopyProjectName() {
+    return this.metadata.labels?.[UI_PROJECT_SECRET];
+  }
+
+  /**
+   * If this is a secret created by a project scoped secret, return the cluster id the project is in
+   */
+  get projectSecretCopyClusterId() {
+    return this.metadata?.labels?.[UI_PROJECT_SECRET_CLUSTER];
+  }
+
+  /**
+   * If this is a project scoped secret, or a project scoped secrets's cloned secret, return it's project
+   *
    */
   get project() {
-    if (!this.isProjectScoped ) {
-      return undefined;
+    let clusterId;
+    let projectName;
+
+    if (this.isProjectSecretCopy) {
+      clusterId = this.projectSecretCopyClusterId;
+      projectName = this.projectSecretCopyProjectName;
     }
 
-    return this.$rootGetters[`${ STORE.MANAGEMENT }/byId`](MANAGEMENT.PROJECT, `${ this.projectScopedClusterId }/${ this.projectScopedProjectId }`);
-  }
-
-  get projectScopedSecretCluster() {
-    if (!this.isProjectScoped ) {
-      return undefined;
+    if (this.isProjectScoped ) {
+      clusterId = this.projectScopedClusterId;
+      projectName = this.projectScopedProjectName;
     }
 
-    return this.$rootGetters[`${ STORE.MANAGEMENT }/byId`](MANAGEMENT.PROJECT, `${ this.projectScopedClusterId }/${ this.projectScopedProjectId }`);
+    if (projectName) {
+      const projectIdWithCluster = `${ clusterId }/${ projectName }`;
+      const projectId = projectName;
+
+      // Try to fetch the project.
+      // Note: The management store might not have the project loaded if we haven't visited the cluster list or project list.
+      // However, if we are in the dashboard, we usually have projects loaded.
+      const project = this.$rootGetters[`${ STORE.MANAGEMENT }/byId`](MANAGEMENT.PROJECT, projectIdWithCluster) ||
+        this.$rootGetters[`${ STORE.MANAGEMENT }/byId`](MANAGEMENT.PROJECT, projectId);
+
+      return project;
+    }
+
+    return undefined;
   }
+
 
   get detailLocation() {
     if (this.isProjectScoped) {

--- a/shell/models/secret.js
+++ b/shell/models/secret.js
@@ -593,6 +593,10 @@ export default class Secret extends SteveModel {
     return this.metadata?.labels?.[UI_PROJECT_SECRET_CLUSTER];
   }
 
+  get projectSecretCopyCluster() {
+    return this.$rootGetters[`${ STORE.MANAGEMENT }/byId`](MANAGEMENT.CLUSTER, this.projectSecretCopyClusterId);
+  }
+
   /**
    * If this is a project scoped secret, or a project scoped secrets's cloned secret, return it's project
    *

--- a/shell/plugins/steve/steve-pagination-utils.ts
+++ b/shell/plugins/steve/steve-pagination-utils.ts
@@ -266,6 +266,10 @@ class StevePaginationUtils extends NamespaceProjectFilters {
     ],
     [SECRET]: [
       { field: `metadata.annotations[${ UI_PROJECT_SECRET_COPY }]` },
+      // the BE connects secret's `'management.cattle.io/project-scoped-secret'` label to a project's id... and exposes project human name via spec.displayName
+      { field: 'spec.displayName' },
+      // the BE connects secret's `'management.cattle.io/project-scoped-secret'` label to a project's id... and exposes project's cluster id via spec.clusterName
+      { field: 'spec.clusterName' }
     ],
     [NAMESPACE]: [
     ],

--- a/shell/store/index.js
+++ b/shell/store/index.js
@@ -1063,7 +1063,8 @@ export const actions = {
         console.warn('Cluster is not ready, cannot load it:', cluster.nameDisplay); // eslint-disable-line no-console
         throw new Error('Unready cluster');
       }
-    } catch {
+    } catch (e) {
+      console.warn('Failed to find cluster, or cluster is not ready. Cluster:', id, '.Error: ', e); // eslint-disable-line no-console
       commit('clusterId', null);
       commit('cluster/applyConfig', { baseUrl: null });
       throw new ClusterNotFoundError(id);

--- a/shell/types/rancher/index.d.ts
+++ b/shell/types/rancher/index.d.ts
@@ -11,6 +11,11 @@ declare module '@shell/plugins/dashboard-store';
 
 declare module '@shell/config/query-params' {
   export const _DETAIL: string;
+  export const SECRET_SCOPE: 'scope';
+  export const SECRET_QUERY_PARAMS: {
+    NAMESPACED: 'namespaced',
+    PROJECT_SCOPED: 'project-scoped'
+  };
 }
 
 declare module '@shell/config/version' {

--- a/shell/types/store/type-map.ts
+++ b/shell/types/store/type-map.ts
@@ -266,7 +266,7 @@ export interface TypeMapVirtualType {
 export interface TableColumn {
   name: string,
   label?: string,
-  value: any,
+  value?: any,
   sort?: string | string[],
   formatter?: string,
   formatterOpts?: any,


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes https://github.com/rancher/dashboard/issues/18539
Backport of https://github.com/rancher/dashboard/pull/15963

### Occurred changes and/or fixed issues
- cherry-pick of https://github.com/rancher/dashboard/pull/15963
  - one merge conflict in e2e test jobs.spec
  - two fixes
     - a lint fix - think we lost this rule in master given the eslint bump
     - removed one arg from package.json e2e target (not needed)
- one fix for sorting secret list by origin column when vai is disabled
  - vai cannot be disabled in 2.16 so this was untested

### Areas or cases that should be tested
- exactly as per original PR
- then same test but with vai disabled
  - disabled vai with `<rancher domain>/v3/features/ui-sql-cache` edit --> value to false --> show request --> send request

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
