### PR TITLE
docs: fix typos in air-gapped extensions and stress test pages

### DIFF
--- a/docusaurus/docs/extensions/advanced/air-gapped-environments.md
+++ b/docusaurus/docs/extensions/advanced/air-gapped-environments.md
@@ -10,7 +10,7 @@ We have implemented an action within the Extensions page to take care of the hea
 
 ## Prerequisites
 
-Loading an extension into an air-gapped envrionment requires a few prerequisites, namely:
+Loading an extension into an air-gapped environment requires a few prerequisites, namely:
 
 - The Extension needs to be bundled into the ECI
 - A registry to house the ECI

--- a/docusaurus/docs/internal/testing/stress-test.md
+++ b/docusaurus/docs/internal/testing/stress-test.md
@@ -45,4 +45,4 @@ const PERF_DATA = {
 };
 ```
   
-The custom fucntion is only applied to generated resources, not the existing resources that are used to generate them.
+The custom function is only applied to generated resources, not the existing resources that are used to generate them.


### PR DESCRIPTION
### Summary

Fixes two typos in the docusaurus docs. Documentation wording only, no code changes.

- `docusaurus/docs/extensions/advanced/air-gapped-environments.md:13` - `envrionment` -> `environment`
- `docusaurus/docs/internal/testing/stress-test.md:48` - `fucntion` -> `function`

Fixes # N/A

### Occurred changes and/or fixed issues

Two words in prose. Nothing else is touched.

Note: the same `envrionment` typo also exists in `docusaurus/extensions_versioned_docs/version-v2/advanced/air-gapped-environments.md:13`. I left the versioned snapshot alone since those files represent already released docs, but I am happy to include it if you would rather have both fixed.

### Technical notes summary

None.

### Areas or cases that should be tested

None. No runtime code is affected, so there is nothing to test in the UI.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone <!-- The milestone should automatically be assigned if the linked issue has one, but does not always happen (incorrectly linked, issue has no milestone, etc) -->
- [x] The PR template has been filled out
- [x] The PR has been self reviewed <!-- There are no TODOs, no incorrect files in the PR, all the required files are there, no commented out code, etc-->
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`