### PR TITLE
improve reporting of cypress axe

### DIFF
--- a/cypress/e2e/tests/accessibility/shell.spec.ts
+++ b/cypress/e2e/tests/accessibility/shell.spec.ts
@@ -47,11 +47,12 @@ import { FleetApplicationCreatePo, FleetGitRepoCreateEditPo } from '@/cypress/e2
 // not be determined because it's outside the viewport". A short viewport on a dense list page
 // pushes real contrast results into the 'needs review' bucket. Scoped to this suite so every other
 // e2e spec keeps the default viewport.
-describe('Shell a11y testing', {
-  tags:           ['@adminUser', '@accessibility'],
-  viewportWidth:  1920,
-  viewportHeight: 1080,
-}, () => {
+//
+// Keep the config object on a single line. `scripts/check-e2e-tests-for-tags` parses spec files line
+// by line and only finds `tags:` if it sits on the same line as `describe(` - splitting this across
+// lines makes the PR gate report every test in the suite as untagged.
+// eslint-disable-next-line object-curly-newline
+describe('Shell a11y testing', { tags: ['@adminUser', '@accessibility'], viewportWidth: 1920, viewportHeight: 1080 }, () => {
   // Colour contrast results are only meaningful against a known palette, so pin the whole suite to
   // Prime branding in light mode instead of relying on the server/browser defaults. See #18621.
   let originalBrand = '';

--- a/cypress/e2e/tests/accessibility/shell.spec.ts
+++ b/cypress/e2e/tests/accessibility/shell.spec.ts
@@ -42,7 +42,16 @@ import { BannersPagePo } from '@/cypress/e2e/po/pages/global-settings/banners.po
 import { USERS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
 import { FleetApplicationCreatePo, FleetGitRepoCreateEditPo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
 
-describe('Shell a11y testing', { tags: ['@adminUser', '@accessibility'] }, () => {
+// Scan at a desktop resolution. Cypress defaults to 1000x660, and one of axe's documented reasons
+// for abandoning a colour-contrast check is `outsideViewport` - "Element's background color could
+// not be determined because it's outside the viewport". A short viewport on a dense list page
+// pushes real contrast results into the 'needs review' bucket. Scoped to this suite so every other
+// e2e spec keeps the default viewport.
+describe('Shell a11y testing', {
+  tags:           ['@adminUser', '@accessibility'],
+  viewportWidth:  1920,
+  viewportHeight: 1080,
+}, () => {
   // Colour contrast results are only meaningful against a known palette, so pin the whole suite to
   // Prime branding in light mode instead of relying on the server/browser defaults. See #18621.
   let originalBrand = '';

--- a/cypress/e2e/tests/accessibility/shell.spec.ts
+++ b/cypress/e2e/tests/accessibility/shell.spec.ts
@@ -41,7 +41,16 @@ import { BannersPagePo } from '@/cypress/e2e/po/pages/global-settings/banners.po
 import { USERS_BASE_URL } from '@/cypress/support/utils/api-endpoints';
 import { FleetApplicationCreatePo, FleetGitRepoCreateEditPo } from '@/cypress/e2e/po/pages/fleet/fleet.cattle.io.application.po';
 
-describe('Shell a11y testing', { tags: ['@adminUser', '@accessibility'] }, () => {
+// Scan at a desktop resolution. Cypress defaults to 1000x660, and one of axe's documented reasons
+// for abandoning a colour-contrast check is `outsideViewport` - "Element's background color could
+// not be determined because it's outside the viewport". A short viewport on a dense list page
+// pushes real contrast results into the 'needs review' bucket. Scoped to this suite so every other
+// e2e spec keeps the default viewport.
+describe('Shell a11y testing', {
+  tags:           ['@adminUser', '@accessibility'],
+  viewportWidth:  1920,
+  viewportHeight: 1080,
+}, () => {
   // Colour contrast results are only meaningful against a known palette, so pin the whole suite to
   // Prime branding in light mode instead of relying on the server/browser defaults. See #18621.
   let originalBrand = '';

--- a/cypress/e2e/tests/accessibility/shell.spec.ts
+++ b/cypress/e2e/tests/accessibility/shell.spec.ts
@@ -46,11 +46,12 @@ import { FleetApplicationCreatePo, FleetGitRepoCreateEditPo } from '@/cypress/e2
 // not be determined because it's outside the viewport". A short viewport on a dense list page
 // pushes real contrast results into the 'needs review' bucket. Scoped to this suite so every other
 // e2e spec keeps the default viewport.
-describe('Shell a11y testing', {
-  tags:           ['@adminUser', '@accessibility'],
-  viewportWidth:  1920,
-  viewportHeight: 1080,
-}, () => {
+//
+// Keep the config object on a single line. `scripts/check-e2e-tests-for-tags` parses spec files line
+// by line and only finds `tags:` if it sits on the same line as `describe(` - splitting this across
+// lines makes the PR gate report every test in the suite as untagged.
+// eslint-disable-next-line object-curly-newline
+describe('Shell a11y testing', { tags: ['@adminUser', '@accessibility'], viewportWidth: 1920, viewportHeight: 1080 }, () => {
   // Colour contrast results are only meaningful against a known palette, so pin the whole suite to
   // Prime branding in light mode instead of relying on the server/browser defaults. See #18621.
   let originalBrand = '';

--- a/cypress/support/commands/accessiblity.ts
+++ b/cypress/support/commands/accessiblity.ts
@@ -1,3 +1,5 @@
+import { LONG_TIMEOUT_OPT } from '@/cypress/support/utils/timeouts';
+
 // Custom violation callback function that prints a list of violations
 // Used when logging to the Cypress log
 const severityIndicators = {
@@ -12,6 +14,30 @@ const severityIndicators = {
 const screenshotIndexes: {[key: string]: number} = {};
 
 const MARKER_DIV_ID = 'a11y_violation_marker_cypress';
+
+type AxeResults = {
+  violations: any[];
+  incomplete: any[];
+};
+
+/**
+ * Run axe directly instead of going through `cy.checkA11y`.
+ *
+ * `cy.checkA11y` only ever hands its callback `results.violations` (see `violationCallback` in
+ * cypress-axe's `dist/index.js`). That means axe's `incomplete` results were being discarded
+ * before they reached the report - and `incomplete` is exactly where `color-contrast` lands
+ * whenever axe can't resolve the background colour with certainty (background images, gradients,
+ * overlapping elements, alpha transparency, elements outside the viewport - 15 documented reasons
+ * in axe-core's `lib/checks/color/color-contrast.json`). Calling `axe.run` ourselves gives us the
+ * full results object.
+ *
+ * As before, nothing here fails the test - we only record.
+ */
+function runAxe(context?: any): Cypress.Chainable<AxeResults> {
+  return cy.window({ log: false }).then(LONG_TIMEOUT_OPT, (win: any) => {
+    return win.axe.run(context || win.document, {}) as Promise<AxeResults>;
+  });
+}
 
 // Log violations to the terminal
 function terminalLog(violations) {
@@ -152,21 +178,72 @@ function getAccessibilityViolationsCallback(description?: string) {
 }
 
 /**
+ * Log the 'needs review' (incomplete) results.
+ *
+ * Deliberately lighter than the violation path - no screenshots and no DOM marking. Incomplete
+ * results are high volume by nature (axe files everything it can't be certain about here) and they
+ * are a triage queue rather than failures, so screenshotting every node would balloon both the run
+ * time and the artifact size for little benefit.
+ */
+function reportIncomplete(incomplete: any[], description?: string) {
+  const suiteTitle = Cypress.currentTest.titlePath.slice(0, -1).join(' > ');
+  const testTitle = Cypress.currentTest.titlePath.slice(-1)[0];
+
+  cy.task('log', `\n📝 Test Suite: ${ suiteTitle }`);
+  cy.task('log', `📌 Test Case: ${ testTitle }`);
+  cy.task('log', `🔍 ${ incomplete.length } accessibility check(s) need manual review\n`);
+
+  cy.task('table', incomplete.map(({
+    id, impact, description: ruleDescription, nodes
+  }) => ({
+    id,
+    impact,
+    description: ruleDescription,
+    nodes:       nodes.length
+  })));
+
+  incomplete.forEach((item) => {
+    Cypress.log({
+      name:         '🔍 A11y review',
+      consoleProps: () => item,
+      $el:          Cypress.$(item.nodes.map((node: any) => node.target).join(',')),
+      message:      `[${ item.help }][${ item.helpUrl }]`
+    });
+  });
+
+  // The violation path appends `<test name> (#n)` because that segment is keyed to the screenshot
+  // index. We take no screenshots, so incomplete results group under the plain test name.
+  const testPath = [...Cypress.currentTest.titlePath];
+
+  testPath.push(description || testPath[testPath.length - 1]);
+
+  cy.task('a11yIncomplete', { incomplete, titlePath: testPath });
+}
+
+function reportResults(results: AxeResults, description?: string) {
+  if (results.violations.length) {
+    getAccessibilityViolationsCallback(description)(results.violations);
+  }
+
+  if (results.incomplete.length) {
+    reportIncomplete(results.incomplete, description);
+  }
+}
+
+/**
  * Checks accessibility of the entire page
  */
-// skipFailures = true will not fail the test when there are accessibility failures
 Cypress.Commands.add('checkPageAccessibility', (description?: string) => {
-  cy.checkA11y(undefined, {}, getAccessibilityViolationsCallback(description), true);
+  runAxe().then((results) => reportResults(results, description));
 });
 
 /**
  * Checks accessibility of a specific element
  */
-// skipFailures = true will not fail the test when there are accessibility failures
 Cypress.Commands.add('checkElementAccessibility', (subject: any, description?: string) => {
   cy.get(subject).then(($el) => {
     cy.log(`✅ Found ${ $el.length } elements matching`);
   });
 
-  cy.checkA11y(subject, {}, getAccessibilityViolationsCallback(description), true);
+  runAxe(subject).then((results) => reportResults(results, description));
 });

--- a/cypress/support/commands/accessiblity.ts
+++ b/cypress/support/commands/accessiblity.ts
@@ -228,44 +228,29 @@ function reportIncomplete(incomplete: any[], description?: string) {
   cy.task('a11yIncomplete', { incomplete, titlePath: testPath });
 }
 
-/**
- * Reduce a bucket to one row per rule.
- *
- * `passes` and `inapplicable` are recorded at rule level only. We want them so we can answer "did
- * this rule actually run?" - a rule missing from all four buckets never executed, which is a very
- * different problem from a rule that ran and found nothing. Keeping their per-node detail would grow
- * `accessibility.json` by orders of magnitude without answering anything extra.
- */
-function summariseRules(results: any[]) {
-  return results.map(({
-    id, help, impact, tags, nodes
-  }) => ({
-    id,
-    help,
-    impact: impact || null,
-    tags,
-    nodes:  nodes.length,
-  }));
-}
-
 function reportResults(results: AxeResults, description?: string) {
-  if (results.violations.length) {
-    getAccessibilityViolationsCallback(description)(results.violations);
+  const violations = Array.isArray(results?.violations) ? results.violations : [];
+  const incomplete = Array.isArray(results?.incomplete) ? results.incomplete : [];
+
+  if (violations.length) {
+    getAccessibilityViolationsCallback(description)(violations);
   }
 
-  if (results.incomplete.length) {
-    reportIncomplete(results.incomplete, description);
+  if (incomplete.length) {
+    reportIncomplete(incomplete, description);
   }
 
-  // Record which bucket every rule landed in for this check, so the run-level summary can show where
-  // each rule ended up across the whole suite.
-  cy.task('a11yRules', {
+  // Hand every bucket to the plugin. The two paths above own their own reporting (screenshots, DOM
+  // marking, the per-test tree); this is what feeds the run-level rule summary and the `passes` and
+  // `inapplicable` reports. The plugin does the summarising so all four buckets are treated the same
+  // way in one place.
+  cy.task('a11yResults', {
     titlePath:      [...Cypress.currentTest.titlePath],
-    availableRules: results.availableRules,
-    violations:     summariseRules(results.violations),
-    incomplete:     summariseRules(results.incomplete),
-    passes:         summariseRules(results.passes),
-    inapplicable:   summariseRules(results.inapplicable),
+    availableRules: results?.availableRules,
+    violations,
+    incomplete,
+    passes:         results?.passes,
+    inapplicable:   results?.inapplicable,
   });
 }
 

--- a/cypress/support/commands/accessiblity.ts
+++ b/cypress/support/commands/accessiblity.ts
@@ -18,6 +18,11 @@ const MARKER_DIV_ID = 'a11y_violation_marker_cypress';
 type AxeResults = {
   violations: any[];
   incomplete: any[];
+  passes: any[];
+  inapplicable: any[];
+  // Every rule axe knows about, whether or not it produced a result. Lets us tell "the rule ran and
+  // found nothing" apart from "the rule never ran".
+  availableRules: string[];
 };
 
 /**
@@ -35,7 +40,10 @@ type AxeResults = {
  */
 function runAxe(context?: any): Cypress.Chainable<AxeResults> {
   return cy.window({ log: false }).then(LONG_TIMEOUT_OPT, (win: any) => {
-    return win.axe.run(context || win.document, {}) as Promise<AxeResults>;
+    return (win.axe.run(context || win.document, {}) as Promise<AxeResults>).then((results) => ({
+      ...results,
+      availableRules: win.axe.getRules().map((rule: any) => rule.ruleId),
+    }));
   });
 }
 
@@ -220,6 +228,26 @@ function reportIncomplete(incomplete: any[], description?: string) {
   cy.task('a11yIncomplete', { incomplete, titlePath: testPath });
 }
 
+/**
+ * Reduce a bucket to one row per rule.
+ *
+ * `passes` and `inapplicable` are recorded at rule level only. We want them so we can answer "did
+ * this rule actually run?" - a rule missing from all four buckets never executed, which is a very
+ * different problem from a rule that ran and found nothing. Keeping their per-node detail would grow
+ * `accessibility.json` by orders of magnitude without answering anything extra.
+ */
+function summariseRules(results: any[]) {
+  return results.map(({
+    id, help, impact, tags, nodes
+  }) => ({
+    id,
+    help,
+    impact: impact || null,
+    tags,
+    nodes:  nodes.length,
+  }));
+}
+
 function reportResults(results: AxeResults, description?: string) {
   if (results.violations.length) {
     getAccessibilityViolationsCallback(description)(results.violations);
@@ -228,6 +256,17 @@ function reportResults(results: AxeResults, description?: string) {
   if (results.incomplete.length) {
     reportIncomplete(results.incomplete, description);
   }
+
+  // Record which bucket every rule landed in for this check, so the run-level summary can show where
+  // each rule ended up across the whole suite.
+  cy.task('a11yRules', {
+    titlePath:      [...Cypress.currentTest.titlePath],
+    availableRules: results.availableRules,
+    violations:     summariseRules(results.violations),
+    incomplete:     summariseRules(results.incomplete),
+    passes:         summariseRules(results.passes),
+    inapplicable:   summariseRules(results.inapplicable),
+  });
 }
 
 /**

--- a/cypress/support/plugins/accessibility/index.ts
+++ b/cypress/support/plugins/accessibility/index.ts
@@ -54,6 +54,30 @@ export type IncompleteOptions = {
   titlePath: string[];
 };
 
+export type RuleSummaryEntry = {
+  id: string;
+  help: string;
+  tags: string[];
+  // Node counts per axe result bucket, summed over every check in the run
+  violations: number;
+  incomplete: number;
+  passes: number;
+  inapplicable: number;
+  // How many of the run's checks evaluated this rule at all
+  checks: number;
+};
+
+export type RuleOptions = {
+  titlePath: string[];
+  availableRules: string[];
+  violations: any[];
+  incomplete: any[];
+  passes: any[];
+  inapplicable: any[];
+};
+
+const BUCKETS: (keyof RuleSummaryEntry)[] = ['violations', 'incomplete', 'passes', 'inapplicable'];
+
 type Screenshot = {
   name: string;
   specName: string;
@@ -72,6 +96,8 @@ const chain: TestViolation[] = [{
 const allViolations = [] as any[];
 const allIncomplete = [] as any[];
 const screenshots = [] as Screenshot[];
+const ruleSummary: {[id: string]: RuleSummaryEntry} = {};
+const availableRules = new Set<string>();
 let folder;
 
 // Tidy up the chain
@@ -127,6 +153,50 @@ function deDuplicate(violations: any[]) {
   return result;
 }
 
+/**
+ * Build the 'needs review' report.
+ *
+ * `axe-html-reporter` only renders detailed per-node cards for whatever sits in `results.violations`.
+ * Its native `incomplete` section is a summary table and nothing else, which isn't enough to triage
+ * from - no element location, no source, no reason axe gave up. So we hand it the incomplete results
+ * in the `violations` slot to get the identical presentation, then correct the wording the template
+ * hard-codes.
+ */
+function createIncompleteReport(incomplete: any[]) {
+  const customSummary = [
+    '<b>These are not confirmed failures.</b> This is axe\'s <code>incomplete</code> bucket - checks it',
+    'could neither pass nor fail with certainty, so it hands them to a human. Every entry needs a manual',
+    'decision: it is either a real issue or a false alarm. Nothing here failed CI.'
+  ].join(' ');
+
+  const html = createHtmlReport({
+    results: { violations: incomplete },
+    options: {
+      projectKey:            'Rancher Manager',
+      customSummary,
+      doNotCreateReportFile: true,
+    },
+  });
+
+  return html
+    .replace('<title>Axe-core® Accessibility Results</title>', '<title>Axe-core® Accessibility Results - Needs Review</title>')
+    .replace('Axe-core® Accessibility Results for', 'Axe-core® Accessibility Results - Needs Review for')
+    .replace(/axe-core found (<span class="badge badge-\w+">\d+<\/span>) violations?/, 'axe-core flagged $1 check(s) that need manual review')
+    .replace('<h3>Failed</h3>', '<h3>Needs review</h3>')
+    .replace(/To solve this violation, you need to\.\.\./g, 'To resolve this check, you need to...');
+}
+
+/**
+ * One row per axe rule, showing which bucket its results landed in over the whole run, plus the rules
+ * axe offered but never produced a single result for.
+ */
+function summariseRules() {
+  const rules = Object.values(ruleSummary).sort((a, b) => a.id.localeCompare(b.id));
+  const neverRun = Array.from(availableRules).filter((id) => !ruleSummary[id]).sort();
+
+  return { rules, neverRun };
+}
+
 function registerHooks(on, config) {
   // Get the folder to write the reports into
   folder = config.env.a11yFolder;
@@ -159,6 +229,34 @@ function registerHooks(on, config) {
 
       found.incomplete.push(...incomplete);
       found.leaf = true;
+
+      return null;
+    },
+
+    // Rule-level tally across all four axe buckets. This is what tells us whether a rule we expect to
+    // see (`color-contrast`, say) ran and passed, ran and matched nothing, or never ran at all.
+    a11yRules(options: RuleOptions) {
+      (options.availableRules || []).forEach((id) => availableRules.add(id));
+
+      BUCKETS.forEach((bucket) => {
+        (options[bucket] || []).forEach((rule) => {
+          if (!ruleSummary[rule.id]) {
+            ruleSummary[rule.id] = {
+              id:           rule.id,
+              help:         rule.help,
+              tags:         rule.tags,
+              violations:   0,
+              incomplete:   0,
+              passes:       0,
+              inapplicable: 0,
+              checks:       0,
+            };
+          }
+
+          (ruleSummary[rule.id][bucket] as number) += rule.nodes;
+          ruleSummary[rule.id].checks++;
+        });
+      });
 
       return null;
     },
@@ -220,10 +318,23 @@ function registerHooks(on, config) {
     delete stats.osName;
     delete stats.osVersion;
 
+    const { rules, neverRun } = summariseRules();
+
     const data = {
       stats,
+      ruleSummary: {
+        rules,
+        neverRun,
+      },
       children: root.children
     };
+
+    console.log('\nAxe rule coverage (node counts per bucket)');
+    console.table(rules);
+
+    if (neverRun.length) {
+      console.log(`\n⚠️  ${ neverRun.length } rule(s) available to axe produced no result in any bucket: ${ neverRun.join(', ') }`);
+    }
 
     fs.writeFileSync(path.join(folder, 'accessibility.json'), JSON.stringify(data, null, 2));
 
@@ -252,6 +363,11 @@ function registerHooks(on, config) {
     });
 
     fs.writeFileSync(path.join(folder, 'accessibility.html'), reportHTML);
+
+    fs.writeFileSync(
+      path.join(folder, 'accessibility-incomplete.html'),
+      createIncompleteReport(deDuplicate(allIncomplete))
+    );
 
     return null;
   });

--- a/cypress/support/plugins/accessibility/index.ts
+++ b/cypress/support/plugins/accessibility/index.ts
@@ -23,6 +23,7 @@ function createPath(testPath: string[]) {
         name:       p,
         children:   [],
         violations: [],
+        incomplete: [],
         leaf:       false,
       };
 
@@ -38,12 +39,18 @@ export type TestViolation = {
   name: string;
   children: TestViolation[];
   violations: any[];
+  incomplete: any[];
   leaf: boolean;
   screenshot?: string;
 };
 
 export type Options = {
   violations: any[];
+  titlePath: string[];
+};
+
+export type IncompleteOptions = {
+  incomplete: any[];
   titlePath: string[];
 };
 
@@ -58,10 +65,12 @@ const chain: TestViolation[] = [{
   name:       'Root',
   children:   [],
   violations: [],
+  incomplete: [],
   leaf:       false,
 }];
 
 const allViolations = [] as any[];
+const allIncomplete = [] as any[];
 const screenshots = [] as Screenshot[];
 let folder;
 
@@ -69,10 +78,11 @@ let folder;
 function tidy(item: TestViolation) {
   item.children.forEach((i) => tidy(i));
 
-  if (item.violations.length === 0 && item.children.length === 1) {
+  if (item.violations.length === 0 && item.incomplete.length === 0 && item.children.length === 1) {
     if (item.children[0].leaf) {
       // Collapse up
       item.violations = item.children[0].violations;
+      item.incomplete = item.children[0].incomplete;
       item.children = [];
     }
   }
@@ -137,7 +147,21 @@ function registerHooks(on, config) {
       found.leaf = true;
 
       return null;
-    }
+    },
+
+    // axe's 'needs review' bucket - results it could neither pass nor fail definitively.
+    // Recorded separately so a clean `violations` list is never mistaken for "no problems".
+    a11yIncomplete(options: IncompleteOptions) {
+      const { incomplete, titlePath } = options;
+      const found = createPath(titlePath);
+
+      allIncomplete.push(...incomplete);
+
+      found.incomplete.push(...incomplete);
+      found.leaf = true;
+
+      return null;
+    },
   });
 
   on('task', {
@@ -158,6 +182,7 @@ function registerHooks(on, config) {
       name:       spec.baseName,
       children:   [],
       violations: [],
+      incomplete: [],
       leaf:       false,
     };
 
@@ -216,7 +241,10 @@ function registerHooks(on, config) {
     });
 
     const reportHTML = createHtmlReport({
-      results: { violations: deDuplicate(allViolations) },
+      results: {
+        violations: deDuplicate(allViolations),
+        incomplete: deDuplicate(allIncomplete),
+      },
       options: {
         projectKey:            'Rancher Manager',
         doNotCreateReportFile: true,

--- a/cypress/support/plugins/accessibility/index.ts
+++ b/cypress/support/plugins/accessibility/index.ts
@@ -67,7 +67,7 @@ export type RuleSummaryEntry = {
   checks: number;
 };
 
-export type RuleOptions = {
+export type ResultOptions = {
   titlePath: string[];
   availableRules: string[];
   violations: any[];
@@ -77,6 +77,22 @@ export type RuleOptions = {
 };
 
 const BUCKETS: (keyof RuleSummaryEntry)[] = ['violations', 'incomplete', 'passes', 'inapplicable'];
+
+/**
+ * Rendering every `passes` node produces an HTML file no browser will open - a full suite run passes
+ * tens of thousands of nodes. Trim per rule so every rule still gets a card, and never silently: what
+ * was dropped goes in the report banner and the terminal.
+ */
+const MAX_REPORT_NODES = Number(process.env.TEST_A11Y_MAX_REPORT_NODES) || 5000;
+
+/**
+ * Everything below crosses the Cypress task boundary, so treat it as untrusted. A bucket that arrives
+ * undefined, null or as something other than an array must not take the rest of the reporting down
+ * with it - `after:run` is the only chance we get to write anything at all.
+ */
+function toArray(value: any): any[] {
+  return Array.isArray(value) ? value : [];
+}
 
 type Screenshot = {
   name: string;
@@ -95,6 +111,8 @@ const chain: TestViolation[] = [{
 
 const allViolations = [] as any[];
 const allIncomplete = [] as any[];
+const allPasses = [] as any[];
+const allInapplicable = [] as any[];
 const screenshots = [] as Screenshot[];
 const ruleSummary: {[id: string]: RuleSummaryEntry} = {};
 const availableRules = new Set<string>();
@@ -125,7 +143,11 @@ function deDuplicate(violations: any[]) {
   const result: any[] = [];
   const seen: {[key: string]: any} = {};
 
-  violations.forEach((item) => {
+  toArray(violations).forEach((item) => {
+    if (!item || !item.id) {
+      return;
+    }
+
     const copy = JSON.parse(JSON.stringify(item));
 
     delete copy.nodes;
@@ -133,13 +155,18 @@ function deDuplicate(violations: any[]) {
     const hash = calcHash(JSON.stringify(copy));
 
     if (!seen[hash]) {
-      seen[hash] = item;
-      result.push(item);
+      // `nodes` and `tags` are the two fields axe-html-reporter dereferences without checking. A rule
+      // missing either renders the whole report as a one-line error string, so normalise them here
+      // rather than discovering it in an artifact nobody can open.
+      seen[hash] = {
+        ...item, nodes: [...toArray(item.nodes)], tags: toArray(item.tags)
+      };
+      result.push(seen[hash]);
     } else {
       // Merge the nodes
       const existing = seen[hash];
 
-      item.nodes.forEach((node) => {
+      toArray(item.nodes).forEach((node) => {
         const str = JSON.stringify(node);
         const exists = existing.nodes.find((n) => JSON.stringify(n) === str);
 
@@ -153,37 +180,145 @@ function deDuplicate(violations: any[]) {
   return result;
 }
 
+type BucketReport = {
+  // File written into the a11y folder
+  file: string;
+  // Appended to the report title, in place of nothing
+  label: string;
+  // Replaces the template's hard-coded 'Failed' section heading
+  heading: string;
+  // Replaces 'To solve this violation, you need to...' in the per-node table
+  nodeColumn: string;
+  // Explains the bucket at the top of the report
+  blurb: string;
+  // Builds the headline, given the node total across the bucket
+  summary: (nodes: number, rules: number) => string;
+  // Inapplicable results carry no nodes at all, so their per-node tables render empty and are dropped
+  dropNodeTables?: boolean;
+};
+
+const REPORTS: {[bucket: string]: BucketReport} = {
+  incomplete: {
+    file:       'accessibility-incomplete.html',
+    label:      'Needs Review',
+    heading:    'Needs review',
+    nodeColumn: 'To resolve this check, you need to...',
+    blurb:      '<b>These are not confirmed failures.</b> This is axe\'s <code>incomplete</code> bucket - checks it ' +
+      'could neither pass nor fail with certainty, so it hands them to a human. Every entry needs a manual ' +
+      'decision: it is either a real issue or a false alarm. Nothing here failed CI.',
+    summary: (nodes) => `axe-core flagged ${ badge(nodes, 'warning') } check(s) that need manual review`,
+  },
+  passes: {
+    file:       'accessibility-passes.html',
+    label:      'Passed',
+    heading:    'Passed',
+    nodeColumn: 'Checks this element satisfied',
+    blurb:      '<b>These all passed.</b> This is axe\'s <code>passes</code> bucket - every element that was ' +
+      'tested and met the rule. It is here so rule coverage can be audited: a rule with a suspiciously low ' +
+      'node count is matching fewer elements than the page actually contains, which is a very different ' +
+      'problem from a rule that fails.',
+    summary: (nodes) => `axe-core recorded ${ badge(nodes, 'success') } passing node(s)`,
+  },
+  inapplicable: {
+    file:           'accessibility-inapplicable.html',
+    label:          'Inapplicable',
+    heading:        'Inapplicable',
+    nodeColumn:     'Notes',
+    dropNodeTables: true,
+    blurb:          '<b>Nothing on any scanned page matched these rules.</b> This is axe\'s <code>inapplicable</code> ' +
+      'bucket. Inapplicable results carry no nodes by definition, so each entry lists the rule only. A rule here ' +
+      'that you expected to apply is worth a look - it means axe found no elements of that kind at all.',
+    summary: (_nodes, rules) => `axe-core found no matching elements for ${ badge(rules, 'secondary') } rule(s)`,
+  },
+};
+
+function badge(count: number, variant: string) {
+  return `<span class="badge badge-${ variant }">${ count }</span>`;
+}
+
 /**
- * Build the 'needs review' report.
+ * Trim a bucket so the report stays openable.
+ *
+ * Spread the budget evenly across rules rather than first-come-first-served, so every rule still gets
+ * a card instead of the tail rendering empty.
+ */
+function capNodes(results: any[]) {
+  const total = results.reduce((sum, rule) => sum + toArray(rule.nodes).length, 0);
+
+  if (total <= MAX_REPORT_NODES || results.length === 0) {
+    return {
+      capped: results, total, shown: total
+    };
+  }
+
+  // Hand out an equal share, smallest rule first, giving whatever a small rule doesn't need back to
+  // the rules that do. A flat `budget / ruleCount` would waste most of the budget - a bucket like
+  // `passes` is a handful of huge rules and a long tail of rules with two or three nodes each.
+  const order = results.map((rule, index) => ({ index, count: toArray(rule.nodes).length }))
+    .sort((a, b) => a.count - b.count);
+  const allowances: number[] = [];
+  let budget = MAX_REPORT_NODES;
+
+  order.forEach(({ index, count }, position) => {
+    const share = Math.max(1, Math.floor(budget / (order.length - position)));
+
+    allowances[index] = Math.min(count, share);
+    budget -= allowances[index];
+  });
+
+  const capped = results.map((rule, index) => ({ ...rule, nodes: toArray(rule.nodes).slice(0, allowances[index]) }));
+  const shown = capped.reduce((sum, rule) => sum + rule.nodes.length, 0);
+
+  return {
+    capped, total, shown
+  };
+}
+
+/**
+ * Build a report for one axe bucket.
  *
  * `axe-html-reporter` only renders detailed per-node cards for whatever sits in `results.violations`.
- * Its native `incomplete` section is a summary table and nothing else, which isn't enough to triage
- * from - no element location, no source, no reason axe gave up. So we hand it the incomplete results
- * in the `violations` slot to get the identical presentation, then correct the wording the template
+ * Its native `passes` / `incomplete` / `inapplicable` sections are summary tables and nothing else -
+ * no element location, no source, nothing to triage from. So we hand each bucket in through the
+ * `violations` slot to get the identical presentation, then correct the wording the template
  * hard-codes.
  */
-function createIncompleteReport(incomplete: any[]) {
-  const customSummary = [
-    '<b>These are not confirmed failures.</b> This is axe\'s <code>incomplete</code> bucket - checks it',
-    'could neither pass nor fail with certainty, so it hands them to a human. Every entry needs a manual',
-    'decision: it is either a real issue or a false alarm. Nothing here failed CI.'
-  ].join(' ');
+function createBucketReport(bucket: string, results: any[]) {
+  const report = REPORTS[bucket];
+  const deduped = deDuplicate(results);
+  const { capped, total, shown } = capNodes(deduped);
 
-  const html = createHtmlReport({
-    results: { violations: incomplete },
+  const trimmed = total > shown ? `<div class="alert alert-info" role="alert">Showing <b>${ shown }</b> of <b>${ total }</b> nodes, spread evenly ` +
+      `across rules. The rest are trimmed to keep this file openable in a browser - raise ` +
+      `<code>TEST_A11Y_MAX_REPORT_NODES</code> and re-run to see more. Per-rule totals are complete and unaffected; ` +
+      `they are in the <code>ruleSummary</code> section of <code>accessibility.json</code>.</div>` : '';
+
+  if (total > shown) {
+    console.log(`  ${ report.file }: trimmed to ${ shown } of ${ total } nodes (TEST_A11Y_MAX_REPORT_NODES=${ MAX_REPORT_NODES })`);
+  }
+
+  let html = createHtmlReport({
+    results: { violations: capped },
     options: {
       projectKey:            'Rancher Manager',
-      customSummary,
+      customSummary:         `${ report.blurb }${ trimmed }`,
       doNotCreateReportFile: true,
     },
   });
 
-  return html
-    .replace('<title>Axe-core® Accessibility Results</title>', '<title>Axe-core® Accessibility Results - Needs Review</title>')
-    .replace('Axe-core® Accessibility Results for', 'Axe-core® Accessibility Results - Needs Review for')
-    .replace(/axe-core found (<span class="badge badge-\w+">\d+<\/span>) violations?/, 'axe-core flagged $1 check(s) that need manual review')
-    .replace('<h3>Failed</h3>', '<h3>Needs review</h3>')
-    .replace(/To solve this violation, you need to\.\.\./g, 'To resolve this check, you need to...');
+  html = html
+    .replace('<title>Axe-core® Accessibility Results</title>', `<title>Axe-core® Accessibility Results - ${ report.label }</title>`)
+    .replace('Axe-core® Accessibility Results for', `Axe-core® Accessibility Results - ${ report.label } for`)
+    .replace(/axe-core found <span class="badge badge-\w+">\d+<\/span> violations?/, report.summary(total, capped.length))
+    .replace('<h3>Failed</h3>', `<h3>${ report.heading }</h3>`)
+    .replace(/To solve this violation, you need to\.\.\./g, report.nodeColumn);
+
+  if (report.dropNodeTables) {
+    // Every one of these tables is empty - inapplicable results have no nodes - so they are noise
+    html = html.replace(/\s*<div class="violationNode">[\s\S]*?<\/table>\s*<\/div>/g, '');
+  }
+
+  return html;
 }
 
 /**
@@ -233,18 +368,23 @@ function registerHooks(on, config) {
       return null;
     },
 
-    // Rule-level tally across all four axe buckets. This is what tells us whether a rule we expect to
-    // see (`color-contrast`, say) ran and passed, ran and matched nothing, or never ran at all.
-    a11yRules(options: RuleOptions) {
-      (options.availableRules || []).forEach((id) => availableRules.add(id));
+    // Every bucket from one axe run. Feeds the rule-level tally - which is what tells us whether a
+    // rule we expect to see (`color-contrast`, say) ran and passed, ran and matched nothing, or never
+    // ran at all - and collects `passes` / `inapplicable` for their own reports.
+    a11yResults(options: ResultOptions) {
+      toArray(options?.availableRules).forEach((id) => availableRules.add(id));
 
       BUCKETS.forEach((bucket) => {
-        (options[bucket] || []).forEach((rule) => {
+        toArray(options?.[bucket]).forEach((rule) => {
+          if (!rule || !rule.id) {
+            return;
+          }
+
           if (!ruleSummary[rule.id]) {
             ruleSummary[rule.id] = {
               id:           rule.id,
               help:         rule.help,
-              tags:         rule.tags,
+              tags:         toArray(rule.tags),
               violations:   0,
               incomplete:   0,
               passes:       0,
@@ -253,10 +393,13 @@ function registerHooks(on, config) {
             };
           }
 
-          (ruleSummary[rule.id][bucket] as number) += rule.nodes;
+          (ruleSummary[rule.id][bucket] as number) += toArray(rule.nodes).length;
           ruleSummary[rule.id].checks++;
         });
       });
+
+      allPasses.push(...toArray(options?.passes));
+      allInapplicable.push(...toArray(options?.inapplicable));
 
       return null;
     },
@@ -364,10 +507,30 @@ function registerHooks(on, config) {
 
     fs.writeFileSync(path.join(folder, 'accessibility.html'), reportHTML);
 
-    fs.writeFileSync(
-      path.join(folder, 'accessibility-incomplete.html'),
-      createIncompleteReport(deDuplicate(allIncomplete))
-    );
+    // One report per remaining bucket. Each is written independently: a bucket that arrives empty,
+    // missing or malformed must not cost us the other reports, and none of it is worth failing the
+    // run over - by this point the tests have already passed and the JSON is on disk.
+    const buckets: {[bucket: string]: any[]} = {
+      incomplete:   allIncomplete,
+      passes:       allPasses,
+      inapplicable: allInapplicable,
+    };
+
+    Object.keys(REPORTS).forEach((bucket) => {
+      const { file } = REPORTS[bucket];
+
+      try {
+        const contents = toArray(buckets[bucket]);
+
+        if (!contents.length) {
+          console.log(`  ${ file }: no '${ bucket }' results recorded, writing an empty report`);
+        }
+
+        fs.writeFileSync(path.join(folder, file), createBucketReport(bucket, contents));
+      } catch (e) {
+        console.error(`Failed to write ${ file }: ${ e }`);
+      }
+    });
 
     return null;
   });


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #

Our axe accessibility CI reports zero colour-contrast issues. A VPAT audit of the same product found 44 unresolved ones, and a browser contrast checker finds real problems on live pages too. This PR closes the gap that explains the discrepancy.

The short version: **we were throwing away half of axe's output.** axe returns four result buckets — `passes`, `violations`, `incomplete`, `inapplicable`. We only ever captured `violations`. The `incomplete` bucket (axe calls it "needs review") is where axe files anything it could neither definitively pass nor definitively fail — and colour-contrast is *the* rule most likely to land there, because working out an element's real background colour is genuinely hard.

Worth stating clearly, because it was the first theory and it's wrong: **the axe config was not filtering out Level AA.** There is no `runOnly` tag filter anywhere in the repo, and the AA `color-contrast` rule was running on every page all along. The problem was never what we tested, it was what we reported.

Net effect before this PR: a green a11y report meant *"axe found nothing it was certain about"*, but it was being read as *"there are no contrast problems"*. Those are very different statements.

### Occurred changes and/or fixed issues
- Capture and report axe's `incomplete` ("needs review") results, which were previously discarded before reaching either report artifact
- `incomplete` results now appear in both `accessibility.json` (full per-node detail) and the generated HTML report (summary section)
- Pin the a11y suite to a 1920x1080 viewport, scoped to that suite only — every other Cypress spec keeps the default

### Technical notes summary
Two changes, both in the Cypress a11y plumbing. No product code is touched.

**1. Stop using `cy.checkA11y`, call axe directly.**

This isn't a stylistic preference — it's a hard limitation of the library. `cypress-axe` only ever hands its callback `results.violations`; it never reads `results.incomplete`. So there was no configuration or option we could have set to get that data. The only way to see it is to call `axe.run()` ourselves via `cy.window()`, which returns the complete results object. This is the same workaround other teams have landed on for the same problem.

The rule set is unchanged — we still pass an empty options object, so axe runs exactly the same checks it did before. And as before, nothing here fails a test: we record, we don't assert.

Violations keep their existing treatment (terminal table, Cypress log, screenshots with the element outlined in red). Incomplete results deliberately get a lighter path — logged and recorded, but no screenshots and no DOM marking. They're high volume by nature and they're a triage queue rather than failures, so screenshotting every node would blow up both run time and artifact size for little benefit.

**2. Report generator now carries a second collection.**

The Cypress task that builds the report gains an `a11yIncomplete` sibling to the existing `a11y` task, and the per-test tree gains an `incomplete` array alongside `violations`. `axe-html-reporter` already supports an incomplete section natively, so the HTML report picks it up with no template work.

**One caveat to set expectations on:** the HTML report renders incomplete as a *summary table only* — rule, description, impact, node count — with no per-node HTML or selectors. That's a limitation of `axe-html-reporter`, not of what we capture. The full per-node detail, including axe's specific reason for giving up on each check, is in `accessibility.json`. If the summary proves too thin for triage we can add a custom section later; that's a report-rendering change, not a data-capture one.

**On the viewport.** One of axe's documented reasons for abandoning a contrast check is literally *"Element's background color could not be determined because it's outside the viewport"*. Cypress defaults to 1000x660, which on a dense Rancher list page leaves a lot of the page off-screen at scan time. Bumping the a11y suite to 1920x1080 should reduce that particular category of incomplete result, and it better reflects how the product is actually used. It's set as a suite-level config override on the a11y `describe` block, so it does not leak into any other spec.

### Areas or cases that should be tested
This is test-infrastructure only — there are no product changes, so there is nothing to click through in the UI.

**The main thing to verify is that the a11y suite still runs and now reports more.**

1. Run the a11y suite: `yarn cy:run --spec cypress/e2e/tests/accessibility/shell.spec.ts`
2. Check the run completes and the same tests pass as before — the change should not fail any test that was previously passing, since we never assert on results
3. Open `cypress/accessibility/accessibility.html` and confirm there is now an **"Incomplete"** accordion alongside the violations section
4. Open `cypress/accessibility/accessibility.json` and confirm nodes now carry an `incomplete` array as well as `violations`
5. **The key check:** confirm `color-contrast` appears somewhere in the incomplete results. If it does, that confirms the diagnosis — those checks were running all along and being silently dropped

**Cross-check against known VPAT findings.** These are real contrast failures the audit found. Worth confirming they now surface somewhere in the output:

| Location | Finding | Success criterion |
|---|---|---|
| Login page | Checkbox border, 1.34:1 | 1.4.11 Non-text Contrast (AA) |
| Homepage | `#3D98D3` on `#E2F0F8` = 2.72:1 | 1.4.3 Contrast Minimum (AA) |
| Homepage | `#3D98D3` on `#FFFFFF` = 3.16:1 | 1.4.3 Contrast Minimum (AA) |

Affected elements include "What's new in 2.9", Preferences, Manage, "2", Import Existing, Create. Both ratios fall short of the 4.5:1 required for normal text. Anything here that *still* doesn't show up points at a further gap beyond this fix.

**Also confirm the viewport is properly scoped.** Run any non-a11y spec and check it still runs at the default 1000x660 — the override should be invisible outside the a11y suite.

⚠️ **Expect the first run to be loud.** `incomplete` is unfiltered uncertainty and there will be a lot of it. That is the intended outcome, not a regression. It's a triage backlog to work through, and it is not gating CI — nothing fails on it.

### Areas which could experience regressions
- **The a11y suite itself.** We swapped the axe invocation, so a mistake here would show up as the suite erroring rather than as bad data. The rule set and the assert-nothing behaviour are both unchanged, so no previously-passing test should start failing.
- **The report artifacts.** `accessibility.json` gains a new field. It's additive — existing consumers reading `violations` are unaffected — but worth a look if anything downstream parses that file.
- **Run time.** The a11y suite may get slower: a larger viewport means more elements in scope for axe, and we're now processing a second, larger result set. No screenshots are taken for incomplete results, which was the deliberate choice to keep this in check.
- **Other Cypress suites.** Should be entirely unaffected. The viewport change is scoped to a single `describe` block and no shared config was touched — but that's the thing to sanity-check if any unrelated spec starts behaving oddly.

### Screenshot/Video
<!-- Attach a before/after of the generated HTML report showing the new Incomplete section -->

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
