### PR TITLE
ci: assign Dependabot milestone with a GitHub App token so the Branch Milestone check re-runs

### DIFF
--- a/.github/workflows/dependabot-milestone.yaml
+++ b/.github/workflows/dependabot-milestone.yaml
@@ -9,6 +9,13 @@ name: Dependabot Milestone
 #   pull_request token is read-only and cannot set a milestone. No PR code is
 #   checked out or executed, only the trusted script from the base branch runs.
 # - schedule / workflow_dispatch: sweeps every open Dependabot PR as a safety net.
+#
+# The milestone is assigned with a GitHub App token (not the default GITHUB_TOKEN).
+# Actions performed with GITHUB_TOKEN do not trigger further workflow runs, so a
+# milestone set with it never re-triggers valid-pr.yaml's `milestoned` event and the
+# "Branch Milestone" check stays red even though the milestone now exists. A milestone
+# set with an App token does cascade, so the check re-runs and passes. This mirrors the
+# strategy already used by port-pr.yaml.
 on:
   pull_request_target:
     types: [opened, reopened]
@@ -33,11 +40,24 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
+      id-token: write
     steps:
+      - name: Read secrets
+        uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # v3
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APPID;
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATEKEY
+      - name: Generate Token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ env.APPID }}
+          private-key: ${{ env.PRIVATEKEY }}
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Assign milestone
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           MODE: event
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
@@ -53,10 +73,23 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
+      id-token: write
     steps:
+      - name: Read secrets
+        uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # v3
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APPID;
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATEKEY
+      - name: Generate Token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ env.APPID }}
+          private-key: ${{ env.PRIVATEKEY }}
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Sweep and assign milestones
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           MODE: sweep
         run: ./.github/workflows/scripts/dependabot-milestone.sh


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary

No issue — CI/infrastructure fix.

Dependabot PRs frequently show the **Branch Milestone** check as failed even though the milestone is present. This makes the check pass on its own once the milestone bot assigns the milestone.

### Occurred changes and/or fixed issues

Assign the Dependabot milestone with a **GitHub App token** instead of the default `GITHUB_TOKEN`, in both jobs of `dependabot-milestone.yaml` (`assign-on-open`, `sweep-open-prs`):

- add `rancher-eio/read-vault-secrets` + `actions/create-github-app-token` steps
- add `id-token: write` to each job
- set `GH_TOKEN` to the generated App token

This mirrors the strategy already used by `port-pr.yaml`.

### Technical notes summary

`pr-check-milestone.sh` reads the milestone from the triggering event's frozen payload (`$GITHUB_EVENT_PATH` → `.pull_request.milestone`), not live. On a Dependabot PR:

1. Dependabot opens the PR — it cannot set a milestone (read-only token), so the `opened` payload has `milestone: null` → the Branch Milestone check fails.
2. `dependabot-milestone.yaml` then assigns the milestone — but it used `GITHUB_TOKEN`.

Actions performed with `GITHUB_TOKEN` do not trigger further workflow runs, so the `milestoned` event never re-triggers `valid-pr.yaml` and the failed `opened` run stays the latest — the check remains red even though the milestone now exists. A human toggling the milestone does re-trigger it, which is why manual re-adds clear it. A milestone set with an App token cascades the same way, so the check re-runs and passes. Backport-bot PRs (already using this approach) demonstrate it working; example stuck failure: https://github.com/rancher/dashboard/pull/18708

### Areas or cases that should be tested

This workflow only runs on `pull_request_target` / `schedule` against the base branch, so it cannot be exercised by CI on this PR. It reuses the same vault app-credentials `port-pr.yaml` already relies on (no new secret setup). Validation is the first Dependabot PR after merge: its milestone should be assigned and the Branch Milestone check should go green without manual intervention.

### Areas which could experience regressions

- Dependabot milestone assignment (both the on-open and daily sweep paths) now depend on vault/OIDC + the GitHub App token, same as `port-pr.yaml`. If vault or the App is unavailable, milestone assignment would fail (previously it used the always-present `GITHUB_TOKEN`).
- No product/runtime code is affected — the change is confined to the CI workflow.

### Screenshot/Video

N/A — CI workflow change.

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
